### PR TITLE
fix(behavior_path_planner): fix utility function

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -484,7 +484,7 @@ bool lerpByTimeStamp(const PredictedPath & path, const double t_query, Pose * le
     return false;
   }
 
-  const double t_final = time_step.seconds() * static_cast<double>(path.path.size());
+  const double t_final = time_step.seconds() * static_cast<double>(path.path.size() - 1);
   if (t_query > t_final) {
     RCLCPP_DEBUG_STREAM(
       rclcpp::get_logger("behavior_path_planner").get_child("utilities"),


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Related Issue(required)

<!-- Link related issue -->

## Description(required)

Fix the utility function in behavior_path_planner.

The timestamp of the last point in predicted_path should be `base timestamp + timstep * (path.size() -1)`
But, in the current code, the last point in predicted_path is `base timestamp + timstep * (path.size() )`

Because of this bug, the following errors are output frequently.
![image](https://user-images.githubusercontent.com/59680180/155119194-a0f38b21-dd67-40d1-9e4f-5d432b796ba5.png)

This PR fixed it.

<!-- Describe what this PR changes. -->

## Review Procedure(required)

comment out the followingapproval topic in behavior_planning.launch.py
```
            ExecuteProcess(
                cmd=[
                    "ros2",
                    "topic",
                    "pub",
                    "/planning/scenario_planning/lane_driving/behavior_planning/"
                    "behavior_path_planner/path_change_approval",
                    "tier4_planning_msgs/msg/Approval",
                    "{approval: true}",
                    "-r",
                    "10",
                ]
            ),
```

(1)Run the planning simulator, and set a goal which requires lane-change.
(2)Put the virtual dynamic object on the path of ego-vehicle

![image](https://user-images.githubusercontent.com/59680180/155118750-5ff70b3c-85e0-4301-9c81-5ca12998b8f4.png)

(3)Confirm that the following errors are not output by merging this PR
![image](https://user-images.githubusercontent.com/59680180/155119194-a0f38b21-dd67-40d1-9e4f-5d432b796ba5.png)


<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
