### PR TITLE
fix: change the default mode of perception.launch

### DIFF
--- a/launch/tier4_autoware_launch/launch/autoware.launch.xml
+++ b/launch/tier4_autoware_launch/launch/autoware.launch.xml
@@ -56,7 +56,6 @@
 
   <!-- Perception -->
   <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml">
-    <!-- options for mode: camera_lidar_fusion, lidar, camera -->
     <arg name="mode" value="lidar" />
     <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)" />
@@ -70,7 +69,6 @@
 
   <!-- Control -->
   <include file="$(find-pkg-share tier4_control_launch)/launch/control.launch.py">
-    <!-- options for lateral_controller_mode: mpc_follower, pure_pursuit -->
     <arg name="lateral_controller_mode" value="mpc_follower" />
     <arg name="vehicle_info_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
   </include>

--- a/launch/tier4_autoware_launch/launch/autoware.launch.xml
+++ b/launch/tier4_autoware_launch/launch/autoware.launch.xml
@@ -57,7 +57,7 @@
   <!-- Perception -->
   <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml">
     <!-- options for mode: camera_lidar_fusion, lidar, camera -->
-    <arg name="mode" value="camera_lidar_fusion" />
+    <arg name="mode" value="lidar" />
     <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)" />
     <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>

--- a/launch/tier4_autoware_launch/launch/logging_simulator.launch.xml
+++ b/launch/tier4_autoware_launch/launch/logging_simulator.launch.xml
@@ -84,7 +84,6 @@
   <!-- Perception -->
   <group>
     <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml" if="$(var perception)">
-      <!-- options for mode: camera_lidar_fusion, lidar, camera -->
       <arg name="mode" value="lidar" />
       <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
       <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)" />
@@ -102,7 +101,6 @@
   <!-- Control -->
   <group>
     <include file="$(find-pkg-share tier4_control_launch)/launch/control.launch.py" if="$(var control)">
-      <!-- options for lateral_controller_mode: mpc_follower, pure_pursuit -->
       <arg name="lateral_controller_mode" value="mpc_follower" />
       <arg name="vehicle_info_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     </include>

--- a/launch/tier4_autoware_launch/launch/logging_simulator.launch.xml
+++ b/launch/tier4_autoware_launch/launch/logging_simulator.launch.xml
@@ -85,7 +85,7 @@
   <group>
     <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml" if="$(var perception)">
       <!-- options for mode: camera_lidar_fusion, lidar, camera -->
-      <arg name="mode" value="camera_lidar_fusion" />
+      <arg name="mode" value="lidar" />
       <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
       <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)" />
       <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="mode" default="camera_lidar_fusion" description="options: `camera_lidar_fusion`, `lidar` or `camera`"/>
+  <arg name="mode" description="options: `camera_lidar_fusion`, `lidar` or `camera`"/>
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`"/>
-  <!-- "camera_lidar_fusion", "lidar" or "camera" -->
   <arg name="image_raw0" default="/image_raw" description="image raw topic name"/>
   <arg name="camera_info0" default="/camera_info" description="camera info topic name"/>
   <arg name="image_raw1" default=""/>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="vehicle_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml" description="path to the file of vehicle info yaml" />
   <!-- common parameters -->
-  <arg name="mode" default="camera_lidar_fusion" description="options: `camera_lidar_fusion`, `lidar` or `camera`"/>
+  <arg name="mode" description="options: `camera_lidar_fusion`, `lidar` or `camera`"/>
   <arg name="image_raw0" default="/sensing/camera/camera0/image_rect_color" description="image raw topic name"/>
   <arg name="camera_info0" default="/sensing/camera/camera0/camera_info" description="camera info topic name"/>
   <arg name="image_raw1" default="/sensing/camera/camera1/image_rect_color"/>


### PR DESCRIPTION
## Description

While I'm writing https://github.com/autowarefoundation/autoware-documentation/pull/28, I found `logging_simulator.launch.xml` doesn't work correctly because there is no camera data in the sample log data.

So I'll change the default mode.

Also, I've removed unnecessary comments and default values.
Since we should always check the component interfaces and adapt to them during the integration phase, they are redundant information.

## Alternative methods

Making the perception mode as a global arg of `logging_simulator.launch.xml` can also solve the problem.
However, since I felt we have to clean up the args, I decided to change the default value for now.