### PR TITLE
fix(motion_velocity_smoother): initialize params for dynamic parameter

### DIFF
--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -124,12 +124,6 @@ private:
     AlgorithmType algorithm_type;  // Option : JerkFiltered, Linf, L2
   } node_param_{};
 
-  SmootherBase::BaseParam base_param_{};
-  JerkFilteredSmoother::Param jerk_filtered_smoother_param_{};
-  L2PseudoJerkSmoother::Param l2_pseudo_jerk_smoother_param_{};
-  LinfPseudoJerkSmoother::Param linf_pseudo_jerk_smoother_param_{};
-  AnalyticalJerkConstrainedSmoother::Param analytical_jerk_constrained_smoother_param_{};
-
   std::shared_ptr<SmootherBase> smoother_;
 
   bool publish_debug_trajs_;  // publish planned trajectories

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -78,6 +78,7 @@ public:
     const TrajectoryPoints & input) const override;
 
   void setParam(const Param & param);
+  Param getParam() const;
 
 private:
   Param smoother_param_;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -50,6 +50,7 @@ public:
     const TrajectoryPoints & input, const double v_current, const int closest_id) const override;
 
   void setParam(const Param & param);
+  Param getParam() const;
 
 private:
   Param smoother_param_;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -48,6 +48,7 @@ public:
     const TrajectoryPoints & input, const double v_current, const int closest_id) const override;
 
   void setParam(const Param & smoother_param);
+  Param getParam() const;
 
 private:
   Param smoother_param_;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -48,6 +48,7 @@ public:
     const TrajectoryPoints & input, const double v_current, const int closest_id) const override;
 
   void setParam(const Param & smoother_param);
+  Param getParam() const;
 
 private:
   Param smoother_param_;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
@@ -68,6 +68,7 @@ public:
   double getMinJerk() const;
 
   void setParam(const BaseParam & param);
+  BaseParam getBaseParam() const;
 
 protected:
   BaseParam base_param_;

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -45,6 +45,8 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
   switch (node_param_.algorithm_type) {
     case AlgorithmType::JERK_FILTERED: {
       smoother_ = std::make_shared<JerkFilteredSmoother>(*this);
+      jerk_filtered_smoother_param_ =
+        std::dynamic_pointer_cast<JerkFilteredSmoother>(smoother_)->getParam();
 
       // Set Publisher for jerk filtered algorithm
       pub_forward_filtered_trajectory_ =
@@ -59,19 +61,26 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
     }
     case AlgorithmType::L2: {
       smoother_ = std::make_shared<L2PseudoJerkSmoother>(*this);
+      l2_pseudo_jerk_smoother_param_ =
+        std::dynamic_pointer_cast<L2PseudoJerkSmoother>(smoother_)->getParam();
       break;
     }
     case AlgorithmType::LINF: {
       smoother_ = std::make_shared<LinfPseudoJerkSmoother>(*this);
+      linf_pseudo_jerk_smoother_param_ =
+        std::dynamic_pointer_cast<LinfPseudoJerkSmoother>(smoother_)->getParam();
       break;
     }
     case AlgorithmType::ANALYTICAL: {
       smoother_ = std::make_shared<AnalyticalJerkConstrainedSmoother>(*this);
+      analytical_jerk_constrained_smoother_param_ =
+        std::dynamic_pointer_cast<AnalyticalJerkConstrainedSmoother>(smoother_)->getParam();
       break;
     }
     default:
       throw std::domain_error("[MotionVelocitySmootherNode] invalid algorithm");
   }
