### PR TITLE
feat: load vehicle info default param

### DIFF
--- a/common/autoware_global_parameter_loader/Readme.md
+++ b/common/autoware_global_parameter_loader/Readme.md
@@ -13,6 +13,8 @@ Add the following lines to the launch file of the node in which you want to get 
   </include>
 ```
 
+The vehicle model parameter is read from `config/vehicle_info.param.yaml` in `vehicle_model`_description package.
+
 ## Assumptions / Known limits
 
 Currently only vehicle_info is loaded by this launcher.

--- a/common/autoware_global_parameter_loader/Readme.md
+++ b/common/autoware_global_parameter_loader/Readme.md
@@ -13,7 +13,7 @@ Add the following lines to the launch file of the node in which you want to get 
   </include>
 ```
 
-The vehicle model parameter is read from `config/vehicle_info.param.yaml` in `vehicle_model`_description package.
+The vehicle model parameter is read from `config/vehicle_info.param.yaml` in `vehicle_model`\_description package.
 
 ## Assumptions / Known limits
 

--- a/control/control_performance_analysis/launch/controller_performance_analysis.launch.xml
+++ b/control/control_performance_analysis/launch/controller_performance_analysis.launch.xml
@@ -8,10 +8,11 @@
   <arg name="output/error_stamped" default="/control_performance/performance_vars" />
 
   <!-- vehicle info -->
-  <include file="$(find-pkg-share autoware_launch)/launch/global_params.launch.py" />
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
 
   <node pkg="control_performance_analysis" exec="control_performance_analysis" name="control_performance_analysis" output="screen">
     <param from="$(var control_performance_analysis_param_path)" />
+    <param from="$(var vehicle_info_param_file)" />
 
     <remap from="~/input/reference_trajectory" to="$(var input/reference_trajectory)" />
     <remap from="~/input/control_raw" to="$(var input/control_raw)" />

--- a/control/lane_departure_checker/launch/lane_departure_checker.launch.xml
+++ b/control/lane_departure_checker/launch/lane_departure_checker.launch.xml
@@ -6,6 +6,9 @@
   <arg name="input/predicted_trajectory" default="/control/trajectory_follower/predicted_trajectory" />
   <arg name="config_file" default="$(find-pkg-share lane_departure_checker)/config/lane_departure_checker.param.yaml" />
 
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
+
   <node pkg="lane_departure_checker" exec="lane_departure_checker_node" name="lane_departure_checker_node" output="screen">
     <remap from="~/input/odometry" to="$(var input/odometry)"/>
     <remap from="~/input/lanelet_map_bin" to="$(var input/lanelet_map_bin)"/>
@@ -13,5 +16,6 @@
     <remap from="~/input/reference_trajectory" to="$(var input/reference_trajectory)"/>
     <remap from="~/input/predicted_trajectory" to="$(var input/predicted_trajectory)"/>
     <param from="$(var config_file)" />
+    <param from="$(var vehicle_info_param_file)" />
   </node>
 </launch>

--- a/control/obstacle_collision_checker/launch/obstacle_collision_checker.launch.xml
+++ b/control/obstacle_collision_checker/launch/obstacle_collision_checker.launch.xml
@@ -5,9 +5,12 @@
   <arg name="input/predicted_trajectory" default="/control/trajectory_follower/predicted_trajectory" />
   <arg name="input/odometry" default="/localization/kinematic_state" />
   <arg name="config_file" default="$(find-pkg-share obstacle_collision_checker)/config/obstacle_collision_checker.param.yaml" />
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
 
   <node pkg="obstacle_collision_checker" exec="obstacle_collision_checker_node" name="obstacle_collision_checker_node" output="screen">
     <param from="$(var config_file)" />
+    <param from="$(var vehicle_info_param_file)" />
     <remap from="input/lanelet_map_bin" to="$(var input/lanelet_map_bin)"/>
     <remap from="input/obstacle_pointcloud" to="$(var input/obstacle_pointcloud)"/>
     <remap from="input/reference_trajectory" to="$(var input/reference_trajectory)"/>

--- a/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
+++ b/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
@@ -4,6 +4,9 @@
   <arg name="use_external_emergency_stop" default="true" />
   <arg name="use_start_request" default="false" />
 
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
+
   <node pkg="vehicle_cmd_gate" exec="vehicle_cmd_gate" name="vehicle_cmd_gate" output="screen">
     <remap from="input/steering" to="/vehicle/status/steering_status"/>
 
