### PR TITLE
feat(system_error_monitor): output emergency reason for debugging

### DIFF
--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -28,18 +28,17 @@
 
 namespace
 {
-enum class DebugLevel { DEBUG = 0, INFO, WARN, ERROR };
+enum class DebugLevel { DEBUG, INFO, WARN, ERROR, FATAL };
 
-// debug: 0, info: 1, warn: 2, error: 3
 template <DebugLevel debug_level>
 void logThrottledNamed(
-  const std::string & logger_name, const rclcpp::Clock::SharedPtr clock, const double duration,
+  const std::string & logger_name, const rclcpp::Clock::SharedPtr clock, const double duration_ms,
   const std::string & message)
 {
   static std::unordered_map<std::string, rclcpp::Time> last_output_time;
   if (last_output_time.count(logger_name) != 0) {
     const auto time_from_last_output = clock->now() - last_output_time.at(logger_name);
-    if (time_from_last_output.seconds() * 1000.0 < duration) {
+    if (time_from_last_output.seconds() * 1000.0 < duration_ms) {
       return;
     }
   }
@@ -53,6 +52,8 @@ void logThrottledNamed(
     RCLCPP_WARN(rclcpp::get_logger(logger_name), message.c_str());
   } else if constexpr (debug_level == DebugLevel::ERROR) {
     RCLCPP_ERROR(rclcpp::get_logger(logger_name), message.c_str());
+  } else if constexpr (debug_level == DebugLevel::FATAL) {
+    RCLCPP_FATAL(rclcpp::get_logger(logger_name), message.c_str());
   }
 }
 

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -26,26 +26,33 @@
 
 #include <fmt/format.h>
 
-#define DEFINE_TIER4_RCLCPP_LOG(LEVEL)                                                   \
-  void TIER4_RCLCPP_##LEVEL##_THROTTLE(                                                  \
-    const std::string & logger_name, rclcpp::Clock clock, const double duration,         \
-    const std::string & message)                                                         \
-  {                                                                                      \
-    static std::unordered_map<std::string, rclcpp::Time> last_output_time;               \
-    if (last_output_time.count(logger_name) != 0) {                                      \
-      const auto time_from_last_output = clock.now() - last_output_time.at(logger_name); \
-      if (time_from_last_output.seconds() * 1000.0 < duration) {                         \
-        return;                                                                          \
-      }                                                                                  \
-    }                                                                                    \
-    last_output_time[logger_name] = clock.now();                                         \
-    RCLCPP_##LEVEL(rclcpp::get_logger(logger_name), message.c_str());                    \
-  }
-
 namespace
 {
-DEFINE_TIER4_RCLCPP_LOG(ERROR);
-DEFINE_TIER4_RCLCPP_LOG(WARN);
+// debug: 0, info: 1, warn: 2, error: 3
+template <int debug_level>
+void logThrottledNamed(
+  const std::string & logger_name, rclcpp::Clock clock, const double duration,
+  const std::string & message)
+{
+  static std::unordered_map<std::string, rclcpp::Time> last_output_time;
+  if (last_output_time.count(logger_name) != 0) {
+    const auto time_from_last_output = clock.now() - last_output_time.at(logger_name);
+    if (time_from_last_output.seconds() * 1000.0 < duration) {
+      return;
+    }
+  }
+
+  last_output_time[logger_name] = clock.now();
+  if constexpr (debug_level == 0) {
+    RCLCPP_DEBUG(rclcpp::get_logger(logger_name), message.c_str());
+  } else if constexpr (debug_level == 1) {
+    RCLCPP_INFO(rclcpp::get_logger(logger_name), message.c_str());
+  } else if constexpr (debug_level == 2) {
+    RCLCPP_WARN(rclcpp::get_logger(logger_name), message.c_str());
+  } else if constexpr (debug_level == 3) {
+    RCLCPP_ERROR(rclcpp::get_logger(logger_name), message.c_str());
+  }
+}
 
 std::vector<std::string> split(const std::string & str, const char delim)
 {
@@ -131,14 +138,13 @@ diagnostic_msgs::msg::DiagnosticArray convertHazardStatusToDiagnosticArray(
   }
   for (const auto & hazard_diag : hazard_status.diag_latent_fault) {
     const std::string logger_name = "system_error_monitor " + hazard_diag.name;
-    TIER4_RCLCPP_WARN_THROTTLE(logger_name, *clock, 5000, "[Latent Fault]: " + hazard_diag.message);
+    logThrottledNamed<2>(logger_name, *clock, 5000, "[Latent Fault]: " + hazard_diag.message);
 
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Latent Fault]"));
   }
   for (const auto & hazard_diag : hazard_status.diag_single_point_fault) {
     const std::string logger_name = "system_error_monitor " + hazard_diag.name;
-    TIER4_RCLCPP_ERROR_THROTTLE(
-      logger_name, *clock, 5000, "[Single Point Fault]: " + hazard_diag.message);
+    logThrottledNamed<3>(logger_name, *clock, 5000, "[Single Point Fault]: " + hazard_diag.message);
 
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Single Point Fault]"));
   }

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -31,18 +31,18 @@ namespace
 // debug: 0, info: 1, warn: 2, error: 3
 template <int debug_level>
 void logThrottledNamed(
-  const std::string & logger_name, rclcpp::Clock clock, const double duration,
+  const std::string & logger_name, const rclcpp::Clock::SharedPtr clock, const double duration,
   const std::string & message)
 {
   static std::unordered_map<std::string, rclcpp::Time> last_output_time;
   if (last_output_time.count(logger_name) != 0) {
-    const auto time_from_last_output = clock.now() - last_output_time.at(logger_name);
+    const auto time_from_last_output = clock->now() - last_output_time.at(logger_name);
     if (time_from_last_output.seconds() * 1000.0 < duration) {
       return;
     }
   }
 
-  last_output_time[logger_name] = clock.now();
+  last_output_time[logger_name] = clock->now();
   if constexpr (debug_level == 0) {
     RCLCPP_DEBUG(rclcpp::get_logger(logger_name), message.c_str());
   } else if constexpr (debug_level == 1) {
@@ -138,13 +138,13 @@ diagnostic_msgs::msg::DiagnosticArray convertHazardStatusToDiagnosticArray(
   }
   for (const auto & hazard_diag : hazard_status.diag_latent_fault) {
     const std::string logger_name = "system_error_monitor " + hazard_diag.name;
-    logThrottledNamed<2>(logger_name, *clock, 5000, "[Latent Fault]: " + hazard_diag.message);
+    logThrottledNamed<2>(logger_name, clock, 5000, "[Latent Fault]: " + hazard_diag.message);
 
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Latent Fault]"));
   }
   for (const auto & hazard_diag : hazard_status.diag_single_point_fault) {
     const std::string logger_name = "system_error_monitor " + hazard_diag.name;
-    logThrottledNamed<3>(logger_name, *clock, 5000, "[Single Point Fault]: " + hazard_diag.message);
+    logThrottledNamed<3>(logger_name, clock, 5000, "[Single Point Fault]: " + hazard_diag.message);
 
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Single Point Fault]"));
   }

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -111,9 +111,15 @@ diagnostic_msgs::msg::DiagnosticArray convertHazardStatusToDiagnosticArray(
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Safe Fault]"));
   }
   for (const auto & hazard_diag : hazard_status.diag_latent_fault) {
+    RCLCPP_WARN_THROTTLE(
+      rclcpp::get_logger("system_error_monitor"), *clock, 5000, "[Latent Fault] %s: %s",
+      hazard_diag.name.c_str(), hazard_diag.message.c_str());
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Latent Fault]"));
   }
   for (const auto & hazard_diag : hazard_status.diag_single_point_fault) {
+    RCLCPP_ERROR_THROTTLE(
+      rclcpp::get_logger("system_error_monitor"), *clock, 5000, "[Single Point Fault] %s: %s",
+      hazard_diag.name.c_str(), hazard_diag.message.c_str());
     diag_array.status.push_back(decorateDiag(hazard_diag, "[Single Point Fault]"));
   }
 


### PR DESCRIPTION
## Related Issue(required)

Resolves https://github.com/autowarefoundation/autoware.universe/issues/508
<!-- Link related issue -->

## Description(required)

output latent fault (as rclcpp warn) and single point fault (as rclcpp error) in system_error_monitor
<!-- Describe what this PR changes. -->

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
