### PR TITLE
fix(behavior_path_planner, motion_velocity_smoother): supress unnecessary output

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -58,7 +58,7 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
   // Get frenet coordinate of current_pose on path
   util::FrenetCoordinate3d vehicle_pose_frenet;
   if (!util::convertToFrenetCoordinate3d(path, current_pose.position, &vehicle_pose_frenet)) {
-    RCLCPP_ERROR_THROTTLE(
+    RCLCPP_DEBUG_THROTTLE(
       logger_, clock, 5000, "failed to convert vehicle pose into frenet coordinate");
     return std::make_pair(turn_signal, distance);
   }

--- a/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -51,7 +51,7 @@ bool L2PseudoJerkSmoother::apply(
 
   if (std::fabs(input.front().longitudinal_velocity_mps) < 0.1) {
     RCLCPP_DEBUG(logger_, "closest v_max < 0.1. assume vehicle stopped. return.");
-    return false;
+    return true;
   }
 
   const unsigned int N = input.size();


### PR DESCRIPTION
## Description

supress unnecessary output

1. motion_velocity_smoother (L2)
When the vehicle speed is low, `apply` function returns false and the following messages are output repeteadly.
`Fail to solve optimization.`

https://github.com/autowarefoundation/autoware.universe/blob/007487adaf152186f8f4e4d97bc8000e97cabb06/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp#L52-L56

https://github.com/autowarefoundation/autoware.universe/blob/007487adaf152186f8f4e4d97bc8000e97cabb06/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp#L632

However, in this case, the optimization has not failed and there is no need to output the avove message.
So, I fixed not to output the above message.

2. turn_signal_decider in behavior_path_planner
When `convertToFrenetCoordinate3d` returns false, the following message are output repeadly.
`failed to convert vehicle pose into frenet coordinate`

(This function does the conversion of self-position to Frenet coordinates.)

However, if the self-position exceeds the goal even a little, the processing of this function will always fail.
So, I changed the output type of this function from ERROR to DEBUG.

https://github.com/autowarefoundation/autoware.universe/blob/007487adaf152186f8f4e4d97bc8000e97cabb06/planning/behavior_path_planner/src/turn_signal_decider.cpp#L60-L63

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
