### PR TITLE
chore(map_based_prediction): improve readability

### DIFF
--- a/perception/map_based_prediction/CMakeLists.txt
+++ b/perception/map_based_prediction/CMakeLists.txt
@@ -21,7 +21,7 @@ ament_auto_add_library(map_based_prediction_node SHARED
 )
 
 rclcpp_components_register_node(map_based_prediction_node
-  PLUGIN "MapBasedPredictionROS"
+  PLUGIN "map_based_prediction::MapBasedPredictionROS"
   EXECUTABLE map_based_prediction
 )
 

--- a/perception/map_based_prediction/include/cubic_spline.hpp
+++ b/perception/map_based_prediction/include/cubic_spline.hpp
@@ -30,6 +30,8 @@
 #include <string>
 #include <vector>
 
+namespace map_based_prediction
+{
 static std::vector<double> vec_diff(const std::vector<double> & input)
 {
   std::vector<double> output;
@@ -250,5 +252,6 @@ private:
     return out_s;
   }
 };
+}  // namespace map_based_prediction
 
 #endif  // CUBIC_SPLINE_HPP_

--- a/perception/map_based_prediction/include/map_based_prediction.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction.hpp
@@ -24,9 +24,18 @@
 
 namespace map_based_prediction
 {
+using autoware_auto_perception_msgs::msg::ObjectClassification;
+using autoware_auto_perception_msgs::msg::PredictedObject;
+using autoware_auto_perception_msgs::msg::PredictedObjectKinematics;
+using autoware_auto_perception_msgs::msg::PredictedObjects;
+using autoware_auto_perception_msgs::msg::PredictedPath;
+using autoware_auto_perception_msgs::msg::TrackedObject;
+using autoware_auto_perception_msgs::msg::TrackedObjectKinematics;
+using autoware_auto_perception_msgs::msg::TrackedObjects;
+
 struct DynamicObjectWithLanes
 {
-  autoware_auto_perception_msgs::msg::TrackedObject object;
+  TrackedObject object;
   std::vector<std::vector<geometry_msgs::msg::Pose>> lanes;
   std::vector<double> confidence;
 };
@@ -49,33 +58,28 @@ private:
   bool getPredictedPath(
     const double height, const double current_d_position, const double current_d_velocity,
     const double current_s_position, const double current_s_velocity,
-    const std_msgs::msg::Header & origin_header, Spline2D & spline2d,
-    autoware_auto_perception_msgs::msg::PredictedPath & path) const;
+    const std_msgs::msg::Header & origin_header, Spline2D & spline2d, PredictedPath & path) const;
 
   void getLinearPredictedPath(
     const geometry_msgs::msg::Pose & object_pose, const geometry_msgs::msg::Twist & object_twist,
-    autoware_auto_perception_msgs::msg::PredictedPath & predicted_path) const;
+    PredictedPath & predicted_path) const;
 
-  void normalizeLikelihood(
-    autoware_auto_perception_msgs::msg::PredictedObjectKinematics & predicted_object_kinematics);
+  void normalizeLikelihood(PredictedObjectKinematics & predicted_object_kinematics);
 
-  autoware_auto_perception_msgs::msg::PredictedObjectKinematics convertToPredictedKinematics(
-    const autoware_auto_perception_msgs::msg::TrackedObjectKinematics & tracked_object);
+  PredictedObjectKinematics convertToPredictedKinematics(
+    const TrackedObjectKinematics & tracked_object);
 
 public:
   MapBasedPrediction(
     double interpolating_resolution, double time_horizon, double sampling_delta_time);
 
   bool doPrediction(
-    const DynamicObjectWithLanesArray & in_objects,
-    std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & out_objects);
+    const DynamicObjectWithLanesArray & in_objects, std::vector<PredictedObject> & out_objects);
 
   bool doLinearPrediction(
-    const autoware_auto_perception_msgs::msg::PredictedObjects & in_objects,
-    std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & out_objects);
+    const PredictedObjects & in_objects, std::vector<PredictedObject> & out_objects);
 
-  autoware_auto_perception_msgs::msg::PredictedObject convertToPredictedObject(
-    const autoware_auto_perception_msgs::msg::TrackedObject & tracked_object);
+  PredictedObject convertToPredictedObject(const TrackedObject & tracked_object);
 };
 }  // namespace map_based_prediction
 

--- a/perception/map_based_prediction/include/map_based_prediction.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction.hpp
@@ -22,6 +22,8 @@
 
 #include <vector>
 