@@ -42,6 +45,7 @@
     <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
 
     <param from="$(var config_file)" />
+    <param from="$(var vehicle_info_param_file)" />
     <param name="use_emergency_handling" value="$(var use_emergency_handling)" />
     <param name="use_external_emergency_stop" value="$(var use_external_emergency_stop)" />
     <param name="use_start_request" value="$(var use_start_request)" />

--- a/perception/ground_segmentation/launch/scan_ground_filter.launch.py
+++ b/perception/ground_segmentation/launch/scan_ground_filter.launch.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import launch
+from ament_index_python.packages import get_package_share_directory
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import LaunchConfigurationEquals
 from launch.conditions import LaunchConfigurationNotEquals

--- a/perception/ground_segmentation/launch/scan_ground_filter.launch.py
+++ b/perception/ground_segmentation/launch/scan_ground_filter.launch.py
@@ -21,6 +21,7 @@ from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
 
+import os
 
 def generate_launch_description():
     def add_launch_arg(name: str, default_value=None):

--- a/perception/ground_segmentation/launch/scan_ground_filter.launch.py
+++ b/perception/ground_segmentation/launch/scan_ground_filter.launch.py
@@ -26,6 +26,16 @@ def generate_launch_description():
     def add_launch_arg(name: str, default_value=None):
         return DeclareLaunchArgument(name, default_value=default_value)
 
+    default_vehicle_info_param = os.path.join(
+        get_package_share_directory('vehicle_info_util'),
+        'config/vehicle_info.param.yaml')
+
+    vehicle_info_param = DeclareLaunchArgument(
+        'vehicle_info_param_file',
+        default_value=default_vehicle_info_param,
+        description='Path to config file for vehicle information'
+    )
+
     nodes = [
         ComposableNode(
             package="ground_segmentation",
@@ -41,7 +51,8 @@ def generate_launch_description():
                     "local_slope_max_angle_deg": 30.0,
                     "split_points_distance_tolerance": 0.2,
                     "split_height_distance": 0.2,
-                }
+                },
+                LaunchConfiguration('vehicle_info_param_file'),
             ],
         ),
     ]
