### PR TITLE
feat(avoidance_module): cancel avoidance when target dissapear

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/path_shifter/path_shifter.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/path_shifter/path_shifter.hpp
@@ -26,6 +26,8 @@
 #include <geometry_msgs/msg/polygon.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <boost/uuid/uuid.hpp>
+
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
@@ -49,6 +51,8 @@ struct ShiftPoint
 
   size_t start_idx{};  // associated start-point index for the reference path
   size_t end_idx{};    // associated end-point index for the reference path
+
+  boost::uuids::uuid associated_object_uuid;
 };
 using ShiftPointArray = std::vector<ShiftPoint>;
 
@@ -181,6 +185,8 @@ public:
   static bool calcShiftPointFromArcLength(
     const PathWithLaneId & path, const Point & origin, double dist_to_start, double dist_to_end,
     double shift_length, ShiftPoint * shift_point);
+
+  void reassignShiftPoints(const ShiftPointArray & shift_points) { shift_points_ = shift_points; }
 
 private:
   // The reference path along which the shift will be performed.

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -89,7 +89,8 @@ private:
 
   // -- for shift point generation --
   AvoidPointArray calcShiftPoints(
-    AvoidPointArray & current_raw_shift_points, DebugData & debug) const;
+    AvoidPointArray & current_raw_shift_points, PathShifter & path_shifter,
+    DebugData & debug) const;
 
   // shift point generation: generator
   AvoidPointArray calcRawShiftPointsFromObjects(const ObjectDataArray & objects) const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -81,8 +81,11 @@ private:
     DebugData & debug) const;
 
   ObjectDataArray registered_objects_;
-  void updateRegisteredObject(const ObjectDataArray & objects);
-  void CompensateDetectionLost(ObjectDataArray & objects) const;
+  ObjectDataMap registered_objects_map_;
+
+  void updateRegisteredObject(const ObjectDataMap & mapped_objects);
+  void CompensateDetectionLost(
+    ObjectDataArray & now_objects, ObjectDataMap & now_mapped_objects) const;
 
   // -- for shift point generation --
   AvoidPointArray calcShiftPoints(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -25,7 +25,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
 #include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_hash.hpp>>
+#include <boost/uuid/uuid_hash.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
 #include <memory>

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -24,8 +24,13 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_hash.hpp>>
+#include <boost/uuid/uuid_io.hpp>
+
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace behavior_path_planner
@@ -36,6 +41,14 @@ using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
+
+struct HashForUuid
+{
+  std::size_t operator()(const boost::uuids::uuid & uuid) const
+  {
+    return boost::hash<boost::uuids::uuid>()(uuid);
+  }
+};
 
 struct AvoidanceParameters
 {
@@ -195,6 +208,7 @@ struct ObjectData  // avoidance target
   double to_road_shoulder_distance{0.0};
 };
 using ObjectDataArray = std::vector<ObjectData>;
+using ObjectDataMap = std::unordered_map<boost::uuids::uuid, ObjectData, HashForUuid>;
 
 /*
  * Shift point with additional info for avoidance planning
@@ -250,6 +264,9 @@ struct AvoidancePlanningData
 
   // avoidance target objects
   ObjectDataArray objects;
+
+  // Information is identical. The differences is only at type
+  ObjectDataMap mapped_objects;
 };
 
 /*

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -327,7 +327,7 @@ void AvoidanceModule::updateRegisteredRawShiftPoints()
       boost::uuids::uuid uuid_to_map_key;
       std::copy(ap_uuid.cbegin(), ap_uuid.cend(), uuid_to_map_key.begin());
 
-      bool less_than_equal_deadline = ap.end_idx <= deadline;
+      bool less_than_equal_deadline = !(ap.end_idx > deadline);
       bool is_not_in_registered_object =
         registered_objects_map_.find(uuid_to_map_key) == registered_objects_map_.end();
       return (less_than_equal_deadline || is_not_in_registered_object);
@@ -370,10 +370,11 @@ AvoidPointArray AvoidanceModule::calcShiftPoints(
   // Remove unwanted shift
   const auto remove_iter =
     std::remove_if(shifts.begin(), shifts.end(), [this](const ShiftPoint & sp) {
-      return (
-        (avoidance_data_.mapped_objects.find(sp.associated_object_uuid) ==
-         avoidance_data_.mapped_objects.cend()) &&
-        (std::abs(sp.length) > 0));
+      const auto & mapped = avoidance_data_.mapped_objects;
+      const auto & uuid = sp.associated_object_uuid;
+      const auto is_object_in_map = (mapped.find(uuid) == mapped.cend());
+      const auto is_shift_point_no_zero = (std::abs(sp.length) > 0);
+      return (is_object_in_map && is_shift_point_no_zero);
     });
   shifts.erase(remove_iter, shifts.end());
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2667,7 +2667,6 @@ void AvoidanceModule::setDebugData(const PathShifter & shifter, const DebugData 
   using marker_utils::createOvehangFurthestLineStringMarkerArray;
   using marker_utils::createPathMarkerArray;
   using marker_utils::createPoseMarkerArray;
-  using marker_utils::createRegisteredObjectMapMarkerArray;
   using marker_utils::createShiftLengthMarkerArray;
   using marker_utils::createShiftPointMarkerArray;
   using marker_utils::makeOverhangToRoadShoulderMarkerArray;
@@ -2697,7 +2696,6 @@ void AvoidanceModule::setDebugData(const PathShifter & shifter, const DebugData 
   add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
   add(createLaneletsAreaMarkerArray(*debug.expanded_lanelets, "expanded_lanelet", 0.8, 0.8, 0.0));
   add(createAvoidanceObjectsMarkerArray(avoidance_data_.objects, "avoidance_object"));
-  add(createRegisteredObjectMapMarkerArray(avoidance_data_.mapped_objects, "mapped_objects"));
   add(makeOverhangToRoadShoulderMarkerArray(avoidance_data_.objects));
   add(createOvehangFurthestLineStringMarkerArray(
     *debug.farthest_linestring_from_overhang, "farthest_linestring_from_overhang", 1.0, 0.0, 1.0));


### PR DESCRIPTION
## Description

Adding remove shift point when target object is no longer present. 


https://user-images.githubusercontent.com/93502286/163900515-50c10fc9-61e2-4cf2-8c69-3d8057dffa9b.mp4

Note 1: The upgrade is currently still under design phase. Therefore it will be change  constantly.
Note 2: The function is a bit unstable during planning the return trajectory after removing shift point, especially is ego is very near to the removed shift points.

## Related links

1. [cancel avoidance when target disappears](https://autowarefoundation.github.io/autoware.universe/main/planning/behavior_path_planner/behavior_path_planner_avoidance-design/#future-extensions-unimplemented-parts)
2. #706 

## Tests performed

1. Run planning_simulator.
2. place ego position and goal
3. place a parked vehicle
4. wait for the avoidance route to appear
5. remove the parked vehicle.

The final result after removing should be the planned route will return to centerline.

## Notes for reviewers

It's better to test this using scenario_simulator_v2 as removing parked vehicle is more "natural".

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
