### PR TITLE
fix(motion_velocity_smoother): fix bug in merge filter

### DIFF
--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -424,8 +424,7 @@ TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
   if (getVx(backward_filtered, 0) < v0) {
     double current_vel = v0;
     double current_acc = a0;
-    while (getVx(backward_filtered, i) < current_vel && current_vel <= getVx(forward_filtered, i) &&
-           i < merged.size() - 1) {
+    while (getVx(backward_filtered, i) < current_vel && i < merged.size() - 1) {
       merged.at(i).longitudinal_velocity_mps = current_vel;
       merged.at(i).acceleration_mps2 = current_acc;
 
@@ -442,6 +441,10 @@ TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
       } else {
         current_vel = current_vel + current_acc * dt + 0.5 * j_min * dt * dt;
         current_acc = current_acc + j_min * dt;
+      }
+
+      if (current_vel > getVx(forward_filtered, i)) {
+        current_vel = getVx(forward_filtered, i);
       }
       ++i;
     }


### PR DESCRIPTION
## Related Issue(required)
<!-- Link related issue -->

## Description(required)
- fix undesired deceleration bug in merge filter

In the merge filter function in motion_velocity_smoother, there was a bug that outputs a trajectory with unnecessarily sudden deceleration when a deceleration/stop point near the ego vehicle is included in the input trajectory.

![image](https://user-images.githubusercontent.com/59680180/154223876-af7f26c7-8fa7-4dda-a58c-d1d79fcb86c7.png)


<!-- Describe what this PR changes. -->

## Review Procedure(requ.ired)

- In the planning simulator, reproduce the situation where a stop line suddenly appears in front while the vehicle is running (like attached screen shot).
- Then, make sure there are no unnecessary sudden deceleration 


<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
