### PR TITLE
feat: output avoidance debug array whenever the avoidance module is enabled

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -157,8 +157,7 @@ private:
   // debug
   mutable DebugData debug_data_;
   void setDebugData(const PathShifter & shifter, const DebugData & debug);
-  mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_object;
-  mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_point;
+  mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_point_;
   // =====================================
   // ========= helper functions ==========
   // =====================================

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -129,7 +129,7 @@ AvoidanceDebugMsgArray BehaviorTreeManager::getAvoidanceDebugMsgArray()
   const auto avoidance_module = std::find_if(
     scene_modules_.begin(), scene_modules_.end(),
     [](const std::shared_ptr<SceneModuleInterface> & module_ptr) {
-      return module_ptr->current_state_ == BT::NodeStatus::SUCCESS;
+      return module_ptr->name() == "Avoidance";
     });
   if (avoidance_module != scene_modules_.end()) {
     const auto & ptr = avoidance_module->get()->getAvoidanceDebugMsgArray();


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description

In the current implementaion, the avoidance debug array is not published when avoidance is not executed such the following case.
![image](https://user-images.githubusercontent.com/59680180/165746810-7920f915-8d9e-4f27-afa3-de00b8b5bae6.png)

I change it to output avoidance debug array whenever the avoidance module is enabled.

I also changed to publish the avoidance debug array only at the end of `calcAvoidancePlanningData`.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
