### PR TITLE
feat(rviz_plugin): console meter is too large on the Rviz with FHD display, isn't it?

### DIFF
--- a/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
+++ b/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
@@ -19,6 +19,7 @@
 #include <rviz_common/uniform_string_stream.hpp>
 
 #include <OgreHardwarePixelBuffer.h>
+#include <X11/Xlib.h>
 
 #include <algorithm>
 #include <iomanip>
@@ -28,20 +29,26 @@ namespace rviz_plugins
 {
 MaxVelocityDisplay::MaxVelocityDisplay()
 {
+  const Screen * screen_info = DefaultScreenOfDisplay(XOpenDisplay(NULL));
+  const bool large_screen = screen_info->height > 2000;
+  const auto left = large_screen ? 595 : 297;
+  const auto top = large_screen ? 280 : 140;
+  const auto length = large_screen ? 96 : 48;
+
   property_topic_name_ = new rviz_common::properties::StringProperty(
     "Topic", "/planning/scenario_planning/current_max_velocity",
     "The topic on which to publish max velocity.", this, SLOT(updateTopic()), this);
   property_text_color_ = new rviz_common::properties::ColorProperty(
     "Text Color", QColor(255, 255, 255), "text color", this, SLOT(updateVisualization()), this);
   property_left_ = new rviz_common::properties::IntProperty(
-    "Left", 128, "Left of the plotter window", this, SLOT(updateVisualization()), this);
+    "Left", left, "Left of the plotter window", this, SLOT(updateVisualization()), this);
   property_left_->setMin(0);
   property_top_ = new rviz_common::properties::IntProperty(
-    "Top", 128, "Top of the plotter window", this, SLOT(updateVisualization()));
+    "Top", top, "Top of the plotter window", this, SLOT(updateVisualization()));
   property_top_->setMin(0);
 
   property_length_ = new rviz_common::properties::IntProperty(
-    "Length", 96, "Length of the plotter window", this, SLOT(updateVisualization()), this);
+    "Length", length, "Length of the plotter window", this, SLOT(updateVisualization()), this);
   property_length_->setMin(10);
   property_value_scale_ = new rviz_common::properties::FloatProperty(
     "Value Scale", 1.0 / 4.0, "Value scale", this, SLOT(updateVisualization()), this);

