### PR TITLE
fix(behavior_path_planner): additional buffer during lane change for intersection

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -317,6 +317,11 @@ PathWithLaneId getCenterLinePath(
   const Pose & pose, const double backward_path_length, const double forward_path_length,
   const BehaviorPathPlannerParameters & parameter);
 
+PathWithLaneId getCenterLinePath(
+  const RouteHandler & route_handler, const lanelet::ConstLanelets & lanelet_sequence,
+  const Pose & pose, const double backward_path_length, const double forward_path_length,
+  const BehaviorPathPlannerParameters & parameter, const double & additional_length);
+
 PathWithLaneId setDecelerationVelocity(
   const RouteHandler & route_handler, const PathWithLaneId & input,
   const lanelet::ConstLanelets & lanelet_sequence, const double lane_change_prepare_duration,
@@ -327,6 +332,11 @@ PathWithLaneId setDecelerationVelocity(
   const lanelet::ConstLanelets & lanelet_sequence, const double distance_after_pullover,
   const double pullover_distance_min, const double distance_before_pull_over,
   const double deceleration_interval, Pose goal_pose);
+
+bool checkLaneIsInIntersection(
+  const RouteHandler & route_handler, const PathWithLaneId & ref,
+  const lanelet::ConstLanelets & lanelet_sequence, const double & lane_change_buffer,
+  double & additional_length_to_add);
 
 // object label
 std::uint8_t getHighestProbLabel(const std::vector<ObjectClassification> & classification);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -315,12 +315,7 @@ void shiftPose(Pose * pose, double shift_length);
 PathWithLaneId getCenterLinePath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & lanelet_sequence,
   const Pose & pose, const double backward_path_length, const double forward_path_length,
-  const BehaviorPathPlannerParameters & parameter);
-
-PathWithLaneId getCenterLinePath(
-  const RouteHandler & route_handler, const lanelet::ConstLanelets & lanelet_sequence,
-  const Pose & pose, const double backward_path_length, const double forward_path_length,
-  const BehaviorPathPlannerParameters & parameter, const double & additional_length);
+  const BehaviorPathPlannerParameters & parameter, double optional_length = 0.0);
 
 PathWithLaneId setDecelerationVelocity(
   const RouteHandler & route_handler, const PathWithLaneId & input,
@@ -335,8 +330,7 @@ PathWithLaneId setDecelerationVelocity(
 
 bool checkLaneIsInIntersection(
   const RouteHandler & route_handler, const PathWithLaneId & ref,
-  const lanelet::ConstLanelets & lanelet_sequence, const double & lane_change_buffer,
-  double & additional_length_to_add);
+  const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add);
 
 // object label
 std::uint8_t getHighestProbLabel(const std::vector<ObjectClassification> & classification);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -237,6 +237,20 @@ PathWithLaneId LaneChangeModule::getReferencePath() const
     return reference_path;
   }
 
+  if (reference_path.points.empty()) {
+    reference_path = util::getCenterLinePath(
+      *route_handler, current_lanes, current_pose, common_parameters.backward_path_length,
+      common_parameters.forward_path_length, common_parameters);
+  }
+
+  double optional_lengths{0.0};
+  const auto isInIntersection = util::checkLaneIsInIntersection(
+    *route_handler, reference_path, current_lanes, optional_lengths);
+  if (isInIntersection) {
+    reference_path = util::getCenterLinePath(
+      *route_handler, current_lanes, current_pose, common_parameters.backward_path_length,
+      common_parameters.forward_path_length, common_parameters, optional_lengths);
+  }
   const double buffer =
     common_parameters.backward_length_buffer_for_end_of_lane;  // buffer for min_lane_change_length
   const int num_lane_change =
@@ -244,26 +258,9 @@ PathWithLaneId LaneChangeModule::getReferencePath() const
   const double lane_change_buffer =
     num_lane_change * (common_parameters.minimum_lane_change_length + buffer);
 
