### PR TITLE
chore: upgrade cmake_minimum_required to 3.14

### DIFF
--- a/common/autoware_ad_api_msgs/CMakeLists.txt
+++ b/common/autoware_ad_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(autoware_ad_api_msgs)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/autoware_auto_common/CMakeLists.txt
+++ b/common/autoware_auto_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(autoware_auto_common)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/autoware_auto_geometry/CMakeLists.txt
+++ b/common/autoware_auto_geometry/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(autoware_auto_geometry)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/autoware_auto_perception_rviz_plugin/CMakeLists.txt
+++ b/common/autoware_auto_perception_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(autoware_auto_perception_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/autoware_auto_tf2/CMakeLists.txt
+++ b/common/autoware_auto_tf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(autoware_auto_tf2)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/autoware_point_types/CMakeLists.txt
+++ b/common/autoware_point_types/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(autoware_point_types)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/autoware_testing/CMakeLists.txt
+++ b/common/autoware_testing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(autoware_testing)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/component_interface_utils/CMakeLists.txt
+++ b/common/component_interface_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
 project(component_interface_utils)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/fake_test_node/CMakeLists.txt
+++ b/common/fake_test_node/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(fake_test_node)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/global_parameter_loader/CMakeLists.txt
+++ b/common/global_parameter_loader/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(global_parameter_loader)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/goal_distance_calculator/CMakeLists.txt
+++ b/common/goal_distance_calculator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(goal_distance_calculator)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/had_map_utils/CMakeLists.txt
+++ b/common/had_map_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(had_map_utils)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/interpolation/CMakeLists.txt
+++ b/common/interpolation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(interpolation)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/kalman_filter/CMakeLists.txt
+++ b/common/kalman_filter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(kalman_filter)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/motion_common/CMakeLists.txt
+++ b/common/motion_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.14)
 project(motion_common)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/motion_testing/CMakeLists.txt
+++ b/common/motion_testing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.14)
 project(motion_testing)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/osqp_interface/CMakeLists.txt
+++ b/common/osqp_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(osqp_interface)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/path_distance_calculator/CMakeLists.txt
+++ b/common/path_distance_calculator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(path_distance_calculator)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/polar_grid/CMakeLists.txt
+++ b/common/polar_grid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(polar_grid)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/signal_processing/CMakeLists.txt
+++ b/common/signal_processing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(signal_processing)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_api_utils/CMakeLists.txt
+++ b/common/tier4_api_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_api_utils)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_autoware_utils/CMakeLists.txt
+++ b/common/tier4_autoware_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_autoware_utils)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_calibration_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_calibration_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_calibration_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_datetime_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_datetime_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_datetime_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_debug_tools/CMakeLists.txt
+++ b/common/tier4_debug_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_debug_tools)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_localization_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_localization_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_localization_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_perception_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_perception_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_perception_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_planning_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_planning_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_planning_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_simulated_clock_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_simulated_clock_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_simulated_clock_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_state_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_state_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_state_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_traffic_light_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_traffic_light_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_traffic_light_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/tier4_vehicle_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_vehicle_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_vehicle_rviz_plugin)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/time_utils/CMakeLists.txt
+++ b/common/time_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.14)
 project(time_utils)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/vehicle_constants_manager/CMakeLists.txt
+++ b/common/vehicle_constants_manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(vehicle_constants_manager)
 
 find_package(autoware_cmake REQUIRED)

--- a/common/web_controller/CMakeLists.txt
+++ b/common/web_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(web_controller)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/control_performance_analysis/CMakeLists.txt
+++ b/control/control_performance_analysis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(control_performance_analysis)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/external_cmd_selector/CMakeLists.txt
+++ b/control/external_cmd_selector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(external_cmd_selector)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/joy_controller/CMakeLists.txt
+++ b/control/joy_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(joy_controller)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/lane_departure_checker/CMakeLists.txt
+++ b/control/lane_departure_checker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(lane_departure_checker)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/obstacle_collision_checker/CMakeLists.txt
+++ b/control/obstacle_collision_checker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(obstacle_collision_checker)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/pure_pursuit/CMakeLists.txt
+++ b/control/pure_pursuit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(pure_pursuit)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/shift_decider/CMakeLists.txt
+++ b/control/shift_decider/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(shift_decider)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/trajectory_follower/CMakeLists.txt
+++ b/control/trajectory_follower/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(trajectory_follower)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/trajectory_follower_nodes/CMakeLists.txt
+++ b/control/trajectory_follower_nodes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(trajectory_follower_nodes)
 
 find_package(autoware_cmake REQUIRED)

