### PR TITLE
fix(planning_errror_monitor): ignore invalid calculation in curvature validation

### DIFF
--- a/planning/planning_error_monitor/src/planning_error_monitor_node.cpp
+++ b/planning/planning_error_monitor/src/planning_error_monitor_node.cpp
@@ -251,6 +251,9 @@ bool PlanningErrorMonitorNode::checkTrajectoryCurvature(
   }
 
   constexpr double points_distance = 1.0;
+  const auto isValidDistance = [points_distance](const auto & p1, const auto & p2) {
+    return calcDistance2d(p1, p2) >= points_distance;
+  };
 
   for (size_t p1_id = 0; p1_id < traj.points.size() - 2; ++p1_id) {
     // Get Point1
@@ -266,6 +269,9 @@ bool PlanningErrorMonitorNode::checkTrajectoryCurvature(
 
     // no need to check for pi, since there is no point with "points_distance" from p1.
     if (p1_id == p2_id || p1_id == p3_id || p2_id == p3_id) {
+      break;
+    }
+    if (!isValidDistance(p1, p2) || !isValidDistance(p1, p3) || !isValidDistance(p2, p3)) {
       break;
     }
 


### PR DESCRIPTION

## Description

Add another validation in curvature calculation. Originally the curvature check is performed only when the curvature is appropriately calculated. The current check for the "appropriateness" is just the index comparison and it was not enough.

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
