### PR TITLE
fix(trajectory_follower_nodes): switch to isolated gtests

### DIFF
--- a/control/trajectory_follower_nodes/CMakeLists.txt
+++ b/control/trajectory_follower_nodes/CMakeLists.txt
@@ -68,7 +68,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
   # Unit tests
   set(TRAJECTORY_FOLLOWER_NODES_TEST test_trajectory_follower_nodes)
-  ament_add_gtest(${TRAJECTORY_FOLLOWER_NODES_TEST}
+  ament_add_ros_isolated_gtest(${TRAJECTORY_FOLLOWER_NODES_TEST}
     test/trajectory_follower_test_utils.hpp
     test/test_latlon_muxer_node.cpp
     test/test_lateral_controller_node.cpp

--- a/control/trajectory_follower_nodes/package.xml
+++ b/control/trajectory_follower_nodes/package.xml
@@ -21,7 +21,7 @@
 
   <exec_depend>ros2launch</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_python</test_depend>
   <!-- <test_depend>ament_lint_auto</test_depend> -->
   <!-- <test_depend>ament_lint_common</test_depend> -->


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR attempts to fix https://github.com/autowarefoundation/autoware.universe/issues/649 by running tests of package `trajectory_follower_nodes` in "isolated" mode.

Such solution has been investigated before: https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/issues/1470

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