-  reference_path = util::getCenterLinePath(
-    *route_handler, current_lanes, current_pose, common_parameters.backward_path_length,
-    common_parameters.forward_path_length, common_parameters);
-
-  double optional_lengths{0.0};
-  const auto isInIntersection = util::checkLaneIsInIntersection(
-    *route_handler, reference_path, current_lanes, lane_change_buffer, optional_lengths);
-
-  if (isInIntersection) {
-    reference_path = util::getCenterLinePath(
-      *route_handler, current_lanes, current_pose, common_parameters.backward_path_length,
-      common_parameters.forward_path_length, common_parameters, optional_lengths);
-    reference_path = util::setDecelerationVelocity(
-      *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
-      lane_change_buffer + optional_lengths);
-  } else {
-    reference_path = util::setDecelerationVelocity(
-      *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
-      lane_change_buffer);
-  }
+  reference_path = util::setDecelerationVelocity(
+    *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
+    lane_change_buffer);
 
   reference_path.drivable_area = util::generateDrivableArea(
     current_lanes, common_parameters.drivable_area_resolution, common_parameters.vehicle_length,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -247,9 +247,24 @@ PathWithLaneId LaneChangeModule::getReferencePath() const
   reference_path = util::getCenterLinePath(
     *route_handler, current_lanes, current_pose, common_parameters.backward_path_length,
     common_parameters.forward_path_length, common_parameters);
-  reference_path = util::setDecelerationVelocity(
-    *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
-    lane_change_buffer);
+
+  double optional_lengths{0.0};
+  const auto isInIntersection = util::checkLaneIsInIntersection(
+    *route_handler, reference_path, current_lanes, lane_change_buffer, optional_lengths);
+
+  if (isInIntersection) {
+    reference_path = util::getCenterLinePath(
+      *route_handler, current_lanes, current_pose, common_parameters.backward_path_length,
+      common_parameters.forward_path_length, common_parameters, optional_lengths);
+    reference_path = util::setDecelerationVelocity(
+      *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
+      lane_change_buffer + optional_lengths);
+  } else {
+    reference_path = util::setDecelerationVelocity(
+      *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
+      lane_change_buffer);
+  }
+
   reference_path.drivable_area = util::generateDrivableArea(
     current_lanes, common_parameters.drivable_area_resolution, common_parameters.vehicle_length,
     planner_data_);

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -102,9 +102,23 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
     const int num_lane_change =
       std::abs(route_handler->getNumLaneToPreferredLane(current_lanes.back()));
     const double lane_change_buffer = num_lane_change * (p.minimum_lane_change_length + buffer);
-    reference_path = util::setDecelerationVelocity(
-      *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
-      lane_change_buffer);
+
+    double optional_lengths{0.0};
+    const auto isInIntersection = util::checkLaneIsInIntersection(
+      *route_handler, reference_path, current_lanes, lane_change_buffer, optional_lengths);
+
+    if (isInIntersection) {
+      reference_path = util::getCenterLinePath(
+        *route_handler, current_lanes, current_pose, p.backward_path_length, p.forward_path_length,
+        p, optional_lengths);
+      reference_path = util::setDecelerationVelocity(
+        *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
+        lane_change_buffer + optional_lengths);
+    } else {
+      reference_path = util::setDecelerationVelocity(
+        *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
+        lane_change_buffer);
+    }
   }
 
   if (parameters_.expand_drivable_area) {

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -97,28 +97,25 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
     *route_handler, current_lanes, current_pose, p.backward_path_length, p.forward_path_length, p);
 
   {
-    // buffer for min_lane_change_length
-    const double buffer = p.backward_length_buffer_for_end_of_lane;
-    const int num_lane_change =
-      std::abs(route_handler->getNumLaneToPreferredLane(current_lanes.back()));
-    const double lane_change_buffer = num_lane_change * (p.minimum_lane_change_length + buffer);
-
     double optional_lengths{0.0};
     const auto isInIntersection = util::checkLaneIsInIntersection(
-      *route_handler, reference_path, current_lanes, lane_change_buffer, optional_lengths);
+      *route_handler, reference_path, current_lanes, optional_lengths);
 
     if (isInIntersection) {
       reference_path = util::getCenterLinePath(
         *route_handler, current_lanes, current_pose, p.backward_path_length, p.forward_path_length,
         p, optional_lengths);
-      reference_path = util::setDecelerationVelocity(
-        *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
-        lane_change_buffer + optional_lengths);
-    } else {
-      reference_path = util::setDecelerationVelocity(
-        *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
-        lane_change_buffer);
     }
