### PR TITLE
feat(obstacle_avoidance_planner): explicitly insert zero velocity

### DIFF
--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/eb_path_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/eb_path_optimizer.hpp
@@ -46,7 +46,6 @@ private:
   struct Anchor
   {
     geometry_msgs::msg::Pose pose;
-    double velocity;
   };
 
   struct ConstrainRectangles

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -231,13 +231,6 @@ private:
 
   void calcOrientation(std::vector<ReferencePoint> & ref_points) const;
 
-  void calcVelocity(std::vector<ReferencePoint> & ref_points) const;
-
-  void calcVelocity(
-    std::vector<ReferencePoint> & ref_points,
-    const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
-    const double yaw_thresh) const;
-
   void calcCurvature(std::vector<ReferencePoint> & ref_points) const;
 
   void calcArcLength(std::vector<ReferencePoint> & ref_points) const;

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
@@ -49,7 +49,7 @@
 namespace
 {
 template <typename T>
-geometry_msgs::msg::Pose lerpPose(
+boost::optional<geometry_msgs::msg::Pose> lerpPose(
   const T & points, const geometry_msgs::msg::Point & target_pos, const size_t closest_seg_idx)
 {
   constexpr double epsilon = 1e-6;
@@ -70,6 +70,10 @@ geometry_msgs::msg::Pose lerpPose(
     interpolated_pose.orientation = next_pose.orientation;
   } else {
     const double ratio = closest_to_target_dist / seg_dist;
+    if (ratio < 0 || 1 < ratio) {
+      return {};
+    }
+
     interpolated_pose.position.x =
       interpolation::lerp(closest_pose.position.x, next_pose.position.x, ratio);
     interpolated_pose.position.y =

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
@@ -257,6 +257,10 @@ private:
   Trajectories getPrevTrajs(
     const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & path_points) const;
 
+  void calcVelocity(
+    const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & path_points,
+    std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & traj_points) const;
+
   void insertZeroVelocityOutsideDrivableArea(
     std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & traj_points,
     const CVMaps & cv_maps);

--- a/planning/obstacle_avoidance_planner/src/eb_path_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/eb_path_optimizer.cpp
@@ -354,8 +354,8 @@ int EBPathOptimizer::getNumFixedPoints(
 
 std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>
 EBPathOptimizer::convertOptimizedPointsToTrajectory(
-  const std::vector<double> optimized_points, const std::vector<ConstrainRectangle> & constraints,
-  const int farthest_idx)
+  const std::vector<double> optimized_points,
+  [[maybe_unused]] const std::vector<ConstrainRectangle> & constraints, const int farthest_idx)
 {
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> traj_points;
   for (int i = 0; i <= farthest_idx; i++) {

--- a/planning/obstacle_avoidance_planner/src/eb_path_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/eb_path_optimizer.cpp
@@ -362,7 +362,6 @@ EBPathOptimizer::convertOptimizedPointsToTrajectory(
     autoware_auto_planning_msgs::msg::TrajectoryPoint tmp_point;
     tmp_point.pose.position.x = optimized_points[i];
     tmp_point.pose.position.y = optimized_points[i + eb_param_.num_sampling_points_for_eb];
-    tmp_point.longitudinal_velocity_mps = constraints[i].velocity;
     traj_points.push_back(tmp_point);
   }
   for (size_t i = 0; i < traj_points.size(); i++) {
@@ -462,7 +461,6 @@ EBPathOptimizer::Anchor EBPathOptimizer::getAnchor(
   Anchor anchor;
   anchor.pose.position = interpolated_points[interpolated_idx];
   anchor.pose.orientation = nearest_q;
-  anchor.velocity = path_points[nearest_idx].longitudinal_velocity_mps;
   return anchor;
 }
 
@@ -595,7 +593,6 @@ ConstrainRectangle EBPathOptimizer::getConstrainRectangle(
   bottom_right.y = -1 * clearance;
   constrain_range.bottom_right =
     geometry_utils::transformToAbsoluteCoordinate2D(bottom_right, anchor.pose);
-  constrain_range.velocity = anchor.velocity;
   return constrain_range;
 }
 
@@ -608,6 +605,5 @@ ConstrainRectangle EBPathOptimizer::getConstrainRectangle(
   rect.top_right = tier4_autoware_utils::calcOffsetPose(anchor.pose, max_x, min_y, 0.0).position;
   rect.bottom_left = tier4_autoware_utils::calcOffsetPose(anchor.pose, min_x, max_y, 0.0).position;
   rect.bottom_right = tier4_autoware_utils::calcOffsetPose(anchor.pose, min_x, min_y, 0.0).position;
-  rect.velocity = anchor.velocity;
   return rect;
 }

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -338,7 +338,6 @@ std::vector<ReferencePoint> MPTOptimizer::getReferencePoints(
     // set some information to reference points considering fix kinematics
     trimPoints(ref_points);
     calcOrientation(ref_points);
-    calcVelocity(ref_points, smoothed_points, traj_param_.delta_yaw_threshold_for_closest_point);
     calcCurvature(ref_points);
     calcArcLength(ref_points);
     calcPlanningFromEgo(
@@ -1146,7 +1145,6 @@ std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> MPTOptimizer::get
     autoware_auto_planning_msgs::msg::TrajectoryPoint traj_point;
     traj_point.pose = calcVehiclePose(ref_point, lat_error, yaw_error, 0.0);
 
-    traj_point.longitudinal_velocity_mps = ref_point.v;
     traj_points.push_back(traj_point);
 
     {  // for debug visualization
@@ -1214,42 +1212,6 @@ void MPTOptimizer::calcOrientation(std::vector<ReferencePoint> & ref_points) con
     }
 
     ref_points.at(i).yaw = yaw_angles.at(i);
-  }
-}
-
-void MPTOptimizer::calcVelocity(
-  std::vector<ReferencePoint> & ref_points,
-  const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & points,
-  const double yaw_thresh) const
-{
-  const auto ref_points_with_yaw =
-    points_utils::convertToPosesWithYawEstimation(points_utils::convertToPoints(ref_points));
-  for (size_t i = 0; i < ref_points.size(); i++) {
-    const size_t nearest_ref_idx = findNearestIndexWithSoftYawConstraints(
-      points_utils::convertToPoints(points), ref_points_with_yaw.at(i), yaw_thresh);
-    const size_t second_nearest_ref_idx = [&]() -> size_t {
-      if (nearest_ref_idx == 0) {
-        return 1;
-      } else if (nearest_ref_idx == points.size() - 1) {
-        return points.size() - 2;
-      }
-
-      const double prev_dist = tier4_autoware_utils::calcDistance2d(
-        ref_points_with_yaw.at(i), points.at(nearest_ref_idx - 1));
-      const double next_dist = tier4_autoware_utils::calcDistance2d(
-        ref_points_with_yaw.at(i), points.at(nearest_ref_idx + 1));
-      if (prev_dist < next_dist) {
-        return nearest_ref_idx - 1;
-      }
-      return nearest_ref_idx + 1;
-    }();
-
-    // NOTE: std::max, not std::min, is used here since ref_points' sampling width may be longer
-    // than points' sampling width. A zero velocity point is guaranteed to be inserted in an output
-    // trajectory in the alignVelocity function in ObstacleAvoidancePlanner.
-    ref_points.at(i).v = std::max(
-      points.at(nearest_ref_idx).longitudinal_velocity_mps,
-      points.at(second_nearest_ref_idx).longitudinal_velocity_mps);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
In obstacle avoidance planner, a stop point is not explicitly inserted in an output trajectory.
Therefore the stop point changes a little bit comparing before and after obstacle avoidance planner.

In this PR, I inserted the stop point in the output trajectory.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
