### PR TITLE
fix(map_based_prediction): add config to INSTALL_TO_SHARE

### DIFF
--- a/perception/map_based_prediction/CMakeLists.txt
+++ b/perception/map_based_prediction/CMakeLists.txt
@@ -34,5 +34,6 @@ endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE
+  config
   launch
 )


### PR DESCRIPTION
## Description

In #545, the config directory is added.
However, the config directory is not made in install directory.
This PR fixes it.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
