### PR TITLE
fix: use hazard in auto command when emergency_handling is false

### DIFF
--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -342,7 +342,7 @@ void VehicleCmdGate::onTimer()
   } else {
     if (current_gate_mode_.data == tier4_control_msgs::msg::GateMode::AUTO) {
       turn_indicator = auto_commands_.turn_indicator;
-      hazard_light = emergency_commands_.hazard_light;
+      hazard_light = auto_commands_.hazard_light;
       gear = auto_commands_.gear;
 
       // Don't send turn signal when autoware is not engaged


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Related Issue(required)

<!-- Link related issue -->

## Description(required)

Fix porting miss in vehicle_cmd_gate.
https://github.com/tier4/AutowareArchitectureProposal.iv/blob/main/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp#L309-310

When `use_emergency_handling` is false, use the auto_commands for hazard_light

<!-- Describe what this PR changes. -->

## Review Procedure(required)
Set `use_emergency_handling` to false in control.launch.py
Launch planning simulator, and start to run the vehicle.
Transition the vehicle state to Emergency in some way, and confirm that the hazard lights  are not enabled.

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [x] Documentation with description of the package is available
- [x] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
