### PR TITLE
fix: change empty pointcloud processing

### DIFF
--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
@@ -354,10 +354,6 @@ void PointCloudConcatenateDataSynchronizerComponent::cloud_callback(
   const sensor_msgs::msg::PointCloud2::SharedPtr & input_ptr, const std::string & topic_name)
 {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (input_ptr->data.empty()) {
-    RCLCPP_WARN(get_logger(), "input pointcloud is empty.");
-    return;
-  }
   sensor_msgs::msg::PointCloud2::SharedPtr xyzi_input_ptr(new sensor_msgs::msg::PointCloud2());
   convertToXYZICloud(input_ptr, xyzi_input_ptr);
 

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
@@ -87,11 +87,6 @@ void DualReturnOutlierFilterComponent::filter(
   PointCloud2 & output)
 {
   boost::mutex::scoped_lock lock(mutex_);
-  if (input->data.empty()) {
-    output.header = input->header;
-    RCLCPP_WARN(get_logger(), "input pointcloud is empty.");
-    return;
-  }
   pcl::PointCloud<return_type_cloud::PointXYZIRADT>::Ptr pcl_input(
     new pcl::PointCloud<return_type_cloud::PointXYZIRADT>);
   pcl::fromROSMsg(*input, *pcl_input);

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -39,10 +39,6 @@ void RingOutlierFilterComponent::filter(
   PointCloud2 & output)
 {
   boost::mutex::scoped_lock lock(mutex_);
-  output.header = input->header;
-  if (input->row_step < 1) {
-    return;
-  }
   std::unordered_map<uint16_t, std::vector<std::size_t>> input_ring_map;
   input_ring_map.reserve(128);
   sensor_msgs::msg::PointCloud2::SharedPtr input_ptr =


### PR DESCRIPTION
Signed-off-by: Shinnosuke Hirakawa <shinnosuke.hirakawa@tier4.jp>

## Related Issue(required)

<!-- Link related issue -->

## Description(required)
### Problem
- The current concatenate process ignore empty input point clouds
  - Ignoring the empty point clouds can cause a timeout.
- The current outlier filters outputs a point cloud without the original `fields` information when an empty point cloud is input.
  - Unlike point clouds without `points`, point clouds without `fields` are difficult to process without errors in other nodes
```
Example of Pointcloud2 without fields data
---
header:
  stamp:
    sec: 1644389857
    nanosec: 588929280
  frame_id: base_link
height: 0
width: 0
fields: '<sequence type: sensor_msgs/msg/PointField, length: 0>'
is_bigendian: false
point_step: 0
row_step: 0
data: '<sequence type: uint8, length: 0>'
is_dense: false
```
### This PR
 - Fix `ConcatenateData` to merge empty point clouds as well
 - Fix `RingOutlierFilter` and `DualReturnOutlierFilter` to keep `fields` data when an empty point cloud is input
   - By Keeping `fields`, other nodes including `ConcatenateData` can process correctly

## Review Procedure(required)
<!-- Explain how to review this PR. -->
- Play rosbags and check pointclouds and rosout
  - It is desirable to also try inputting an empty point cloud.

## Related PR(optional)

<!-- Link related PR -->
https://github.com/autowarefoundation/autoware.universe/pull/253
https://github.com/autowarefoundation/autoware.universe/pull/373

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