+  base_param_ = smoother_->getBaseParam();
 
   // publishers, subscribers
   pub_trajectory_ = create_publisher<Trajectory>("~/output/trajectory", 1);

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -45,8 +45,6 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
   switch (node_param_.algorithm_type) {
     case AlgorithmType::JERK_FILTERED: {
       smoother_ = std::make_shared<JerkFilteredSmoother>(*this);
-      jerk_filtered_smoother_param_ =
-        std::dynamic_pointer_cast<JerkFilteredSmoother>(smoother_)->getParam();
 
       // Set Publisher for jerk filtered algorithm
       pub_forward_filtered_trajectory_ =
@@ -61,26 +59,19 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
     }
     case AlgorithmType::L2: {
       smoother_ = std::make_shared<L2PseudoJerkSmoother>(*this);
-      l2_pseudo_jerk_smoother_param_ =
-        std::dynamic_pointer_cast<L2PseudoJerkSmoother>(smoother_)->getParam();
       break;
     }
     case AlgorithmType::LINF: {
       smoother_ = std::make_shared<LinfPseudoJerkSmoother>(*this);
-      linf_pseudo_jerk_smoother_param_ =
-        std::dynamic_pointer_cast<LinfPseudoJerkSmoother>(smoother_)->getParam();
       break;
     }
     case AlgorithmType::ANALYTICAL: {
       smoother_ = std::make_shared<AnalyticalJerkConstrainedSmoother>(*this);
-      analytical_jerk_constrained_smoother_param_ =
-        std::dynamic_pointer_cast<AnalyticalJerkConstrainedSmoother>(smoother_)->getParam();
       break;
     }
     default:
       throw std::domain_error("[MotionVelocitySmootherNode] invalid algorithm");
   }
-  base_param_ = smoother_->getBaseParam();
 
   // publishers, subscribers
   pub_trajectory_ = create_publisher<Trajectory>("~/output/trajectory", 1);
@@ -159,7 +150,7 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
   }
 
   {
-    auto & p = base_param_;
+    auto p = smoother_->getBaseParam();
     update_param("normal.max_acc", p.max_accel);
     update_param("normal.min_acc", p.min_decel);
     update_param("stop_decel", p.stop_decel);
@@ -181,7 +172,7 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
 
   switch (node_param_.algorithm_type) {
     case AlgorithmType::JERK_FILTERED: {
-      auto & p = jerk_filtered_smoother_param_;
+      auto p = std::dynamic_pointer_cast<JerkFilteredSmoother>(smoother_)->getParam();
       update_param("jerk_weight", p.jerk_weight);
       update_param("over_v_weight", p.over_v_weight);
       update_param("over_a_weight", p.over_a_weight);
@@ -191,7 +182,7 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
       break;
     }
     case AlgorithmType::L2: {
-      auto & p = l2_pseudo_jerk_smoother_param_;
+      auto p = std::dynamic_pointer_cast<L2PseudoJerkSmoother>(smoother_)->getParam();
       update_param("pseudo_jerk_weight", p.pseudo_jerk_weight);
       update_param("over_v_weight", p.over_v_weight);
       update_param("over_a_weight", p.over_a_weight);
@@ -199,7 +190,7 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
       break;
     }
     case AlgorithmType::LINF: {
-      auto & p = linf_pseudo_jerk_smoother_param_;
+      auto p = std::dynamic_pointer_cast<LinfPseudoJerkSmoother>(smoother_)->getParam();
       update_param("pseudo_jerk_weight", p.pseudo_jerk_weight);
       update_param("over_v_weight", p.over_v_weight);
       update_param("over_a_weight", p.over_a_weight);
@@ -207,7 +198,7 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
       break;
     }
     case AlgorithmType::ANALYTICAL: {
-      auto & p = analytical_jerk_constrained_smoother_param_;
+      auto p = std::dynamic_pointer_cast<AnalyticalJerkConstrainedSmoother>(smoother_)->getParam();
       update_param("resample.delta_yaw_threshold", p.resample.delta_yaw_threshold);
       update_param(
         "latacc.constant_velocity_dist_threshold", p.latacc.constant_velocity_dist_threshold);

--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -91,6 +91,11 @@ void AnalyticalJerkConstrainedSmoother::setParam(const Param & smoother_param)
   smoother_param_ = smoother_param;
 }
 
+AnalyticalJerkConstrainedSmoother::Param AnalyticalJerkConstrainedSmoother::getParam() const
+{
+  return smoother_param_;
+}
+
 bool AnalyticalJerkConstrainedSmoother::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
   TrajectoryPoints & output, [[maybe_unused]] std::vector<TrajectoryPoints> & debug_trajectories)

--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -47,6 +47,11 @@ void JerkFilteredSmoother::setParam(const Param & smoother_param)
   smoother_param_ = smoother_param;
 }
 
