### PR TITLE
feat(ndt_scan_matcher): add tolerance of initial pose

### DIFF
--- a/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
+++ b/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
@@ -33,7 +33,7 @@
     initial_pose_stamp_tolerance_sec: 1.0
 
     # Tolerance of distance difference between two initial poses used for linear interpolation. [m]
-    initial_pose_distance_tolerance_m: 3.0
+    initial_pose_distance_tolerance_m: 10.0
 
     # neighborhood search method in OMP
     # 0=KDTREE, 1=DIRECT26, 2=DIRECT7, 3=DIRECT1

--- a/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
+++ b/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
@@ -30,7 +30,7 @@
     initial_estimate_particles_num: 100
     
     # Tolerance of timestamp difference between initial_pose and sensor pointcloud. [sec]
-    initial_pose_stamp_tolerance_sec: 1.0
+    initial_pose_timeout_sec: 1.0
 
     # Tolerance of distance difference between two initial poses used for linear interpolation. [m]
     initial_pose_distance_tolerance_m: 10.0

--- a/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
+++ b/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
@@ -28,6 +28,12 @@
 
     # The number of particles to estimate initial pose
     initial_estimate_particles_num: 100
+    
+    # Tolerance of timestamp difference between initial_pose and sensor pointcloud. [sec]
+    initial_pose_stamp_tolerance_sec: 1.0
+
+    # Tolerance of distance difference between two initial poses used for linear interpolation. [m]
+    initial_pose_distance_tolerance_m: 3.0
 
     # neighborhood search method in OMP
     # 0=KDTREE, 1=DIRECT26, 2=DIRECT7, 3=DIRECT1

--- a/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
+++ b/launch/tier4_localization_launch/config/ndt_scan_matcher.param.yaml
@@ -28,7 +28,7 @@
 
     # The number of particles to estimate initial pose
     initial_estimate_particles_num: 100
-    
+
     # Tolerance of timestamp difference between initial_pose and sensor pointcloud. [sec]
     initial_pose_timeout_sec: 1.0
 

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -29,6 +29,12 @@
 
     # The number of particles to estimate initial pose
     initial_estimate_particles_num: 100
+    
+    # Tolerance of timestamp difference between initial_pose and sensor pointcloud. [sec]
+    initial_pose_stamp_tolerance_sec: 1.0
+
+    # Tolerance of distance difference between two initial poses used for linear interpolation. [m]
+    initial_pose_distance_tolerance_m: 3.0
 
     # neighborhood search method in OMP
     # 0=KDTREE, 1=DIRECT26, 2=DIRECT7, 3=DIRECT1

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -29,7 +29,7 @@
 
     # The number of particles to estimate initial pose
     initial_estimate_particles_num: 100
-    
+
     # Tolerance of timestamp difference between initial_pose and sensor pointcloud. [sec]
     initial_pose_timeout_sec: 1.0
 

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -31,7 +31,7 @@
     initial_estimate_particles_num: 100
     
     # Tolerance of timestamp difference between initial_pose and sensor pointcloud. [sec]
-    initial_pose_stamp_tolerance_sec: 1.0
+    initial_pose_timeout_sec: 1.0
 
     # Tolerance of distance difference between two initial poses used for linear interpolation. [m]
     initial_pose_distance_tolerance_m: 10.0

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -34,7 +34,7 @@
     initial_pose_stamp_tolerance_sec: 1.0
 
     # Tolerance of distance difference between two initial poses used for linear interpolation. [m]
-    initial_pose_distance_tolerance_m: 3.0
+    initial_pose_distance_tolerance_m: 10.0
 
     # neighborhood search method in OMP
     # 0=KDTREE, 1=DIRECT26, 2=DIRECT7, 3=DIRECT1

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -114,7 +114,7 @@ private:
     const geometry_msgs::msg::TransformStamped::SharedPtr & transform_stamped_ptr);
 
   bool validateTimeStampDifference(
-    const rclcpp::Time & target_time, const rclcpp::Time & refarence_time,
+    const rclcpp::Time & target_time, const rclcpp::Time & reference_time,
     const double time_tolerance_sec);
   bool validatePositionDifference(
     const geometry_msgs::msg::Point & target_point,

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -113,6 +113,9 @@ private:
     const std::string & target_frame, const std::string & source_frame,
     const geometry_msgs::msg::TransformStamped::SharedPtr & transform_stamped_ptr);
 
