### PR TITLE
fix(osqp_interface): memory leak problem

### DIFF
--- a/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
+++ b/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
@@ -79,7 +79,7 @@ public:
   /****************
    * OPTIMIZATION
    ****************/
-  /// \brief Solves the stored convec quadratic program (QP) problem using the OSQP solver.
+  /// \brief Solves the stored convex quadratic program (QP) problem using the OSQP solver.
   //
   /// \return The function returns a tuple containing the solution as two float vectors.
   /// \return The first element of the tuple contains the 'primal' solution.

--- a/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
+++ b/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
@@ -44,7 +44,7 @@ using autoware::common::types::float64_t;
 class OSQP_INTERFACE_PUBLIC OSQPInterface
 {
 private:
-  OSQPWorkspace * m_work = nullptr;
+  std::unique_ptr<OSQPWorkspace, std::function<void(OSQPWorkspace *)>> m_work;
   std::unique_ptr<OSQPSettings> m_settings;
   std::unique_ptr<OSQPData> m_data;
   // store last work info since work is cleaned up at every execution to prevent memory leak.
@@ -58,6 +58,8 @@ private:
 
   // Runs the solver on the stored problem.
   std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t> solve();
+
+  static void OSQPWorkspaceDeleter(OSQPWorkspace * ptr) noexcept;
 
 public:
   /// \brief Constructor without problem formulation
@@ -73,7 +75,6 @@ public:
   OSQPInterface(
     const Eigen::MatrixXd & P, const Eigen::MatrixXd & A, const std::vector<float64_t> & q,
     const std::vector<float64_t> & l, const std::vector<float64_t> & u, const c_float eps_abs);
-  ~OSQPInterface();
 
   /****************
    * OPTIMIZATION


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

There are memory leak problems in the nodes using osqp_interface.
To fix this problem, I changed the type of `m_work` from a raw pointer to std::unique_ptr.

<!-- Describe what this PR changes. -->

## Review Procedure(required)

<!-- Explain how to review this PR. -->
Check memory usage of control_container, for example.

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
