### PR TITLE
fix(behavior_velocity_planner): ignore pass judge when external_stop is true

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -123,8 +123,8 @@ bool IntersectionModule::modifyPathVelocity(
     return false;
   }
 
-  if (stop_line_idx <= 0 || pass_judge_line_idx <= 0) {
-    RCLCPP_DEBUG(logger_, "stop line or pass judge line is at path[0], ignore planning.");
+  if (stop_line_idx <= 0) {
+    RCLCPP_DEBUG(logger_, "stop line line is at path[0], ignore planning.");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     return true;
   }


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description


https://github.com/autowarefoundation/autoware.universe/blob/23cb41a36f837bf04a3400095d308ff062a7d4d2/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp#L146

In intersection module, pass_judge is expected to be ignored when external_stop is true.
(When external_stop is true, intersection status becomes STOP regardless of the result of the pass judge)

But, in actual, sometimes intersection status does not become STOP when external_stop is true because of following line
https://github.com/autowarefoundation/autoware.universe/blob/23cb41a36f837bf04a3400095d308ff062a7d4d2/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp#L126

I fixed it.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## How to Test
Using the planning simulator, send the topic with status:0 for /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_intersection_states
when the vehicle is traveling at high speed just before the stop line at the intersection

Compare the behavior before and after the PR merge.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
