### PR TITLE
feat(ndt_scan_matcher): add nearest voxel transfromation probability

### DIFF
--- a/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
+++ b/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
@@ -24,8 +24,8 @@
     max_iterations: 30
 
     # Converged param type
-    # 0=TRANSFORM_PROBABILITY, 1=NEAREST_VOXEL_TRANSFORMATION_PROBABILITY
-    # NEAREST_VOXEL_TRANSFORMATION_PROBABILITY is only available when NDTImplementType::OMP is selected
+    # 0=TRANSFORM_PROBABILITY, 1=NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD
+    # NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD is only available when NDTImplementType::OMP is selected
     converged_param_type: 1
 
     # If converged_param_type is 0
@@ -34,7 +34,7 @@
 
     # If converged_param_type is 1
     # Threshold for deciding whether to trust the estimation result
-    converged_param_nearest_voxel_transformation_probability: 2.3
+    converged_param_nearest_voxel_transformation_likelihood: 2.3
 
     # The number of particles to estimate initial pose
     initial_estimate_particles_num: 100

--- a/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
+++ b/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
@@ -23,8 +23,18 @@
     # The number of iterations required to calculate alignment
     max_iterations: 30
 
+    # Converged param type
+    # 0=TRANSFORM_PROBABILITY, 1=NEAREST_VOXEL_TRANSFORMATION_PROBABILITY
+    # NEAREST_VOXEL_TRANSFORMATION_PROBABILITY is only available when NDTImplementType::OMP is selected
+    converged_param_type: 1
+
+    # If converged_param_type is 0
     # Threshold for deciding whether to trust the estimation result
     converged_param_transform_probability: 3.0
+
+    # If converged_param_type is 1
+    # Threshold for deciding whether to trust the estimation result
+    converged_param_nearest_voxel_transformation_probability: 2.3
 
     # The number of particles to estimate initial pose
     initial_estimate_particles_num: 100

--- a/launch/tier4_localization_launch/launch/pose_estimator/pose_estimator.launch.xml
+++ b/launch/tier4_localization_launch/launch/pose_estimator/pose_estimator.launch.xml
@@ -3,7 +3,7 @@
 
   <include file="$(find-pkg-share ndt_scan_matcher)/launch/ndt_scan_matcher.launch.xml">
     <arg name="input_map_points_topic" value="/map/pointcloud_map"/>
-    <arg name="input_sensor_points_topic" value="/localization/util/downsample/pointcloud"/>
+    <arg name="input/pointcloud" value="/localization/util/downsample/pointcloud"/>
     <arg name="input_initial_pose_topic" value="/localization/pose_twist_fusion_filter/pose_with_covariance_without_yawbias"/>
 
 

--- a/localization/ndt/include/ndt/base.hpp
+++ b/localization/ndt/include/ndt/base.hpp
@@ -44,7 +44,7 @@ public:
   virtual double getStepSize() const = 0;
   virtual double getTransformationEpsilon() = 0;
   virtual double getTransformationProbability() const = 0;
-  virtual double getNearestVoxelTransformationProbability() const = 0;
+  virtual double getNearestVoxelTransformationLikelihood() const = 0;
   virtual double getFitnessScore() = 0;
   virtual boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const = 0;
   virtual boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const = 0;
@@ -58,7 +58,7 @@ public:
 
   virtual double calculateTransformationProbability(
     const pcl::PointCloud<PointSource> & trans_cloud) const = 0;
-  virtual double calculateNearestVoxelTransformationProbability(
+  virtual double calculateNearestVoxelTransformationLikelihood(
     const pcl::PointCloud<PointSource> & trans_cloud) const = 0;
 };
 

--- a/localization/ndt/include/ndt/base.hpp
+++ b/localization/ndt/include/ndt/base.hpp
@@ -56,8 +56,10 @@ public:
 
   virtual boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const = 0;
 
-  virtual double calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const = 0;
-  virtual double calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const = 0;
+  virtual double calculateTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const = 0;
+  virtual double calculateNearestVoxelTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const = 0;
 };
 
 #include "ndt/impl/base.hpp"

--- a/localization/ndt/include/ndt/base.hpp
+++ b/localization/ndt/include/ndt/base.hpp
@@ -55,6 +55,9 @@ public:
   virtual Eigen::Matrix<double, 6, 6> getHessian() const = 0;
 
   virtual boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const = 0;
+
+  virtual double calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const = 0;
+  virtual double calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const = 0;
 };
 
 #include "ndt/impl/base.hpp"

--- a/localization/ndt/include/ndt/base.hpp
+++ b/localization/ndt/include/ndt/base.hpp
@@ -44,6 +44,7 @@ public:
   virtual double getStepSize() const = 0;
   virtual double getTransformationEpsilon() = 0;
   virtual double getTransformationProbability() const = 0;
+  virtual double getNearestVoxelTransformationProbability() const = 0;
   virtual double getFitnessScore() = 0;
   virtual boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const = 0;
   virtual boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const = 0;

--- a/localization/ndt/include/ndt/impl/omp.hpp
+++ b/localization/ndt/include/ndt/impl/omp.hpp
@@ -203,4 +203,8 @@ NormalDistributionsTransformOMP<PointSource, PointTarget>::getNeighborhoodSearch
   return ndt_ptr_->getNeighborhoodSearchMethod();
 }
 
+<<<<<<< HEAD
 #endif  // NDT__IMPL__OMP_HPP_
+=======
+#endif  // NORMAL_DISTRIBUTIONS_TRANSFORM_OMP_HPP
+>>>>>>> add calculateTransformationProbability funcs

--- a/localization/ndt/include/ndt/impl/omp.hpp
+++ b/localization/ndt/include/ndt/impl/omp.hpp
@@ -110,9 +110,9 @@ double NormalDistributionsTransformOMP<PointSource, PointTarget>::getTransformat
 
 template <class PointSource, class PointTarget>
 double NormalDistributionsTransformOMP<
-  PointSource, PointTarget>::getNearestVoxelTransformationProbability() const
+  PointSource, PointTarget>::getNearestVoxelTransformationLikelihood() const
 {
-  return ndt_ptr_->getNearestVoxelTransformationProbability();
+  return ndt_ptr_->getNearestVoxelTransformationLikelihood();
 }
 
 template <class PointSource, class PointTarget>
@@ -174,10 +174,10 @@ NormalDistributionsTransformOMP<PointSource, PointTarget>::calculateTransformati
 
 template <class PointSource, class PointTarget>
 double NormalDistributionsTransformOMP<PointSource, PointTarget>::
