### PR TITLE
fix(map_tf_generator): modify build error in rolling

### DIFF
--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -12,7 +12,8 @@
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 


### PR DESCRIPTION
## Description

This PR fixes the following build error on rolling distro.
```
gmake[2]: *** [CMakeFiles/map_tf_generator_node.dir/build.make:76: CMakeFiles/map_tf_generator_node.dir/src/map_tf_generator_node.cpp.o] エラー 1
gmake[1]: *** [CMakeFiles/Makefile2:139: CMakeFiles/map_tf_generator_node.dir/all] エラー 2
gmake: *** [Makefile:146: all] エラー 2
--- stderr: map_tf_generator
/home/daisuke/workspace/autoware.proj.universe.rolling/src/autoware/universe/map/map_tf_generator/src/map_tf_generator_node.cpp:91:10: fatal error: rclcpp_components/register_node_macro.hpp: そのようなファイルやディレクトリはありません
   91 | #include <rclcpp_components/register_node_macro.hpp>
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
