### PR TITLE
feat(costmap_generator): merge extra costmap

### DIFF
--- a/planning/costmap_generator/README.md
+++ b/planning/costmap_generator/README.md
@@ -12,6 +12,7 @@ This node reads `PointCloud` and/or `DynamicObjectArray` and creates an `Occupan
 | `~input/points_no_ground` | sensor_msgs::PointCloud2                        | ground-removed points, for obstacle areas which can't be detected as objects |
 | `~input/vector_map`       | autoware_auto_mapping_msgs::HADMapBin           | vector map, for drivable areas                                               |
 | `~input/scenario`         | tier4_planning_msgs::Scenario                   | scenarios to be activated, for node activation                               |
+| `~/input/extra_occgrid`   | nav_msgs::OccupancyGrid                         | extra occgrid which is merged into the costmap                               |
 
 ### Output topics
 
@@ -38,6 +39,7 @@ None
 | `use_objects`                | bool   | whether using `~input/objects` or not                                                          |
 | `use_points`                 | bool   | whether using `~input/points_no_ground` or not                                                 |
 | `use_wayarea`                | bool   | whether using `wayarea` from `~input/vector_map` or not                                        |
+| `use_extra`                  | bool   | whether using extra costmap from `~/input/extra_occgrid` or not                                |
 | `costmap_frame`              | string | created costmap's coordinate                                                                   |
 | `vehicle_frame`              | string | vehicle's coordinate                                                                           |
 | `map_frame`                  | string | map's coordinate                                                                               |
@@ -50,6 +52,7 @@ None
 | `grid_position_y`            | int    | offset from coordinate in y direction                                                          |
 | `maximum_lidar_height_thres` | double | maximum height threshold for pointcloud data                                                   |
 | `minimum_lidar_height_thres` | double | minimum height threshold for pointcloud data                                                   |
+| `extra_occgrid_thres_`       | double | grids above this threshold will be considered as obstacle                                      |
 | `expand_rectangle_size`      | double | expand object's rectangle with this value                                                      |
 | `size_of_expansion_kernel`   | int    | kernel size for blurring effect on object's costmap                                            |
 

--- a/planning/costmap_generator/include/costmap_generator/costmap_generator.hpp
+++ b/planning/costmap_generator/include/costmap_generator/costmap_generator.hpp
@@ -78,6 +78,7 @@ private:
   bool use_points_;
   bool use_wayarea_;
   bool use_extra_occgrid_;
+  float extra_occgrid_thres_;
 
   lanelet::LaneletMapPtr lanelet_map_;
   autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_;

--- a/planning/costmap_generator/include/costmap_generator/costmap_generator.hpp
+++ b/planning/costmap_generator/include/costmap_generator/costmap_generator.hpp
@@ -77,10 +77,12 @@ private:
   bool use_objects_;
   bool use_points_;
   bool use_wayarea_;
+  bool use_extra_occgrid_;
 
   lanelet::LaneletMapPtr lanelet_map_;
   autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_;
   sensor_msgs::msg::PointCloud2::ConstSharedPtr points_;
+  nav_msgs::msg::OccupancyGrid::ConstSharedPtr extra_occgrid_;
 
   std::string costmap_frame_;
   std::string vehicle_frame_;
@@ -111,6 +113,7 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_points_;
   rclcpp::Subscription<autoware_auto_perception_msgs::msg::PredictedObjects>::SharedPtr
     sub_objects_;
+  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr sub_extra_occgrid_;
   rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_lanelet_bin_map_;
   rclcpp::Subscription<tier4_planning_msgs::msg::Scenario>::SharedPtr sub_scenario_;
 
@@ -131,6 +134,7 @@ private:
     static constexpr const char * objects = "objects";
     static constexpr const char * points = "points";
     static constexpr const char * wayarea = "wayarea";
+    static constexpr const char * extra = "extra";
     static constexpr const char * combined = "combined";
   };
 
@@ -151,6 +155,8 @@ private:
   void onPoints(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
 
   void onScenario(const tier4_planning_msgs::msg::Scenario::ConstSharedPtr msg);
+
+  void onOccgrid(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg);
 
   void onTimer();
 

--- a/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
+++ b/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
@@ -183,6 +183,7 @@ CostmapGenerator::CostmapGenerator(const rclcpp::NodeOptions & node_options)
   use_points_ = this->declare_parameter<bool>("use_points", true);
   use_wayarea_ = this->declare_parameter<bool>("use_wayarea", true);
   use_extra_occgrid_ = this->declare_parameter<bool>("use_extra_occgrid", false);
+  extra_occgrid_thres_ = this->declare_parameter<float>("extra_occgrid_thres", 1.0);
   expand_polygon_size_ = this->declare_parameter<double>("expand_polygon_size", 1.0);
   size_of_expansion_kernel_ = this->declare_parameter<int>("size_of_expansion_kernel", 9);
 
@@ -341,7 +342,7 @@ void CostmapGenerator::onTimer()
     auto & mat = extra_gridmap.get("extra");
     for (int i = 0; i < mat.cols(); ++i) {
       for (int j = 0; j < mat.rows(); ++j) {
-        mat(i, j) = (mat(i, j) > 1.0 ? 1.0 : 0.0);
+        mat(i, j) = (mat(i, j) > extra_occgrid_thres_ ? grid_max_value_ : grid_min_value_);
       }
     }
     costmap_.addDataFrom(extra_gridmap, false, true, true);


### PR DESCRIPTION
## Description

This commits enables merging extra costmap into the costmap in the costmap generator.  
For example, if you add the following in remapping of costmage_generator's launch file
```
 ("~/input/extra_occgrid", "/perception/occupancy_grid_map/map"),
```
and add 
```
"use_extra_occgrid": True,
"extra_occgrid_thres": 1.0,
```
to the parameters, then you can get the following costmap: 

![uhouho](https://user-images.githubusercontent.com/38597814/165717236-2fe3e31e-5d05-4fe8-ae85-0fd02c67c035.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
