### PR TITLE
fix(tier4_vehicle_launch): refer to launch packages to find vehicle_interface.launch.xml

### DIFF
--- a/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
+++ b/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
@@ -6,7 +6,7 @@
   <arg name="simulation" default="false" description="use simulation"/>
   <arg name="initial_engage_state" default="false" description="/vehicle/engage state after starting Autoware"/>
 
-  <let name="vehicle_model_pkg" value="$(find-pkg-share $(var vehicle_model)_description)"/>
+  <let name="vehicle_launch_pkg" value="$(find-pkg-share $(var vehicle_model)_launch)"/>
 
   <!-- vehicle description -->
   <group>
@@ -18,7 +18,7 @@
 
   <!-- vehicle interface -->
   <group unless="$(var simulation)">
-    <include file="$(var vehicle_model_pkg)/launch/vehicle_interface.launch.xml">
+    <include file="$(var vehicle_launch_pkg)/launch/vehicle_interface.launch.xml">
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
       <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
     </include>


### PR DESCRIPTION
It has moved.
https://github.com/autowarefoundation/sample_vehicle_launch/blob/7b9294ba3177515bf41f3f90f8858453f9844123/sample_vehicle_launch/launch/vehicle_interface.launch.xml