### PR TITLE
feat: add angle limitation to mpt

### DIFF
--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -235,7 +235,8 @@ private:
 
   void calcVelocity(
     std::vector<ReferencePoint> & ref_points,
-    const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points) const;
+    const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
+    const double yaw_thresh) const;
 
   void calcCurvature(std::vector<ReferencePoint> & ref_points) const;
 
@@ -298,6 +299,10 @@ private:
     const bool enable_avoidance, const MPTMatrix & mpt_mat,
     const std::vector<ReferencePoint> & ref_points,
     std::shared_ptr<DebugData> debug_data_ptr) const;
+
+  size_t findNearestIndexWithSoftYawConstraints(
+    const std::vector<geometry_msgs::msg::Point> & points, const geometry_msgs::msg::Pose & pose,
+    const double yaw_threshold) const;
 
 public:
   MPTOptimizer(

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils.hpp
@@ -27,6 +27,7 @@
 #include "boost/optional/optional_fwd.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils.hpp
@@ -188,14 +188,19 @@ T clipBackwardPoints(
 
 template <typename T>
 T clipBackwardPoints(
-  const T & points, const geometry_msgs::msg::Point pos, const double backward_length,
-  const double delta_length)
+  const T & points, const geometry_msgs::msg::Pose pose, const double backward_length,
+  const double delta_length, const double delta_yaw)
 {
   if (points.empty()) {
     return T{};
   }
 
-  const size_t target_idx = tier4_autoware_utils::findNearestIndex(points, pos);
+  const auto target_idx_optional = tier4_autoware_utils::findNearestIndex(
+    points, pose, std::numeric_limits<double>::max(), delta_yaw);
+
+  const size_t target_idx = target_idx_optional
+                              ? *target_idx_optional
+                              : tier4_autoware_utils::findNearestIndex(points, pose.position);
 
   const int begin_idx =
     std::max(0, static_cast<int>(target_idx) - static_cast<int>(backward_length / delta_length));

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -286,9 +286,14 @@ std::vector<ReferencePoint> MPTOptimizer::getReferencePoints(
         // interpolate and crop backward
         const auto interpolated_points = interpolation_utils::getInterpolatedPoints(
           smoothed_points, mpt_param_.delta_arc_length_for_mpt_points);
-        const auto cropped_interpolated_points = points_utils::clipBackwardPoints(
-          interpolated_points, current_ego_pose_.position, traj_param_.backward_fixing_distance,
-          mpt_param_.delta_arc_length_for_mpt_points);
+        const auto interpolated_points_with_yaw =
+          points_utils::convertToPosesWithYawEstimation(interpolated_points);
+        const auto cropped_interpolated_points_with_yaw = points_utils::clipBackwardPoints(
+          interpolated_points_with_yaw, current_ego_pose_, traj_param_.backward_fixing_distance,
+          mpt_param_.delta_arc_length_for_mpt_points,
+          traj_param_.delta_yaw_threshold_for_closest_point);
+        const auto cropped_interpolated_points =
+          points_utils::convertToPoints(cropped_interpolated_points_with_yaw);
 
         return points_utils::convertToReferencePoints(cropped_interpolated_points);
       }

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1376,7 +1376,7 @@ void MPTOptimizer::calcBounds(
       BoundsCandidates filtered_bounds_candidates;
       for (const auto & bounds_candidate : bounds_candidates) {
         // Step 1. Bounds is continuous to the previous one,
-        //         and the overlapped signed length is longer than vehice width
+        //         and the overlapped signed length is longer than vehicle width
         //         overlapped_signed_length already considers vehicle width.
         const double overlapped_signed_length =
           calcOverlappedBoundsSignedLength(prev_continuous_bounds, bounds_candidate);

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -1387,16 +1387,22 @@ ObstacleAvoidancePlanner::alignVelocity(
   for (size_t i = 0; i < fine_traj_points_with_vel.size(); ++i) {
     const auto truncated_points = points_utils::clipForwardPoints(path_points, prev_begin_idx, 5.0);
 
-    const auto & target_pos = fine_traj_points_with_vel[i].pose.position;
-    const size_t closest_seg_idx =
-      tier4_autoware_utils::findNearestSegmentIndex(truncated_points, target_pos);
+    const auto & target_pose = fine_traj_points_with_vel[i].pose;
+    const auto closest_seg_idx_optional = tier4_autoware_utils::findNearestSegmentIndex(
+      truncated_points, target_pose, std::numeric_limits<double>::max(),
+      traj_param_.delta_yaw_threshold_for_closest_point);
+
+    const auto closest_seg_idx =
+      closest_seg_idx_optional
+        ? *closest_seg_idx_optional
+        : tier4_autoware_utils::findNearestSegmentIndex(truncated_points, target_pose.position);
 
     // lerp z
     fine_traj_points_with_vel[i].pose.position.z =
-      lerpPoseZ(truncated_points, target_pos, closest_seg_idx);
+      lerpPoseZ(truncated_points, target_pose.position, closest_seg_idx);
 
     // lerp vx
-    const double target_vel = lerpTwistX(truncated_points, target_pos, closest_seg_idx);
+    const double target_vel = lerpTwistX(truncated_points, target_pose.position, closest_seg_idx);
     if (i >= zero_vel_fine_traj_idx) {
       fine_traj_points_with_vel[i].longitudinal_velocity_mps = 0.0;
     } else if (target_vel < 1e-6) {  // NOTE: velocity may be negative due to linear interpolation


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description

add angle limitation to the nearest index/segment search in obstacle_avoidance_planner.

## Background

In the current implementation, when the route intersects, there is a possibility that the nearest point of the own vehicle will be calculated incorrectly. I fixed it by adding angle limitation to search the nearest point.


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
