### PR TITLE
fix(surround_obstacle_checker): fix ego footprint polygon

### DIFF
--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -131,8 +131,8 @@ Polygon2d createSelfPolygon(const VehicleInfo & vehicle_info)
 
   ego_polygon.outer().push_back(Point2d(front_m, -width_m));
   ego_polygon.outer().push_back(Point2d(front_m, width_m));
-  ego_polygon.outer().push_back(Point2d(-rear_m, width_m));
-  ego_polygon.outer().push_back(Point2d(-rear_m, -width_m));
+  ego_polygon.outer().push_back(Point2d(rear_m, width_m));
+  ego_polygon.outer().push_back(Point2d(rear_m, -width_m));
 
   bg::correct(ego_polygon);
 


### PR DESCRIPTION
## Description

I misunderstood that `min_longitudinal_offset_m` is **POSITIVE** value, but actualy the value is **NEGATIVE**. So, I fixed create polygon function.

FYI: code to calculate `min_longitudinal_offset_m`
https://github.com/autowarefoundation/autoware.universe/blob/178a65c40a5d3caad2c1d66cd0853dc14ffd79e2/vehicle/vehicle_info_util/include/vehicle_info_util/vehicle_info.hpp#L57

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
