### PR TITLE
fix(simple_planning_simulator): fix bug in function to apply noise

### DIFF
--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -383,7 +383,7 @@ void SimplePlanningSimulator::add_measurement_noise(
   odom.pose.pose.position.x += (*n.pos_dist_)(*n.rand_engine_);
   odom.pose.pose.position.y += (*n.pos_dist_)(*n.rand_engine_);
   const auto velocity_noise = (*n.vel_dist_)(*n.rand_engine_);
-  odom.twist.twist.linear.x = velocity_noise;
+  odom.twist.twist.linear.x += velocity_noise;
   float32_t yaw = motion::motion_common::to_angle(odom.pose.pose.orientation);
   yaw += static_cast<float>((*n.rpy_dist_)(*n.rand_engine_));
   odom.pose.pose.orientation = motion::motion_common::from_angle(yaw);


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

- fix bug in `add_measurement_noise()`

Please set `add_measurement_noise` as `Ture` in config file `simulator_model.param.yaml` in order to reproduce this invalid behavior. The config file may be in `*_description/config/simulator_model.param.yaml`.

### with bug (vehicle velocity has diverged.)
https://user-images.githubusercontent.com/44889564/162653014-207f337c-6b0a-4cf5-ae6b-adf9f8ad3345.mp4

### without bug
https://user-images.githubusercontent.com/44889564/162652985-eea65319-a1e5-47c8-9ec5-6e4f3571848b.mp4
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
