### PR TITLE
fix(euclidean cluster): suppress warnings 

### DIFF
--- a/perception/euclidean_cluster/CMakeLists.txt
+++ b/perception/euclidean_cluster/CMakeLists.txt
@@ -15,6 +15,7 @@ ament_auto_find_build_dependencies()
 
 include_directories(
   include
+  SYSTEM
   ${PCL_COMMON_INCLUDE_DIRS}
   ${PCL_INCLUDE_DIRS}
 )

--- a/perception/euclidean_cluster/CMakeLists.txt
+++ b/perception/euclidean_cluster/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT CMAKE_CXX_STANDARD)
 	set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 find_package(ament_cmake_auto REQUIRED)


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

This PR changes below
- add Werror
- fix following error
  ```
  In file included from /usr/include/pcl-1.10/pcl/octree/octree_base.h:45,
                   from /usr/include/pcl-1.10/pcl/octree/octree_pointcloud.h:41,
                   from /usr/include/pcl-1.10/pcl/octree/octree_search.h:43,
                   from /usr/include/pcl-1.10/pcl/search/octree.h:42,
                   from /usr/include/pcl-1.10/pcl/search/pcl_search.h:44,
                   from /usr/include/pcl-1.10/pcl/segmentation/extract_clusters.h:44,
                   from /home/hrkota/autoware.proj.s1.universe/src/autoware/universe/perception/euclidean_cluster/lib/euclidean_cluster.cpp:18:
  /usr/include/pcl-1.10/pcl/octree/octree_key.h:155:9: error: ISO C++ prohibits anonymous structs [-Werror=pedantic]
    155 |         };
  ```

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
