### PR TITLE
fix(dummy_perception_publisher): modified objects also use baselink z-position

### DIFF
--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -402,6 +402,18 @@ void DummyPerceptionPublisherNode::objectCallback(
           dummy_perception_publisher::msg::Object object;
           objects_.at(i) = *msg;
           tf2::toMsg(tf_map2object_origin, objects_.at(i).initial_state.pose_covariance.pose);
+
+          // Use base_link Z
+          geometry_msgs::msg::TransformStamped ros_map2base_link;
+          try {
+            ros_map2base_link = tf_buffer_.lookupTransform(
+              "map", "base_link", rclcpp::Time(0), rclcpp::Duration::from_seconds(0.5));
+            objects_.at(i).initial_state.pose_covariance.pose.position.z =
+              ros_map2base_link.transform.translation.z;
+          } catch (tf2::TransformException & ex) {
+            RCLCPP_WARN_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000, "%s", ex.what());
+            return;
+          }
           break;
         }
       }


### PR DESCRIPTION


## Description
If objects do **NOT** use baselink z-position, the point cloud will be outside the boundary in the following section, and perception topic may not be output correctly.

https://github.com/autowarefoundation/autoware.universe/blob/0abf13a3ecd3f0d937c2f259ea964136d531bf48/simulator/dummy_perception_publisher/src/node.cpp#L322-L330

So, this PR fix following point:
- modified objects also use baselink z-position

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
