### PR TITLE
fix(fault_injection): fix empty hardware_id

### DIFF
--- a/simulator/fault_injection/include/fault_injection/diagnostic_storage.hpp
+++ b/simulator/fault_injection/include/fault_injection/diagnostic_storage.hpp
@@ -39,7 +39,7 @@ public:
   {
     DiagnosticStatus status;
     status.name = diag_config.diag_name;
-    status.hardware_id = "";
+    status.hardware_id = "fault_injection";
     status.level = DiagnosticStatus::OK;
     status.message = "OK";
     event_diag_map_[diag_config.sim_name] = status;


### PR DESCRIPTION
## Description

In fault_injection node, all diags had empty hardware_id.
This is because hardware_id was replaced with the following value in updateEventDiag().
https://github.com/autowarefoundation/autoware.universe/blob/377b7ffca5ad50619d46e9ac10ef0f0e011aca1a/simulator/fault_injection/include/fault_injection/diagnostic_storage.hpp#L42
I fix it.

## Review Procedure

Confirm some  fault injection diag has `fault injection` as hardware_id like following image in rqt_robot_monitor.
![image](https://user-images.githubusercontent.com/9547070/165254577-7857cd31-0ca0-4375-bd40-ef820e262322.png)

 
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
