### PR TITLE
feat(multi_object_tracker): add velocity observation

### DIFF
--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
@@ -54,6 +54,7 @@ private:
     float r_cov_x;
     float r_cov_y;
     float r_cov_yaw;
+    float r_cov_vx;
     float p0_cov_x;
     float p0_cov_y;
     float p0_cov_yaw;

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
@@ -54,6 +54,7 @@ private:
     float r_cov_x;
     float r_cov_y;
     float r_cov_yaw;
+    float r_cov_vx;
     float p0_cov_x;
     float p0_cov_y;
     float p0_cov_yaw;

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -288,11 +288,12 @@ bool NormalVehicleTracker::measureWithPose(
 
   if (object.kinematics.has_twist) {
     Y(IDX::VX, 0) = object.kinematics.twist_with_covariance.twist.linear.x;
-    C(3, IDX::VX) = 1.0;   // for vx
+    C(3, IDX::VX) = 1.0;  // for vx
 
-    if(!ekf_params_.use_measurement_covariance ||
+    if (
+      !ekf_params_.use_measurement_covariance ||
       object.kinematics.twist_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0) {
-      R(3, 3) = ekf_params_.r_cov_vx;                                       // vx -vx
+      R(3, 3) = ekf_params_.r_cov_vx;  // vx -vx
     } else {
       R(3, 3) = object.kinematics.twist_with_covariance.covariance[utils::MSG_COV_IDX::X_X];
     }

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -232,7 +232,8 @@ bool NormalVehicleTracker::measureWithPose(
     r_cov_y = ekf_params_.r_cov_y;
   }
 
-  const int dim_y = object.kinematics.has_twist ? 4 : 3;  // pos x, pos y, yaw, vx depending on Pose output
+  const int dim_y =
+    object.kinematics.has_twist ? 4 : 3;  // pos x, pos y, yaw, vx depending on Pose output
   double measurement_yaw = tier4_autoware_utils::normalizeRadian(
     tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation));
   {
@@ -252,13 +253,14 @@ bool NormalVehicleTracker::measureWithPose(
   Eigen::MatrixXd C = Eigen::MatrixXd::Zero(dim_y, ekf_params_.dim_x);
   Eigen::MatrixXd R = Eigen::MatrixXd::Zero(dim_y, dim_y);
 
-  if(object.kinematics.has_twist) {
+  if (object.kinematics.has_twist) {
     Y << object.kinematics.pose_with_covariance.pose.position.x,
-      object.kinematics.pose_with_covariance.pose.position.y, measurement_yaw, object.kinematics.twist_with_covariance.twist.linear.x;
+      object.kinematics.pose_with_covariance.pose.position.y, measurement_yaw,
+      object.kinematics.twist_with_covariance.twist.linear.x;
     C(0, IDX::X) = 1.0;    // for pos x
     C(1, IDX::Y) = 1.0;    // for pos y
     C(2, IDX::YAW) = 1.0;  // for yaw
-    C(3, IDX::VX) = 1.0;  // for vx
+    C(3, IDX::VX) = 1.0;   // for vx
 
     /* Set measurement noise covariance */
     if (
@@ -300,7 +302,7 @@ bool NormalVehicleTracker::measureWithPose(
       !ekf_params_.use_measurement_covariance ||
       object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
       object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0 ||
-      object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW] == 0.0 ) {
+      object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW] == 0.0) {
       const double cos_yaw = std::cos(measurement_yaw);
       const double sin_yaw = std::sin(measurement_yaw);
       const double sin_2yaw = std::sin(2.0f * measurement_yaw);
@@ -321,7 +323,6 @@ bool NormalVehicleTracker::measureWithPose(
       R(2, 2) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW];
     }
   }
-
 
   // update
   if (!ekf_.update(Y, C, R)) {


### PR DESCRIPTION
## Description
Currently, Kalman filter in the multi-object tracker cannot update its velocity with the observed velocity value when the measurement object has valid velocity value. In this PR, I change the tracker that can accept the velocity term when it can use velocity. 
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
