### PR TITLE
fix(behavior_velocity_planner): avoid zero division in pcl

### DIFF
--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -263,7 +263,9 @@ void BehaviorVelocityPlannerNode::onNoGroundPointCloud(
 
   Eigen::Affine3f affine = tf2::transformToEigen(transform.transform).cast<float>();
   pcl::PointCloud<pcl::PointXYZ>::Ptr pc_transformed(new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::transformPointCloud(pc, *pc_transformed, affine);
+  if (pc.width > 0) {
+    pcl::transformPointCloud(pc, *pc_transformed, affine);
+  }
 
   {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -263,7 +263,7 @@ void BehaviorVelocityPlannerNode::onNoGroundPointCloud(
 
   Eigen::Affine3f affine = tf2::transformToEigen(transform.transform).cast<float>();
   pcl::PointCloud<pcl::PointXYZ>::Ptr pc_transformed(new pcl::PointCloud<pcl::PointXYZ>);
-  if (pc.width > 0) {
+  if (!pc.empty()) {
     pcl::transformPointCloud(pc, *pc_transformed, affine);
   }
 


### PR DESCRIPTION
## Description
```
(gdb) f 0
#0  0x00007ff724455d4f in pcl::PointCloud<pcl::PointXYZ>::assign<__gnu_cxx::__normal_iterator<pcl::PointXYZ const*, std::vector<pcl::PointXYZ, Eigen::aligned_allocator<pcl::PointXYZ> > > > (this=0x562a877a4240, first=non-dereferenceable iterator for std::vector, 
    last=non-dereferenceable iterator for std::vector, new_width=0) at /usr/include/pcl-1.12/pcl/point_cloud.h:600
600	        height = size() / width;
(gdb) f 1
#1  0x00007ff724441ff6 in pcl::transformPointCloud<pcl::PointXYZ, float> (cloud_in=..., cloud_out=..., transform=..., copy_all_fields=true)
    at /usr/include/pcl-1.12/pcl/common/impl/transforms.hpp:232
232	      cloud_out.assign (cloud_in.begin (), cloud_in.end (), cloud_in.width);
(gdb) f 2
#2  0x00007ff724435c50 in pcl::transformPointCloud<pcl::PointXYZ> (cloud_in=..., cloud_out=..., transform=..., copy_all_fields=true)
    at /usr/include/pcl-1.12/pcl/common/transforms.h:74
74	    return (transformPointCloud<PointT, float> (cloud_in, cloud_out, transform.matrix (), copy_all_fields));
(gdb) f 3
#3  0x00007ff72441cb80 in behavior_velocity_planner::BehaviorVelocityPlannerNode::onNoGroundPointCloud (this=0x562a853f9e30, 
    msg=std::shared_ptr<const sensor_msgs::msg::PointCloud2_<std::allocator<void> >> (use count 4, weak count 0) = {...})
    at /home/daisuke/workspace/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/src/node.cpp:266
266	  pcl::transformPointCloud(pc, *pc_transformed, affine);
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
