### PR TITLE
fix(ekf_localizer): update predict frequency with measured timer rate

### DIFF
--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -37,7 +37,6 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <chrono>
-#include <deque>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -81,8 +81,9 @@ private:
   rclcpp::Clock::SharedPtr clock_;
   //!< @brief time for ekf calculation callback
   rclcpp::TimerBase::SharedPtr timer_control_;
-  //!< @brief time buffer for updating ekf rate
-  std::deque<rclcpp::Time> time_buffer_;
+  //!< @brief last predict time
+  std::shared_ptr<const rclcpp::Time> last_predict_time_;
+
   //!< @brief timer to send transform
   rclcpp::TimerBase::SharedPtr timer_tf_;
   //!< @brief tf broadcaster
@@ -181,14 +182,7 @@ private:
   void initEKF();
 
   /**
-   * @brief calculate timer rate
-   * @param window_size calculate the average rate of this size
-   * @return average timer rate
-   */
-  double calcTimerRate(size_t window_size) const;
-
-  /**
-   * @brief update predict frequency because timer rate will be /clock rate when using /clock.
+   * @brief update predict frequency
    */
   void updatePredictFrequency();
 

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -76,8 +76,6 @@ private:
   //!< @brief measurement twist with covariance subscriber
   rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
     sub_twist_with_cov_;
-  //!< @brief clock
-  rclcpp::Clock::SharedPtr clock_;
   //!< @brief time for ekf calculation callback
   rclcpp::TimerBase::SharedPtr timer_control_;
   //!< @brief last predict time


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->
fix https://github.com/autowarefoundation/autoware.universe/issues/398

## Description(required)

<!-- Describe what this PR changes. -->
ekf_localizer fails when the tiemrCallback is not triggered at a proper frequency due to the following reasons.
-  high CPU utilization.
-  low clock rate #398

Imporove performance in these conditions by updating ekf_rate with the measured tiemrCallback rate.

## Review Procedure(required)

<!-- Explain how to review this PR. -->
- Check that localization does not fail at low clock rate. 
  - I confirmed it with the same param to https://github.com/autowarefoundation/autoware.universe/issues/398 predict_frequency:50 , clock_rate:20
https://user-images.githubusercontent.com/39142679/154258185-9f6a7a85-f9b4-4cee-8f97-ab5a25706074.mp4
- Check that localization does not fail  at a sufficiently large clock rate
   - I confirmed it with predict_frequency:50 , clock_rate:100
- Check if the code is ok.

## Related PR(optional) 
<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
