### PR TITLE
fix(system_monitor): fix truncation warning in strncpy

### DIFF
--- a/system/system_monitor/CMakeLists.txt
+++ b/system/system_monitor/CMakeLists.txt
@@ -4,9 +4,6 @@ project(system_monitor)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-# TODO: remove (https://github.com/autowarefoundation/autoware.universe/issues/851)
-add_compile_options(-Wno-stringop-truncation)
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(NVML)
 find_package(fmt REQUIRED)

--- a/system/system_monitor/reader/hdd_reader/hdd_reader.cpp
+++ b/system/system_monitor/reader/hdd_reader/hdd_reader.cpp
@@ -220,14 +220,14 @@ int get_ata_identify(int fd, HDDInfo * info)
   // IDENTIFY DEVICE
   // Word 10..19 Serial number
   char serial_number[20 + 1]{};
-  strncpy(serial_number, reinterpret_cast<char *>(data) + 20, 20);
+  memcpy(serial_number, data + 20, 20);
   swap_char(serial_number, 20);
   info->serial_ = serial_number;
   boost::trim(info->serial_);
 
   // Word 27..46 Model number
   char model_number[40 + 1]{};
-  strncpy(model_number, reinterpret_cast<char *>(data) + 54, 40);
+  memcpy(model_number, data + 54, 40);
   swap_char(model_number, 40);
   info->model_ = model_number;
   boost::trim(info->model_);
@@ -339,13 +339,13 @@ int get_nvme_identify(int fd, HDDInfo * info)
   // Identify Controller Data Structure
   // Bytes 23:04 Serial Number (SN)
   char serial_number[20 + 1]{};
-  strncpy(serial_number, data + 4, 20);
+  memcpy(serial_number, data + 4, 20);
   info->serial_ = serial_number;
   boost::trim(info->serial_);
 
   // Bytes 63:24 Model Number (MN)
   char model_number[40 + 1]{};
-  strncpy(model_number, data + 24, 40);
+  memcpy(model_number, data + 24, 40);
   info->model_ = model_number;
   boost::trim(info->model_);
 


### PR DESCRIPTION
## Description

Fix string truncation warning in `strncpy`.
This fix is related to the issue https://github.com/autowarefoundation/autoware.universe/issues/851.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
