### PR TITLE
fix(system_monitor): modify build error in rolling

### DIFF
--- a/system/system_monitor/CMakeLists.txt
+++ b/system/system_monitor/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-stringop-truncation)
 endif()
 
 find_package(ament_cmake_auto REQUIRED)

--- a/system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
+++ b/system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
@@ -183,10 +183,10 @@ void GPUMonitor::addProcessUsage(
   uint32_t info_count = MAX_ARRAY_SIZE;
   std::unique_ptr<nvmlProcessInfo_t[]> infos;
   infos = std::make_unique<nvmlProcessInfo_t[]>(MAX_ARRAY_SIZE);
-  ret = nvmlDeviceGetComputeRunningProcesses_v2(device, &info_count, infos.get());
+  ret = nvmlDeviceGetComputeRunningProcesses(device, &info_count, infos.get());
   if (ret != NVML_SUCCESS) {
     RCLCPP_WARN(
-      this->get_logger(), "Failed to nvmlDeviceGetComputeRunningProcesses_v2 NVML: %s",
+      this->get_logger(), "Failed to nvmlDeviceGetComputeRunningProcesses NVML: %s",
       nvmlErrorString(ret));
     return;
   }
@@ -197,10 +197,10 @@ void GPUMonitor::addProcessUsage(
   // Get Graphics Process ID
   info_count = MAX_ARRAY_SIZE;
   infos = std::make_unique<nvmlProcessInfo_t[]>(MAX_ARRAY_SIZE);
-  ret = nvmlDeviceGetGraphicsRunningProcesses_v2(device, &info_count, infos.get());
+  ret = nvmlDeviceGetGraphicsRunningProcesses(device, &info_count, infos.get());
   if (ret != NVML_SUCCESS) {
     RCLCPP_WARN(
-      this->get_logger(), "Failed to nvmlDeviceGetGraphicsRunningProcesses_v2 NVML: %s",
+      this->get_logger(), "Failed to nvmlDeviceGetGraphicsRunningProcesses NVML: %s",
       nvmlErrorString(ret));
     return;
   }


### PR DESCRIPTION
## Description

This PR fixes the following build error in rolling.
```
/home/daisuke/workspace/autoware.proj.universe.rolling/src/autoware/universe/system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp: In member function ‘void GPUMonitor::addProcessUsage(int, nvmlDevice_t, diagnostic_updater::DiagnosticStatusWrapper&)’:
/home/daisuke/workspace/autoware.proj.universe.rolling/src/autoware/universe/system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp:186:9: error: ‘nvmlDeviceGetComputeRunningProcesses_v2’ was not declared in this scope; did you mean ‘nvmlDeviceGetComputeRunningProcesses_v3’?
  186 |   ret = nvmlDeviceGetComputeRunningProcesses_v2(device, &info_count, infos.get());
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         nvmlDeviceGetComputeRunningProcesses_v3
/home/daisuke/workspace/autoware.proj.universe.rolling/src/autoware/universe/system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp:200:9: error: ‘nvmlDeviceGetGraphicsRunningProcesses_v2’ was not declared in this scope; did you mean ‘nvmlDeviceGetGraphicsRunningProcesses_v3’?
  200 |   ret = nvmlDeviceGetGraphicsRunningProcesses_v2(device, &info_count, infos.get());
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         nvmlDeviceGetGraphicsRunningProcesses_v3

```
```
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘int get_nvme_identify(int, HDDInfo*)’ at /home/daisuke/workspace/autoware.proj.universe.rolling/src/autoware/universe/system/system_monitor/reader/hdd_reader/hdd_reader.cpp:342:10:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:34: error: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ output may be truncated copying 20 bytes from a string of length 4091 [-Werror=stringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
