### PR TITLE
fix(initial pose button panel): suppress warnings 

### DIFF
--- a/localization/initial_pose_button_panel/CMakeLists.txt
+++ b/localization/initial_pose_button_panel/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 find_package(ament_cmake_auto REQUIRED)

--- a/localization/initial_pose_button_panel/src/initial_pose_button_panel.cpp
+++ b/localization/initial_pose_button_panel/src/initial_pose_button_panel.cpp
@@ -105,9 +105,8 @@ void InitialPoseButtonPanel::pushInitializeButton()
     req->pose_with_covariance = pose_cov_msg_;
 
     client_->async_send_request(
-      req,
-      [this](rclcpp::Client<tier4_localization_msgs::srv::PoseWithCovarianceStamped>::SharedFuture
-               result) {
+      req, [this]([[maybe_unused]] rclcpp::Client<
+                  tier4_localization_msgs::srv::PoseWithCovarianceStamped>::SharedFuture result) {
         status_label_->setStyleSheet("QLabel { background-color : lightgreen;}");
         status_label_->setText("OK!!!");
 


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

This PR has two changes.

- suppess warnings `-Wunused-parameter`
- add `Werror`

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
