### PR TITLE
ci(build): don't skip jobs even if the targets are empty

### DIFF
--- a/.github/workflows/build-and-test-pr.yaml
+++ b/.github/workflows/build-and-test-pr.yaml
@@ -14,7 +14,6 @@ jobs:
 
   build-and-test:
     needs: get-modified-packages
-    if: ${{ needs.get-modified-packages.outputs.modified-packages != '' }}
     uses: autowarefoundation/autoware-github-actions/.github/workflows/reusable-colcon-build-and-test.yaml@tier4/proposal
     with:
       rosdistro: galactic
@@ -23,7 +22,6 @@ jobs:
 
   clang-tidy:
     needs: [get-modified-source-files, build-and-test]
-    if: ${{ needs.get-modified-source-files.outputs.modified-source-files != '' }}
     uses: autowarefoundation/autoware-github-actions/.github/workflows/reusable-clang-tidy.yaml@tier4/proposal
     with:
       script-ref: tier4/proposal

--- a/.github/workflows/build-and-test-scheduled.yaml
+++ b/.github/workflows/build-and-test-scheduled.yaml
@@ -11,7 +11,6 @@ jobs:
 
   build-and-test:
     needs: get-self-packages
-    if: ${{ needs.get-self-packages.outputs.self-packages != '' }}
     uses: autowarefoundation/autoware-github-actions/.github/workflows/reusable-colcon-build-and-test.yaml@tier4/proposal
     with:
       rosdistro: galactic
@@ -20,7 +19,6 @@ jobs:
 
   build-and-test-arm64:
     needs: get-self-packages
-    if: ${{ needs.get-self-packages.outputs.self-packages != '' }}
     uses: autowarefoundation/autoware-github-actions/.github/workflows/reusable-colcon-build-and-test.yaml@tier4/proposal
     with:
       os: ARM64


### PR DESCRIPTION
Skipped jobs cannot be set to required.