### PR TITLE
fix: ignore cross_line in turn signal judge

### DIFF
--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -258,7 +258,6 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   // Turn signal on when conditions below are satisfied
   //  1. lateral offset is larger than tl_on_threshold_lat for left signal
   //                      smaller than tl_on_threshold_lat for right signal
-  //  2. side point at shift start/end point cross the line
   double distance_to_shift_start;
   {
     const auto arc_position_shift_start =
@@ -291,6 +290,7 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
     right_end_point.position.y += std::cos(end_yaw) * (-shift_to_outside);
   }
 
+  /*
   bool left_start_point_is_in_lane = false;
   bool right_start_point_is_in_lane = false;
   bool left_end_point_is_in_lane = false;
@@ -318,11 +318,12 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
     right_start_point_is_in_lane != right_end_point_is_in_lane) {
     cross_line = true;
   }
+  */
 
   if (time_to_shift_start < prev_sec || distance_to_shift_start < tl_on_threshold_long) {
-    if (diff > tl_on_threshold_lat && cross_line) {
+    if (diff > tl_on_threshold_lat) {
       turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
-    } else if (diff < -tl_on_threshold_lat && cross_line) {
+    } else if (diff < -tl_on_threshold_lat) {
       turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
     }
   }

--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -290,7 +290,6 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
     right_end_point.position.y += std::cos(end_yaw) * (-shift_to_outside);
   }
 
-  /*
   bool left_start_point_is_in_lane = false;
   bool right_start_point_is_in_lane = false;
   bool left_end_point_is_in_lane = false;
@@ -313,17 +312,21 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   }
 
   bool cross_line = false;
-  if (
-    left_start_point_is_in_lane != left_end_point_is_in_lane ||
-    right_start_point_is_in_lane != right_end_point_is_in_lane) {
+  bool TEMPORARY_SET_CROSSLINE_TRUE =
+    true;  // due to a bug. See link:
+           // https://github.com/autowarefoundation/autoware.universe/pull/748
+  if (TEMPORARY_SET_CROSSLINE_TRUE) {
     cross_line = true;
+  } else {
+    cross_line =
+      (left_start_point_is_in_lane != left_end_point_is_in_lane ||
+       right_start_point_is_in_lane != right_end_point_is_in_lane);
   }
-  */
 
   if (time_to_shift_start < prev_sec || distance_to_shift_start < tl_on_threshold_long) {
-    if (diff > tl_on_threshold_lat) {
+    if (diff > tl_on_threshold_lat && cross_line) {
       turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
-    } else if (diff < -tl_on_threshold_lat) {
+    } else if (diff < -tl_on_threshold_lat && cross_line) {
       turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
     }
   }

--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -258,6 +258,7 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   // Turn signal on when conditions below are satisfied
   //  1. lateral offset is larger than tl_on_threshold_lat for left signal
   //                      smaller than tl_on_threshold_lat for right signal
+  //  2. side point at shift start/end point cross the line
   double distance_to_shift_start;
   {
     const auto arc_position_shift_start =


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description

In the current implementation, there are some serious bugs in determining whether to cross lanes.
Therefore, excluded the condition of crossing lanes when deciding whether to turn on the turn signal.

After PR merging, the turn signal will always turn on when avoiding the parking vehicle

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
