### PR TITLE
feat: replace VehicleStateCommand with GearCommand

### DIFF
--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
@@ -144,7 +144,7 @@ private:
   /**
    * @brief calculate velocity with considering current velocity and gear
    * @param [in] state current state
-   * @param [in] gear current gear (defined in autoware_auto_msgs/VehicleStateCommand)
+   * @param [in] gear current gear (defined in autoware_auto_msgs/GearCommand)
    */
   float64_t calcVelocityWithGear(const Eigen::VectorXd & state, const uint8_t gear) const;
 };

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
@@ -113,7 +113,7 @@ private:
   /**
    * @brief calculate velocity with considering current velocity and gear
    * @param [in] state current state
-   * @param [in] gear current gear (defined in autoware_auto_msgs/VehicleStateCommand)
+   * @param [in] gear current gear (defined in autoware_auto_msgs/GearCommand)
    */
   float64_t calcVelocityWithGear(const Eigen::VectorXd & state, const uint8_t gear) const;
 };

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_interface.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_interface.hpp
@@ -16,7 +16,7 @@
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_INTERFACE_HPP_
 
 #include "eigen3/Eigen/Core"
-#include "autoware_auto_vehicle_msgs/msg/vehicle_state_command.hpp"
+#include "autoware_auto_vehicle_msgs/msg/gear_command.hpp"
 #include "common/types.hpp"
 
 using autoware::common::types::float32_t;
@@ -35,8 +35,8 @@ protected:
   Eigen::VectorXd state_;  //!< @brief vehicle state vector
   Eigen::VectorXd input_;  //!< @brief vehicle input vector
 
-  //!< @brief gear command defined in autoware_auto_msgs/VehicleStateCommand
-  uint8_t gear_ = autoware_auto_vehicle_msgs::msg::VehicleStateCommand::GEAR_DRIVE;
+  //!< @brief gear command defined in autoware_auto_msgs/GearCommand
+  uint8_t gear_ = autoware_auto_vehicle_msgs::msg::GearCommand::DRIVE;
 
 public:
   /**
@@ -77,7 +77,7 @@ public:
 
   /**
    * @brief set gear
-   * @param [in] gear gear command defined in autoware_auto_msgs/VehicleStateCommand
+   * @param [in] gear gear command defined in autoware_auto_msgs/GearCommand
    */
   void setGear(const uint8_t gear);
 

--- a/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -67,14 +67,14 @@ public:
     pub_initialpose_ = create_publisher<PoseWithCovarianceStamped>(
       "/initialpose",
       rclcpp::QoS{1});
-    pub_state_cmd_ = create_publisher<VehicleStateCommand>(
+    pub_state_cmd_ = create_publisher<GearCommand>(
       "/input/vehicle_state_command",
       rclcpp::QoS{1});
   }
 
   rclcpp::Publisher<VehicleControlCommand>::SharedPtr pub_control_command_;
   rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_ackermann_command_;
-  rclcpp::Publisher<VehicleStateCommand>::SharedPtr pub_state_cmd_;
+  rclcpp::Publisher<GearCommand>::SharedPtr pub_state_cmd_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_initialpose_;
   rclcpp::Subscription<VehicleKinematicState>::SharedPtr kinematic_state_sub_;
 
@@ -137,7 +137,7 @@ void sendGear(
   uint8_t gear, rclcpp::Node::SharedPtr sim_node,
   std::shared_ptr<PubSubNode> pub_sub_node)
 {
-  VehicleStateCommand cmd;
+  GearCommand cmd;
   cmd.stamp = sim_node->now();
   cmd.gear = gear;
   for (int i = 0; i < 10; ++i) {
@@ -336,9 +336,9 @@ TEST(test_simple_planning_simulator, test_moving_ackermann)
     const float32_t target_steer = 0.2f;
 
     auto _resetInitialpose = [&]() {resetInitialpose(sim_node, pub_sub_node);};
-    auto _sendFwdGear = [&]() {sendGear(VehicleStateCommand::GEAR_DRIVE, sim_node, pub_sub_node);};
+    auto _sendFwdGear = [&]() {sendGear(GearCommand::DRIVE, sim_node, pub_sub_node);};
     auto _sendBwdGear =
-      [&]() {sendGear(VehicleStateCommand::GEAR_REVERSE, sim_node, pub_sub_node);};
+      [&]() {sendGear(GearCommand::REVERSE, sim_node, pub_sub_node);};
     auto _sendCommand = [&](const auto & _cmd) {
         sendCommand(_cmd, sim_node, pub_sub_node);
       };


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Related Issue(required)

https://github.com/autowarefoundation/autoware.universe/issues/216

## Description(required)

Replaced VehicleStateCommand with GearCommand

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