-  calculateNearestVoxelTransformationProbability(
+  calculateNearestVoxelTransformationLikelihood(
     const pcl::PointCloud<PointSource> & trans_cloud) const
 {
-  return ndt_ptr_->calculateNearestVoxelTransformationProbability(trans_cloud);
+  return ndt_ptr_->calculateNearestVoxelTransformationLikelihood(trans_cloud);
 }
 
 template <class PointSource, class PointTarget>

--- a/localization/ndt/include/ndt/impl/omp.hpp
+++ b/localization/ndt/include/ndt/impl/omp.hpp
@@ -164,6 +164,20 @@ NormalDistributionsTransformOMP<PointSource, PointTarget>::getSearchMethodTarget
 }
 
 template <class PointSource, class PointTarget>
+double
+NormalDistributionsTransformOMP<PointSource, PointTarget>::calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+{
+  return ndt_ptr_->calculateTransformationProbability(trans_cloud);
+}
+
+template <class PointSource, class PointTarget>
+double
+NormalDistributionsTransformOMP<PointSource, PointTarget>::calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+{
+  return ndt_ptr_->calculateNearestVoxelTransformationProbability(trans_cloud);
+}
+
+template <class PointSource, class PointTarget>
 void NormalDistributionsTransformOMP<PointSource, PointTarget>::setNumThreads(int n)
 {
   ndt_ptr_->setNumThreads(n);
@@ -187,13 +201,6 @@ pclomp::NeighborSearchMethod
 NormalDistributionsTransformOMP<PointSource, PointTarget>::getNeighborhoodSearchMethod() const
 {
   return ndt_ptr_->getNeighborhoodSearchMethod();
-}
-
-template <class PointSource, class PointTarget>
-double
-NormalDistributionsTransformOMP<PointSource, PointTarget>::calculateScore(const pcl::PointCloud<PointSource> & trans_cloud) const
-{
-  return ndt_ptr_->calculateScore(trans_cloud);
 }
 
 #endif  // NDT__IMPL__OMP_HPP_

--- a/localization/ndt/include/ndt/impl/omp.hpp
+++ b/localization/ndt/include/ndt/impl/omp.hpp
@@ -203,8 +203,4 @@ NormalDistributionsTransformOMP<PointSource, PointTarget>::getNeighborhoodSearch
   return ndt_ptr_->getNeighborhoodSearchMethod();
 }
 
-<<<<<<< HEAD
 #endif  // NDT__IMPL__OMP_HPP_
-=======
-#endif  // NORMAL_DISTRIBUTIONS_TRANSFORM_OMP_HPP
->>>>>>> add calculateTransformationProbability funcs

--- a/localization/ndt/include/ndt/impl/omp.hpp
+++ b/localization/ndt/include/ndt/impl/omp.hpp
@@ -109,7 +109,8 @@ double NormalDistributionsTransformOMP<PointSource, PointTarget>::getTransformat
 }
 
 template <class PointSource, class PointTarget>
-double NormalDistributionsTransformOMP<PointSource, PointTarget>::getNearestVoxelTransformationProbability() const
+double NormalDistributionsTransformOMP<
+  PointSource, PointTarget>::getNearestVoxelTransformationProbability() const
 {
   return ndt_ptr_->getNearestVoxelTransformationProbability();
 }
@@ -165,14 +166,16 @@ NormalDistributionsTransformOMP<PointSource, PointTarget>::getSearchMethodTarget
 
 template <class PointSource, class PointTarget>
 double
-NormalDistributionsTransformOMP<PointSource, PointTarget>::calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+NormalDistributionsTransformOMP<PointSource, PointTarget>::calculateTransformationProbability(
+  const pcl::PointCloud<PointSource> & trans_cloud) const
 {
   return ndt_ptr_->calculateTransformationProbability(trans_cloud);
 }
 
 template <class PointSource, class PointTarget>
-double
-NormalDistributionsTransformOMP<PointSource, PointTarget>::calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+double NormalDistributionsTransformOMP<PointSource, PointTarget>::
+  calculateNearestVoxelTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const
 {
   return ndt_ptr_->calculateNearestVoxelTransformationProbability(trans_cloud);
 }

--- a/localization/ndt/include/ndt/impl/omp.hpp
+++ b/localization/ndt/include/ndt/impl/omp.hpp
@@ -109,6 +109,12 @@ double NormalDistributionsTransformOMP<PointSource, PointTarget>::getTransformat
 }
 
 template <class PointSource, class PointTarget>
+double NormalDistributionsTransformOMP<PointSource, PointTarget>::getNearestVoxelTransformationProbability() const
+{
+  return ndt_ptr_->getNearestVoxelTransformationProbability();
+}
+
+template <class PointSource, class PointTarget>
 double NormalDistributionsTransformOMP<PointSource, PointTarget>::getFitnessScore()
 {
   return ndt_ptr_->getFitnessScore();
@@ -181,6 +187,13 @@ pclomp::NeighborSearchMethod
 NormalDistributionsTransformOMP<PointSource, PointTarget>::getNeighborhoodSearchMethod() const
 {
   return ndt_ptr_->getNeighborhoodSearchMethod();
+}
+
+template <class PointSource, class PointTarget>
+double
+NormalDistributionsTransformOMP<PointSource, PointTarget>::calculateScore(const pcl::PointCloud<PointSource> & trans_cloud) const
+{
+  return ndt_ptr_->calculateScore(trans_cloud);
 }
 
 #endif  // NDT__IMPL__OMP_HPP_

--- a/localization/ndt/include/ndt/impl/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_generic.hpp
@@ -112,9 +112,9 @@ double NormalDistributionsTransformPCLGeneric<
 
 template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLGeneric<
-  PointSource, PointTarget>::getNearestVoxelTransformationProbability() const
+  PointSource, PointTarget>::getNearestVoxelTransformationLikelihood() const
 {
-  // return ndt_ptr_->getTransformationProbability();
+  // return ndt_ptr_->getNearestVoxelTransformationLikelihood();
   return 0.0;
 }
 
@@ -178,10 +178,10 @@ double NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::
 
 template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::
-  calculateNearestVoxelTransformationProbability(
+  calculateNearestVoxelTransformationLikelihood(
     const pcl::PointCloud<PointSource> & trans_cloud) const
 {
-  // return ndt_ptr_->calculateNearestVoxelTransformationProbability(trans_cloud);
+  // return ndt_ptr_->calculateNearestVoxelTransformationLikelihood(trans_cloud);
   return 0.0;
 }
 

--- a/localization/ndt/include/ndt/impl/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_generic.hpp
@@ -172,6 +172,7 @@ template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::
   calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
 {
+  (void)trans_cloud;
   // return ndt_ptr_->calculateTransformationProbability(trans_cloud);
   return 0.0;
 }
@@ -181,6 +182,7 @@ double NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::
   calculateNearestVoxelTransformationLikelihood(
     const pcl::PointCloud<PointSource> & trans_cloud) const
 {
+  (void)trans_cloud;
   // return ndt_ptr_->calculateNearestVoxelTransformationLikelihood(trans_cloud);
   return 0.0;
 }

--- a/localization/ndt/include/ndt/impl/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_generic.hpp
@@ -111,6 +111,14 @@ double NormalDistributionsTransformPCLGeneric<
 }
 
 template <class PointSource, class PointTarget>
+double NormalDistributionsTransformPCLGeneric<
+  PointSource, PointTarget>::getNearestVoxelTransformationProbability() const
+{
+  // return ndt_ptr_->getTransformationProbability();
+  return 0.0;
+}
+
+template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::getFitnessScore()
 {
   return ndt_ptr_->getFitnessScore();

--- a/localization/ndt/include/ndt/impl/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_generic.hpp
@@ -168,4 +168,20 @@ NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::getSearchMetho
   return ndt_ptr_->getSearchMethodTarget();
 }
 
+template <class PointSource, class PointTarget>
+double
+NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+{
+  // return ndt_ptr_->calculateTransformationProbability(trans_cloud);
+  return 0.0;
+}
+
+template <class PointSource, class PointTarget>
+double
+NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+{
+  // return ndt_ptr_->calculateNearestVoxelTransformationProbability(trans_cloud);
+  return 0.0;
+}
+
 #endif  // NDT__IMPL__PCL_GENERIC_HPP_

--- a/localization/ndt/include/ndt/impl/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_generic.hpp
@@ -169,16 +169,17 @@ NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::getSearchMetho
 }
 
 template <class PointSource, class PointTarget>
