### PR TITLE
[obsolete] feat(tier4_planning_launch): generalize launch files

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/adaptive_cruise_control.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/adaptive_cruise_control.param.yaml
@@ -10,6 +10,7 @@
       obstacle_velocity_thresh_to_start_acc: 1.5 # start adaptive cruise control when the velocity of the forward obstacle exceeds this value [m/s]
       obstacle_velocity_thresh_to_stop_acc: 1.0 # stop adaptive cruise control when the velocity of the forward obstacle falls below this value [m/s]
       emergency_stop_acceleration: -5.0 # supposed minimum acceleration (deceleration) in emergency stop [m/ss]
+      obstacle_emergency_stop_acceleration: -5.0
       emergency_stop_idling_time: 0.5 # supposed idling time to start emergency stop [s]
       min_dist_stop: 4.0 # minimum distance of emergency stop [m]
       max_standard_acceleration: 0.5 # supposed maximum acceleration in active cruise control [m/ss]
@@ -18,6 +19,9 @@
       min_dist_standard: 4.0 # minimum distance in active cruise control [m]
       obstacle_min_standard_acceleration: -1.5 # supposed minimum acceleration of forward obstacle [m/ss]
       margin_rate_to_change_vel: 0.3 # margin to insert upper velocity [-]
+
+      use_time_compensation_to_calc_distance: true
+      lowpass_gain_of_upper_velocity: 0.75
 
       # pid parameter for ACC
       p_coefficient_positive: 0.1 # coefficient P in PID control (used when target dist -current_dist >=0) [-]
@@ -33,6 +37,5 @@
       valid_estimated_vel_max: 20.0 # Maximum value of valid speed estimation results in speed estimation using a point cloud [m/s]
       valid_estimated_vel_min: -20.0 # Minimum value of valid speed estimation results in speed estimation using a point cloud [m/s]
       thresh_vel_to_stop: 1.5 # Embed a stop line if the maximum speed calculated by ACC is lower than this speed [m/s]
