### PR TITLE
fix(ndt_scan_matcher): disable `march=native` when the target is Intel processor

### DIFF
--- a/localization/ndt/CMakeLists.txt
+++ b/localization/ndt/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(ndt)
 
-add_compile_options(-march=native)
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+  if(BUILD_WITH_MARCH_NATIVE)
+    add_compile_options(-march=native)
+  endif()
+else()
+  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+endif()
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/localization/ndt/CMakeLists.txt
+++ b/localization/ndt/CMakeLists.txt
@@ -1,12 +1,22 @@
 cmake_minimum_required(VERSION 3.5)
 project(ndt)
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+# Compile flags for SIMD instructions
+# Be careful to change these options, especially when `ndt_omp` implementaiton is used.
+# All packages linked to `ndt_omp` should use the same SIMD instruction set.
+# In case mismatched instruction set are used, program causes a crash at its initialization
+# because of a misaligned access to the `Eigen` librarie's data structure.
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+  # For x86_64 architecture, SIMD instruction set is fixed below versions,
+  # because the `ndt_omp` is optimized to these versions.
+  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+else()
+  # For other architecture, like arm64, compile flags are generally prepared by compiler
+  # march=native is disabled as default for specific depending pcl libraries
+  # or pre-building packages for other computers.
   if(BUILD_WITH_MARCH_NATIVE)
     add_compile_options(-march=native)
   endif()
-else()
-  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
 endif()
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/localization/ndt/CMakeLists.txt
+++ b/localization/ndt/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 project(ndt)
 
 # Compile flags for SIMD instructions
-# Be careful to change these options, especially when `ndt_omp` implementaiton is used.
+# Be careful to change these options, especially when `ndt_omp` implementation is used.
 # All packages linked to `ndt_omp` should use the same SIMD instruction set.
 # In case mismatched instruction set are used, program causes a crash at its initialization
-# because of a misaligned access to the `Eigen` librarie's data structure.
+# because of a misaligned access to the `Eigen` libraries' data structure.
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
   # For x86_64 architecture, SIMD instruction set is fixed below versions,
   # because the `ndt_omp` is optimized to these versions.

--- a/localization/ndt_pcl_modified/CMakeLists.txt
+++ b/localization/ndt_pcl_modified/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(ndt_pcl_modified)
 
-add_compile_options(-march=native)
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+  if(BUILD_WITH_MARCH_NATIVE)
+    add_compile_options(-march=native)
+  endif()
+else()
+  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+endif()
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/localization/ndt_pcl_modified/CMakeLists.txt
+++ b/localization/ndt_pcl_modified/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 project(ndt_pcl_modified)
 
 # Compile flags for SIMD instructions
-# Be careful to change these options, especially when `ndt_omp` implementaiton is used.
+# Be careful to change these options, especially when `ndt_omp` implementation is used.
 # All packages linked to `ndt_omp` should use the same SIMD instruction set.
 # In case mismatched instruction set are used, program causes a crash at its initialization
-# because of a misaligned access to the `Eigen` librarie's data structure.
+# because of a misaligned access to the `Eigen` libraries' data structure.
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
   # For x86_64 architecture, SIMD instruction set is fixed below versions,
   # because the `ndt_omp` is optimized to these versions.

--- a/localization/ndt_pcl_modified/CMakeLists.txt
+++ b/localization/ndt_pcl_modified/CMakeLists.txt
@@ -1,12 +1,22 @@
 cmake_minimum_required(VERSION 3.5)
 project(ndt_pcl_modified)
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+# Compile flags for SIMD instructions
+# Be careful to change these options, especially when `ndt_omp` implementaiton is used.
+# All packages linked to `ndt_omp` should use the same SIMD instruction set.
+# In case mismatched instruction set are used, program causes a crash at its initialization
+# because of a misaligned access to the `Eigen` librarie's data structure.
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+  # For x86_64 architecture, SIMD instruction set is fixed below versions,
+  # because the `ndt_omp` is optimized to these versions.
+  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+else()
+  # For other architecture, like arm64, compile flags are generally prepared by compiler
+  # march=native is disabled as default for specific depending pcl libraries
+  # or pre-building packages for other computers.
   if(BUILD_WITH_MARCH_NATIVE)
     add_compile_options(-march=native)
   endif()
-else()
-  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
 endif()
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/localization/ndt_scan_matcher/CMakeLists.txt
+++ b/localization/ndt_scan_matcher/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 project(ndt_scan_matcher)
 
 # Compile flags for SIMD instructions
-# Be careful to change these options, especially when `ndt_omp` implementaiton is used.
+# Be careful to change these options, especially when `ndt_omp` implementation is used.
 # All packages linked to `ndt_omp` should use the same SIMD instruction set.
 # In case mismatched instruction set are used, program causes a crash at its initialization
-# because of a misaligned access to the `Eigen` librarie's data structure.
+# because of a misaligned access to the `Eigen` libraries' data structure.
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
   # For x86_64 architecture, SIMD instruction set is fixed below versions,
   # because the `ndt_omp` is optimized to these versions.

--- a/localization/ndt_scan_matcher/CMakeLists.txt
+++ b/localization/ndt_scan_matcher/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(ndt_scan_matcher)
 
-add_compile_options(-march=native)
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+  if(BUILD_WITH_MARCH_NATIVE)
+    add_compile_options(-march=native)
+  endif()
+else()
+  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+endif()
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/localization/ndt_scan_matcher/CMakeLists.txt
+++ b/localization/ndt_scan_matcher/CMakeLists.txt
@@ -1,12 +1,22 @@
 cmake_minimum_required(VERSION 3.5)
 project(ndt_scan_matcher)
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+# Compile flags for SIMD instructions
+# Be careful to change these options, especially when `ndt_omp` implementaiton is used.
+# All packages linked to `ndt_omp` should use the same SIMD instruction set.
+# In case mismatched instruction set are used, program causes a crash at its initialization
+# because of a misaligned access to the `Eigen` librarie's data structure.
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+  # For x86_64 architecture, SIMD instruction set is fixed below versions,
+  # because the `ndt_omp` is optimized to these versions.
+  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+else()
+  # For other architecture, like arm64, compile flags are generally prepared by compiler
+  # march=native is disabled as default for specific depending pcl libraries
+  # or pre-building packages for other computers.
   if(BUILD_WITH_MARCH_NATIVE)
     add_compile_options(-march=native)
   endif()
-else()
-  add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
 endif()
 
 if(NOT CMAKE_CXX_STANDARD)


### PR DESCRIPTION
# Description

Current options causes a SIMD misaligned segmentation faults, when the pre-build Autoware is executed on the different machine.

The `-march=native` option might make an invalid instruction for the target machine.

# Changes

For Intel (x86-64), SIMD options are added explicitly for each SIMD version. These sse options are most stable.

For other machine like ARM, no option is added as default, because the difference of instruction sets are smaller than the Intel.
The SIMD optimization is a default feature of the compiler, so we need not to add any other compiler options.

# Related Issue

When you use the `ndt_omp` as ndt_scan_matcher implementation, you need to merge the [related fix] (https://github.com/tier4/ndt_omp/commit/d67ac1efdfeeefc4f3711d28a45806f437742278) in `ndt_omp` .

# Pre-review checklist for the PR author
PR author must check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
- [ ] The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).

# In-review checklist for the PR reviewers
Reviewers must check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

# Post-review checklist for the PR author
PR author must check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has the write access can merge the PR.