### PR TITLE
feat: add cpu and net diag in resource monitoring

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/system.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/system.param.yaml
@@ -76,6 +76,18 @@
                   contains: [": CPU Thermal Throttling"]
                   timeout: 3.0
 
+                frequency:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: frequency
+                  contains: [": CPU Frequency"]
+                  timeout: 3.0
+
+                load_average:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: load_average
+                  contains: [": CPU Load Average"]
+                  timeout: 3.0
+
             gpu:
               type: diagnostic_aggregator/AnalyzerGroup
               path: gpu
@@ -122,6 +134,12 @@
                   type: diagnostic_aggregator/GenericAnalyzer
                   path: network_usage
                   contains: [": Network Usage"]
+                  timeout: 3.0
+
+                network_traffic:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: network_traffic
+                  contains: [": Network Traffic"]
                   timeout: 3.0
 
             storage:


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

some diags  is not classified under resource_monitoring, `CPU Frequency`, `CPU Load Average` and `Network Traffic`.
This PR fix it.


## Review Procedure(required)

In rqt_robot_monitor, please confirm some diags is classified correctly like the following image.
![image](https://user-images.githubusercontent.com/9547070/158364739-6a8ccc4c-d8e6-41e4-9525-13f429823db3.png)


## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
