### PR TITLE
feat(diagnostic_aggregator): add `localization_tf_status` to `/autoware/localization/node_alive_monitoring/tf_status`

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
@@ -14,6 +14,12 @@
               contains: [": localization_topic_status"]
               timeout: 1.0
 
+            tf_status:
+              type: diagnostic_aggregator/GenericAnalyzer
+              path: tf_status
+              contains: [": localization_tf_status"]
+              timeout: 1.0
+
         performance_monitoring:
           type: diagnostic_aggregator/AnalyzerGroup
           path: performance_monitoring


### PR DESCRIPTION
## Description
I add `localization_tf_status` to `/autoware/localization/node_alive_monitoring/`. 
So far it have been classified in `Other`.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed
Please check before and after in `rqt_robot_monitor`.
before:
![image](https://user-images.githubusercontent.com/9547070/158940941-bd10e2c5-3127-4fab-9a98-8e03d7e02798.png)

After:
![image](https://user-images.githubusercontent.com/9547070/158940851-ee44e7f4-c9cf-4aba-b3cf-ee6c9e05d9f6.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
