### PR TITLE
fix: particle distribution of initial pose estimatation

### DIFF
--- a/localization/ndt_scan_matcher/src/util_func.cpp
+++ b/localization/ndt_scan_matcher/src/util_func.cpp
@@ -220,12 +220,12 @@ std::vector<geometry_msgs::msg::Pose> createRandomPoseArray(
   const Eigen::Map<const RowMatrixXd> covariance =
     makeEigenCovariance(base_pose_with_cov.pose.covariance);
 
-  std::normal_distribution<> x_distribution(0.0, covariance(0, 0));
-  std::normal_distribution<> y_distribution(0.0, covariance(1, 1));
-  std::normal_distribution<> z_distribution(0.0, covariance(2, 2));
-  std::normal_distribution<> roll_distribution(0.0, covariance(3, 3));
-  std::normal_distribution<> pitch_distribution(0.0, covariance(4, 4));
-  std::normal_distribution<> yaw_distribution(0.0, covariance(5, 5));
+  std::normal_distribution<> x_distribution(0.0, std::sqrt(covariance(0, 0)));
+  std::normal_distribution<> y_distribution(0.0, std::sqrt(covariance(1, 1)));
+  std::normal_distribution<> z_distribution(0.0, std::sqrt(covariance(2, 2)));
+  std::normal_distribution<> roll_distribution(0.0, std::sqrt(covariance(3, 3)));
+  std::normal_distribution<> pitch_distribution(0.0, std::sqrt(covariance(4, 4)));
+  std::normal_distribution<> yaw_distribution(0.0, std::sqrt(covariance(5, 5)));
 
   const auto base_rpy = getRPY(base_pose_with_cov);
 


### PR DESCRIPTION
## Related Issue(required)
https://github.com/tier4/AutowareArchitectureProposal.iv/issues/473

<!-- Link related issue -->

## Description(required)
`std::normal_distribution` should be used the standard deviation as its argument, 
but it have been used the variance value by mistake.

<!-- Describe what this PR changes. -->

## Review Procedure(required)
The initial position estimation should work.
However, the scattering range of particles is narrower than before.
<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