-double
-NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+double NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::
+  calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
 {
   // return ndt_ptr_->calculateTransformationProbability(trans_cloud);
   return 0.0;
 }
 
 template <class PointSource, class PointTarget>
-double
-NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+double NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::
+  calculateNearestVoxelTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const
 {
   // return ndt_ptr_->calculateNearestVoxelTransformationProbability(trans_cloud);
   return 0.0;

--- a/localization/ndt/include/ndt/impl/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_modified.hpp
@@ -108,6 +108,7 @@ template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLModified<
   PointSource, PointTarget>::getTransformationProbability() const
 {
+  // return ndt_ptr_->getTransformationProbability();
   return ndt_ptr_->getTransformationProbability();
 }
 
@@ -166,6 +167,22 @@ boost::shared_ptr<pcl::search::KdTree<PointTarget>>
 NormalDistributionsTransformPCLModified<PointSource, PointTarget>::getSearchMethodTarget() const
 {
   return ndt_ptr_->getSearchMethodTarget();
+}
+
+template <class PointSource, class PointTarget>
+double
+NormalDistributionsTransformPCLModified<PointSource, PointTarget>::calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+{
+  // return ndt_ptr_->calculateTransformationProbability(trans_cloud);
+  return 0.0;
+}
+
+template <class PointSource, class PointTarget>
+double
+NormalDistributionsTransformPCLModified<PointSource, PointTarget>::calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+{
+  // return ndt_ptr_->calculateNearestVoxelTransformationProbability(trans_cloud);
+  return 0.0;
 }
 
 #endif  // NDT__IMPL__PCL_MODIFIED_HPP_

--- a/localization/ndt/include/ndt/impl/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_modified.hpp
@@ -172,6 +172,7 @@ template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLModified<PointSource, PointTarget>::
   calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
 {
+  (void)trans_cloud;
   // return ndt_ptr_->calculateTransformationProbability(trans_cloud);
   return 0.0;
 }
@@ -181,6 +182,7 @@ double NormalDistributionsTransformPCLModified<PointSource, PointTarget>::
   calculateNearestVoxelTransformationLikelihood(
     const pcl::PointCloud<PointSource> & trans_cloud) const
 {
+  (void)trans_cloud;
   // return ndt_ptr_->calculateNearestVoxelTransformationLikelihood(trans_cloud);
   return 0.0;
 }

--- a/localization/ndt/include/ndt/impl/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_modified.hpp
@@ -170,16 +170,17 @@ NormalDistributionsTransformPCLModified<PointSource, PointTarget>::getSearchMeth
 }
 
 template <class PointSource, class PointTarget>
-double
-NormalDistributionsTransformPCLModified<PointSource, PointTarget>::calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+double NormalDistributionsTransformPCLModified<PointSource, PointTarget>::
+  calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
 {
   // return ndt_ptr_->calculateTransformationProbability(trans_cloud);
   return 0.0;
 }
 
 template <class PointSource, class PointTarget>
-double
-NormalDistributionsTransformPCLModified<PointSource, PointTarget>::calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const
+double NormalDistributionsTransformPCLModified<PointSource, PointTarget>::
+  calculateNearestVoxelTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const
 {
   // return ndt_ptr_->calculateNearestVoxelTransformationProbability(trans_cloud);
   return 0.0;

--- a/localization/ndt/include/ndt/impl/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_modified.hpp
@@ -112,6 +112,14 @@ double NormalDistributionsTransformPCLModified<
 }
 
 template <class PointSource, class PointTarget>
