### PR TITLE
feat(hdd_monitor): add unit to value side as well as other metrics

### DIFF
--- a/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -268,9 +268,9 @@ void HDDMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
       stat.add(fmt::format("HDD {}: status", hdd_index), usage_dict_.at(level));
       stat.add(fmt::format("HDD {}: filesystem", hdd_index), list[0].c_str());
-      stat.add(fmt::format("HDD {}: size (MB)", hdd_index), list[1].c_str());
-      stat.add(fmt::format("HDD {}: used (MB)", hdd_index), list[2].c_str());
-      stat.add(fmt::format("HDD {}: avail (MB)", hdd_index), list[3].c_str());
+      stat.add(fmt::format("HDD {}: size", hdd_index), (list[1] + " MiB").c_str());
+      stat.add(fmt::format("HDD {}: used", hdd_index), (list[2] + " MiB").c_str());
+      stat.add(fmt::format("HDD {}: avail", hdd_index), (list[3] + " MiB").c_str());
       stat.add(fmt::format("HDD {}: use", hdd_index), list[4].c_str());
       std::string mounted_ = list[5];
       if (list.size() > 6) {


### PR DESCRIPTION
## Related Issue(required)

This PR is same as https://github.com/tier4/AutowareArchitectureProposal.iv/pull/775


## Description(required)

To align other metrics, unit (Mebibyte) would be added to value side instead of key.
It means that other metrics, like CPU Usage, are expressed with 12.34%, which has a unit.
On the other hand, HDD volume metrics are expressed with only value like 245,678, without MiB.

So, I think that adding unit to value is reasonable to align other metrics, like CPU usage, or GPU usage.

## Review Procedure(required)

1. Run Autoware or system_monitor
1. Launch rqt_runtime_monitor
1. Check RuntimeMonitor


![rqt_runtime_monitor__RuntimeMonitor - rqt_001](https://user-images.githubusercontent.com/38586589/151788827-a81cf10b-fb26-4e0f-a87e-7d5c6af4637c.png)

## Related PR(optional)
https://github.com/tier4/AutowareArchitectureProposal.iv/pull/775

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
