### PR TITLE
fix(ekf_localizer): rosbag clock jump bug

### DIFF
--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -116,15 +116,20 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
 void EKFLocalizer::updatePredictFrequency()
 {
   if (last_predict_time_) {
-    ekf_rate_ = 1.0 / (get_clock()->now() - *last_predict_time_).seconds();
-    DEBUG_INFO(get_logger(), "[EKF] update ekf_rate_ to %f hz", ekf_rate_);
-    ekf_dt_ = 1.0 / std::max(ekf_rate_, 0.1);
+    if (get_clock()->now() < *last_predict_time_) {
+      RCLCPP_WARN(get_logger(), "Detected jump back in time");
+    }
+    else {
+      ekf_rate_ = 1.0 / (get_clock()->now() - *last_predict_time_).seconds();
+      DEBUG_INFO(get_logger(), "[EKF] update ekf_rate_ to %f hz", ekf_rate_);
+      ekf_dt_ = 1.0 / std::max(ekf_rate_, 0.1);
 
-    /* Update discrete proc_cov*/
-    proc_cov_vx_d_ = std::pow(proc_stddev_vx_c_ * ekf_dt_, 2.0);
-    proc_cov_wz_d_ = std::pow(proc_stddev_wz_c_ * ekf_dt_, 2.0);
-    proc_cov_yaw_d_ = std::pow(proc_stddev_yaw_c_ * ekf_dt_, 2.0);
-    proc_cov_yaw_bias_d_ = std::pow(proc_stddev_yaw_bias_c_ * ekf_dt_, 2.0);
+      /* Update discrete proc_cov*/
+      proc_cov_vx_d_ = std::pow(proc_stddev_vx_c_ * ekf_dt_, 2.0);
+      proc_cov_wz_d_ = std::pow(proc_stddev_wz_c_ * ekf_dt_, 2.0);
+      proc_cov_yaw_d_ = std::pow(proc_stddev_yaw_c_ * ekf_dt_, 2.0);
+      proc_cov_yaw_bias_d_ = std::pow(proc_stddev_yaw_bias_c_ * ekf_dt_, 2.0);
+    }
   }
   last_predict_time_ = std::make_shared<const rclcpp::Time>(get_clock()->now());
 }

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -118,8 +118,7 @@ void EKFLocalizer::updatePredictFrequency()
   if (last_predict_time_) {
     if (get_clock()->now() < *last_predict_time_) {
       RCLCPP_WARN(get_logger(), "Detected jump back in time");
-    }
-    else {
+    } else {
       ekf_rate_ = 1.0 / (get_clock()->now() - *last_predict_time_).seconds();
       DEBUG_INFO(get_logger(), "[EKF] update ekf_rate_ to %f hz", ekf_rate_);
       ekf_dt_ = 1.0 / std::max(ekf_rate_, 0.1);


### PR DESCRIPTION
Signed-off-by: YamatoAndo <yamato.ando@gmail.com>

## Description
When switching rosbag, clock sometimes goes back to the past.
In that case, ekf_rate is not updated.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers
Prepare a continuous rosbag and check the behavior.
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
