### PR TITLE
fix(obstacle_stop_planner): use utils function to caluculate nearest index from ego

### DIFF
--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -6,6 +6,7 @@
       step_length: 1.0 # step length for pointcloud search range [m]
       extend_distance: 0.0 # extend trajectory to consider after goal obstacle in the extend_distance
       expand_stop_range: 0.0 # margin of vehicle footprint [m]
+      max_yaw_deviation_deg: 90.0 # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)
 
     slow_down_planner:
       # slow down planner parameters

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -24,8 +24,10 @@
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <signal_processing/lowpass_filter_1d.hpp>
+#include <tier4_autoware_utils/math/unit_conversion.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 #include <tier4_autoware_utils/trajectory/tmp_conversion.hpp>
+#include <tier4_autoware_utils/trajectory/trajectory.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
@@ -96,10 +98,12 @@ public:
 
   struct NodeParam
   {
-    bool enable_slow_down;     // set True, slow down for obstacle beside the path
-    double max_velocity;       // max velocity [m/s]
-    double lowpass_gain;       // smoothing calculated current acceleration [-]
-    double hunting_threshold;  // keep slow down or stop state if obstacle vanished [s]
+    bool enable_slow_down;         // set True, slow down for obstacle beside the path
+    double max_velocity;           // max velocity [m/s]
+    double lowpass_gain;           // smoothing calculated current acceleration [-]
+    double hunting_threshold;      // keep slow down or stop state if obstacle vanished [s]
+    double max_yaw_deviation_rad;  // maximum ego yaw deviation from trajectory [rad] (measures
+                                   // against overlapping lanes)
   };
 
   struct StopParam

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -445,6 +445,8 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
     p.hunting_threshold = declare_parameter("hunting_threshold", 0.5);
     p.lowpass_gain = declare_parameter("lowpass_gain", 0.9);
     lpf_acc_ = std::make_shared<LowpassFilter1d>(0.0, p.lowpass_gain);
+    const double max_yaw_deviation_deg = declare_parameter("max_yaw_deviation_deg", 90.0);
+    p.max_yaw_deviation_rad = tier4_autoware_utils::deg2rad(max_yaw_deviation_deg);
   }
 
   {
@@ -1219,18 +1221,13 @@ TrajectoryPoints ObstacleStopPlannerNode::trimTrajectoryWithIndexFromSelfPose(
 {
   TrajectoryPoints output{};
 
-  double min_distance = 0.0;
   size_t min_distance_index = 0;
-  bool is_init = false;
-  for (size_t i = 0; i < input.size(); ++i) {
-    const double x = input.at(i).pose.position.x - self_pose.position.x;
-    const double y = input.at(i).pose.position.y - self_pose.position.y;
-    const double squared_distance = x * x + y * y;
-    if (!is_init || squared_distance < min_distance * min_distance) {
-      is_init = true;
-      min_distance = std::sqrt(squared_distance);
-      min_distance_index = i;
-    }
+  const auto nearest_index = tier4_autoware_utils::findNearestIndex(
+    input, self_pose, 10.0, node_param_.max_yaw_deviation_rad);
+  if (!nearest_index) {
+    min_distance_index = tier4_autoware_utils::findNearestIndex(input, self_pose.position);
+  } else {
+    min_distance_index = nearest_index.value();
   }
   for (size_t i = min_distance_index; i < input.size(); ++i) {
     output.push_back(input.at(i));


### PR DESCRIPTION
…index from ego

Signed-off-by: Azumi Suzuki <azumi.suzuki@tier4.jp>

## Description

`obstalce_stop_planner` sometimes not work when driving in overlapping lanes.

When referring to the index on the trajectory closest to the vehicle, it may refer to the opposite trajectory on the overlapping lane.
In which case the obstacle stop function will not work and a crash will occur.

Obstacle stop does not work because it refer to the trajectory in the opposite direction
![Screenshot from 2022-04-07 16-15-09](https://user-images.githubusercontent.com/38061530/162161883-012d7859-a516-4ed8-b532-f916d8877721.png)

Obstacle stop works if it refer to the correct trajectory
![Screenshot from 2022-04-07 16-15-31](https://user-images.githubusercontent.com/38061530/162161893-a7468653-50e0-4ee3-833f-0f5c49e4aeb0.png)


In this PR, use existing function that take into account the angle between the vehicle and the trajectory to solve the problem.

Internal PR for tier4:
- https://github.com/tier4/autoware.iv/pull/2441

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