+JerkFilteredSmoother::Param JerkFilteredSmoother::getParam() const
+{
+  return smoother_param_;
+}
+
 bool JerkFilteredSmoother::apply(
   const double v0, const double a0, const TrajectoryPoints & input, TrajectoryPoints & output,
   std::vector<TrajectoryPoints> & debug_trajectories)

--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -47,10 +47,7 @@ void JerkFilteredSmoother::setParam(const Param & smoother_param)
   smoother_param_ = smoother_param;
 }
 
-JerkFilteredSmoother::Param JerkFilteredSmoother::getParam() const
-{
-  return smoother_param_;
-}
+JerkFilteredSmoother::Param JerkFilteredSmoother::getParam() const { return smoother_param_; }
 
 bool JerkFilteredSmoother::apply(
   const double v0, const double a0, const TrajectoryPoints & input, TrajectoryPoints & output,

--- a/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -43,6 +43,11 @@ void L2PseudoJerkSmoother::setParam(const Param & smoother_param)
   smoother_param_ = smoother_param;
 }
 
+L2PseudoJerkSmoother::Param L2PseudoJerkSmoother::getParam() const
+{
+  return smoother_param_;
+}
+
 bool L2PseudoJerkSmoother::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
   TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories)

--- a/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -43,10 +43,7 @@ void L2PseudoJerkSmoother::setParam(const Param & smoother_param)
   smoother_param_ = smoother_param;
 }
 
-L2PseudoJerkSmoother::Param L2PseudoJerkSmoother::getParam() const
-{
-  return smoother_param_;
-}
+L2PseudoJerkSmoother::Param L2PseudoJerkSmoother::getParam() const { return smoother_param_; }
 
 bool L2PseudoJerkSmoother::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -43,10 +43,7 @@ void LinfPseudoJerkSmoother::setParam(const Param & smoother_param)
   smoother_param_ = smoother_param;
 }
 
-LinfPseudoJerkSmoother::Param LinfPseudoJerkSmoother::getParam() const
-{
-  return smoother_param_;
-}
+LinfPseudoJerkSmoother::Param LinfPseudoJerkSmoother::getParam() const { return smoother_param_; }
 
 bool LinfPseudoJerkSmoother::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -43,6 +43,11 @@ void LinfPseudoJerkSmoother::setParam(const Param & smoother_param)
   smoother_param_ = smoother_param;
 }
 
+LinfPseudoJerkSmoother::Param LinfPseudoJerkSmoother::getParam() const
+{
+  return smoother_param_;
+}
+
 bool LinfPseudoJerkSmoother::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
   TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories)

--- a/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
@@ -48,6 +48,8 @@ SmootherBase::SmootherBase(rclcpp::Node & node)
 
 void SmootherBase::setParam(const BaseParam & param) { base_param_ = param; }
 
+SmootherBase::BaseParam SmootherBase::getBaseParam() const { return base_param_; }
+
 double SmootherBase::getMaxAccel() const { return base_param_.max_accel; }
 
 double SmootherBase::getMinDecel() const { return base_param_.min_decel; }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fix the bug caused by the following commit.
https://github.com/autowarefoundation/autoware.universe/pull/609

- Member variables were not initialized for dynamically parameter settings

How to check

- Confirmation that each smoother can be used to run on the simulator

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
