### PR TITLE
fix(side_shift): side shift unable to properly reset

### DIFF
--- a/planning/behavior_path_planner/config/side_shift/side_shift.param.yaml
+++ b/planning/behavior_path_planner/config/side_shift/side_shift.param.yaml
@@ -6,3 +6,4 @@
       shifting_lateral_jerk: 0.2
       min_shifting_distance: 5.0
       min_shifting_speed: 5.56
+      shift_request_time_limit: 1.0

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -56,13 +56,13 @@ struct SideShiftRequestTimer
 
   bool override_request = true;
 
-  bool isRequestAllowed(const double & change_time)
+  bool isRequestAllowed(const double & min_request_time_sec)
   {
     time_point<high_resolution_clock> current_request_clock = high_resolution_clock::now();
-    const auto requested =
+    const auto interval_from_last_time_sec =
       duration<double, std::milli>(current_request_clock - last_request_clock).count() * 0.001;
 
-    if (requested >= change_time && override_request) {
+    if (interval_from_last_time_sec >= min_request_time_sec && override_request) {
       last_request_clock = current_request_clock;
       return true;
     } else {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -48,6 +48,7 @@ struct SideShiftParameters
   double drivable_area_resolution;
   double drivable_area_width;
   double drivable_area_height;
+  double shift_request_time_limit;
 };
 
 struct SideShiftRequestTimer

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -24,6 +24,7 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -32,6 +33,9 @@ namespace behavior_path_planner
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::OccupancyGrid;
+using std::chrono::duration;
+using std::chrono::high_resolution_clock;
+using std::chrono::time_point;
 using tier4_planning_msgs::msg::LateralOffset;
 
 struct SideShiftParameters
@@ -44,6 +48,27 @@ struct SideShiftParameters
   double drivable_area_resolution;
   double drivable_area_width;
   double drivable_area_height;
+};
+
+struct SideShiftRequestTimer
+{
+  time_point<high_resolution_clock> last_request_clock = high_resolution_clock::now();
+
+  bool override_request = true;
+
+  bool isRequestAllowed(const double & change_time)
+  {
+    time_point<high_resolution_clock> current_request_clock = high_resolution_clock::now();
+    const auto requested =
+      duration<double, std::milli>(current_request_clock - last_request_clock).count() * 0.001;
+
+    if (requested >= change_time && override_request) {
+      last_request_clock = current_request_clock;
+      return true;
+    } else {
+      return false;
+    }
+  }
 };
 
 class SideShiftModule : public SceneModuleInterface
@@ -107,6 +132,8 @@ private:
   inline PoseStamped getEgoPose() const { return *(planner_data_->self_pose); }
   PathWithLaneId calcCenterLinePath(
     const std::shared_ptr<const PlannerData> & planner_data, const PoseStamped & pose) const;
+
+  SideShiftRequestTimer request_time;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -51,27 +51,6 @@ struct SideShiftParameters
   double shift_request_time_limit;
 };
 
-struct SideShiftRequestTimer
-{
-  time_point<high_resolution_clock> last_request_clock = high_resolution_clock::now();
-
-  bool override_request = true;
-
-  bool isRequestAllowed(const double & min_request_time_sec)
-  {
-    time_point<high_resolution_clock> current_request_clock = high_resolution_clock::now();
-    const auto interval_from_last_time_sec =
-      duration<double, std::milli>(current_request_clock - last_request_clock).count() * 0.001;
-
-    if (interval_from_last_time_sec >= min_request_time_sec && override_request) {
-      last_request_clock = current_request_clock;
-      return true;
-    } else {
-      return false;
-    }
-  }
-};
-
 class SideShiftModule : public SceneModuleInterface
 {
 public:
@@ -80,6 +59,8 @@ public:
 
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
+  bool isReadyForNextRequest(
+    const double & min_request_time_sec, bool override_requests = false) const noexcept;
   BT::NodeStatus updateState() override;
   void updateData() override;
   BehaviorModuleOutput plan() override;
@@ -134,7 +115,7 @@ private:
   PathWithLaneId calcCenterLinePath(
     const std::shared_ptr<const PlannerData> & planner_data, const PoseStamped & pose) const;
 
-  SideShiftRequestTimer request_timer_;
+  mutable rclcpp::Time last_requested_shift_change_time_{clock_->now()};
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -133,7 +133,7 @@ private:
   PathWithLaneId calcCenterLinePath(
     const std::shared_ptr<const PlannerData> & planner_data, const PoseStamped & pose) const;
 
-  SideShiftRequestTimer request_time;
+  SideShiftRequestTimer request_timer_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -190,6 +190,7 @@ SideShiftParameters BehaviorPathPlannerNode::getSideShiftParam()
   p.shifting_lateral_jerk = dp("shifting_lateral_jerk", 0.2);
   p.min_shifting_distance = dp("min_shifting_distance", 5.0);
   p.min_shifting_speed = dp("min_shifting_speed", 5.56);
+  p.shift_request_time_limit = dp("shift_request_time_limit", 1.0);
 
   return p;
 }

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -74,7 +74,7 @@ void SideShiftModule::initVariables()
   lateral_offset_ = 0.0;
   prev_output_ = ShiftedPath{};
   path_shifter_ = PathShifter{};
