### PR TITLE
fix(route_handler): fix backward search logic

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1733,8 +1733,8 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
         }
 
         // get previous lane, and return false if previous lane does not exist
-        lanelet::ConstLanelet prev_lane;
-        if (!route_handler->getPreviousLaneletWithinRoute(lane, &prev_lane)) {
+        lanelet::ConstLanelets prev_lanes;
+        if (!route_handler->getPreviousLaneletsWithinRoute(lane, &prev_lanes)) {
           return false;
         }
 

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -90,8 +90,8 @@ public:
   std::vector<lanelet::ConstLanelet> getLanesAfterGoal(const double vehicle_length) const;
 
   // for lanelet
-  bool getPreviousLaneletWithinRoute(
-    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * prev_lanelet) const;
+  bool getPreviousLaneletsWithinRoute(
+    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelets * prev_lanelets) const;
   bool isDeadEndLanelet(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getLaneletsFromPoint(const lanelet::ConstPoint3d & point) const;
 

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1515,7 +1515,10 @@ std::vector<HADMapSegment> RouteHandler::createMapSegments(
 lanelet::ConstLanelets RouteHandler::getMainLanelets(
   const lanelet::ConstLanelets & path_lanelets) const
 {
-  auto lanelet_sequence = getLaneletSequence(path_lanelets.back());
+  const double backward_distance =
+    boost::geometry::length(path_lanelets.front().centerline().basicLineString());
+  const double epsilon = 0.01;
+  auto lanelet_sequence = getLaneletSequence(path_lanelets.back(), backward_distance + epsilon);
   lanelet::ConstLanelets main_lanelets;
   while (!lanelet_sequence.empty()) {
     main_lanelets.insert(main_lanelets.begin(), lanelet_sequence.begin(), lanelet_sequence.end());

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -495,15 +495,40 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequenceUpTo(
 
   lanelet::ConstLanelet current_lanelet = lanelet;
   double length = 0;
-
-  while (rclcpp::ok() && length < min_length) {
-    lanelet::ConstLanelet prev_lanelet;
-    if (!getPreviousLaneletWithinRoute(current_lanelet, &prev_lanelet)) {
+  bool break_flag = false;
+  while (rclcpp::ok() && length < min_length && !break_flag) {
+    lanelet::ConstLanelets candidate_lanelets;
+    if (!getPreviousLaneletsWithinRoute(current_lanelet, &candidate_lanelets)) {
       break;
     }
-    lanelet_sequence_backward.push_back(prev_lanelet);
-    length += boost::geometry::length(prev_lanelet.centerline().basicLineString());
-    current_lanelet = prev_lanelet;
+
+    // If lanelet_sequence_backward with input lanelet contains all candidate lanelets,
+    // break the loop.
+    if (std::all_of(
+          candidate_lanelets.begin(), candidate_lanelets.end(),
+          [lanelet_sequence_backward, lanelet](auto & prev_llt) {
+            return std::any_of(
+              lanelet_sequence_backward.begin(), lanelet_sequence_backward.end(),
+              [prev_llt, lanelet](auto & llt) {
+                return (llt.id() == prev_llt.id() || lanelet.id() == prev_llt.id());
+              });
+          })) {
+      break;
+    }
+
+    for (const auto & prev_lanelet : candidate_lanelets) {
+      if (std::any_of(
+            lanelet_sequence_backward.begin(), lanelet_sequence_backward.end(),
+            [prev_lanelet, lanelet](auto & llt) {
+              return (llt.id() == prev_lanelet.id() || lanelet.id() == prev_lanelet.id());
+            })) {
+        continue;
+      }
+      lanelet_sequence_backward.push_back(prev_lanelet);
+      length += boost::geometry::length(prev_lanelet.centerline().basicLineString());
+      current_lanelet = prev_lanelet;
+      break;
+    }
   }
 
   std::reverse(lanelet_sequence_backward.begin(), lanelet_sequence_backward.end());
@@ -744,20 +769,20 @@ lanelet::ConstLanelets RouteHandler::getNextLanelets(const lanelet::ConstLanelet
   return routing_graph_ptr_->following(lanelet);
 }
 
-bool RouteHandler::getPreviousLaneletWithinRoute(
-  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * prev_lanelet) const
+bool RouteHandler::getPreviousLaneletsWithinRoute(
+  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelets * prev_lanelets) const
 {
   if (exists(start_lanelets_, lanelet)) {
     return false;
   }
-  lanelet::ConstLanelets previous_lanelets = routing_graph_ptr_->previous(lanelet);
-  for (const auto & llt : previous_lanelets) {
+  lanelet::ConstLanelets candidate_lanelets = routing_graph_ptr_->previous(lanelet);
+  prev_lanelets->clear();
+  for (const auto & llt : candidate_lanelets) {
     if (exists(route_lanelets_, llt)) {
-      *prev_lanelet = llt;
-      return true;
+      prev_lanelets->push_back(llt);
     }
   }
-  return false;
+  return !(prev_lanelets->empty());
 }
 
 lanelet::ConstLanelets RouteHandler::getLaneletsFromPoint(const lanelet::ConstPoint3d & point) const
@@ -1359,15 +1384,42 @@ lanelet::ConstLanelets RouteHandler::getLaneSequence(const lanelet::ConstLanelet
 lanelet::ConstLanelets RouteHandler::getLaneSequenceUpTo(
   const lanelet::ConstLanelet & lanelet) const
 {
-  lanelet::ConstLanelets lane_sequence_backward;
+  lanelet::ConstLanelets lanelet_sequence_backward;
   if (!exists(route_lanelets_, lanelet)) {
-    return lane_sequence_backward;
+    return lanelet_sequence_backward;
   }
 
   lanelet::ConstLanelet current_lanelet = lanelet;
   while (rclcpp::ok()) {
+    lanelet::ConstLanelets candidate_lanelets;
+    if (!getPreviousLaneletsWithinRoute(current_lanelet, &candidate_lanelets)) {
+      break;
+    }
+
+    // If lanelet_sequence_backward with input lanelet contains all candidate lanelets,
+    // break the loop.
+    if (std::all_of(
+          candidate_lanelets.begin(), candidate_lanelets.end(),
+          [lanelet_sequence_backward, lanelet](auto & prev_llt) {
+            return std::any_of(
+              lanelet_sequence_backward.begin(), lanelet_sequence_backward.end(),
+              [prev_llt, lanelet](auto & llt) {
+                return (llt.id() == prev_llt.id() || lanelet.id() == prev_llt.id());
+              });
+          })) {
+      break;
+    }
+
     lanelet::ConstLanelet prev_lanelet;
-    if (!getPreviousLaneletWithinRoute(current_lanelet, &prev_lanelet)) {
+    for (const auto & prev_llt : candidate_lanelets) {
+      if (std::any_of(
+            lanelet_sequence_backward.begin(), lanelet_sequence_backward.end(),
+            [prev_llt, lanelet](auto & llt) {
+              return (llt.id() == prev_llt.id() || lanelet.id() == prev_llt.id());
+            })) {
+        continue;
+      }
+      prev_lanelet = prev_llt;
       break;
     }
 
@@ -1376,12 +1428,12 @@ lanelet::ConstLanelets RouteHandler::getLaneSequenceUpTo(
     if (!isBijectiveConnection(prev_lanelet_section, current_lanelet_section)) {
       break;
     }
-    lane_sequence_backward.push_back(prev_lanelet);
+    lanelet_sequence_backward.push_back(prev_lanelet);
     current_lanelet = prev_lanelet;
   }
 
-  std::reverse(lane_sequence_backward.begin(), lane_sequence_backward.end());
-  return lane_sequence_backward;
+  std::reverse(lanelet_sequence_backward.begin(), lanelet_sequence_backward.end());
+  return lanelet_sequence_backward;
 }
 
 lanelet::ConstLanelets RouteHandler::getLaneSequenceAfter(
@@ -1515,10 +1567,7 @@ std::vector<HADMapSegment> RouteHandler::createMapSegments(
 lanelet::ConstLanelets RouteHandler::getMainLanelets(
   const lanelet::ConstLanelets & path_lanelets) const
 {
-  const double backward_distance =
-    boost::geometry::length(path_lanelets.front().centerline().basicLineString());
-  const double epsilon = 0.01;
-  auto lanelet_sequence = getLaneletSequence(path_lanelets.back(), backward_distance + epsilon);
+  auto lanelet_sequence = getLaneletSequence(path_lanelets.back());
   lanelet::ConstLanelets main_lanelets;
   while (!lanelet_sequence.empty()) {
     main_lanelets.insert(main_lanelets.begin(), lanelet_sequence.begin(), lanelet_sequence.end());

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -495,8 +495,7 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequenceUpTo(
 
   lanelet::ConstLanelet current_lanelet = lanelet;
   double length = 0;
-  bool break_flag = false;
-  while (rclcpp::ok() && length < min_length && !break_flag) {
+  while (rclcpp::ok() && length < min_length) {
     lanelet::ConstLanelets candidate_lanelets;
     if (!getPreviousLaneletsWithinRoute(current_lanelet, &candidate_lanelets)) {
       break;


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Related Issue(required)

<!-- Link related issue -->

## Description(required)
In `RouteHandler::getMainLanelets()`, the default value of `backward_distance`, which is the 2nd argument of `getLaneletSequence()`, is `std::numeric_limits<double>::max()`.
However, in the specific situation, searching backward lanelets becomes almost infinite loop.

If the shortest path has loop, the backward search becomes (almost) infinite loop.
For example, please check the following figure.

![image](https://user-images.githubusercontent.com/10190493/156347793-ee57bb89-4188-4f20-b0d1-0cabafa40fc3.png)

To avoid this, I fixed the logic of backward search.

<!-- Describe what this PR changes. -->

## Review Procedure(required)

Before applying this change, it enters the infinite loop by throwing the goal pose like the above figure.
Please check that it does not happen this error by applying this change.

![Screenshot from 2022-03-02 19-42-00](https://user-images.githubusercontent.com/10190493/156348809-d3fc73a1-b00a-45ad-920b-3bfde10bb8f2.png)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
