### PR TITLE
refactor(freespace_planning_algorithm): dump and load rosbag for plotting results

### DIFF
--- a/planning/freespace_planning_algorithms/package.xml
+++ b/planning/freespace_planning_algorithms/package.xml
@@ -16,6 +16,7 @@
 
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
+  <depend>rosbag2_cpp</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/planning/freespace_planning_algorithms/test/debug_plot.py
+++ b/planning/freespace_planning_algorithms/test/debug_plot.py
@@ -20,6 +20,7 @@ from math import asin
 from math import atan2
 from math import cos
 from math import sin
+import os
 from typing import Tuple
 
 from geometry_msgs.msg import Pose
@@ -162,14 +163,15 @@ def plot_problem(pd: ProblemDescription, ax):
 
 
 if __name__ == "__main__":
-    for postfix in ["single", "multi"]:
-        for idx in range(4):
-            pose_list = []
-            bag_path = "/tmp/result_{0}{1}".format(postfix, idx)
+    for cand_dir in os.listdir("/tmp"):
+        if cand_dir.startswith("fpalgos"):
+            bag_path = os.path.join("/tmp", cand_dir)
             pd = ProblemDescription.from_rosbag_path(bag_path)
+
             fig, ax = plt.subplots()
             plot_problem(pd, ax)
             fig.tight_layout()
-            file_name = bag_path + "-plot.png"
+
+            file_name = os.path.join("/tmp", cand_dir + "-plot.png")
             plt.savefig(file_name)
             print("saved to {}".format(file_name))

--- a/planning/freespace_planning_algorithms/test/debug_plot.py
+++ b/planning/freespace_planning_algorithms/test/debug_plot.py
@@ -15,120 +15,161 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import csv
+from dataclasses import dataclass
+from math import asin
+from math import atan2
 from math import cos
 from math import sin
+from typing import Tuple
 
 from geometry_msgs.msg import Pose
+from geometry_msgs.msg import PoseArray
 import matplotlib.pyplot as plt
-from nav_msgs.msg import MapMetaData
 from nav_msgs.msg import OccupancyGrid
 import numpy as np
+from rclpy.serialization import deserialize_message
+import rosbag2_py
+from rosidl_runtime_py.utilities import get_message
+from std_msgs.msg import Float64
 
 
-class CarModel(object):
-    def __init__(self, length=5.5, width=2.75, base2back=1.5):
-        self.length = length
-        self.width = width
-        self.base2back = base2back
+@dataclass
+class ProblemDescription:
+    costmap: OccupancyGrid
+    start: Pose
+    goal: Pose
+    trajectory: PoseArray
+    vehicle_length: Float64
+    vehicle_width: Float64
+    vehicle_base2back: Float64
+    elapsed_time: Float64
 
-    def _get_four_points(self):
+    @classmethod
+    def from_rosbag_path(cls, path: str) -> "ProblemDescription":
+        # ref: rosbag2/rosbag2_py/test/test_sequential_reader.py
+        storage_options, converter_options = cls.get_rosbag_options(bag_path)
+        reader = rosbag2_py.SequentialReader()
+        reader.open(storage_options, converter_options)
+        topic_types = reader.get_all_topics_and_types()
+
+        type_map = {topic_types[i].name: topic_types[i].type for i in range(len(topic_types))}
+        message_map = {}
+
+        while reader.has_next():
+            (topic, data, t) = reader.read_next()
+            msg_type = get_message(type_map[topic])
+            msg = deserialize_message(data, msg_type)
+            message_map[topic] = msg
+
+        return cls(**message_map)
+
+    @staticmethod
+    def get_rosbag_options(path: str, serialization_format="cdr"):
+        # copied from rosbag2/rosbag2_py/test/test_sequential_reader.py
+        storage_options = rosbag2_py.StorageOptions(uri=path, storage_id="sqlite3")
+
+        converter_options = rosbag2_py.ConverterOptions(
+            input_serialization_format=serialization_format,
+            output_serialization_format=serialization_format,
+        )
+
+        return storage_options, converter_options
+
+
+@dataclass
+class VehicleModel:
+    length: float
+    width: float
+    base2back: float
+
+    @classmethod
+    def from_problem_description(cls, pd: ProblemDescription) -> "VehicleModel":
+        return cls(pd.vehicle_length.data, pd.vehicle_width.data, pd.vehicle_base2back.data)
+
+    def get_vertices(self, pose: Pose) -> np.ndarray:
+        x, y, yaw = self.posemsg_to_nparr(pose)
+
         back = -1.0 * self.base2back
         front = self.length - self.base2back
         right = -0.5 * self.width
         left = 0.5 * self.width