--- a/control/vehicle_cmd_gate/CMakeLists.txt
+++ b/control/vehicle_cmd_gate/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(vehicle_cmd_gate)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_autoware_api_launch/CMakeLists.txt
+++ b/launch/tier4_autoware_api_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_autoware_api_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_control_launch/CMakeLists.txt
+++ b/launch/tier4_control_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_control_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_integration_launch/CMakeLists.txt
+++ b/launch/tier4_integration_launch/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_integration_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_localization_launch/CMakeLists.txt
+++ b/launch/tier4_localization_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_localization_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_map_launch/CMakeLists.txt
+++ b/launch/tier4_map_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_map_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_perception_launch/CMakeLists.txt
+++ b/launch/tier4_perception_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_perception_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_planning_launch/CMakeLists.txt
+++ b/launch/tier4_planning_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_planning_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_sensing_launch/CMakeLists.txt
+++ b/launch/tier4_sensing_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_sensing_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_simulator_launch/CMakeLists.txt
+++ b/launch/tier4_simulator_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_simulator_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_system_launch/CMakeLists.txt
+++ b/launch/tier4_system_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_system_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/launch/tier4_vehicle_launch/CMakeLists.txt
+++ b/launch/tier4_vehicle_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_vehicle_launch)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/ekf_localizer/CMakeLists.txt
+++ b/localization/ekf_localizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(ekf_localizer)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/gyro_odometer/CMakeLists.txt
+++ b/localization/gyro_odometer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(gyro_odometer)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/initial_pose_button_panel/CMakeLists.txt
+++ b/localization/initial_pose_button_panel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(initial_pose_button_panel)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/localization_error_monitor/CMakeLists.txt
+++ b/localization/localization_error_monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(localization_error_monitor)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/ndt/CMakeLists.txt
+++ b/localization/ndt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(ndt)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/ndt_pcl_modified/CMakeLists.txt
+++ b/localization/ndt_pcl_modified/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(ndt_pcl_modified)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/ndt_scan_matcher/CMakeLists.txt
+++ b/localization/ndt_scan_matcher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(ndt_scan_matcher)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/pose2twist/CMakeLists.txt
+++ b/localization/pose2twist/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(pose2twist)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/pose_initializer/CMakeLists.txt
+++ b/localization/pose_initializer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(pose_initializer)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/stop_filter/CMakeLists.txt
+++ b/localization/stop_filter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(stop_filter)
 
 find_package(autoware_cmake REQUIRED)

--- a/localization/vehicle_velocity_converter/CMakeLists.txt
+++ b/localization/vehicle_velocity_converter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(vehicle_velocity_converter)
 
 find_package(autoware_cmake REQUIRED)

--- a/map/lanelet2_extension/CMakeLists.txt
+++ b/map/lanelet2_extension/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(lanelet2_extension)
 
 find_package(autoware_cmake REQUIRED)

--- a/map/map_loader/CMakeLists.txt
+++ b/map/map_loader/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(map_loader)
 
 find_package(autoware_cmake REQUIRED)

--- a/map/map_tf_generator/CMakeLists.txt
+++ b/map/map_tf_generator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(map_tf_generator)
 
 find_package(autoware_cmake REQUIRED)

--- a/map/util/lanelet2_map_preprocessor/CMakeLists.txt
+++ b/map/util/lanelet2_map_preprocessor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(lanelet2_map_preprocessor)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/compare_map_segmentation/CMakeLists.txt
+++ b/perception/compare_map_segmentation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(compare_map_segmentation)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/detected_object_feature_remover/CMakeLists.txt
+++ b/perception/detected_object_feature_remover/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(detected_object_feature_remover)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/detected_object_validation/CMakeLists.txt
+++ b/perception/detected_object_validation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(detected_object_validation)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/detection_by_tracker/CMakeLists.txt
+++ b/perception/detection_by_tracker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(detection_by_tracker)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/elevation_map_loader/CMakeLists.txt
+++ b/perception/elevation_map_loader/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(elevation_map_loader)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/euclidean_cluster/CMakeLists.txt
+++ b/perception/euclidean_cluster/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(euclidean_cluster)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/ground_segmentation/CMakeLists.txt
+++ b/perception/ground_segmentation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(ground_segmentation)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/image_projection_based_fusion/CMakeLists.txt
+++ b/perception/image_projection_based_fusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
 project(image_projection_based_fusion)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
