### PR TITLE
fix(behavior_velocity): occlusion spot partition

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/scene_occlusion_spot.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/scene_occlusion_spot.hpp
@@ -62,7 +62,6 @@ private:
   PlannerParam param_;
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
   std::vector<lanelet::BasicPolygon2d> partition_lanelets_;
-  std::vector<lanelet::BasicPolygon2d> close_partition_;
 
 protected:
   int64_t module_id_{};

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
@@ -109,7 +109,8 @@ bool OcclusionSpotModule::modifyPathVelocity(
   std::vector<utils::PossibleCollisionInfo> possible_collisions;
   // extract only close lanelet
   if (param_.use_partition_lanelet) {
-    planning_utils::extractClosePartition(ego_pose.position, partition_lanelets_, close_partition_);
+    planning_utils::extractClosePartition(
+      ego_pose.position, partition_lanelets_, debug_data_.close_partition);
   }
   DEBUG_PRINT(show_time, "extract[ms]: ", stop_watch_.toc("processing_time", true));
   std::vector<geometry_msgs::msg::Point> parked_vehicle_point;
@@ -153,7 +154,6 @@ bool OcclusionSpotModule::modifyPathVelocity(
   utils::applySafeVelocityConsideringPossibleCollision(path, possible_collisions, param_);
   // these debug topics needs computation resource
   debug_data_.parked_vehicle_point = parked_vehicle_point;
-  debug_data_.close_partition = close_partition_;
   debug_data_.z = path->points.front().point.pose.position.z;
   debug_data_.possible_collisions = possible_collisions;
   debug_data_.interp_path = interp_path;


### PR DESCRIPTION
## Description

- fix unused member variables

![image](https://user-images.githubusercontent.com/65527974/160802952-cd1706c8-ef3b-4b84-8b34-35330520031a.png)

- make sure close_partition_ is not used

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