+double NormalDistributionsTransformPCLModified<
+  PointSource, PointTarget>::getNearestVoxelTransformationProbability() const
+{
+  // return ndt_ptr_->getTransformationProbability();
+  return 0.0;
+}
+
+template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLModified<PointSource, PointTarget>::getFitnessScore()
 {
   return ndt_ptr_->getFitnessScore();

--- a/localization/ndt/include/ndt/impl/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_modified.hpp
@@ -108,15 +108,14 @@ template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLModified<
   PointSource, PointTarget>::getTransformationProbability() const
 {
-  // return ndt_ptr_->getTransformationProbability();
   return ndt_ptr_->getTransformationProbability();
 }
 
 template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLModified<
-  PointSource, PointTarget>::getNearestVoxelTransformationProbability() const
+  PointSource, PointTarget>::getNearestVoxelTransformationLikelihood() const
 {
-  // return ndt_ptr_->getTransformationProbability();
+  // return ndt_ptr_->getTransformationLikelihood();
   return 0.0;
 }
 
@@ -179,10 +178,10 @@ double NormalDistributionsTransformPCLModified<PointSource, PointTarget>::
 
 template <class PointSource, class PointTarget>
 double NormalDistributionsTransformPCLModified<PointSource, PointTarget>::
-  calculateNearestVoxelTransformationProbability(
+  calculateNearestVoxelTransformationLikelihood(
     const pcl::PointCloud<PointSource> & trans_cloud) const
 {
-  // return ndt_ptr_->calculateNearestVoxelTransformationProbability(trans_cloud);
+  // return ndt_ptr_->calculateNearestVoxelTransformationLikelihood(trans_cloud);
   return 0.0;
 }
 

--- a/localization/ndt/include/ndt/omp.hpp
+++ b/localization/ndt/include/ndt/omp.hpp
@@ -59,13 +59,15 @@ public:
 
   boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
 
+  double calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
+  double calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
+
   // only OMP Impl
   void setNumThreads(int n);
   void setNeighborhoodSearchMethod(pclomp::NeighborSearchMethod method);
 
   int getNumThreads() const;
   pclomp::NeighborSearchMethod getNeighborhoodSearchMethod() const;
-  double calculateScore(const pcl::PointCloud<PointSource> & trans_cloud) const;
 private:
   boost::shared_ptr<pclomp::NormalDistributionsTransform<PointSource, PointTarget>> ndt_ptr_;
 };

--- a/localization/ndt/include/ndt/omp.hpp
+++ b/localization/ndt/include/ndt/omp.hpp
@@ -47,6 +47,7 @@ public:
   double getStepSize() const override;
   double getTransformationEpsilon() override;
   double getTransformationProbability() const override;
+  double getNearestVoxelTransformationProbability() const override;
   double getFitnessScore() override;
   boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
   boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
@@ -64,7 +65,7 @@ public:
 
   int getNumThreads() const;
   pclomp::NeighborSearchMethod getNeighborhoodSearchMethod() const;
-
+  double calculateScore(const pcl::PointCloud<PointSource> & trans_cloud) const;
 private:
   boost::shared_ptr<pclomp::NormalDistributionsTransform<PointSource, PointTarget>> ndt_ptr_;
 };

--- a/localization/ndt/include/ndt/omp.hpp
+++ b/localization/ndt/include/ndt/omp.hpp
@@ -47,7 +47,7 @@ public:
   double getStepSize() const override;
   double getTransformationEpsilon() override;
   double getTransformationProbability() const override;
-  double getNearestVoxelTransformationProbability() const override;
+  double getNearestVoxelTransformationLikelihood() const override;
   double getFitnessScore() override;
   boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
   boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
