### PR TITLE
fix(obstacle_stop_planner): fix yaw calculation in acc

### DIFF
--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/adaptive_cruise_control.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/adaptive_cruise_control.hpp
@@ -180,12 +180,15 @@ private:
     const geometry_msgs::msg::Pose & self_pose, const pcl::PointXYZ & nearest_collision_point,
     const rclcpp::Time & nearest_collision_point_time, double * distance,
     const std_msgs::msg::Header & trajectory_header);
-  double calcTrajYaw(const TrajectoryPoints & trajectory, const int collision_point_idx);
+  double calcTrajYaw(
+    const TrajectoryPoints & trajectory, const geometry_msgs::msg::Point & point,
+    const double minimum_distance = 5.0);
   bool estimatePointVelocityFromObject(
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr object_ptr,
-    const double traj_yaw, const pcl::PointXYZ & nearest_collision_point, double * velocity);
+    const TrajectoryPoints & trajectory, const pcl::PointXYZ & nearest_collision_point,
+    double * velocity);
   bool estimatePointVelocityFromPcl(
-    const double traj_yaw, const pcl::PointXYZ & nearest_collision_point,
+    const TrajectoryPoints & trajectory, const pcl::PointXYZ & nearest_collision_point,
     const rclcpp::Time & nearest_collision_point_time, double * velocity);
   double estimateRoughPointVelocity(double current_vel);
   bool isObstacleVelocityHigh(const double obj_vel);
@@ -202,6 +205,7 @@ private:
     const geometry_msgs::msg::Pose self_pose, const double current_vel, const double target_vel,
     const double dist_to_collision_point, TrajectoryPoints * output_trajectory);
   void registerQueToVelocity(const double vel, const rclcpp::Time & vel_time);
+  geometry_msgs::msg::Point convertToPoint(const pcl::PointXYZ & point);
 
   /* Debug */
   mutable tier4_debug_msgs::msg::Float32MultiArrayStamped debug_values_;

--- a/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -343,12 +343,12 @@ double AdaptiveCruiseController::calcTrajYaw(
   geometry_msgs::msg::Point next_point;
 
   // search next point for calculating yaw
-  double accumlated_length = 0.0;
+  double accumulated_length = 0.0;
   for (size_t i = nearest_idx + 1; i < trajectory.size(); i++) {
     next_point = trajectory.at(i).pose.position;
-    accumlated_length += tier4_autoware_utils::calcDistance2d(
+    accumulated_length += tier4_autoware_utils::calcDistance2d(
       trajectory.at(i - 1).pose.position, trajectory.at(i).pose.position);
-    if (accumlated_length > minimum_distance) break;
+    if (accumulated_length > minimum_distance) break;
   }
 
   const double diff_x = next_point.x - curr_point.x;


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Related Issue(required)

<!-- Link related issue -->

## Description(required)
- Bug fix of adaptive cruise controller in obstacle_stop_planner.

1. Change the point used to calculate trajectory-yaw. 

In acc, target object velocity `v`  is calculated as folloing.

`v = object_velocity * cos(object_yaw - trajectory_yaw)`

Then, the yaw of trajectory is calculated using collision point(blue arrow). 
Thereby, the difference of yaw of object (green arrow) and between trajectory is inaccurately calculated.

![image](https://user-images.githubusercontent.com/59680180/154428269-8bf79618-e2b2-4476-b726-2cd85282d05e.png)

In this PR, the nearest point to object (red arrow) is used for calculating yaw of trajectory.

2. re-calculate yaw in the acc function

Previously, the `orientation` of point  was used to calculate the trajectory yaw.
However, the `orientation` may be inaccurate.

In this PR, the yaw of trajectory point is recalculated  in the ACC node, and  `orientation` information of trajectory point is not used..

<!-- Describe what this PR changes. -->

## Review Procedure(required)
 test cases as below.
![image](https://user-images.githubusercontent.com/59680180/154432358-7abecc30-59fe-4291-8dfb-0842686683f0.png)

In this cases, `v` ( = object_velocity * cos(object_yaw - trajectory_yaw) ) of the crossing object should be 0 or less than 0.
However, `v` was sometimes calculated as positive due to the above bug, and then the mode transitions to ACC and obstacle stop did not work without merging this PR.

Confirm that the bug is fixed by this PR. 
(Confirm that the `obstacle stop` works properly)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
