### PR TITLE
fix(pointcloud_preprocessor): empty pointcloud bug

### DIFF
--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
@@ -354,7 +354,10 @@ void PointCloudConcatenateDataSynchronizerComponent::cloud_callback(
   const sensor_msgs::msg::PointCloud2::SharedPtr & input_ptr, const std::string & topic_name)
 {
   std::lock_guard<std::mutex> lock(mutex_);
-
+  if (input_ptr->data.empty()) {
+    RCLCPP_WARN(get_logger(), "input pointcloud is empty.");
+    return;
+  }
   sensor_msgs::msg::PointCloud2::SharedPtr xyzi_input_ptr(new sensor_msgs::msg::PointCloud2());
   convertToXYZICloud(input_ptr, xyzi_input_ptr);
 

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
@@ -87,12 +87,14 @@ void DualReturnOutlierFilterComponent::filter(
   PointCloud2 & output)
 {
   boost::mutex::scoped_lock lock(mutex_);
+  if (input->data.empty()) {
+    output.header = input->header;
+    RCLCPP_WARN(get_logger(), "input pointcloud is empty.");
+    return;
+  }
   pcl::PointCloud<return_type_cloud::PointXYZIRADT>::Ptr pcl_input(
     new pcl::PointCloud<return_type_cloud::PointXYZIRADT>);
   pcl::fromROSMsg(*input, *pcl_input);
-  if (pcl_input->points.empty()) {
-    return;
-  }
 
   uint32_t vertical_bins = vertical_bins_;
   uint32_t horizontal_bins = 36;


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

 - Fixed a bug that caused some modules to crash when the input point cloud was empty.

## Review Procedure(required)
- Play rosbags and check pointclouds and rosout
<!-- Explain how to review this PR. -->

## Related PR(optional)
<!-- Link related PR -->
https://github.com/autowarefoundation/autoware.universe/pull/253

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
