### PR TITLE
test(simple_planning_simulator): add node test

### DIFF
--- a/simulator/simple_planning_simulator/CMakeLists.txt
+++ b/simulator/simple_planning_simulator/CMakeLists.txt
@@ -37,6 +37,15 @@ rclcpp_components_register_node(${PROJECT_NAME}
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(test_simple_planning_simulator
+    test/test_simple_planning_simulator.cpp
+    TIMEOUT 120
+  )
+
+  target_link_libraries(test_simple_planning_simulator
+    ${PROJECT_NAME}
+  )
 endif()
 
 

--- a/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -187,9 +187,19 @@ void declareVehicleInfoParams(rclcpp::NodeOptions & node_options)
   node_options.append_parameter_override("vehicle_height", 1.5);
 }
 
-void testVehicleMotion(const std::string & vehicle_model_type)
+
+
+// Send a control command and run the simulation.
+// Then check if the vehicle is moving in the desired direction.
+class TestSimplePlanningSimulator : public ::testing::TestWithParam<std::string>
+{
+};
+
+TEST_P(TestSimplePlanningSimulator, TestIdealSteerVel)
 {
   rclcpp::init(0, nullptr);
+
+  const auto vehicle_model_type = GetParam();
 
   std::cout << "\n\n vehicle model = " << vehicle_model_type << std::endl << std::endl;
   rclcpp::NodeOptions node_options;
@@ -253,29 +263,14 @@ void testVehicleMotion(const std::string & vehicle_model_type)
   rclcpp::shutdown();
 }
 
-// Send a control command and run the simulation.
-// Then check if the vehicle is moving in the desired direction.
-TEST(TestSimplePlanningSimulator, TestIdealSteerVel)
-{
-  testVehicleMotion("IDEAL_STEER_VEL");
-}
-TEST(TestSimplePlanningSimulator, TestIdealSteerAcc)
-{
-  testVehicleMotion("IDEAL_STEER_ACC");
-}
-TEST(TestSimplePlanningSimulator, TestIdealSteerAccGeared)
-{
-  testVehicleMotion("IDEAL_STEER_ACC_GEARED");
-}
-TEST(TestSimplePlanningSimulator, TestDelaySteerVel)
-{
-  testVehicleMotion("DELAY_STEER_VEL");
-}
-TEST(TestSimplePlanningSimulator, TestDelaySteerAcc)
-{
-  testVehicleMotion("DELAY_STEER_ACC");
-}
-TEST(TestSimplePlanningSimulator, TestDelaySteerAccGeared)
-{
-  testVehicleMotion("DELAY_STEER_ACC_GEARED");
-}
+const std::string VEHICLE_MODEL_LIST[] = {
+  "IDEAL_STEER_VEL",
+  "IDEAL_STEER_ACC",
+  "IDEAL_STEER_ACC_GEARED",
+  "DELAY_STEER_VEL",
+  "DELAY_STEER_ACC",
+  "DELAY_STEER_ACC_GEARED",
+};
+
+INSTANTIATE_TEST_CASE_P(
+  TestForEachVehicleModel, TestSimplePlanningSimulator, ::testing::ValuesIn(VEHICLE_MODEL_LIST));

--- a/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -12,111 +12,75 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <memory>
 #include "gtest/gtest.h"
-
 #include "simple_planning_simulator/simple_planning_simulator_core.hpp"
-#include "motion_common/motion_common.hpp"
+#include "tf2/utils.h"
+
+#include <memory>
 
 using autoware_auto_control_msgs::msg::AckermannControlCommand;
 using autoware_auto_vehicle_msgs::msg::GearCommand;
-using autoware_auto_vehicle_msgs::msg::VehicleControlCommand;
-using autoware_auto_vehicle_msgs::msg::VehicleKinematicState;
 using geometry_msgs::msg::PoseWithCovarianceStamped;
+using nav_msgs::msg::Odometry;
 
 using simulation::simple_planning_simulator::SimplePlanningSimulator;
 
