### PR TITLE
feat(obstacle_avoidance_planner): parameterize bounds search widths

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -123,6 +123,8 @@
           eps_rel: 1.0e-10 # eps rel when solving OSQP
 
       mpt:
+        bounds_search_widths: [0.45, 0.15, 0.05, 0.01]
+
         clearance:  # clearance(distance) between vehicle and roads/objects when generating trajectory
           hard_clearance_from_road: 0.0 # clearance from road boundary[m]
           soft_clearance_from_road: 0.1 # clearance from road boundary[m]

--- a/planning/obstacle_avoidance_planner/README.md
+++ b/planning/obstacle_avoidance_planner/README.md
@@ -706,6 +706,15 @@ $N_{circle}$ is the number of circles to check collision.
 - max steering wheel degree
   - `mpt.kinematics.max_steer_deg`
 
+### Boundary search
+
+- `advanced.mpt.bounds_search_widths`
+  - In order to efficiently search precise lateral boundaries on each trajectory point, different resolutions of search widths are defined.
+  - By default, [0.45, 0.15, 0.05, 0.01] is used. In this case, the goal is to get the boundaries' length on each trajectory point with 0.01 [m] resolution.
+  - Firstly, lateral boundaries are searhed with a rough resolution (= 0.45 [m]).
+  - Then, within its 0.45 [m] resolution which boundaries are inside, they are searched again with a bit precise resolution (= 0.15 [m]).
+  - Following this rule, finally boundaries with 0.01 [m] will be found.
+
 ### Assumptions
 
 - EB optimized trajectory length should be longer than MPT optimized trajectory length

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -123,6 +123,8 @@
           eps_rel: 1.0e-10 # eps rel when solving OSQP
 
       mpt:
+        bounds_search_widths: [0.1, 0.03, 0.01]
+
         clearance:  # clearance(distance) between vehicle and roads/objects when generating trajectory
           hard_clearance_from_road: 0.0 # clearance from road boundary[m]
           soft_clearance_from_road: 0.1 # clearance from road boundary[m]

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -123,7 +123,7 @@
           eps_rel: 1.0e-10 # eps rel when solving OSQP
 
       mpt:
-        bounds_search_widths: [0.1, 0.03, 0.01]
+        bounds_search_widths: [0.45, 0.15, 0.05, 0.01]
 
         clearance:  # clearance(distance) between vehicle and roads/objects when generating trajectory
           hard_clearance_from_road: 0.0 # clearance from road boundary[m]

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
@@ -245,6 +245,8 @@ struct MPTParam
   double optimization_center_offset;
   double max_steer_rad;
 
+  std::vector<double> bounds_search_widths;
+
   bool soft_constraint;
   bool hard_constraint;
   bool l_inf_norm;

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -408,6 +408,10 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
       "mpt.kinematics.optimization_center_offset",
       vehicle_param_.wheelbase * default_wheelbase_ratio);
 
+    // bounds search
+    mpt_param_.bounds_search_widths =
+      declare_parameter<std::vector<double>>("advanced.mpt.bounds_search_widths");
+
     // collision free constraints
     mpt_param_.l_inf_norm =
       declare_parameter<bool>("advanced.mpt.collision_free_constraints.option.l_inf_norm");


### PR DESCRIPTION
## Description

Just set bounds_search_widths as a ros parameter, which will be different depending on the vehicle size
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
