### PR TITLE
fix(simple psim): gear bug to update state in simple psim

### DIFF
--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
@@ -142,11 +142,14 @@ private:
   Eigen::VectorXd calcModel(const Eigen::VectorXd & state, const Eigen::VectorXd & input) override;
 
   /**
-   * @brief calculate velocity with considering current velocity and gear
+   * @brief update state considering current gear
    * @param [in] state current state
+   * @param [in] prev_state previous state
    * @param [in] gear current gear (defined in autoware_auto_msgs/GearCommand)
+   * @param [in] dt delta time to update state
    */
-  float64_t calcVelocityWithGear(const Eigen::VectorXd & state, const uint8_t gear) const;
+  void updateStateWithGear(Eigen::VectorXd & state, const Eigen::VectorXd & prev_state, const uint8_t gear, const double dt);
+
 };
 
 #endif  // SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_GEARED_HPP_

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
@@ -149,7 +149,6 @@ private:
    * @param [in] dt delta time to update state
    */
   void updateStateWithGear(Eigen::VectorXd & state, const Eigen::VectorXd & prev_state, const uint8_t gear, const double dt);
-
 };
 
 #endif  // SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_GEARED_HPP_

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
@@ -111,11 +111,13 @@ private:
   Eigen::VectorXd calcModel(const Eigen::VectorXd & state, const Eigen::VectorXd & input) override;
 
   /**
-   * @brief calculate velocity with considering current velocity and gear
+   * @brief update state considering current gear
    * @param [in] state current state
+   * @param [in] prev_state previous state
    * @param [in] gear current gear (defined in autoware_auto_msgs/GearCommand)
+   * @param [in] dt delta time to update state
    */
-  float64_t calcVelocityWithGear(const Eigen::VectorXd & state, const uint8_t gear) const;
+  void updateStateWithGear(Eigen::VectorXd & state, const Eigen::VectorXd & prev_state, const uint8_t gear, const double dt);
 };
 
 #endif  // SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_ACC_GEARED_HPP_

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
@@ -58,17 +58,15 @@ void SimModelDelaySteerAccGeared::update(const float64_t & dt)
   delayed_input(IDX_U::STEER_DES) = steer_input_queue_.front();
   steer_input_queue_.pop_front();
 
-  const auto prev_vx = state_(IDX::VX);
-
+  const auto prev_state = state_;
   updateRungeKutta(dt, delayed_input);
 
   // take velocity limit explicitly
   state_(IDX::VX) = std::max(-vx_lim_, std::min(state_(IDX::VX), vx_lim_));
 
-  state_(IDX::VX) = calcVelocityWithGear(state_, gear_);
-
-  // calc acc directly after gear consideration
-  state_(IDX::ACCX) = (state_(IDX::VX) - prev_vx) / std::max(dt, 1.0e-5);
+  // consider gear
+  // update position and velocity first, and then acceleration is calculated naturally
+  updateStateWithGear(state_, prev_state, gear_, dt);
 }
 
 void SimModelDelaySteerAccGeared::initializeInputQueue(const float64_t & dt)
@@ -107,9 +105,8 @@ Eigen::VectorXd SimModelDelaySteerAccGeared::calcModel(
   return d_state;
 }
 
-
-float64_t SimModelDelaySteerAccGeared::calcVelocityWithGear(
-  const Eigen::VectorXd & state, const uint8_t gear) const
+void SimModelDelaySteerAccGeared::updateStateWithGear(
+  Eigen::VectorXd & state, const Eigen::VectorXd & prev_state, const uint8_t gear, const double dt)
 {
   using autoware_auto_vehicle_msgs::msg::GearCommand;
   if (
@@ -123,17 +120,29 @@ float64_t SimModelDelaySteerAccGeared::calcVelocityWithGear(
     gear == GearCommand::DRIVE_18 || gear == GearCommand::LOW || gear == GearCommand::LOW_2)
   {
     if (state(IDX::VX) < 0.0) {
-      return 0.0;
+      state(IDX::VX) = 0.0;
+      state(IDX::X) = prev_state(IDX::X);
+      state(IDX::Y) = prev_state(IDX::Y);
+      state(IDX::YAW) = prev_state(IDX::YAW);
     }
   } else if (gear == GearCommand::REVERSE || gear == GearCommand::REVERSE_2) {
     if (state(IDX::VX) > 0.0) {
-      return 0.0;
+      state(IDX::VX) = 0.0;
+      state(IDX::X) = prev_state(IDX::X);
+      state(IDX::Y) = prev_state(IDX::Y);
+      state(IDX::YAW) = prev_state(IDX::YAW);
     }
   } else if (gear == GearCommand::PARK) {
-    return 0.0;
+    state(IDX::VX) = 0.0;
+    state(IDX::X) = prev_state(IDX::X);
+    state(IDX::Y) = prev_state(IDX::Y);
+    state(IDX::YAW) = prev_state(IDX::YAW);
   } else {
-    return 0.0;
+    state(IDX::VX) = 0.0;
+    state(IDX::X) = prev_state(IDX::X);
+    state(IDX::Y) = prev_state(IDX::Y);
+    state(IDX::YAW) = prev_state(IDX::YAW);
   }
 
-  return state(IDX::VX);
+  state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
 }


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Related Issue(required)

https://github.com/autowarefoundation/autoware.universe/issues/371

## Description(required)

Apply gear to current pose update (previously, only velocity and acceleration was updated)

## Review Procedure(required)

run simple psim

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
