### PR TITLE
feat(behavior_velocity): add pass judge and fix detection area for blindspot 

### DIFF
--- a/planning/behavior_velocity_planner/config/blind_spot.param.yaml
+++ b/planning/behavior_velocity_planner/config/blind_spot.param.yaml
@@ -1,6 +1,7 @@
 /**:
   ros__parameters:
     blind_spot:
+      use_pass_judge_line: true
       stop_line_margin: 1.0 # [m]
       backward_length: 15.0 # [m]
       ignore_width_from_center_line: 0.7 # [m]

--- a/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
@@ -98,8 +98,9 @@ public:
 public:
   struct PlannerParam
   {
-    double stop_line_margin;  //! distance from auto-generated stopline to detection_area boundary
-    double backward_length;   //! distance[m] from closest path point to the edge of beginning point
+    bool use_pass_judge_line;  //! distance which ego can stop with max brake
+    double stop_line_margin;   //! distance from auto-generated stopline to detection_area boundary
+    double backward_length;  //! distance[m] from closest path point to the edge of beginning point
     double ignore_width_from_center_line;  //! ignore width from center line from detection_area
     double
       max_future_movement_time;  //! maximum time[second] for considering future movement of object
@@ -216,7 +217,7 @@ private:
    */
   int insertPoint(
     const int insert_idx_ip, const autoware_auto_planning_msgs::msg::PathWithLaneId path_ip,
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path) const;
+    autoware_auto_planning_msgs::msg::PathWithLaneId * path, bool & is_point_inserted) const;
 
   /**
    * @brief Calculate first path index that is conflicting lanelets.

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
@@ -59,6 +59,7 @@ BlindSpotModuleManager::BlindSpotModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
 {
   const std::string ns(getModuleName());
+  planner_param_.use_pass_judge_line = node.declare_parameter(ns + ".use_pass_judge_line", false);
   planner_param_.stop_line_margin = node.declare_parameter(ns + ".stop_line_margin", 1.0);
   planner_param_.backward_length = node.declare_parameter(ns + ".backward_length", 15.0);
   planner_param_.ignore_width_from_center_line =

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -89,7 +89,7 @@ bool BlindSpotModule::modifyPathVelocity(
     return false;
   }
 
-  if (stop_line_idx <= 0 || pass_judge_line_idx <= 0) {
+  if (stop_line_idx <= 0 || (planner_param_.use_pass_judge_line && pass_judge_line_idx <= 0)) {
     RCLCPP_DEBUG(
       logger_, "[Blind Spot] stop line or pass judge line is at path[0], ignore planning.");
     *path = input_path;  // reset path
@@ -472,7 +472,7 @@ boost::optional<BlindSpotPolygons> BlindSpotModule::generateBlindSpotPolygons(
     const auto conflict_area = lanelet::utils::getPolygonFromArcLength(
       blind_spot_lanelets, current_arc.length, stop_line_arc.length);
     const auto detection_area = lanelet::utils::getPolygonFromArcLength(
-      blind_spot_lanelets, detection_area_start_length, current_arc.length);
+      blind_spot_lanelets, detection_area_start_length, stop_line_arc.length);
 
     BlindSpotPolygons blind_spot_polygons;
     blind_spot_polygons.conflict_area = conflict_area;

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -303,7 +303,7 @@ int BlindSpotModule::insertPoint(
   int insert_idx = -1;
   // initialize with epsilon so that comparison with insert_point_s = 0.0 would work
   constexpr double eps = 1e-4;
-  double accum_s = eps;
+  double accum_s = eps * 2.0;
   for (size_t i = 1; i < inout_path->points.size(); i++) {
     accum_s += planning_utils::calcDist2d(
       inout_path->points[i].point.pose.position, inout_path->points[i - 1].point.pose.position);
@@ -318,7 +318,7 @@ int BlindSpotModule::insertPoint(
     // copy from previous point
     inserted_point = inout_path->points.at(std::max(insert_idx - 1, 0));
     inserted_point.point.pose = path_ip.points[insert_idx_ip].point.pose;
-    constexpr double min_dist = eps * 2.0;  // to make sure path point is forward insert index
+    constexpr double min_dist = eps;  // to make sure path point is forward insert index
     //! avoid to insert duplicated point
     if (
       planning_utils::calcDist2d(inserted_point, inout_path->points.at(insert_idx).point) <


### PR DESCRIPTION
## Description

- fix detection area for blinspot
- add option for pass  judge flag to blindspot
- strict pass judge point accuracy(not effective much)

but ideally pass judge should be done without inserting path point like other scene modules.

## Related links

#361 

## Tests performed

using scenario sim

Problem

https://user-images.githubusercontent.com/65527974/159675875-4e28c6bd-d07b-4719-91f2-0cd73cad90b4.mp4

Solved after this PR

https://user-images.githubusercontent.com/65527974/159676045-20af5d21-60e9-4f06-9a97-f2e73f86e398.mp4


## Notes for reviewers

this pass judgement should be united in each module or insert velocity should use 

please keep track of this change
cc : @yukkysaito 


## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
