### PR TITLE
fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set

### DIFF
--- a/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
@@ -105,7 +105,7 @@ boost::optional<TrajectoryPoints> SmootherBase::applyLateralAccelerationFilter(
   for (size_t i = 0; i < output->size(); ++i) {
     double curvature = 0.0;
     const size_t start = i > after_decel_index ? i - after_decel_index : 0;
-    const size_t end = std::min(output->size(), i + before_decel_index);
+    const size_t end = std::min(output->size(), i + before_decel_index + 1);
     for (size_t j = start; j < end; ++j) {
       curvature = std::max(curvature, std::fabs(curvature_v->at(j)));
     }


### PR DESCRIPTION
## Description

Fix curve deceleration bug.
When the parameters in the `motion_velocity_smoother` are set like below,

```
decel_distance_before_curve: 0.0
decel_distance_after_curve: 0.0
```

the curve deceleration will not work at all. The cause is very clear and has been fixed in this PR.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/