### PR TITLE
fix(motion_velocity_smoother): add missing rclcpp dependency

### DIFF
--- a/planning/motion_velocity_smoother/package.xml
+++ b/planning/motion_velocity_smoother/package.xml
@@ -19,6 +19,7 @@
   <depend>libboost-dev</depend>
   <depend>nav_msgs</depend>
   <depend>osqp_interface</depend>
+  <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>


### PR DESCRIPTION
Signed-off-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>

## Description
<!-- Write a brief description of this PR. -->
I only added `rclcpp` dependency declaration in this PR.
`rclcpp` dependency declaration was missing in the latest branch. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
