### PR TITLE
fix(behavior_path_planner): fix undefined symbol in rolling

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -74,7 +74,6 @@ inline geometry_msgs::msg::Pose getPose(
 }
 }  // namespace tier4_autoware_utils
 
-#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 namespace tf2
 {
 inline void fromMsg(const geometry_msgs::msg::PoseStamped & msg, tf2::Stamped<tf2::Transform> & out)
@@ -85,7 +84,7 @@ inline void fromMsg(const geometry_msgs::msg::PoseStamped & msg, tf2::Stamped<tf
   fromMsg(msg.pose, tmp);
   out.setData(tmp);
 }
-
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 // Remove after this commit is released
 // https://github.com/ros2/geometry2/commit/e9da371d81e388a589540357c050e262442f1b4a
 inline geometry_msgs::msg::Point & toMsg(const tf2::Vector3 & in, geometry_msgs::msg::Point & out)
@@ -115,8 +114,8 @@ inline void doTransform(
   tf2::Vector3 v_out = t * v_in;
   toMsg(v_out, t_out);
 }
-}  // namespace tf2
 #endif
+}  // namespace tf2
 
 namespace behavior_path_planner
 {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
fix the following undefined symbol.
```
[component_container_mt-48] /opt/ros/rolling/lib/rclcpp_components/component_container_mt: symbol lookup error: /home/daisuke/workspace/autoware.proj.universe.rolling/install/behavior_path_planner/lib/libbehavior_path_planner_node.so: undefined symbol: _ZN3tf27fromMsgIN13geometry_msgs3msg12PoseStamped_ISaIvEEENS_7StampedINS_9TransformEEEEEvRKT_RT0_
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
