### PR TITLE
feat(behavior_path_planner): add drivable area visualization to observe shared linestring

### DIFF
--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -16,3 +16,5 @@
 
     refine_goal_search_radius_range: 7.5
     intersection_search_distance: 30.0
+
+    visualize_drivable_area_for_shared_linestrings_lanelet: false

--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -17,4 +17,4 @@
     refine_goal_search_radius_range: 7.5
     intersection_search_distance: 30.0
 
-    visualize_drivable_area_for_shared_linestrings_lanelet: false
+    visualize_drivable_area_for_shared_linestrings_lanelet: true

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -18,6 +18,7 @@
 #include "behavior_path_planner/behavior_tree_manager.hpp"
 #include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module.hpp"
+#include "behavior_path_planner/scene_module/avoidance/debug.hpp"
 #include "behavior_path_planner/scene_module/lane_change/lane_change_module.hpp"
 #include "behavior_path_planner/scene_module/lane_following/lane_following_module.hpp"
 #include "behavior_path_planner/scene_module/pull_out/pull_out_module.hpp"
@@ -156,7 +157,7 @@ private:
 
 private:
   rclcpp::Publisher<OccupancyGrid>::SharedPtr debug_drivable_area_publisher_;
-  rclcpp::Publisher<OccupancyGrid>::SharedPtr debug_drivable_area_lanelets_publisher_;
+  rclcpp::Publisher<MarkerArray>::SharedPtr debug_drivable_area_lanelets_publisher_;
   rclcpp::Publisher<Path>::SharedPtr debug_path_publisher_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_marker_publisher_;
   void publishDebugMarker(const std::vector<MarkerArray> & debug_markers);

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -126,7 +126,6 @@ private:
     const PathWithLaneId & path) const;  // (TODO) move to util
 
   void clipPathLength(PathWithLaneId & path) const;  // (TODO) move to util
