### PR TITLE
feat(map_based_prediction): upgrade yaw difference tolerance

### DIFF
--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -46,7 +46,6 @@
 
 namespace map_based_prediction
 {
-
 struct ObjectData
 {
   std_msgs::msg::Header header;

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -423,8 +423,8 @@ bool MapBasedPredictionNode::checkCloseLaneletCondition(
   // of the lanelets that are below max_dist and max_delta_yaw
   if (
     lanelet.first < dist_threshold_for_searching_lanelet_ &&
-    (abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_ ||
-     abs_norm_delta > M_PI - delta_yaw_threshold_for_searching_lanelet_)) {
+    (M_PI - delta_yaw_threshold_for_searching_lanelet_< abs_norm_delta  ||
+     abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_)) {
     return true;
   }
 

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -428,7 +428,7 @@ bool MapBasedPredictionNode::checkCloseLaneletCondition(
   // of the lanelets that are below max_dist and max_delta_yaw
   if (
     lanelet.first < dist_threshold_for_searching_lanelet_ &&
-    (M_PI - delta_yaw_threshold_for_searching_lanelet_< abs_norm_delta  ||
+    (M_PI - delta_yaw_threshold_for_searching_lanelet_ < abs_norm_delta ||
      abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_)) {
     return true;
   }

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -423,7 +423,8 @@ bool MapBasedPredictionNode::checkCloseLaneletCondition(
   // of the lanelets that are below max_dist and max_delta_yaw
   if (
     lanelet.first < dist_threshold_for_searching_lanelet_ &&
-    abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_) {
+    (abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_ ||
+     abs_norm_delta > M_PI - delta_yaw_threshold_for_searching_lanelet_)) {
     return true;
   }
 


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
When yaw inversion occurred, map based prediction does not generate appropriate paths for that object even the object is on the reasonable lanelet. In this PR, I fixed that problem, and allow map based prediction to generate predicted trajectories when the object's yaw is inverse's 180. 

Before the PR:
![image](https://user-images.githubusercontent.com/43805014/164685283-a59da16a-8cda-46bf-a94f-8faf90d4ab9c.png)


After the PR:
![image](https://user-images.githubusercontent.com/43805014/164684941-3b98da8f-04e3-4dd8-b1f1-0f1f1489a1ef.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
