### PR TITLE
feat(ad_service_state_monitor): add non recieved topic in state monitor

### DIFF
--- a/system/ad_service_state_monitor/include/ad_service_state_monitor/ad_service_state_monitor_node.hpp
+++ b/system/ad_service_state_monitor/include/ad_service_state_monitor/ad_service_state_monitor_node.hpp
@@ -23,6 +23,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
+#include "tier4_debug_msgs/msg/string_stamped.hpp"
 #include <autoware_auto_planning_msgs/msg/had_map_route.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
@@ -103,6 +104,7 @@ private:
   // Publisher
   rclcpp::Publisher<autoware_auto_system_msgs::msg::AutowareState>::SharedPtr pub_autoware_state_;
   rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr pub_autoware_engage_;
+  rclcpp::Publisher<tier4_debug_msgs::msg::StringStamped>::SharedPtr pub_non_recieved_topic_;
 
   bool isEngaged();
   void setDisengage();

--- a/system/ad_service_state_monitor/package.xml
+++ b/system/ad_service_state_monitor/package.xml
@@ -24,6 +24,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
+  <depend>tier4_debug_msgs</depend>
 
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>tier4_perception_msgs</exec_depend>

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -232,6 +232,19 @@ void AutowareStateMonitorNode::onTimer()
     pub_autoware_state_->publish(autoware_state_msg);
   }
 
+  // Publish non-recieved topic
+  {
+    const auto non_recieved_topic = state_machine_->getMessages();
+
+    tier4_debug_msgs::msg::StringStamped non_recieved_topic_msg;
+    non_recieved_topic_msg.stamp = this->now();
+    for (const auto & str : non_recieved_topic) {
+      non_recieved_topic_msg.data.append(str);
+    }
+
+    pub_non_recieved_topic_->publish(non_recieved_topic_msg);
+  }
+
   // Publish diag message
   updater_.force_update();
 }
@@ -452,6 +465,8 @@ AutowareStateMonitorNode::AutowareStateMonitorNode()
     "output/autoware_state", 1);
   pub_autoware_engage_ =
     this->create_publisher<autoware_auto_vehicle_msgs::msg::Engage>("output/autoware_engage", 1);
+  pub_non_recieved_topic_ =
+    this->create_publisher<tier4_debug_msgs::msg::StringStamped>("debug/non_recieved_topic", 1);
 
   // Diagnostic Updater
   setupDiagnosticUpdater();

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -239,7 +239,8 @@ void AutowareStateMonitorNode::onTimer()
     tier4_debug_msgs::msg::StringStamped non_recieved_topic_msg;
     non_recieved_topic_msg.stamp = this->now();
     for (const auto & str : non_recieved_topic) {
-      non_recieved_topic_msg.data.append(str);
+      non_recieved_topic_msg.data += str;
+      non_recieved_topic_msg.data += "\n";
     }
 
     pub_non_recieved_topic_->publish(non_recieved_topic_msg);


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Related Issue(required)

https://github.com/autowarefoundation/autoware.universe/issues/396

## Description(required)

add publisher of non recieved (ready) topics in state monitor for debugging

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
