### PR TITLE
feat: move empty_objects_publisher

### DIFF
--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -29,21 +29,22 @@
   <!-- perception module -->
   <group>
     <push-ros-namespace namespace="perception"/>
-    <!-- object recognition -->
-    <group if="$(var perception/enable_object_recognition)">
-      <push-ros-namespace namespace="object_recognition"/>
-      <!-- tracking module -->
-      <group>
-        <push-ros-namespace namespace="tracking"/>
-        <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/tracking/tracking.launch.xml">
-        </include>
-      </group>
-      <!-- prediction module -->
-      <group>
-        <push-ros-namespace namespace="prediction"/>
-        <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/prediction/prediction.launch.xml">
-          <arg name="use_vector_map" value="true" />
-        </include>
+      <!-- object recognition -->
+      <group if="$(var perception/enable_object_recognition)">
+        <push-ros-namespace namespace="object_recognition"/>
+        <!-- tracking module -->
+        <group>
+          <push-ros-namespace namespace="tracking"/>
+          <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/tracking/tracking.launch.xml">
+          </include>
+        </group>
+        <!-- prediction module -->
+        <group>
+          <push-ros-namespace namespace="prediction"/>
+          <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/prediction/prediction.launch.xml">
+            <arg name="use_vector_map" value="true" />
+          </include>
+        </group>
       </group>
 
       <!-- publish empty objects instead of object recognition module -->
@@ -53,8 +54,6 @@
           <remap from="~/output/objects" to="/perception/object_recognition/objects" />
         </node>
       </group>
-
-    </group>
 
     <!-- object segmentation module -->
     <group>
@@ -73,6 +72,7 @@
       <push-ros-namespace namespace="traffic_light_recognition"/>
       <include file="$(find-pkg-share tier4_perception_launch)/launch/traffic_light_recognition/traffic_light.launch.xml"></include>
     </group>
+
   </group>
 
   <!-- Simulator model -->

--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -45,6 +45,15 @@
           <arg name="use_vector_map" value="true" />
         </include>
       </group>
+
+      <!-- publish empty objects instead of object recognition module -->
+      <group unless="$(var perception/enable_object_recognition)">
+        <push-ros-namespace namespace="object_recognition"/>
+        <node pkg="dummy_perception_publisher" exec="empty_objects_publisher" name="empty_objects_publisher" output="screen">
+          <remap from="~/output/objects" to="/perception/object_recognition/objects" />
+        </node>
+      </group>
+
     </group>
 
     <!-- object segmentation module -->

--- a/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -46,16 +46,4 @@
     </include>
 
   </group>
-
-  <!-- perception module -->
-  <group>
-    <push-ros-namespace namespace="perception"/>
-    <!-- publish empty objects instead of object recognition module -->
-    <group unless="$(var use_object_recognition)">
-      <push-ros-namespace namespace="object_recognition"/>
-      <node pkg="dummy_perception_publisher" exec="empty_objects_publisher" name="empty_objects_publisher" output="screen">
-        <remap from="~/output/objects" to="/perception/object_recognition/objects" />
-      </node>
-    </group>
-  </group>
 </launch>


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
move the description of empty_objects_publisher from dummy_perception_publisher.launch to simulator.launch
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
