### PR TITLE
feat(osqp_interface): add interface to give csc matrix directly to enable warm start for computation time improvement.

### DIFF
--- a/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
+++ b/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
@@ -57,7 +57,7 @@ private:
   int64_t m_exitflag;
 
   // Runs the solver on the stored problem.
-  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t> solve();
+  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int64_t> solve();
 
   static void OSQPWorkspaceDeleter(OSQPWorkspace * ptr) noexcept;
 
@@ -74,6 +74,9 @@ public:
   /// \param eps_abs: Absolute convergence tolerance.
   OSQPInterface(
     const Eigen::MatrixXd & P, const Eigen::MatrixXd & A, const std::vector<float64_t> & q,
+    const std::vector<float64_t> & l, const std::vector<float64_t> & u, const c_float eps_abs);
+  OSQPInterface(
+    const CSC_Matrix & P, const CSC_Matrix & A, const std::vector<float64_t> & q,
     const std::vector<float64_t> & l, const std::vector<float64_t> & u, const c_float eps_abs);
 
   /****************
@@ -97,7 +100,7 @@ public:
   /// \details        std::vector<float> param = std::get<0>(result);
   /// \details        float64_t x_0 = param[0];
   /// \details        float64_t x_1 = param[1];
-  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t> optimize();
+  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int64_t> optimize();
 
   /// \brief Solves convex quadratic programs (QPs) using the OSQP solver.
   /// \return The function returns a tuple containing the solution as two float vectors.
@@ -115,7 +118,7 @@ public:
   /// \details        std::vector<float> param = std::get<0>(result);
   /// \details        float64_t x_0 = param[0];
   /// \details        float64_t x_1 = param[1];
-  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t> optimize(
+  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int64_t> optimize(
     const Eigen::MatrixXd & P, const Eigen::MatrixXd & A, const std::vector<float64_t> & q,
     const std::vector<float64_t> & l, const std::vector<float64_t> & u);
 
@@ -128,6 +131,9 @@ public:
   int64_t initializeProblem(
     const Eigen::MatrixXd & P, const Eigen::MatrixXd & A, const std::vector<float64_t> & q,
     const std::vector<float64_t> & l, const std::vector<float64_t> & u);
+  int64_t initializeProblem(
+    CSC_Matrix P, CSC_Matrix A, const std::vector<float64_t> & q,
+    const std::vector<float64_t> & l, const std::vector<float64_t> & u);
 
   // Updates problem parameters while keeping solution in memory.
   //
@@ -138,7 +144,9 @@ public:
   //   l_new: (m) vector defining the lower bound problem constraint.
   //   u_new: (m) vector defining the upper bound problem constraint.
   void updateP(const Eigen::MatrixXd & P_new);
+  void updateCscP(const CSC_Matrix & P_csc);
   void updateA(const Eigen::MatrixXd & A_new);
+  void updateCscA(const CSC_Matrix & A_csc);
   void updateQ(const std::vector<double> & q_new);
   void updateL(const std::vector<double> & l_new);
   void updateU(const std::vector<double> & u_new);

--- a/common/osqp_interface/src/osqp_interface.cpp
+++ b/common/osqp_interface/src/osqp_interface.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rclcpp/rclcpp.hpp"
 #include "osqp_interface/osqp_interface.hpp"
 
 #include "osqp/osqp.h"
@@ -60,6 +61,15 @@ OSQPInterface::OSQPInterface(
   initializeProblem(P, A, q, l, u);
 }
 
+OSQPInterface::OSQPInterface(
+  const CSC_Matrix & P, const CSC_Matrix & A, const std::vector<float64_t> & q,
+  const std::vector<float64_t> & l, const std::vector<float64_t> & u,
+  const c_float eps_abs)
+: OSQPInterface(eps_abs)
+{
+  initializeProblem(P, A, q, l, u);
+}
+
 void OSQPInterface::OSQPWorkspaceDeleter(OSQPWorkspace * ptr) noexcept
 {
   if (ptr != nullptr) {
@@ -82,6 +92,11 @@ void OSQPInterface::updateP(const Eigen::MatrixXd & P_new)
   osqp_update_P(m_work.get(), P_csc.m_vals.data(), OSQP_NULL, static_cast<c_int>(P_csc.m_vals.size()));
 }
 
+void OSQPInterface::updateCscP(const CSC_Matrix & P_csc)
+{
+  osqp_update_P(m_work.get(), P_csc.m_vals.data(), OSQP_NULL, static_cast<c_int>(P_csc.m_vals.size()));
+}
+
 void OSQPInterface::updateA(const Eigen::MatrixXd & A_new)
 {
   /*
@@ -94,6 +109,11 @@ void OSQPInterface::updateA(const Eigen::MatrixXd & A_new)
   CSC_Matrix A_csc = calCSCMatrix(A_new);
   osqp_update_A(m_work.get(), A_csc.m_vals.data(), OSQP_NULL, static_cast<c_int>(A_csc.m_vals.size()));
   return;
+}
+
+void OSQPInterface::updateCscA(const CSC_Matrix & A_csc)
+{
+  osqp_update_A(m_work.get(), A_csc.m_vals.data(), OSQP_NULL, static_cast<c_int>(A_csc.m_vals.size()));
 }
 
 void OSQPInterface::updateQ(const std::vector<double> & q_new)
@@ -184,11 +204,43 @@ int64_t OSQPInterface::initializeProblem(
   const Eigen::MatrixXd & P, const Eigen::MatrixXd & A, const std::vector<float64_t> & q,
   const std::vector<float64_t> & l, const std::vector<float64_t> & u)
 {
-  /*******************
-   * SET UP MATRICES
-   *******************/
+  // check if arguments are valid
+  std::stringstream ss;
+  if (P.rows() != P.cols()) {
+    ss << "P.rows() and P.cols() are not the same. P.rows() = " << P.rows()
+       << ", P.cols() = " << P.cols();
+    throw std::invalid_argument(ss.str());
+  }
+  if (P.rows() != static_cast<int>(q.size())) {
+    ss << "P.rows() and q.size() are not the same. P.rows() = " << P.rows()
+       << ", q.size() = " << q.size();
+    throw std::invalid_argument(ss.str());
+  }
+  if (P.rows() != A.cols()) {
+    ss << "P.rows() and A.cols() are not the same. P.rows() = " << P.rows()
+       << ", A.cols() = " << A.cols();
+    throw std::invalid_argument(ss.str());
+  }
+  if (A.rows() != static_cast<int>(l.size())) {
+    ss << "A.rows() and l.size() are not the same. A.rows() = " << A.rows()
+       << ", l.size() = " << l.size();
+    throw std::invalid_argument(ss.str());
+  }
+  if (A.rows() != static_cast<int>(u.size())) {
+    ss << "A.rows() and u.size() are not the same. A.rows() = " << A.rows()
+       << ", u.size() = " << u.size();
+    throw std::invalid_argument(ss.str());
+  }
+
   CSC_Matrix P_csc = calCSCMatrixTrapezoidal(P);
   CSC_Matrix A_csc = calCSCMatrix(A);
