### PR TITLE
fix(accel_brake_map_calibrator): rviz panel type

### DIFF
--- a/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.cpp
+++ b/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.cpp
@@ -75,7 +75,7 @@ void AccelBrakeMapCalibratorButtonPanel::onInitialize()
       &AccelBrakeMapCalibratorButtonPanel::callbackUpdateSuggest, this, std::placeholders::_1));
 
   client_ = raw_node->create_client<tier4_vehicle_msgs::srv::UpdateAccelBrakeMap>(
-    "/vehicle/calibration/accel_brake_map_calibrator/update_map_dir");
+    "/accel_brake_map_calibrator/update_map_dir");
 }
 
 void AccelBrakeMapCalibratorButtonPanel::callbackUpdateSuggest(

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/README.md
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/README.md
@@ -17,7 +17,7 @@ ros2 launch accel_brake_map_calibrator accel_brake_map_calibrator.launch.xml rvi
 Or if you want to use rosbag files, run the following commands.
 
 ```sh
-ros2 param set /use_sim_time true
+ros2 launch accel_brake_map_calibrator accel_brake_map_calibrator.launch.xml rviz:=true use_sim_time:=true
 ros2 bag play <rosbag_file> --clock
 ```
 

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/README.md
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/README.md
@@ -110,7 +110,7 @@ ros2 run accel_brake_map_calibrator view_statistics.py
 You can save accel and brake map anytime with the following command.
 
 ```sh
-ros2 service call /accel_brake_map_calibrator/update_map_dir "path: '<accel/brake map directory>'"
+ros2 service call /accel_brake_map_calibrator/update_map_dir tier4_vehicle_msgs/srv/UpdateAccelBrakeMap "path: '<accel/brake map directory>'"
 ```
 
 You can also save accel and brake map in the default directory where Autoware reads accel_map.csv/brake_map.csv using the RViz plugin (AccelBrakeMapCalibratorButtonPanel) as following.

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/rviz/occupancy.rviz
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/rviz/occupancy.rviz
@@ -17,9 +17,9 @@ Panels:
       - /Current View1
     Name: Views
     Splitter Ratio: 0.5
-  - Class: autoware_localization_rviz_plugin/InitialPoseButtonPanel
+  - Class: tier4_localization_rviz_plugin/InitialPoseButtonPanel
     Name: InitialPoseButtonPanel
-  - Class: autoware_localization_rviz_plugin/InitialPoseButtonPanel
+  - Class: tier4_localization_rviz_plugin/InitialPoseButtonPanel
     Name: InitialPoseButtonPanel
 Preferences:
   PromptSaveOnExit: true


### PR DESCRIPTION
## Update the rviz panel type 

This PR contains the modification of "InitialPoseButtonPanel" in rviz/occupancy.rviz given the change of rviz_plugin name in common/tier4_localization_rviz_plugin.

Also this PR contains a minor update of "How to calibrate" part in README.md. I think running the launch file with `use_sim_time:=true` flag is better than settting `ros2 param set /use_sim_time true` when replaying the bug file, because the flag is not passed to accel_brake_calib node if we set `use_sim_time` from command line. Actually I encountered [TF_OLD_DATA error](https://answers.ros.org/question/201948/tf_old_data-ignoring-data-from-the-past-for-frame-odom/) when I followed the current instruction.

## Pre-review checklist for the PR author

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