@@ -64,6 +75,7 @@ def generate_launch_description():
 
     return launch.LaunchDescription(
         [
+            vehicle_info_param,
             add_launch_arg("container", ""),
             add_launch_arg("input/pointcloud", "pointcloud"),
             add_launch_arg("output/pointcloud", "no_ground/pointcloud"),

--- a/perception/ground_segmentation/launch/scan_ground_filter.launch.py
+++ b/perception/ground_segmentation/launch/scan_ground_filter.launch.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import os
-import yaml
 
-import launch
 from ament_index_python.packages import get_package_share_directory
+import launch
 from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
 from launch.actions import OpaqueFunction
@@ -26,8 +25,8 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
+import yaml
 
-import os
 
 def launch_setup(context, *args, **kwargs):
     vehicle_info_param_path = LaunchConfiguration("vehicle_info_param_file").perform(context)
@@ -71,7 +70,6 @@ def launch_setup(context, *args, **kwargs):
         condition=LaunchConfigurationEquals("container", ""),
     )
 
-
     group = GroupAction(
         [
             container,
@@ -80,6 +78,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     return [group]
+
 
 def generate_launch_description():
     def add_launch_arg(name: str, default_value=None):
@@ -100,7 +99,7 @@ def generate_launch_description():
             vehicle_info_param,
             add_launch_arg("container", ""),
             add_launch_arg("input/pointcloud", "pointcloud"),
-            add_launch_arg("output/pointcloud", "no_ground/pointcloud")
+            add_launch_arg("output/pointcloud", "no_ground/pointcloud"),
         ]
         + [OpaqueFunction(function=launch_setup)]
     )

--- a/perception/ground_segmentation/package.xml
+++ b/perception/ground_segmentation/package.xml
@@ -28,6 +28,7 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
+  <depend>vehicle_info_util</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/occupancy_grid_map_outlier_filter/package.xml
+++ b/perception/occupancy_grid_map_outlier_filter/package.xml
@@ -40,7 +40,6 @@
   <depend>tf2_ros</depend>
   <depend>tier4_debug_msgs</depend>
   <depend>tier4_pcl_extensions</depend>
-  <depend>vehicle_info_util</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/behavior_path_planner/launch/behavior_path_planner.launch.xml
+++ b/planning/behavior_path_planner/launch/behavior_path_planner.launch.xml
@@ -2,6 +2,9 @@
   <arg name="input_route_topic_name" default="/planning/mission_planning/route" />
   <arg name="map_topic_name" default="/map/vector_map" />
 
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
+
   <node pkg="behavior_path_planner" exec="behavior_path_planner" name="behavior_path_planner" output="screen">
     <remap from="~/input/route" to="$(var input_route_topic_name)" />
     <remap from="~/input/vector_map" to="$(var map_topic_name)" />
@@ -11,5 +14,6 @@
 
     <param from="$(find-pkg-share behavior_path_planner)/config/side_shift/side_shift.param.yaml" />
     <param name="bt_tree_config_path" value="$(find-pkg-share behavior_path_planner)/config/behavior_path_planner_tree.xml" />
+    <param from="$(var vehicle_info_param_file)" />
   </node>
 </launch>

--- a/planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
+++ b/planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
-  <include file="$(find-pkg-share autoware_global_parameter_loader)/launch/global_params.launch.py"/>
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
 
   <arg name="input_route_topic_name" default="/planning/mission_planning/route" />
   <arg name="input_traffic_light_topic_name" default="/perception/traffic_light_recognition/traffic_signals" />
@@ -36,6 +37,7 @@
     <param from="$(find-pkg-share behavior_velocity_planner)/config/occlusion_spot.param.yaml" />
     <param from="$(find-pkg-share behavior_velocity_planner)/config/no_stopping_area.param.yaml" />
 
+    <param from="$(var vehicle_info_param_file)" />
     <remap from="~/input/path_with_lane_id" to="path_with_lane_id" />
     <remap from="~/input/vector_map" to="$(var map_topic_name)" />
     <remap from="~/input/vehicle_odometry" to="/localization/kinematic_state" />

--- a/planning/freespace_planner/launch/freespace_planner.launch.xml
+++ b/planning/freespace_planner/launch/freespace_planner.launch.xml
@@ -8,6 +8,9 @@
 
   <arg name="param_file" default="$(find-pkg-share freespace_planner)/config/freespace_planner.param.yaml"/>
 
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
+
   <node pkg="freespace_planner" exec="freespace_planner" name="freespace_planner" output="screen">
     <remap from="~/input/route" to="$(var input_route)" />
     <remap from="~/input/occupancy_grid" to="$(var input_occupancy_grid)" />
@@ -16,5 +19,6 @@
     <remap from="~/output/trajectory" to="$(var output_trajectory)" />
     <remap from="is_completed" to="$(var is_completed)" />
     <param from="$(var param_file)"/>
+    <param from="$(var vehicle_info_param_file)" />
   </node>
 </launch>

--- a/planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
+++ b/planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
@@ -3,6 +3,9 @@
   <arg name="adaptive_cruise_control_param_path" default="$(find-pkg-share obstacle_stop_planner)/config/adaptive_cruise_control.param.yaml" />
   <arg name="obstacle_stop_planner_param_path" default="$(find-pkg-share obstacle_stop_planner)/config/obstacle_stop_planner.param.yaml" />
 
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
+
   <arg name="enable_slow_down" default="false" />
   <arg name="input_objects" default="/perception/object_recognition/objects" />
   <arg name="input_pointcloud" default="input/pointcloud" />
@@ -17,6 +20,7 @@
     <param from="$(var common_param_path)" />
     <param from="$(var adaptive_cruise_control_param_path)" />
     <param from="$(var obstacle_stop_planner_param_path)" />
+    <param from="$(var vehicle_info_param_file)" />
     <param name="enable_slow_down" value="$(var enable_slow_down)" />
     <!-- remap topic name -->
     <remap from="~/output/stop_reason" to="/planning/scenario_planning/status/stop_reason" />

--- a/planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
+++ b/planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
@@ -1,6 +1,9 @@
 <launch>
   <arg name="param_path" default="$(find-pkg-share surround_obstacle_checker)/config/surround_obstacle_checker.param.yaml" />
 
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
+
   <arg name="input_trajectory" default="input/trajectory" />
   <arg name="input_objects" default="/perception/object_recognition/objects" />
   <arg name="input_odometry" default="/localization/kinematic_state" />
@@ -9,6 +12,7 @@
 
   <node pkg="surround_obstacle_checker" exec="surround_obstacle_checker_node" name="surround_obstacle_checker" output="screen">
     <param from="$(var param_path)" />
+    <param from="$(var vehicle_info_param_file)" />
     <remap from="~/output/no_start_reason" to="/planning/scenario_planning/status/no_start_reason" />
     <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons" />
     <remap from="~/output/trajectory" to="$(var output_trajectory)" />

--- a/sensing/pointcloud_preprocessor/package.xml
+++ b/sensing/pointcloud_preprocessor/package.xml
@@ -39,7 +39,6 @@
   <depend>tf2_ros</depend>
   <depend>tier4_debug_msgs</depend>
   <depend>tier4_pcl_extensions</depend>
-  <depend>vehicle_info_util</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -37,7 +37,7 @@ def generate_launch_description():
 
     default_vehicle_info_param = os.path.join(
         get_package_share_directory('vehicle_info_util'),
-        '/config/vehicle_info.param.yaml')
+        'config/vehicle_info.param.yaml')
 
     vehicle_info_param = DeclareLaunchArgument(
         'vehicle_info_param_file',

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -35,6 +35,16 @@ def generate_launch_description():
         description='Path to config file for vehicle characteristics'
     )
 
