### PR TITLE
fix(tier4_perception_rviz_plugin): fix dummy pedestrian shape

### DIFF
--- a/common/tier4_perception_rviz_plugin/src/tools/pedestrian_pose.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/pedestrian_pose.cpp
@@ -290,8 +290,8 @@ void PedestrianInitialPoseTool::onPoseSet(double x, double y, double theta)
 
   // shape
   output_msg.shape.type = autoware_auto_perception_msgs::msg::Shape::CYLINDER;
-  const double width = 0.8;
-  const double length = 0.8;
+  const double width = 0.6;
+  const double length = 0.6;
   output_msg.shape.dimensions.x = length;
   output_msg.shape.dimensions.y = width;
   output_msg.shape.dimensions.z = 2.0;


### PR DESCRIPTION
## Description
The following changes made it harder to detect dummy_pedestrian. 
Therefore, the size of dummy_pedestrian was reduced.
https://github.com/autowarefoundation/autoware.universe/pull/541

### before
![image](https://user-images.githubusercontent.com/57553950/159611923-7c3c23ca-10d1-4cb4-b44f-9d584687794c.png)

### after
![image](https://user-images.githubusercontent.com/57553950/159611822-6f684a3e-f5ae-4c0b-a63d-b9cf408c0a30.png)

Originally, it is necessary to change the pointcloud to be output as a circle, but the change is too large, so in this PR, it is supported by changing the size of dummy_pedestrian.
## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
