### PR TITLE
fix: traffic light module

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
@@ -101,7 +101,7 @@ private:
 
   bool isPassthrough(const double & signed_arc_length) const;
 
-  bool hasTrafficLightColor(
+  bool hasTrafficLightCircleColor(
     const autoware_auto_perception_msgs::msg::TrafficSignal & tl_state,
     const uint8_t & lamp_color) const;
 

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -489,9 +489,12 @@ bool TrafficLightModule::hasTrafficLightColor(
   const autoware_auto_perception_msgs::msg::TrafficSignal & tl_state,
   const uint8_t & lamp_color) const
 {
-  const auto it_lamp = std::find_if(
-    tl_state.lights.begin(), tl_state.lights.end(),
-    [&lamp_color](const auto & x) { return x.color == lamp_color; });
+  using autoware_auto_perception_msgs::msg::TrafficLight;
+
+  const auto it_lamp =
+    std::find_if(tl_state.lights.begin(), tl_state.lights.end(), [&lamp_color](const auto & x) {
+      return x.shape == TrafficLight::CIRCLE && x.color == lamp_color;
+    });
 
   return it_lamp != tl_state.lights.end();
 }

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -364,7 +364,8 @@ bool TrafficLightModule::isPassthrough(const double & signed_arc_length) const
 bool TrafficLightModule::isTrafficSignalStop(
   const autoware_auto_perception_msgs::msg::TrafficSignal & tl_state) const
 {
-  if (hasTrafficLightColor(tl_state, autoware_auto_perception_msgs::msg::TrafficLight::GREEN)) {
+  if (hasTrafficLightCircleColor(
+        tl_state, autoware_auto_perception_msgs::msg::TrafficLight::GREEN)) {
     return false;
   }
 
@@ -485,7 +486,7 @@ autoware_auto_planning_msgs::msg::PathWithLaneId TrafficLightModule::insertStopP
   return modified_path;
 }
 
-bool TrafficLightModule::hasTrafficLightColor(
+bool TrafficLightModule::hasTrafficLightCircleColor(
   const autoware_auto_perception_msgs::msg::TrafficSignal & tl_state,
   const uint8_t & lamp_color) const
 {


### PR DESCRIPTION
## Description
In traffic light module, If the traffic light has green lamp, the vehicle will pass intersection.

( This decision is made in the hasTrafficLightColor function. )

Originally, the vehicle should pass a intersection when traffic light has a green "CIRCLE" lamp. 
With the current implementation, the vehicle pass a intersection when traffic light has only a green "ARROW" lamp.
(For example, even if the traffic light is a right arrow signal, the vehicle will go at a left turn intersection. )

I fixed it.


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers
Please check the vehicle behavior using planning simulator
Compare the vehicle behavior when turning left with the traffic light state being a right arrow signal

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
