### PR TITLE
fix(costmap_generator): modify build error in rolling

### DIFF
--- a/planning/costmap_generator/CMakeLists.txt
+++ b/planning/costmap_generator/CMakeLists.txt
@@ -33,6 +33,13 @@ target_link_libraries(costmap_generator_lib
   FLANN::FLANN
 )
 
+if(${PCL_VERSION} GREATER_EQUAL 1.12.1)
+  find_package(Qhull REQUIRED)
+  target_link_libraries(costmap_generator_lib
+    QHULL::QHULL
+  )
+endif()
+
 ament_auto_add_library(costmap_generator_node SHARED
   nodes/costmap_generator/costmap_generator_node.cpp
 )


### PR DESCRIPTION
## Description

The way to find qhull has been changed since pcl-1.12.
https://github.com/PointCloudLibrary/pcl/pull/4923

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
