### PR TITLE
feat(behavior_path_planner): parametrize avoidance target type

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -54,7 +54,7 @@
         trailer: true
         unknown: false
         bicycle: false
-        motorbike: false
+        motorcycle: false
         pedestrian: false
 
       # ---------- advanced parameters ----------

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -46,5 +46,16 @@
       longitudinal_collision_margin_min_distance: 0.0          # [m]
       longitudinal_collision_margin_time: 0.0
 
+      # avoidance is performed for the object type with true
+      target_object:
+        car: true
+        truck: true
+        bus: true
+        trailer: true
+        unknown: false
+        bicycle: false
+        motorbike: false
+        pedestrian: false
+
       # ---------- advanced parameters ----------
       avoidance_execution_lateral_threshold: 0.499

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -54,7 +54,7 @@
         trailer: true
         unknown: false
         bicycle: false
-        motorbike: false
+        motorcycle: false
         pedestrian: false
 
       # ---------- advanced parameters ----------

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -46,5 +46,16 @@
       longitudinal_collision_margin_min_distance: 0.0          # [m]
       longitudinal_collision_margin_time: 0.0
 
+      # avoidance is performed for the object type with true
+      target_object:
+        car: true
+        truck: true
+        bus: true
+        trailer: true
+        unknown: false
+        bicycle: false
+        motorbike: false
+        pedestrian: false
+
       # ---------- advanced parameters ----------
       avoidance_execution_lateral_threshold: 0.499

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -155,7 +155,7 @@ struct AvoidanceParameters
   // false by default
   bool avoid_unknown{false};     // avoidance is performed for type object unknown
   bool avoid_bicycle{false};     // avoidance is performed for type object bicycle
-  bool avoid_motorbike{false};   // avoidance is performed for type object motorbike
+  bool avoid_motorcycle{false};  // avoidance is performed for type object motorbike
   bool avoid_pedestrian{false};  // avoidance is performed for type object pedestrian
 
   // debug

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -147,10 +147,10 @@ struct AvoidanceParameters
   double avoidance_execution_lateral_threshold;
 
   // true by default
-  bool avoid_car{true};          // avoidance is performed for type object car
-  bool avoid_truck{true};        // avoidance is performed for type object truck
-  bool avoid_bus{true};          // avoidance is performed for type object bus
-  bool avoid_trailer{true};      // avoidance is performed for type object trailer
+  bool avoid_car{true};      // avoidance is performed for type object car
+  bool avoid_truck{true};    // avoidance is performed for type object truck
+  bool avoid_bus{true};      // avoidance is performed for type object bus
+  bool avoid_trailer{true};  // avoidance is performed for type object trailer
 
   // false by default
   bool avoid_unknown{false};     // avoidance is performed for type object unknown

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -146,6 +146,18 @@ struct AvoidanceParameters
   // avoidance path will be generated unless their lateral margin difference exceeds this value.
   double avoidance_execution_lateral_threshold;
 
+  // true by default
+  bool avoid_car{true};          // avoidance is performed for type object car
+  bool avoid_truck{true};        // avoidance is performed for type object truck
+  bool avoid_bus{true};          // avoidance is performed for type object bus
+  bool avoid_trailer{true};      // avoidance is performed for type object trailer
+
+  // false by default
+  bool avoid_unknown{false};     // avoidance is performed for type object unknown
+  bool avoid_bicycle{false};     // avoidance is performed for type object bicycle
+  bool avoid_motorbike{false};   // avoidance is performed for type object motorbike
+  bool avoid_pedestrian{false};  // avoidance is performed for type object pedestrian
+
   // debug
   bool publish_debug_marker = false;
   bool print_debug_info = false;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -258,7 +258,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.avoid_trailer = dp("target_object.trailer", true);
   p.avoid_unknown = dp("target_object.unknown", false);
   p.avoid_bicycle = dp("target_object.bicycle", false);
-  p.avoid_motorbike = dp("target_object.motorbike", false);
+  p.avoid_motorcycle = dp("target_object.motorcycle", false);
   p.avoid_pedestrian = dp("target_object.pedestrian", false);
 
   p.avoidance_execution_lateral_threshold = dp("avoidance_execution_lateral_threshold", 0.499);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -252,6 +252,15 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.publish_debug_marker = dp("publish_debug_marker", false);
   p.print_debug_info = dp("print_debug_info", false);
 
+  p.avoid_car = dp("target_object.car", true);
+  p.avoid_truck = dp("target_object.truck", true);
+  p.avoid_bus = dp("target_object.bus", true);
+  p.avoid_trailer = dp("target_object.trailer", true);
+  p.avoid_unknown = dp("target_object.unknown", false);
+  p.avoid_bicycle = dp("target_object.bicycle", false);
+  p.avoid_motorbike = dp("target_object.motorbike", false);
+  p.avoid_pedestrian = dp("target_object.pedestrian", false);
+
   p.avoidance_execution_lateral_threshold = dp("avoidance_execution_lateral_threshold", 0.499);
 
   return p;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2528,8 +2528,14 @@ bool AvoidanceModule::isTargetObjectType(const PredictedObject & object) const
   using autoware_auto_perception_msgs::msg::ObjectClassification;
   const auto t = util::getHighestProbLabel(object.classification);
   const auto is_object_type =
-    (t == ObjectClassification::CAR || t == ObjectClassification::TRUCK ||
-     t == ObjectClassification::BUS);
+    ((t == ObjectClassification::CAR && parameters_.avoid_car) ||
+     (t == ObjectClassification::TRUCK && parameters_.avoid_truck) ||
+     (t == ObjectClassification::BUS && parameters_.avoid_bus) ||
+     (t == ObjectClassification::TRAILER && parameters_.avoid_trailer) ||
+     (t == ObjectClassification::UNKNOWN && parameters_.avoid_unknown) ||
+     (t == ObjectClassification::BICYCLE && parameters_.avoid_bicycle) ||
+     (t == ObjectClassification::MOTORCYCLE && parameters_.avoid_motorbike) ||
+     (t == ObjectClassification::PEDESTRIAN && parameters_.avoid_pedestrian));
   return is_object_type;
 }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2534,7 +2534,7 @@ bool AvoidanceModule::isTargetObjectType(const PredictedObject & object) const
      (t == ObjectClassification::TRAILER && parameters_.avoid_trailer) ||
      (t == ObjectClassification::UNKNOWN && parameters_.avoid_unknown) ||
      (t == ObjectClassification::BICYCLE && parameters_.avoid_bicycle) ||
-     (t == ObjectClassification::MOTORCYCLE && parameters_.avoid_motorbike) ||
+     (t == ObjectClassification::MOTORCYCLE && parameters_.avoid_motorcycle) ||
      (t == ObjectClassification::PEDESTRIAN && parameters_.avoid_pedestrian));
   return is_object_type;
 }


### PR DESCRIPTION
## Description

Parametrize avoidance target obstacle type.

How-To-Test

 - merge this PR with https://github.com/tier4/autoware_launch/pull/248.
 - check the avoidance path is generated for the VEHICLE obstacle, but not for the PEDESTRIAN obstacle by default.
 - set the parameter `target_object.pedestrian` to true, then check the avoidance path is generated for the PEDESTRIAN obstacle.

Please merge with https://github.com/tier4/autoware_launch/pull/248.

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
