### PR TITLE
revert(dummy_perception): change leaf size and disable ray trace

### DIFF
--- a/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -17,7 +17,7 @@
         <remap from="input/reset" to="input/reset" />
         <param name="visible_range" value="$(var visible_range)" />
         <param name="detection_successful_rate" value="0.999" />
-        <param name="enable_ray_tracing" value="true" />
+        <param name="enable_ray_tracing" value="false" />
         <param name="use_object_recognition" value="$(var use_object_recognition)" />
       </node>
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">

--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -180,9 +180,7 @@ void DummyPerceptionPublisherNode::timerCallback()
       new pcl::PointCloud<pcl::PointXYZ>);
     pcl::VoxelGridOcclusionEstimation<pcl::PointXYZ> ray_tracing_filter;
     ray_tracing_filter.setInputCloud(merged_pointcloud_ptr);
-    // above this value raytrace won't be as expected
-    const double leaf_size = 0.02;
-    ray_tracing_filter.setLeafSize(leaf_size, leaf_size, leaf_size);
+    ray_tracing_filter.setLeafSize(0.25, 0.25, 0.25);
     ray_tracing_filter.initializeVoxelGrid();
     for (size_t i = 0; i < v_pointcloud.size(); ++i) {
       pcl::PointCloud<pcl::PointXYZ>::Ptr ray_traced_pointcloud_ptr(


### PR DESCRIPTION
## Related Issue(required)

without raytrace occupancy grid looks good but with raytrace leaf size is sensitive.  as shown in #413 
However as #460 says it's heavy to use small voxel size to calculate so I revert this

## Description(required)

revert 414

## Review Procedure(required)

launch psim

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