+++ b/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(lidar_apollo_instance_segmentation)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/lidar_centerpoint/CMakeLists.txt
+++ b/perception/lidar_centerpoint/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(lidar_centerpoint)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/map_based_prediction/CMakeLists.txt
+++ b/perception/map_based_prediction/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(map_based_prediction)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/multi_object_tracker/CMakeLists.txt
+++ b/perception/multi_object_tracker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(multi_object_tracker)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/object_merger/CMakeLists.txt
+++ b/perception/object_merger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(object_merger)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/object_range_splitter/CMakeLists.txt
+++ b/perception/object_range_splitter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(object_range_splitter)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/occupancy_grid_map_outlier_filter/CMakeLists.txt
+++ b/perception/occupancy_grid_map_outlier_filter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(occupancy_grid_map_outlier_filter)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/shape_estimation/CMakeLists.txt
+++ b/perception/shape_estimation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(shape_estimation)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/tensorrt_yolo/CMakeLists.txt
+++ b/perception/tensorrt_yolo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tensorrt_yolo)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/traffic_light_classifier/CMakeLists.txt
+++ b/perception/traffic_light_classifier/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(traffic_light_classifier)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/traffic_light_map_based_detector/CMakeLists.txt
+++ b/perception/traffic_light_map_based_detector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(traffic_light_map_based_detector)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(traffic_light_ssd_fine_detector)
 
 find_package(autoware_cmake REQUIRED)

--- a/perception/traffic_light_visualization/CMakeLists.txt
+++ b/perception/traffic_light_visualization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(traffic_light_visualization)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(behavior_path_planner)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(behavior_velocity_planner)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/costmap_generator/CMakeLists.txt
+++ b/planning/costmap_generator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(costmap_generator)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/external_velocity_limit_selector/CMakeLists.txt
+++ b/planning/external_velocity_limit_selector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(external_velocity_limit_selector)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/freespace_planner/CMakeLists.txt
+++ b/planning/freespace_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(freespace_planner)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/freespace_planning_algorithms/CMakeLists.txt
+++ b/planning/freespace_planning_algorithms/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(freespace_planning_algorithms)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/mission_planner/CMakeLists.txt
+++ b/planning/mission_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(mission_planner)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/motion_velocity_smoother/CMakeLists.txt
+++ b/planning/motion_velocity_smoother/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(motion_velocity_smoother)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/obstacle_avoidance_planner/CMakeLists.txt
+++ b/planning/obstacle_avoidance_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(obstacle_avoidance_planner)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/obstacle_stop_planner/CMakeLists.txt
+++ b/planning/obstacle_stop_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(obstacle_stop_planner)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/planning_error_monitor/CMakeLists.txt
+++ b/planning/planning_error_monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(planning_error_monitor)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/planning_evaluator/CMakeLists.txt
+++ b/planning/planning_evaluator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(planning_evaluator)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/route_handler/CMakeLists.txt
+++ b/planning/route_handler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(route_handler)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/scenario_selector/CMakeLists.txt
+++ b/planning/scenario_selector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(scenario_selector)
 
 find_package(autoware_cmake REQUIRED)

--- a/planning/surround_obstacle_checker/CMakeLists.txt
+++ b/planning/surround_obstacle_checker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(surround_obstacle_checker)
 
 find_package(autoware_cmake REQUIRED)

--- a/sensing/geo_pos_conv/CMakeLists.txt
+++ b/sensing/geo_pos_conv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(geo_pos_conv)
 
 find_package(autoware_cmake REQUIRED)

--- a/sensing/gnss_poser/CMakeLists.txt
+++ b/sensing/gnss_poser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(gnss_poser)
 
 find_package(autoware_cmake REQUIRED)

--- a/sensing/image_transport_decompressor/CMakeLists.txt
+++ b/sensing/image_transport_decompressor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(image_transport_decompressor)
 
 find_package(autoware_cmake REQUIRED)

