### PR TITLE
chore: save engine file in the same directory as onnx file

### DIFF
--- a/perception/traffic_light_classifier/CMakeLists.txt
+++ b/perception/traffic_light_classifier/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(traffic_light_classifier)
 
 if(NOT CMAKE_CXX_STANDARD)
-	set(CMAKE_CXX_STANDARD 14)
+	set(CMAKE_CXX_STANDARD 17)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wno-deprecated-declarations -Werror)
@@ -133,7 +133,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     ${CUDA_LIBRARIES}
     ${CUBLAS_LIBRARIES}
     ${CUDNN_LIBRARY}
-    ${Boost_LIBRARIES}
+    stdc++fs
   )
 
   ament_auto_add_library(traffic_light_classifier_nodelet SHARED

--- a/perception/traffic_light_classifier/src/cnn_classifier.cpp
+++ b/perception/traffic_light_classifier/src/cnn_classifier.cpp
@@ -42,9 +42,7 @@ CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
 
   readLabelfile(label_file_path, labels_);
 
-  std::string cache_dir =
-    ament_index_cpp::get_package_share_directory("traffic_light_classifier") + "/data";
-  trt_ = std::make_shared<Tn::TrtCommon>(model_file_path, cache_dir, precision);
+  trt_ = std::make_shared<Tn::TrtCommon>(model_file_path, precision);
   trt_->setup();
 }
 

--- a/perception/traffic_light_classifier/utils/trt_common.hpp
+++ b/perception/traffic_light_classifier/utils/trt_common.hpp
@@ -18,8 +18,6 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
-#include <boost/filesystem.hpp>
-
 #include <./cudnn.h>
 #include <NvInfer.h>
 #include <NvOnnxParser.h>
@@ -110,7 +108,7 @@ Tn::UniquePtr<T> make_unique()
 class TrtCommon
 {
 public:
-  TrtCommon(std::string model_path, std::string cache_dir, std::string precision);
+  TrtCommon(std::string model_path, std::string precision);
   ~TrtCommon() {}
 
   bool loadEngine(std::string engine_file_path);

--- a/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
@@ -123,8 +123,6 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     ${CUDA_INCLUDE_DIRS}
   )
 
-  set(CMAKE_CXX_FLAGS "-O2 -Wall -Wunused-variable ${CMAKE_CXX_FLAGS} -fpic -std=c++11 -pthread")
-
   ### ssd ###
   ament_auto_add_library(ssd SHARED
     lib/src/trt_ssd.cpp
@@ -149,6 +147,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
 
   target_link_libraries(traffic_light_ssd_fine_detector_nodelet
     ${OpenCV_LIB}
+    stdc++fs
     ssd
   )
 

--- a/perception/traffic_light_ssd_fine_detector/src/nodelet.cpp
+++ b/perception/traffic_light_ssd_fine_detector/src/nodelet.cpp
@@ -14,8 +14,15 @@
 
 #include "traffic_light_ssd_fine_detector/nodelet.hpp"
 
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cuda_utils.hpp>
+
+#if (defined(_MSC_VER) or (defined(__GNUC__) and (7 <= __GNUC_MAJOR__)))
+#include <filesystem>
+namespace fs = ::std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = ::std::experimental::filesystem;
+#endif
 
 #include <memory>
 #include <string>
@@ -36,16 +43,14 @@ TrafficLightSSDFineDetectorNodelet::TrafficLightSSDFineDetectorNodelet(
   using std::placeholders::_1;
   using std::placeholders::_2;
 
-  std::string package_path =
-    ament_index_cpp::get_package_share_directory("traffic_light_ssd_fine_detector");
-  std::string data_path = package_path + "/data/";
-  std::string engine_path = package_path + "/data/mb2-ssd-lite.engine";
-  std::ifstream fs(engine_path);
   std::vector<std::string> labels;
   const int max_batch_size = this->declare_parameter("max_batch_size", 8);
   const std::string onnx_file = this->declare_parameter<std::string>("onnx_file");
   const std::string label_file = this->declare_parameter<std::string>("label_file");
   const std::string mode = this->declare_parameter("mode", "FP32");
+
+  fs::path engine_path{onnx_file};
+  engine_path.replace_extension("engine");
 
   if (readLabelFile(label_file, labels)) {
     if (!getTlrIdFromLabel(labels, tlr_id_)) {
@@ -53,8 +58,8 @@ TrafficLightSSDFineDetectorNodelet::TrafficLightSSDFineDetectorNodelet(
     }
   }
 
-  if (fs.is_open()) {
-    RCLCPP_INFO(this->get_logger(), "Found %s", engine_path.c_str());
+  if (fs::exists(engine_path)) {
+    RCLCPP_INFO(this->get_logger(), "Found %s", engine_path.string().c_str());
     net_ptr_.reset(new ssd::Net(engine_path, false));
     if (max_batch_size != net_ptr_->getMaxBatchSize()) {
       RCLCPP_INFO(
@@ -69,7 +74,7 @@ TrafficLightSSDFineDetectorNodelet::TrafficLightSSDFineDetectorNodelet(
   } else {
     RCLCPP_INFO(
       this->get_logger(), "Could not find %s, try making TensorRT engine from onnx",
-      engine_path.c_str());
+      engine_path.string().c_str());
     net_ptr_.reset(new ssd::Net(onnx_file, mode, max_batch_size));
     net_ptr_->save(engine_path);
   }


### PR DESCRIPTION
Signed-off-by: wep21 <border_goldenmarket@yahoo.co.jp>

## Related Issue(required)

<!-- Link related issue -->

## Description(required)

save an engine file in the same directory as an onnx file to handle the model files in the directory which is different from the default location.

## Review Procedure(required)

launch with the model path argument and confirm an engine file is created in the same directory as an onnx file.

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