+  bool validateTimeStampDifference(const rclcpp::Time & target_time, const rclcpp::Time & refarence_time, const double time_tolerance_sec);
+  bool validatePositionDifference(const geometry_msgs::msg::Point & target_point, const geometry_msgs::msg::Point & reference_point, const double distance_tolerance_m_);
+
   void timerDiagnostic();
 
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr initial_pose_sub_;

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -157,7 +157,7 @@ private:
   std::string map_frame_;
   double converged_param_transform_probability_;
   int initial_estimate_particles_num_;
-  double initial_pose_stamp_tolerance_sec_;
+  double initial_pose_timeout_sec_;
   double initial_pose_distance_tolerance_m_;
   float inversion_vector_threshold_;
   float oscillation_threshold_;

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -113,8 +113,12 @@ private:
     const std::string & target_frame, const std::string & source_frame,
     const geometry_msgs::msg::TransformStamped::SharedPtr & transform_stamped_ptr);
 
-  bool validateTimeStampDifference(const rclcpp::Time & target_time, const rclcpp::Time & refarence_time, const double time_tolerance_sec);
-  bool validatePositionDifference(const geometry_msgs::msg::Point & target_point, const geometry_msgs::msg::Point & reference_point, const double distance_tolerance_m_);
+  bool validateTimeStampDifference(
+    const rclcpp::Time & target_time, const rclcpp::Time & refarence_time,
+    const double time_tolerance_sec);
+  bool validatePositionDifference(
+    const geometry_msgs::msg::Point & target_point,
+    const geometry_msgs::msg::Point & reference_point, const double distance_tolerance_m_);
 
   void timerDiagnostic();
 

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -154,6 +154,8 @@ private:
   std::string map_frame_;
   double converged_param_transform_probability_;
   int initial_estimate_particles_num_;
+  double initial_pose_stamp_tolerance_sec_;
+  double initial_pose_distance_tolerance_m_;
   float inversion_vector_threshold_;
   float oscillation_threshold_;
   std::array<double, 36> output_pose_covariance_;

--- a/localization/ndt_scan_matcher/package.xml
+++ b/localization/ndt_scan_matcher/package.xml
@@ -25,6 +25,7 @@
   <depend>tier4_debug_msgs</depend>
   <depend>tier4_localization_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>fmt</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/localization/ndt_scan_matcher/package.xml
+++ b/localization/ndt_scan_matcher/package.xml
@@ -8,6 +8,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>diagnostic_msgs</depend>
+  <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>ndt</depend>
@@ -25,7 +26,6 @@
   <depend>tier4_debug_msgs</depend>
   <depend>tier4_localization_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>fmt</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -713,3 +713,23 @@ bool NDTScanMatcher::getTransform(
   }
   return true;
 }
+
+bool NDTScanMatcher::validateTimeStampDifference(const rclcpp::Time & target_time, const rclcpp::Time & refarence_time, const double time_tolerance_sec)
+{
+  double time_stamp_diff_sec = std::abs((target_time - refarence_time).seconds());
+  if (time_stamp_diff_sec > time_tolerance_sec) {
+    RCLCPP_WARN(get_logger(), "Validation error. The reference time is %lf[sec], but the target time is %lf[sec]. The difference is %lf[sec] (the tolerance is %lf[sec]).", refarence_time.seconds(), target_time.seconds(), time_stamp_diff_sec, time_tolerance_sec);
+    return false;
+  }
+  return true;
+}
+
+bool NDTScanMatcher::validatePositionDifference(const geometry_msgs::msg::Point & target_point, const geometry_msgs::msg::Point & reference_point, const double distance_tolerance_m_)
+{
+  double distance_m = norm(target_point, reference_point);
+  if (distance_m > distance_tolerance_m_) {
+    RCLCPP_WARN(get_logger(), "Validation error. The distance from reference position to target position is %lf[m] (the tolerance is %lf[m]).", distance_m, distance_tolerance_m_);
+    return false;
+  }
+  return true;
+}

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -103,12 +103,9 @@ NDTScanMatcher::NDTScanMatcher()
   ndt_base_frame_("ndt_base_link"),
   map_frame_("map"),
   converged_param_transform_probability_(4.5),
-<<<<<<< HEAD
   initial_estimate_particles_num_(100),
-=======
   initial_pose_stamp_tolerance_sec_(1.0),
