### PR TITLE
fix(behavior_path_planner): parametrize avoidance lateral distance threshold

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -45,3 +45,6 @@
       # not enabled yet
       longitudinal_collision_margin_min_distance: 0.0          # [m]
       longitudinal_collision_margin_time: 0.0
+
+      # ---------- advanced parameters ----------
+      avoidance_execution_lateral_threshold: 0.499

--- a/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
@@ -409,6 +409,7 @@ TODO
 | avoidance_execution_lateral_threshold      | [m]    | double | The lateral distance deviation threshold between the current path and suggested avoidance point to execute avoidance. (\*2) | 0.5           |
 
 (\*2) If there are multiple vehicles in a row to be avoided, no new avoidance path will be generated unless their lateral margin difference exceeds this value.
+
 ### Speed limit modification
 
 | Name                                   | Unit   | Type   | Description                                                                 | Default value |

--- a/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
@@ -406,7 +406,9 @@ TODO
 | max_right_shift_length                     | [m]    | double | Maximum shift length for right direction                                                                    | 5.0           |
 | max_left_shift_length                      | [m]    | double | Maximum shift length for left direction                                                                     | 5.0           |
 | road_shoulder_safety_margin                | [m]    | double | Prevents the generated path to come too close to the road shoulders.                                        | 0.5           |
+| avoidance_execution_lateral_threshold      | [m]    | double | The lateral distance deviation threshold between the current path and suggested avoidance point to execute avoidance. (\*2) | 0.5           |
 
+(\*2) If there are multiple vehicles in a row to be avoided, no new avoidance path will be generated unless their lateral margin difference exceeds this value.
 ### Speed limit modification
 
 | Name                                   | Unit   | Type   | Description                                                                 | Default value |

--- a/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
@@ -388,24 +388,24 @@ TODO
 
 ### Avoidance path generation
 
-| Name                                       | Unit   | Type   | Description                                                                                                 | Default value |
-| :----------------------------------------- | :----- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
-| resample_interval_for_planning             | [m]    | double | Path resample interval for avoidance planning path.                                                         | 0.3           |
-| resample_interval_for_output               | [m]    | double | Path resample interval for output path. Too short interval increases computational cost for latter modules. | 3.0           |
-| lateral_collision_margin                   | [m]    | double | The lateral distance between ego and avoidance targets.                                                     | 1.5           |
-| lateral_collision_safety_buffer            | [m]    | double | Creates an additional gap that will prevent the vehicle from getting to near to the obstacle                | 0.5           |
-| longitudinal_collision_margin_min_distance | [m]    | double | when complete avoidance motion, there is a distance margin with the object for longitudinal direction.      | 0.0           |
-| longitudinal_collision_margin_time         | [s]    | double | when complete avoidance motion, there is a time margin with the object for longitudinal direction.          | 0.0           |
-| prepare_time                               | [s]    | double | Avoidance shift starts from point ahead of this time x ego_speed to avoid sudden path change.               | 1.0           |
-| min_prepare_distance                       | [m]    | double | Minimum distance for "prepare_time" x "ego_speed".                                                          | 1.0           |
-| nominal_lateral_jerk                       | [m/s3] | double | Avoidance path is generated with this jerk when there is enough distance from ego.                          | 0.3           |
-| max_lateral_jerk                           | [m/s3] | double | Avoidance path gets sharp up to this jerk limit when there is not enough distance from ego.                 | 2.0           |
-| min_avoidance_distance                     | [m]    | double | Minimum distance of avoidance path (i.e. this distance is needed even if its lateral jerk is very low)      | 10.0          |
-| min_nominal_avoidance_speed                | [m/s]  | double | Minimum speed for jerk calculation in a nominal situation (\*1).                                            | 5.0           |
-| min_sharp_avoidance_speed                  | [m/s]  | double | Minimum speed for jerk calculation in a sharp situation (\*1).                                              | 1.0           |
-| max_right_shift_length                     | [m]    | double | Maximum shift length for right direction                                                                    | 5.0           |
-| max_left_shift_length                      | [m]    | double | Maximum shift length for left direction                                                                     | 5.0           |
-| road_shoulder_safety_margin                | [m]    | double | Prevents the generated path to come too close to the road shoulders.                                        | 0.5           |
+| Name                                       | Unit   | Type   | Description                                                                                                                 | Default value |
+| :----------------------------------------- | :----- | :----- | :-------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| resample_interval_for_planning             | [m]    | double | Path resample interval for avoidance planning path.                                                                         | 0.3           |
+| resample_interval_for_output               | [m]    | double | Path resample interval for output path. Too short interval increases computational cost for latter modules.                 | 3.0           |
+| lateral_collision_margin                   | [m]    | double | The lateral distance between ego and avoidance targets.                                                                     | 1.5           |
+| lateral_collision_safety_buffer            | [m]    | double | Creates an additional gap that will prevent the vehicle from getting to near to the obstacle                                | 0.5           |
+| longitudinal_collision_margin_min_distance | [m]    | double | when complete avoidance motion, there is a distance margin with the object for longitudinal direction.                      | 0.0           |
+| longitudinal_collision_margin_time         | [s]    | double | when complete avoidance motion, there is a time margin with the object for longitudinal direction.                          | 0.0           |
+| prepare_time                               | [s]    | double | Avoidance shift starts from point ahead of this time x ego_speed to avoid sudden path change.                               | 1.0           |
+| min_prepare_distance                       | [m]    | double | Minimum distance for "prepare_time" x "ego_speed".                                                                          | 1.0           |
+| nominal_lateral_jerk                       | [m/s3] | double | Avoidance path is generated with this jerk when there is enough distance from ego.                                          | 0.3           |
+| max_lateral_jerk                           | [m/s3] | double | Avoidance path gets sharp up to this jerk limit when there is not enough distance from ego.                                 | 2.0           |
+| min_avoidance_distance                     | [m]    | double | Minimum distance of avoidance path (i.e. this distance is needed even if its lateral jerk is very low)                      | 10.0          |
+| min_nominal_avoidance_speed                | [m/s]  | double | Minimum speed for jerk calculation in a nominal situation (\*1).                                                            | 5.0           |
+| min_sharp_avoidance_speed                  | [m/s]  | double | Minimum speed for jerk calculation in a sharp situation (\*1).                                                              | 1.0           |
+| max_right_shift_length                     | [m]    | double | Maximum shift length for right direction                                                                                    | 5.0           |
+| max_left_shift_length                      | [m]    | double | Maximum shift length for left direction                                                                                     | 5.0           |
+| road_shoulder_safety_margin                | [m]    | double | Prevents the generated path to come too close to the road shoulders.                                                        | 0.5           |
 | avoidance_execution_lateral_threshold      | [m]    | double | The lateral distance deviation threshold between the current path and suggested avoidance point to execute avoidance. (\*2) | 0.5           |
 
 (\*2) If there are multiple vehicles in a row to be avoided, no new avoidance path will be generated unless their lateral margin difference exceeds this value.

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -45,3 +45,6 @@
       # not enabled yet
       longitudinal_collision_margin_min_distance: 0.0          # [m]
       longitudinal_collision_margin_time: 0.0
