### PR TITLE
fix(scene module interface):skipping emplace back stop reason if it is empty

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
@@ -123,7 +123,7 @@ public:
       tier4_planning_msgs::msg::StopReason stop_reason;
       scene_module->setPlannerData(planner_data_);
       scene_module->modifyPathVelocity(path, &stop_reason);
-      stop_reason_array.stop_reasons.emplace_back(stop_reason);
+      if (stop_reason.reason != "") stop_reason_array.stop_reasons.emplace_back(stop_reason);
 
       if (const auto command = scene_module->getInfrastructureCommand()) {
         infrastructure_command_array.commands.push_back(*command);


### PR DESCRIPTION
Signed-off-by: TakumiKozaka-T4 <takumi.kozaka@tier4.jp>

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
