### PR TITLE
fix: ignore roll and pitch for creating drivable_area

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -881,7 +881,7 @@ OccupancyGrid generateDrivableArea(
     const double origin_offset_x_m = (-width / 4) * cos(yaw) - (-height / 2) * sin(yaw);
     const double origin_offset_y_m = (-width / 4) * sin(yaw) + (-height / 2) * cos(yaw);
     // Only current yaw should be considered as the orientation of grid_origin.
-    grid_origin.pose.orientation = autoware_utils::createQuaternionFromYaw(yaw);
+    grid_origin.pose.orientation = tier4_autoware_utils::createQuaternionFromYaw(yaw);
     grid_origin.pose.position.x = current_pose.pose.position.x + origin_offset_x_m;
     grid_origin.pose.position.y = current_pose.pose.position.y + origin_offset_y_m;
     grid_origin.pose.position.z = current_pose.pose.position.z;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -881,8 +881,7 @@ OccupancyGrid generateDrivableArea(
     const double origin_offset_x_m = (-width / 4) * cos(yaw) - (-height / 2) * sin(yaw);
     const double origin_offset_y_m = (-width / 4) * sin(yaw) + (-height / 2) * cos(yaw);
     // Only current yaw should be considered as the orientation of grid_origin.
-    grid_origin.pose.orientation =
-      autoware_utils::createQuaternionFromYaw(yaw);
+    grid_origin.pose.orientation = autoware_utils::createQuaternionFromYaw(yaw);
     grid_origin.pose.position.x = current_pose.pose.position.x + origin_offset_x_m;
     grid_origin.pose.position.y = current_pose.pose.position.y + origin_offset_y_m;
     grid_origin.pose.position.z = current_pose.pose.position.z;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -880,7 +880,9 @@ OccupancyGrid generateDrivableArea(
     const double yaw = tf2::getYaw(current_pose.pose.orientation);
     const double origin_offset_x_m = (-width / 4) * cos(yaw) - (-height / 2) * sin(yaw);
     const double origin_offset_y_m = (-width / 4) * sin(yaw) + (-height / 2) * cos(yaw);
-    grid_origin.pose.orientation = current_pose.pose.orientation;
+    // Only current yaw should be considered as the orientation of grid_origin.
+    grid_origin.pose.orientation =
+      autoware_utils::createQuaternionFromYaw(tf2::getYaw(current_pose.pose.orientation));
     grid_origin.pose.position.x = current_pose.pose.position.x + origin_offset_x_m;
     grid_origin.pose.position.y = current_pose.pose.position.y + origin_offset_y_m;
     grid_origin.pose.position.z = current_pose.pose.position.z;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -882,7 +882,7 @@ OccupancyGrid generateDrivableArea(
     const double origin_offset_y_m = (-width / 4) * sin(yaw) + (-height / 2) * cos(yaw);
     // Only current yaw should be considered as the orientation of grid_origin.
     grid_origin.pose.orientation =
-      autoware_utils::createQuaternionFromYaw(tf2::getYaw(current_pose.pose.orientation));
+      autoware_utils::createQuaternionFromYaw(yaw);
     grid_origin.pose.position.x = current_pose.pose.position.x + origin_offset_x_m;
     grid_origin.pose.position.y = current_pose.pose.position.y + origin_offset_y_m;
     grid_origin.pose.position.z = current_pose.pose.position.z;


### PR DESCRIPTION
## Related Issue(required)
<!-- Link related issue -->

## Description(required)
Fix coordinate transformation of drivable area in behavior_path_planner. In some cases, the position of dribable area shifted from the actual lanelets.

<!-- Describe what this PR changes. -->

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)
https://github.com/tier4/AutowareArchitectureProposal.iv/pull/786
<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
