### PR TITLE
feat(map_tf_generator): accelerate the 'viewer' coordinate calculation

### DIFF
--- a/map/map_tf_generator/CMakeLists.txt
+++ b/map/map_tf_generator/CMakeLists.txt
@@ -16,25 +16,21 @@ rclcpp_components_register_node(map_tf_generator_node
   EXECUTABLE map_tf_generator
 )
 
-function(add_testcase filepath)
-  get_filename_component(filename ${filepath} NAME)
-  string(REGEX REPLACE ".cpp" "" test_name ${filename})
 
-  ament_add_gmock(${test_name} ${filepath})
-  target_include_directories(${test_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-  ament_target_dependencies(${test_name} ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
-endfunction()
-
-set(BUILD_TESTING ON)
 if(BUILD_TESTING)
+  function(add_testcase filepath)
+    get_filename_component(filename ${filepath} NAME)
+    string(REGEX REPLACE ".cpp" "" test_name ${filename})
+
+    ament_add_gmock(${test_name} ${filepath})
+    target_include_directories(${test_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    ament_target_dependencies(${test_name} ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+  endfunction()
+
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  file(GLOB TEST_FILES test/*)
-  message("TEST_FILES = ${TEST_FILES}")
-  foreach(filepath ${TEST_FILES})
-    add_testcase(${filepath})
-  endforeach()
+  add_testcase(test/test_uniform_random.cpp)
 endif()
 
 ## Install

--- a/map/map_tf_generator/CMakeLists.txt
+++ b/map/map_tf_generator/CMakeLists.txt
@@ -33,7 +33,6 @@ if(BUILD_TESTING)
   add_testcase(test/test_uniform_random.cpp)
 endif()
 
-## Install
 ament_auto_package(INSTALL_TO_SHARE
   launch
 )

--- a/map/map_tf_generator/CMakeLists.txt
+++ b/map/map_tf_generator/CMakeLists.txt
@@ -16,6 +16,28 @@ rclcpp_components_register_node(map_tf_generator_node
   EXECUTABLE map_tf_generator
 )
 
+function(add_testcase filepath)
+  get_filename_component(filename ${filepath} NAME)
+  string(REGEX REPLACE ".cpp" "" test_name ${filename})
+
+  ament_add_gmock(${test_name} ${filepath})
+  target_include_directories(${test_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  ament_target_dependencies(${test_name} ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+endfunction()
+
+set(BUILD_TESTING ON)
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  file(GLOB TEST_FILES test/*)
+  message("TEST_FILES = ${TEST_FILES}")
+  foreach(filepath ${TEST_FILES})
+    add_testcase(${filepath})
+  endforeach()
+endif()
+
+## Install
 ament_auto_package(INSTALL_TO_SHARE
   launch
 )

--- a/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
+++ b/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
+++ b/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MAP_TF_GENERETOR__UNIFORM_RANDOM_HPP_
-#define MAP_TF_GENERETOR__UNIFORM_RANDOM_HPP_
+#ifndef MAP_TF_GENERATOR__UNIFORM_RANDOM_HPP_
+#define MAP_TF_GENERATOR__UNIFORM_RANDOM_HPP_
 
 #include <random>
 #include <vector>
 
-std::vector<int> UniformRandom(const int max_excluded, const int n) {
+std::vector<int> UniformRandom(const int max_excluded, const int n)
+{
   std::default_random_engine generator;
-  std::uniform_int_distribution<int> distribution(0, max_excluded-1);
+  std::uniform_int_distribution<int> distribution(0, max_excluded - 1);
 
   std::vector<int> v(n);
   for (int i = 0; i < n; ++i) {
@@ -29,4 +30,4 @@ std::vector<int> UniformRandom(const int max_excluded, const int n) {
   return v;
 }
 
-#endif  // MAP_TF_GENERETOR__UNIFORM_RANDOM_HPP_
+#endif  // MAP_TF_GENERATOR__UNIFORM_RANDOM_HPP_

--- a/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
+++ b/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
@@ -18,13 +18,13 @@
 #include <random>
 #include <vector>
 
-std::vector<size_t> UniformRandom(const int max_excluded, const int n)
+std::vector<size_t> UniformRandom(const size_t max_exclusive, const size_t n)
 {
   std::default_random_engine generator;
-  std::uniform_int_distribution<size_t> distribution(0, max_excluded - 1);
+  std::uniform_int_distribution<size_t> distribution(0, max_exclusive - 1);
 
   std::vector<size_t> v(n);
-  for (int i = 0; i < n; ++i) {
+  for (size_t i = 0; i < n; i++) {
     v[i] = distribution(generator);
   }
   return v;

--- a/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
+++ b/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
@@ -18,12 +18,12 @@
 #include <random>
 #include <vector>
 
-std::vector<int> UniformRandom(const int max_excluded, const int n)
+std::vector<size_t> UniformRandom(const int max_excluded, const int n)
 {
   std::default_random_engine generator;
-  std::uniform_int_distribution<int> distribution(0, max_excluded - 1);
+  std::uniform_int_distribution<size_t> distribution(0, max_excluded - 1);
 
-  std::vector<int> v(n);
+  std::vector<size_t> v(n);
   for (int i = 0; i < n; ++i) {
     v[i] = distribution(generator);
   }

--- a/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
+++ b/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
@@ -1,0 +1,32 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MAP_TF_GENERETOR__UNIFORM_RANDOM_HPP_
+#define MAP_TF_GENERETOR__UNIFORM_RANDOM_HPP_
+
+#include <random>
+#include <vector>
+
+std::vector<int> UniformRandom(const int max_excluded, const int n) {
+  std::default_random_engine generator;
+  std::uniform_int_distribution<int> distribution(0, max_excluded-1);
+
+  std::vector<int> v(n);
+  for (int i = 0; i < n; ++i) {
+    v[i] = distribution(generator);
+  }
+  return v;
+}
+
+#endif  // MAP_TF_GENERETOR__UNIFORM_RANDOM_HPP_

--- a/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
+++ b/map/map_tf_generator/include/map_tf_generator/uniform_random.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2022 Tier IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -24,7 +24,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -19,11 +19,11 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_gmock</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -20,7 +20,6 @@
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -22,6 +22,9 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/map/map_tf_generator/src/map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/map_tf_generator_node.cpp
@@ -55,6 +55,8 @@ private:
 
   void onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr clouds_ros)
   {
+    srand(3939);
+
     PointCloud clouds;
     pcl::fromROSMsg<pcl::PointXYZ>(*clouds_ros, clouds);
 

--- a/map/map_tf_generator/src/map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/map_tf_generator_node.cpp
@@ -58,9 +58,9 @@ private:
     PointCloud clouds;
     pcl::fromROSMsg<pcl::PointXYZ>(*clouds_ros, clouds);
 
-    const std::vector<int> indices = UniformRandom(clouds.size(), N_SAMPLES);
+    const std::vector<size_t> indices = UniformRandom(clouds.size(), N_SAMPLES);
     double coordinate[3] = {0, 0, 0};
-    for (const int i : indices) {
+    for (const auto i : indices) {
       coordinate[0] += clouds.points[i].x;
       coordinate[1] += clouds.points[i].y;
       coordinate[2] += clouds.points[i].z;

--- a/map/map_tf_generator/src/map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/map_tf_generator_node.cpp
@@ -55,6 +55,7 @@ private:
 
   void onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr clouds_ros)
   {
+    // fix random seed to produce the same viewer position every time
     srand(3939);
 
     PointCloud clouds;

--- a/map/map_tf_generator/src/map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/map_tf_generator_node.cpp
@@ -56,6 +56,7 @@ private:
   void onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr clouds_ros)
   {
     // fix random seed to produce the same viewer position every time
+    // 3939 is just the author's favorite number
     srand(3939);
 
     PointCloud clouds;

--- a/map/map_tf_generator/src/map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/map_tf_generator_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "map_tf_generator/uniform_random.hpp"
+
 #include <rclcpp/rclcpp.hpp>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -24,8 +26,6 @@
 
 #include <memory>
 #include <string>
-
-#include "map_tf_generator/uniform_random.hpp"
 
 const int N_SAMPLES = 20;
 

--- a/map/map_tf_generator/src/map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/map_tf_generator_node.cpp
@@ -27,7 +27,7 @@
 #include <memory>
 #include <string>
 
-const int N_SAMPLES = 20;
+constexpr size_t N_SAMPLES = 20;
 
 class MapTFGeneratorNode : public rclcpp::Node
 {

--- a/map/map_tf_generator/src/map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/map_tf_generator_node.cpp
@@ -25,6 +25,10 @@
 #include <memory>
 #include <string>
 
+#include "map_tf_generator/uniform_random.hpp"
+
+const int N_SAMPLES = 20;
+
 class MapTFGeneratorNode : public rclcpp::Node
 {
 public:
@@ -54,16 +58,16 @@ private:
     PointCloud clouds;
     pcl::fromROSMsg<pcl::PointXYZ>(*clouds_ros, clouds);
 
-    const unsigned int sum = clouds.points.size();
+    const std::vector<int> indices = UniformRandom(clouds.size(), N_SAMPLES);
     double coordinate[3] = {0, 0, 0};
-    for (unsigned int i = 0; i < sum; i++) {
+    for (const int i : indices) {
       coordinate[0] += clouds.points[i].x;
       coordinate[1] += clouds.points[i].y;
       coordinate[2] += clouds.points[i].z;
     }
-    coordinate[0] = coordinate[0] / sum;
-    coordinate[1] = coordinate[1] / sum;
-    coordinate[2] = coordinate[2] / sum;
+    coordinate[0] = coordinate[0] / indices.size();
+    coordinate[1] = coordinate[1] / indices.size();
+    coordinate[2] = coordinate[2] / indices.size();
 
     geometry_msgs::msg::TransformStamped static_transformStamped;
     static_transformStamped.header.stamp = this->now();

--- a/map/map_tf_generator/test/test_uniform_random.cpp
+++ b/map/map_tf_generator/test/test_uniform_random.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/map/map_tf_generator/test/test_uniform_random.cpp
+++ b/map/map_tf_generator/test/test_uniform_random.cpp
@@ -1,0 +1,39 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "map_tf_generator/uniform_random.hpp"
+
+using testing::Each;
+using testing::AllOf;
+using testing::Ge;
+using testing::Lt;
+
+
+TEST(UniformRandom, UniformRandom)
+{
+  {
+    const std::vector<int> random = UniformRandom(4, 0);
+    ASSERT_EQ(random.size(), static_cast<long unsigned int>(0));
+  }
+
+  {
+    for (int i = 0; i < 50; i++) {
+      const std::vector<int> random = UniformRandom(4, 10);
+      ASSERT_EQ(random.size(), static_cast<long unsigned int>(10));
+      ASSERT_THAT(random, Each(AllOf(Ge(0), Lt(4))));  // in range [0, 4)
+    }
+  }
+}

--- a/map/map_tf_generator/test/test_uniform_random.cpp
+++ b/map/map_tf_generator/test/test_uniform_random.cpp
@@ -28,6 +28,8 @@ TEST(UniformRandom, UniformRandom)
     ASSERT_EQ(random.size(), static_cast<size_t>(0));
   }
 
+  // checks if the returned values are in range of [min, max)
+  // note that the minimun range is always zero and the max value is exclusive
   {
     const size_t min_inclusive = 0;
     const size_t max_exclusive = 4;

--- a/map/map_tf_generator/test/test_uniform_random.cpp
+++ b/map/map_tf_generator/test/test_uniform_random.cpp
@@ -29,13 +29,13 @@ TEST(UniformRandom, UniformRandom)
   }
 
   {
-    const size_t min_inclusize = 0;
+    const size_t min_inclusive = 0;
     const size_t max_exclusive = 4;
 
     for (int i = 0; i < 50; i++) {
       const std::vector<size_t> random = UniformRandom(4, 10);
       ASSERT_EQ(random.size(), static_cast<size_t>(10));
-      ASSERT_THAT(random, Each(AllOf(Ge(min_inclusize), Lt(max_exclusive))));  // in range [0, 4)
+      ASSERT_THAT(random, Each(AllOf(Ge(min_inclusive), Lt(max_exclusive))));  // in range [0, 4)
     }
   }
 }

--- a/map/map_tf_generator/test/test_uniform_random.cpp
+++ b/map/map_tf_generator/test/test_uniform_random.cpp
@@ -24,15 +24,18 @@ using testing::Lt;
 TEST(UniformRandom, UniformRandom)
 {
   {
-    const std::vector<int> random = UniformRandom(4, 0);
-    ASSERT_EQ(random.size(), static_cast<long unsigned int>(0));
+    const std::vector<size_t> random = UniformRandom(4, 0);
+    ASSERT_EQ(random.size(), static_cast<size_t>(0));
   }
 
   {
+    const size_t min_inclusize = 0;
+    const size_t max_exclusive = 4;
+
     for (int i = 0; i < 50; i++) {
-      const std::vector<int> random = UniformRandom(4, 10);
-      ASSERT_EQ(random.size(), static_cast<long unsigned int>(10));
-      ASSERT_THAT(random, Each(AllOf(Ge(0), Lt(4))));  // in range [0, 4)
+      const std::vector<size_t> random = UniformRandom(4, 10);
+      ASSERT_EQ(random.size(), static_cast<size_t>(10));
+      ASSERT_THAT(random, Each(AllOf(Ge(min_inclusize), Lt(max_exclusive))));  // in range [0, 4)
     }
   }
 }

--- a/map/map_tf_generator/test/test_uniform_random.cpp
+++ b/map/map_tf_generator/test/test_uniform_random.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
-
 #include "map_tf_generator/uniform_random.hpp"
 
-using testing::Each;
+#include <gmock/gmock.h>
+
 using testing::AllOf;
+using testing::Each;
 using testing::Ge;
 using testing::Lt;
-
 
 TEST(UniformRandom, UniformRandom)
 {

--- a/map/map_tf_generator/test/test_uniform_random.cpp
+++ b/map/map_tf_generator/test/test_uniform_random.cpp
@@ -36,7 +36,7 @@ TEST(UniformRandom, UniformRandom)
 
     for (int i = 0; i < 50; i++) {
       const std::vector<size_t> random = UniformRandom(4, 10);
-      ASSERT_EQ(random.size(), static_cast<size_t>(10));
+      ASSERT_EQ(random.size(), 10U);
       ASSERT_THAT(random, Each(AllOf(Ge(min_inclusive), Lt(max_exclusive))));  // in range [0, 4)
     }
   }

--- a/map/map_tf_generator/test/test_uniform_random.cpp
+++ b/map/map_tf_generator/test/test_uniform_random.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2022 Tier IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Accelerated the 'viewer' tf calculation by randomly sampling map points

I found that all map points are used to calculate the tf viewer coordinate so I randomly sampled only a few points from the map for faster calculation

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Tested the random sampling function
The test checks

* if the random index range is within [0, point size)
* if the random index vector has the expected length

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
