### PR TITLE
fix: avoid useless cast

### DIFF
--- a/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
+++ b/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
@@ -33,7 +33,7 @@ namespace common
 {
 namespace osqp
 {
-constexpr c_float INF = OSQP_INFTY;
+constexpr c_float INF = 1e30;
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
 


### PR DESCRIPTION
## Description

fix the following error in rolling distro
```
/home/daisuke/workspace/autoware/install/osqp_interface/include/osqp_interface/osqp_interface.hpp:36:25: note: in expansion of macro ‘OSQP_INFTY’
   36 | constexpr c_float INF = OSQP_INFTY;
      |                         ^~~~~~~~~~
/opt/ros/rolling/include/osqp/constants.h:100:23: error: useless cast to type ‘c_float’ {aka ‘double’} [-Werror=useless-cast]
  100 | #  define OSQP_INFTY ((c_float)1e30)        // infinity
      |                       ^~~~~~~~~~~~~
/home/daisuke/workspace/autoware/install/osqp_interface/include/osqp_interface/osqp_interface.hpp:36:25: note: in expansion of macro ‘OSQP_INFTY’
   36 | constexpr c_float INF = OSQP_INFTY;
      |                         ^~~~~~~~~~
In file included from /opt/ros/rolling/include/osqp/types.h:9,
                 from /opt/ros/rolling/include/osqp/osqp.h:9,
                 from /home/daisuke/workspace/autoware/install/osqp_interface/include/osqp_interface/osqp_interface.hpp:20,
                 from /home/daisuke/workspace/autoware/src/universe/autoware.universe/control/trajectory_follower/include/trajectory_follower/mpc.hpp:22,
                 from /home/daisuke/workspace/autoware/src/universe/autoware.universe/control/trajectory_follower/src/mpc.cpp:15:
/opt/ros/rolling/include/osqp/constants.h:100:32: warning: use of old-style cast to ‘c_float’ {aka ‘double’} [-Wold-style-cast]
  100 | #  define OSQP_INFTY ((c_float)1e30)        // infinity
      |                                ^~~~
/opt/ros/rolling/include/osqp/constants.h:100:32: note: in definition of macro ‘OSQP_INFTY’
  100 | #  define OSQP_INFTY ((c_float)1e30)        // infinity
      |                                ^~~~
/opt/ros/rolling/include/osqp/constants.h:100:23: error: useless cast to type ‘c_float’ {aka ‘double’} [-Werror=useless-cast]
  100 | #  define OSQP_INFTY ((c_float)1e30)        // infinity
      |                       ^~~~~~~~~~~~~
/home/daisuke/workspace/autoware/install/osqp_interface/include/osqp_interface/osqp_interface.hpp:36:25: note: in expansion of macro ‘OSQP_INFTY’
   36 | constexpr c_float INF = OSQP_INFTY;
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
