### PR TITLE
fix(osqp_interface): modify build error in rolling

### DIFF
--- a/common/osqp_interface/CMakeLists.txt
+++ b/common/osqp_interface/CMakeLists.txt
@@ -19,13 +19,15 @@ project(osqp_interface)
 # require that dependencies from package.xml be available
 find_package(ament_cmake_auto REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(osqp REQUIRED)
-get_target_property(OSQP_INCLUDE_DIR osqp::osqp INTERFACE_INCLUDE_DIRECTORIES)
 
 ament_auto_find_build_dependencies(REQUIRED
   ${${PROJECT_NAME}_BUILD_DEPENDS}
   ${${PROJECT_NAME}_BUILDTOOL_DEPENDS}
 )
+
+find_package(osqp REQUIRED)
+get_target_property(OSQP_INCLUDE_SUB_DIR osqp::osqp INTERFACE_INCLUDE_DIRECTORIES)
+get_filename_component(OSQP_INCLUDE_DIR ${OSQP_INCLUDE_SUB_DIR} PATH)
 
 set(OSQP_INTERFACE_LIB_SRC
   src/csc_matrix_conv.cpp
@@ -46,7 +48,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 autoware_set_compile_options(${PROJECT_NAME})
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-error=old-style-cast -Wno-error=useless-cast)
 
-target_include_directories(osqp_interface PUBLIC "${OSQP_INCLUDE_DIR}")
+target_include_directories(osqp_interface
+  SYSTEM PUBLIC
+    "${OSQP_INCLUDE_DIR}"
+)
+
 ament_target_dependencies(osqp_interface
   Eigen3
   osqp_vendor

--- a/common/osqp_interface/CMakeLists.txt
+++ b/common/osqp_interface/CMakeLists.txt
@@ -25,6 +25,7 @@ ament_auto_find_build_dependencies(REQUIRED
   ${${PROJECT_NAME}_BUILDTOOL_DEPENDS}
 )
 
+# after find_package(osqp_vendor) in ament_auto_find_build_dependencies
 find_package(osqp REQUIRED)
 get_target_property(OSQP_INCLUDE_SUB_DIR osqp::osqp INTERFACE_INCLUDE_DIRECTORIES)
 get_filename_component(OSQP_INCLUDE_DIR ${OSQP_INCLUDE_SUB_DIR} PATH)


### PR DESCRIPTION
## Description

This PR fixes the following build error on rolling distro.
```
gmake[1]: *** [CMakeFiles/Makefile2:157: CMakeFiles/osqp_interface.dir/all] エラー 2
gmake: *** [Makefile:146: all] エラー 2
--- stderr: osqp_interface                             
In file included from /home/daisuke/workspace/autoware.proj.universe.rolling/src/autoware/universe/common/osqp_interface/src/osqp_interface.cpp:15:
/home/daisuke/workspace/autoware.proj.universe.rolling/src/autoware/universe/common/osqp_interface/include/osqp_interface/osqp_interface.hpp:20:10: fatal error: osqp/osqp.h: そのようなファイルやディレクトリはありません
   20 | #include "osqp/osqp.h"
      |          ^~~~~~~~~~~~~
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
