### PR TITLE
fix(tier4_perception_rviz_plugin): set interactive object velocity to zero on releasing the object

### DIFF
--- a/common/tier4_perception_rviz_plugin/src/tools/interactive_object.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/interactive_object.cpp
@@ -114,11 +114,11 @@ void InteractiveObject::update(const Ogre::Vector3 & point)
              : std::atan2(velocity_.y, velocity_.x);
 }
 
+void InteractiveObject::reset() { velocity_ = Ogre::Vector3::ZERO; }
+
 double InteractiveObject::distance(const Ogre::Vector3 & point) { return point_.distance(point); }
 
 InteractiveObjectCollection::InteractiveObjectCollection() { target_ = nullptr; }
-
-void InteractiveObjectCollection::reset() { target_ = nullptr; }
 
 void InteractiveObjectCollection::select(const Ogre::Vector3 & point)
 {
@@ -126,6 +126,19 @@ void InteractiveObjectCollection::select(const Ogre::Vector3 & point)
   if (index != objects_.size()) {
     target_ = objects_[index].get();
   }
+}
+
+boost::optional<std::array<uint8_t, 16>> InteractiveObjectCollection::reset()
+{
+  if (!target_) {
+    return {};
+  }
+
+  const auto uuid = target_->uuid();
+  target_->reset();
+  target_ = nullptr;
+
+  return uuid;
 }
 
 boost::optional<std::array<uint8_t, 16>> InteractiveObjectCollection::create(
@@ -304,7 +317,8 @@ int InteractiveObjectTool::processMouseEvent(rviz_common::ViewportMouseEvent & e
   }
 
   if (event.rightUp()) {
-    objects_.reset();
+    const auto uuid = objects_.reset();
+    publishObjectMsg(uuid.get(), Object::MODIFY);
     return 0;
   }
 

--- a/common/tier4_perception_rviz_plugin/src/tools/interactive_object.hpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/interactive_object.hpp
@@ -90,6 +90,7 @@ public:
   void twist(geometry_msgs::msg::Twist & twist) const;
   void transform(tf2::Transform & tf_map2object) const;
   void update(const Ogre::Vector3 & point);
+  void reset();
   double distance(const Ogre::Vector3 & point);
 
 private:
@@ -105,8 +106,8 @@ public:
   InteractiveObjectCollection();
   ~InteractiveObjectCollection() {}
 
-  void reset();
   void select(const Ogre::Vector3 & point);
+  boost::optional<std::array<uint8_t, 16>> reset();
   boost::optional<std::array<uint8_t, 16>> create(const Ogre::Vector3 & point);
   boost::optional<std::array<uint8_t, 16>> remove(const Ogre::Vector3 & point);
   boost::optional<std::array<uint8_t, 16>> update(const Ogre::Vector3 & point);


### PR DESCRIPTION

Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

If the interactive object still has velocity on releasing, there will be a discrepancy between the interactive object position and the potition of dummy_perception_publisher output, so this PR fix to set interactive object velocity to zero on releasing the object.

Please see the topic `/simulation/dummy_perception_publisher/object_info` and check the object velocity on releasing. (It has **ZERO** velocity.)

```sh
...
 twist_covariance:                                                                                                                                                                                            
    twist:                                                                                                                                                                                                     
      linear:                                                                                                                                                                                                  
        x: 0.0                                                                                                                                                                                                 
        y: 0.0                                                                                                                                                                                                 
        z: 0.0                                                                                                                                                                                                 
      angular:                                                                                                                                                                                                 
        x: 0.0                                                                                                                                                                                                 
        y: 0.0
        z: 0.0
    covariance:
    - 0.0
    - 0.0
    - 0.0
...
```

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
