### PR TITLE
feat(state_rviz_plugin): add GateMode and PathChangeApproval Button

### DIFF
--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware_state_panel.hpp"
 
+#include <QHBoxLayout>
 #include <QString>
 #include <QVBoxLayout>
 #include <rviz_common/display_context.hpp>
@@ -80,6 +81,15 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   engage_button_ptr_ = new QPushButton("Engage");
   connect(engage_button_ptr_, SIGNAL(clicked()), SLOT(onClickAutowareEngage()));
 
+  // Gate Mode Button
+  gate_mode_button_ptr_ = new QPushButton("Gate Mode");
+  connect(gate_mode_button_ptr_, SIGNAL(clicked()), SLOT(onClickGateMode()));
+
+  // Path Change Approval Button
+  path_change_approval_button_ptr_ = new QPushButton("Path Change Approval");
+  connect(path_change_approval_button_ptr_, SIGNAL(clicked()), SLOT(onClickPathChangeApproval()));
+
+  // Velocity Limit
   velocity_limit_button_ptr_ = new QPushButton("Send Velocity Limit");
   pub_velocity_limit_input_ = new QSpinBox();
   pub_velocity_limit_input_->setRange(-100.0, 100.0);
@@ -87,7 +97,9 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   pub_velocity_limit_input_->setSingleStep(5.0);
   connect(velocity_limit_button_ptr_, SIGNAL(clicked()), this, SLOT(onClickVelocityLimit()));
 
+  // Layout
   auto * v_layout = new QVBoxLayout;
+  auto * gate_mode_path_change_approval_layout = new QHBoxLayout;
   auto * velocity_limit_layout = new QHBoxLayout();
   v_layout->addLayout(gate_layout);
   v_layout->addLayout(selector_layout);
@@ -96,6 +108,9 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   v_layout->addLayout(engage_status_layout);
   v_layout->addWidget(engage_button_ptr_);
   v_layout->addLayout(engage_status_layout);
+  gate_mode_path_change_approval_layout->addWidget(gate_mode_button_ptr_);
+  gate_mode_path_change_approval_layout->addWidget(path_change_approval_button_ptr_);
+  v_layout->addLayout(gate_mode_path_change_approval_layout);
   velocity_limit_layout->addWidget(velocity_limit_button_ptr_);
   velocity_limit_layout->addWidget(pub_velocity_limit_input_);
   velocity_limit_layout->addWidget(new QLabel("  [km/h]"));
@@ -130,6 +145,14 @@ void AutowareStatePanel::onInitialize()
 
   pub_velocity_limit_ = raw_node_->create_publisher<tier4_planning_msgs::msg::VelocityLimit>(
     "/planning/scenario_planning/max_velocity_default", rclcpp::QoS(1));
+
+  pub_gate_mode_ = raw_node_->create_publisher<tier4_control_msgs::msg::GateMode>(
+    "/control/gate_mode_cmd", rclcpp::QoS(1));
+
+  pub_path_change_approval_ = raw_node_->create_publisher<tier4_planning_msgs::msg::Approval>(
+    "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/"
+    "path_change_approval",
+    rclcpp::QoS(1));
 }
 
 void AutowareStatePanel::onGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg)
@@ -258,6 +281,23 @@ void AutowareStatePanel::onClickAutowareEngage()
     });
 }
 
+void AutowareStatePanel::onClickGateMode()
+{
+  const auto data = gate_mode_label_ptr_->text().toStdString() == "AUTO"
+                      ? tier4_control_msgs::msg::GateMode::EXTERNAL
+                      : tier4_control_msgs::msg::GateMode::AUTO;
+  RCLCPP_INFO(raw_node_->get_logger(), "data : %d", data);
+  pub_gate_mode_->publish(
+    tier4_control_msgs::build<tier4_control_msgs::msg::GateMode>().data(data));
+}
+
+void AutowareStatePanel::onClickPathChangeApproval()
+{
+  pub_path_change_approval_->publish(
+    tier4_planning_msgs::build<tier4_planning_msgs::msg::Approval>()
+      .stamp(raw_node_->now())
+      .approval(true));
+}
 }  // namespace rviz_plugins
 
 #include <pluginlib/class_list_macros.hpp>

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -30,6 +30,7 @@
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
+#include <tier4_planning_msgs/msg/approval.hpp>
 
 namespace rviz_plugins
 {
@@ -44,6 +45,8 @@ public:
 public Q_SLOTS:
   void onClickAutowareEngage();
   void onClickVelocityLimit();
+  void onClickGateMode();
+  void onClickPathChangeApproval();
 
 protected:
   void onGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg);
@@ -65,6 +68,8 @@ protected:
   rclcpp::Client<tier4_external_api_msgs::srv::Engage>::SharedPtr client_engage_;
 
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
+  rclcpp::Publisher<tier4_control_msgs::msg::GateMode>::SharedPtr pub_gate_mode_;
+  rclcpp::Publisher<tier4_planning_msgs::msg::Approval>::SharedPtr pub_path_change_approval_;
 
   QLabel * gate_mode_label_ptr_;
   QLabel * selector_mode_label_ptr_;
@@ -73,6 +78,8 @@ protected:
   QLabel * engage_status_label_ptr_;
   QPushButton * engage_button_ptr_;
   QPushButton * velocity_limit_button_ptr_;
+  QPushButton * gate_mode_button_ptr_;
+  QPushButton * path_change_approval_button_ptr_;
   QSpinBox * pub_velocity_limit_input_;
 
   bool current_engage_;

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -29,8 +29,8 @@
 #include <tier4_control_msgs/msg/external_command_selector_mode.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/approval.hpp>
+#include <tier4_planning_msgs/msg/velocity_limit.hpp>
 
 namespace rviz_plugins
 {


### PR DESCRIPTION
## Description

- Add GateMode button to publish publising `/control/gate_mode_cmd`
- Add PathChangeApproval Button to publish `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/path_change_approval`

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

- GateMode Button

https://user-images.githubusercontent.com/9547070/168057737-a3d7b6b6-f9d0-478f-8623-44f836b1e1ce.mp4


- PathChangeApproval Button

https://user-images.githubusercontent.com/9547070/168057777-40049cec-ca5d-4ce4-8659-ed9bef135ad5.mp4


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
