### PR TITLE
feat(planning_error_monitor): read params from yaml

### DIFF
--- a/planning/planning_error_monitor/CMakeLists.txt
+++ b/planning/planning_error_monitor/CMakeLists.txt
@@ -58,6 +58,6 @@ endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE
-  config
-  launch
+    config
+    launch
 )

--- a/planning/planning_error_monitor/CMakeLists.txt
+++ b/planning/planning_error_monitor/CMakeLists.txt
@@ -58,5 +58,6 @@ endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE
-    launch
+  config
+  launch
 )

--- a/planning/planning_error_monitor/config/planning_error_monitor.param.yaml
+++ b/planning/planning_error_monitor/config/planning_error_monitor.param.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    # trajectory check
+    error_interval: 100.0 # error interval distance threshold [m]
+    error_curvature: 2.0 # error curvature threshold
+    error_sharp_angle: 0.785398 # error sharp angle threshold
+    ignore_too_close_points: 0.01 # ignore too close distance threshold

--- a/planning/planning_error_monitor/config/planning_error_monitor.param.yaml
+++ b/planning/planning_error_monitor/config/planning_error_monitor.param.yaml
@@ -2,6 +2,6 @@
   ros__parameters:
     # trajectory check
     error_interval: 100.0 # error interval distance threshold [m]
-    error_curvature: 2.0 # error curvature threshold
-    error_sharp_angle: 0.785398 # error sharp angle threshold
-    ignore_too_close_points: 0.01 # ignore too close distance threshold
+    error_curvature: 2.0 # error curvature threshold [rad/m]
+    error_sharp_angle: 0.785398 # error sharp angle threshold [rad]
+    ignore_too_close_points: 0.01 # ignore too close distance threshold [m]

--- a/planning/planning_error_monitor/launch/planning_error_monitor.launch.xml
+++ b/planning/planning_error_monitor/launch/planning_error_monitor.launch.xml
@@ -1,15 +1,15 @@
 <launch>
   <!--select run mode for analyze trajectory-->
   <arg name="run_mode" default="final_output" description="options: final_output, avoidance,surround_obstacle,obstacle_stop"/>
+  <arg name="planning_error_monitor_param_path" default="$(find-pkg-share planning_error_monitor)/config/planning_error_monitor.param.yaml"/>
   <arg name="input/trajectory" default="/planning/scenario_planning/trajectory"/>
   <let name="input/trajectory" value="/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/trajectory" if="$(eval &quot;'$(var run_mode)'=='avoidance'&quot;)"/>
   <let name="input/trajectory" value="/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/trajectory" if="$(eval &quot;'$(var run_mode)'=='surround_obstacle'&quot;)"/>
   <let name="input/trajectory" value="/planning/scenario_planning/lane_driving/trajectory" if="$(eval &quot;'$(var run_mode)'=='obstacle_stop'&quot;)"/>
   <node name="planning_error_monitor" exec="planning_error_monitor" pkg="planning_error_monitor" output="screen">
+    <!-- load config a file -->
+    <param from="$(var planning_error_monitor_param_path)"/>
+    <!-- remap topic name -->
     <remap from="~/input/trajectory" to="$(var input/trajectory)"/>
-    <param name="error_interval" value="100.0"/>
-    <param name="error_curvature" value="2.0"/>
-    <param name="error_sharp_angle" value="0.785398"/>
-    <param name="ignore_too_close_points" value="0.01"/>
   </node>
 </launch>

--- a/planning/planning_error_monitor/launch/planning_error_monitor.launch.xml
+++ b/planning/planning_error_monitor/launch/planning_error_monitor.launch.xml
@@ -1,11 +1,11 @@
 <launch>
   <!--select run mode for analyze trajectory-->
   <arg name="run_mode" default="final_output" description="options: final_output, avoidance,surround_obstacle,obstacle_stop"/>
-  <arg name="planning_error_monitor_param_path" default="$(find-pkg-share planning_error_monitor)/config/planning_error_monitor.param.yaml"/>
   <arg name="input/trajectory" default="/planning/scenario_planning/trajectory"/>
   <let name="input/trajectory" value="/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/trajectory" if="$(eval &quot;'$(var run_mode)'=='avoidance'&quot;)"/>
   <let name="input/trajectory" value="/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/trajectory" if="$(eval &quot;'$(var run_mode)'=='surround_obstacle'&quot;)"/>
   <let name="input/trajectory" value="/planning/scenario_planning/lane_driving/trajectory" if="$(eval &quot;'$(var run_mode)'=='obstacle_stop'&quot;)"/>
+  <arg name="planning_error_monitor_param_path" default="$(find-pkg-share planning_error_monitor)/config/planning_error_monitor.param.yaml"/>
   <node name="planning_error_monitor" exec="planning_error_monitor" pkg="planning_error_monitor" output="screen">
     <!-- load config a file -->
     <param from="$(var planning_error_monitor_param_path)"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Add a planning_error_monitor param yaml file.
This feature enables planning_error_monitor to read some parameters from above yaml file.
This is so that abobe parameters can be changed in other projects.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
