### PR TITLE
feat(route_handler): better avoidance drivable areas extension in behavior path planning

### DIFF
--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -94,12 +94,79 @@ public:
     const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * prev_lanelet) const;
   bool isDeadEndLanelet(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getLaneletsFromPoint(const lanelet::ConstPoint3d & point) const;
+
+  /**
+   * @brief Check if same-direction lane is available at the right side of the lanelet
+   * Searches for any lanes regardless of whether it is lane-changeable or not.
+   * Required the linestring to be shared(same line ID) between the lanelets.
+   * @param the lanelet of interest
+   * @return vector of lanelet having same direction if true
+   */
   boost::optional<lanelet::ConstLanelet> getRightLanelet(
     const lanelet::ConstLanelet & lanelet) const;
+
+  /**
+   * @brief Check if same-direction lane is available at the left side of the lanelet
+   * Searches for any lanes regardless of whether it is lane-changeable or not.
+   * Required the linestring to be shared(same line ID) between the lanelets.
+   * @param the lanelet of interest
+   * @return vector of lanelet having same direction if true
+   */
   boost::optional<lanelet::ConstLanelet> getLeftLanelet(
     const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getNextLanelets(const lanelet::ConstLanelet & lanelet) const;
-  lanelet::Lanelets getOppositeLanelets(const lanelet::ConstLanelet & lanelet) const;
+
+  /**
+   * @brief Check if opposite-direction lane is available at the right side of the lanelet
+   * Required the linestring to be shared(same line ID) between the lanelets.
+   * @param the lanelet of interest
+   * @return vector of lanelet with opposite direction if true
+   */
+  lanelet::Lanelets getRightOppositeLanelets(const lanelet::ConstLanelet & lanelet) const;
+
+  /**
+   * @brief Check if opposite-direction lane is available at the left side of the lanelet
+   * Required the linestring to be shared between(same line ID) the lanelets.
+   * @param the lanelet of interest
+   * @return vector of lanelet with opposite direction if true
+   */
+  lanelet::Lanelets getLeftOppositeLanelets(const lanelet::ConstLanelet & lanelet) const;
+
+  /**
+   * @brief Searches the furthest linestring to the right side of the lanelet
+   * Only lanelet with same direction is considered
+   * @param the lanelet of interest
+   * @return right most linestring of the lane with same direction
+   */
+  lanelet::ConstLineString3d getRightMostSameDirectionLinestring(
+    const lanelet::ConstLanelet & lanelet) const noexcept;
+
+  /**
+   * @brief Searches the furthest linestring to the right side of the lanelet
+   * Used to search for road shoulders. Lane direction is ignored
+   * @param the lanelet of interest
+   * @return right most linestring
+   */
+  lanelet::ConstLineString3d getRightMostLinestring(
+    const lanelet::ConstLanelet & lanelet) const noexcept;
+
+  /**
+   * @brief Searches the furthest linestring to the left side of the lanelet
+   * Only lanelet with same direction is considered
+   * @param the lanelet of interest
+   * @return left most linestring of the lane with same direction
+   */
+  lanelet::ConstLineString3d getLeftMostSameDirectionLinestring(
+    const lanelet::ConstLanelet & lanelet) const noexcept;
+
+  /**
+   * @brief Searches the furthest linestring to the left side of the lanelet
+   * Used to search for road shoulders. Lane direction is ignored
+   * @param the lanelet of interest
+   * @return left most linestring
+   */
+  lanelet::ConstLineString3d getLeftMostLinestring(
+    const lanelet::ConstLanelet & lanelet) const noexcept;
   int getNumLaneToPreferredLane(const lanelet::ConstLanelet & lanelet) const;
   bool getClosestLaneletWithinRoute(
     const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -90,7 +90,16 @@ public:
   std::vector<lanelet::ConstLanelet> getLanesAfterGoal(const double vehicle_length) const;
 
   // for lanelet
+  bool getPreviousLaneletWithinRoute(
+    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * prev_lanelet) const;
   bool isDeadEndLanelet(const lanelet::ConstLanelet & lanelet) const;
+  lanelet::ConstLanelets getLaneletsFromPoint(const lanelet::ConstPoint3d & point) const;
+  boost::optional<lanelet::ConstLanelet> getRightLanelet(
+    const lanelet::ConstLanelet & lanelet) const;
+  boost::optional<lanelet::ConstLanelet> getLeftLanelet(
+    const lanelet::ConstLanelet & lanelet) const;
+  lanelet::ConstLanelets getNextLanelets(const lanelet::ConstLanelet & lanelet) const;
+  lanelet::Lanelets getOppositeLanelets(const lanelet::ConstLanelet & lanelet) const;
   int getNumLaneToPreferredLane(const lanelet::ConstLanelet & lanelet) const;
   bool getClosestLaneletWithinRoute(
     const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;
@@ -163,8 +172,6 @@ private:
   bool isBijectiveConnection(
     const lanelet::ConstLanelets & lanelet_section1,
     const lanelet::ConstLanelets & lanelet_section2) const;
-  bool getPreviousLaneletWithinRoute(
-    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * prev_lanelet) const;
   bool getNextLaneletWithinRoute(
     const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * next_lanelet) const;
   bool getPreviousLaneletWithinRouteExceptGoal(

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -845,13 +845,13 @@ boost::optional<lanelet::ConstLanelet> RouteHandler::getRightLanelet(
   const lanelet::ConstLanelet & lanelet) const
 {
   // routable lane
-  const auto right_lane = routing_graph_ptr_->right(lanelet);
+  const auto & right_lane = routing_graph_ptr_->right(lanelet);
   if (right_lane) {
     return right_lane;
   }
 
   // non-routable lane (e.g. lane change infeasible)
-  const auto adjacent_right_lane = routing_graph_ptr_->adjacentRight(lanelet);
+  const auto & adjacent_right_lane = routing_graph_ptr_->adjacentRight(lanelet);
   return adjacent_right_lane;
 }
 
@@ -871,19 +871,81 @@ boost::optional<lanelet::ConstLanelet> RouteHandler::getLeftLanelet(
   const lanelet::ConstLanelet & lanelet) const
 {
   // routable lane
-  const auto left_lane = routing_graph_ptr_->left(lanelet);
+  const auto & left_lane = routing_graph_ptr_->left(lanelet);
   if (left_lane) {
     return left_lane;
   }
 
   // non-routable lane (e.g. lane change infeasible)
-  const auto adjacent_left_lane = routing_graph_ptr_->adjacentLeft(lanelet);
+  const auto & adjacent_left_lane = routing_graph_ptr_->adjacentLeft(lanelet);
   return adjacent_left_lane;
 }
 
-lanelet::Lanelets RouteHandler::getOppositeLanelets(const lanelet::ConstLanelet & lanelet) const
+lanelet::Lanelets RouteHandler::getRightOppositeLanelets(
+  const lanelet::ConstLanelet & lanelet) const
 {
   return lanelet_map_ptr_->laneletLayer.findUsages(lanelet.rightBound().invert());
+}
+
+lanelet::Lanelets RouteHandler::getLeftOppositeLanelets(const lanelet::ConstLanelet & lanelet) const
+{
+  return lanelet_map_ptr_->laneletLayer.findUsages(lanelet.leftBound().invert());
+}
+
+lanelet::ConstLineString3d RouteHandler::getRightMostSameDirectionLinestring(
+  const lanelet::ConstLanelet & lanelet) const noexcept
+{
+  // recursively compute the width of the lanes
+  const auto & same = getRightLanelet(lanelet);
+
+  if (same) {
+    return getRightMostSameDirectionLinestring(same.get());
+  }
+  return lanelet.rightBound();
+}
+
+lanelet::ConstLineString3d RouteHandler::getRightMostLinestring(
+  const lanelet::ConstLanelet & lanelet) const noexcept
+{
+  const auto & same = getRightLanelet(lanelet);
+  const auto & opposite = getRightOppositeLanelets(lanelet);
+  if (!same && opposite.empty()) {
+    return lanelet.rightBound();
+  } else if (same) {
+    return getRightMostLinestring(same.get());
+  } else if (!opposite.empty()) {
+    return getLeftMostLinestring(lanelet::ConstLanelet(opposite.front()));
+  }
+  return {};
+}
+
+lanelet::ConstLineString3d RouteHandler::getLeftMostSameDirectionLinestring(
+  const lanelet::ConstLanelet & lanelet) const noexcept
+{
+  // recursively compute the width of the lanes
+  const auto & same = getLeftLanelet(lanelet);
+
+  if (same) {
+    return getLeftMostSameDirectionLinestring(same.get());
+  }
+  return lanelet.leftBound();
+}
+
+lanelet::ConstLineString3d RouteHandler::getLeftMostLinestring(
+  const lanelet::ConstLanelet & lanelet) const noexcept
+{
+  // recursively compute the width of the lanes
+  const auto & same = getLeftLanelet(lanelet);
+  const auto & opposite = getLeftOppositeLanelets(lanelet);
+
+  if (!same && opposite.empty()) {
+    return lanelet.leftBound();
+  } else if (same) {
+    return getLeftMostLinestring(same.get());
+  } else if (!opposite.empty()) {
+    return getRightMostLinestring(lanelet::ConstLanelet(opposite.front()));
+  }
+  return {};
 }
 
 bool RouteHandler::getLaneChangeTarget(

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -739,6 +739,11 @@ bool RouteHandler::getNextLaneletWithinRoute(
   return false;
 }
 
+lanelet::ConstLanelets RouteHandler::getNextLanelets(const lanelet::ConstLanelet & lanelet) const
+{
+  return routing_graph_ptr_->following(lanelet);
+}
+
 bool RouteHandler::getPreviousLaneletWithinRoute(
   const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * prev_lanelet) const
 {
@@ -753,6 +758,11 @@ bool RouteHandler::getPreviousLaneletWithinRoute(
     }
   }
   return false;
+}
+
+lanelet::ConstLanelets RouteHandler::getLaneletsFromPoint(const lanelet::ConstPoint3d & point) const
+{
+  return lanelet::utils::findUsagesInLanelets(*lanelet_map_ptr_, point);
 }
 
 bool RouteHandler::getRightLaneletWithinRoute(
@@ -831,6 +841,20 @@ bool RouteHandler::isBijectiveConnection(
   return true;
 }
 
+boost::optional<lanelet::ConstLanelet> RouteHandler::getRightLanelet(
+  const lanelet::ConstLanelet & lanelet) const
+{
+  // routable lane
+  const auto right_lane = routing_graph_ptr_->right(lanelet);
+  if (right_lane) {
+    return right_lane;
+  }
+
+  // non-routable lane (e.g. lane change infeasible)
+  const auto adjacent_right_lane = routing_graph_ptr_->adjacentRight(lanelet);
+  return adjacent_right_lane;
+}
+
 bool RouteHandler::getLeftLaneletWithinRoute(
   const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * left_lanelet) const
 {
@@ -841,6 +865,25 @@ bool RouteHandler::getLeftLaneletWithinRoute(
   } else {
     return false;
   }
+}
+
+boost::optional<lanelet::ConstLanelet> RouteHandler::getLeftLanelet(
+  const lanelet::ConstLanelet & lanelet) const
+{
+  // routable lane
+  const auto left_lane = routing_graph_ptr_->left(lanelet);
+  if (left_lane) {
+    return left_lane;
+  }
+
+  // non-routable lane (e.g. lane change infeasible)
+  const auto adjacent_left_lane = routing_graph_ptr_->adjacentLeft(lanelet);
+  return adjacent_left_lane;
+}
+
+lanelet::Lanelets RouteHandler::getOppositeLanelets(const lanelet::ConstLanelet & lanelet) const
+{
+  return lanelet_map_ptr_->laneletLayer.findUsages(lanelet.rightBound().invert());
 }
 
 bool RouteHandler::getLaneChangeTarget(


### PR DESCRIPTION
## Related Issue(required)

#234 

## Description(required)

This PR add adjacent lane check for left side and right side of input lanelet.
by implementing the check function, it is possible to check whether there exist any lane at the left side or right side of ego vehicle lane.

This PR is a port from .iv. It is divided into two parts, 

1. route_handler(no change to behavior)
2. behavior_path_planner (shift_length computation feature)


The feature implement adjacent lanelet search to prevent planner from generating avoidance path that extend towards non-lane areas like below

![image](https://user-images.githubusercontent.com/65527974/150710030-cc72d07c-c90c-486c-b2a7-cd7ad15db0b9.png)


It also improve drivable area extension by appending lanelet that is nearby obstacle.

## Review Procedure(required)



## Related PR(optional)
universe
#285 

this feature is tested in autoware.iv this scenario simulator
.iv
Azu : https://github.com/tier4/autoware.iv/pull/2383
Murooka : https://github.com/tier4/autoware.iv/pull/1839
https://github.com/tier4/AutonomousDrivingScenarios/pull/287


## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