-std::string toStrInfo(const VehicleKinematicState & state)
+std::string toStrInfo(const Odometry & o)
 {
-  const auto & s = state.state;
+  const auto & p = o.pose.pose;
+  const auto & t = o.twist.twist;
   std::stringstream ss;
-  ss << "state x: " << s.pose.position.x << ", y: " << s.pose.position.y << ", yaw: " <<
-    motion::motion_common::to_angle(
-    s.pose.orientation) << ", vx = " << s.longitudinal_velocity_mps << ", vy: " <<
-    s.lateral_velocity_mps <<
-    ", ax: " << s.acceleration_mps2 << ", steer: " << s.front_wheel_angle_rad;
+  ss << "state x: " << p.position.x << ", y: " << p.position.y
+     << ", yaw: " << tf2::getYaw(p.orientation) << ", vx = " << t.linear.x << ", vy: " << t.linear.y
+     << ", wz: " << t.angular.z;
   return ss.str();
 }
 
-const std::vector<std::string> vehicle_model_type_vec = { // NOLINT
-  "IDEAL_STEER_VEL",
-  "IDEAL_STEER_ACC",
-  "IDEAL_STEER_ACC_GEARED",
-  "DELAY_STEER_VEL",
-  "DELAY_STEER_ACC",
-  "DELAY_STEER_ACC_GEARED",
-};
-
-static constexpr float64_t COM_TO_BASELINK = 1.5;
 class PubSubNode : public rclcpp::Node
 {
 public:
-  PubSubNode()
-  : Node{"test_simple_planning_simulator_pubsub"}
+  PubSubNode() : Node{"test_simple_planning_simulator_pubsub"}
   {
-    kinematic_state_sub_ = create_subscription<VehicleKinematicState>(
-      "output/kinematic_state", rclcpp::QoS{1},
-      [this](const VehicleKinematicState::SharedPtr msg) {
-        current_state_ = msg;
+    current_odom_sub_ = create_subscription<Odometry>(
+      "output/odometry", rclcpp::QoS{1}, [this](const Odometry::SharedPtr msg) {
+        current_odom_ = msg;
       });
-    pub_control_command_ = create_publisher<VehicleControlCommand>(
-      "input/vehicle_control_command",
-      rclcpp::QoS{1});
-    pub_ackermann_command_ = create_publisher<AckermannControlCommand>(
-      "input/ackermann_control_command",
-      rclcpp::QoS{1});
-    pub_initialpose_ = create_publisher<PoseWithCovarianceStamped>(
-      "/initialpose",
-      rclcpp::QoS{1});
-    pub_state_cmd_ = create_publisher<GearCommand>(
-      "/input/vehicle_state_command",
-      rclcpp::QoS{1});
+    pub_ackermann_command_ =
+      create_publisher<AckermannControlCommand>("input/ackermann_control_command", rclcpp::QoS{1});
+    pub_initialpose_ = create_publisher<PoseWithCovarianceStamped>("/initialpose", rclcpp::QoS{1});
+    pub_gear_cmd_ = create_publisher<GearCommand>("/input/gear_command", rclcpp::QoS{1});
   }
 
-  rclcpp::Publisher<VehicleControlCommand>::SharedPtr pub_control_command_;
+  rclcpp::Subscription<Odometry>::SharedPtr current_odom_sub_;
   rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_ackermann_command_;
-  rclcpp::Publisher<GearCommand>::SharedPtr pub_state_cmd_;
+  rclcpp::Publisher<GearCommand>::SharedPtr pub_gear_cmd_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_initialpose_;
-  rclcpp::Subscription<VehicleKinematicState>::SharedPtr kinematic_state_sub_;
 
-  VehicleKinematicState::SharedPtr current_state_;
+  Odometry::SharedPtr current_odom_;
 };
-
-/**
- * @brief Generate a VehicleControlCommand message
- * @param [in] t timestamp
- * @param [in] steer [rad] steering
- * @param [in] vel [m/s] velocity
- * @param [in] acc [m/s²] acceleration
- */
-VehicleControlCommand cmdGen(
-  const builtin_interfaces::msg::Time & t, float32_t steer, float32_t vel, float32_t acc)
-{
-  VehicleControlCommand cmd;
-  cmd.stamp = t;
-  cmd.front_wheel_angle_rad = steer;
-  cmd.velocity_mps = vel;
-  cmd.long_accel_mps2 = acc;
-  return cmd;
-}
 
 /**
  * @brief Generate an AckermannControlCommand message
  * @param [in] t timestamp
  * @param [in] steer [rad] steering
+ * @param [in] steer_rate [rad/s] steering rotation rate
  * @param [in] vel [m/s] velocity
  * @param [in] acc [m/s²] acceleration
+ * @param [in] jerk [m/s3] jerk
  */
-AckermannControlCommand ackermannCmdGen(
-  const builtin_interfaces::msg::Time & t, float32_t steer, float32_t vel, float32_t acc)
+AckermannControlCommand cmdGen(
+  const builtin_interfaces::msg::Time & t, float32_t steer, float32_t steer_rate, float32_t vel,
+  float32_t acc, float32_t jerk)
 {
   AckermannControlCommand cmd;
   cmd.stamp = t;
   cmd.lateral.stamp = t;
   cmd.lateral.steering_tire_angle = steer;
+  cmd.lateral.steering_tire_rotation_rate = steer_rate;
   cmd.longitudinal.stamp = t;
   cmd.longitudinal.speed = vel;
   cmd.longitudinal.acceleration = acc;
+  cmd.longitudinal.jerk = jerk;
   return cmd;
 }
 
@@ -135,32 +99,13 @@ void resetInitialpose(rclcpp::Node::SharedPtr sim_node, std::shared_ptr<PubSubNo
 }
 
 void sendGear(
-  uint8_t gear, rclcpp::Node::SharedPtr sim_node,
-  std::shared_ptr<PubSubNode> pub_sub_node)
+  uint8_t gear, rclcpp::Node::SharedPtr sim_node, std::shared_ptr<PubSubNode> pub_sub_node)
 {
   GearCommand cmd;
   cmd.stamp = sim_node->now();
-  cmd.gear = gear;
+  cmd.command = gear;
   for (int i = 0; i < 10; ++i) {
-    pub_sub_node->pub_state_cmd_->publish(cmd);
-    rclcpp::spin_some(sim_node);
-    rclcpp::spin_some(pub_sub_node);
-    std::this_thread::sleep_for(std::chrono::milliseconds{10LL});
-  }
-}
-
-/**
- * @brief publish the given command message
- * @param [in] cmd command to publish
- * @param [in] sim_node pointer to the simulation node
- * @param [in] pub_sub_node pointer to the node used for communication
- */
-void sendCommand(
-  const VehicleControlCommand & cmd, rclcpp::Node::SharedPtr sim_node,
-  std::shared_ptr<PubSubNode> pub_sub_node)
-{
-  for (int i = 0; i < 150; ++i) {
-    pub_sub_node->pub_control_command_->publish(cmd);
+    pub_sub_node->pub_gear_cmd_->publish(cmd);
     rclcpp::spin_some(sim_node);
     rclcpp::spin_some(pub_sub_node);
     std::this_thread::sleep_for(std::chrono::milliseconds{10LL});
@@ -185,16 +130,6 @@ void sendCommand(
   }
 }
 
-VehicleKinematicState comToBaselink(const VehicleKinematicState & com)
-{
-  auto baselink = com;
-  float64_t yaw = motion::motion_common::to_angle(com.state.pose.orientation);
-  baselink.state.pose.position.x -= COM_TO_BASELINK * std::cos(yaw);
-  baselink.state.pose.position.y -= COM_TO_BASELINK * std::sin(yaw);
-  return baselink;
-}
-
-
 // Check which direction the vehicle is heading on the baselink coordinates.
 //                      y
 //                      |
@@ -205,183 +140,142 @@ VehicleKinematicState comToBaselink(const VehicleKinematicState & com)
 //        (Bwd-Right)   |
 //                      |
 //
-void isOnForward(const VehicleKinematicState & _state, const VehicleKinematicState & _init)
+void isOnForward(const Odometry & state, const Odometry & init)
 {
   float64_t forward_thr = 1.0;
-  auto state = comToBaselink(_state);
-  auto init = comToBaselink(_init);
-  float64_t dx = state.state.pose.position.x - init.state.pose.position.x;
+  float64_t dx = state.pose.pose.position.x - init.pose.pose.position.x;
   EXPECT_GT(dx, forward_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
 }
 
-void isOnBackward(const VehicleKinematicState & _state, const VehicleKinematicState & _init)
+void isOnBackward(const Odometry & state, const Odometry & init)
 {
   float64_t backward_thr = -1.0;
-  auto state = comToBaselink(_state);
-  auto init = comToBaselink(_init);
-  float64_t dx = state.state.pose.position.x - init.state.pose.position.x;
+  float64_t dx = state.pose.pose.position.x - init.pose.pose.position.x;
   EXPECT_LT(dx, backward_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
 }
 
-void isOnForwardLeft(const VehicleKinematicState & _state, const VehicleKinematicState & _init)
+void isOnForwardLeft(const Odometry & state, const Odometry & init)
 {
   float64_t forward_thr = 1.0;
   float64_t left_thr = 0.1f;
-  auto state = comToBaselink(_state);
-  auto init = comToBaselink(_init);
-  float64_t dx = state.state.pose.position.x - init.state.pose.position.x;
-  float64_t dy = state.state.pose.position.y - init.state.pose.position.y;
+  float64_t dx = state.pose.pose.position.x - init.pose.pose.position.x;
+  float64_t dy = state.pose.pose.position.y - init.pose.pose.position.y;
   EXPECT_GT(dx, forward_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
   EXPECT_GT(dy, left_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
 }
 
-void isOnBackwardRight(const VehicleKinematicState & _state, const VehicleKinematicState & _init)
+void isOnBackwardRight(const Odometry & state, const Odometry & init)
 {
   float64_t backward_thr = -1.0;
   float64_t right_thr = -0.1;
-  auto state = comToBaselink(_state);
-  auto init = comToBaselink(_init);
-  float64_t dx = state.state.pose.position.x - init.state.pose.position.x;
-  float64_t dy = state.state.pose.position.y - init.state.pose.position.y;
+  float64_t dx = state.pose.pose.position.x - init.pose.pose.position.x;
+  float64_t dy = state.pose.pose.position.y - init.pose.pose.position.y;
   EXPECT_LT(dx, backward_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
   EXPECT_LT(dy, right_thr) << "[curr] " << toStrInfo(state) << ", [init] " << toStrInfo(init);
 }
 
-// Send a control command and run the simulation.
-// Then check if the vehicle is moving in the desired direction.
-TEST(TestSimplePlanningSimulatorIdealSteerVel, TestMoving)
+void declareVehicleInfoParams(rclcpp::NodeOptions & node_options)
+{
+  node_options.append_parameter_override("wheel_radius", 0.5);
+  node_options.append_parameter_override("wheel_width", 0.2);
+  node_options.append_parameter_override("wheel_base", 3.0);
+  node_options.append_parameter_override("wheel_tread", 2.0);
+  node_options.append_parameter_override("front_overhang", 1.0);
+  node_options.append_parameter_override("rear_overhang", 1.0);
+  node_options.append_parameter_override("left_overhang", 0.5);
+  node_options.append_parameter_override("right_overhang", 0.5);
+  node_options.append_parameter_override("vehicle_height", 1.5);
+}
+
+void testVehicleMotion(const std::string & vehicle_model_type)
 {
   rclcpp::init(0, nullptr);
 
-  for (const auto & vehicle_model_type : vehicle_model_type_vec) {
-    std::cout << "\n\n vehicle model = " << vehicle_model_type << std::endl << std::endl;
-    rclcpp::NodeOptions node_options;
-    node_options.append_parameter_override("initialize_source", "INITIAL_POSE_TOPIC");
-    node_options.append_parameter_override("cg_to_rear_m", COM_TO_BASELINK);
-    node_options.append_parameter_override("vehicle_model_type", vehicle_model_type);
-    const auto sim_node = std::make_shared<SimplePlanningSimulator>(node_options);
+  std::cout << "\n\n vehicle model = " << vehicle_model_type << std::endl << std::endl;
+  rclcpp::NodeOptions node_options;
+  node_options.append_parameter_override("initialize_source", "INITIAL_POSE_TOPIC");
+  node_options.append_parameter_override("vehicle_model_type", vehicle_model_type);
+  node_options.append_parameter_override("initial_engage_state", true);
+  node_options.append_parameter_override("add_measurement_noise", false);
+  declareVehicleInfoParams(node_options);
+  const auto sim_node = std::make_shared<SimplePlanningSimulator>(node_options);
 
-    const auto pub_sub_node = std::make_shared<PubSubNode>();
+  const auto pub_sub_node = std::make_shared<PubSubNode>();
 
-    const float32_t target_vel = 5.0f;
-    const float32_t target_acc = 5.0f;
-    const float32_t target_steer = 0.2f;
+  const float32_t target_vel = 5.0f;
+  const float32_t target_acc = 5.0f;
+  const float32_t target_steer = 0.2f;
 
-    auto _resetInitialpose = [&]() {resetInitialpose(sim_node, pub_sub_node);};
-    auto _sendFwdGear = [&]() {sendGear(GearCommand::DRIVE, sim_node, pub_sub_node);};
-    auto _sendBwdGear = [&]() {sendGear(GearCommand::REVERSE, sim_node, pub_sub_node);};
-    auto _sendCommand = [&](const auto & _cmd) {
-        sendCommand(_cmd, sim_node, pub_sub_node);
-      };
+  auto _resetInitialpose = [&]() { resetInitialpose(sim_node, pub_sub_node); };
+  auto _sendFwdGear = [&]() { sendGear(GearCommand::DRIVE, sim_node, pub_sub_node); };
+  auto _sendBwdGear = [&]() { sendGear(GearCommand::REVERSE, sim_node, pub_sub_node); };
+  auto _sendCommand = [&](const auto & _cmd) { sendCommand(_cmd, sim_node, pub_sub_node); };
 
-    // check pub-sub connections
-    {
-      size_t expected = 1;
-      EXPECT_EQ(pub_sub_node->pub_control_command_->get_subscription_count(), expected);
-      EXPECT_EQ(pub_sub_node->pub_ackermann_command_->get_subscription_count(), expected);
-      EXPECT_EQ(pub_sub_node->pub_state_cmd_->get_subscription_count(), expected);
-      EXPECT_EQ(pub_sub_node->pub_initialpose_->get_subscription_count(), expected);
-      EXPECT_EQ(pub_sub_node->kinematic_state_sub_->get_publisher_count(), expected);
-    }
-
-    // check initial pose
-    _resetInitialpose();
-    const auto init_state = *(pub_sub_node->current_state_);
-
-    // go forward
-    _resetInitialpose();
-    _sendFwdGear();
-    _sendCommand(cmdGen(sim_node->now(), 0.0f, target_vel, target_acc));
-    isOnForward(*(pub_sub_node->current_state_), init_state);
-
-    // go backward
-    _resetInitialpose();
-    _sendBwdGear();
-    _sendCommand(cmdGen(sim_node->now(), 0.0f, -target_vel, -target_acc));
-    isOnBackward(*(pub_sub_node->current_state_), init_state);
-
-    // go forward left
-    _resetInitialpose();
-    _sendFwdGear();
-    _sendCommand(cmdGen(sim_node->now(), target_steer, target_vel, target_acc));
-    isOnForwardLeft(*(pub_sub_node->current_state_), init_state);
-
-    // go backward right
-    _resetInitialpose();
-    _sendBwdGear();
-    _sendCommand(cmdGen(sim_node->now(), -target_steer, -target_vel, -target_acc));
-    isOnBackwardRight(*(pub_sub_node->current_state_), init_state);
+  // check pub-sub connections
+  {
+    size_t expected = 1;
+    EXPECT_EQ(pub_sub_node->pub_ackermann_command_->get_subscription_count(), expected);
+    EXPECT_EQ(pub_sub_node->pub_gear_cmd_->get_subscription_count(), expected);
+    EXPECT_EQ(pub_sub_node->pub_initialpose_->get_subscription_count(), expected);
+    EXPECT_EQ(pub_sub_node->current_odom_sub_->get_publisher_count(), expected);
   }
+
+  // check initial pose
+  _resetInitialpose();
+  const auto init_state = *(pub_sub_node->current_odom_);
+
+  // go forward
+  _resetInitialpose();
+  _sendFwdGear();
+  _sendCommand(cmdGen(sim_node->now(), 0.0f, 0.0f, target_vel, target_acc, 0.0f));
+  isOnForward(*(pub_sub_node->current_odom_), init_state);
+
+  // go backward
+  // NOTE: positive acceleration with reverse gear drives the vehicle backward.
+  _resetInitialpose();
+  _sendBwdGear();
+  _sendCommand(cmdGen(sim_node->now(), 0.0f, 0.0f, -target_vel, target_acc, 0.0f));
+  isOnBackward(*(pub_sub_node->current_odom_), init_state);
+
+  // go forward left
+  _resetInitialpose();
+  _sendFwdGear();
+  _sendCommand(cmdGen(sim_node->now(), target_steer, 0.0f, target_vel, target_acc, 0.0f));
+  isOnForwardLeft(*(pub_sub_node->current_odom_), init_state);
+
+  // go backward right
+  // NOTE: positive acceleration with reverse gear drives the vehicle backward.
+  _resetInitialpose();
+  _sendBwdGear();
+  _sendCommand(cmdGen(sim_node->now(), -target_steer, 0.0f, -target_vel, target_acc, 0.0f));
+  isOnBackwardRight(*(pub_sub_node->current_odom_), init_state);
 
   rclcpp::shutdown();
 }
 
 // Send a control command and run the simulation.
 // Then check if the vehicle is moving in the desired direction.
-TEST(test_simple_planning_simulator, test_moving_ackermann)
+TEST(TestSimplePlanningSimulator, TestIdealSteerVel)
 {
-  rclcpp::init(0, nullptr);
-
-  for (const auto & vehicle_model_type : vehicle_model_type_vec) {
-    std::cout << "\n\n vehicle model = " << vehicle_model_type << std::endl << std::endl;
-    rclcpp::NodeOptions node_options;
-    node_options.append_parameter_override("initialize_source", "INITIAL_POSE_TOPIC");
-    node_options.append_parameter_override("cg_to_rear_m", COM_TO_BASELINK);
-    node_options.append_parameter_override("vehicle_model_type", vehicle_model_type);
-    const auto sim_node = std::make_shared<SimplePlanningSimulator>(node_options);
-
-    const auto pub_sub_node = std::make_shared<PubSubNode>();
-
-    const float32_t target_vel = 5.0f;
-    const float32_t target_acc = 5.0f;
-    const float32_t target_steer = 0.2f;
-
-    auto _resetInitialpose = [&]() {resetInitialpose(sim_node, pub_sub_node);};
-    auto _sendFwdGear = [&]() {sendGear(GearCommand::DRIVE, sim_node, pub_sub_node);};
-    auto _sendBwdGear =
-      [&]() {sendGear(GearCommand::REVERSE, sim_node, pub_sub_node);};
-    auto _sendCommand = [&](const auto & _cmd) {
-        sendCommand(_cmd, sim_node, pub_sub_node);
-      };
-
-    // check pub-sub connections
-    {
-      size_t expected = 1;
-      EXPECT_EQ(pub_sub_node->pub_control_command_->get_subscription_count(), expected);
-      EXPECT_EQ(pub_sub_node->pub_ackermann_command_->get_subscription_count(), expected);
-      EXPECT_EQ(pub_sub_node->pub_state_cmd_->get_subscription_count(), expected);
-      EXPECT_EQ(pub_sub_node->pub_initialpose_->get_subscription_count(), expected);
-      EXPECT_EQ(pub_sub_node->kinematic_state_sub_->get_publisher_count(), expected);
-    }
-
-    // check initial pose
-    _resetInitialpose();
-    const auto init_state = *(pub_sub_node->current_state_);
-
-    // go forward
-    _resetInitialpose();
-    _sendFwdGear();
-    _sendCommand(ackermannCmdGen(sim_node->now(), 0.0f, target_vel, target_acc));
-    isOnForward(*(pub_sub_node->current_state_), init_state);
-
-    // go backward
-    _resetInitialpose();
-    _sendBwdGear();
-    _sendCommand(ackermannCmdGen(sim_node->now(), 0.0f, -target_vel, -target_acc));
-    isOnBackward(*(pub_sub_node->current_state_), init_state);
-
-    // go forward left
-    _resetInitialpose();
-    _sendFwdGear();
-    _sendCommand(ackermannCmdGen(sim_node->now(), target_steer, target_vel, target_acc));
-    isOnForwardLeft(*(pub_sub_node->current_state_), init_state);
-
-    // go backward right
-    _resetInitialpose();
-    _sendBwdGear();
-    _sendCommand(ackermannCmdGen(sim_node->now(), -target_steer, -target_vel, -target_acc));
-    isOnBackwardRight(*(pub_sub_node->current_state_), init_state);
-  }
-
-  rclcpp::shutdown();
+  testVehicleMotion("IDEAL_STEER_VEL");
+}
+TEST(TestSimplePlanningSimulator, TestIdealSteerAcc)
+{
+  testVehicleMotion("IDEAL_STEER_ACC");
+}
+TEST(TestSimplePlanningSimulator, TestIdealSteerAccGeared)
+{
+  testVehicleMotion("IDEAL_STEER_ACC_GEARED");
+}
+TEST(TestSimplePlanningSimulator, TestDelaySteerVel)
+{
+  testVehicleMotion("DELAY_STEER_VEL");
+}
+TEST(TestSimplePlanningSimulator, TestDelaySteerAcc)
+{
+  testVehicleMotion("DELAY_STEER_ACC");
+}
+TEST(TestSimplePlanningSimulator, TestDelaySteerAccGeared)
+{
+  testVehicleMotion("DELAY_STEER_ACC_GEARED");
 }


### PR DESCRIPTION
## Related Issue(required)

None

## Description(required)

The test code in the `simple_planning_simulator` was disabled when it was ported from the autoware.auto. This PR fixes some message and topic interface issues and enables the existing test code.

Contents of this test are described below:

1. `pubsub_node` (defined in the test code locally) and `simple_planning_simulator` nodes are generated in the test code.
2. Generate the control commands in the test code.
3. The control command is published through the `pubsub_node`.
4. The `simple_planning_simulator` receives the control command, calculates the vehicle position, and publishes it.
5. The `pubsub_node` receives the calculated vehicle position.
6. The test code checks if the vehicle moves in the appropriate direction.

The above testing runs for all `vehicle_model_type`.

## Review Procedure(required)

run `colcon test`.

## Related PR(optional)

None

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
