### PR TITLE
fix(motion_velocity_smoother): velocity limit when engage status

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -286,7 +286,7 @@ void MotionVelocitySmootherNode::onExternalVelocityLimit(const VelocityLimit::Co
         const double a0 = prev_closest_point_->acceleration_mps2;
 
         if (isEngageStatus(v0)) {
-          max_velocity_with_deceleration_ = external_velocity_limit_;
+          max_velocity_with_deceleration_ = msg->max_velocity;
           external_velocity_limit_dist_ = 0.0;
         } else {
           const double a_min =


### PR DESCRIPTION
Signed-off-by: Makoto Kurihara <mkuri8m@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
![velocity-limit-problem](https://user-images.githubusercontent.com/876355/161226593-34f78368-d33c-4b6c-a3dd-d191a76fa9e1.png)

Fixed an issue that when velocity limit is updated during engage status, the velocity limit before the update remains.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