+namespace map_based_prediction
+{
 struct DynamicObjectWithLanes
 {
   autoware_auto_perception_msgs::msg::TrackedObject object;
@@ -75,5 +77,6 @@ public:
   autoware_auto_perception_msgs::msg::PredictedObject convertToPredictedObject(
     const autoware_auto_perception_msgs::msg::TrackedObject & tracked_object);
 };
+}  // namespace map_based_prediction
 
 #endif  // MAP_BASED_PREDICTION_HPP_

--- a/perception/map_based_prediction/include/map_based_prediction_ros.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction_ros.hpp
@@ -64,6 +64,7 @@ class TrafficRules;
 
 namespace map_based_prediction
 {
+using autoware_auto_mapping_msgs::msg::HADMapBin;
 using autoware_auto_perception_msgs::msg::ObjectClassification;
 using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
@@ -104,7 +105,7 @@ private:
   double diff_dist_threshold_to_right_bound_;
 
   rclcpp::Subscription<TrackedObjects>::SharedPtr sub_objects_;
-  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_map_;
+  rclcpp::Subscription<HADMapBin>::SharedPtr sub_map_;
   rclcpp::Publisher<PredictedObjects>::SharedPtr pub_objects_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_markers_;
 
@@ -130,7 +131,7 @@ private:
     lanelet::routing::LaneletPaths & valid_paths);
 
   void objectsCallback(const TrackedObjects::ConstSharedPtr in_objects);
-  void mapCallback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
+  void mapCallback(const HADMapBin::ConstSharedPtr msg);
 
   bool getClosestLanelets(
     const TrackedObject & object, const lanelet::LaneletMapPtr & lanelet_map_ptr,

--- a/perception/map_based_prediction/include/map_based_prediction_ros.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction_ros.hpp
@@ -62,6 +62,8 @@ class TrafficRules;
 }  // namespace traffic_rules
 }  // namespace lanelet
 
+namespace map_based_prediction
+{
 struct ObjectData
 {
   lanelet::ConstLanelets current_lanelets;
@@ -154,5 +156,6 @@ private:
 public:
   explicit MapBasedPredictionROS(const rclcpp::NodeOptions & node_options);
 };
+}  // namespace map_based_prediction
 
 #endif  // MAP_BASED_PREDICTION_ROS_HPP_

--- a/perception/map_based_prediction/include/map_based_prediction_ros.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction_ros.hpp
@@ -64,6 +64,12 @@ class TrafficRules;
 
 namespace map_based_prediction
 {
+using autoware_auto_perception_msgs::msg::ObjectClassification;
+using autoware_auto_perception_msgs::msg::PredictedObject;
+using autoware_auto_perception_msgs::msg::PredictedObjects;
+using autoware_auto_perception_msgs::msg::TrackedObject;
+using autoware_auto_perception_msgs::msg::TrackedObjects;
+
 struct ObjectData
 {
   lanelet::ConstLanelets current_lanelets;
@@ -97,9 +103,9 @@ private:
   double diff_dist_threshold_to_left_bound_;
   double diff_dist_threshold_to_right_bound_;
 
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr sub_objects_;
+  rclcpp::Subscription<TrackedObjects>::SharedPtr sub_objects_;
   rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_map_;
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::PredictedObjects>::SharedPtr pub_objects_;
+  rclcpp::Publisher<PredictedObjects>::SharedPtr pub_objects_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_markers_;
 
   std::unordered_map<std::string, std::deque<ObjectData>> object_buffer_;
@@ -115,32 +121,28 @@ private:
   bool getSelfPose(geometry_msgs::msg::Pose & self_pose, const std_msgs::msg::Header & header);
   bool getSelfPoseInMap(geometry_msgs::msg::Pose & self_pose);
 
-  double getObjectYaw(const autoware_auto_perception_msgs::msg::TrackedObject & object);
+  double getObjectYaw(const TrackedObject & object);
   double calculateLikelihood(
-    const std::vector<geometry_msgs::msg::Pose> & path,
-    const autoware_auto_perception_msgs::msg::TrackedObject & object);
+    const std::vector<geometry_msgs::msg::Pose> & path, const TrackedObject & object);
 
   void addValidPath(
     const lanelet::routing::LaneletPaths & candidate_paths,
     lanelet::routing::LaneletPaths & valid_paths);
 
-  void objectsCallback(
-    const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr in_objects);
+  void objectsCallback(const TrackedObjects::ConstSharedPtr in_objects);
   void mapCallback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
 
   bool getClosestLanelets(
-    const autoware_auto_perception_msgs::msg::TrackedObject & object,
-    const lanelet::LaneletMapPtr & lanelet_map_ptr, lanelet::ConstLanelets & closest_lanelets);
+    const TrackedObject & object, const lanelet::LaneletMapPtr & lanelet_map_ptr,
+    lanelet::ConstLanelets & closest_lanelets);
 
   bool checkCloseLaneletCondition(
-    const std::pair<double, lanelet::Lanelet> & lanelet,
-    const autoware_auto_perception_msgs::msg::TrackedObject & object,
+    const std::pair<double, lanelet::Lanelet> & lanelet, const TrackedObject & object,
     const lanelet::BasicPoint2d & search_point);
 
   void removeInvalidObject(const double current_time);
   bool updateObjectBuffer(
-    const std_msgs::msg::Header & header,
-    const autoware_auto_perception_msgs::msg::TrackedObject & object,
+    const std_msgs::msg::Header & header, const TrackedObject & object,
     lanelet::ConstLanelets & current_lanelets);
   void updatePossibleLanelets(
     const std::string object_id, const lanelet::routing::LaneletPaths & paths);
