### PR TITLE
feat(behavior_velocity): find occlusion more efficiently

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
@@ -3,7 +3,6 @@
     occlusion_spot:
       detection_method: "occupancy_grid"    # [-] candidate is "occupancy_grid" or "predicted_object"
       pass_judge: "smooth_velocity"         # [-] candidate is "smooth_velocity" or "current_velocity"
-      filter_occupancy_grid: true           # [-] whether to filter occupancy grid by morphologyEx or not
       use_object_info: true                 # [-] whether to reflect object info to occupancy grid map or not
       use_moving_object_ray_cast: true      # [-] whether to reflect moving object ray_cast to occupancy grid map or not
       use_partition_lanelet: true           # [-] whether to use partition lanelet map data

--- a/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
+++ b/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
@@ -3,7 +3,6 @@
     occlusion_spot:
       detection_method: "occupancy_grid"    # [-] candidate is "occupancy_grid" or "predicted_object"
       pass_judge: "smooth_velocity"         # [-] candidate is "smooth_velocity" or "current_velocity"
-      filter_occupancy_grid: true           # [-] whether to filter occupancy grid by morphologyEx or not
       use_object_info: true                 # [-] whether to reflect object info to occupancy grid map or not
       use_moving_object_ray_cast: true      # [-] whether to reflect moving object ray_cast to occupancy grid map or not
       use_partition_lanelet: true           # [-] whether to use partition lanelet map data

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/grid_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/grid_utils.hpp
@@ -109,7 +109,7 @@ namespace occlusion_cost_value
 static constexpr unsigned char FREE_SPACE = 0;
 static constexpr unsigned char UNKNOWN = 50;
 static constexpr unsigned char OCCUPIED = 100;
-static constexpr unsigned char UNKNOWN_IMAGE = 128;
+static constexpr unsigned char UNKNOWN_IMAGE = 100;
 static constexpr unsigned char OCCUPIED_IMAGE = 255;
 }  // namespace occlusion_cost_value
 
@@ -133,24 +133,7 @@ struct GridParam
   int free_space_max;  // maximum value of a freespace cell in the occupancy grid
   int occupied_min;    // minimum value of an occupied cell in the occupancy grid
 };
-struct OcclusionSpotSquare
-{
-  grid_map::Index index;        // index of the anchor
-  grid_map::Position position;  // position of the anchor
-  int min_occlusion_size;       // number of cells for each side of the square
-};
-// @brief structure representing a OcclusionSpot on the OccupancyGrid
-struct OcclusionSpot
-{
-  double distance_along_lanelet;
-  lanelet::ConstLanelet lanelet;
-  lanelet::BasicPoint2d position;
-};
-//!< @brief Return true
-// if the given cell is a occlusion_spot square of size min_size*min_size in the given grid
-bool isOcclusionSpotSquare(
-  OcclusionSpotSquare & occlusion_spot, const grid_map::Matrix & grid_data,
-  const grid_map::Index & cell, const int min_occlusion_size, const grid_map::Size & grid_size);
+
 //!< @brief Find all occlusion spots inside the given lanelet
 void findOcclusionSpots(
   std::vector<grid_map::Position> & occlusion_spot_positions, const grid_map::GridMap & grid,
@@ -159,10 +142,6 @@ void findOcclusionSpots(
 bool isCollisionFree(
   const grid_map::GridMap & grid, const grid_map::Position & p1, const grid_map::Position & p2,
   const double radius);
-//!< @brief get the corner positions of the square described by the given anchor
-void getCornerPositions(
-  std::vector<grid_map::Position> & corner_positions, const grid_map::GridMap & grid,
-  const OcclusionSpotSquare & occlusion_spot_square);
 boost::optional<Polygon2d> generateOccupiedPolygon(
   const Polygon2d & occupancy_poly, const Polygons2d & stuck_vehicle_foot_prints,
   const Polygons2d & moving_vehicle_foot_prints, const Point & position);
@@ -180,8 +159,7 @@ void denoiseOccupancyGridCV(
   const OccupancyGrid::ConstSharedPtr occupancy_grid_ptr,
   const Polygons2d & stuck_vehicle_foot_prints, const Polygons2d & moving_vehicle_foot_prints,
   grid_map::GridMap & grid_map, const GridParam & param, const bool is_show_debug_window,
-  const bool filter_occupancy_grid, const bool use_object_footprints,
-  const bool use_object_ray_casts);
+  const int num_iter, const bool use_object_footprints, const bool use_object_ray_casts);
 void addObjectsToGridMap(const std::vector<PredictedObject> & objs, grid_map::GridMap & grid);
 }  // namespace grid_utils
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
@@ -121,7 +121,6 @@ struct PlannerParam
   bool is_show_occlusion;           // [-]
   bool is_show_cv_window;           // [-]
   bool is_show_processing_time;     // [-]
