### PR TITLE
fix: add pure_pursuit as lateral controller into launch files

### DIFF
--- a/control/pure_pursuit/CMakeLists.txt
+++ b/control/pure_pursuit/CMakeLists.txt
@@ -56,4 +56,5 @@ endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch
+  config
 )

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -270,7 +270,6 @@ def launch_setup(context, *args, **kwargs):
             # condition=LaunchConfigurationEquals("lateral_controller_mode", "mpc"),
         )
 
-
     group = GroupAction(
         [
             PushRosNamespace("control"),
@@ -298,8 +297,11 @@ def generate_launch_description():
     #     "lateral controller mode: `mpc_follower` or `pure_pursuit`",
     # )
 
-    add_launch_arg("lateral_controller_mode", "mpc_follower", "lateral controller mode: `mpc_follower` or `pure_pursuit`")
-
+    add_launch_arg(
+        "lateral_controller_mode",
+        "mpc_follower",
+        "lateral controller mode: `mpc_follower` or `pure_pursuit`",
+    )
 
     add_launch_arg(
         "vehicle_info_param_file",

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -291,11 +291,8 @@ def generate_launch_description():
             DeclareLaunchArgument(name, default_value=default_value, description=description)
         )
 
-    # add_launch_arg(
-    #     "lateral_controller_mode",
-    #     "mpc_follower",
-    #     "lateral controller mode: `mpc_follower` or `pure_pursuit`",
-    # )
+
+    # lateral controller
 
     add_launch_arg(
         "lateral_controller_mode",
@@ -365,7 +362,6 @@ def generate_launch_description():
     )
     add_launch_arg("enable_pub_debug", "true", "enable to publish debug information")
 
-    # lateral controller
 
     # vehicle cmd gate
     add_launch_arg("use_emergency_handling", "false", "use emergency handling")

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -291,7 +291,6 @@ def generate_launch_description():
             DeclareLaunchArgument(name, default_value=default_value, description=description)
         )
 
-
     # lateral controller
 
     add_launch_arg(
@@ -361,7 +360,6 @@ def generate_launch_description():
         "enable_smooth_stop", "true", "enable smooth stop (in velocity controller state)"
     )
     add_launch_arg("enable_pub_debug", "true", "enable to publish debug information")
-
 
     # vehicle cmd gate
     add_launch_arg("use_emergency_handling", "false", "use emergency handling")

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -31,6 +31,7 @@ import yaml
 
 
 def launch_setup(context, *args, **kwargs):
+    lateral_controller_mode = LaunchConfiguration("lateral_controller_mode").perform(context)
     vehicle_info_param_path = LaunchConfiguration("vehicle_info_param_file").perform(context)
     with open(vehicle_info_param_path, "r") as f:
         vehicle_info_param = yaml.safe_load(f)["/**"]["ros__parameters"]
@@ -43,7 +44,9 @@ def launch_setup(context, *args, **kwargs):
     latlon_muxer_param_path = LaunchConfiguration("latlon_muxer_param_path").perform(context)
     with open(latlon_muxer_param_path, "r") as f:
         latlon_muxer_param = yaml.safe_load(f)["/**"]["ros__parameters"]
-
+    pure_pursuit_param_path = LaunchConfiguration("pure_pursuit_param_path").perform(context)
+    with open(pure_pursuit_param_path, "r") as f:
+        pure_pursuit_param = yaml.safe_load(f)["/**"]["ros__parameters"]
     vehicle_cmd_gate_param_path = LaunchConfiguration("vehicle_cmd_gate_param_path").perform(
         context
     )
@@ -72,6 +75,22 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             lat_controller_param,
             vehicle_info_param,
+        ],
+        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+    )
+
+    pure_pursuit_component = ComposableNode(
+        package="pure_pursuit",
+        plugin="pure_pursuit::PurePursuitNode",
+        name="pure_pursuit_node_exe",
+        namespace="trajectory_follower",
+        remappings=[
+            ("input/reference_trajectory", "/planning/scenario_planning/trajectory"),
+            ("input/current_odometry", "/localization/kinematic_state"),
+            ("output/control_raw", "lateral/control_cmd"),
+        ],
+        parameters=[
+            pure_pursuit_param,
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
@@ -238,11 +257,19 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # lateral controller is separated since it may be another controller (e.g. pure pursuit)
-    lat_controller_loader = LoadComposableNodes(
-        composable_node_descriptions=[lat_controller_component],
-        target_container=container,
-        # condition=LaunchConfigurationEquals("lateral_controller_mode", "mpc"),
-    )
+    if lateral_controller_mode == "mpc_follower":
+        lat_controller_loader = LoadComposableNodes(
+            composable_node_descriptions=[lat_controller_component],
+            target_container=container,
+            # condition=LaunchConfigurationEquals("lateral_controller_mode", "mpc"),
+        )
+    elif lateral_controller_mode == "pure_pursuit":
+        lat_controller_loader = LoadComposableNodes(
+            composable_node_descriptions=[pure_pursuit_component],
+            target_container=container,
+            # condition=LaunchConfigurationEquals("lateral_controller_mode", "mpc"),
+        )
+
 
     group = GroupAction(
         [
@@ -271,6 +298,9 @@ def generate_launch_description():
     #     "lateral controller mode: `mpc_follower` or `pure_pursuit`",
     # )
 
+    add_launch_arg("lateral_controller_mode", "mpc_follower", "lateral controller mode: `mpc_follower` or `pure_pursuit`")
+
+
     add_launch_arg(
         "vehicle_info_param_file",
         [
@@ -285,6 +315,14 @@ def generate_launch_description():
         [
             FindPackageShare("tier4_control_launch"),
             "/config/trajectory_follower/lateral_controller.param.yaml",
+        ],
+        "path to the parameter file of lateral controller",
+    )
+    add_launch_arg(
+        "pure_pursuit_param_path",
+        [
+            FindPackageShare("pure_pursuit"),
+            "/config/pure_pursuit.param.yaml",
         ],
         "path to the parameter file of lateral controller",
     )
@@ -324,6 +362,8 @@ def generate_launch_description():
         "enable_smooth_stop", "true", "enable smooth stop (in velocity controller state)"
     )
     add_launch_arg("enable_pub_debug", "true", "enable to publish debug information")
+
+    # lateral controller
 
     # vehicle cmd gate
     add_launch_arg("use_emergency_handling", "false", "use emergency handling")


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Closes  (#749)
Related (#567)
`tier4_control_launch/launch/control.launch.py` lateral_controller_mode option is not working.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
