### PR TITLE
fix: fix package and name space for VoxelBasedCompareMapFilterComponent

### DIFF
--- a/perception/euclidean_cluster/launch/euclidean_cluster.launch.py
+++ b/perception/euclidean_cluster/launch/euclidean_cluster.launch.py
@@ -49,8 +49,8 @@ def launch_setup(context, *args, **kwargs):
 
     # set compare map filter as a component
     compare_map_filter_component = ComposableNode(
-        package="pointcloud_preprocessor",
-        plugin="pointcloud_preprocessor::VoxelBasedCompareMapFilterComponent",
+        package="compare_map_segmentation",
+        plugin="compare_map_segmentation::VoxelBasedCompareMapFilterComponent",
         name=AnonName("compare_map_filter"),
         remappings=[
             ("input", "voxel_grid_filtered/pointcloud"),


### PR DESCRIPTION
## Description

- The `pointcloud_preprocessor::VoxelBasedCompareMapFilterComponent` does not exist.
  https://github.com/autowarefoundation/autoware.universe/tree/main/sensing/pointcloud_preprocessor.
- `VoxelBasedCompareMapFilterComponent` is now in `compare_map_segmentation`. 
  https://github.com/autowarefoundation/autoware.universe/blob/main/perception/compare_map_segmentation

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