-        P = np.array([[back, left], [back, right], [front, right], [front, left]])
-        return P
+        vertices_local = np.array([[back, left], [back, right], [front, right], [front, left]])
 
-    def get_four_points(self, pos, yaw=0.0):
         R_mat = np.array([[cos(yaw), -sin(yaw)], [sin(yaw), cos(yaw)]])
-        pos = np.array(pos)
-        P_ = self._get_four_points()
-        P = P_.dot(R_mat.T) + pos[None, :]
-        return P
+        vertices_global = vertices_local.dot(R_mat.T) + np.array([x, y])
+        return vertices_global
+
+    def plot_pose(self, pose: Pose, ax, color="black", lw=1):
+        x = pose.position.x
+        y = pose.position.y
+        V = self.get_vertices(pose)
+        ax.scatter(x, y, c=color, s=2)
+        for idx_pair in [[0, 1], [1, 2], [2, 3], [3, 0]]:
+            i, j = idx_pair
+            ax.plot([V[i, 0], V[j, 0]], [V[i, 1], V[j, 1]], color=color, linewidth=lw)
+
+    @staticmethod
+    def euler_from_quaternion(quaternion):
+        x = quaternion.x
+        y = quaternion.y
+        z = quaternion.z
+        w = quaternion.w
+
+        sinr_cosp = 2 * (w * x + y * z)
+        cosr_cosp = 1 - 2 * (x * x + y * y)
+        roll = atan2(sinr_cosp, cosr_cosp)
+
+        sinp = 2 * (w * y - z * x)
+        pitch = asin(sinp)
+
+        siny_cosp = 2 * (w * z + x * y)
+        cosy_cosp = 1 - 2 * (y * y + z * z)
+        yaw = atan2(siny_cosp, cosy_cosp)
+        return roll, pitch, yaw
+
+    @staticmethod
+    def posemsg_to_nparr(pose_msg: Pose) -> Tuple[float, float, float]:
+        _, _, yaw = VehicleModel.euler_from_quaternion(pose_msg.orientation)
+        return pose_msg.position.x, pose_msg.position.y, yaw
 
 
-def create_costmap_msg():
-    costmap_msg = OccupancyGrid()
+def plot_problem(pd: ProblemDescription, ax):
+    info = pd.costmap.info
+    n_grid = np.array([info.width, info.height])
+    res = info.resolution
+    origin = info.origin
+    arr = np.array(pd.costmap.data).reshape((n_grid[1], n_grid[0]))
+    b_min = np.array([origin.position.x, origin.position.y])
+    b_max = b_min + n_grid * res
 
-    origin = Pose()
-    origin.orientation.w = 1.0
+    x_lin, y_lin = [np.linspace(b_min[i], b_max[i], n_grid[i]) for i in range(2)]
+    X, Y = np.meshgrid(x_lin, y_lin)
+    ax.contourf(X, Y, arr, cmap="Greys")
 
-    info = MapMetaData()
-    info.width = 150
-    info.height = 150
-    info.resolution = 0.2
-    info.origin = origin
-    costmap_msg.info = info
+    vmodel = VehicleModel.from_problem_description(pd)
+    vmodel.plot_pose(pd.start, ax, "green")
+    vmodel.plot_pose(pd.goal, ax, "red")
 
-    data = np.zeros((info.height, info.width), dtype=int)
-    data[:, :10] = 100
-    data[:, -10:] = 100
-    data[:10, :] = 100
-    data[-10:, :] = 100
-    costmap_msg.data = data.flatten().tolist()
-    return costmap_msg
+    for pose in pd.trajectory.poses:
+        vmodel.plot_pose(pose, ax, "black", 0.5)
 
+    text = "elapsed : {0} [msec]".format(int(round(pd.elapsed_time.data)))
+    ax.text(0.3, 0.3, text, fontsize=15, color="gray")
 
