### PR TITLE
fix(lane_change): intersection check not considering size equal 1

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1711,7 +1711,7 @@ bool checkLaneIsInIntersection(
   const RouteHandler & route_handler, const PathWithLaneId & reference_path,
   const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add)
 {
-  if (lanelet_sequence.empty()) {
+  if (lanelet_sequence.size() < 2) {
     return false;
   }
 


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

Related issue: https://github.com/autowarefoundation/autoware.universe/issues/810

During lane change, no lane following path is generated. 

![Screenshot from 2022-04-26 09-27-25](https://user-images.githubusercontent.com/93502286/165196172-4b2d7839-d63b-45ec-9e30-319e58cd98a5.png)

The actual behavior should be two path generated in this case, the first is the lane following trajectory, and another is the candidate path.

![Screenshot from 2022-04-26 09-25-07](https://user-images.githubusercontent.com/93502286/165196313-6b5ac4f1-a939-4981-afc6-bd20f9cad03f.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