-  initial_pose_distance_tolerance_m_(3.0),
->>>>>>> feat(ndt_scan_matcher): add tolerance of initial pose
+  initial_pose_distance_tolerance_m_(10.0),
   inversion_vector_threshold_(-0.9),
   oscillation_threshold_(10)
 {

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -171,8 +171,8 @@ NDTScanMatcher::NDTScanMatcher()
   initial_estimate_particles_num_ =
     this->declare_parameter("initial_estimate_particles_num", initial_estimate_particles_num_);
 
-  initial_pose_timeout_sec_ = this->declare_parameter(
-    "initial_pose_timeout_sec", initial_pose_timeout_sec_);
+  initial_pose_timeout_sec_ =
+    this->declare_parameter("initial_pose_timeout_sec", initial_pose_timeout_sec_);
 
   initial_pose_distance_tolerance_m_ = this->declare_parameter(
     "initial_pose_distance_tolerance_m", initial_pose_distance_tolerance_m_);
@@ -443,11 +443,15 @@ void NDTScanMatcher::callbackSensorPoints(
   popOldPose(initial_pose_msg_ptr_array_, sensor_ros_time);
 
   // check the time stamp
-  bool valid_old_timestamp = validateTimeStampDifference(initial_pose_old_msg_ptr->header.stamp, sensor_ros_time, initial_pose_timeout_sec_);
-  bool valid_new_timestamp = validateTimeStampDifference(initial_pose_new_msg_ptr->header.stamp, sensor_ros_time, initial_pose_timeout_sec_);
+  bool valid_old_timestamp = validateTimeStampDifference(
+    initial_pose_old_msg_ptr->header.stamp, sensor_ros_time, initial_pose_timeout_sec_);
+  bool valid_new_timestamp = validateTimeStampDifference(
+    initial_pose_new_msg_ptr->header.stamp, sensor_ros_time, initial_pose_timeout_sec_);
 
   // check the position jumping (ex. immediately after the initial pose estimation)
-  bool valid_new_to_old_distance = validatePositionDifference(initial_pose_old_msg_ptr->pose.pose.position, initial_pose_new_msg_ptr->pose.pose.position, initial_pose_distance_tolerance_m_);
+  bool valid_new_to_old_distance = validatePositionDifference(
+    initial_pose_old_msg_ptr->pose.pose.position, initial_pose_new_msg_ptr->pose.pose.position,
+    initial_pose_distance_tolerance_m_);
 
   // must all validations are true
   if (!(valid_old_timestamp && valid_new_timestamp && valid_new_to_old_distance)) {
@@ -711,21 +715,33 @@ bool NDTScanMatcher::getTransform(
   return true;
 }
 
-bool NDTScanMatcher::validateTimeStampDifference(const rclcpp::Time & target_time, const rclcpp::Time & refarence_time, const double time_tolerance_sec)
+bool NDTScanMatcher::validateTimeStampDifference(
+  const rclcpp::Time & target_time, const rclcpp::Time & refarence_time,
+  const double time_tolerance_sec)
 {
   const double dt = std::abs((target_time - refarence_time).seconds());
   if (dt > time_tolerance_sec) {
-    RCLCPP_WARN(get_logger(), "Validation error. The reference time is %lf[sec], but the target time is %lf[sec]. The difference is %lf[sec] (the tolerance is %lf[sec]).", refarence_time.seconds(), target_time.seconds(), dt, time_tolerance_sec);
+    RCLCPP_WARN(
+      get_logger(),
+      "Validation error. The reference time is %lf[sec], but the target time is %lf[sec]. The "
+      "difference is %lf[sec] (the tolerance is %lf[sec]).",
+      refarence_time.seconds(), target_time.seconds(), dt, time_tolerance_sec);
     return false;
   }
   return true;
 }
 
-bool NDTScanMatcher::validatePositionDifference(const geometry_msgs::msg::Point & target_point, const geometry_msgs::msg::Point & reference_point, const double distance_tolerance_m_)
+bool NDTScanMatcher::validatePositionDifference(
+  const geometry_msgs::msg::Point & target_point, const geometry_msgs::msg::Point & reference_point,
+  const double distance_tolerance_m_)
 {
   double distance = norm(target_point, reference_point);
   if (distance > distance_tolerance_m_) {
-    RCLCPP_WARN(get_logger(), "Validation error. The distance from reference position to target position is %lf[m] (the tolerance is %lf[m]).", distance, distance_tolerance_m_);
+    RCLCPP_WARN(
+      get_logger(),
+      "Validation error. The distance from reference position to target position is %lf[m] (the "
+      "tolerance is %lf[m]).",
+      distance, distance_tolerance_m_);
     return false;
   }
   return true;

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -716,16 +716,16 @@ bool NDTScanMatcher::getTransform(
 }
 
 bool NDTScanMatcher::validateTimeStampDifference(
-  const rclcpp::Time & target_time, const rclcpp::Time & refarence_time,
+  const rclcpp::Time & target_time, const rclcpp::Time & reference_time,
   const double time_tolerance_sec)
 {
-  const double dt = std::abs((target_time - refarence_time).seconds());
+  const double dt = std::abs((target_time - reference_time).seconds());
   if (dt > time_tolerance_sec) {
     RCLCPP_WARN(
       get_logger(),
       "Validation error. The reference time is %lf[sec], but the target time is %lf[sec]. The "
       "difference is %lf[sec] (the tolerance is %lf[sec]).",
-      refarence_time.seconds(), target_time.seconds(), dt, time_tolerance_sec);
+      reference_time.seconds(), target_time.seconds(), dt, time_tolerance_sec);
     return false;
   }
   return true;

--- a/localization/ndt_scan_matcher/src/util_func.cpp
+++ b/localization/ndt_scan_matcher/src/util_func.cpp
@@ -254,23 +254,3 @@ std::vector<geometry_msgs::msg::Pose> createRandomPoseArray(
 
   return poses;
 }
-
-bool validateTimeStampDifference(const rclcpp::Time & target_time, const rclcpp::Time & refarence_time, const double time_tolerance_sec)
-{
-  double time_stamp_diff_sec = std::abs(target_time - refarence_time).seconds();
-  if (time_stamp_diff_sec > time_tolerance_sec) {
-    RCLCPP_WARN(get_logger(), "Validation error. The reference time is %lf[sec], but the target time is %lf[sec]. The difference is %lf[sec] (the tolerance is %lf[sec]).", refarence_time.seconds(), target_time.seconds(), time_stamp_diff_sec, time_tolerance_sec);
-    return false;
-  }
-  return true;
-}
-
-bool validatePositionDifference(const geometry_msgs::msg::Point & target_point, const geometry_msgs::msg::Point & reference_point, const double distance_tolerance_m_)
-{
-  double distance_m = norm(target_point, reference_point);
-  if (distance_m > distance_tolerance_m_) {
-    RCLCPP_WARN(get_logger(), "Validation error. The distance from reference position to target position is %lf[m] (the tolerance is %lf[m]).", distance_m, distance_tolerance_m_);
-    return false;
-  }
-  return true;
-}

--- a/localization/ndt_scan_matcher/src/util_func.cpp
+++ b/localization/ndt_scan_matcher/src/util_func.cpp
@@ -254,3 +254,23 @@ std::vector<geometry_msgs::msg::Pose> createRandomPoseArray(
 
   return poses;
 }
+
+bool validateTimeStampDifference(const rclcpp::Time & target_time, const rclcpp::Time & refarence_time, const double time_tolerance_sec)
+{
+  double time_stamp_diff_sec = std::abs(target_time - refarence_time).seconds();
+  if (time_stamp_diff_sec > time_tolerance_sec) {
+    RCLCPP_WARN(get_logger(), "Validation error. The reference time is %lf[sec], but the target time is %lf[sec]. The difference is %lf[sec] (the tolerance is %lf[sec]).", refarence_time.seconds(), target_time.seconds(), time_stamp_diff_sec, time_tolerance_sec);
+    return false;
+  }
+  return true;
+}
+
+bool validatePositionDifference(const geometry_msgs::msg::Point & target_point, const geometry_msgs::msg::Point & reference_point, const double distance_tolerance_m_)
+{
+  double distance_m = norm(target_point, reference_point);
+  if (distance_m > distance_tolerance_m_) {
+    RCLCPP_WARN(get_logger(), "Validation error. The distance from reference position to target position is %lf[m] (the tolerance is %lf[m]).", distance_m, distance_tolerance_m_);
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)
Add validation for initial pose which is from ekf_localizer node.
- Validation of timestamp difference between initial_pose and sensor pointcloud. 
- Validation of distance difference between two initial poses used for linear interpolation. 

<!-- Describe what this PR changes. -->

## Review Procedure(required)
Build with https://github.com/tier4/autoware_launch/pull/211.

1. Immediately after the initial position estimation, make sure that the validation error occurs.
Because the estimation of ekf_localizer starts from (0, 0, 0), but the coordinate values jump a lot after the initial position estimation. Therefore, a validation error often occurs after the initial position estimation.

1. Change validation params, then make sure that the validation error occurs or not.

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
