### PR TITLE
fix: replace boost::mutex::scoped_lock to std::scoped_lock

### DIFF
--- a/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
@@ -43,7 +43,7 @@ void DistanceBasedCompareMapFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   if (map_ptr_ == NULL || tree_ == NULL) {
     output = *input;
     return;
@@ -65,7 +65,7 @@ void DistanceBasedCompareMapFilterComponent::input_target_callback(const PointCl
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
   const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   map_ptr_ = map_pcl_ptr;
   tf_input_frame_ = map_ptr_->header.frame_id;
   if (!tree_) {
@@ -81,7 +81,7 @@ void DistanceBasedCompareMapFilterComponent::input_target_callback(const PointCl
 rcl_interfaces::msg::SetParametersResult DistanceBasedCompareMapFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "distance_threshold", distance_threshold_)) {
     RCLCPP_DEBUG(get_logger(), "Setting new distance threshold to: %f.", distance_threshold_);

--- a/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
@@ -45,7 +45,7 @@ void VoxelBasedApproximateCompareMapFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   if (voxel_map_ptr_ == NULL) {
     output = *input;
     return;
@@ -74,7 +74,7 @@ void VoxelBasedApproximateCompareMapFilterComponent::input_target_callback(
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
   const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   set_map_in_voxel_grid_ = true;
   tf_input_frame_ = map_pcl_ptr->header.frame_id;
   voxel_map_ptr_.reset(new pcl::PointCloud<pcl::PointXYZ>);
@@ -88,7 +88,7 @@ rcl_interfaces::msg::SetParametersResult
 VoxelBasedApproximateCompareMapFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "distance_threshold", distance_threshold_)) {
     voxel_grid_.setLeafSize(distance_threshold_, distance_threshold_, distance_threshold_);

--- a/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
@@ -45,7 +45,7 @@ void VoxelBasedCompareMapFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   if (voxel_map_ptr_ == NULL) {
     output = *input;
     return;
@@ -241,7 +241,7 @@ void VoxelBasedCompareMapFilterComponent::input_target_callback(const PointCloud
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
   const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   set_map_in_voxel_grid_ = true;
   tf_input_frame_ = map_pcl_ptr->header.frame_id;
   voxel_map_ptr_.reset(new pcl::PointCloud<pcl::PointXYZ>);
@@ -254,7 +254,7 @@ void VoxelBasedCompareMapFilterComponent::input_target_callback(const PointCloud
 rcl_interfaces::msg::SetParametersResult VoxelBasedCompareMapFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "distance_threshold", distance_threshold_)) {
     voxel_grid_.setLeafSize(distance_threshold_, distance_threshold_, distance_threshold_);

--- a/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
@@ -43,7 +43,7 @@ void VoxelDistanceBasedCompareMapFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   if (voxel_map_ptr_ == NULL || map_ptr_ == NULL || tree_ == NULL) {
     output = *input;
     return;
@@ -76,7 +76,7 @@ void VoxelDistanceBasedCompareMapFilterComponent::input_target_callback(
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
   const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   tf_input_frame_ = map_pcl_ptr->header.frame_id;
   // voxel
   voxel_map_ptr_.reset(new pcl::PointCloud<pcl::PointXYZ>);
@@ -99,7 +99,7 @@ void VoxelDistanceBasedCompareMapFilterComponent::input_target_callback(
 rcl_interfaces::msg::SetParametersResult VoxelDistanceBasedCompareMapFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "distance_threshold", distance_threshold_)) {
     voxel_grid_.setLeafSize(distance_threshold_, distance_threshold_, distance_threshold_);

--- a/perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp
@@ -231,7 +231,7 @@ void RANSACGroundFilterComponent::filter(
   const PointCloud2::ConstSharedPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   sensor_msgs::msg::PointCloud2::SharedPtr input_transformed_ptr(new sensor_msgs::msg::PointCloud2);
   if (!transformPointCloud(base_frame_, input, input_transformed_ptr)) {
     RCLCPP_ERROR_STREAM_THROTTLE(
@@ -322,7 +322,7 @@ void RANSACGroundFilterComponent::filter(
 rcl_interfaces::msg::SetParametersResult RANSACGroundFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "base_frame", base_frame_)) {
     RCLCPP_DEBUG(get_logger(), "Setting base_frame to: %s.", base_frame_.c_str());

--- a/perception/ground_segmentation/src/ray_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/ray_ground_filter_nodelet.cpp
@@ -310,7 +310,7 @@ void RayGroundFilterComponent::filter(
   const PointCloud2::ConstSharedPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   sensor_msgs::msg::PointCloud2::SharedPtr input_transformed_ptr(new sensor_msgs::msg::PointCloud2);
   bool succeeded = TransformPointCloud(base_frame_, input, input_transformed_ptr);
@@ -366,7 +366,7 @@ void RayGroundFilterComponent::filter(
 rcl_interfaces::msg::SetParametersResult RayGroundFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "min_x", min_x_)) {
     RCLCPP_DEBUG(get_logger(), "Setting min_x to: %f.", min_x_);

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/filter.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/filter.hpp
@@ -167,7 +167,7 @@ protected:
   std::string tf_output_frame_;
 
   /** \brief Internal mutex. */
-  boost::mutex mutex_;
+  std::mutex mutex_;
 
   /** \brief Virtual abstract filter method. To be implemented by every child.
    * \param input the input point cloud dataset.

--- a/sensing/pointcloud_preprocessor/src/blockage_diag/blockage_diag_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/blockage_diag/blockage_diag_nodelet.cpp
@@ -106,7 +106,7 @@ void BlockageDiagComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   uint horizontal_bins = static_cast<uint>((angle_range_deg_[1] - angle_range_deg_[0]));
   uint vertical_bins = vertical_bins_;
   pcl::PointCloud<PointXYZIRADRT>::Ptr pcl_input(new pcl::PointCloud<PointXYZIRADRT>);
@@ -224,7 +224,7 @@ void BlockageDiagComponent::filter(
 rcl_interfaces::msg::SetParametersResult BlockageDiagComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   if (get_param(p, "blockage_ratio_threshold", blockage_ratio_threshold_)) {
     RCLCPP_DEBUG(
       get_logger(), "Setting new blockage_ratio_threshold to: %f.", blockage_ratio_threshold_);

--- a/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
@@ -90,7 +90,7 @@ void CropBoxFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   output.data.resize(input->data.size());
   Eigen::Vector3f pt(Eigen::Vector3f::Zero());
@@ -188,7 +188,7 @@ void CropBoxFilterComponent::publishCropBoxPolygon()
 rcl_interfaces::msg::SetParametersResult CropBoxFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   CropBoxParam new_param{};
 

--- a/sensing/pointcloud_preprocessor/src/downsample_filter/approximate_downsample_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/downsample_filter/approximate_downsample_filter_nodelet.cpp
@@ -77,7 +77,7 @@ ApproximateDownsampleFilterComponent::ApproximateDownsampleFilterComponent(
 void ApproximateDownsampleFilterComponent::filter(
   const PointCloud2ConstPtr & input, const IndicesPtr & /*indices*/, PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::fromROSMsg(*input, *pcl_input);
@@ -94,7 +94,7 @@ void ApproximateDownsampleFilterComponent::filter(
 rcl_interfaces::msg::SetParametersResult ApproximateDownsampleFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "voxel_size_x", voxel_size_x_)) {
     RCLCPP_DEBUG(get_logger(), "Setting new distance threshold to: %f.", voxel_size_x_);

--- a/sensing/pointcloud_preprocessor/src/downsample_filter/random_downsample_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/downsample_filter/random_downsample_filter_nodelet.cpp
@@ -69,7 +69,7 @@ RandomDownsampleFilterComponent::RandomDownsampleFilterComponent(
 void RandomDownsampleFilterComponent::filter(
   const PointCloud2ConstPtr & input, const IndicesPtr & /*indices*/, PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::fromROSMsg(*input, *pcl_input);
@@ -87,7 +87,7 @@ void RandomDownsampleFilterComponent::filter(
 rcl_interfaces::msg::SetParametersResult RandomDownsampleFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "sample_num", sample_num_)) {
     RCLCPP_DEBUG(get_logger(), "Setting new sample num to: %zu.", sample_num_);

--- a/sensing/pointcloud_preprocessor/src/downsample_filter/voxel_grid_downsample_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/downsample_filter/voxel_grid_downsample_filter_nodelet.cpp
@@ -77,7 +77,7 @@ VoxelGridDownsampleFilterComponent::VoxelGridDownsampleFilterComponent(
 void VoxelGridDownsampleFilterComponent::filter(
   const PointCloud2ConstPtr & input, const IndicesPtr & /*indices*/, PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::fromROSMsg(*input, *pcl_input);
@@ -95,7 +95,7 @@ void VoxelGridDownsampleFilterComponent::filter(
 rcl_interfaces::msg::SetParametersResult VoxelGridDownsampleFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "voxel_size_x", voxel_size_x_)) {
     RCLCPP_DEBUG(get_logger(), "Setting new distance threshold to: %f.", voxel_size_x_);

--- a/sensing/pointcloud_preprocessor/src/filter.cpp
+++ b/sensing/pointcloud_preprocessor/src/filter.cpp
@@ -210,7 +210,7 @@ void pointcloud_preprocessor::Filter::computePublish(
 rcl_interfaces::msg::SetParametersResult pointcloud_preprocessor::Filter::filterParamCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "input_frame", tf_input_frame_)) {
     RCLCPP_DEBUG(get_logger(), "Setting the input TF frame to: %s.", tf_input_frame_.c_str());

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/dual_return_outlier_filter_nodelet.cpp
@@ -115,7 +115,7 @@ void DualReturnOutlierFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   pcl::PointCloud<PointXYZIRADRT>::Ptr pcl_input(new pcl::PointCloud<PointXYZIRADRT>);
   pcl::fromROSMsg(*input, *pcl_input);
 
@@ -349,7 +349,7 @@ void DualReturnOutlierFilterComponent::filter(
 rcl_interfaces::msg::SetParametersResult DualReturnOutlierFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "weak_first_distance_ratio", weak_first_distance_ratio_)) {
     RCLCPP_DEBUG(

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/radius_search_2d_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/radius_search_2d_outlier_filter_nodelet.cpp
@@ -43,7 +43,7 @@ void RadiusSearch2DOutlierFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   pcl::PointCloud<pcl::PointXYZ>::Ptr xyz_cloud(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::fromROSMsg(*input, *xyz_cloud);
 
@@ -71,7 +71,7 @@ void RadiusSearch2DOutlierFilterComponent::filter(
 rcl_interfaces::msg::SetParametersResult RadiusSearch2DOutlierFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "min_neighbors", min_neighbors_)) {
     RCLCPP_DEBUG(get_logger(), "Setting new min neighbors to: %zu.", min_neighbors_);

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -38,7 +38,7 @@ void RingOutlierFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   std::unordered_map<uint16_t, std::vector<std::size_t>> input_ring_map;
   input_ring_map.reserve(128);
   sensor_msgs::msg::PointCloud2::SharedPtr input_ptr =
@@ -114,7 +114,7 @@ void RingOutlierFilterComponent::filter(
 rcl_interfaces::msg::SetParametersResult RingOutlierFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "distance_ratio", distance_ratio_)) {
     RCLCPP_DEBUG(get_logger(), "Setting new distance ratio to: %f.", distance_ratio_);

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/voxel_grid_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/voxel_grid_outlier_filter_nodelet.cpp
@@ -42,7 +42,7 @@ void VoxelGridOutlierFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_voxelized_input(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
@@ -70,7 +70,7 @@ void VoxelGridOutlierFilterComponent::filter(
 rcl_interfaces::msg::SetParametersResult VoxelGridOutlierFilterComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "voxel_size_x", voxel_size_x_)) {
     RCLCPP_DEBUG(get_logger(), "Setting new distance threshold to: %f.", voxel_size_x_);

--- a/sensing/pointcloud_preprocessor/src/passthrough_filter/passthrough_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/passthrough_filter/passthrough_filter_nodelet.cpp
@@ -70,14 +70,14 @@ void PassThroughFilterComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   output = *input;
 }
 
 rcl_interfaces::msg::SetParametersResult PassThroughFilterComponent::paramCallback(
   [[maybe_unused]] const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   // write me
 

--- a/sensing/pointcloud_preprocessor/src/passthrough_filter/passthrough_filter_uint16_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/passthrough_filter/passthrough_filter_uint16_nodelet.cpp
@@ -48,7 +48,7 @@ PassThroughFilterUInt16Component::PassThroughFilterUInt16Component(
 void PassThroughFilterUInt16Component::filter(
   const PointCloud2ConstPtr & input, const IndicesPtr & indices, PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
   pcl_conversions::toPCL(*(input), *(pcl_input));
@@ -62,7 +62,7 @@ void PassThroughFilterUInt16Component::filter(
 rcl_interfaces::msg::SetParametersResult PassThroughFilterUInt16Component::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   std::uint16_t filter_min, filter_max;
   impl_.getFilterLimits(filter_min, filter_max);

--- a/sensing/pointcloud_preprocessor/src/pointcloud_accumulator/pointcloud_accumulator_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/pointcloud_accumulator/pointcloud_accumulator_nodelet.cpp
@@ -37,7 +37,7 @@ void PointcloudAccumulatorComponent::filter(
   const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
   PointCloud2 & output)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
   pointcloud_buffer_.push_front(input);
   rclcpp::Time last_time = input->header.stamp;
   pcl::PointCloud<pcl::PointXYZ> pcl_input;
@@ -56,7 +56,7 @@ void PointcloudAccumulatorComponent::filter(
 rcl_interfaces::msg::SetParametersResult PointcloudAccumulatorComponent::paramCallback(
   const std::vector<rclcpp::Parameter> & p)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::scoped_lock lock(mutex_);
 
   if (get_param(p, "accumulation_time_sec", accumulation_time_sec_)) {
     RCLCPP_DEBUG(get_logger(), "Setting new accumulation time to: %f.", accumulation_time_sec_);


### PR DESCRIPTION
## Description

Replace boost::mutex::scoped_lock to std::scoped_lock available from c++17.

## Pre-review checklist for the PR author

https://github.com/orgs/autowarefoundation/discussions/293

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
