### PR TITLE
fix(behavior_path_planner): fix reservation of predicted path

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -352,7 +352,7 @@ PredictedPath convertToPredictedPath(
 {
   PredictedPath predicted_path{};
   predicted_path.time_step = rclcpp::Duration::from_seconds(resolution);
-  predicted_path.path.reserve(path.points.size());
+  predicted_path.path.reserve(std::min(path.points.size(), static_cast<size_t>(100)));
   if (path.points.empty()) {
     return predicted_path;
   }


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Related Issue(required)

<!-- Link related issue -->

## Description(required)

The size of path in `autoware_auto_perception_msgs::msg::PredictedPath` is limited to 100.
However, in `behavior_path_planner` package, it may reserve the path points over 100.
In this PR, I fixed it.

<!-- Describe what this PR changes. -->

## Review Procedure(required)

Please run the car on the long path with lane change without auto approval.
To turn-off the auto approval, please comment out here.
https://github.com/tier4/autoware_launch/blob/31fe5912a2d4eb5caadc6803df85ff14f78318ff/planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py#L352-L364
 
<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
