### PR TITLE
fix(control performance analysis): suppress warnings

### DIFF
--- a/control/control_performance_analysis/CMakeLists.txt
+++ b/control/control_performance_analysis/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 find_package(ament_cmake_auto REQUIRED)

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_node.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_node.hpp
@@ -88,7 +88,6 @@ private:
 
   // Parameters
   Param param_{};  // wheelbase, control period and feedback coefficients.
-  TargetPerformanceMsgVars target_error_vars_{};
 
   // Subscriber Parameters
   Trajectory::ConstSharedPtr current_trajectory_ptr_;  // ConstPtr to local traj.

--- a/control/control_performance_analysis/src/control_performance_analysis_core.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_core.cpp
@@ -162,8 +162,6 @@ bool ControlPerformanceAnalysisCore::isDataReady() const
 
 std::pair<bool, TargetPerformanceMsgVars> ControlPerformanceAnalysisCore::getPerformanceVars()
 {
-  constexpr double EPS = std::numeric_limits<double>::epsilon();
-
   // Check if data is ready.
   if (!isDataReady() || !idx_prev_wp_) {
     return std::make_pair(false, TargetPerformanceMsgVars{});
@@ -224,9 +222,6 @@ std::pair<bool, TargetPerformanceMsgVars> ControlPerformanceAnalysisCore::getPer
 
   target_vars.error_energy = error_vec.dot(error_vec);
   target_vars.value_approximation = error_vec.transpose() * lyap_P_ * error_vec;  // x'Px
-
-  double prev_value_approximation = prev_target_vars_->value_approximation;
-  double && value_decay = target_vars.value_approximation - prev_value_approximation;
 
   target_vars.curvature_estimate = curvature_est;
   target_vars.curvature_estimate_pp = curvature_est_pp;
@@ -400,8 +395,6 @@ double ControlPerformanceAnalysisCore::estimateCurvature()
   double ds_arc_length = std::hypot(
     front_axleWP_pose_prev.position.x - front_axleWP_pose.position.x,
     front_axleWP_pose_prev.position.y - front_axleWP_pose.position.y);
-
-  auto distance_to_traj0 = idx_prev_waypoint * ds_arc_length;
 
   // Define waypoints 10 meters behind the rear axle if exist.
   // If not exist, we will take the first point of the


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

This PR has two changes.
- suppess warnings `-Wunused-variable`, `clang-diagnostic-unused-private-field`.
- add `Werror` 

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