+
+    // buffer for min_lane_change_length
+    const double buffer = p.backward_length_buffer_for_end_of_lane + optional_lengths;
+    const int num_lane_change =
+      std::abs(route_handler->getNumLaneToPreferredLane(current_lanes.back()));
+    const double lane_change_buffer = num_lane_change * (p.minimum_lane_change_length + buffer);
+
+    reference_path = util::setDecelerationVelocity(
+      *route_handler, reference_path, current_lanes, parameters_.lane_change_prepare_duration,
+      lane_change_buffer);
   }
 
   if (parameters_.expand_drivable_area) {

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1749,7 +1749,7 @@ bool checkLaneIsInIntersection(
   const lanelet::ConstLanelets & lanelet_sequence, const double & lane_change_buffer,
   double & additional_length_to_add)
 {
-  if(lanelet_sequence.empty()){
+  if (lanelet_sequence.empty()) {
     return false;
   }
   const auto & path_points = ref.points;
@@ -1785,7 +1785,7 @@ bool checkLaneIsInIntersection(
 
   const auto lanes = route_handler.getNextLanelets(prev_lanelets.back());
   if (isHaveNeighborWithTurnDirection(lanes)) {
-    lanelet::ConstLanelets lane_of_interest {check_lane};
+    lanelet::ConstLanelets lane_of_interest{check_lane};
     // additional_length_to_add = lanelet::utils::getLaneletLength2d(check_lane);
     for (auto itr = prev_lanelets.crbegin(); itr != prev_lanelets.crend(); ++itr) {
       if (!itr->hasAttribute(lanelet::AttributeNamesString::LaneChange)) {

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1773,10 +1773,10 @@ bool checkLaneIsInIntersection(
   const auto prohibited_arc_coordinate =
     lanelet::utils::getArcCoordinates(lane_change_prohibited_lanes, end_of_route_pose);
 
-  constexpr double small_earliear_stopping_buffer = 0.2;
+  constexpr double small_earlier_stopping_buffer = 0.2;
   additional_length_to_add =
     prohibited_arc_coordinate.length +
-    small_earliear_stopping_buffer;  // additional a slight "buffer so that vehicle stop earlier"
+    small_earlier_stopping_buffer;  // additional a slight "buffer so that vehicle stop earlier"
 
   return true;
 }

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1745,14 +1745,14 @@ PathWithLaneId getCenterLinePath(
 }
 
 bool checkLaneIsInIntersection(
-  const RouteHandler & route_handler, const PathWithLaneId & ref,
+  const RouteHandler & route_handler, const PathWithLaneId & reference_path,
   const lanelet::ConstLanelets & lanelet_sequence, const double & lane_change_buffer,
   double & additional_length_to_add)
 {
   if (lanelet_sequence.empty()) {
     return false;
   }
-  const auto & path_points = ref.points;
+  const auto & path_points = reference_path.points;
   const auto last_arc_coordine =
     lanelet::utils::getArcCoordinates(lanelet_sequence, path_points.back().point.pose);
   const auto last_arc_length = last_arc_coordine.length;


### PR DESCRIPTION
This is so that if lane change is performed on restricted areas, the final lane
change point will be before the restricted areas.

Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Related Issue(required)

https://github.com/autowarefoundation/autoware.universe/issues/531

## Description(required)

The PR adds additional check to see the end trajectory is in the intersection, and if it is in the intersection, the the function will compute the necessary distance for the vehicle to stop just in front of the intersection.

## Review Procedure(required)
Place goal just after the intersection and see that the end of trajectory is before the intersection

https://user-images.githubusercontent.com/93502286/160962209-776238b0-11d7-4a92-97fe-69cfe1c4076a.mp4

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [X] Read [commit-guidelines][commit-guidelines]
- [X] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
