### PR TITLE
fix: fix external velocity in smoother

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -367,7 +367,7 @@ void MotionVelocitySmootherNode::onExternalVelocityLimit(const VelocityLimit::Co
   // constraints
   if (!prev_output_.empty()) {
     // if external velocity limit decreases
-    if ((external_velocity_limit_ - msg->max_velocity) > eps) {
+    if (std::fabs((external_velocity_limit_ - msg->max_velocity)) > eps) {
       if (prev_closest_point_) {
         const double v0 = prev_closest_point_->longitudinal_velocity_mps;
         const double a0 = prev_closest_point_->acceleration_mps2;
@@ -404,9 +404,6 @@ void MotionVelocitySmootherNode::onExternalVelocityLimit(const VelocityLimit::Co
           }
         }
       }
-      // if external velocity limit increases
-    } else if ((msg->max_velocity - external_velocity_limit_) > eps) {
-      max_velocity_with_deceleration_ = msg->max_velocity;
     }
   }
 


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)
Fix bug about external_velocity in motion_velocity_smoother.

Issues: 
When the current speed of the car is high enough, the car will stop suddenly if you send the external velocity twice as shown below.

- Send A [m/s] speed as external velocity ; A < current_velocity
- Next, send B[m/s] speed as external velocity; B < A

<!-- Describe what this PR changes. -->

## Review Procedure(required)

On the planning simulator, and run the Autoware.

When the vehicle speed exceeds about 30kmh, send following command.
```
ros2 topic pub /planning/scenario_planning/max_velocity tier4_planning_msgs/msg/VelocityLimit "{max_velocity: 3.00}" 
```

Immediately after that, re-send following command.
```
ros2 topic pub /planning/scenario_planning/max_velocity tier4_planning_msgs/msg/VelocityLimit "{max_velocity: 2.50}" 
```

Then, you can check that the car will stop suddenly before merging this PR, and the issue is fixed by merging this PR.



<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
