### PR TITLE
fix(behavior_path_planner): add function to check the shift points in avoidance module

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -186,6 +186,7 @@ private:
   double getCurrentBaseShift() const { return path_shifter_.getBaseOffset(); }
   double getCurrentShift() const;
   double getCurrentLinearShift() const;
+  bool shiftedpathcheck(ShiftedPath shifted_path)const;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -255,6 +255,8 @@ struct AvoidancePlanningData
 
   // current driving lanelet
   lanelet::ConstLanelets current_lanelets;
+  lanelet::ConstLanelets right_lanelets;
+  lanelet::ConstLanelets left_lanelets;
 
   // avoidance target objects
   ObjectDataArray objects;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -28,6 +28,12 @@ bool isOnRight(const ObjectData & obj);
 lanelet::ConstLanelets calcLaneAroundPose(
   const std::shared_ptr<const PlannerData> & planner_data, const Pose & pose,
   const double backward_length);
+  
+lanelet::ConstLanelets calcRightLaneAroundPose(
+  const std::shared_ptr<const PlannerData> & planner_data,lanelet::ConstLanelets curlanelets);
+
+lanelet::ConstLanelets calcLeftLaneAroundPose(
+  const std::shared_ptr<const PlannerData> & planner_data,lanelet::ConstLanelets curlanelets);
 
 size_t findPathIndexFromArclength(
   const std::vector<double> & path_arclength_arr, const double target_arc);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2686,7 +2686,7 @@ void AvoidanceModule::setDebugData(const PathShifter & shifter, const DebugData 
 }
 bool AvoidanceModule::shiftedpathcheck(ShiftedPath shifted_path)const
 {
-  PathWithLaneId path_refence = shifted_path.path;
+  PathWithLaneId path_reference = shifted_path.path;
    auto shift_length = shifted_path.shift_length;
    lanelet::ConstLanelets current_lanelets;
    lanelet::ConstLanelets left_lanelets;
@@ -2711,7 +2711,7 @@ bool AvoidanceModule::shiftedpathcheck(ShiftedPath shifted_path)const
    bool out_flag=false;
    size_t i=0;
    auto with = planner_data_->parameters.vehicle_width*0.5;
-   for (auto & pt : path_refence.points)
+   for (auto & pt : path_reference.points)
    {
       if(fabs(shift_length.at(i))>1.0e-2)
       {

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -53,6 +53,37 @@ lanelet::ConstLanelets calcLaneAroundPose(
 
   return current_lanes;
 }
+lanelet::ConstLanelets calcRightLaneAroundPose(
+  const std::shared_ptr<const PlannerData> & planner_data,lanelet::ConstLanelets curlanelets)
+{
+  const auto & route_handler = planner_data->route_handler;
+  lanelet::ConstLanelets rightlanelets;
+  for(auto lane :curlanelets)
+  {        
+    auto right_lane = route_handler->getRightLanelet(lane);
+    if(right_lane)
+    {
+       rightlanelets.push_back(right_lane.get());
+    }
+  }
+  return rightlanelets;
+}
+
+lanelet::ConstLanelets calcLeftLaneAroundPose(
+  const std::shared_ptr<const PlannerData> & planner_data,lanelet::ConstLanelets curlanelets)
+{
+  const auto & route_handler = planner_data->route_handler;
+  lanelet::ConstLanelets leftlanelets;
+  for(auto lane :curlanelets)
+  {        
+    auto left_lane = route_handler->getLeftLanelet(lane);
+    if(left_lane)
+    {
+       leftlanelets.push_back(left_lane.get());
+    }
+  }
+  return leftlanelets;
+}
 
 ShiftedPath toShiftedPath(const PathWithLaneId & path)
 {


### PR DESCRIPTION
## Description

To solve #706

We can add function to detect points with offset distance to make sure they are within the drivable zone.
We can determine whether the offset points  are all in the driveable lane in the generateAvoidancePath of avoidance module(Consider the width of the vehicle when detecting),otherwise we use reference_path as the obstacle avoidance path(No obstacle avoidance behavior)

## Related links
Wrong path planned by avoidance module in a special case https://github.com/autowarefoundation/autoware.universe/issues/706

## Tests performed
Case1:
1.Run planning_simulator.
2.place ego position and goal
3. Set a obstacle near discontinuous adjacent lanes 
4. result -- ego vehicle stops
![2022-04-25 11-19-01](https://user-images.githubusercontent.com/102840938/165015981-863c9a67-aabb-494b-bb54-b27f53d8cd24.png)
Case2:
1.Run planning_simulator.
2.place ego position and goal
3. Set a obstacle in continuous adjacent lanes 
4. result-- ego vehicle bypasses obstacle
![2022-04-25 11-25-21](https://user-images.githubusercontent.com/102840938/165016090-adf663e5-952b-41fc-b67c-e2f3cea84217.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
