### PR TITLE
fix(turn_signal_decider): fix getintersectionturnsignal of turn_signal_decider

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -87,9 +87,7 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
       if (
         lane.attributeOr("turn_signal_distance", std::numeric_limits<double>::max()) <
         distance_from_vehicle_front) {
-        if (1 < path_point.lane_ids.size() && lane.id() == path_point.lane_ids.back()) {
           continue;
-        }
       }
       if (lane.attributeOr("turn_direction", std::string("none")) == "left") {
         turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -87,7 +87,7 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
       if (
         lane.attributeOr("turn_signal_distance", std::numeric_limits<double>::max()) <
         distance_from_vehicle_front) {
-          continue;
+        continue;
       }
       if (lane.attributeOr("turn_direction", std::string("none")) == "left") {
         turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

<!-- Describe what this PR changes. -->
Deleted if-condition in getIntersectionTurnSignal of turn_signal_decider 
## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->
https://github.com/tier4/autoware.iv/pull/2430
## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
