### PR TITLE
fix(behavior_velocity): avoid to insert the same point

### DIFF
--- a/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
@@ -144,13 +144,13 @@ inline bool smoothPath(
   const auto traj_lateral_acc_filtered = smoother->applyLateralAccelerationFilter(trajectory);
   auto nearest_idx =
     tier4_autoware_utils::findNearestIndex(*traj_lateral_acc_filtered, current_pose.position);
-  const auto dist_to_neraest = tier4_autoware_utils::calcSignedArcLength(
+  const auto dist_to_nearest = tier4_autoware_utils::calcSignedArcLength(
     *traj_lateral_acc_filtered, current_pose.position, nearest_idx);
 
   // if trajectory has the almost same point as ego, don't insert the ego point
   constexpr double epsilon = 1e-2;
   TrajectoryPoints traj_with_ego_point_on_path = *traj_lateral_acc_filtered;
-  if (std::fabs(dist_to_neraest) > epsilon) {
+  if (std::fabs(dist_to_nearest) > epsilon) {
     // calc ego internal division point on path
     const auto traj_with_ego_point_with_idx =
       getLerpTrajectoryPointWithIdx(*traj_lateral_acc_filtered, current_pose.position);

--- a/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
@@ -100,7 +100,13 @@ TrajectoryPointWithIdx getLerpTrajectoryPointWithIdx(
     tier4_autoware_utils::calcLongitudinalOffsetToSegment(points, nearest_seg_idx, point);
   const double len_segment =
     tier4_autoware_utils::calcSignedArcLength(points, nearest_seg_idx, nearest_seg_idx + 1);
-  const double interpolate_ratio = std::clamp(len_to_interpolated / len_segment, 0.0, 1.0);
+
+  // avoid to insert the same point
+  constexpr double epsilon = 1e-3;
+  const double ratio_min = epsilon;
+  const double ratio_max = 1.0 - epsilon;
+  const double interpolate_ratio =
+    std::clamp(len_to_interpolated / len_segment, ratio_min, ratio_max);
   {
     const size_t i = nearest_seg_idx;
     const auto & pos0 = points.at(i).pose.position;

--- a/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
@@ -100,13 +100,7 @@ TrajectoryPointWithIdx getLerpTrajectoryPointWithIdx(
     tier4_autoware_utils::calcLongitudinalOffsetToSegment(points, nearest_seg_idx, point);
   const double len_segment =
     tier4_autoware_utils::calcSignedArcLength(points, nearest_seg_idx, nearest_seg_idx + 1);
-
-  // avoid to insert the same point
-  constexpr double epsilon = 1e-3;
-  const double ratio_min = epsilon;
-  const double ratio_max = 1.0 - epsilon;
-  const double interpolate_ratio =
-    std::clamp(len_to_interpolated / len_segment, ratio_min, ratio_max);
+  const double interpolate_ratio = std::clamp(len_to_interpolated / len_segment, 0.0, 1.0);
   {
     const size_t i = nearest_seg_idx;
     const auto & pos0 = points.at(i).pose.position;

--- a/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
@@ -142,18 +142,29 @@ inline bool smoothPath(
       0, trajectory.size(), external_v_limit->max_velocity, trajectory);
   }
   const auto traj_lateral_acc_filtered = smoother->applyLateralAccelerationFilter(trajectory);
-  // calc ego internal division point on path
-  const auto traj_with_ego_point_with_idx =
-    getLerpTrajectoryPointWithIdx(*traj_lateral_acc_filtered, current_pose.position);
+  auto nearest_idx =
+    tier4_autoware_utils::findNearestIndex(*traj_lateral_acc_filtered, current_pose.position);
+  const auto dist_to_neraest = tier4_autoware_utils::calcSignedArcLength(
+    *traj_lateral_acc_filtered, current_pose.position, nearest_idx);
+
+  // if trajectory has the almost same point as ego, don't insert the ego point
+  constexpr double epsilon = 1e-2;
   TrajectoryPoints traj_with_ego_point_on_path = *traj_lateral_acc_filtered;
-  TrajectoryPoint ego_point_on_path = traj_with_ego_point_with_idx.first;
-  const size_t nearest_seg_idx = traj_with_ego_point_with_idx.second;
-  //! insert ego projected pose on path so new nearest segment will be nearest_seg_idx + 1
-  traj_with_ego_point_on_path.insert(
-    traj_with_ego_point_on_path.begin() + nearest_seg_idx, ego_point_on_path);
+  if (std::fabs(dist_to_neraest) > epsilon) {
+    // calc ego internal division point on path
+    const auto traj_with_ego_point_with_idx =
+      getLerpTrajectoryPointWithIdx(*traj_lateral_acc_filtered, current_pose.position);
+    TrajectoryPoint ego_point_on_path = traj_with_ego_point_with_idx.first;
+    const size_t nearest_seg_idx = traj_with_ego_point_with_idx.second;
+    //! insert ego projected pose on path so new nearest segment will be nearest_seg_idx + 1
+    traj_with_ego_point_on_path.insert(
+      traj_with_ego_point_on_path.begin() + nearest_seg_idx, ego_point_on_path);
+
+    // ego point inserted is new nearest point
+    nearest_idx = traj_with_ego_point_with_idx.second + 1;
+  }
   // Resample trajectory with ego-velocity based interval distances
-  auto traj_resampled =
-    smoother->resampleTrajectory(traj_with_ego_point_on_path, v0, nearest_seg_idx + 1);
+  auto traj_resampled = smoother->resampleTrajectory(traj_with_ego_point_on_path, v0, nearest_idx);
   const auto traj_resampled_closest = findNearestIndex(*traj_resampled, current_pose, max, M_PI_4);
   std::vector<TrajectoryPoints> debug_trajectories;
   // Clip trajectory from closest point


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description
`getLerpTrajectoryPointWithIdx` function returns the same point if `const T & points` have the same point as `const geometry_msgs::msg::Point & point`.
I fixed the function so it doesn't return the same point.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
