### PR TITLE
fix(freespace_planning_algorithms): initialize priority queue of astar algorithm

### DIFF
--- a/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/astar_search.hpp
+++ b/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/astar_search.hpp
@@ -117,6 +117,7 @@ public:
 
 private:
   bool search();
+  void clearNodes();
   void setPath(const AstarNode & goal);
   bool setStartNode();
   bool setGoalNode();

--- a/planning/freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/freespace_planning_algorithms/src/astar_search.cpp
@@ -135,15 +135,16 @@ void AstarSearch::setMap(const nav_msgs::msg::OccupancyGrid & costmap)
 {
   AbstractPlanningAlgorithm::setMap(costmap);
 
+  clearNodes();
+
   const auto height = costmap_.info.height;
   const auto width = costmap_.info.width;
 
   // Initialize nodes
-  nodes_.clear();
   nodes_.resize(height);
-  for (uint32_t i = 0; i < height; i++) {
+  for (size_t i = 0; i < height; i++) {
     nodes_[i].resize(width);
-    for (uint32_t j = 0; j < width; j++) {
+    for (size_t j = 0; j < width; j++) {
       nodes_[i][j].resize(planner_common_param_.theta_size);
     }
   }
@@ -164,6 +165,14 @@ bool AstarSearch::makePlan(
   }
 
   return search();
+}
+
+void AstarSearch::clearNodes()
+{
+  // clearing openlist is necessary because otherwise remaining elements of openlist
+  // point to deleted node.
+  nodes_.clear();
+  openlist_ = std::priority_queue<AstarNode *, std::vector<AstarNode *>, NodeComparison>();
 }
 
 bool AstarSearch::setStartNode()

--- a/planning/freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
+++ b/planning/freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
@@ -53,21 +53,21 @@ nav_msgs::msg::OccupancyGrid construct_cost_map(
 
   for (int i = 0; i < n_padding; i++) {
     // fill left
-    for (int j = width * i; j <= width * (i + 1); j++) {
+    for (int j = width * i; j < width * (i + 1); j++) {
       costmap_msg.data[j] = 100.0;
     }
     // fill right
-    for (int j = width * (height - n_padding + i); j <= width * (height - n_padding + i + 1); j++) {
+    for (int j = width * (height - n_padding + i); j < width * (height - n_padding + i + 1); j++) {
       costmap_msg.data[j] = 100.0;
     }
   }
 
   for (int i = 0; i < height; i++) {
     // fill bottom
-    for (int j = i * width; j <= i * width + n_padding; j++) {
+    for (int j = i * width; j < i * width + n_padding; j++) {
       costmap_msg.data[j] = 100.0;
     }
-    for (int j = (i + 1) * width - n_padding; j <= (i + 1) * width; j++) {
+    for (int j = (i + 1) * width - n_padding; j < (i + 1) * width; j++) {
       costmap_msg.data[j] = 100.0;
     }
   }


### PR DESCRIPTION
## Description

In the original implementation, `openlist_` ( priority queue of astar nodes) are not initialized when clearing `nodes_`. This is problematic because without clearing priority queue after `nodes_` are cleared, the remaining elements of priority queue points to deleted nodes, which causes `heap-use-after-free` error when comparator of the priority queue runs over the remaining elements. This PR fixes the bag. 

@TakaHoribe 
We previously talked about this bug. And this PR is the solution.  

This bug was observed when the astar planning is run many times in `freespace_planner`. An simple example  to reproduce the bug only using the freespace_planing_algorithms is can be found 
 in https://github.com/HiroIshida/autoware.universe/tree/reproduce-astar-error
It compiles the program with address sanitizer https://github.com/google/sanitizers, and the output when running the unit test is as follows. 

Not directly related to the bug above, but I also fixed the heap bufferflow error in the unit test program. So I fixed that in https://github.com/autowarefoundation/autoware.universe/commit/f3f09d4f411108c1e8925ecbd6bc771f1b250780

```
h-ishida@stonet4:~/pilot-auto/build/freespace_planning_algorithms [(HEAD detached at 62a5ce98)]
$ ./freespace_planning_algorithms-test 
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from AstarSearchTestSuite
[ RUN      ] AstarSearchTestSuite.SingleCurvature
plan success : 182.233[msec]
=================================================================
==8630==ERROR: AddressSanitizer: heap-use-after-free on address 0x625001b5da60 at pc 0x7fa58c482633 bp 0x7fffb2bf5550 sp 0x7fffb2bf5540
READ of size 8 at 0x625001b5da60 thread T0
    #0 0x7fa58c482632 in freespace_planning_algorithms::AstarNode::cost() const (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x67632)
    #1 0x7fa58c482693 in freespace_planning_algorithms::NodeComparison::operator()(freespace_planning_algorithms::AstarNode const*, freespace_planning_algorithms::AstarNode const*) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x67693)
    #2 0x7fa58c48e1d7 in bool __gnu_cxx::__ops::_Iter_comp_val<freespace_planning_algorithms::NodeComparison>::operator()<__gnu_cxx::__normal_iterator<freespace_planning_algorithms::AstarNode**, std::vector<freespace_planning_algorithms::AstarNode*, std::allocator<freespace_planning_algorithms::AstarNode*> > >, freespace_planning_algorithms::AstarNode*>(__gnu_cxx::__normal_iterator<freespace_planning_algorithms::AstarNode**, std::vector<freespace_planning_algorithms::AstarNode*, std::allocator<freespace_planning_algorithms::AstarNode*> > >, freespace_planning_algorithms::AstarNode*&) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x731d7)
    #3 0x7fa58c48b678 in void std::__push_heap<__gnu_cxx::__normal_iterator<freespace_planning_algorithms::AstarNode**, std::vector<freespace_planning_algorithms::AstarNode*, std::allocator<freespace_planning_algorithms::AstarNode*> > >, long, freespace_planning_algorithms::AstarNode*, __gnu_cxx::__ops::_Iter_comp_val<freespace_planning_algorithms::NodeComparison> >(__gnu_cxx::__normal_iterator<freespace_planning_algorithms::AstarNode**, std::vector<freespace_planning_algorithms::AstarNode*, std::allocator<freespace_planning_algorithms::AstarNode*> > >, long, long, freespace_planning_algorithms::AstarNode*, __gnu_cxx::__ops::_Iter_comp_val<freespace_planning_algorithms::NodeComparison>&) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x70678)
    #4 0x7fa58c4879ef in void std::push_heap<__gnu_cxx::__normal_iterator<freespace_planning_algorithms::AstarNode**, std::vector<freespace_planning_algorithms::AstarNode*, std::allocator<freespace_planning_algorithms::AstarNode*> > >, freespace_planning_algorithms::NodeComparison>(__gnu_cxx::__normal_iterator<freespace_planning_algorithms::AstarNode**, std::vector<freespace_planning_algorithms::AstarNode*, std::allocator<freespace_planning_algorithms::AstarNode*> > >, __gnu_cxx::__normal_iterator<freespace_planning_algorithms::AstarNode**, std::vector<freespace_planning_algorithms::AstarNode*, std::allocator<freespace_planning_algorithms::AstarNode*> > >, freespace_planning_algorithms::NodeComparison) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x6c9ef)
    #5 0x7fa58c4844eb in std::priority_queue<freespace_planning_algorithms::AstarNode*, std::vector<freespace_planning_algorithms::AstarNode*, std::allocator<freespace_planning_algorithms::AstarNode*> >, freespace_planning_algorithms::NodeComparison>::push(freespace_planning_algorithms::AstarNode* const&) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x694eb)
    #6 0x7fa58c47d605 in freespace_planning_algorithms::AstarSearch::setStartNode() (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x62605)
    #7 0x7fa58c47d0eb in freespace_planning_algorithms::AstarSearch::makePlan(geometry_msgs::msg::Pose_<std::allocator<void> > const&, geometry_msgs::msg::Pose_<std::allocator<void> > const&) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x620eb)
    #8 0x55754764047b in test_astar(std::array<double, 3ul>, std::array<double, 3ul>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x2447b)
    #9 0x557547641886 in AstarSearchTestSuite_SingleCurvature_Test::TestBody() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x25886)
    #10 0x5575476c9c1a in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0xadc1a)
    #11 0x5575476ba119 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x9e119)
    #12 0x5575476615a9 in testing::Test::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x455a9)
    #13 0x557547662a2e in testing::TestInfo::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x46a2e)
    #14 0x557547663763 in testing::TestSuite::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x47763)
    #15 0x557547680247 in testing::internal::UnitTestImpl::RunAllTests() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x64247)
    #16 0x5575476ccb2e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0xb0b2e)
    #17 0x5575476bcd58 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0xa0d58)
    #18 0x55754767ccdb in testing::UnitTest::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x60cdb)
    #19 0x557547644fdf in RUN_ALL_TESTS() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x28fdf)
    #20 0x557547642df5 in main (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x26df5)
    #21 0x7fa58b5f70b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
    #22 0x55754763f13d in _start (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x2313d)

0x625001b5da60 is located 2400 bytes inside of 9216-byte region [0x625001b5d100,0x625001b5f500)
freed by thread T0 here:
    #0 0x7fa58c5c851f in operator delete(void*) ../../../../src/libsanitizer/asan/asan_new_delete.cc:165
    #1 0x55754764d5c9 in __gnu_cxx::new_allocator<freespace_planning_algorithms::AstarNode>::deallocate(freespace_planning_algorithms::AstarNode*, unsigned long) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x315c9)
    #2 0x55754764d58f in std::allocator_traits<std::allocator<freespace_planning_algorithms::AstarNode> >::deallocate(std::allocator<freespace_planning_algorithms::AstarNode>&, freespace_planning_algorithms::AstarNode*, unsigned long) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x3158f)
    #3 0x55754764d523 in std::_Vector_base<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >::_M_deallocate(freespace_planning_algorithms::AstarNode*, unsigned long) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x31523)
    #4 0x55754764d47d in std::_Vector_base<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >::~_Vector_base() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x3147d)
    #5 0x55754764d3d1 in std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >::~vector() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x313d1)
    #6 0x55754764d33f in void std::_Destroy<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > >(std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x3133f)
    #7 0x55754764d2ba in void std::_Destroy_aux<false>::__destroy<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*>(std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*, std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x312ba)
    #8 0x55754764d1ef in void std::_Destroy<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*>(std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*, std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x311ef)
    #9 0x55754764d0e8 in void std::_Destroy<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*, std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > >(std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*, std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >*, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > >&) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x310e8)
    #10 0x55754764cecb in std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >::~vector() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x30ecb)
    #11 0x55754764cd8d in void std::_Destroy<std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > > >(std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x30d8d)
    #12 0x55754764cc82 in void std::_Destroy_aux<false>::__destroy<std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*>(std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*, std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x30c82)
    #13 0x55754764cb09 in void std::_Destroy<std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*>(std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*, std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x30b09)
    #14 0x55754764c90a in void std::_Destroy<std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*, std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > > >(std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*, std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*, std::allocator<std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > > >&) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x3090a)
    #15 0x7fa58c486596 in std::vector<std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >, std::allocator<std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > > > >::_M_erase_at_end(std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >*) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x6b596)
    #16 0x7fa58c484282 in std::vector<std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > >, std::allocator<std::vector<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >, std::allocator<std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> > > > > >::clear() (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x69282)
    #17 0x7fa58c47ce12 in freespace_planning_algorithms::AstarSearch::setMap(nav_msgs::msg::OccupancyGrid_<std::allocator<void> > const&) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x61e12)
    #18 0x557547640235 in test_astar(std::array<double, 3ul>, std::array<double, 3ul>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x24235)
    #19 0x557547641886 in AstarSearchTestSuite_SingleCurvature_Test::TestBody() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x25886)
    #20 0x5575476c9c1a in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0xadc1a)
    #21 0x5575476ba119 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x9e119)
    #22 0x5575476615a9 in testing::Test::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x455a9)
    #23 0x557547662a2e in testing::TestInfo::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x46a2e)
    #24 0x557547663763 in testing::TestSuite::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x47763)
    #25 0x557547680247 in testing::internal::UnitTestImpl::RunAllTests() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x64247)
    #26 0x5575476ccb2e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0xb0b2e)
    #27 0x5575476bcd58 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0xa0d58)
    #28 0x55754767ccdb in testing::UnitTest::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x60cdb)
    #29 0x557547644fdf in RUN_ALL_TESTS() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x28fdf)

previously allocated by thread T0 here:
    #0 0x7fa58c5c7587 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cc:104
    #1 0x7fa58c48f5ce in __gnu_cxx::new_allocator<freespace_planning_algorithms::AstarNode>::allocate(unsigned long, void const*) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x745ce)
    #2 0x7fa58c48da04 in std::allocator_traits<std::allocator<freespace_planning_algorithms::AstarNode> >::allocate(std::allocator<freespace_planning_algorithms::AstarNode>&, unsigned long) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x72a04)
    #3 0x7fa58c48aaeb in std::_Vector_base<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >::_M_allocate(unsigned long) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x6faeb)
    #4 0x7fa58c487196 in std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >::_M_default_append(unsigned long) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x6c196)
    #5 0x7fa58c48443e in std::vector<freespace_planning_algorithms::AstarNode, std::allocator<freespace_planning_algorithms::AstarNode> >::resize(unsigned long) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x6943e)
    #6 0x7fa58c47cef8 in freespace_planning_algorithms::AstarSearch::setMap(nav_msgs::msg::OccupancyGrid_<std::allocator<void> > const&) (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x61ef8)
    #7 0x557547640235 in test_astar(std::array<double, 3ul>, std::array<double, 3ul>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x24235)
    #8 0x557547641886 in AstarSearchTestSuite_SingleCurvature_Test::TestBody() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x25886)
    #9 0x5575476c9c1a in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0xadc1a)
    #10 0x5575476ba119 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x9e119)
    #11 0x5575476615a9 in testing::Test::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x455a9)
    #12 0x557547662a2e in testing::TestInfo::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x46a2e)
    #13 0x557547663763 in testing::TestSuite::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x47763)
    #14 0x557547680247 in testing::internal::UnitTestImpl::RunAllTests() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x64247)
    #15 0x5575476ccb2e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0xb0b2e)
    #16 0x5575476bcd58 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0xa0d58)
    #17 0x55754767ccdb in testing::UnitTest::Run() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x60cdb)
    #18 0x557547644fdf in RUN_ALL_TESTS() (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x28fdf)
    #19 0x557547642df5 in main (/home/h-ishida/pilot-auto/build/freespace_planning_algorithms/freespace_planning_algorithms-test+0x26df5)
    #20 0x7fa58b5f70b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)

SUMMARY: AddressSanitizer: heap-use-after-free (/home/h-ishida/pilot-auto/install/freespace_planning_algorithms/lib/libfreespace_planning_algorithms.so+0x67632) in freespace_planning_algorithms::AstarNode::cost() const
Shadow bytes around the buggy address:
  0x0c4a80363af0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80363b00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80363b10: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80363b20: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80363b30: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c4a80363b40: fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd fd fd
  0x0c4a80363b50: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80363b60: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80363b70: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80363b80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80363b90: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==8630==ABORTING
```




## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
