### PR TITLE
refactor(avoidance_module): change implementation to lambda

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1685,7 +1685,7 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
         }
 
         if (lanelet_at_left && extend_to_opposite_lane) {  // means lanelets in the opposite
-                                                            // direction exist
+                                                           // direction exist
           auto lanelet_at_right = route_handler->getRightLanelet(lanelet_at_left.get());
           while (lanelet_at_right) {
             lanelet_to_be_extended.push_back(lanelet_at_right.get());
@@ -1704,7 +1704,7 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
           lanelet_at_right = route_handler->getRightLanelet(lanelet_at_right.get());
         }
         if (lanelet_at_right && extend_to_opposite_lane) {  // means lanelets in the opposite
-                                                             // direction exist
+                                                            // direction exist
           auto lanelet_at_left = route_handler->getLeftLanelet(lanelet_at_right.get());
           while (lanelet_at_left) {
             lanelet_to_be_extended.push_back(lanelet_at_left.get());

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1676,14 +1676,16 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
     // 0. Extend to right/left of objects
     const auto searchLeftLaneletsAndAppendToDrivableAreas =
       [&route_handler](
-        const lanelet::ConstLanelet & current_lanelet, auto & lanelet_to_be_extended) noexcept {
+        const lanelet::ConstLanelet & current_lanelet, auto & lanelet_to_be_extended,
+        bool extend_to_opposite_lane = true) noexcept {
         auto lanelet_at_left = route_handler->getLeftLanelet(current_lanelet);
         while (lanelet_at_left) {
           lanelet_to_be_extended.push_back(lanelet_at_left.get());
           lanelet_at_left = route_handler->getLeftLanelet(lanelet_at_left.get());
         }
 
-        if (lanelet_at_left) {  // means lanelets in the opposite direction exist
+        if (lanelet_at_left && extend_to_opposite_lane) {  // means lanelets in the opposite
+                                                            // direction exist
           auto lanelet_at_right = route_handler->getRightLanelet(lanelet_at_left.get());
           while (lanelet_at_right) {
             lanelet_to_be_extended.push_back(lanelet_at_right.get());
@@ -1694,13 +1696,15 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
 
     const auto searchRightLaneletsAndAppendToDrivableAreas =
       [&route_handler](
-        const lanelet::ConstLanelet & current_lanelet, auto & lanelet_to_be_extended) noexcept {
+        const lanelet::ConstLanelet & current_lanelet, auto & lanelet_to_be_extended,
+        bool extend_to_opposite_lane = true) noexcept {
         auto lanelet_at_right = route_handler->getRightLanelet(current_lanelet);
         while (lanelet_at_right) {
           lanelet_to_be_extended.push_back(lanelet_at_right.get());
           lanelet_at_right = route_handler->getRightLanelet(lanelet_at_right.get());
         }
-        if (lanelet_at_right) {  // means lanelets in the opposite direction exist
+        if (lanelet_at_right && extend_to_opposite_lane) {  // means lanelets in the opposite
+                                                             // direction exist
           auto lanelet_at_left = route_handler->getLeftLanelet(lanelet_at_right.get());
           while (lanelet_at_left) {
             lanelet_to_be_extended.push_back(lanelet_at_left.get());

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1674,35 +1674,47 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
 
   {
     // 0. Extend to right/left of objects
-    for (const auto & obstacle : avoidance_data_.objects) {
-      auto object_lanelet = obstacle.overhang_lanelet;
-      if (isOnRight(obstacle)) {
-        auto lanelet_at_left = route_handler->getLeftLanelet(object_lanelet);
+    const auto searchLeftLaneletsAndAppendToDrivableAreas =
+      [&route_handler](
+        const lanelet::ConstLanelet & current_lanelet, auto & lanelet_to_be_extended) noexcept {
+        auto lanelet_at_left = route_handler->getLeftLanelet(current_lanelet);
         while (lanelet_at_left) {
-          extended_lanelets.push_back(lanelet_at_left.get());
+          lanelet_to_be_extended.push_back(lanelet_at_left.get());
           lanelet_at_left = route_handler->getLeftLanelet(lanelet_at_left.get());
         }
-        if (lanelet_at_left) {
-          auto lanelet_at_right =
-            planner_data_->route_handler->getRightLanelet(lanelet_at_left.get());
+
+        if (lanelet_at_left) {  // means lanelets in the opposite direction exist
+          auto lanelet_at_right = route_handler->getRightLanelet(lanelet_at_left.get());
           while (lanelet_at_right) {
-            extended_lanelets.push_back(lanelet_at_right.get());
+            lanelet_to_be_extended.push_back(lanelet_at_right.get());
             lanelet_at_right = route_handler->getRightLanelet(lanelet_at_right.get());
           }
         }
-      } else {
-        auto lanelet_at_right = route_handler->getRightLanelet(object_lanelet);
+      };
+
+    const auto searchRightLaneletsAndAppendToDrivableAreas =
+      [&route_handler](
+        const lanelet::ConstLanelet & current_lanelet, auto & lanelet_to_be_extended) noexcept {
+        auto lanelet_at_right = route_handler->getRightLanelet(current_lanelet);
         while (lanelet_at_right) {
-          extended_lanelets.push_back(lanelet_at_right.get());
+          lanelet_to_be_extended.push_back(lanelet_at_right.get());
           lanelet_at_right = route_handler->getRightLanelet(lanelet_at_right.get());
         }
-        if (lanelet_at_right) {
+        if (lanelet_at_right) {  // means lanelets in the opposite direction exist
           auto lanelet_at_left = route_handler->getLeftLanelet(lanelet_at_right.get());
           while (lanelet_at_left) {
-            extended_lanelets.push_back(lanelet_at_left.get());
+            lanelet_to_be_extended.push_back(lanelet_at_left.get());
             lanelet_at_left = route_handler->getLeftLanelet(lanelet_at_left.get());
           }
         }
+      };
+
+    for (const auto & obstacle : avoidance_data_.objects) {
+      auto object_lanelet = obstacle.overhang_lanelet;
+      if (isOnRight(obstacle)) {
+        searchLeftLaneletsAndAppendToDrivableAreas(object_lanelet, extended_lanelets);
+      } else {
+        searchRightLaneletsAndAppendToDrivableAreas(object_lanelet, extended_lanelets);
       }
     }
   }

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -138,6 +138,12 @@ public:
    */
   lanelet::Lanelets getLeftOppositeLanelets(const lanelet::ConstLanelet & lanelet) const;
 
+  lanelet::ConstLanelets getAllLeftSharedLinestringLanelets(
+    const lanelet::ConstLanelet & lane, const bool & include_opposite) const noexcept;
+
+  lanelet::ConstLanelets getAllRightSharedLinestringLanelets(
+    const lanelet::ConstLanelet & lane, const bool & include_opposite) const noexcept;
+
   lanelet::ConstLanelets getAllSharedLineStringLanelets(
     const lanelet::ConstLanelet & current_lane, bool is_right = true, bool is_left = true,
     bool is_opposite = true) const noexcept;

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -138,6 +138,10 @@ public:
    */
   lanelet::Lanelets getLeftOppositeLanelets(const lanelet::ConstLanelet & lanelet) const;
 
+  lanelet::ConstLanelets getAllSharedLineStringLanelets(
+    const lanelet::ConstLanelet & current_lane, bool is_right = true, bool is_left = true,
+    bool is_opposite = true) const noexcept;
+
   /**
    * @brief Searches the furthest linestring to the right side of the lanelet
    * Only lanelet with same direction is considered

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -138,12 +138,32 @@ public:
    */
   lanelet::Lanelets getLeftOppositeLanelets(const lanelet::ConstLanelet & lanelet) const;
 
+  /**
+   * @brief Searches and return all lanelet on the left that shares same linestring
+   * @param the lanelet of interest
+   * @param (optional) flag to include the lane with opposite direction
+   * @return vector of lanelet that is connected via share linestring
+   */
   lanelet::ConstLanelets getAllLeftSharedLinestringLanelets(
     const lanelet::ConstLanelet & lane, const bool & include_opposite) const noexcept;
 
+  /**
+   * @brief Searches and return all lanelet on the right that shares same linestring
+   * @param the lanelet of interest
+   * @param (optional) flag to include the lane with opposite direction
+   * @return vector of lanelet that is connected via share linestring
+   */
   lanelet::ConstLanelets getAllRightSharedLinestringLanelets(
     const lanelet::ConstLanelet & lane, const bool & include_opposite) const noexcept;
 
+  /**
+   * @brief Searches and return all lanelet (left and right) that shares same linestring
+   * @param the lanelet of interest
+   * @param (optional) flag to search only right side
+   * @param (optional) flag to search only left side
+   * @param (optional) flag to include the lane with opposite direction
+   * @return vector of lanelet that is connected via share linestring
+   */
   lanelet::ConstLanelets getAllSharedLineStringLanelets(
     const lanelet::ConstLanelet & current_lane, bool is_right = true, bool is_left = true,
     bool is_opposite = true) const noexcept;

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -203,6 +203,19 @@ public:
    */
   lanelet::ConstLineString3d getLeftMostLinestring(
     const lanelet::ConstLanelet & lanelet) const noexcept;
+
+  /**
+   * @brief Return furthest linestring on both side of the lanelet
+   * @param the lanelet of interest
+   * @param (optional) search furthest right side
+   * @param (optional) search furthest left side
+   * @param (optional) include opposite lane as well
+   * @return right and left linestrings
+   */
+  lanelet::ConstLineStrings3d getFurthestLinestring(
+    const lanelet::ConstLanelet & lanelet, bool is_right = true, bool is_left = true,
+    bool is_opposite = true) const noexcept;
+
   int getNumLaneToPreferredLane(const lanelet::ConstLanelet & lanelet) const;
   bool getClosestLaneletWithinRoute(
     const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -911,6 +911,65 @@ lanelet::Lanelets RouteHandler::getRightOppositeLanelets(
   return lanelet_map_ptr_->laneletLayer.findUsages(lanelet.rightBound().invert());
 }
 
+lanelet::ConstLanelets RouteHandler::getAllSharedLineStringLanelets(
+  const lanelet::ConstLanelet & current_lane, bool is_right, bool is_left,
+  bool is_opposite) const noexcept
+{
+  const auto searchAllLeftLanelets = [this, &is_opposite](
+                                       const lanelet::ConstLanelet & current_lanelet,
+                                       auto & lanelet_to_be_extended) noexcept {
+    auto lanelet_at_left = getLeftLanelet(current_lanelet);
+    auto lanelet_at_left_opposite = getLeftOppositeLanelets(current_lanelet);
+    while (lanelet_at_left) {
+      lanelet_to_be_extended.push_back(lanelet_at_left.get());
+      lanelet_at_left = getLeftLanelet(lanelet_at_left.get());
+      lanelet_at_left_opposite = getLeftOppositeLanelets(lanelet_at_left.get());
+    }
+
+    if (!lanelet_at_left_opposite.empty() && is_opposite) {
+      auto lanelet_at_right = getRightLanelet(lanelet_at_left_opposite.front());
+      while (lanelet_at_right) {
+        lanelet_to_be_extended.push_back(lanelet_at_right.get());
+        lanelet_at_right = getRightLanelet(lanelet_at_right.get());
+      }
+    }
+  };
+
+  const auto searchAllRightLanelets = [this, &is_opposite](
+                                        const lanelet::ConstLanelet & current_lanelet,
+                                        auto & lanelet_to_be_extended) noexcept {
+    auto lanelet_at_right = getRightLanelet(current_lanelet);
+    auto lanelet_at_right_opposite = getRightOppositeLanelets(current_lanelet);
+    while (lanelet_at_right) {
+      lanelet_to_be_extended.push_back(lanelet_at_right.get());
+      lanelet_at_right = getRightLanelet(lanelet_at_right.get());
+      lanelet_at_right_opposite = getRightOppositeLanelets(lanelet_at_right.get());
+    }
+
+    if (!lanelet_at_right_opposite.empty() && is_opposite) {  // means lanelets in
+                                                              // the opposite
+                                                              // direction exist
+      lanelet_to_be_extended.push_back(lanelet_at_right_opposite.front());
+      auto lanelet_at_left = getLeftLanelet(lanelet_at_right_opposite.front());
+      while (lanelet_at_left) {
+        lanelet_to_be_extended.push_back(lanelet_at_left.get());
+        lanelet_at_left = getLeftLanelet(lanelet_at_left.get());
+      }
+    }
+  };
+
+  lanelet::ConstLanelets shared_linestring_lanelet;
+  shared_linestring_lanelet.push_back(current_lane);
+  if (is_right) {
+    searchAllRightLanelets(current_lane, shared_linestring_lanelet);
+  }
+  if (is_left) {
+    searchAllLeftLanelets(current_lane, shared_linestring_lanelet);
+  }
+
+  return shared_linestring_lanelet;
+}
+
 lanelet::Lanelets RouteHandler::getLeftOppositeLanelets(const lanelet::ConstLanelet & lanelet) const
 {
   return lanelet_map_ptr_->laneletLayer.findUsages(lanelet.leftBound().invert());

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1039,6 +1039,31 @@ lanelet::ConstLineString3d RouteHandler::getLeftMostLinestring(
   return {};
 }
 
+lanelet::ConstLineStrings3d RouteHandler::getFurthestLinestring(
+  const lanelet::ConstLanelet & lanelet, bool is_right, bool is_left,
+  bool is_opposite) const noexcept
+{
+  lanelet::ConstLineStrings3d linestrings;
+  linestrings.reserve(2);
+
+  if (is_right && is_opposite) {
+    linestrings.emplace_back(getRightMostLinestring(lanelet));
+  } else if (is_right && !is_opposite) {
+    linestrings.emplace_back(getRightMostSameDirectionLinestring(lanelet));
+  } else {
+    linestrings.emplace_back(lanelet.rightBound());
+  }
+
+  if (is_left && is_opposite) {
+    linestrings.emplace_back(getLeftMostLinestring(lanelet));
+  } else if (is_left && !is_opposite) {
+    linestrings.emplace_back(getLeftMostSameDirectionLinestring(lanelet));
+  } else {
+    linestrings.emplace_back(lanelet.leftBound());
+  }
+  return linestrings;
+}
+
 bool RouteHandler::getLaneChangeTarget(
   const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const
 {

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -914,47 +914,47 @@ lanelet::Lanelets RouteHandler::getRightOppositeLanelets(
 lanelet::ConstLanelets RouteHandler::getAllLeftSharedLinestringLanelets(
   const lanelet::ConstLanelet & lane, const bool & include_opposite) const noexcept
 {
-  lanelet::ConstLanelets shared;
+  lanelet::ConstLanelets linestring_shared;
   auto lanelet_at_left = getLeftLanelet(lane);
   auto lanelet_at_left_opposite = getLeftOppositeLanelets(lane);
   while (lanelet_at_left) {
-    shared.push_back(lanelet_at_left.get());
+    linestring_shared.push_back(lanelet_at_left.get());
     lanelet_at_left = getLeftLanelet(lanelet_at_left.get());
     lanelet_at_left_opposite = getLeftOppositeLanelets(lanelet_at_left.get());
   }
 
   if (!lanelet_at_left_opposite.empty() && include_opposite) {
-    shared.push_back(lanelet_at_left_opposite.front());
+    linestring_shared.push_back(lanelet_at_left_opposite.front());
     auto lanelet_at_right = getRightLanelet(lanelet_at_left_opposite.front());
     while (lanelet_at_right) {
-      shared.push_back(lanelet_at_right.get());
+      linestring_shared.push_back(lanelet_at_right.get());
       lanelet_at_right = getRightLanelet(lanelet_at_right.get());
     }
   }
-  return shared;
+  return linestring_shared;
 }
 
 lanelet::ConstLanelets RouteHandler::getAllRightSharedLinestringLanelets(
   const lanelet::ConstLanelet & lane, const bool & include_opposite) const noexcept
 {
-  lanelet::ConstLanelets shared;
+  lanelet::ConstLanelets linestring_shared;
   auto lanelet_at_right = getRightLanelet(lane);
   auto lanelet_at_right_opposite = getRightOppositeLanelets(lane);
   while (lanelet_at_right) {
-    shared.push_back(lanelet_at_right.get());
+    linestring_shared.push_back(lanelet_at_right.get());
     lanelet_at_right = getRightLanelet(lanelet_at_right.get());
     lanelet_at_right_opposite = getRightOppositeLanelets(lanelet_at_right.get());
   }
 
   if (!lanelet_at_right_opposite.empty() && include_opposite) {
-    shared.push_back(lanelet_at_right_opposite.front());
+    linestring_shared.push_back(lanelet_at_right_opposite.front());
     auto lanelet_at_left = getLeftLanelet(lanelet_at_right_opposite.front());
     while (lanelet_at_left) {
-      shared.push_back(lanelet_at_left.get());
+      linestring_shared.push_back(lanelet_at_left.get());
       lanelet_at_left = getLeftLanelet(lanelet_at_left.get());
     }
   }
-  return shared;
+  return linestring_shared;
 }
 
 lanelet::ConstLanelets RouteHandler::getAllSharedLineStringLanelets(


### PR DESCRIPTION
In the generateExtendedDrivableArea function, the implementation to extend
drivable areas with reference to object is moved to `route_handler` library.

This will allow the function to be reused for some future planned updates.

The refactor **doesn't affect the behavior of the avoidance_module**.

Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Related Issue(required)

#485 
#499 

## Description(required)

Refactoring the function so that the intent is much more clear, therefore it doensn't affect the behavior of the avoidance_module.
This also allows the function to be reused for debug visualization if necessary.

## Review Procedure(required)

See build pass (no behavior change)
![image](https://user-images.githubusercontent.com/93502286/156984746-fdf5e5fe-9bad-479a-b26f-87fea3690c02.png)


## Related PR(optional)
#285 
#365 

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