-class Plotter(object):
-    def __init__(self, msg):
-        info = msg.info
-        n_grid = np.array([info.width, info.height])
-        res = info.resolution
-        origin = info.origin
-
-        tmp = np.array(msg.data).reshape((n_grid[1], n_grid[0]))  # about to be transposed!!
-
-        self.arr = tmp  # [IMPORTANT] !!
-        self.b_min = np.array([origin.position.x, origin.position.y])
-        self.b_max = self.b_min + n_grid * res
-        self.n_grid = n_grid
-        self.origin = origin
-
-    def plot(self, pose_start=None, pose_goal=None, pose_seq=None, plan_duration=None):
-        fig, ax = plt.subplots()
-        x_lin, y_lin = [np.linspace(self.b_min[i], self.b_max[i], self.n_grid[i]) for i in range(2)]
-        X, Y = np.meshgrid(x_lin, y_lin)
-        ax.contourf(X, Y, self.arr, cmap="Greys")
-
-        car = CarModel()
-
-        def plot_pose(pose, color, lw=1.0):
-            pos_xy = pose[:2]
-            yaw = pose[2]
-            P = car.get_four_points(pos_xy, yaw=yaw)
-            ax.scatter(pos_xy[0], pos_xy[1], c=color, s=2)
-            for idx_pair in [[0, 1], [1, 2], [2, 3], [3, 0]]:
-                i, j = idx_pair
-                ax.plot([P[i, 0], P[j, 0]], [P[i, 1], P[j, 1]], color=color, linewidth=lw)
-
-        if pose_start:
-            plot_pose(pose_start, "green")
-        if pose_goal:
-            plot_pose(pose_goal, "red")
-
-        if pose_seq is not None:
-            for pose in pose_seq:
-                plot_pose(pose, "blue", lw=0.5)
-
-        ax.axis("equal")
-        ax.text(4, 25, "elapsed : {0} [sec]".format(plan_duration * 1e-3), fontsize=12)
+    ax.set_xlim([0, 10])
+    ax.set_ylim([b_min[1], b_max[1]])
+    ax.axis("equal")
 
 
 if __name__ == "__main__":
     for postfix in ["single", "multi"]:
         for idx in range(4):
             pose_list = []
-            file_base = "/tmp/result_{0}{1}".format(postfix, idx)
-            with open(file_base + ".txt", "r") as f:
-                reader = csv.reader(f)
-                plan_duration = float(next(reader)[0])
-                pose_start = [float(e) for e in next(reader)]
-                pose_goal = [float(e) for e in next(reader)]
-                for row in reader:
-                    pose_list.append([float(e) for e in row])
-
-            costmap_msg = create_costmap_msg()
-            plotter = Plotter(costmap_msg)
-            plotter.plot(pose_start, pose_goal, pose_list, plan_duration)
-            plt.savefig(file_base + ".png")
+            bag_path = "/tmp/result_{0}{1}".format(postfix, idx)
+            pd = ProblemDescription.from_rosbag_path(bag_path)
+            fig, ax = plt.subplots()
+            plot_problem(pd, ax)
+            fig.tight_layout()
+            file_name = bag_path + "-plot.png"
+            plt.savefig(file_name)
+            print("saved to {}".format(file_name))

--- a/planning/freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
+++ b/planning/freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
@@ -15,8 +15,13 @@
 #include "freespace_planning_algorithms/astar_search.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <rcpputils/filesystem_helper.hpp>
+#include <rosbag2_cpp/writer.hpp>
+
+#include <std_msgs/msg/float64.hpp>
 
 #include <gtest/gtest.h>
+#include <rcutils/time.h>
 #include <tf2/utils.h>
 
 #include <array>
@@ -26,7 +31,7 @@
 
 namespace fpa = freespace_planning_algorithms;
 