--- a/sensing/imu_corrector/CMakeLists.txt
+++ b/sensing/imu_corrector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(imu_corrector)
 
 find_package(autoware_cmake REQUIRED)

--- a/sensing/livox/livox_tag_filter/CMakeLists.txt
+++ b/sensing/livox/livox_tag_filter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(livox_tag_filter)
 
 find_package(autoware_cmake REQUIRED)

--- a/sensing/pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/pointcloud_preprocessor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(pointcloud_preprocessor)
 
 find_package(autoware_cmake REQUIRED)

--- a/sensing/probabilistic_occupancy_grid_map/CMakeLists.txt
+++ b/sensing/probabilistic_occupancy_grid_map/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(probabilistic_occupancy_grid_map)
 
 find_package(autoware_cmake REQUIRED)

--- a/sensing/tier4_pcl_extensions/CMakeLists.txt
+++ b/sensing/tier4_pcl_extensions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(tier4_pcl_extensions)
 
 find_package(autoware_cmake REQUIRED)

--- a/simulator/dummy_perception_publisher/CMakeLists.txt
+++ b/simulator/dummy_perception_publisher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(dummy_perception_publisher)
 
 find_package(autoware_cmake REQUIRED)

--- a/simulator/fault_injection/CMakeLists.txt
+++ b/simulator/fault_injection/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(fault_injection)
 
 find_package(autoware_cmake REQUIRED)

--- a/simulator/simple_planning_simulator/CMakeLists.txt
+++ b/simulator/simple_planning_simulator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.14)
 project(simple_planning_simulator)
 
 find_package(autoware_cmake REQUIRED)

--- a/system/ad_service_state_monitor/CMakeLists.txt
+++ b/system/ad_service_state_monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(ad_service_state_monitor)
 
 find_package(autoware_cmake REQUIRED)

--- a/system/default_ad_api/CMakeLists.txt
+++ b/system/default_ad_api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
 project(default_ad_api)
 
 find_package(autoware_cmake REQUIRED)

--- a/system/dummy_diag_publisher/CMakeLists.txt
+++ b/system/dummy_diag_publisher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(dummy_diag_publisher)
 
 find_package(autoware_cmake REQUIRED)

--- a/system/dummy_infrastructure/CMakeLists.txt
+++ b/system/dummy_infrastructure/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(dummy_infrastructure)
 
 find_package(autoware_cmake REQUIRED)

--- a/system/emergency_handler/CMakeLists.txt
+++ b/system/emergency_handler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(emergency_handler)
 
 find_package(autoware_cmake REQUIRED)

--- a/system/system_error_monitor/CMakeLists.txt
+++ b/system/system_error_monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(system_error_monitor)
 
 find_package(autoware_cmake REQUIRED)

--- a/system/system_monitor/CMakeLists.txt
+++ b/system/system_monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(system_monitor)
 
 find_package(autoware_cmake REQUIRED)

--- a/system/topic_state_monitor/CMakeLists.txt
+++ b/system/topic_state_monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(topic_state_monitor)
 
 find_package(autoware_cmake REQUIRED)

--- a/system/velodyne_monitor/CMakeLists.txt
+++ b/system/velodyne_monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(velodyne_monitor)
 
 find_package(autoware_cmake REQUIRED)

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/CMakeLists.txt
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(accel_brake_map_calibrator)
 
 find_package(autoware_cmake REQUIRED)

--- a/vehicle/external_cmd_converter/CMakeLists.txt
+++ b/vehicle/external_cmd_converter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(external_cmd_converter)
 
 find_package(autoware_cmake REQUIRED)

--- a/vehicle/raw_vehicle_cmd_converter/CMakeLists.txt
+++ b/vehicle/raw_vehicle_cmd_converter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(raw_vehicle_cmd_converter)
 
 find_package(autoware_cmake REQUIRED)

--- a/vehicle/vehicle_info_util/CMakeLists.txt
+++ b/vehicle/vehicle_info_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(vehicle_info_util)
 
 find_package(autoware_cmake REQUIRED)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Seeing https://www.ros.org/reps/rep-2000.html#humble-hawksbill-may-2022-may-2027, it seems it can be upgraded to `3.14`.

The reason I'd like to upgrade the version is to use new features like this. It's `New in version 3.12.`.
https://cmake.org/cmake/help/latest/command/add_compile_definitions.html#command:add_compile_definitions

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