+    default_vehicle_info_param = os.path.join(
+        get_package_share_directory('vehicle_info_util'),
+        '/config/vehicle_info.param.yaml')
+
+    vehicle_info_param = DeclareLaunchArgument(
+        'vehicle_info_param_file',
+        default_value=default_vehicle_info_param,
+        description='Path to config file for vehicle information'
+    )
+
     simple_planning_simulator_node = launch_ros.actions.Node(
         package='simple_planning_simulator',
         executable='simple_planning_simulator_exe',
@@ -48,6 +58,7 @@ def generate_launch_description():
                 )
             ),
             LaunchConfiguration('vehicle_characteristics_param_file'),
+            LaunchConfiguration('vehicle_info_param_file')
         ],
         remappings=[
             ('input/ackermann_control_command', '/control/command/control_cmd'),
@@ -75,6 +86,7 @@ def generate_launch_description():
 
     ld = launch.LaunchDescription([
         vehicle_characteristics_param,
+        vehicle_info_param,
         simple_planning_simulator_node,
         map_to_odom_tf_publisher
     ])

--- a/vehicle/pacmod_interface/launch/pacmod_interface.launch.xml
+++ b/vehicle/pacmod_interface/launch/pacmod_interface.launch.xml
@@ -4,10 +4,13 @@
   <arg name="pacmod_param_path" default="$(find-pkg-share pacmod_interface)/config/pacmod.param.yaml"/>
   <arg name="pacmod_extra_param_path" default="$(find-pkg-share pacmod_interface)/config/pacmod_extra.param.yaml"/>
 
+  <!-- vehicle info -->
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" />
 
   <!-- pacmod interface -->
   <node pkg="pacmod_interface" exec="pacmod_interface" name="pacmod_interface" output="screen">
     <param from="$(var pacmod_param_path)" />
+    <param from="$(var vehicle_info_param_file)" />
   </node>
 
   <!-- pacmod diagnostics publisher -->


### PR DESCRIPTION
## Related Issue(required)
https://github.com/autowarefoundation/autoware.universe/issues/1
https://github.com/autowarefoundation/autoware.universe/issues/123
<!-- Link related issue -->

## Description(required)

set default vehicle_info parameter to the launch file of the packages which use vehicle_info_util

package list
- control_performance_analysis
- lane_departure_checker
- obstacle_collision_checker
- vehicle_cmd_gate
- ground_segmentation
- behavior_path_planner
- behavior_velocity_planner
- freespace_planner
- obstacle_stop_planner
- surround_obstacle_checker
- simple_planning_simulator
- pacmod_interface
- scan_ground_filter
- ~trajectory_follower_nodes~ ( no launch file)


## Review Procedure(required)
launch packages as `ros2 launch simple_planning_simulator simple_planning_simulator.launch.py `, and check that following error message does not output.

> Failed to get parameter `wheel_radius`, please set it when you launch the node.

<!-- Explain how to review this PR. -->

## Related PR(optional)

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
