### PR TITLE
fix(behavior_path_planner): initialize scene module status

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -83,7 +83,8 @@ public:
   : name_{name},
     logger_{node.get_logger().get_child(name)},
     clock_{node.get_clock()},
-    approval_handler_(node)
+    approval_handler_(node),
+    current_state_{BT::NodeStatus::IDLE}
   {
   }
 


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description

When we set an initial pose and a goal pose, `behavior_path_planner` outputs an empty path.
This problem occurs because the state of pull over module becomes `BT::NodeStatus::RUNNING` unintentionally.
It seems to happen because `current_state_` is not initialized in the constructor of `SceneModuleInterface`.
The initial state should be `BT::NodeStatus::IDLE`.

https://github.com/autowarefoundation/autoware.universe/issues/641
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
