### PR TITLE
fix: simple psim with vehicle engage

### DIFF
--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -55,6 +55,9 @@ def launch_setup(context, *args, **kwargs):
             vehicle_info_param,
             vehicle_characteristics_param,
             simulator_model_param,
+            {
+                "initial_engage_state": LaunchConfiguration("initial_engage_state"),
+            },
         ],
         remappings=[
             ('input/ackermann_control_command', '/control/command/control_cmd'),

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -242,7 +242,10 @@ void SimplePlanningSimulator::on_timer()
   // update vehicle dynamics
   {
     const float64_t dt = delta_time_.get_dt(get_clock()->now());
-    vehicle_model_ptr_->update(dt);
+
+    if (current_engage_) {
+      vehicle_model_ptr_->update(dt);
+    }
   }
 
   // set current state

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -76,12 +76,12 @@ namespace simple_planning_simulator
 SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & options)
 : Node("simple_planning_simulator", options),
   tf_buffer_(get_clock()),
-  tf_listener_(tf_buffer_, std::shared_ptr<rclcpp::Node>(this, [](auto) {}), false),
-  current_engage_(false)
+  tf_listener_(tf_buffer_, std::shared_ptr<rclcpp::Node>(this, [](auto) {}), false)
 {
   simulated_frame_id_ = declare_parameter("simulated_frame_id", "base_link");
   origin_frame_id_ = declare_parameter("origin_frame_id", "odom");
   add_measurement_noise_ = declare_parameter("add_measurement_noise", false);
+  current_engage_ = declare_parameter<bool>("initial_engage_state");
 
   using rclcpp::QoS;
   using std::placeholders::_1;


### PR DESCRIPTION
## Related Issue(required)

https://github.com/autowarefoundation/autoware.universe/issues/300

## Description(required)

Reverted features which dropped during .universe porting
- considered /vehicle/engage result for whether simulating or not (simulating only when /vehicle/engage result is true)
- defined default parameter for /vehicle/engage result (current_engage_ variable). Set true by default in launch file.

## Review Procedure(required)

Run simple psim and check the reverted functions. (Some other members and I've already verified that this PR worked well)

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
