### PR TITLE
Install config  to INSTALL_TO_SHARE

### DIFF
--- a/perception/map_based_prediction/CMakeLists.txt
+++ b/perception/map_based_prediction/CMakeLists.txt
@@ -34,5 +34,6 @@ endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE
+  config
   launch
 )


### PR DESCRIPTION
update CMakelists.txt, Install config to INSTALL_TO_SHARE by ament_auto_package.
if not will get this WARNING:
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: /autoware/install/map_based_prediction/share/map_based_prediction/config/map_based_prediction.param.yaml

**Note**: Confirm our [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)
