### PR TITLE
fix: remove unused orocos kdl from dependencies

### DIFF
--- a/common/autoware_auto_tf2/CMakeLists.txt
+++ b/common/autoware_auto_tf2/CMakeLists.txt
@@ -43,7 +43,6 @@ if(BUILD_TESTING)
     "autoware_auto_system_msgs"
     "autoware_auto_geometry_msgs"
     "geometry_msgs"
-    "orocos_kdl"
     "tf2"
     "tf2_geometry_msgs"
     "tf2_ros"

--- a/common/autoware_auto_tf2/package.xml
+++ b/common/autoware_auto_tf2/package.xml
@@ -15,7 +15,6 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>orocos_kdl</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>


### PR DESCRIPTION
## Description

The rosdep key of `orocos_kdl` has been renamed to `orocos_kdl_vendor` for rolling/humble in [this PR](https://github.com/ros/rosdistro/pull/33028).
`orocos_kdl` seems not to be used in `autoware_auto_tf2`, so I remove the dependecy to make `rosdep install` work.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
