### PR TITLE
fix(behavior_path_planner): add transformation to polygon, obj frame to map frame

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -594,9 +594,13 @@ bool calcObjectPolygon(const PredictedObject & object, Polygon2d * object_polygo
         obj_x + r * std::cos(2.0 * M_PI / N * i), obj_y + r * std::sin(2.0 * M_PI / N * i));
     }
   } else if (object.shape.type == Shape::POLYGON) {
+    tf2::Transform tf_map2obj;
+    tf2::fromMsg(object.state.pose_covariance.pose, tf_map2obj);
     const auto obj_points = object.shape.footprint.points;
     for (const auto & obj_point : obj_points) {
-      object_polygon->outer().emplace_back(obj_point.x, obj_point.y);
+      tf2::Vector3 obj(obj_point.x, obj_point.y, obj_point.z);
+      tf2::Vector3 tf_obj = tf_map2obj * obj;
+      object_polygon->outer().emplace_back(tf_obj.x(), tf_obj.y());
     }
   } else {
     RCLCPP_WARN(

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -595,7 +595,7 @@ bool calcObjectPolygon(const PredictedObject & object, Polygon2d * object_polygo
     }
   } else if (object.shape.type == Shape::POLYGON) {
     tf2::Transform tf_map2obj;
-    tf2::fromMsg(object.state.pose_covariance.pose, tf_map2obj);
+    tf2::fromMsg(object.kinematics.initial_pose_with_covariance.pose, tf_map2obj);
     const auto obj_points = object.shape.footprint.points;
     for (const auto & obj_point : obj_points) {
       tf2::Vector3 obj(obj_point.x, obj_point.y, obj_point.z);


### PR DESCRIPTION

## Related Issue(required)

<!-- Link related issue -->

## Description(required)
This PR fixes transformation of objects generated by using polygon footprint.

## Review Procedure(required)

When objects has Shape::Polygon, this node can generate the avoidance path against it.

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
