### PR TITLE
ci(config): add missing CPPLINT.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ log/
 
 # Python
 *.pyc
-

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,13 @@
+# Modified from https://github.com/ament/ament_lint/blob/ebd524bb9973d5ec1dc48a670ce54f958a5a0243/ament_cpplint/ament_cpplint/main.py#L64-L120
+set noparent
+linelength=100
+includeorder=standardcfirst
+filter=-build/c++11               # we do allow C++11
+filter=-build/namespaces_literals # we allow using namespace for literals
+filter=-runtime/references        # we consider passing non-const references to be ok
+filter=-whitespace/braces         # we wrap open curly braces for namespaces, classes and functions
+filter=-whitespace/indent         # we don't indent keywords like public, protected and private with one space
+filter=-whitespace/parens         # we allow closing parenthesis to be on the next line
+filter=-whitespace/semicolon      # we allow the developer to decide about whitespace after a semicolon
+filter=-build/header_guard        # TODO(Kenji Miyake): Support ROS-style rule in cpplint or add auto-fix script in pre-commit
+filter=-build/include_order       # we use the custom include order


### PR DESCRIPTION
# Related Issue
https://github.com/autowarefoundation/autoware.universe/issues/1

# Description
Signed-off-by: Kenji Miyake <kenji.miyake@tier4.jp>

* Add CPPLINT.cfg

only selected lint commit from ci setting PR