-geometry_msgs::msg::Pose construct_pose_msg(std::array<double, 3> pose3d)
+geometry_msgs::msg::Pose create_pose_msg(std::array<double, 3> pose3d)
 {
   geometry_msgs::msg::Pose pose{};
   tf2::Quaternion quat{};
@@ -36,6 +41,13 @@ geometry_msgs::msg::Pose construct_pose_msg(std::array<double, 3> pose3d)
   pose.position.y = pose3d[1];
   pose.position.z = 0.0;
   return pose;
+}
+
+std_msgs::msg::Float64 create_float_msg(double val)
+{
+  std_msgs::msg::Float64 msg;
+  msg.data = val;
+  return msg;
 }
 
 nav_msgs::msg::OccupancyGrid construct_cost_map(
@@ -74,8 +86,35 @@ nav_msgs::msg::OccupancyGrid construct_cost_map(
   return costmap_msg;
 }
 
+template <typename MessageT>
+void add_message_to_rosbag(
+  rosbag2_cpp::Writer & writer, const MessageT & message, const std::string & name,
+  const std::string & type)
+{
+  rclcpp::SerializedMessage serialized_msg;
+  rclcpp::Serialization<MessageT> serialization;
+  serialization.serialize_message(&message, &serialized_msg);
+
+  rosbag2_storage::TopicMetadata tm;
+  tm.name = name;
+  tm.type = type;
+  tm.serialization_format = "cdr";
+  writer.create_topic(tm);
+
+  auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  auto ret = rcutils_system_time_now(&bag_message->time_stamp);
+  if (ret != RCL_RET_OK) {
+    RCLCPP_ERROR(rclcpp::get_logger("saveToBag"), "couldn't assign time rosbag message");
+  }
+
+  bag_message->topic_name = tm.name;
+  bag_message->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
+    &serialized_msg.get_rcl_serialized_message(), [](rcutils_uint8_array_t * /* data */) {});
+  writer.write(bag_message);
+}
+
 bool test_astar(
-  std::array<double, 3> start, std::array<double, 3> goal, std::string file_name,
+  std::array<double, 3> start, std::array<double, 3> goal, std::string dir_name,
   double maximum_turning_radius = 9.0, int turning_radius_size = 1)
 {
   // set problem configuration
@@ -119,7 +158,7 @@ bool test_astar(
 
   rclcpp::Clock clock{RCL_SYSTEM_TIME};
   const rclcpp::Time begin = clock.now();
-  bool success = astar.makePlan(construct_pose_msg(start), construct_pose_msg(goal));
+  bool success = astar.makePlan(create_pose_msg(start), create_pose_msg(goal));
   const rclcpp::Time now = clock.now();
   const double msec = (now - begin).seconds() * 1000.0;
   if (success) {
@@ -129,17 +168,36 @@ bool test_astar(
   }
   auto result = astar.getWaypoints();
 
-  // dump waypoints (will be used for debugging. the dumped file can be loaded by debug_plot.py)
-  std::ofstream file(file_name);
-  file << msec << std::endl;
-  file << start[0] << ", " << start[1] << ", " << start[2] << std::endl;
-  file << goal[0] << ", " << goal[1] << ", " << goal[2] << std::endl;
-  for (auto & point : result.waypoints) {
-    auto & pos = point.pose.pose.position;
-    auto & ori = point.pose.pose.orientation;
-    file << pos.x << ", " << pos.y << ", " << tf2::getYaw(ori) << std::endl;
+  geometry_msgs::msg::PoseArray result_trajectory;
+  for (const auto & pose : result.waypoints) {
+    result_trajectory.poses.push_back(pose.pose.pose);
   }
-  file.close();
+
+  rcpputils::fs::remove_all(dir_name);
+
+  rosbag2_storage::StorageOptions storage_options;
+  storage_options.uri = dir_name;
+  storage_options.storage_id = "sqlite3";
+
+  rosbag2_cpp::ConverterOptions converter_options;
+  converter_options.input_serialization_format = "cdr";
+  converter_options.output_serialization_format = "cdr";
+
+  rosbag2_cpp::Writer writer(std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
+  writer.open(storage_options, converter_options);
+
+  add_message_to_rosbag(
+    writer, create_float_msg(shape.length), "vehicle_length", "std_msgs/msg/Float64");
+  add_message_to_rosbag(
+    writer, create_float_msg(shape.width), "vehicle_width", "std_msgs/msg/Float64");
+  add_message_to_rosbag(
+    writer, create_float_msg(shape.base2back), "vehicle_base2back", "std_msgs/msg/Float64");
+
+  add_message_to_rosbag(writer, costmap_msg, "costmap", "nav_msgs/msg/OccupancyGrid");
+  add_message_to_rosbag(writer, create_pose_msg(start), "start", "geometry_msgs/msg/Pose");
+  add_message_to_rosbag(writer, create_pose_msg(goal), "goal", "geometry_msgs/msg/Pose");
+  add_message_to_rosbag(writer, result_trajectory, "trajectory", "geometry_msgs/msg/PoseArray");
+  add_message_to_rosbag(writer, create_float_msg(msec), "elapsed_time", "std_msgs/msg/Float64");
 
   // backtrace the path and confirm that the entire path is collision-free
   return success && astar.hasFeasibleSolution();
@@ -151,8 +209,8 @@ TEST(AstarSearchTestSuite, SingleCurvature)
   for (size_t i = 0; i < goal_xs.size(); i++) {
     std::array<double, 3> start{6., 4., 0.5 * 3.1415};
     std::array<double, 3> goal{goal_xs[i], 4., 0.5 * 3.1415};
-    std::string file_name = "/tmp/result_single" + std::to_string(i) + ".txt";
-    EXPECT_TRUE(test_astar(start, goal, file_name));
+    std::string dir_name = "/tmp/result_single" + std::to_string(i);
+    EXPECT_TRUE(test_astar(start, goal, dir_name));
   }
 }
 
@@ -164,8 +222,8 @@ TEST(AstarSearchTestSuite, MultiCurvature)
   for (size_t i = 0; i < goal_xs.size(); i++) {
     std::array<double, 3> start{6., 4., 0.5 * 3.1415};
     std::array<double, 3> goal{goal_xs[i], 4., 0.5 * 3.1415};
-    std::string file_name = "/tmp/result_multi" + std::to_string(i) + ".txt";
-    EXPECT_TRUE(test_astar(start, goal, file_name, maximum_turning_radius, turning_radius_size));
+    std::string dir_name = "/tmp/result_multi" + std::to_string(i);
+    EXPECT_TRUE(test_astar(start, goal, dir_name, maximum_turning_radius, turning_radius_size));
   }
 }
 

--- a/planning/freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
+++ b/planning/freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
@@ -209,7 +209,7 @@ TEST(AstarSearchTestSuite, SingleCurvature)
   for (size_t i = 0; i < goal_xs.size(); i++) {
     std::array<double, 3> start{6., 4., 0.5 * 3.1415};
     std::array<double, 3> goal{goal_xs[i], 4., 0.5 * 3.1415};
-    std::string dir_name = "/tmp/result_single" + std::to_string(i);
+    std::string dir_name = "/tmp/fpalgos-result_single" + std::to_string(i);
     EXPECT_TRUE(test_astar(start, goal, dir_name));
   }
 }
@@ -222,7 +222,7 @@ TEST(AstarSearchTestSuite, MultiCurvature)
   for (size_t i = 0; i < goal_xs.size(); i++) {
     std::array<double, 3> start{6., 4., 0.5 * 3.1415};
     std::array<double, 3> goal{goal_xs[i], 4., 0.5 * 3.1415};
-    std::string dir_name = "/tmp/result_multi" + std::to_string(i);
+    std::string dir_name = "/tmp/fpalgos-result_multi" + std::to_string(i);
     EXPECT_TRUE(test_astar(start, goal, dir_name, maximum_turning_radius, turning_radius_size));
   }
 }


### PR DESCRIPTION
Signed-off-by: Hirokazu Ishida <h-ishida@jsk.imi.i.u-tokyo.ac.jp>

## Description
Previously, cpp test code dumps result as a text file, and the python side reads and plots the result using pyplot. Problem of this way is that costmap cannot easily be dumped as a csv file, thus previously, the same costmap as the cpp side was hand-coded again in python side. In this PR, we use `rosbag` as a file format, and put everything (start pose, goal pose, costmap, elapsed time ... ) in a rosbag file, and load it by using `rosbag_py` in python side. 

By this change, we no longer have to hard-code the costmap in python again. Also, we can use ros2's default serialization/deserization method by using rosbag, rather than hand parsing the text file. So I believe, the new method is much cleaner.

Also, I heavily refactored the python file, which wrote by me 1 years ago, because the original code was not easy to read.  

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
