### PR TITLE
fix: use anon to make unique node name instead of diag name

### DIFF
--- a/system/dummy_diag_publisher/launch/dummy_diag_publisher_node.launch.xml
+++ b/system/dummy_diag_publisher/launch/dummy_diag_publisher_node.launch.xml
@@ -5,9 +5,7 @@
   <arg name="status" default="0"/>
 
   <group>
-    <push-ros-namespace namespace="dummy_diag_publisher"/>
-
-    <node pkg="dummy_diag_publisher" exec="dummy_diag_publisher" name="$(var diag_name)" output="screen">
+    <node pkg="dummy_diag_publisher" exec="dummy_diag_publisher" name="$(anon dummy_diag_publisher)" output="screen">
       <param name="diag_name" value="$(var diag_name)"/>
       <param name="update_rate" value="$(var update_rate)"/>
       <param name="is_active" value="$(var is_active)"/>


### PR DESCRIPTION
## Description

When a diag name includes some spaces like `CPU Temperature`, dummy diag publisher failed to launch since node name can not include spaces.
Therefore I use `$(anon )` to name unique node name instead of a diag name.


## Related links

<!-- Write the links related to this PR. -->

## Tests performed

When you launch multiple dummy diag publishers to publish dummy diags, `localization_accuracy` and `CPU Temperature`, you can view like following image in rqt_robot_monitor.

![image](https://user-images.githubusercontent.com/9547070/161897707-c56f43bb-ce0c-453b-a648-9ea40694b03b.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
