### PR TITLE
feat(pose_initializer): introduce an array copy function

### DIFF
--- a/localization/pose_initializer/CMakeLists.txt
+++ b/localization/pose_initializer/CMakeLists.txt
@@ -10,7 +10,26 @@ ament_auto_add_executable(pose_initializer
   src/pose_initializer_node.cpp
   src/pose_initializer_core.cpp
 )
-target_link_libraries(pose_initializer ${PCL_LIBRARIES})
+
+# fmt often fails to automatically link so manually specify here
+target_link_libraries(pose_initializer ${PCL_LIBRARIES} fmt)
+
+if(BUILD_TESTING)
+  function(add_testcase filepath)
+    get_filename_component(filename ${filepath} NAME)
+    string(REGEX REPLACE ".cpp" "" test_name ${filename})
+
+    ament_add_gmock(${test_name} ${filepath})
+    target_include_directories(${test_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    target_link_libraries(${test_name} fmt)
+    ament_target_dependencies(${test_name} ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+  endfunction()
+
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  add_testcase(test/test_copy_vector_to_array.cpp)
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
+++ b/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
@@ -20,16 +20,14 @@
 #include <array>
 #include <vector>
 
-template<typename T, unsigned long int N>
+template <typename T, unsigned long int N>
 void CopyVectorToArray(const std::vector<T> & vector, std::array<T, N> & array)
 {
   if (N != vector.size()) {
     // throws the error to prevent causing an anonymous bug
     // such as only partial array is initialized
-    throw std::invalid_argument(
-      fmt::format(
-        "Vector size (which is {}) is different from the copy size (which is {})",
-        vector.size(), N));
+    throw std::invalid_argument(fmt::format(
+      "Vector size (which is {}) is different from the copy size (which is {})", vector.size(), N));
   }
 
   std::copy_n(vector.begin(), N, array.begin());

--- a/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
+++ b/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
@@ -17,6 +17,7 @@
 
 #include <fmt/core.h>
 
+#include <algorithm>
 #include <array>
 #include <vector>
 

--- a/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
+++ b/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
@@ -1,0 +1,38 @@
+// Copyright 2022 Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POSE_INITIALIZER__COPY_VECTOR_TO_ARRAY_HPP_
+#define POSE_INITIALIZER__COPY_VECTOR_TO_ARRAY_HPP_
+
+#include <fmt/core.h>
+
+#include <array>
+#include <vector>
+
+template<typename T, unsigned long int N>
+void CopyVectorToArray(const std::vector<T> & vector, std::array<T, N> & array)
+{
+  if (N != vector.size()) {
+    // throws the error to prevent causing an anonymous bug
+    // such as only partial array is initialized
+    throw std::invalid_argument(
+      fmt::format(
+        "Vector size (which is {}) is different from the copy size (which is {})",
+        vector.size(), N));
+  }
+
+  std::copy_n(vector.begin(), N, array.begin());
+}
+
+#endif  // POSE_INITIALIZER__COPY_VECTOR_TO_ARRAY_HPP_

--- a/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
+++ b/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
@@ -21,7 +21,7 @@
 #include <array>
 #include <vector>
 
-template <typename T, unsigned long int N>
+template<typename T, size_t N>
 void CopyVectorToArray(const std::vector<T> & vector, std::array<T, N> & array)
 {
   if (N != vector.size()) {

--- a/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
+++ b/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
@@ -21,7 +21,7 @@
 #include <array>
 #include <vector>
 
-template<typename T, size_t N>
+template <typename T, size_t N>
 void CopyVectorToArray(const std::vector<T> & vector, std::array<T, N> & array)
 {
   if (N != vector.size()) {

--- a/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
+++ b/localization/pose_initializer/include/pose_initializer/copy_vector_to_array.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Autoware Contributors
+// Copyright 2022 The Autoware Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/localization/pose_initializer/package.xml
+++ b/localization/pose_initializer/package.xml
@@ -25,8 +25,8 @@
   <depend>tier4_external_api_msgs</depend>
   <depend>tier4_localization_msgs</depend>
 
-  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/localization/pose_initializer/package.xml
+++ b/localization/pose_initializer/package.xml
@@ -11,6 +11,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
@@ -24,6 +25,7 @@
   <depend>tier4_external_api_msgs</depend>
   <depend>tier4_localization_msgs</depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/localization/pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/pose_initializer/src/pose_initializer_core.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "pose_initializer/pose_initializer_core.hpp"
+
 #include "pose_initializer/copy_vector_to_array.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
@@ -27,7 +28,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-
 
 double getGroundHeight(const pcl::PointCloud<pcl::PointXYZ>::Ptr pcdmap, const tf2::Vector3 & point)
 {

--- a/localization/pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/pose_initializer/src/pose_initializer_core.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "pose_initializer/pose_initializer_core.hpp"
+#include "pose_initializer/copy_vector_to_array.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
 #ifdef ROS_DISTRO_GALACTIC
@@ -26,6 +27,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+
 
 double getGroundHeight(const pcl::PointCloud<pcl::PointXYZ>::Ptr pcdmap, const tf2::Vector3 & point)
 {
@@ -50,29 +52,21 @@ PoseInitializer::PoseInitializer()
 {
   enable_gnss_callback_ = this->declare_parameter("enable_gnss_callback", true);
 
-  std::vector<double> initialpose_particle_covariance =
+  const std::vector<double> initialpose_particle_covariance =
     this->declare_parameter<std::vector<double>>("initialpose_particle_covariance");
-  for (std::size_t i = 0; i < initialpose_particle_covariance.size(); ++i) {
-    initialpose_particle_covariance_[i] = initialpose_particle_covariance[i];
-  }
+  CopyVectorToArray(initialpose_particle_covariance, initialpose_particle_covariance_);
 
-  std::vector<double> gnss_particle_covariance =
+  const std::vector<double> gnss_particle_covariance =
     this->declare_parameter<std::vector<double>>("gnss_particle_covariance");
-  for (std::size_t i = 0; i < gnss_particle_covariance.size(); ++i) {
-    gnss_particle_covariance_[i] = gnss_particle_covariance[i];
-  }
+  CopyVectorToArray(gnss_particle_covariance, gnss_particle_covariance_);
 
-  std::vector<double> service_particle_covariance =
+  const std::vector<double> service_particle_covariance =
     this->declare_parameter<std::vector<double>>("service_particle_covariance");
-  for (std::size_t i = 0; i < service_particle_covariance.size(); ++i) {
-    service_particle_covariance_[i] = service_particle_covariance[i];
-  }
+  CopyVectorToArray(service_particle_covariance, service_particle_covariance_);
 
-  std::vector<double> output_pose_covariance =
+  const std::vector<double> output_pose_covariance =
     this->declare_parameter<std::vector<double>>("output_pose_covariance");
-  for (std::size_t i = 0; i < output_pose_covariance.size(); ++i) {
-    output_pose_covariance_[i] = output_pose_covariance[i];
-  }
+  CopyVectorToArray(output_pose_covariance, output_pose_covariance_);
 
   // We can't use _1 because pcl leaks an alias to boost::placeholders::_1, so it would be ambiguous
   initial_pose_sub_ = this->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(

--- a/localization/pose_initializer/test/test_copy_vector_to_array.cpp
+++ b/localization/pose_initializer/test/test_copy_vector_to_array.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
-
 #include "pose_initializer/copy_vector_to_array.hpp"
+
+#include <gmock/gmock.h>
 
 TEST(CopyVectorToArray, CopyAllElements)
 {
@@ -22,7 +22,6 @@ TEST(CopyVectorToArray, CopyAllElements)
   std::array<int, 5> array;
   CopyVectorToArray<int, 5>(vector, array);
   EXPECT_THAT(array, testing::ElementsAre(0, 1, 2, 3, 4));
-
 }
 
 TEST(CopyVectorToArray, CopyZeroElements)
@@ -35,21 +34,17 @@ TEST(CopyVectorToArray, CopyZeroElements)
 
 TEST(CopyVectorToArray, ThrowsInvalidArgumentIfMoreElementsExpected)
 {
-  auto f = []{
+  auto f = [] {
     const std::vector<int> vector{0, 1, 2, 3, 4};
     std::array<int, 6> array;
     CopyVectorToArray<int, 6>(vector, array);
   };
 
   EXPECT_THROW(
-    try {
-      f();
-    } catch(std::exception & e) {
+    try { f(); } catch (std::exception & e) {
       EXPECT_STREQ(
-        e.what(),
-        "Vector size (which is 5) is different from the copy size (which is 6)");
+        e.what(), "Vector size (which is 5) is different from the copy size (which is 6)");
       throw;
     },
-    std::invalid_argument
-  );
+    std::invalid_argument);
 }

--- a/localization/pose_initializer/test/test_copy_vector_to_array.cpp
+++ b/localization/pose_initializer/test/test_copy_vector_to_array.cpp
@@ -1,0 +1,55 @@
+// Copyright 2022 Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "pose_initializer/copy_vector_to_array.hpp"
+
+TEST(CopyVectorToArray, CopyAllElements)
+{
+  const std::vector<int> vector{0, 1, 2, 3, 4};
+  std::array<int, 5> array;
+  CopyVectorToArray<int, 5>(vector, array);
+  EXPECT_THAT(array, testing::ElementsAre(0, 1, 2, 3, 4));
+
+}
+
+TEST(CopyVectorToArray, CopyZeroElements)
+{
+  const std::vector<int> vector{};
+  // just confirm that this works
+  std::array<int, 0> array;
+  CopyVectorToArray<int, 0>(vector, array);
+}
+
+TEST(CopyVectorToArray, ThrowsInvalidArgumentIfMoreElementsExpected)
+{
+  auto f = []{
+    const std::vector<int> vector{0, 1, 2, 3, 4};
+    std::array<int, 6> array;
+    CopyVectorToArray<int, 6>(vector, array);
+  };
+
+  EXPECT_THROW(
+    try {
+      f();
+    } catch(std::exception & e) {
+      EXPECT_STREQ(
+        e.what(),
+        "Vector size (which is 5) is different from the copy size (which is 6)");
+      throw;
+    },
+    std::invalid_argument
+  );
+}

--- a/localization/pose_initializer/test/test_copy_vector_to_array.cpp
+++ b/localization/pose_initializer/test/test_copy_vector_to_array.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Autoware Contributors
+// Copyright 2022 The Autoware Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: IshitaTakeshi <ishitah.takeshi@gmail.com>

## Description

Add an array copy function to simplify array initialization

There were a lot of reputation of for-loops that copy std::vector to std::array so I introduced a copy function and simplified the syntax

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed
Tests include:

* one that ensures all elements are copied
* one that ensures it works even for a zero element array 
* one that ensures to raise an invalid argument exception when an unexpected array size is given

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