-  void visualizeDrivableAreasWithSharedLanelets();
 
   /**
    * @brief Execute behavior tree and publish planned data.

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -126,6 +126,7 @@ private:
     const PathWithLaneId & path) const;  // (TODO) move to util
 
   void clipPathLength(PathWithLaneId & path) const;  // (TODO) move to util
+  void visualizeDrivableAreasWithSharedLanelets();
 
   /**
    * @brief Execute behavior tree and publish planned data.
@@ -156,6 +157,7 @@ private:
 
 private:
   rclcpp::Publisher<OccupancyGrid>::SharedPtr debug_drivable_area_publisher_;
+  rclcpp::Publisher<OccupancyGrid>::SharedPtr debug_drivable_area_lanelets_publisher_;
   rclcpp::Publisher<Path>::SharedPtr debug_path_publisher_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_marker_publisher_;
   void publishDebugMarker(const std::vector<MarkerArray> & debug_markers);

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -48,6 +48,9 @@ struct BehaviorPathPlannerParameters
   double right_over_hang;
   double base_link2front;
   double base_link2rear;
+
+  // drivable area visualization
+  bool visualize_drivable_area_for_shared_linestrings_lanelet;
 };
 
 #endif  // BEHAVIOR_PATH_PLANNER__PARAMETERS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -96,6 +96,8 @@ MarkerArray makeOverhangToRoadShoulderMarkerArray(
 MarkerArray createOvehangFurthestLineStringMarkerArray(
   const lanelet::ConstLineStrings3d & linestrings, const std::string & ns, const double r,
   const double g, const double b);
+
+MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3d & linestrings);
 }  // namespace marker_utils
 
 std::string toStrInfo(const behavior_path_planner::ShiftPointArray & sp_arr);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -251,7 +251,7 @@ OccupancyGrid generateDrivableArea(
   const lanelet::ConstLanelets & lanes, const double resolution, const double vehicle_length,
   const std::shared_ptr<const PlannerData> planner_data);
 
-lanelet::ConstLineStrings3d getDrivableAreaforAllSharedLinestringLanelets(
+lanelet::ConstLineStrings3d getDrivableAreaForAllSharedLinestringLanelets(
   const std::shared_ptr<const PlannerData> & planner_data);
 // goal management
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -251,6 +251,9 @@ OccupancyGrid generateDrivableArea(
   const lanelet::ConstLanelets & lanes, const double resolution, const double vehicle_length,
   const std::shared_ptr<const PlannerData> planner_data);
 
+OccupancyGrid generateDrivableAreaForAllSharedLinestringLanelets(
+  const std::shared_ptr<const PlannerData> planner_data);
+
 // goal management
 
 /**

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -251,9 +251,8 @@ OccupancyGrid generateDrivableArea(
   const lanelet::ConstLanelets & lanes, const double resolution, const double vehicle_length,
   const std::shared_ptr<const PlannerData> planner_data);
 
-OccupancyGrid generateDrivableAreaForAllSharedLinestringLanelets(
-  const std::shared_ptr<const PlannerData> planner_data);
-
+lanelet::ConstLineStrings3d getDrivableAreaforAllSharedLinestringLanelets(
+  const std::shared_ptr<const PlannerData> & planner_data);
 // goal management
 
 /**

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -84,7 +84,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
   if (planner_data_->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
     debug_drivable_area_lanelets_publisher_ =
-      create_publisher<OccupancyGrid>("~/drivable_area_lanelet", 1);
+      create_publisher<MarkerArray>("~/drivable_area_lanelet", 1);
   }
 
   // behavior tree manager
@@ -510,8 +510,10 @@ void BehaviorPathPlannerNode::run()
   publishDebugMarker(bt_manager_->getDebugMarkers());
 
   if (planner_data_->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
-    debug_drivable_area_lanelets_publisher_->publish(
-      util::generateDrivableAreaForAllSharedLinestringLanelets(planner_data_));
+    const auto drivable_area_lines = marker_utils::createOvehangFurthestLineStringMarkerArray(
+      util::getDrivableAreaforAllSharedLinestringLanelets(planner_data_), "drivables", 0.984, 0.831,
+      0.725);
+    debug_drivable_area_lanelets_publisher_->publish(drivable_area_lines);
   }
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -84,7 +84,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
   if (planner_data_->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
     debug_drivable_area_lanelets_publisher_ =
-      create_publisher<MarkerArray>("~/drivable_area_lanelet", 1);
+      create_publisher<MarkerArray>("~/drivable_area_boundary", 1);
   }
 
   // behavior tree manager
@@ -166,7 +166,7 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.turn_light_on_threshold_dis_long = declare_parameter("turn_light_on_threshold_dis_long", 10.0);
   p.turn_light_on_threshold_time = declare_parameter("turn_light_on_threshold_time", 3.0);
   p.visualize_drivable_area_for_shared_linestrings_lanelet =
-    declare_parameter("visualize_drivable_area_for_shared_linestrings_lanelet", false);
+    declare_parameter("visualize_drivable_area_for_shared_linestrings_lanelet", true);
 
   // vehicle info
   const auto vehicle_info = VehicleInfoUtil(*this).getVehicleInfo();
@@ -511,7 +511,7 @@ void BehaviorPathPlannerNode::run()
 
   if (planner_data_->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
     const auto drivable_area_lines = marker_utils::createFurthestLineStringMarkerArray(
-      util::getDrivableAreaforAllSharedLinestringLanelets(planner_data_));
+      util::getDrivableAreaForAllSharedLinestringLanelets(planner_data_));
     debug_drivable_area_lanelets_publisher_->publish(drivable_area_lines);
   }
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -510,9 +510,8 @@ void BehaviorPathPlannerNode::run()
   publishDebugMarker(bt_manager_->getDebugMarkers());
 
   if (planner_data_->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
-    const auto drivable_area_lines = marker_utils::createOvehangFurthestLineStringMarkerArray(
-      util::getDrivableAreaforAllSharedLinestringLanelets(planner_data_), "drivables", 0.984, 0.831,
-      0.725);
+    const auto drivable_area_lines = marker_utils::createFurthestLineStringMarkerArray(
+      util::getDrivableAreaforAllSharedLinestringLanelets(planner_data_));
     debug_drivable_area_lanelets_publisher_->publish(drivable_area_lines);
   }
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -504,7 +504,8 @@ void BehaviorPathPlannerNode::run()
 
   publishDebugMarker(bt_manager_->getDebugMarkers());
 
-  visualizeDrivableAreasWithSharedLanelets();
+  debug_drivable_area_lanelets_publisher_->publish(
+    util::generateDrivableAreaForAllSharedLinestringLanelets(planner_data_));
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }
 
@@ -706,12 +707,6 @@ PathWithLaneId BehaviorPathPlannerNode::modifyPathForSmoothGoalConnection(
   refined_path.header.stamp = this->now();
 
   return refined_path;
-}
-
-void BehaviorPathPlannerNode::visualizeDrivableAreasWithSharedLanelets()
-{
-  debug_drivable_area_lanelets_publisher_->publish(
-    util::generateDrivableAreaForAllSharedLinestringLanelets(planner_data_));
 }
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -71,6 +71,8 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     create_publisher<TurnIndicatorsCommand>("~/output/turn_indicators_cmd", 1);
   hazard_signal_publisher_ = create_publisher<HazardLightsCommand>("~/output/hazard_lights_cmd", 1);
   debug_drivable_area_publisher_ = create_publisher<OccupancyGrid>("~/debug/drivable_area", 1);
+  debug_drivable_area_lanelets_publisher_ =
+    create_publisher<OccupancyGrid>("~/drivable_area_lanelet", 1);
   debug_path_publisher_ = create_publisher<Path>("~/debug/path_for_visualize", 1);
 
   // For remote operation
@@ -502,6 +504,7 @@ void BehaviorPathPlannerNode::run()
 
   publishDebugMarker(bt_manager_->getDebugMarkers());
 
+  visualizeDrivableAreasWithSharedLanelets();
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }
 
@@ -705,6 +708,80 @@ PathWithLaneId BehaviorPathPlannerNode::modifyPathForSmoothGoalConnection(
   return refined_path;
 }
 
+void BehaviorPathPlannerNode::visualizeDrivableAreasWithSharedLanelets()
+{
+  [[maybe_unused]] const auto & route_handler = planner_data_->route_handler;
+  const auto ego_pose = planner_data_->self_pose->pose;
+  lanelet::ConstLanelet current_lane;
+  if (!route_handler->getClosestLaneletWithinRoute(ego_pose, &current_lane)) {
+    return;
+  }
+
+  lanelet::ConstLanelets current_lanes =
+    route_handler->getLaneletSequence(current_lane, ego_pose, 0.5, 3.0);
+
+  [[maybe_unused]] const auto searchLeftLaneletsAndAppendToDrivableAreas =
+    [&route_handler](
+      const lanelet::ConstLanelet & current_lanelet, auto & lanelet_to_be_extended,
+      bool extend_to_opposite_lane = true) noexcept {
+      auto lanelet_at_left = route_handler->getLeftLanelet(current_lanelet);
+      auto lanelet_at_left_opposite = route_handler->getLeftOppositeLanelets(current_lanelet);
+      while (lanelet_at_left) {
+        lanelet_to_be_extended.push_back(lanelet_at_left.get());
+        lanelet_at_left = route_handler->getLeftLanelet(lanelet_at_left.get());
+        lanelet_at_left_opposite = route_handler->getLeftOppositeLanelets(lanelet_at_left.get());
+      }
+
+      if (!lanelet_at_left_opposite.empty() && extend_to_opposite_lane) {
+        auto lanelet_at_right = route_handler->getRightLanelet(lanelet_at_left_opposite.front());
+        while (lanelet_at_right) {
+          lanelet_to_be_extended.push_back(lanelet_at_right.get());
+          lanelet_at_right = route_handler->getRightLanelet(lanelet_at_right.get());
+        }
+      }
+    };
+
+  [[maybe_unused]] const auto searchRightLaneletsAndAppendToDrivableAreas =
+    [&route_handler](
+      const lanelet::ConstLanelet & current_lanelet, auto & lanelet_to_be_extended,
+      bool extend_to_opposite_lane = true) noexcept {
+      auto lanelet_at_right = route_handler->getRightLanelet(current_lanelet);
+      auto lanelet_at_right_opposite = route_handler->getRightOppositeLanelets(current_lanelet);
+      while (lanelet_at_right) {
+        lanelet_to_be_extended.push_back(lanelet_at_right.get());
+        lanelet_at_right = route_handler->getRightLanelet(lanelet_at_right.get());
+        lanelet_at_right_opposite = route_handler->getRightOppositeLanelets(lanelet_at_right.get());
+      }
+
+      if (!lanelet_at_right_opposite.empty() && extend_to_opposite_lane) {  // means lanelets in the
+                                                                            // opposite
+                                                                            // direction exist
+        lanelet_to_be_extended.push_back(lanelet_at_right_opposite.front());
+        auto lanelet_at_left = route_handler->getLeftLanelet(lanelet_at_right_opposite.front());
+        while (lanelet_at_left) {
+          lanelet_to_be_extended.push_back(lanelet_at_left.get());
+          lanelet_at_left = route_handler->getLeftLanelet(lanelet_at_left.get());
+        }
+      }
+    };
+
+  lanelet::ConstLanelets debug_connected;
+  for (auto & lane : current_lanes) {
+    debug_connected.push_back(lane);
+    searchRightLaneletsAndAppendToDrivableAreas(lane, debug_connected);
+
+    constexpr bool isRightHandDriving = false;
+    searchLeftLaneletsAndAppendToDrivableAreas(lane, debug_connected, !isRightHandDriving);
+  }
+
+  constexpr double area_resolution = 0.1;
+  const auto & vehicle_length = planner_data_->parameters.vehicle_length;
+  std::cout << debug_connected.size() << '\n';
+
+  const auto drivabless =
+    util::generateDrivableArea(debug_connected, area_resolution, vehicle_length, planner_data_);
+  debug_drivable_area_lanelets_publisher_->publish(drivabless);
+}
 }  // namespace behavior_path_planner
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -71,8 +71,6 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     create_publisher<TurnIndicatorsCommand>("~/output/turn_indicators_cmd", 1);
   hazard_signal_publisher_ = create_publisher<HazardLightsCommand>("~/output/hazard_lights_cmd", 1);
   debug_drivable_area_publisher_ = create_publisher<OccupancyGrid>("~/debug/drivable_area", 1);
-  debug_drivable_area_lanelets_publisher_ =
-    create_publisher<OccupancyGrid>("~/drivable_area_lanelet", 1);
   debug_path_publisher_ = create_publisher<Path>("~/debug/path_for_visualize", 1);
 
   // For remote operation
@@ -83,6 +81,11 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
   // Debug
   debug_marker_publisher_ = create_publisher<MarkerArray>("~/debug/markers", 1);
+
+  if (planner_data_->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
+    debug_drivable_area_lanelets_publisher_ =
+      create_publisher<OccupancyGrid>("~/drivable_area_lanelet", 1);
+  }
 
   // behavior tree manager
   {
@@ -162,6 +165,8 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.turn_light_on_threshold_dis_lat = declare_parameter("turn_light_on_threshold_dis_lat", 0.3);
   p.turn_light_on_threshold_dis_long = declare_parameter("turn_light_on_threshold_dis_long", 10.0);
   p.turn_light_on_threshold_time = declare_parameter("turn_light_on_threshold_time", 3.0);
+  p.visualize_drivable_area_for_shared_linestrings_lanelet =
+    declare_parameter("visualize_drivable_area_for_shared_linestrings_lanelet", false);
 
   // vehicle info
   const auto vehicle_info = VehicleInfoUtil(*this).getVehicleInfo();
@@ -504,8 +509,10 @@ void BehaviorPathPlannerNode::run()
 
   publishDebugMarker(bt_manager_->getDebugMarkers());
 
-  debug_drivable_area_lanelets_publisher_->publish(
-    util::generateDrivableAreaForAllSharedLinestringLanelets(planner_data_));
+  if (planner_data_->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
+    debug_drivable_area_lanelets_publisher_->publish(
+      util::generateDrivableAreaForAllSharedLinestringLanelets(planner_data_));
+  }
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -584,11 +584,11 @@ MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3
   rights.reserve(reserve_size);
 
   for (size_t idx = 1; idx < linestrings.size(); idx += 2) {
-    lefts.emplace_back(linestrings.at(idx - 1));
-    rights.emplace_back(linestrings.at(idx));
+    rights.emplace_back(linestrings.at(idx - 1));
+    lefts.emplace_back(linestrings.at(idx));
   }
 
-  const auto & first_ls = linestrings.front().basicLineString();
+  const auto & first_ls = lefts.front().basicLineString();
   for (const auto & ls : first_ls) {
     Point p;
     p.x = ls.x();

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -570,7 +570,6 @@ MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3
   marker.ns = "shared_linestring_lanelets";
   marker.lifetime = rclcpp::Duration::from_seconds(0.2);
 
-
   marker.type = Marker::LINE_STRIP;
   marker.action = Marker::ADD;
   marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
@@ -584,18 +583,18 @@ MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3
   lefts.reserve(reserve_size);
   rights.reserve(reserve_size);
 
-  for (size_t idx = 1; idx < linestrings.size(); idx+=2) {
+  for (size_t idx = 1; idx < linestrings.size(); idx += 2) {
     lefts.emplace_back(linestrings.at(idx - 1));
     rights.emplace_back(linestrings.at(idx));
   }
 
   const auto & first_ls = linestrings.front().basicLineString();
-  for(const auto & ls:first_ls){
-  Point p;
-  p.x = ls.x();
-  p.y = ls.y();
-  p.z = ls.z();
-  marker.points.push_back(p);
+  for (const auto & ls : first_ls) {
+    Point p;
+    p.x = ls.x();
+    p.y = ls.y();
+    p.z = ls.z();
+    marker.points.push_back(p);
   }
 
   for (auto idx = lefts.cbegin() + 1; idx != lefts.cend(); ++idx) {
@@ -610,7 +609,8 @@ MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3
     front_inverted.x = left_inverted_front.x();
     front_inverted.y = left_inverted_front.y();
     front_inverted.z = left_inverted_front.z();
-    const bool cond = tier4_autoware_utils::calcDistance2d(marker_back, front) < tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
+    const bool cond = tier4_autoware_utils::calcDistance2d(marker_back, front) <
+                      tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
     const auto & left_ls = (cond) ? idx->basicLineString() : idx->invert().basicLineString();
     for (auto ls = left_ls.cbegin(); ls != left_ls.cend(); ++ls) {
       Point p;
@@ -632,7 +632,8 @@ MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3
     front_inverted.x = right_inverted_front.x();
     front_inverted.y = right_inverted_front.y();
     front_inverted.z = right_inverted_front.z();
-    const bool cond = tier4_autoware_utils::calcDistance2d(marker_back, front) > tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
+    const bool cond = tier4_autoware_utils::calcDistance2d(marker_back, front) >
+                      tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
     const auto & right_ls = (cond) ? idx->basicLineString() : idx->invert().basicLineString();
     for (auto ls = right_ls.crbegin(); ls != right_ls.crend(); ++ls) {
       Point p;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -557,6 +557,95 @@ MarkerArray createOvehangFurthestLineStringMarkerArray(
 
   return msg;
 }
+
+MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3d & linestrings)
+{
+  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+
+  MarkerArray msg;
+
+  Marker marker{};
+  marker.header.frame_id = "map";
+  marker.header.stamp = current_time;
+  marker.ns = "shared_linestring_lanelets";
+  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+
+
+  marker.type = Marker::LINE_STRIP;
+  marker.action = Marker::ADD;
+  marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
+  marker.scale = tier4_autoware_utils::createMarkerScale(0.3, 0.0, 0.0);
+  marker.color = tier4_autoware_utils::createMarkerColor(0.996, 0.658, 0.466, 0.999);
+
+  const auto reserve_size = linestrings.size() / 2;
+
+  lanelet::ConstLineStrings3d lefts;
+  lanelet::ConstLineStrings3d rights;
+  lefts.reserve(reserve_size);
+  rights.reserve(reserve_size);
+
+  for (size_t idx = 1; idx < linestrings.size(); idx+=2) {
+    lefts.emplace_back(linestrings.at(idx - 1));
+    rights.emplace_back(linestrings.at(idx));
+  }
+
+  const auto & first_ls = linestrings.front().basicLineString();
+  for(const auto & ls:first_ls){
+  Point p;
+  p.x = ls.x();
+  p.y = ls.y();
+  p.z = ls.z();
+  marker.points.push_back(p);
+  }
+
+  for (auto idx = lefts.cbegin() + 1; idx != lefts.cend(); ++idx) {
+    const auto marker_back = marker.points.back();
+    const auto left_front = idx->basicLineString().front();
+    Point front;
+    front.x = left_front.x();
+    front.y = left_front.y();
+    front.z = left_front.z();
+    const auto left_inverted_front = idx->invert().basicLineString().front();
+    Point front_inverted;
+    front_inverted.x = left_inverted_front.x();
+    front_inverted.y = left_inverted_front.y();
+    front_inverted.z = left_inverted_front.z();
+    const bool cond = tier4_autoware_utils::calcDistance2d(marker_back, front) < tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
+    const auto & left_ls = (cond) ? idx->basicLineString() : idx->invert().basicLineString();
+    for (auto ls = left_ls.cbegin(); ls != left_ls.cend(); ++ls) {
+      Point p;
+      p.x = ls->x();
+      p.y = ls->y();
+      p.z = ls->z();
+      marker.points.push_back(p);
+    }
+  }
+  for (auto idx = rights.crbegin(); idx != rights.crend(); ++idx) {
+    const auto marker_back = marker.points.back();
+    const auto right_front = idx->basicLineString().front();
+    Point front;
+    front.x = right_front.x();
+    front.y = right_front.y();
+    front.z = right_front.z();
+    const auto right_inverted_front = idx->invert().basicLineString().front();
+    Point front_inverted;
+    front_inverted.x = right_inverted_front.x();
+    front_inverted.y = right_inverted_front.y();
+    front_inverted.z = right_inverted_front.z();
+    const bool cond = tier4_autoware_utils::calcDistance2d(marker_back, front) > tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
+    const auto & right_ls = (cond) ? idx->basicLineString() : idx->invert().basicLineString();
+    for (auto ls = right_ls.crbegin(); ls != right_ls.crend(); ++ls) {
+      Point p;
+      p.x = ls->x();
+      p.y = ls->y();
+      p.z = ls->z();
+      marker.points.push_back(p);
+    }
+  }
+  marker.points.push_back(marker.points.front());
+  msg.markers.push_back(marker);
+  return msg;
+}
 }  // namespace marker_utils
 
 std::string toStrInfo(const behavior_path_planner::ShiftPointArray & sp_arr)
@@ -593,7 +682,6 @@ std::string toStrInfo(const behavior_path_planner::AvoidPointArray & ap_arr)
   }
   return ss.str();
 }
-
 std::string toStrInfo(const behavior_path_planner::AvoidPoint & ap)
 {
   std::stringstream pids;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1618,7 +1618,7 @@ std::shared_ptr<PathWithLaneId> generateCenterLinePath(
 
 // TODO(Azu) Some parts of is the same with generateCenterLinePath. Therefore it might be better if
 // we can refactor some of the code for better readability
-lanelet::ConstLineStrings3d getDrivableAreaforAllSharedLinestringLanelets(
+lanelet::ConstLineStrings3d getDrivableAreaForAllSharedLinestringLanelets(
   const std::shared_ptr<const PlannerData> & planner_data)
 {
   const auto & p = planner_data->parameters;


### PR DESCRIPTION
## Related Issue(required)

#485 

## Description(required)

The PR includes visualization for drivable area.
In the lanelet map, there are times when two connected lanelets doesn't share same linestring. Therefore it is better if we can observe them without enabling any of the modules.

The PR depends on [refactor(avoidance_module): change implementation to lambda #486](https://github.com/autowarefoundation/autoware.universe/pull/486) , since it is done using the refactored function from the route handler.

The feature doesn't change any behavior of the behavior path planner module.

#### Odaiba Vector Map example
<!--
<img src="https://user-images.githubusercontent.com/93502286/157263205-f7a6b600-027e-483c-b966-fc4fd12b54de.png" width="400"> <img src="https://user-images.githubusercontent.com/93502286/157263242-3ff3bcef-cf76-4d12-84b5-833839f28676.png" width="400"> -->
<img src="https://user-images.githubusercontent.com/93502286/158483628-50843fe1-3f2b-4756-992d-406ac69b2f14.png" width="400">
#### Kashiwanoha Vector Map example
<!--
<img src="https://user-images.githubusercontent.com/93502286/157263441-a65bde80-451b-487a-af40-d356150b1689.png" width="400"> <img src="https://user-images.githubusercontent.com/93502286/157263479-47639fdb-4889-48e4-9e6f-cfc418c86c06.png" width="400">
<img src="https://user-images.githubusercontent.com/93502286/157263463-e94226fb-4cf4-413e-8add-902e82dac274.png" width="400"> -->


## Prerequisit before review
1. checkout the launcher PR https://github.com/tier4/autoware_launch/pull/239
    1. In behavior_path_planner.param.yaml set the debug flag `visualize_drivable_area_for_shared_linestrings_lanelet` value to true 
3. checkout #486 (Not required if it is merged later).

## Review Procedure(required)
1. Use `vector_map` that contains not lanelets that doesn't share same linestring. 
4. Place ego starting position and the goal
5. Add the `map` marker via `planning` > `scenario_planning` > `lane_driving` > `behavior_driving` > `behavior_path_planner` > `drivable_area_lanelet`

## Related PR(Required)

https://github.com/autowarefoundation/autoware.universe/pull/486

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
