### PR TITLE
fix(image_projection_based_fusion): set imagebuffersize

### DIFF
--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/debugger.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/debugger.hpp
@@ -38,7 +38,8 @@ using sensor_msgs::msg::RegionOfInterest;
 class Debugger
 {
 public:
-  explicit Debugger(rclcpp::Node * node_ptr, const std::size_t image_num,const std::size_t image_buffer_size);
+  explicit Debugger(
+    rclcpp::Node * node_ptr, const std::size_t image_num, const std::size_t image_buffer_size);
 
   void publishImage(const std::size_t image_id, const rclcpp::Time & stamp);
 

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/debugger.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/debugger.hpp
@@ -38,7 +38,7 @@ using sensor_msgs::msg::RegionOfInterest;
 class Debugger
 {
 public:
-  explicit Debugger(rclcpp::Node * node_ptr, const std::size_t image_num);
+  explicit Debugger(rclcpp::Node * node_ptr, const std::size_t image_num,const std::size_t image_buffer_size);
 
   void publishImage(const std::size_t image_id, const rclcpp::Time & stamp);
 
@@ -57,7 +57,7 @@ private:
   std::vector<image_transport::Subscriber> image_subs_;
   std::vector<image_transport::Publisher> image_pubs_;
   std::vector<boost::circular_buffer<sensor_msgs::msg::Image::ConstSharedPtr>> image_buffers_;
-  std::size_t image_buffer_size{5};
+  std::size_t image_buffer_size_;
 };
 
 }  // namespace image_projection_based_fusion

--- a/perception/image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
+++ b/perception/image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
@@ -24,6 +24,7 @@
 
   <!-- debug -->
   <arg name="debug_mode" default="false"/>
+  <arg name="image_buffer_size" default="15"/>
   <arg name="input/image0" default="/image_raw0"/>
   <arg name="input/image1" default="/image_raw1"/>
   <arg name="input/image2" default="/image_raw2"/>
@@ -70,6 +71,7 @@
 
       <!-- debug -->
       <param name="debug_mode" value="$(var debug_mode)"/>
+      <param name="image_buffer_size" value="$(var image_buffer_size)"/>
     </node>
   </group>
 </launch>

--- a/perception/image_projection_based_fusion/launch/roi_detected_object_fusion.launch.xml
+++ b/perception/image_projection_based_fusion/launch/roi_detected_object_fusion.launch.xml
@@ -24,6 +24,7 @@
 
   <!-- debug -->
   <arg name="debug_mode" default="false"/>
+  <arg name="image_buffer_size" default="15"/>
   <arg name="input/image0" default="/image_raw0"/>
   <arg name="input/image1" default="/image_raw1"/>
   <arg name="input/image2" default="/image_raw2"/>
@@ -70,6 +71,7 @@
 
       <!-- debug -->
       <param name="debug_mode" value="$(var debug_mode)"/>
+      <param name="image_buffer_size" value="$(var image_buffer_size)"/>
     </node>
   </group>
 </launch>

--- a/perception/image_projection_based_fusion/src/debugger.cpp
+++ b/perception/image_projection_based_fusion/src/debugger.cpp
@@ -34,7 +34,9 @@ void drawRoiOnImage(
 
 namespace image_projection_based_fusion
 {
-Debugger::Debugger(rclcpp::Node * node_ptr, const std::size_t image_num,const std::size_t image_buffer_size) : node_ptr_(node_ptr)
+Debugger::Debugger(
+  rclcpp::Node * node_ptr, const std::size_t image_num, const std::size_t image_buffer_size)
+: node_ptr_(node_ptr)
 {
   image_buffers_.resize(image_num);
   image_buffer_size_ = image_buffer_size;

--- a/perception/image_projection_based_fusion/src/debugger.cpp
+++ b/perception/image_projection_based_fusion/src/debugger.cpp
@@ -34,9 +34,10 @@ void drawRoiOnImage(
 
 namespace image_projection_based_fusion
 {
-Debugger::Debugger(rclcpp::Node * node_ptr, const std::size_t image_num) : node_ptr_(node_ptr)
+Debugger::Debugger(rclcpp::Node * node_ptr, const std::size_t image_num,const std::size_t image_buffer_size) : node_ptr_(node_ptr)
 {
   image_buffers_.resize(image_num);
+  image_buffer_size_ = image_buffer_size;
   for (std::size_t img_i = 0; img_i < image_num; ++img_i) {
     auto sub = image_transport::create_subscription(
       node_ptr, "input/image_raw" + std::to_string(img_i),
@@ -54,7 +55,7 @@ Debugger::Debugger(rclcpp::Node * node_ptr, const std::size_t image_num) : node_
     auto pub =
       image_transport::create_publisher(node_ptr, "output/image_raw" + std::to_string(img_i));
     image_pubs_.push_back(pub);
-    image_buffers_.at(img_i).set_capacity(image_buffer_size);
+    image_buffers_.at(img_i).set_capacity(image_buffer_size_);
   }
 }
 

--- a/perception/image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/image_projection_based_fusion/src/fusion_node.cpp
@@ -121,7 +121,8 @@ FusionNode<Msg>::FusionNode(const std::string & node_name, const rclcpp::NodeOpt
 
   // debugger
   if (declare_parameter("debug_mode", false)) {
-    debugger_ = std::make_shared<Debugger>(this, rois_number_);
+    std::size_t image_buffer_size = static_cast<std::size_t>(declare_parameter("image_buffer_size", 15));
+    debugger_ = std::make_shared<Debugger>(this, rois_number_,image_buffer_size);
   }
 }
 

--- a/perception/image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/image_projection_based_fusion/src/fusion_node.cpp
@@ -121,8 +121,9 @@ FusionNode<Msg>::FusionNode(const std::string & node_name, const rclcpp::NodeOpt
 
   // debugger
   if (declare_parameter("debug_mode", false)) {
-    std::size_t image_buffer_size = static_cast<std::size_t>(declare_parameter("image_buffer_size", 15));
-    debugger_ = std::make_shared<Debugger>(this, rois_number_,image_buffer_size);
+    std::size_t image_buffer_size =
+      static_cast<std::size_t>(declare_parameter("image_buffer_size", 15));
+    debugger_ = std::make_shared<Debugger>(this, rois_number_, image_buffer_size);
   }
 }
 


### PR DESCRIPTION
## Description
when roi_cluster_fusion output debug image,it judges if image timestamp matchs roi timestamp,only publish image when they are equal.   roi_cluster_fusion will save several images in a buffer, buffer_size is now 5 in code, when roi comes later than image, there would be a problem:it can not find image whose timestamp equals roi timestamp, so it publish debug image in a very low frequency. so buffer size should be configured by user accroding to their actual situation.


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