-      lowpass_gain_of_upper_velocity: 0.75 # Lowpass-gain of upper velocity
       use_rough_velocity_estimation: false # Use rough estimated velocity if the velocity estimation is failed (#### If this parameter is true, the vehicle may collide with the front car. Be careful. ####)
       rough_velocity_rate: 0.9 # In the rough velocity estimation, the velocity of front car is estimated as self current velocity * this value

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/obstacle_stop_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/obstacle_stop_planner.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    enable_slow_down: False
+
     stop_planner:
       stop_margin: 5.0 # stop margin distance from obstacle on the path [m]
       min_behavior_stop_margin: 5.0 # stop margin distance when any other stop point is inserted in stop margin [m]

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/obstacle_stop_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/obstacle_stop_planner.param.yaml
@@ -1,6 +1,10 @@
 /**:
   ros__parameters:
     enable_slow_down: False
+    max_velocity: 20.0
+    hunting_threshold: 0.5
+    lowpass_gain: 0.9
+    max_yaw_deviation_deg: 90.0
 
     stop_planner:
       stop_margin: 5.0 # stop margin distance from obstacle on the path [m]
@@ -25,3 +29,6 @@
       jerk_span: -0.01 # fineness param for planning deceleration jerk [m/sss]
       jerk_start: -0.1 # init jerk used for deceleration planning [m/sss]
       slow_down_vel: 1.38 # target slow down velocity [m/s]
+
+      vel_threshold_reset_velocity_limit: 0.2
+      dec_threshold_reset_velocity_limit: 0.1

--- a/launch/tier4_planning_launch/launch/planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/planning.launch.xml
@@ -2,6 +2,9 @@
   <!-- planning module -->
 
   <arg name="vehicle_info_param_file"/>
+  <arg name="bt_tree_config_file" default="$(find-pkg-share behavior_path_planner)/config/behavior_path_planner_tree.xml"/>
+  <arg name="use_surround_obstacle_check" default="true"/>
+  <arg name="motion_velocity_smoother_type" default="JerkFiltered" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>
 
   <group>
     <push-ros-namespace namespace="planning"/>
@@ -16,6 +19,9 @@
       <push-ros-namespace namespace="scenario_planning"/>
       <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/scenario_planning.launch.xml">
         <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
+        <arg name="bt_tree_config_file" value="$(var bt_tree_config_file)"/>
+        <arg name="use_surround_obstacle_check" value="$(var use_surround_obstacle_check)"/>
+        <arg name="motion_velocity_smoother_type" value="$(var motion_velocity_smoother_type)"/>
       </include>
     </group>
 

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
@@ -2,6 +2,7 @@
   <!-- common param -->
   <arg name="common_param_path"/>
   <arg name="vehicle_info_param_file"/>
+  <arg name="use_surround_obstacle_check"/>
 
   <!-- lane_driving scenario -->
   <group>
@@ -11,6 +12,7 @@
       <push-ros-namespace namespace="behavior_planning"/>
       <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py">
         <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
+        <arg name="bt_tree_config_file" value="$(var bt_tree_config_file)"/>
         <arg name="use_multithread" value="true"/>
       </include>
     </group>
@@ -20,6 +22,7 @@
       <push-ros-namespace namespace="motion_planning"/>
       <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.py">
         <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
+        <arg name="use_surround_obstacle_check" value="$(var use_surround_obstacle_check)"/>
         <arg name="use_multithread" value="true"/>
       </include>
     </group>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -26,7 +26,6 @@ from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
-from launch_ros.substitutions import FindPackageShare
 import yaml
 
 
@@ -36,6 +35,9 @@ def launch_setup(context, *args, **kwargs):
     vehicle_info_param_path = LaunchConfiguration("vehicle_info_param_file").perform(context)
     with open(vehicle_info_param_path, "r") as f:
         vehicle_info_param = yaml.safe_load(f)["/**"]["ros__parameters"]
+
+    # parameters for each behavior package
+    bt_tree_config_path = LaunchConfiguration("bt_tree_config_file").perform(context)
 
     # behavior path planner
     side_shift_param_path = os.path.join(
@@ -178,10 +180,7 @@ def launch_setup(context, *args, **kwargs):
             behavior_path_planner_param,
             vehicle_info_param,
             {
-                "bt_tree_config_path": [
-                    FindPackageShare("behavior_path_planner"),
-                    "/config/behavior_path_planner_tree.xml",
-                ],
+                "bt_tree_config_path": bt_tree_config_path,
                 "planning_hz": 10.0,
             },
         ],
@@ -404,15 +403,7 @@ def generate_launch_description():
             DeclareLaunchArgument(name, default_value=default_value, description=description)
         )
 
-    add_launch_arg(
-        "vehicle_info_param_file",
-        [
-            FindPackageShare("vehicle_info_util"),
-            "/config/vehicle_info.param.yaml",
-        ],
-        "path to the parameter file of vehicle information",
-    )
-
+    # input of behavior
     add_launch_arg(
         "input_route_topic_name", "/planning/mission_planning/route", "input topic of route"
     )

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.py
@@ -26,7 +26,6 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
-from launch_ros.substitutions import FindPackageShare
 import yaml
 
 
@@ -180,7 +179,6 @@ def launch_setup(context, *args, **kwargs):
             obstacle_stop_planner_param,
             obstacle_stop_planner_acc_param,
             vehicle_info_param,
-            {"enable_slow_down": False},
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
@@ -221,26 +219,14 @@ def generate_launch_description():
             DeclareLaunchArgument(name, default_value=default_value, description=description)
         )
 
-    # vehicle information parameter file
-    add_launch_arg(
-        "vehicle_info_param_file",
-        [
-            FindPackageShare("vehicle_info_util"),
-            "/config/vehicle_info.param.yaml",
-        ],
-        "path to the parameter file of vehicle information",
-    )
-
-    # obstacle_avoidance_planner
+    # input of motion
     add_launch_arg(
         "input_path_topic",
         "/planning/scenario_planning/lane_driving/behavior_planning/path",
         "input path topic of obstacle_avoidance_planner",
     )
 
-    # surround obstacle checker
-    add_launch_arg("use_surround_obstacle_check", "true", "launch surround_obstacle_checker or not")
-
+    # component
     add_launch_arg("use_intra_process", "false", "use ROS2 component container communication")
     add_launch_arg("use_multithread", "false", "use multithread")
 

--- a/launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
@@ -2,6 +2,8 @@
   <!-- common param -->
   <arg name="common_param_path" default="$(find-pkg-share tier4_planning_launch)/config/scenario_planning/common/common.param.yaml"/>
   <arg name="vehicle_info_param_file"/>
+  <arg name="use_surround_obstacle_check"/>
+  <arg name="motion_velocity_smoother_type"/>
 
   <!-- scenario selector -->
   <include file="$(find-pkg-share scenario_selector)/launch/scenario_selector.launch.xml">
@@ -24,14 +26,13 @@
       <arg name="param_path" value="$(var param_path)"/>
     </include>
     <!-- motion velocity smoother -->
-    <arg name="smoother_type" default="JerkFiltered" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>
     <set_remap from="~/input/trajectory" to="/planning/scenario_planning/scenario_selector/trajectory"/>
     <set_remap from="~/output/trajectory" to="/planning/scenario_planning/trajectory"/>
     <include file="$(find-pkg-share motion_velocity_smoother)/launch/motion_velocity_smoother.launch.xml">
-      <arg name="smoother_type" value="$(var smoother_type)"/>
+      <arg name="smoother_type" value="$(var motion_velocity_smoother_type)"/>
       <arg name="common_param_path" value="$(var common_param_path)"/>
       <arg name="param_path" value="$(var param_path)"/>
-      <arg name="smoother_param_path" value="$(find-pkg-share tier4_planning_launch)/config/scenario_planning/common/motion_velocity_smoother/$(var smoother_type).param.yaml"/>
+      <arg name="smoother_param_path" value="$(find-pkg-share tier4_planning_launch)/config/scenario_planning/common/motion_velocity_smoother/$(var motion_velocity_smoother_type).param.yaml"/>
     </include>
   </group>
 
@@ -41,6 +42,8 @@
     <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/lane_driving.launch.xml">
       <arg name="common_param_path" value="$(var common_param_path)"/>
       <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
+      <arg name="bt_tree_config_file" value="$(var bt_tree_config_file)"/>
+      <arg name="use_surround_obstacle_check" value="$(var use_surround_obstacle_check)"/>
     </include>
     <!-- parking -->
     <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/parking.launch.py">

--- a/planning/obstacle_stop_planner/config/adaptive_cruise_control.param.yaml
+++ b/planning/obstacle_stop_planner/config/adaptive_cruise_control.param.yaml
@@ -10,16 +10,18 @@
       obstacle_velocity_thresh_to_start_acc: 1.5 # start adaptive cruise control when the velocity of the forward obstacle exceeds this value [m/s]
       obstacle_velocity_thresh_to_stop_acc: 1.0 # stop adaptive cruise control when the velocity of the forward obstacle falls below this value [m/s]
       emergency_stop_acceleration: -5.0 # supposed minimum acceleration (deceleration) in emergency stop [m/ss]
+      obstacle_emergency_stop_acceleration: -5.0
       emergency_stop_idling_time: 0.5 # supposed idling time to start emergency stop [s]
       min_dist_stop: 4.0 # minimum distance of emergency stop [m]
-      obstacle_emergency_stop_acceleration: -5.0 # supposed minimum acceleration (deceleration) in emergency stop [m/ss]
       max_standard_acceleration: 0.5 # supposed maximum acceleration in active cruise control [m/ss]
       min_standard_acceleration: -1.0 # supposed minimum acceleration (deceleration) in active cruise control
       standard_idling_time: 0.5 # supposed idling time to react object in active cruise control [s]
       min_dist_standard: 4.0 # minimum distance in active cruise control [m]
       obstacle_min_standard_acceleration: -1.5 # supposed minimum acceleration of forward obstacle [m/ss]
       margin_rate_to_change_vel: 0.3 # margin to insert upper velocity [-]
-      use_time_compensation_to_calc_distance: true # use time-compensation to calculate distance to forward vehicle
+
+      use_time_compensation_to_calc_distance: true
+      lowpass_gain_of_upper_velocity: 0.75
 
       # pid parameter for ACC
       p_coefficient_positive: 0.1 # coefficient P in PID control (used when target dist -current_dist >=0) [-]
@@ -35,6 +37,5 @@
       valid_estimated_vel_max: 20.0 # Maximum value of valid speed estimation results in speed estimation using a point cloud [m/s]
       valid_estimated_vel_min: -20.0 # Minimum value of valid speed estimation results in speed estimation using a point cloud [m/s]
       thresh_vel_to_stop: 1.5 # Embed a stop line if the maximum speed calculated by ACC is lower than this speed [m/s]
-      lowpass_gain_of_upper_velocity: 0.75 # Lowpass-gain of upper velocity
       use_rough_velocity_estimation: false # Use rough estimated velocity if the velocity estimation is failed (#### If this parameter is true, the vehicle may collide with the front car. Be careful. ####)
       rough_velocity_rate: 0.9 # In the rough velocity estimation, the velocity of front car is estimated as self current velocity * this value

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -1,19 +1,22 @@
 /**:
   ros__parameters:
     enable_slow_down: False
+    max_velocity: 20.0
+    hunting_threshold: 0.5
+    lowpass_gain: 0.9
+    max_yaw_deviation_deg: 90.0
 
     stop_planner:
       stop_margin: 5.0 # stop margin distance from obstacle on the path [m]
-      min_behavior_stop_margin: 2.0 # stop margin distance when any other stop point is inserted in stop margin [m]
+      min_behavior_stop_margin: 5.0 # stop margin distance when any other stop point is inserted in stop margin [m]
       step_length: 1.0 # step length for pointcloud search range [m]
       extend_distance: 0.0 # extend trajectory to consider after goal obstacle in the extend_distance
       expand_stop_range: 0.0 # margin of vehicle footprint [m]
-      max_yaw_deviation_deg: 90.0 # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)
 
     slow_down_planner:
       # slow down planner parameters
       forward_margin: 5.0 # margin distance from slow down point to vehicle front [m]
-      backward_margin: 5.0 # margin distance from slow down point to vehicle rear [m]
+      backward_margin: 0.0 # margin distance from slow down point to vehicle rear [m]
       expand_slow_down_range: 1.0 # offset from vehicle side edge for expanding the search area of the surrounding point cloud [m]
       max_slow_down_vel: 1.38 # max slow down velocity [m/s]
       min_slow_down_vel: 0.28 # min slow down velocity [m/s]
@@ -22,7 +25,10 @@
       consider_constraints: False # set "True", if no decel plan found under jerk/dec constrains, relax target slow down vel
       forward_margin_min: 1.0 # min margin for relaxing slow down margin [m/s]
       forward_margin_span: -0.1 # fineness param for relaxing slow down margin [m/s]
-      jerk_min_slow_down: -0.3 # min slow down jerk constraint [m/sss]
+      jerk_min_slow_down: -0.6 # min slow down jerk constraint [m/sss]
       jerk_span: -0.01 # fineness param for planning deceleration jerk [m/sss]
       jerk_start: -0.1 # init jerk used for deceleration planning [m/sss]
       slow_down_vel: 1.38 # target slow down velocity [m/s]
+
+      vel_threshold_reset_velocity_limit: 0.2
+      dec_threshold_reset_velocity_limit: 0.1

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    enable_slow_down: False
+
     stop_planner:
       stop_margin: 5.0 # stop margin distance from obstacle on the path [m]
       min_behavior_stop_margin: 2.0 # stop margin distance when any other stop point is inserted in stop margin [m]


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

Updated tier4_planning_launch so that tier4_planning_launch will be product-agnostic.
Not all parameters may be extracted in `planning.launch.xml`, but most of them which are important to be product-agnostic were extracted.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
