### PR TITLE
feat(planning_error_monitor): suppress error when no message was set.

### DIFF
--- a/planning/planning_error_monitor/src/planning_error_monitor_node.cpp
+++ b/planning/planning_error_monitor/src/planning_error_monitor_node.cpp
@@ -74,6 +74,7 @@ void PlanningErrorMonitorNode::onCurrentTrajectory(const Trajectory::ConstShared
 void PlanningErrorMonitorNode::onTrajectoryPointValueChecker(DiagnosticStatusWrapper & stat)
 {
   if (!current_trajectory_) {
+    stat.summary(DiagnosticStatus::OK, "No trajectory message was set.");
     return;
   }
 
@@ -87,6 +88,7 @@ void PlanningErrorMonitorNode::onTrajectoryPointValueChecker(DiagnosticStatusWra
 void PlanningErrorMonitorNode::onTrajectoryIntervalChecker(DiagnosticStatusWrapper & stat)
 {
   if (!current_trajectory_) {
+    stat.summary(DiagnosticStatus::OK, "No trajectory message was set.");
     return;
   }
 
@@ -101,6 +103,7 @@ void PlanningErrorMonitorNode::onTrajectoryIntervalChecker(DiagnosticStatusWrapp
 void PlanningErrorMonitorNode::onTrajectoryCurvatureChecker(DiagnosticStatusWrapper & stat)
 {
   if (!current_trajectory_) {
+    stat.summary(DiagnosticStatus::OK, "No trajectory message was set.");
     return;
   }
 
@@ -115,6 +118,7 @@ void PlanningErrorMonitorNode::onTrajectoryCurvatureChecker(DiagnosticStatusWrap
 void PlanningErrorMonitorNode::onTrajectoryRelativeAngleChecker(DiagnosticStatusWrapper & stat)
 {
   if (!current_trajectory_) {
+    stat.summary(DiagnosticStatus::OK, "No trajectory message was set.");
     return;
   }
 


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Related Issue(required)

Error diag is output from planning_error_monitor before trajectory message comes, which is misleading to developers.
Even if there are no required topics, it should be seen in another monitoring.
<!-- Link related issue -->

## Description(required)

No error diagnostics from planning_error_monitor before trajectory message comes.
<!-- Describe what this PR changes. -->

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