+
+      # ---------- advanced parameters ----------
+      avoidance_execution_lateral_threshold: 0.499

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -140,6 +140,12 @@ struct AvoidanceParameters
   // turn signal is not turned on.
   double avoidance_search_distance;
 
+  // The avoidance path generation is performed when the shift distance of the
+  // avoidance points is greater than this threshold.
+  // In multiple targets case: if there are multiple vehicles in a row to be avoided, no new
+  // avoidance path will be generated unless their lateral margin difference exceeds this value.
+  double avoidance_execution_lateral_threshold;
+
   // debug
   bool publish_debug_marker = false;
   bool print_debug_info = false;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -244,6 +244,8 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.publish_debug_marker = dp("publish_debug_marker", false);
   p.print_debug_info = dp("print_debug_info", false);
 
+  p.avoidance_execution_lateral_threshold = dp("avoidance_execution_lateral_threshold", 0.499);
+
   return p;
 }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2249,9 +2249,6 @@ boost::optional<AvoidPointArray> AvoidanceModule::findNewShiftPoint(
       ap.getRelativeLength(), ap.getRelativeLongitudinal(), getSharpAvoidanceEgoSpeed());
   };
 
-  // TODO(Horibe) maybe this value must be same with trimSmallShift's.
-  constexpr double NEW_POINT_THRESHOLD = 0.5 - 1.0e-3;
-
   for (size_t i = 0; i < candidates.size(); ++i) {
     const auto & candidate = candidates.at(i);
     std::stringstream ss;
@@ -2279,7 +2276,8 @@ boost::optional<AvoidPointArray> AvoidanceModule::findNewShiftPoint(
     // TODO(Horibe) test fails with this print. why?
     // DEBUG_PRINT("%s, shift current: %f, candidate: %f", pfx, current_shift, candidate.length);
 
-    if (std::abs(candidate.length - current_shift) > NEW_POINT_THRESHOLD) {
+    const auto new_point_threshold = parameters_.avoidance_execution_lateral_threshold;
+    if (std::abs(candidate.length - current_shift) > new_point_threshold) {
       DEBUG_PRINT(
         "%s, New shift point is found!!! shift change: %f -> %f", pfx, current_shift,
         candidate.length);


### PR DESCRIPTION
## Related Issue(required)

Hard code parameter should be parametrized in avoidance module.

## Description(required)

The lateral distance threshold for the avoidance execution is parametrized in this PR.

## Review Procedure(required)

Change the associated parameter and see the avoidance behavior will change.
Small threshold executes multi-path-changes for multi-parked vehicles on the road shoulder. Long threshold executes only one time path change for multi-parked vehicles.

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