-  request_time = SideShiftRequestTimer();
+  request_timer = SideShiftRequestTimer();
 }
 
 void SideShiftModule::onEntry()

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -74,7 +74,7 @@ void SideShiftModule::initVariables()
   lateral_offset_ = 0.0;
   prev_output_ = ShiftedPath{};
   path_shifter_ = PathShifter{};
-  request_timer = SideShiftRequestTimer();
+  request_timer_ = SideShiftRequestTimer();
 }
 
 void SideShiftModule::onEntry()
@@ -306,7 +306,7 @@ void SideShiftModule::onLateralOffset(const LateralOffset::ConstSharedPtr latera
   }
 
   // new offset is requested.
-  if (request_time.isRequestAllowed(parameters_.time_to_start_shifting)) {
+  if (request_timer_.isRequestAllowed(parameters_.time_to_start_shifting)) {
     lateral_offset_change_request_ = true;
 
     lateral_offset_ = new_lateral_offset;

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -127,7 +127,7 @@ BT::NodeStatus SideShiftModule::updateState()
       const auto length = std::fabs(last_sp.get().length);
       const auto lateral_offset = std::fabs(lateral_offset_);
       offset_diff = lateral_offset - length;
-      if(!isAlmostZero(offset_diff)){
+      if (!isAlmostZero(offset_diff)) {
         lateral_offset_change_request_ = true;
       }
     }

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -74,6 +74,7 @@ void SideShiftModule::initVariables()
   lateral_offset_ = 0.0;
   prev_output_ = ShiftedPath{};
   path_shifter_ = PathShifter{};
+  request_timer_ = SideShiftRequestTimer();
 }
 
 void SideShiftModule::onEntry()
@@ -113,20 +114,6 @@ bool SideShiftModule::isExecutionRequested() const
 bool SideShiftModule::isExecutionReady() const
 {
   return true;  // TODO(Horibe) is it ok to say "always safe"?
-}
-
-bool SideShiftModule::isReadyForNextRequest(
-  const double & min_request_time_sec, bool override_requests) const noexcept
-{
-  rclcpp::Time current_time = clock_->now();
-  const auto interval_from_last_request_sec = current_time - last_requested_shift_change_time_;
-
-  if (interval_from_last_request_sec.seconds() >= min_request_time_sec && !override_requests) {
-    last_requested_shift_change_time_ = current_time;
-    return true;
-  }
-
-  return false;
 }
 
 BT::NodeStatus SideShiftModule::updateState()
@@ -327,7 +314,7 @@ void SideShiftModule::onLateralOffset(const LateralOffset::ConstSharedPtr latera
       getLogger(), "Shift request time might be too low. Generated trajectory might be wavy");
   }
   // new offset is requested.
-  if (isReadyForNextRequest(parameters_.shift_request_time_limit)) {
+  if (request_timer_.isRequestAllowed(parameters_.shift_request_time_limit)) {
     lateral_offset_change_request_ = true;
 
     lateral_offset_ = new_lateral_offset;

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -129,10 +129,10 @@ BT::NodeStatus SideShiftModule::updateState()
       const auto offset_diff = lateral_offset - length;
       if (!isAlmostZero(offset_diff)) {
         lateral_offset_change_request_ = true;
-        return true;
+        return false;
       }
     }
-    return false;
+    return true;
   }();
 
   const bool no_offset_diff = isOffsetDiffAlmostZero;


### PR DESCRIPTION
Add comparison between lateral offset and shift point.

the last shift point was compared.

Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Related Issue(required)

#441 

## Description(required)

Shifting happen (as the image below) even despite reset button was pressed.

<img src="https://user-images.githubusercontent.com/93502286/155637344-3c1bbb26-1592-4b81-8924-a077b66c8cc7.png" width="500">

The following is the current implementation of `updateStatus` function

<img src="https://user-images.githubusercontent.com/93502286/156111701-33196ada-267a-4f29-b241-31c0f543e719.png" width="500">

This PR adds shift point with lateral offset comparison
<img src="https://user-images.githubusercontent.com/93502286/156499585-347bd7dd-e469-435e-999c-2b74f05c588d.png" width="500">

And prevents continuous lateral offset change request by modifying
following `onLateralOffset` function

<img src="https://user-images.githubusercontent.com/93502286/156113636-d4745e40-3ad9-46cf-855c-7e673980920f.png" width="400">

to 

<img src="https://user-images.githubusercontent.com/93502286/156499797-9e1042a7-c9d5-498a-966f-07679a093ad4.png" width="500">

## Review Procedure(required)

Require updated [configuration file](https://github.com/tier4/autoware_launch/pull/226)
1. Run FOA Console and Planning Simulator.
2. Select start position and goal.
3. Engage ego vehicle.
4. While ego vehicle is moving, perform side shift to the left and right again and again.
5. Then press reset to return shift point to the middle of the lane.
6. Let ego vehicle stay for some time to see whether there is any shifting occured.

<img src="https://user-images.githubusercontent.com/93502286/155638795-f0cf42c8-9810-4658-a744-009033ec1d8b.png" width="500">


## Related PR(optional)

[launch file](https://github.com/tier4/autoware_launch/pull/226)

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
