### PR TITLE
fix(behavior_path_planner): fix getIntersectionTurnSignal func

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
@@ -55,6 +55,8 @@ private:
   // data
   double intersection_search_distance_{0.0};
   double base_link2front_{0.0};
+  double turn_signal_distance_threshold_{0.5};
+  double min_turn_signal_distance_{1.0};
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -69,7 +69,8 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
   auto prev_point = path.points.front();
   auto prev_lane_id = lanelet::InvalId;
   for (const auto & path_point : path.points) {
-    const double path_distance = tier4_autoware_utils::calcDistance3d(prev_point.point, path_point.point);
+    const double path_distance =
+      tier4_autoware_utils::calcDistance3d(prev_point.point, path_point.point);
     accumulated_distance += path_distance;
     prev_point = path_point;
     const double distance_from_vehicle_front =
@@ -82,7 +83,8 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
       if (lane.id() != path_point.lane_ids.back()) {
         continue;
       }
-      double turn_distance = lane.attributeOr("turn_signal_distance", intersection_search_distance_);
+      double turn_distance =
+        lane.attributeOr("turn_signal_distance", intersection_search_distance_);
       if (turn_distance < min_turn_signal_distance_) {
         turn_distance = min_turn_signal_distance_;
       }
@@ -93,8 +95,7 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
       if (turn_distance < path_distance) {
         judge_distance = turn_distance - path_distance;
         turn_distance += turn_signal_distance_threshold_;
-      }
-      else {
+      } else {
         judge_distance = 0.0;
       }
       if (distance_from_vehicle_front < judge_distance) {


### PR DESCRIPTION
Signed-off-by: k-obitsu <koichi.obitsu@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
Fix getIntersectionTurnSignal function of turn_signal_decider in the following points.
1. In case that the distance of 'turn_signal_distance' is shorter than the distance between two pass points.
![Screenshot from 2022-03-22 20-32-17](https://user-images.githubusercontent.com/56008637/159472623-3c9f3e14-4986-4165-8676-f3309f32b361.png)
2. in case that the distance of 'turn_signal_distance' is larger than the distance of 'intersection_search_distance'.

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
