### PR TITLE
fix(emergency_handler): add missing timestamp for emergency control command

### DIFF
--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -132,6 +132,8 @@ void EmergencyHandler::publishControlCommands()
     autoware_auto_control_msgs::msg::AckermannControlCommand msg;
     msg = selectAlternativeControlCommand();
     msg.stamp = stamp;
+    msg.lateral.stamp = stamp;
+    msg.longitudinal.stamp = stamp;
     pub_control_command_->publish(msg);
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fix timestamp for lateral and longitudinal in the topic of `/system/emergency/control_cmd`. 
Related issue: https://github.com/autowarefoundation/autoware.universe/issues/742

The output of `$ ros2 topic echo /system/emergency/control_cmd ` is as follows:

Before
![Screenshot from 2022-04-22 14-24-08](https://user-images.githubusercontent.com/42209144/164610725-59b0c8f0-4673-443e-991b-b610b31c4513.png)

After
![Screenshot from 2022-04-22 14-36-33](https://user-images.githubusercontent.com/42209144/164610737-2fe3e929-35d7-4374-9312-62376be386dc.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

