### PR TITLE
fix(pointcloud_preprocessor): change point cloud conversion logic

### DIFF
--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_data_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_data_nodelet.hpp
@@ -149,7 +149,7 @@ private:
     PointCloud2::SharedPtr & out);
   void publish();
 
-  void removeRADTFields(
+  void convertToXYZICloud(
     const sensor_msgs::msg::PointCloud2 & input_cloud,
     sensor_msgs::msg::PointCloud2 & output_cloud);
   void setPeriod(const int64_t new_period);

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
@@ -298,26 +298,13 @@ void PointCloudConcatenateDataSynchronizerComponent::publish()
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void PointCloudConcatenateDataSynchronizerComponent::removeRADTFields(
+void PointCloudConcatenateDataSynchronizerComponent::convertToXYZICloud(
   const sensor_msgs::msg::PointCloud2 & input_cloud, sensor_msgs::msg::PointCloud2 & output_cloud)
 {
-  bool has_intensity = std::any_of(
-    input_cloud.fields.begin(), input_cloud.fields.end(),
-    [](auto & field) { return field.name == "intensity"; });
-
-  if (input_cloud.fields.size() == 3 || (input_cloud.fields.size() == 4 && has_intensity)) {
-    output_cloud = input_cloud;
-  } else if (has_intensity) {
-    pcl::PointCloud<PointXYZI> tmp_cloud;
-    pcl::fromROSMsg(input_cloud, tmp_cloud);
-    pcl::toROSMsg(tmp_cloud, output_cloud);
-    output_cloud.header = input_cloud.header;
-  } else {
-    pcl::PointCloud<pcl::PointXYZ> tmp_cloud;
-    pcl::fromROSMsg(input_cloud, tmp_cloud);
-    pcl::toROSMsg(tmp_cloud, output_cloud);
-    output_cloud.header = input_cloud.header;
-  }
+  pcl::PointCloud<PointXYZI> tmp_cloud;
+  pcl::fromROSMsg(input_cloud, tmp_cloud);
+  pcl::toROSMsg(tmp_cloud, output_cloud);
+  output_cloud.header = input_cloud.header;
 }
 
 void PointCloudConcatenateDataSynchronizerComponent::setPeriod(const int64_t new_period)
@@ -342,7 +329,7 @@ void PointCloudConcatenateDataSynchronizerComponent::cloud_callback(
   std::lock_guard<std::mutex> lock(mutex_);
 
   sensor_msgs::msg::PointCloud2 xyz_cloud;
-  removeRADTFields(*input_ptr, xyz_cloud);
+  convertToXYZICloud(*input_ptr, xyz_cloud);
   sensor_msgs::msg::PointCloud2::ConstSharedPtr xyz_input_ptr(
     new sensor_msgs::msg::PointCloud2(xyz_cloud));
 


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)
 This PR changes
 - Fix the method of converting the type of pointcloud before concatenating
 - Change the function name
## Review Procedure(required)
 - Play rosbags and make sure the concatenated pointcloud is output.
<!-- Explain how to review this PR. -->

## Related PR(optional)
https://github.com/tier4/autoware.iv/pull/1912

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
