### PR TITLE
feat: add new diag for hdd_monitor to diagnostics aggregator

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/system.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/system.param.yaml
@@ -138,6 +138,18 @@
                   contains: [": HDD Usage"]
                   timeout: 3.0
 
+                power_on_hours:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: usage
+                  contains: [": HDD PowerOnHours"]
+                  timeout: 3.0
+
+                total_data_written:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: usage
+                  contains: [": HDD TotalDataWritten"]
+                  timeout: 3.0
+
             process:
               type: diagnostic_aggregator/AnalyzerGroup
               path: process


### PR DESCRIPTION
## Description

In #560, two new diags are added but not adde to diagnostics aggregator config.
This PR fixes it.

## Related links

#560

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