@@ -150,8 +152,8 @@ private:
   double calcLeftLateralOffset(
     const lanelet::ConstLineString2d & bound_line, const geometry_msgs::msg::Pose & search_pose);
   Maneuver detectLaneChange(
-    const autoware_auto_perception_msgs::msg::TrackedObject & object,
-    const lanelet::ConstLanelet & current_lanelet, const double current_time);
+    const TrackedObject & object, const lanelet::ConstLanelet & current_lanelet,
+    const double current_time);
 
 public:
   explicit MapBasedPredictionROS(const rclcpp::NodeOptions & node_options);

--- a/perception/map_based_prediction/src/map_based_prediction.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction.cpp
@@ -22,6 +22,8 @@
 #include <chrono>
 #include <vector>
 
+namespace map_based_prediction
+{
 MapBasedPrediction::MapBasedPrediction(
   double interpolating_resolution, double time_horizon, double sampling_delta_time)
 : interpolating_resolution_(interpolating_resolution),
@@ -302,3 +304,4 @@ void MapBasedPrediction::getLinearPredictedPath(
   predicted_path.confidence = 1.0;
   predicted_path.time_step = rclcpp::Duration::from_seconds(sampling_delta_time);
 }
+}  // namespace map_based_prediction

--- a/perception/map_based_prediction/src/map_based_prediction.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction.cpp
@@ -195,7 +195,7 @@ bool MapBasedPrediction::getPredictedPath(
   const double height, const double current_d_position, const double current_d_velocity,
   const double current_s_position, const double current_s_velocity,
   [[maybe_unused]] const std_msgs::msg::Header & origin_header, Spline2D & spline2d,
-  autoware_auto_perception_msgs::msg::PredictedPath & path) const
+  autoware_auto_perception_msgs::msg::PredictedPath & path)
 {
   // Quintic polynomial for d
   // A = np.array([[T**3, T**4, T**5],
@@ -271,7 +271,7 @@ bool MapBasedPrediction::getPredictedPath(
 
 void MapBasedPrediction::getLinearPredictedPath(
   const geometry_msgs::msg::Pose & object_pose, const geometry_msgs::msg::Twist & object_twist,
-  autoware_auto_perception_msgs::msg::PredictedPath & predicted_path) const
+  autoware_auto_perception_msgs::msg::PredictedPath & predicted_path)
 {
   const double & sampling_delta_time = sampling_delta_time_;
   const double & time_horizon = time_horizon_;

--- a/perception/map_based_prediction/src/map_based_prediction.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction.cpp
@@ -33,11 +33,10 @@ MapBasedPrediction::MapBasedPrediction(
 }
 
 bool MapBasedPrediction::doPrediction(
-  const DynamicObjectWithLanesArray & in_objects,
-  std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & out_objects)
+  const DynamicObjectWithLanesArray & in_objects, std::vector<PredictedObject> & out_objects)
 {
   for (auto & object_with_lanes : in_objects.objects) {
-    autoware_auto_perception_msgs::msg::PredictedObject tmp_object;
+    PredictedObject tmp_object;
     tmp_object = convertToPredictedObject(object_with_lanes.object);
     for (size_t path_id = 0; path_id < object_with_lanes.lanes.size(); ++path_id) {
       std::vector<double> tmp_x;
@@ -103,7 +102,7 @@ bool MapBasedPrediction::doPrediction(
         std::fabs(object_with_lanes.object.kinematics.twist_with_covariance.twist.linear.x);
 
       // Predict Path
-      autoware_auto_perception_msgs::msg::PredictedPath predicted_path;
+      PredictedPath predicted_path;
       getPredictedPath(
         object_point.z, current_d_position, current_d_velocity, current_s_position,
         current_s_velocity, in_objects.header, spline2d, predicted_path);
@@ -137,15 +136,14 @@ bool MapBasedPrediction::doPrediction(
 }
 
 bool MapBasedPrediction::doLinearPrediction(
-  const autoware_auto_perception_msgs::msg::PredictedObjects & in_objects,
-  std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & out_objects)
+  const PredictedObjects & in_objects, std::vector<PredictedObject> & out_objects)
 {
   for (const auto & object : in_objects.objects) {
-    autoware_auto_perception_msgs::msg::PredictedPath path;
+    PredictedPath path;
     getLinearPredictedPath(
       object.kinematics.initial_pose_with_covariance.pose,
       object.kinematics.initial_twist_with_covariance.twist, path);
-    autoware_auto_perception_msgs::msg::PredictedObject tmp_object;
+    PredictedObject tmp_object;
     tmp_object = object;
     tmp_object.kinematics.predicted_paths.push_back(path);
     out_objects.push_back(tmp_object);
@@ -154,10 +152,9 @@ bool MapBasedPrediction::doLinearPrediction(
   return true;
 }
 
-autoware_auto_perception_msgs::msg::PredictedObject MapBasedPrediction::convertToPredictedObject(
-  const autoware_auto_perception_msgs::msg::TrackedObject & tracked_object)
+PredictedObject MapBasedPrediction::convertToPredictedObject(const TrackedObject & tracked_object)
 {
-  autoware_auto_perception_msgs::msg::PredictedObject output;
+  PredictedObject output;
   output.object_id = tracked_object.object_id;
   output.existence_probability = tracked_object.existence_probability;
   output.classification = tracked_object.classification;
@@ -166,11 +163,10 @@ autoware_auto_perception_msgs::msg::PredictedObject MapBasedPrediction::convertT
   return output;
 }
 
-autoware_auto_perception_msgs::msg::PredictedObjectKinematics
-MapBasedPrediction::convertToPredictedKinematics(
-  const autoware_auto_perception_msgs::msg::TrackedObjectKinematics & tracked_object)
+PredictedObjectKinematics MapBasedPrediction::convertToPredictedKinematics(
+  const TrackedObjectKinematics & tracked_object)
 {
-  autoware_auto_perception_msgs::msg::PredictedObjectKinematics output;
+  PredictedObjectKinematics output;
   output.initial_pose_with_covariance = tracked_object.pose_with_covariance;
   output.initial_twist_with_covariance = tracked_object.twist_with_covariance;
   output.initial_acceleration_with_covariance = tracked_object.acceleration_with_covariance;
@@ -178,7 +174,7 @@ MapBasedPrediction::convertToPredictedKinematics(
 }
 
 void MapBasedPrediction::normalizeLikelihood(
-  autoware_auto_perception_msgs::msg::PredictedObjectKinematics & predicted_object_kinematics)
+  PredictedObjectKinematics & predicted_object_kinematics)
 {
   // might not be the smartest way
   double sum_confidence = 0.0;
@@ -195,7 +191,7 @@ bool MapBasedPrediction::getPredictedPath(
   const double height, const double current_d_position, const double current_d_velocity,
   const double current_s_position, const double current_s_velocity,
   [[maybe_unused]] const std_msgs::msg::Header & origin_header, Spline2D & spline2d,
-  autoware_auto_perception_msgs::msg::PredictedPath & path)
+  PredictedPath & path) const
 {
   // Quintic polynomial for d
   // A = np.array([[T**3, T**4, T**5],
@@ -271,7 +267,7 @@ bool MapBasedPrediction::getPredictedPath(
 
 void MapBasedPrediction::getLinearPredictedPath(
   const geometry_msgs::msg::Pose & object_pose, const geometry_msgs::msg::Twist & object_twist,
-  autoware_auto_perception_msgs::msg::PredictedPath & predicted_path)
+  PredictedPath & predicted_path) const
 {
   const double & sampling_delta_time = sampling_delta_time_;
   const double & time_horizon = time_horizon_;

--- a/perception/map_based_prediction/src/map_based_prediction_ros.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_ros.cpp
@@ -83,21 +83,19 @@ MapBasedPredictionROS::MapBasedPredictionROS(const rclcpp::NodeOptions & node_op
   map_based_prediction_ = std::make_shared<MapBasedPrediction>(
     interpolating_resolution_, prediction_time_horizon_, prediction_sampling_delta_time_);
 
-  sub_objects_ = this->create_subscription<autoware_auto_perception_msgs::msg::TrackedObjects>(
+  sub_objects_ = this->create_subscription<TrackedObjects>(
     "/perception/object_recognition/tracking/objects", 1,
     std::bind(&MapBasedPredictionROS::objectsCallback, this, std::placeholders::_1));
   sub_map_ = this->create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
     "/vector_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&MapBasedPredictionROS::mapCallback, this, std::placeholders::_1));
 
-  pub_objects_ = this->create_publisher<autoware_auto_perception_msgs::msg::PredictedObjects>(
-    "objects", rclcpp::QoS{1});
+  pub_objects_ = this->create_publisher<PredictedObjects>("objects", rclcpp::QoS{1});
   pub_markers_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
     "objects_path_markers", rclcpp::QoS{1});
 }
 
-double MapBasedPredictionROS::getObjectYaw(
-  const autoware_auto_perception_msgs::msg::TrackedObject & object)
+double MapBasedPredictionROS::getObjectYaw(const TrackedObject & object)
 {
   if (object.kinematics.orientation_availability) {
     return tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
@@ -121,8 +119,7 @@ double MapBasedPredictionROS::getObjectYaw(
 }
 
 double MapBasedPredictionROS::calculateLikelihood(
-  const std::vector<geometry_msgs::msg::Pose> & path,
-  const autoware_auto_perception_msgs::msg::TrackedObject & object)
+  const std::vector<geometry_msgs::msg::Pose> & path, const TrackedObject & object)
 {
   // We compute the confidence value based on the object current position and angle
   // Calculate path length
@@ -161,8 +158,7 @@ double MapBasedPredictionROS::calculateLikelihood(
 }
 
 bool MapBasedPredictionROS::checkCloseLaneletCondition(
-  const std::pair<double, lanelet::Lanelet> & lanelet,
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
+  const std::pair<double, lanelet::Lanelet> & lanelet, const TrackedObject & object,
   const lanelet::BasicPoint2d & search_point)
 {
   // Step1. If we only have one point in the centerline, we will ignore the lanelet
@@ -210,8 +206,8 @@ bool MapBasedPredictionROS::checkCloseLaneletCondition(
 }
 
 bool MapBasedPredictionROS::getClosestLanelets(
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
-  const lanelet::LaneletMapPtr & lanelet_map_ptr_, lanelet::ConstLanelets & closest_lanelets)
+  const TrackedObject & object, const lanelet::LaneletMapPtr & lanelet_map_ptr_,
+  lanelet::ConstLanelets & closest_lanelets)
 {
   std::chrono::high_resolution_clock::time_point begin = std::chrono::high_resolution_clock::now();
 
@@ -308,11 +304,10 @@ void MapBasedPredictionROS::removeInvalidObject(const double current_time)
 }
 
 bool MapBasedPredictionROS::updateObjectBuffer(
-  const std_msgs::msg::Header & header,
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
+  const std_msgs::msg::Header & header, const TrackedObject & object,
   lanelet::ConstLanelets & current_lanelets)
 {
-  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+  using Label = ObjectClassification;
   // Ignore non-vehicle object
   if (
     object.classification.front().label != Label::CAR &&
@@ -436,8 +431,8 @@ double MapBasedPredictionROS::calcLeftLateralOffset(
 }
 
 Maneuver MapBasedPredictionROS::detectLaneChange(
-  const autoware_auto_perception_msgs::msg::TrackedObject & object,
-  const lanelet::ConstLanelet & current_lanelet, const double current_time)
+  const TrackedObject & object, const lanelet::ConstLanelet & current_lanelet,
+  const double current_time)
 {
   // Step1. Check if we have the object in the buffer
   const std::string object_id = toHexString(object.object_id);
@@ -534,8 +529,7 @@ Maneuver MapBasedPredictionROS::detectLaneChange(
   return Maneuver::LANE_FOLLOW;
 }
 
-void MapBasedPredictionROS::objectsCallback(
-  const autoware_auto_perception_msgs::msg::TrackedObjects::ConstSharedPtr in_objects)
+void MapBasedPredictionROS::objectsCallback(const TrackedObjects::ConstSharedPtr in_objects)
 {
   debug_accumulated_time_ = 0.0;
   std::chrono::high_resolution_clock::time_point begin = std::chrono::high_resolution_clock::now();
@@ -574,7 +568,7 @@ void MapBasedPredictionROS::objectsCallback(
   /////////////////////////////////////////////////////////
   ///////////////////// Prediction ///////////////////////
   ///////////////////////////////////////////////////////
-  autoware_auto_perception_msgs::msg::PredictedObjects objects_without_map;
+  PredictedObjects objects_without_map;
   objects_without_map.header = in_objects->header;
   DynamicObjectWithLanesArray prediction_input;
   prediction_input.header = in_objects->header;
@@ -738,14 +732,14 @@ void MapBasedPredictionROS::objectsCallback(
   std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
   std::chrono::nanoseconds time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin);
 
-  std::vector<autoware_auto_perception_msgs::msg::PredictedObject> out_objects_in_map;
+  std::vector<PredictedObject> out_objects_in_map;
   map_based_prediction_->doPrediction(prediction_input, out_objects_in_map);
-  autoware_auto_perception_msgs::msg::PredictedObjects output;
+  PredictedObjects output;
   output.header = in_objects->header;
   output.header.frame_id = "map";
   output.objects = out_objects_in_map;
 
-  std::vector<autoware_auto_perception_msgs::msg::PredictedObject> out_objects_without_map;
+  std::vector<PredictedObject> out_objects_without_map;
   map_based_prediction_->doLinearPrediction(objects_without_map, out_objects_without_map);
   output.objects.insert(
     output.objects.begin(), out_objects_without_map.begin(), out_objects_without_map.end());

--- a/perception/map_based_prediction/src/map_based_prediction_ros.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_ros.cpp
@@ -86,7 +86,7 @@ MapBasedPredictionROS::MapBasedPredictionROS(const rclcpp::NodeOptions & node_op
   sub_objects_ = this->create_subscription<TrackedObjects>(
     "/perception/object_recognition/tracking/objects", 1,
     std::bind(&MapBasedPredictionROS::objectsCallback, this, std::placeholders::_1));
-  sub_map_ = this->create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
+  sub_map_ = this->create_subscription<HADMapBin>(
     "/vector_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&MapBasedPredictionROS::mapCallback, this, std::placeholders::_1));
 
@@ -746,8 +746,7 @@ void MapBasedPredictionROS::objectsCallback(const TrackedObjects::ConstSharedPtr
   pub_objects_->publish(output);
 }
 
-void MapBasedPredictionROS::mapCallback(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg)
+void MapBasedPredictionROS::mapCallback(const HADMapBin::ConstSharedPtr msg)
 {
   RCLCPP_INFO(get_logger(), "Start loading lanelet");
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();

--- a/perception/map_based_prediction/src/map_based_prediction_ros.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_ros.cpp
@@ -37,6 +37,8 @@
 #include <utility>
 #include <vector>
 
+namespace
+{
 std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
 {
   std::stringstream ss;
@@ -45,7 +47,9 @@ std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
   }
   return ss.str();
 }
-
+}  // namespace
+namespace map_based_prediction
+{
 MapBasedPredictionROS::MapBasedPredictionROS(const rclcpp::NodeOptions & node_options)
 : Node("map_based_prediction", node_options),
   interpolating_resolution_(0.5),
@@ -757,6 +761,7 @@ void MapBasedPredictionROS::mapCallback(
     *msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
   RCLCPP_INFO(get_logger(), "Map is loaded");
 }
+}  // namespace map_based_prediction
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(MapBasedPredictionROS)
+RCLCPP_COMPONENTS_REGISTER_NODE(map_based_prediction::MapBasedPredictionROS)


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

`autoware_auto_xxx_msgs` is used in so many places to define variables in map_based_prediction package, and it should use alias to improve readability. I used following aliases:

- autoware_auto_preception_msgs::msg::xxx
- autoware_auto_mapping_msgs::msg::xxx

<!-- Describe what this PR changes. -->

There is no change in prediction logic.

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