--- a/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
+++ b/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
@@ -30,10 +30,12 @@ namespace rviz_plugins
 MaxVelocityDisplay::MaxVelocityDisplay()
 {
   const Screen * screen_info = DefaultScreenOfDisplay(XOpenDisplay(NULL));
-  const bool large_screen = screen_info->height > 2000;
-  const auto left = large_screen ? 595 : 297;
-  const auto top = large_screen ? 280 : 140;
-  const auto length = large_screen ? 96 : 48;
+
+  constexpr float hight_4k = 2160.0;
+  const float scale = static_cast<float>(screen_info->height) / hight_4k;
+  const int left = static_cast<int>(std::round(595 * scale));
+  const int top = static_cast<int>(std::round(280 * scale));
+  const int length = static_cast<int>(std::round(96 * scale));
 
   property_topic_name_ = new rviz_common::properties::StringProperty(
     "Topic", "/planning/scenario_planning/current_max_velocity",

--- a/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
@@ -26,10 +26,11 @@ ConsoleMeterDisplay::ConsoleMeterDisplay()
 {
   const Screen * screen_info = DefaultScreenOfDisplay(XOpenDisplay(NULL));
 
-  const bool large_screen = screen_info->height > 2000;
-  const auto left = large_screen ? 512 : 256;
-  const auto top = large_screen ? 128 : 64;
-  const auto length = large_screen ? 256 : 128;
+  constexpr float hight_4k = 2160.0;
+  const float scale = static_cast<float>(screen_info->height) / hight_4k;
+  const auto left = static_cast<int>(std::round(512 * scale));
+  const auto top = static_cast<int>(std::round(128 * scale));
+  const auto length = static_cast<int>(std::round(256 * scale));
 
   property_text_color_ = new rviz_common::properties::ColorProperty(
     "Text Color", QColor(25, 255, 240), "text color", this, SLOT(updateVisualization()), this);

--- a/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
@@ -17,23 +17,31 @@
 #include <QPainter>
 #include <rviz_common/uniform_string_stream.hpp>
 
-#include <algorithm>
+#include <X11/Xlib.h>
 
+#include <algorithm>
 namespace rviz_plugins
 {
 ConsoleMeterDisplay::ConsoleMeterDisplay()
 {
+  const Screen * screen_info = DefaultScreenOfDisplay(XOpenDisplay(NULL));
+
+  const bool large_screen = screen_info->height > 2000;
+  const auto left = large_screen ? 512 : 256;
+  const auto top = large_screen ? 128 : 64;
+  const auto length = large_screen ? 256 : 128;
+
   property_text_color_ = new rviz_common::properties::ColorProperty(
     "Text Color", QColor(25, 255, 240), "text color", this, SLOT(updateVisualization()), this);
   property_left_ = new rviz_common::properties::IntProperty(
-    "Left", 128, "Left of the plotter window", this, SLOT(updateVisualization()), this);
+    "Left", left, "Left of the plotter window", this, SLOT(updateVisualization()), this);
   property_left_->setMin(0);
   property_top_ = new rviz_common::properties::IntProperty(
-    "Top", 128, "Top of the plotter window", this, SLOT(updateVisualization()));
+    "Top", top, "Top of the plotter window", this, SLOT(updateVisualization()));
   property_top_->setMin(0);
 
   property_length_ = new rviz_common::properties::IntProperty(
-    "Length", 256, "Length of the plotter window", this, SLOT(updateVisualization()), this);
+    "Length", length, "Length of the plotter window", this, SLOT(updateVisualization()), this);
   property_length_->setMin(10);
   property_value_height_offset_ = new rviz_common::properties::IntProperty(
     "Value height offset", 0, "Height offset of the plotter window", this,

--- a/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -18,6 +18,8 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rviz_common/uniform_string_stream.hpp>
 
+#include <X11/Xlib.h>
+
 #include <algorithm>
 #include <iomanip>
 #include <memory>
@@ -31,17 +33,24 @@ SteeringAngleDisplay::SteeringAngleDisplay()
                   "/images/handle.png")
                   .c_str())
 {
+  const Screen * screen_info = DefaultScreenOfDisplay(XOpenDisplay(NULL));
+
+  const bool large_screen = screen_info->height > 2000;
+  const auto left = large_screen ? 128 : 64;
+  const auto top = large_screen ? 128 : 64;
+  const auto length = large_screen ? 256 : 128;
+
   property_text_color_ = new rviz_common::properties::ColorProperty(
     "Text Color", QColor(25, 255, 240), "text color", this, SLOT(updateVisualization()), this);
   property_left_ = new rviz_common::properties::IntProperty(
-    "Left", 128, "Left of the plotter window", this, SLOT(updateVisualization()), this);
+    "Left", left, "Left of the plotter window", this, SLOT(updateVisualization()), this);
   property_left_->setMin(0);
   property_top_ = new rviz_common::properties::IntProperty(
-    "Top", 128, "Top of the plotter window", this, SLOT(updateVisualization()));
+    "Top", top, "Top of the plotter window", this, SLOT(updateVisualization()));
   property_top_->setMin(0);
 
   property_length_ = new rviz_common::properties::IntProperty(
-    "Length", 256, "Length of the plotter window", this, SLOT(updateVisualization()), this);
+    "Length", length, "Length of the plotter window", this, SLOT(updateVisualization()), this);
   property_length_->setMin(10);
   property_value_height_offset_ = new rviz_common::properties::IntProperty(
     "Value height offset", 0, "Height offset of the plotter window", this,

--- a/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -34,10 +34,12 @@ SteeringAngleDisplay::SteeringAngleDisplay()
                   .c_str())
 {
   const Screen * screen_info = DefaultScreenOfDisplay(XOpenDisplay(NULL));
-  const bool large_screen = screen_info->height > 2000;
-  const auto left = large_screen ? 128 : 64;
-  const auto top = large_screen ? 128 : 64;
-  const auto length = large_screen ? 256 : 128;
+
+  constexpr float hight_4k = 2160.0;
+  const float scale = static_cast<float>(screen_info->height) / hight_4k;
+  const auto left = static_cast<int>(std::round(128 * scale));
+  const auto top = static_cast<int>(std::round(128 * scale));
+  const auto length = static_cast<int>(std::round(256 * scale));
 
   property_text_color_ = new rviz_common::properties::ColorProperty(
     "Text Color", QColor(25, 255, 240), "text color", this, SLOT(updateVisualization()), this);

--- a/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -34,7 +34,6 @@ SteeringAngleDisplay::SteeringAngleDisplay()
                   .c_str())
 {
   const Screen * screen_info = DefaultScreenOfDisplay(XOpenDisplay(NULL));
-
   const bool large_screen = screen_info->height > 2000;
   const auto left = large_screen ? 128 : 64;
   const auto top = large_screen ? 128 : 64;

--- a/common/tier4_vehicle_rviz_plugin/src/tools/turn_signal.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/turn_signal.cpp
@@ -18,22 +18,32 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rviz_common/uniform_string_stream.hpp>
 
+#include <X11/Xlib.h>
+
 namespace rviz_plugins
 {
 TurnSignalDisplay::TurnSignalDisplay()
 {
+  const Screen * screen_info = DefaultScreenOfDisplay(XOpenDisplay(NULL));
+
+  const bool large_screen = screen_info->height > 2000;
+  const auto left = large_screen ? 196 : 98;
+  const auto top = large_screen ? 350 : 175;
+  const auto width = large_screen ? 512 : 256;
+  const auto height = large_screen ? 256 : 128;
+
   property_left_ = new rviz_common::properties::IntProperty(
-    "Left", 128, "Left of the plotter window", this, SLOT(updateVisualization()), this);
+    "Left", left, "Left of the plotter window", this, SLOT(updateVisualization()), this);
   property_left_->setMin(0);
   property_top_ = new rviz_common::properties::IntProperty(
-    "Top", 128, "Top of the plotter window", this, SLOT(updateVisualization()));
+    "Top", top, "Top of the plotter window", this, SLOT(updateVisualization()));
   property_top_->setMin(0);
 
   property_width_ = new rviz_common::properties::IntProperty(
-    "Width", 256, "Width of the plotter window", this, SLOT(updateVisualization()), this);
+    "Width", width, "Width of the plotter window", this, SLOT(updateVisualization()), this);
   property_width_->setMin(10);
   property_height_ = new rviz_common::properties::IntProperty(
-    "Height", 256, "Height of the plotter window", this, SLOT(updateVisualization()), this);
+    "Height", height, "Height of the plotter window", this, SLOT(updateVisualization()), this);
   property_height_->setMin(10);
 }
 

