### PR TITLE
fix(behavior_path_planner): getAvoidanceDebugMsgArray caused crash

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -196,7 +196,9 @@ public:
 
   AvoidanceDebugMsgArray::SharedPtr getAvoidanceDebugMsgArray()
   {
-    debug_avoidance_msg_array_ptr_->header.stamp = clock_->now();
+    if (debug_avoidance_msg_array_ptr_) {
+      debug_avoidance_msg_array_ptr_->header.stamp = clock_->now();
+    }
     return debug_avoidance_msg_array_ptr_;
   }
 


### PR DESCRIPTION
this is due to the assignment to pointer without guards in the function

Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

The new `getAvoidanceDebugMsgArray` caused the behavior_planning container to crash.
This is caused by the lack of `nullptr` check during the clock assigment.

https://user-images.githubusercontent.com/93502286/165691762-eb062fb7-fad8-4467-851d-babe7d723002.mp4

### How to review

1. place the ego vehicle start.
2. place the ego vehicle so that it run the lane change.
3. success if behavior planning container doesn't crash.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