-  bool filter_occupancy_grid;       // [-]
   bool use_object_info;             // [-]
   bool use_moving_object_ray_cast;  // [-]
   bool use_partition_lanelet;       // [-]

--- a/planning/behavior_velocity_planner/occlusion-spot-design.md
+++ b/planning/behavior_velocity_planner/occlusion-spot-design.md
@@ -112,7 +112,6 @@ obstacle that can run out from occlusion is interruped by moving vehicle.
 
 | Parameter               | Type | Description                                                      |
 | ----------------------- | ---- | ---------------------------------------------------------------- |
-| `filter_occupancy_grid` | bool | [-] whether to filter occupancy grid by morphologyEx or not.     |
 | `use_object_info`       | bool | [-] whether to reflect object info to occupancy grid map or not. |
 | `use_partition_lanelet` | bool | [-] whether to use partition lanelet map data.                   |
 

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
@@ -58,7 +58,6 @@ OcclusionSpotModuleManager::OcclusionSpotModuleManager(rclcpp::Node & node)
         "[behavior_velocity]: occlusion spot pass judge method has invalid argument"};
     }
   }
-  pp.filter_occupancy_grid = node.declare_parameter(ns + ".filter_occupancy_grid", false);
   pp.use_object_info = node.declare_parameter(ns + ".use_object_info", true);
   pp.use_moving_object_ray_cast = node.declare_parameter(ns + ".use_moving_object_ray_cast", true);
   pp.use_partition_lanelet = node.declare_parameter(ns + ".use_partition_lanelet", false);

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
@@ -151,9 +151,12 @@ bool OcclusionSpotModule::modifyPathVelocity(
       filtered_vehicles, stuck_vehicle_foot_prints, moving_vehicle_foot_prints,
       param_.stuck_vehicle_vel);
     // occ -> image
+    // find out occlusion from erode occlusion candidate num iter is strength of filter
+    const int num_iter = static_cast<int>(
+      (param_.detection_area.min_occlusion_spot_size / occ_grid_ptr->info.resolution) - 1);
     grid_utils::denoiseOccupancyGridCV(
       occ_grid_ptr, stuck_vehicle_foot_prints, moving_vehicle_foot_prints, grid_map, param_.grid,
-      param_.is_show_cv_window, param_.filter_occupancy_grid, param_.use_object_info,
+      param_.is_show_cv_window, num_iter, param_.use_object_info,
       param_.use_moving_object_ray_cast);
     DEBUG_PRINT(show_time, "grid [ms]: ", stop_watch_.toc("processing_time", true));
     // Note: Don't consider offset from path start to ego here
@@ -183,8 +186,10 @@ bool OcclusionSpotModule::modifyPathVelocity(
   // these debug topics needs computation resource
   debug_data_.z = path->points.front().point.pose.position.z;
   debug_data_.possible_collisions = possible_collisions;
-  debug_data_.path_interpolated = path_interpolated;
-  debug_data_.path_raw = clipped_path;
+  if (param_.is_show_occlusion) {
+    debug_data_.path_interpolated = path_interpolated;
+    debug_data_.path_raw.points = clipped_path.points;
+  }
   DEBUG_PRINT(show_time, "total [ms]: ", stop_watch_.toc("total_processing_time", true));
   return true;
 }


### PR DESCRIPTION
## Description

Occupancy Grid is divided to (free space+occupied space) image & occlusion image(eroded with custom 2 by 2 kernel)
this can 
- remove redundant grid map occlusion size search 
- remove sensing noise

![Screenshot from 2022-04-24 19-46-03](https://user-images.githubusercontent.com/65527974/164972722-f5e1e4ce-6f74-4279-a3f1-1fcc59dfb6c0.png)

![image](https://user-images.githubusercontent.com/65527974/165051190-bade87dc-93ed-4ceb-94fb-d2283bbef3b8.png)

## Related links


## Tests performed

by 
- planning simulator
- scenario simulator



https://user-images.githubusercontent.com/65527974/167342928-54b82c05-128a-45ec-888a-d624500a07da.mp4



## Notes for reviewers


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