--- a/common/tier4_vehicle_rviz_plugin/src/tools/turn_signal.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/turn_signal.cpp
@@ -26,11 +26,12 @@ TurnSignalDisplay::TurnSignalDisplay()
 {
   const Screen * screen_info = DefaultScreenOfDisplay(XOpenDisplay(NULL));
 
-  const bool large_screen = screen_info->height > 2000;
-  const auto left = large_screen ? 196 : 98;
-  const auto top = large_screen ? 350 : 175;
-  const auto width = large_screen ? 512 : 256;
-  const auto height = large_screen ? 256 : 128;
+  constexpr float hight_4k = 2160.0;
+  const float scale = static_cast<float>(screen_info->height) / hight_4k;
+  const auto left = static_cast<int>(std::round(196 * scale));
+  const auto top = static_cast<int>(std::round(350 * scale));
+  const auto width = static_cast<int>(std::round(512 * scale));
+  const auto height = static_cast<int>(std::round(256 * scale));
 
   property_left_ = new rviz_common::properties::IntProperty(
     "Left", left, "Left of the plotter window", this, SLOT(updateVisualization()), this);


### PR DESCRIPTION
Note: must be merged with https://github.com/autowarefoundation/autoware_launch/pull/44

## Description

I wanted to adjust the size of the plugins to our screen size.

I modified the default size so that these plugins are displayed at smaller sizes on a screen smaller than 4k.
Note: I'm not satisfied with my approach. (Although I hate the current size more.) Any better solution is welcome. 

Now on FHD: Steering, you are not the main character.
![Screenshot from 2022-03-25 19-02-47](https://user-images.githubusercontent.com/21360593/160229402-2bf2d525-fb79-4468-a3e5-4ea237d02088.png)

With this PR. It's cool. Nice.

on 4k.
![Screenshot from 2022-03-25 19-02-03](https://user-images.githubusercontent.com/21360593/160229451-cc9586d1-c3f8-4ba9-8302-4a0c83958dbc.png)

on FHD.
![Screenshot from 2022-03-25 19-00-51](https://user-images.githubusercontent.com/21360593/160229453-1c16a108-0680-49b5-9590-29c9673dae16.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
