### PR TITLE
fix(autoware_state_panel): fix message type for /api/autoware/get/engage

### DIFF
--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -109,7 +109,7 @@ void AutowareStatePanel::onInitialize()
   sub_gear_ = raw_node_->create_subscription<autoware_auto_vehicle_msgs::msg::GearReport>(
     "/vehicle/status/gear_status", 10, std::bind(&AutowareStatePanel::onShift, this, _1));
 
-  sub_engage_ = raw_node_->create_subscription<tier4_external_api_msgs::msg::EngageStatus>(
+  sub_engage_ = raw_node_->create_subscription<autoware_auto_vehicle_msgs::msg::Engage>(
     "/api/autoware/get/engage", 10, std::bind(&AutowareStatePanel::onEngageStatus, this, _1));
 
   client_engage_ = raw_node_->create_client<tier4_external_api_msgs::srv::Engage>(
@@ -209,7 +209,7 @@ void AutowareStatePanel::onShift(
 }
 
 void AutowareStatePanel::onEngageStatus(
-  const tier4_external_api_msgs::msg::EngageStatus::ConstSharedPtr msg)
+  const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
   current_engage_ = msg->engage;
   engage_status_label_ptr_->setText(QString::fromStdString(Bool2String(current_engage_)));

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -26,7 +26,7 @@
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
 #include <tier4_control_msgs/msg/external_command_selector_mode.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
-#include <tier4_external_api_msgs/msg/engage_status.hpp>
+#include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
 
 namespace rviz_plugins
@@ -48,7 +48,7 @@ protected:
     const tier4_control_msgs::msg::ExternalCommandSelectorMode::ConstSharedPtr msg);
   void onAutowareState(const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr msg);
   void onShift(const autoware_auto_vehicle_msgs::msg::GearReport::ConstSharedPtr msg);
-  void onEngageStatus(const tier4_external_api_msgs::msg::EngageStatus::ConstSharedPtr msg);
+  void onEngageStatus(const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
 
   rclcpp::Node::SharedPtr raw_node_;
   rclcpp::Subscription<tier4_control_msgs::msg::GateMode>::SharedPtr sub_gate_mode_;
@@ -57,7 +57,7 @@ protected:
   rclcpp::Subscription<autoware_auto_system_msgs::msg::AutowareState>::SharedPtr
     sub_autoware_state_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::GearReport>::SharedPtr sub_gear_;
-  rclcpp::Subscription<tier4_external_api_msgs::msg::EngageStatus>::SharedPtr sub_engage_;
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr sub_engage_;
 
   rclcpp::Client<tier4_external_api_msgs::srv::Engage>::SharedPtr client_engage_;
 

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -23,10 +23,10 @@
 #include <rviz_common/panel.hpp>
 
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
+#include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
 #include <tier4_control_msgs/msg/external_command_selector_mode.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
-#include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
 
 namespace rviz_plugins


### PR DESCRIPTION
## Description

- fix message type for `/api/autoware/get/engage`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