@@ -61,7 +61,7 @@ public:
 
   double calculateTransformationProbability(
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
-  double calculateNearestVoxelTransformationProbability(
+  double calculateNearestVoxelTransformationLikelihood(
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
 
   // only OMP Impl

--- a/localization/ndt/include/ndt/omp.hpp
+++ b/localization/ndt/include/ndt/omp.hpp
@@ -59,8 +59,10 @@ public:
 
   boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
 
-  double calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
-  double calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
+  double calculateTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const override;
+  double calculateNearestVoxelTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const override;
 
   // only OMP Impl
   void setNumThreads(int n);
@@ -68,6 +70,7 @@ public:
 
   int getNumThreads() const;
   pclomp::NeighborSearchMethod getNeighborhoodSearchMethod() const;
+
 private:
   boost::shared_ptr<pclomp::NormalDistributionsTransform<PointSource, PointTarget>> ndt_ptr_;
 };

--- a/localization/ndt/include/ndt/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/pcl_generic.hpp
@@ -59,8 +59,10 @@ public:
 
   boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
 
-  double calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
-  double calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
+  double calculateTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const override;
+  double calculateNearestVoxelTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const override;
 
 private:
   boost::shared_ptr<pcl::NormalDistributionsTransform<PointSource, PointTarget>> ndt_ptr_;

--- a/localization/ndt/include/ndt/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/pcl_generic.hpp
@@ -47,7 +47,7 @@ public:
   double getStepSize() const override;
   double getTransformationEpsilon() override;
   double getTransformationProbability() const override;
-  double getNearestVoxelTransformationProbability() const override;
+  double getNearestVoxelTransformationLikelihood() const override;
   double getFitnessScore() override;
   boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
   boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
@@ -61,7 +61,7 @@ public:
 
   double calculateTransformationProbability(
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
-  double calculateNearestVoxelTransformationProbability(
+  double calculateNearestVoxelTransformationLikelihood(
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
 
 private:

--- a/localization/ndt/include/ndt/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/pcl_generic.hpp
@@ -47,6 +47,7 @@ public:
   double getStepSize() const override;
   double getTransformationEpsilon() override;
   double getTransformationProbability() const override;
+  double getNearestVoxelTransformationProbability() const override;
   double getFitnessScore() override;
   boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
   boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;

--- a/localization/ndt/include/ndt/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/pcl_generic.hpp
@@ -59,6 +59,9 @@ public:
 
   boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
 
+  double calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
+  double calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
+
 private:
   boost::shared_ptr<pcl::NormalDistributionsTransform<PointSource, PointTarget>> ndt_ptr_;
 };

--- a/localization/ndt/include/ndt/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/pcl_modified.hpp
@@ -60,6 +60,9 @@ public:
 
   boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
 
+  double calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
+  double calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
+
 private:
   boost::shared_ptr<pcl::NormalDistributionsTransformModified<PointSource, PointTarget>> ndt_ptr_;
 };

--- a/localization/ndt/include/ndt/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/pcl_modified.hpp
@@ -48,6 +48,7 @@ public:
   double getStepSize() const override;
   double getTransformationEpsilon() override;
   double getTransformationProbability() const override;
+  double getNearestVoxelTransformationProbability() const override;
   double getFitnessScore() override;
   boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
   boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;

--- a/localization/ndt/include/ndt/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/pcl_modified.hpp
@@ -48,7 +48,7 @@ public:
   double getStepSize() const override;
   double getTransformationEpsilon() override;
   double getTransformationProbability() const override;
-  double getNearestVoxelTransformationProbability() const override;
+  double getNearestVoxelTransformationLikelihood() const override;
   double getFitnessScore() override;
   boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
   boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
@@ -62,7 +62,7 @@ public:
 
   double calculateTransformationProbability(
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
-  double calculateNearestVoxelTransformationProbability(
+  double calculateNearestVoxelTransformationLikelihood(
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
 
 private:

--- a/localization/ndt/include/ndt/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/pcl_modified.hpp
@@ -60,8 +60,10 @@ public:
 
   boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
 
-  double calculateTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
-  double calculateNearestVoxelTransformationProbability(const pcl::PointCloud<PointSource> & trans_cloud) const override;
+  double calculateTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const override;
+  double calculateNearestVoxelTransformationProbability(
+    const pcl::PointCloud<PointSource> & trans_cloud) const override;
 
 private:
   boost::shared_ptr<pcl::NormalDistributionsTransformModified<PointSource, PointTarget>> ndt_ptr_;

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -25,8 +25,8 @@
     max_iterations: 30
 
     # Converged param type
-    # 0=TRANSFORM_PROBABILITY, 1=NEAREST_VOXEL_TRANSFORMATION_PROBABILITY
-    # NEAREST_VOXEL_TRANSFORMATION_PROBABILITY is only available when NDTImplementType::OMP is selected
+    # 0=TRANSFORM_PROBABILITY, 1=NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD
+    # NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD is only available when NDTImplementType::OMP is selected
     converged_param_type: 1
 
     # If converged_param_type is 0
@@ -35,7 +35,7 @@
 
     # If converged_param_type is 1
     # Threshold for deciding whether to trust the estimation result
-    converged_param_nearest_voxel_transformation_probability: 2.3
+    converged_param_nearest_voxel_transformation_likelihood: 2.3
 
     # The number of particles to estimate initial pose
     initial_estimate_particles_num: 100

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -29,9 +29,11 @@
     # NEAREST_VOXEL_TRANSFORMATION_PROBABILITY is only available when NDTImplementType::OMP is selected
     converged_param_type: 1
 
+    # If converged_param_type is 0
     # Threshold for deciding whether to trust the estimation result
     converged_param_transform_probability: 3.0
 
+    # If converged_param_type is 1
     # Threshold for deciding whether to trust the estimation result
     converged_param_nearest_voxel_transformation_probability: 2.3
 

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -24,8 +24,16 @@
     # The number of iterations required to calculate alignment
     max_iterations: 30
 
+    # Converged param type
+    # 0=TRANSFORM_PROBABILITY, 1=NEAREST_VOXEL_TRANSFORMATION_PROBABILITY
+    # NEAREST_VOXEL_TRANSFORMATION_PROBABILITY is only available when NDTImplementType::OMP is selected
+    converged_param_type: 1
+
     # Threshold for deciding whether to trust the estimation result
     converged_param_transform_probability: 3.0
+
+    # Threshold for deciding whether to trust the estimation result
+    converged_param_nearest_voxel_transformation_probability: 2.3
 
     # The number of particles to estimate initial pose
     initial_estimate_particles_num: 100

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -54,7 +54,7 @@
 enum class NDTImplementType { PCL_GENERIC = 0, PCL_MODIFIED = 1, OMP = 2 };
 enum class ConvergedParamType {
   TRANSFORM_PROBABILITY = 0,
-  NEAREST_VOXEL_TRANSFORMATION_PROBABILITY = 1
+  NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD = 1
 };
 
 template <typename PointSource, typename PointTarget>
@@ -139,7 +139,7 @@ private:
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr exe_time_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr transform_probability_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
-    nearest_voxel_transformation_probability_pub_;
+    nearest_voxel_transformation_likelihood_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Int32Stamped>::SharedPtr iteration_num_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
     initial_to_result_distance_pub_;
@@ -168,7 +168,7 @@ private:
 
   ConvergedParamType converged_param_type_;
   double converged_param_transform_probability_;
-  double converged_param_nearest_voxel_transformation_probability_;
+  double converged_param_nearest_voxel_transformation_likelihood_;
 
   int initial_estimate_particles_num_;
   double initial_pose_timeout_sec_;

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -52,7 +52,7 @@
 #include <vector>
 
 enum class NDTImplementType { PCL_GENERIC = 0, PCL_MODIFIED = 1, OMP = 2 };
-enum class ConveredParamType {
+enum class ConvergedParamType {
   TRANSFORM_PROBABILITY = 0,
   NEAREST_VOXEL_TRANSFORMATION_PROBABILITY = 1
 };
@@ -166,7 +166,7 @@ private:
   std::string ndt_base_frame_;
   std::string map_frame_;
 
-  ConveredParamType converged_param_type_;
+  ConvergedParamType converged_param_type_;
   double converged_param_transform_probability_;
   double converged_param_nearest_voxel_transformation_probability_;
 

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -52,7 +52,10 @@
 #include <vector>
 
 enum class NDTImplementType { PCL_GENERIC = 0, PCL_MODIFIED = 1, OMP = 2 };
-enum class ConveredParamType { TRANSFORM_PROBABILITY = 0, NEAREST_VOXEL_TRANSFORMATION_PROBABILITY = 1 };
+enum class ConveredParamType {
+  TRANSFORM_PROBABILITY = 0,
+  NEAREST_VOXEL_TRANSFORMATION_PROBABILITY = 1
+};
 
 template <typename PointSource, typename PointTarget>
 std::shared_ptr<NormalDistributionsTransformBase<PointSource, PointTarget>> getNDT(
@@ -135,7 +138,8 @@ private:
     initial_pose_with_covariance_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr exe_time_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr transform_probability_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr nearest_voxel_transformation_probability_pub_;
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
+    nearest_voxel_transformation_probability_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Int32Stamped>::SharedPtr iteration_num_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
     initial_to_result_distance_pub_;

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -28,7 +28,6 @@
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <nav_msgs/msg/occupancy_grid.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
 #include <tier4_debug_msgs/msg/int32_stamped.hpp>
@@ -147,8 +146,6 @@ private:
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr ndt_marker_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     ndt_monte_carlo_initial_pose_marker_pub_;
-  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr
-    tp_grid_map_pub_;
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
 
   rclcpp::Service<tier4_localization_msgs::srv::PoseWithCovarianceStamped>::SharedPtr service_;

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -28,6 +28,7 @@
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
 #include <tier4_debug_msgs/msg/int32_stamped.hpp>
@@ -134,6 +135,7 @@ private:
     initial_pose_with_covariance_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr exe_time_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr transform_probability_pub_;
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr transform_probability_nearest_voxel_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Int32Stamped>::SharedPtr iteration_num_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
     initial_to_result_distance_pub_;
@@ -144,6 +146,8 @@ private:
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr ndt_marker_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     ndt_monte_carlo_initial_pose_marker_pub_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr
+    tp_grid_map_pub_;
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
 
   rclcpp::Service<tier4_localization_msgs::srv::PoseWithCovarianceStamped>::SharedPtr service_;

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -53,6 +53,7 @@
 #include <vector>
 
 enum class NDTImplementType { PCL_GENERIC = 0, PCL_MODIFIED = 1, OMP = 2 };
+enum class ConveredParamType { TRANSFORM_PROBABILITY = 0, NEAREST_VOXEL_TRANSFORMATION_PROBABILITY = 1 };
 
 template <typename PointSource, typename PointTarget>
 std::shared_ptr<NormalDistributionsTransformBase<PointSource, PointTarget>> getNDT(
@@ -135,7 +136,7 @@ private:
     initial_pose_with_covariance_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr exe_time_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr transform_probability_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr transform_probability_nearest_voxel_pub_;
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr transformation_probability_nearest_voxel_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Int32Stamped>::SharedPtr iteration_num_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
     initial_to_result_distance_pub_;
@@ -163,7 +164,11 @@ private:
   std::string base_frame_;
   std::string ndt_base_frame_;
   std::string map_frame_;
+
+  ConveredParamType converged_param_type_;
   double converged_param_transform_probability_;
+  double converged_param_nearest_voxel_transformation_probability_;
+
   int initial_estimate_particles_num_;
   double initial_pose_timeout_sec_;
   double initial_pose_distance_tolerance_m_;

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -136,7 +136,7 @@ private:
     initial_pose_with_covariance_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr exe_time_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr transform_probability_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr transformation_probability_nearest_voxel_pub_;
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr nearest_voxel_transformation_probability_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Int32Stamped>::SharedPtr iteration_num_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
     initial_to_result_distance_pub_;

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -564,8 +564,7 @@ void NDTScanMatcher::callbackSensorPoints(
         get_logger(), "Transform Probability is below the threshold. Score: %lf, Threshold: %lf",
         transform_probability, converged_param_transform_probability_);
     }
-  } else if (
-    converged_param_type_ == ConvergedParamType::NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD) {
+  } else if (converged_param_type_ == ConvergedParamType::NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD) {
     is_ok_converged_param = nearest_voxel_transformation_likelihood >
                             converged_param_nearest_voxel_transformation_likelihood_;
     if (!is_ok_converged_param) {

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -629,17 +629,13 @@ void NDTScanMatcher::callbackSensorPoints(
     key_value_stdmap_["is_local_optimal_solution_oscillation"] = "0";
   }
 
-  if (ndt_implement_type_ == NDTImplementType::OMP) {
-    using T = NormalDistributionsTransformOMP<PointSource, PointTarget>;
-
-    std::shared_ptr<T> ndt_omp_ptr = std::dynamic_pointer_cast<T>(ndt_ptr_);
-
+  {
     nav_msgs::msg::OccupancyGrid grid_map_msg;
     grid_map_msg.header.stamp = sensor_ros_time;
     grid_map_msg.header.frame_id = map_frame_;
     grid_map_msg.info.resolution = 1.0;
-    grid_map_msg.info.width = 19;
-    grid_map_msg.info.height = 19 ;
+    grid_map_msg.info.width = 21;
+    grid_map_msg.info.height = 21 ;
     auto rpy = getRPY(result_pose_msg);
     grid_map_msg.info.origin = result_pose_msg;
     double orig_x = -static_cast<int>(grid_map_msg.info.width)/2*grid_map_msg.info.resolution -grid_map_msg.info.resolution/2.0;
@@ -661,7 +657,7 @@ void NDTScanMatcher::callbackSensorPoints(
         auto offset_sensor_points_mapTF_ptr = std::make_shared<pcl::PointCloud<PointSource>>();
         pcl::transformPointCloud(*sensor_points_mapTF_ptr, *offset_sensor_points_mapTF_ptr, offset_pose_matrix);
 
-        double tp = ndt_omp_ptr->calculateScore(*offset_sensor_points_mapTF_ptr);
+        double tp = ndt_ptr_->calculateNearestVoxelTransformationProbability(*offset_sensor_points_mapTF_ptr);
         std::cerr << tp << " ";
         tp -= 2.0;
         tp *= 200.0;

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -247,9 +247,6 @@ NDTScanMatcher::NDTScanMatcher()
   ndt_monte_carlo_initial_pose_marker_pub_ =
     this->create_publisher<visualization_msgs::msg::MarkerArray>(
       "monte_carlo_initial_pose_marker", 10);
-  tp_grid_map_pub_ =
-    this->create_publisher<nav_msgs::msg::OccupancyGrid>(
-      "tp_grid_map", 10);
 
   diagnostics_pub_ =
     this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -665,51 +665,6 @@ void NDTScanMatcher::callbackSensorPoints(
     key_value_stdmap_["is_local_optimal_solution_oscillation"] = "0";
   }
 
-  // debug code
-  // {
-  //   nav_msgs::msg::OccupancyGrid grid_map_msg;
-  //   grid_map_msg.header.stamp = sensor_ros_time;
-  //   grid_map_msg.header.frame_id = map_frame_;
-  //   grid_map_msg.info.resolution = 1.0;
-  //   grid_map_msg.info.width = 21;
-  //   grid_map_msg.info.height = 21 ;
-  //   auto rpy = getRPY(result_pose_msg);
-  //   grid_map_msg.info.origin = result_pose_msg;
-  //   double orig_x = -static_cast<int>(grid_map_msg.info.width)/2*grid_map_msg.info.resolution -grid_map_msg.info.resolution/2.0;
-  //   double orig_y = -static_cast<int>(grid_map_msg.info.height)/2*grid_map_msg.info.resolution-grid_map_msg.info.resolution/2.0;
-  //   grid_map_msg.info.origin.position.x += orig_x * std::cos(rpy.z) - orig_y * std::sin(rpy.z);
-  //   grid_map_msg.info.origin.position.y += orig_x * std::sin(rpy.z) + orig_y * std::cos(rpy.z);
-
-  //   for (size_t i = 0; i < grid_map_msg.info.height; ++i) {
-  //     for (size_t j = 0; j < grid_map_msg.info.width; ++j) {
-  //       Eigen::Matrix4f offset_pose_matrix;
-  //       offset_pose_matrix.setIdentity();
-
-  //       double offset_x = (static_cast<int>(j)-static_cast<int>(grid_map_msg.info.width)/2)*grid_map_msg.info.resolution;
-  //       double offset_y = (static_cast<int>(i)-static_cast<int>(grid_map_msg.info.height)/2)*grid_map_msg.info.resolution;
-
-  //       offset_pose_matrix(0,3) = offset_x * std::cos(rpy.z) - offset_y * std::sin(rpy.z);
-  //       offset_pose_matrix(1,3) = offset_x * std::sin(rpy.z) + offset_y * std::cos(rpy.z);
-
-  //       auto offset_sensor_points_mapTF_ptr = std::make_shared<pcl::PointCloud<PointSource>>();
-  //       pcl::transformPointCloud(*sensor_points_mapTF_ptr, *offset_sensor_points_mapTF_ptr, offset_pose_matrix);
-
-  //       double tp = ndt_ptr_->calculateNearestVoxelTransformationProbability(*offset_sensor_points_mapTF_ptr);
-  //       std::cerr << tp << " ";
-  //       tp -= 2.0;
-  //       tp *= 200.0;
-  //       // tp -= 2.0;
-  //       // tp *= 100.0;
-  //       tp = std::max(tp, 1.0);
-  //       tp = std::min(tp, 99.0);
-  //       grid_map_msg.data.push_back(static_cast<int>(tp));
-  //     }
-  //     std::cerr << std::endl;
-  //   }
-  // std::cerr << std::endl;
-  // tp_grid_map_pub_->publish(grid_map_msg);
-  // }
-
 }
 
 geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::alignUsingMonteCarlo(

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -102,7 +102,7 @@ NDTScanMatcher::NDTScanMatcher()
   base_frame_("base_link"),
   ndt_base_frame_("ndt_base_link"),
   map_frame_("map"),
-  converged_param_type_(ConveredParamType::TRANSFORM_PROBABILITY)
+  converged_param_type_(ConveredParamType::TRANSFORM_PROBABILITY),
   converged_param_transform_probability_(4.5),
   converged_param_nearest_voxel_transformation_probability_(2.3),
   initial_estimate_particles_num_(100),

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -167,18 +167,23 @@ NDTScanMatcher::NDTScanMatcher()
     get_logger(), "trans_epsilon: %lf, step_size: %lf, resolution: %lf, max_iterations: %d",
     trans_epsilon, step_size, resolution, max_iterations);
 
-
   int converged_param_type_tmp = this->declare_parameter("converged_param_type", 0);
   converged_param_type_ = static_cast<ConveredParamType>(converged_param_type_tmp);
-  if (ndt_implement_type_ != NDTImplementType::OMP && converged_param_type_ == ConveredParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
-    RCLCPP_ERROR(get_logger(), "ConveredParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY is only available when NDTImplementType::OMP is selected.");
+  if (
+    ndt_implement_type_ != NDTImplementType::OMP &&
+    converged_param_type_ == ConveredParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
+    RCLCPP_ERROR(
+      get_logger(),
+      "ConveredParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY is only available when "
+      "NDTImplementType::OMP is selected.");
     return;
   }
 
   converged_param_transform_probability_ = this->declare_parameter(
     "converged_param_transform_probability", converged_param_transform_probability_);
   converged_param_nearest_voxel_transformation_probability_ = this->declare_parameter(
-    "converged_param_nearest_voxel_transformation_probability", converged_param_nearest_voxel_transformation_probability_);
+    "converged_param_nearest_voxel_transformation_probability",
+    converged_param_nearest_voxel_transformation_probability_);
 
   initial_estimate_particles_num_ =
     this->declare_parameter("initial_estimate_particles_num", initial_estimate_particles_num_);
@@ -232,7 +237,8 @@ NDTScanMatcher::NDTScanMatcher()
   transform_probability_pub_ =
     this->create_publisher<tier4_debug_msgs::msg::Float32Stamped>("transform_probability", 10);
   nearest_voxel_transformation_probability_pub_ =
-    this->create_publisher<tier4_debug_msgs::msg::Float32Stamped>("nearest_voxel_transformation_probability", 10);
+    this->create_publisher<tier4_debug_msgs::msg::Float32Stamped>(
+      "nearest_voxel_transformation_probability", 10);
   iteration_num_pub_ =
     this->create_publisher<tier4_debug_msgs::msg::Int32Stamped>("iteration_num", 10);
   initial_to_result_distance_pub_ =
@@ -518,7 +524,8 @@ void NDTScanMatcher::callbackSensorPoints(
     1000.0;
 
   const float transform_probability = ndt_ptr_->getTransformationProbability();
-  const float nearest_voxel_transformation_probability = ndt_ptr_->getNearestVoxelTransformationProbability();
+  const float nearest_voxel_transformation_probability =
+    ndt_ptr_->getNearestVoxelTransformationProbability();
 
   const int iteration_num = ndt_ptr_->getFinalNumIteration();
 
@@ -536,7 +543,11 @@ void NDTScanMatcher::callbackSensorPoints(
   *****************************************************************************/
   bool is_ok_iteration_num = iteration_num < ndt_ptr_->getMaximumIterations() + 2;
   if (!is_ok_iteration_num) {
-      RCLCPP_WARN(get_logger(), "The number of iterations has reached its upper limit. The number of iterations: %d, Limit: %d", iteration_num, ndt_ptr_->getMaximumIterations() + 2);
+    RCLCPP_WARN(
+      get_logger(),
+      "The number of iterations has reached its upper limit. The number of iterations: %d, Limit: "
+      "%d",
+      iteration_num, ndt_ptr_->getMaximumIterations() + 2);
   }
 
   bool is_local_optimal_solution_oscillation = false;
@@ -545,23 +556,28 @@ void NDTScanMatcher::callbackSensorPoints(
       result_pose_matrix_array, oscillation_threshold_, inversion_vector_threshold_);
   }
 
-
   bool is_ok_converged_param = false;
   if (converged_param_type_ == ConveredParamType::TRANSFORM_PROBABILITY) {
     is_ok_converged_param = transform_probability > converged_param_transform_probability_;
     if (!is_ok_converged_param) {
-      RCLCPP_WARN(get_logger(), "Transform Probability is below the threshold. Score: %lf, Threshold: %lf", transform_probability, converged_param_transform_probability_);
+      RCLCPP_WARN(
+        get_logger(), "Transform Probability is below the threshold. Score: %lf, Threshold: %lf",
+        transform_probability, converged_param_transform_probability_);
     }
-  }
-  else if (converged_param_type_ == ConveredParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
-    is_ok_converged_param = nearest_voxel_transformation_probability > converged_param_nearest_voxel_transformation_probability_;
+  } else if (converged_param_type_ == ConveredParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
+    is_ok_converged_param = nearest_voxel_transformation_probability >
+                            converged_param_nearest_voxel_transformation_probability_;
     if (!is_ok_converged_param) {
-      RCLCPP_WARN(get_logger(), "Nearest Voxel Transform Probability is below the threshold. Score: %lf, Threshold: %lf", nearest_voxel_transformation_probability, converged_param_nearest_voxel_transformation_probability_);
+      RCLCPP_WARN(
+        get_logger(),
+        "Nearest Voxel Transform Probability is below the threshold. Score: %lf, Threshold: %lf",
+        nearest_voxel_transformation_probability,
+        converged_param_nearest_voxel_transformation_probability_);
     }
-  }
-  else {
+  } else {
     is_ok_converged_param = false;
-    RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1, "Unknown converged param type.");
+    RCLCPP_ERROR_STREAM_THROTTLE(
+      this->get_logger(), *this->get_clock(), 1, "Unknown converged param type.");
   }
 
   bool is_converged = false;
@@ -633,7 +649,8 @@ void NDTScanMatcher::callbackSensorPoints(
   exe_time_pub_->publish(makeFloat32Stamped(sensor_ros_time, exe_time));
 
   transform_probability_pub_->publish(makeFloat32Stamped(sensor_ros_time, transform_probability));
-  nearest_voxel_transformation_probability_pub_->publish(makeFloat32Stamped(sensor_ros_time, nearest_voxel_transformation_probability));
+  nearest_voxel_transformation_probability_pub_->publish(
+    makeFloat32Stamped(sensor_ros_time, nearest_voxel_transformation_probability));
 
   iteration_num_pub_->publish(makeInt32Stamped(sensor_ros_time, iteration_num));
 
@@ -653,7 +670,8 @@ void NDTScanMatcher::callbackSensorPoints(
     makeFloat32Stamped(sensor_ros_time, initial_to_result_distance_new));
 
   key_value_stdmap_["transform_probability"] = std::to_string(transform_probability);
-  key_value_stdmap_["nearest_voxel_transformation_probability"] = std::to_string(nearest_voxel_transformation_probability);
+  key_value_stdmap_["nearest_voxel_transformation_probability"] =
+    std::to_string(nearest_voxel_transformation_probability);
   key_value_stdmap_["iteration_num"] = std::to_string(iteration_num);
   key_value_stdmap_["skipping_publish_num"] = std::to_string(skipping_publish_num);
   if (is_local_optimal_solution_oscillation) {
@@ -661,7 +679,6 @@ void NDTScanMatcher::callbackSensorPoints(
   } else {
     key_value_stdmap_["is_local_optimal_solution_oscillation"] = "0";
   }
-
 }
 
 geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::alignUsingMonteCarlo(

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -102,7 +102,7 @@ NDTScanMatcher::NDTScanMatcher()
   base_frame_("base_link"),
   ndt_base_frame_("ndt_base_link"),
   map_frame_("map"),
-  converged_param_type_(ConveredParamType::TRANSFORM_PROBABILITY),
+  converged_param_type_(ConvergedParamType::TRANSFORM_PROBABILITY),
   converged_param_transform_probability_(4.5),
   converged_param_nearest_voxel_transformation_probability_(2.3),
   initial_estimate_particles_num_(100),
@@ -168,13 +168,13 @@ NDTScanMatcher::NDTScanMatcher()
     trans_epsilon, step_size, resolution, max_iterations);
 
   int converged_param_type_tmp = this->declare_parameter("converged_param_type", 0);
-  converged_param_type_ = static_cast<ConveredParamType>(converged_param_type_tmp);
+  converged_param_type_ = static_cast<ConvergedParamType>(converged_param_type_tmp);
   if (
     ndt_implement_type_ != NDTImplementType::OMP &&
-    converged_param_type_ == ConveredParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
+    converged_param_type_ == ConvergedParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
     RCLCPP_ERROR(
       get_logger(),
-      "ConveredParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY is only available when "
+      "ConvergedParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY is only available when "
       "NDTImplementType::OMP is selected.");
     return;
   }
@@ -557,14 +557,14 @@ void NDTScanMatcher::callbackSensorPoints(
   }
 
   bool is_ok_converged_param = false;
-  if (converged_param_type_ == ConveredParamType::TRANSFORM_PROBABILITY) {
+  if (converged_param_type_ == ConvergedParamType::TRANSFORM_PROBABILITY) {
     is_ok_converged_param = transform_probability > converged_param_transform_probability_;
     if (!is_ok_converged_param) {
       RCLCPP_WARN(
         get_logger(), "Transform Probability is below the threshold. Score: %lf, Threshold: %lf",
         transform_probability, converged_param_transform_probability_);
     }
-  } else if (converged_param_type_ == ConveredParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
+  } else if (converged_param_type_ == ConvergedParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
     is_ok_converged_param = nearest_voxel_transformation_probability >
                             converged_param_nearest_voxel_transformation_probability_;
     if (!is_ok_converged_param) {

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -564,7 +564,8 @@ void NDTScanMatcher::callbackSensorPoints(
         get_logger(), "Transform Probability is below the threshold. Score: %lf, Threshold: %lf",
         transform_probability, converged_param_transform_probability_);
     }
-  } else if (converged_param_type_ == ConvergedParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
+  } else if (
+    converged_param_type_ == ConvergedParamType::NEAREST_VOXEL_TRANSFORMATION_PROBABILITY) {
     is_ok_converged_param = nearest_voxel_transformation_probability >
                             converged_param_nearest_voxel_transformation_probability_;
     if (!is_ok_converged_param) {


### PR DESCRIPTION
**Please merge ~https://github.com/tier4/ndt_omp/pull/10~ (merged) and https://github.com/tier4/ndt_omp/pull/13 before this PR. Otherwise, the build and test will not pass.**


## Related Issue(required)

<!-- Link related issue -->

## Description(required)
Add new score to determine convergence "nearest voxel transformation probability".
（If converged_param_type is set to 0, we can use "transfomation probability" as before.）

### Background
In ndt_scan_matcher, the success or failure of convergence is determined by the Transformation Probability (TP).
However, there are some factors that cause the TP to fluctuate regardless of the convergence result, as shown in the following example, which often leads to misjudgment.
- The TP depends on the completeness of the map point cloud. The TP will be low when the map point cloud is inadequate, for example, buildings that should exist are not in the map point cloud.
- The TP depends on the distance of the sensor point cloud. When the distance is increased, the influence on the completeness of the map point cloud becomes stronger, and the TP tends to become low.

Therefore, I propose a new score that has less of this dependency.

### Evaluation results
Graphing each score when offset from the correct position using rosbag in urban areas.

#### Transformation Probability
![Screenshot from 2022-03-09 16-49-08](https://user-images.githubusercontent.com/13819566/157396290-267cc62c-893a-4594-8411-c9e3bb0321f0.png)

#### Nearest Voxel Transformation Probability
![Screenshot from 2022-03-09 16-53-44](https://user-images.githubusercontent.com/13819566/157397099-0fbe9061-1304-4f18-8cfd-c00ccf6282bc.png)

#### Consideration
The TP is highly variable, so it is not appropriate to use it to determine convergence.
The NVTP has a more stable value than TP, so we should use the NVTP instead of the TP.

## Review Procedure(required)
Build with https://github.com/tier4/autoware_launch/pull/198, ~https://github.com/tier4/ndt_omp/pull/10~ and https://github.com/tier4/ndt_omp/pull/13.

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