+  return initializeProblem(P_csc, A_csc, q, l, u);
+}
+
+int64_t OSQPInterface::initializeProblem(
+  CSC_Matrix P_csc, CSC_Matrix A_csc, const std::vector<float64_t> & q,
+  const std::vector<float64_t> & l, const std::vector<float64_t> & u)
+{
   // Dynamic float arrays
   std::vector<float64_t> q_tmp(q.begin(), q.end());
   std::vector<float64_t> l_tmp(l.begin(), l.end());
@@ -200,15 +252,12 @@ int64_t OSQPInterface::initializeProblem(
   /**********************
    * OBJECTIVE FUNCTION
    **********************/
-  // Number of constraints
-  c_int constr_m = A.rows();
-  // Number of parameters
-  m_param_n = P.rows();
+  m_param_n = static_cast<int>(q.size());
+  m_data->m = static_cast<int>(l.size());
 
   /*****************
    * POPULATE DATA
    *****************/
-  m_data->m = constr_m;
   m_data->n = m_param_n;
   m_data->P = csc_matrix(
     m_data->n, m_data->n, static_cast<c_int>(P_csc.m_vals.size()), P_csc.m_vals.data(),
@@ -229,7 +278,7 @@ int64_t OSQPInterface::initializeProblem(
   return m_exitflag;
 }
 
-std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t> OSQPInterface::solve()
+std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int64_t> OSQPInterface::solve()
 {
   // Solve Problem
   osqp_solve(m_work.get());
@@ -241,28 +290,29 @@ std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t> OSQ
   float64_t * sol_y = m_work->solution->y;
   std::vector<float64_t> sol_primal(sol_x, sol_x + m_param_n);
   std::vector<float64_t> sol_lagrange_multiplier(sol_y, sol_y + m_param_n);
-  // Solver polish status
+
   int64_t status_polish = m_work->info->status_polish;
-  // Solver solution status
   int64_t status_solution = m_work->info->status_val;
+  int64_t status_iteration = m_work->info->iter;
+
   // Result tuple
-  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t> result =
-    std::make_tuple(sol_primal, sol_lagrange_multiplier, status_polish, status_solution);
+  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int64_t> result =
+    std::make_tuple(sol_primal, sol_lagrange_multiplier, status_polish, status_solution, status_iteration);
 
   m_latest_work_info = *(m_work->info);
 
   return result;
 }
 
-std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t>
+std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int64_t>
 OSQPInterface::optimize()
 {
   // Run the solver on the stored problem representation.
-  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t> result = solve();
+  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int64_t> result = solve();
   return result;
 }
 
-std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t>
+std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int64_t>
 OSQPInterface::optimize(
   const Eigen::MatrixXd & P, const Eigen::MatrixXd & A, const std::vector<float64_t> & q,
   const std::vector<float64_t> & l, const std::vector<float64_t> & u)
@@ -271,7 +321,7 @@ OSQPInterface::optimize(
   initializeProblem(P, A, q, l, u);
 
   // Run the solver on the stored problem representation.
-  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t> result = solve();
+  std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int64_t> result = solve();
 
   m_work.reset();
   m_work_initialized = false;

--- a/common/osqp_interface/src/osqp_interface.cpp
+++ b/common/osqp_interface/src/osqp_interface.cpp
@@ -288,7 +288,7 @@ std::tuple<std::vector<float64_t>, std::vector<float64_t>, int64_t, int64_t, int
   float64_t * sol_x = m_work->solution->x;
   float64_t * sol_y = m_work->solution->y;
   std::vector<float64_t> sol_primal(sol_x, sol_x + m_param_n);
-  std::vector<float64_t> sol_lagrange_multiplier(sol_y, sol_y + m_param_n);
+  std::vector<float64_t> sol_lagrange_multiplier(sol_y, sol_y + m_data->m);
 
   int64_t status_polish = m_work->info->status_polish;
   int64_t status_solution = m_work->info->status_val;

--- a/common/osqp_interface/src/osqp_interface.cpp
+++ b/common/osqp_interface/src/osqp_interface.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rclcpp/rclcpp.hpp"
 #include "osqp_interface/osqp_interface.hpp"
 
 #include "osqp/osqp.h"

--- a/common/osqp_interface/test/test_osqp_interface.cpp
+++ b/common/osqp_interface/test/test_osqp_interface.cpp
@@ -64,93 +64,68 @@ TEST(TestOsqpInterface, BasicQp) {
       EXPECT_NEAR(dual_val[3], 0.0, ep);
     };
 
+  const Eigen::MatrixXd P = (Eigen::MatrixXd(2, 2) << 4, 1, 1, 2).finished();
+  const Eigen::MatrixXd A = (Eigen::MatrixXd(4, 2) << 1, 1, 1, 0, 0, 1, 0, 1).finished();
+  const std::vector<float64_t> q = {1.0, 1.0};
+  const std::vector<float64_t> l = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
+  const std::vector<float64_t> u = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
+
   {
     // Define problem during optimization
     autoware::common::osqp::OSQPInterface osqp;
-    Eigen::MatrixXd P(2, 2);
-    P << 4, 1, 1, 2;
-    Eigen::MatrixXd A(4, 2);
-    A << 1, 1, 1, 0, 0, 1, 0, 1;
-    std::vector<float64_t> q = {1.0, 1.0};
-    std::vector<float64_t> l = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
-    std::vector<float64_t> u = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
     std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result = osqp.optimize(
       P, A, q, l, u);
     check_result(result);
   }
+
   {
     // Define problem during initialization
-    Eigen::MatrixXd P(2, 2);
-    P << 4, 1, 1, 2;
-    Eigen::MatrixXd A(4, 2);
-    A << 1, 1, 1, 0, 0, 1, 0, 1;
-    std::vector<float64_t> q = {1.0, 1.0};
-    std::vector<float64_t> l = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
-    std::vector<float64_t> u = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
     autoware::common::osqp::OSQPInterface osqp(P, A, q, l, u, 1e-6);
     std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result = osqp.optimize();
     check_result(result);
   }
+
   {
     std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result;
     // Dummy initial problem
-    Eigen::MatrixXd P = Eigen::MatrixXd::Zero(2, 2);
-    Eigen::MatrixXd A = Eigen::MatrixXd::Zero(4, 2);
-    std::vector<float64_t> q(2, 0.0);
-    std::vector<float64_t> l(4, 0.0);
-    std::vector<float64_t> u(4, 0.0);
-    autoware::common::osqp::OSQPInterface osqp(P, A, q, l, u, 1e-6);
+    Eigen::MatrixXd P_ini = Eigen::MatrixXd::Zero(2, 2);
+    Eigen::MatrixXd A_ini = Eigen::MatrixXd::Zero(4, 2);
+    std::vector<float64_t> q_ini(2, 0.0);
+    std::vector<float64_t> l_ini(4, 0.0);
+    std::vector<float64_t> u_ini(4, 0.0);
+    autoware::common::osqp::OSQPInterface osqp(P_ini, A_ini, q_ini, l_ini, u_ini, 1e-6);
     osqp.optimize();
+
     // Redefine problem before optimization
-    Eigen::MatrixXd P_new(2, 2);
-    P_new << 4, 1, 1, 2;
-    Eigen::MatrixXd A_new(4, 2);
-    A_new << 1, 1, 1, 0, 0, 1, 0, 1;
-    std::vector<float64_t> q_new = {1.0, 1.0};
-    std::vector<float64_t> l_new = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
-    std::vector<float64_t> u_new = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
-    osqp.initializeProblem(P_new, A_new, q_new, l_new, u_new);
+    osqp.initializeProblem(P, A, q, l, u);
     result = osqp.optimize();
     check_result(result);
   }
+
   {
     // Define problem during initialization with csc matrix
-    Eigen::MatrixXd P(2, 2);
-    P << 4, 1, 1, 2;
     CSC_Matrix P_csc = calCSCMatrixTrapezoidal(P);
-    Eigen::MatrixXd A(4, 2);
-    A << 1, 1, 1, 0, 0, 1, 0, 1;
     CSC_Matrix A_csc = calCSCMatrix(A);
-    std::vector<float64_t> q = {1.0, 1.0};
-    std::vector<float64_t> l = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
-    std::vector<float64_t> u = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
     autoware::common::osqp::OSQPInterface osqp(P_csc, A_csc, q, l, u, 1e-6);
     std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result = osqp.optimize();
     check_result(result);
   }
+
   {
     std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result;
     // Dummy initial problem with csc matrix
-    Eigen::MatrixXd P = Eigen::MatrixXd::Zero(2, 2);
-    CSC_Matrix P_csc = calCSCMatrixTrapezoidal(P);
-    Eigen::MatrixXd A = Eigen::MatrixXd::Zero(4, 2);
-    CSC_Matrix A_csc = calCSCMatrix(A);
-    std::vector<float64_t> q(2, 0.0);
-    std::vector<float64_t> l(4, 0.0);
-    std::vector<float64_t> u(4, 0.0);
-    autoware::common::osqp::OSQPInterface osqp(P_csc, A_csc, q, l, u, 1e-6);
+    CSC_Matrix P_ini_csc = calCSCMatrixTrapezoidal(Eigen::MatrixXd::Zero(2, 2));
+    CSC_Matrix A_ini_csc = calCSCMatrix(Eigen::MatrixXd::Zero(4, 2));
+    std::vector<float64_t> q_ini(2, 0.0);
+    std::vector<float64_t> l_ini(4, 0.0);
+    std::vector<float64_t> u_ini(4, 0.0);
+    autoware::common::osqp::OSQPInterface osqp(P_ini_csc, A_ini_csc, q_ini, l_ini, u_ini, 1e-6);
     osqp.optimize();
+
     // Redefine problem before optimization
-    Eigen::MatrixXd P_new(2, 2);
-    P_new << 4, 1, 1, 2;
-    CSC_Matrix P_new_csc = calCSCMatrixTrapezoidal(P_new);
-    Eigen::MatrixXd A_new(4, 2);
-    A_new << 1, 1, 1, 0, 0, 1, 0, 1;
-    CSC_Matrix A_new_csc = calCSCMatrix(A_new);
-    std::vector<float64_t> q_new = {1.0, 1.0};
-    std::vector<float64_t> l_new = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
-    std::vector<float64_t> u_new = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
-    osqp.initializeProblem(P_new_csc, A_new_csc, q_new, l_new, u_new);
+    CSC_Matrix P_csc = calCSCMatrixTrapezoidal(P);
+    CSC_Matrix A_csc = calCSCMatrix(A);
+    osqp.initializeProblem(P_csc, A_csc, q, l, u);
     result = osqp.optimize();
     check_result(result);
   }

--- a/common/osqp_interface/test/test_osqp_interface.cpp
+++ b/common/osqp_interface/test/test_osqp_interface.cpp
@@ -27,7 +27,7 @@ using autoware::common::osqp::float64_t;
 // cppcheck-suppress syntaxError
 TEST(TestOsqpInterface, BasicQp) {
   auto check_result =
-    [](const std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int> & result) {
+    [](const std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> & result) {
       EXPECT_EQ(std::get<2>(result), 1);
       EXPECT_EQ(std::get<3>(result), 1);
       ASSERT_EQ(std::get<0>(result).size(), size_t(2));
@@ -35,7 +35,7 @@ TEST(TestOsqpInterface, BasicQp) {
       EXPECT_DOUBLE_EQ(std::get<0>(result)[0], 0.3);
       EXPECT_DOUBLE_EQ(std::get<0>(result)[1], 0.7);
       EXPECT_DOUBLE_EQ(std::get<1>(result)[0], -2.9);
-      EXPECT_NEAR(std::get<1>(result)[1], 0.2, 1e-6);
+      EXPECT_NEAR(std::get<1>(result)[1], 0.0, 1e-6);
     };
 
   {
@@ -43,12 +43,12 @@ TEST(TestOsqpInterface, BasicQp) {
     autoware::common::osqp::OSQPInterface osqp;
     Eigen::MatrixXd P(2, 2);
     P << 4, 1, 1, 2;
-    Eigen::MatrixXd A(2, 4);
+    Eigen::MatrixXd A(4, 2);
     A << 1, 1, 1, 0, 0, 1, 0, 1;
     std::vector<float64_t> q = {1.0, 1.0};
     std::vector<float64_t> l = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
     std::vector<float64_t> u = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
-    std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int> result = osqp.optimize(
+    std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result = osqp.optimize(
       P, A, q, l, u);
     check_result(result);
   }
@@ -56,20 +56,20 @@ TEST(TestOsqpInterface, BasicQp) {
     // Define problem during initialization
     Eigen::MatrixXd P(2, 2);
     P << 4, 1, 1, 2;
-    Eigen::MatrixXd A(2, 4);
+    Eigen::MatrixXd A(4, 2);
     A << 1, 1, 1, 0, 0, 1, 0, 1;
     std::vector<float64_t> q = {1.0, 1.0};
     std::vector<float64_t> l = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
     std::vector<float64_t> u = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
     autoware::common::osqp::OSQPInterface osqp(P, A, q, l, u, 1e-6);
-    std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int> result = osqp.optimize();
+    std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result = osqp.optimize();
     check_result(result);
   }
   {
-    std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int> result;
+    std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result;
     // Dummy initial problem
     Eigen::MatrixXd P = Eigen::MatrixXd::Zero(2, 2);
-    Eigen::MatrixXd A = Eigen::MatrixXd::Zero(2, 4);
+    Eigen::MatrixXd A = Eigen::MatrixXd::Zero(4, 2);
     std::vector<float64_t> q(2, 0.0);
     std::vector<float64_t> l(4, 0.0);
     std::vector<float64_t> u(4, 0.0);
@@ -78,7 +78,7 @@ TEST(TestOsqpInterface, BasicQp) {
     // Redefine problem before optimization
     Eigen::MatrixXd P_new(2, 2);
     P_new << 4, 1, 1, 2;
-    Eigen::MatrixXd A_new(2, 4);
+    Eigen::MatrixXd A_new(4, 2);
     A_new << 1, 1, 1, 0, 0, 1, 0, 1;
     std::vector<float64_t> q_new = {1.0, 1.0};
     std::vector<float64_t> l_new = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};

--- a/common/osqp_interface/test/test_osqp_interface.cpp
+++ b/common/osqp_interface/test/test_osqp_interface.cpp
@@ -26,6 +26,10 @@ using autoware::common::osqp::float64_t;
 /// Problem taken from https://github.com/osqp/osqp/blob/master/tests/basic_qp/generate_problem.py
 // cppcheck-suppress syntaxError
 TEST(TestOsqpInterface, BasicQp) {
+  using autoware::common::osqp::CSC_Matrix;
+  using autoware::common::osqp::calCSCMatrix;
+  using autoware::common::osqp::calCSCMatrixTrapezoidal;
+
   auto check_result =
     [](const std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> & result) {
       EXPECT_EQ(std::get<2>(result), 1);
@@ -84,6 +88,47 @@ TEST(TestOsqpInterface, BasicQp) {
     std::vector<float64_t> l_new = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
     std::vector<float64_t> u_new = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
     osqp.initializeProblem(P_new, A_new, q_new, l_new, u_new);
+    result = osqp.optimize();
+    check_result(result);
+  }
+  {
+    // Define problem during initialization with csc matrix
+    Eigen::MatrixXd P(2, 2);
+    P << 4, 1, 1, 2;
+    CSC_Matrix P_csc = calCSCMatrixTrapezoidal(P);
+    Eigen::MatrixXd A(4, 2);
+    A << 1, 1, 1, 0, 0, 1, 0, 1;
+    CSC_Matrix A_csc = calCSCMatrix(A);
+    std::vector<float64_t> q = {1.0, 1.0};
+    std::vector<float64_t> l = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
+    std::vector<float64_t> u = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
+    autoware::common::osqp::OSQPInterface osqp(P_csc, A_csc, q, l, u, 1e-6);
+    std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result = osqp.optimize();
+    check_result(result);
+  }
+  {
+    std::tuple<std::vector<float64_t>, std::vector<float64_t>, int, int, int> result;
+    // Dummy initial problem with csc matrix
+    Eigen::MatrixXd P = Eigen::MatrixXd::Zero(2, 2);
+    CSC_Matrix P_csc = calCSCMatrixTrapezoidal(P);
+    Eigen::MatrixXd A = Eigen::MatrixXd::Zero(4, 2);
+    CSC_Matrix A_csc = calCSCMatrix(A);
+    std::vector<float64_t> q(2, 0.0);
+    std::vector<float64_t> l(4, 0.0);
+    std::vector<float64_t> u(4, 0.0);
+    autoware::common::osqp::OSQPInterface osqp(P_csc, A_csc, q, l, u, 1e-6);
+    osqp.optimize();
+    // Redefine problem before optimization
+    Eigen::MatrixXd P_new(2, 2);
+    P_new << 4, 1, 1, 2;
+    CSC_Matrix P_new_csc = calCSCMatrixTrapezoidal(P_new);
+    Eigen::MatrixXd A_new(4, 2);
+    A_new << 1, 1, 1, 0, 0, 1, 0, 1;
+    CSC_Matrix A_new_csc = calCSCMatrix(A_new);
+    std::vector<float64_t> q_new = {1.0, 1.0};
+    std::vector<float64_t> l_new = {1.0, 0.0, 0.0, -autoware::common::osqp::INF};
+    std::vector<float64_t> u_new = {1.0, 0.7, 0.7, autoware::common::osqp::INF};
+    osqp.initializeProblem(P_new_csc, A_new_csc, q_new, l_new, u_new);
     result = osqp.optimize();
     check_result(result);
   }


### PR DESCRIPTION
## Related Issue(required)

https://github.com/autowarefoundation/autoware.universe/issues/347

## Description(required)

Add a new interface in `osqp_interface` to enable warm-start which improves the computation time of the optimization. Details are below.

- added initializer of osqp_interface with csc matrix, and matrix update functions with csc matrix
- added a function to validate the size of P, q, A, l, u.
- fixed the existing test and added test for new functions

NOTE: we do not have to care about the existing applications which use osqp_interface since the existing member functions' behavior of osqp_interface will not change.

## Review Procedure(required)

run test

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
