### PR TITLE
chore: remove unnecessary comments for uncrustify

### DIFF
--- a/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
-
-// *INDENT-OFF*
 #include "compare_map_segmentation/voxel_based_approximate_compare_map_filter_nodelet.hpp"
-// *INDENT-ON*
 
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/search/kdtree.h>
 #include <pcl/segmentation/segment_differences.h>
+
+#include <vector>
 
 namespace compare_map_segmentation
 {

--- a/perception/occupancy_grid_map_outlier_filter/include/occupancy_grid_map_outlier_filter/occupancy_grid_map_outlier_filter_nodelet.hpp
+++ b/perception/occupancy_grid_map_outlier_filter/include/occupancy_grid_map_outlier_filter/occupancy_grid_map_outlier_filter_nodelet.hpp
@@ -81,16 +81,13 @@ private:
 private:
   class Debugger
   {
-    // *INDENT-OFF*
   public:
-    // *INDENT-ON*
     explicit Debugger(OccupancyGridMapOutlierFilterComponent & node);
     void publishOutlier(const PclPointCloud & input, const Header & header);
     void publishHighConfidence(const PclPointCloud & input, const Header & header);
     void publishLowConfidence(const PclPointCloud & input, const Header & header);
-    // *INDENT-OFF*
+
   private:
-    // *INDENT-ON*
     void transformToBaseLink(
       const PclPointCloud & input, const Header & header, PointCloud2 & output);
     rclcpp::Publisher<PointCloud2>::SharedPtr outlier_pointcloud_pub_;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -16,9 +16,12 @@
 #define MOTION_VELOCITY_SMOOTHER__MOTION_VELOCITY_SMOOTHER_NODE_HPP_
 
 #include "motion_velocity_smoother/resample.hpp"
+#include "motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp"
 #include "motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp"
 #include "motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
 #include "motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
+#include "motion_velocity_smoother/smoother/smoother_base.hpp"
+#include "motion_velocity_smoother/trajectory_utils.hpp"
 #include "osqp_interface/osqp_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
@@ -42,12 +45,6 @@
 #include <string>
 #include <tuple>
 #include <vector>
-
-// *INDENT-OFF*
-#include "motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp"
-// *INDENT-ON*
-#include "motion_velocity_smoother/smoother/smoother_base.hpp"
-#include "motion_velocity_smoother/trajectory_utils.hpp"
 
 namespace motion_velocity_smoother
 {

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// *INDENT-OFF*
 #ifndef MOTION_VELOCITY_SMOOTHER__SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER_HPP_  // NOLINT
 #define MOTION_VELOCITY_SMOOTHER__SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER_HPP_  // NOLINT
-// *INDENT-ON*
 
+#include "motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
+#include "motion_velocity_smoother/smoother/smoother_base.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tier4_autoware_utils/trajectory/trajectory.hpp"
@@ -27,11 +27,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-// *INDENT-OFF*
-#include "motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
-// *INDENT-ON*
-#include "motion_velocity_smoother/smoother/smoother_base.hpp"
 
 namespace motion_velocity_smoother
 {

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// *INDENT-OFF*
 #ifndef MOTION_VELOCITY_SMOOTHER__SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER__VELOCITY_PLANNING_UTILS_HPP_  // NOLINT
 #define MOTION_VELOCITY_SMOOTHER__SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER__VELOCITY_PLANNING_UTILS_HPP_  // NOLINT
-// *INDENT-ON*
 
 #include "motion_velocity_smoother/linear_interpolation.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp"
+
 #include <algorithm>
 #include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
-
-// *INDENT-OFF*
-#include "motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp"
-// *INDENT-ON*
 
 namespace
 {
@@ -544,14 +542,12 @@ bool AnalyticalJerkConstrainedSmoother::calcEnoughDistForDecel(
   const double a0 = trajectory.at(start_index).acceleration_mps2;
   const double jerk_acc = std::abs(planning_jerk);
   const double jerk_dec = planning_jerk;
-  // *INDENT-OFF*
   auto calcMinAcc = [&params](const double planning_jerk) {
     if (planning_jerk < params.backward.min_jerk_mild_stop) {
       return params.backward.min_acc;
     }
     return params.backward.min_acc_mild_stop;
   };
-  // *INDENT-ON*
   const double min_acc = calcMinAcc(planning_jerk);
   type = 0;
   times.clear();
@@ -589,14 +585,12 @@ bool AnalyticalJerkConstrainedSmoother::applyDecelVelocityFilter(
   const double a0 = output_trajectory.at(decel_start_index).acceleration_mps2;
   const double jerk_acc = std::abs(planning_jerk);
   const double jerk_dec = planning_jerk;
-  // *INDENT-OFF*
   auto calcMinAcc = [&params](const double planning_jerk) {
     if (planning_jerk < params.backward.min_jerk_mild_stop) {
       return params.backward.min_acc;
     }
     return params.backward.min_acc_mild_stop;
   };
-  // *INDENT-ON*
   const double min_acc = calcMinAcc(planning_jerk);
 
   if (!analytical_velocity_planning_utils::calcStopVelocityWithConstantJerkAccLimit(

--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
+
 #include <algorithm>
 #include <vector>
-
-// *INDENT-OFF*
-#include "motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
-// *INDENT-ON*
 
 namespace motion_velocity_smoother
 {

--- a/sensing/laserscan_to_occupancy_grid_map/include/laserscan_to_occupancy_grid_map/updater/occupancy_grid_map_binary_bayes_filter_updater.hpp
+++ b/sensing/laserscan_to_occupancy_grid_map/include/laserscan_to_occupancy_grid_map/updater/occupancy_grid_map_binary_bayes_filter_updater.hpp
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// *INDENT-OFF*
 #ifndef LASERSCAN_TO_OCCUPANCY_GRID_MAP__UPDATER__OCCUPANCY_GRID_MAP_BINARY_BAYES_FILTER_UPDATER_HPP_
 #define LASERSCAN_TO_OCCUPANCY_GRID_MAP__UPDATER__OCCUPANCY_GRID_MAP_BINARY_BAYES_FILTER_UPDATER_HPP_
-// *INDENT-ON*
 
 #include "laserscan_to_occupancy_grid_map/updater/occupancy_grid_map_updater_interface.hpp"
 


### PR DESCRIPTION
Since `INDENT-OFF` and `INDENT-ON` are for `uncrustify`, I've removed them.