### PR TITLE
feat(obstacle_avoidance_planner): some fix for narrow driving

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -83,28 +83,6 @@
 
     # advanced parameters to improve performance as much as possible
     advanced:
-      option:
-        # check if planned trajectory is outside drivable area
-        drivability_check:
-          # true: vehicle shape is considered as a set of circles
-          # false: vehicle shape is considered as footprint (= rectangle)
-          use_vehicle_circles: false
-
-          # parameters only when use_vehicle_circles is true
-          vehicle_circles:
-            use_manual_vehicle_circles: false
-            num_for_constraints: 4
-
-            # parameters only when use_manual_vehicle_circles is true
-            longitudinal_offsets: [-0.15, 0.88, 1.9, 2.95]
-            radius: 0.95
-
-            # parameters only when use_manual_vehicle_circles is false
-            radius_ratio: 0.9
-            # If this parameter is commented out, the parameter is calculated automatically
-            # based on the vehicle length and width
-            # num_for_radius: 4
-
       eb:
         common:
           num_joint_buffer_points: 3 # number of joint buffer points
@@ -161,15 +139,13 @@
             # two_step_soft_constraint: false
 
           vehicle_circles:
-            use_manual_vehicle_circles: false
-            num_for_constraints: 3
+            method: "rear_drive"
 
-            # parameters only when use_manual_vehicle_circles is true
-            longitudinal_offsets: [-0.15, 0.88, 1.9, 2.95]
-            radius: 0.95
+            uniform_circle:
+              num: 3
+              radius_ratio: 0.8
 
-            # parameters only when use_manual_vehicle_circles is false
-            radius_ratio: 0.8
-            # If this parameter is commented out, the parameter is calculated automatically
-            # based on the vehicle length and width
-            # num_for_radius: 4
+            rear_drive:
+              num_for_calculation: 3
+              front_radius_ratio: 1.0
+              rear_radius_ratio: 1.0

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -83,28 +83,6 @@
 
     # advanced parameters to improve performance as much as possible
     advanced:
-      option:
-        # check if planned trajectory is outside drivable area
-        drivability_check:
-          # true: vehicle shape is considered as a set of circles
-          # false: vehicle shape is considered as footprint (= rectangle)
-          use_vehicle_circles: false
-
-          # parameters only when use_vehicle_circles is true
-          vehicle_circles:
-            use_manual_vehicle_circles: false
-            num_for_constraints: 4
-
-            # parameters only when use_manual_vehicle_circles is true
-            longitudinal_offsets: [-0.15, 0.88, 1.9, 2.95]
-            radius: 0.95
-
-            # parameters only when use_manual_vehicle_circles is false
-            radius_ratio: 0.9
-            # If this parameter is commented out, the parameter is calculated automatically
-            # based on the vehicle length and width
-            # num_for_radius: 4
-
       eb:
         common:
           num_joint_buffer_points: 3 # number of joint buffer points

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -161,15 +161,13 @@
             # two_step_soft_constraint: false
 
           vehicle_circles:
-            use_manual_vehicle_circles: false
-            num_for_constraints: 3
+            method: "rear_drive"
 
-            # parameters only when use_manual_vehicle_circles is true
-            longitudinal_offsets: [-0.15, 0.88, 1.9, 2.95]
-            radius: 0.95
+            uniform_circle:
+              num: 3
+              radius_ratio: 0.8
 
-            # parameters only when use_manual_vehicle_circles is false
-            radius_ratio: 0.8
-            # If this parameter is commented out, the parameter is calculated automatically
-            # based on the vehicle length and width
-            # num_for_radius: 4
+            rear_drive:
+              num_for_calculation: 3
+              front_radius_ratio: 1.0
+              rear_radius_ratio: 1.0

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
@@ -126,20 +126,20 @@ struct DebugData
   void init(
     const bool local_is_showing_calculation_time, const int local_mpt_visualize_sampling_num,
     const geometry_msgs::msg::Pose & local_current_ego_pose,
-    const double local_vehicle_circle_radius,
+    const std::vector<double> & local_vehicle_circle_radiuses,
     const std::vector<double> & local_vehicle_circle_longitudinal_offsets)
   {
     msg_stream.is_showing_calculation_time = local_is_showing_calculation_time;
     mpt_visualize_sampling_num = local_mpt_visualize_sampling_num;
     current_ego_pose = local_current_ego_pose;
-    vehicle_circle_radius = local_vehicle_circle_radius;
+    vehicle_circle_radiuses = local_vehicle_circle_radiuses;
     vehicle_circle_longitudinal_offsets = local_vehicle_circle_longitudinal_offsets;
   }
 
   StreamWithPrint msg_stream;
   size_t mpt_visualize_sampling_num;
   geometry_msgs::msg::Pose current_ego_pose;
-  double vehicle_circle_radius;
+  std::vector<double> vehicle_circle_radiuses;
   std::vector<double> vehicle_circle_longitudinal_offsets;
 
   boost::optional<geometry_msgs::msg::Pose> stop_pose_by_drivable_area = boost::none;
@@ -212,7 +212,7 @@ struct MPTParam
   int num_curvature_sampling_points;
 
   std::vector<double> vehicle_circle_longitudinal_offsets;  // from base_link
-  double vehicle_circle_radius;
+  std::vector<double> vehicle_circle_radiuses;
 
   double delta_arc_length_for_mpt_points;
 

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -219,6 +219,7 @@ private:
 
   void calcBounds(
     std::vector<ReferencePoint> & ref_points, const bool enable_avoidance, const CVMaps & maps,
+    const std::unique_ptr<Trajectories> & prev_trajs,
     std::shared_ptr<DebugData> debug_data_ptr) const;
 
   void calcVehicleBounds(

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
@@ -43,6 +43,7 @@
 #include "boost/optional.hpp"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace
@@ -114,6 +115,7 @@ private:
   bool reset_prev_optimization_;
 
   // vehicle circles info for for mpt constraints
+  std::string vehicle_circle_method_;
   int vehicle_circle_num_for_calculation_;
   std::vector<double> vehicle_circle_radius_ratios_;
 

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
@@ -113,20 +113,9 @@ private:
   bool skip_optimization_;
   bool reset_prev_optimization_;
 
-  // vehicle circles info for drivability check
-  bool use_vehicle_circles_for_drivability_;
-  bool use_manual_vehicle_circles_for_drivability_;
-  int vehicle_circle_constraints_num_for_drivability_;
-  int vehicle_circle_radius_num_for_drivability_;
-  double vehicle_circle_radius_ratio_for_drivability_;
-  double vehicle_circle_radius_for_drivability_;
-  std::vector<double> vehicle_circle_longitudinal_offsets_for_drivability_;
-
   // vehicle circles info for for mpt constraints
-  bool use_manual_vehicle_circles_for_mpt_;
-  int vehicle_circle_constraints_num_for_mpt_;
-  int vehicle_circle_radius_num_for_mpt_;
-  double vehicle_circle_radius_ratio_for_mpt_;
+  int vehicle_circle_num_for_calculation_;
+  std::vector<double> vehicle_circle_radius_ratios_;
 
   // params for replan
   double max_path_shape_change_dist_for_replan_;

--- a/planning/obstacle_avoidance_planner/src/cv_utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/cv_utils.cpp
@@ -441,7 +441,7 @@ bool isOutsideDrivableAreaFromRectangleFootprint(
   return false;
 }
 
-bool isOutsideDrivableAreaFromCirclesFootprint(
+[[maybe_unused]] bool isOutsideDrivableAreaFromCirclesFootprint(
   const autoware_auto_planning_msgs::msg::TrajectoryPoint & traj_point,
   const cv::Mat & road_clearance_map, const nav_msgs::msg::MapMetaData & map_info,
   const std::vector<double> vehicle_circle_longitudinal_offsets, const double vehicle_circle_radius)

--- a/planning/obstacle_avoidance_planner/src/debug_visualization.cpp
+++ b/planning/obstacle_avoidance_planner/src/debug_visualization.cpp
@@ -484,7 +484,7 @@ visualization_msgs::msg::MarkerArray getBoundsCandidatesLineMarkerArray(
 
 visualization_msgs::msg::MarkerArray getBoundsLineMarkerArray(
   const std::vector<ReferencePoint> & ref_points, const double r, const double g, const double b,
-  const double vehicle_circle_radius, const size_t sampling_num)
+  const double vehicle_width, const size_t sampling_num)
 {
   const auto current_time = rclcpp::Clock().now();
   visualization_msgs::msg::MarkerArray msg;
@@ -507,7 +507,7 @@ visualization_msgs::msg::MarkerArray getBoundsLineMarkerArray(
 
         const geometry_msgs::msg::Pose & pose = ref_points.at(i).vehicle_bounds_poses.at(bound_idx);
         const double lb_y =
-          ref_points.at(i).vehicle_bounds[bound_idx].lower_bound - vehicle_circle_radius;
+          ref_points.at(i).vehicle_bounds[bound_idx].lower_bound - vehicle_width / 2.0;
         const auto lb = tier4_autoware_utils::calcOffsetPose(pose, 0.0, lb_y, 0.0).position;
 
         marker.points.push_back(pose.position);
@@ -529,7 +529,7 @@ visualization_msgs::msg::MarkerArray getBoundsLineMarkerArray(
 
         const geometry_msgs::msg::Pose & pose = ref_points.at(i).vehicle_bounds_poses.at(bound_idx);
         const double ub_y =
-          ref_points.at(i).vehicle_bounds[bound_idx].upper_bound + vehicle_circle_radius;
+          ref_points.at(i).vehicle_bounds[bound_idx].upper_bound + vehicle_width / 2.0;
         const auto ub = tier4_autoware_utils::calcOffsetPose(pose, 0.0, ub_y, 0.0).position;
 
         marker.points.push_back(pose.position);
@@ -544,7 +544,7 @@ visualization_msgs::msg::MarkerArray getBoundsLineMarkerArray(
 
 visualization_msgs::msg::MarkerArray getVehicleCircleLineMarkerArray(
   const std::vector<std::vector<geometry_msgs::msg::Pose>> & vehicle_circles_pose,
-  const double vehicle_circle_radius, const size_t sampling_num, const std::string & ns,
+  const double vehicle_width, const size_t sampling_num, const std::string & ns,
   const double r, const double g, const double b)
 {
   const auto current_time = rclcpp::Clock().now();
@@ -563,9 +563,9 @@ visualization_msgs::msg::MarkerArray getVehicleCircleLineMarkerArray(
     for (size_t j = 0; j < vehicle_circles_pose.at(i).size(); ++j) {
       const geometry_msgs::msg::Pose & pose = vehicle_circles_pose.at(i).at(j);
       const auto ub =
-        tier4_autoware_utils::calcOffsetPose(pose, 0.0, vehicle_circle_radius, 0.0).position;
+        tier4_autoware_utils::calcOffsetPose(pose, 0.0, vehicle_width / 2.0, 0.0).position;
       const auto lb =
-        tier4_autoware_utils::calcOffsetPose(pose, 0.0, -vehicle_circle_radius, 0.0).position;
+        tier4_autoware_utils::calcOffsetPose(pose, 0.0, -vehicle_width / 2.0, 0.0).position;
 
       marker.points.push_back(ub);
       marker.points.push_back(lb);
@@ -605,13 +605,15 @@ visualization_msgs::msg::MarkerArray getLateralErrorsLineMarkerArray(
 visualization_msgs::msg::MarkerArray getCurrentVehicleCirclesMarkerArray(
   const geometry_msgs::msg::Pose & current_ego_pose,
   const std::vector<double> & vehicle_circle_longitudinal_offsets,
-  const double vehicle_circle_radius, const std::string & ns, const double r, const double g,
+  const std::vector<double> & vehicle_circle_radiuses, const std::string & ns, const double r, const double g,
   const double b)
 {
   visualization_msgs::msg::MarkerArray msg;
 
   size_t id = 0;
-  for (const double offset : vehicle_circle_longitudinal_offsets) {
+  for (size_t v_idx = 0; v_idx < vehicle_circle_longitudinal_offsets.size(); ++v_idx) {
+    const double offset = vehicle_circle_longitudinal_offsets.at(v_idx);
+
     auto marker = createDefaultMarker(
       "map", rclcpp::Clock().now(), ns, id, visualization_msgs::msg::Marker::LINE_STRIP,
       createMarkerScale(0.05, 0.0, 0.0), createMarkerColor(r, g, b, 0.8));
@@ -624,8 +626,8 @@ visualization_msgs::msg::MarkerArray getCurrentVehicleCirclesMarkerArray(
 
       const double edge_angle =
         static_cast<double>(e_idx) / static_cast<double>(circle_dividing_num) * 2.0 * M_PI;
-      edge_pos.x = vehicle_circle_radius * std::cos(edge_angle);
-      edge_pos.y = vehicle_circle_radius * std::sin(edge_angle);
+      edge_pos.x = vehicle_circle_radiuses.at(v_idx) * std::cos(edge_angle);
+      edge_pos.y = vehicle_circle_radiuses.at(v_idx) * std::sin(edge_angle);
 
       marker.points.push_back(edge_pos);
     }
@@ -639,7 +641,7 @@ visualization_msgs::msg::MarkerArray getCurrentVehicleCirclesMarkerArray(
 visualization_msgs::msg::MarkerArray getVehicleCirclesMarkerArray(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & mpt_traj_points,
   const std::vector<double> & vehicle_circle_longitudinal_offsets,
-  const double vehicle_circle_radius, const size_t sampling_num, const std::string & ns,
+  const std::vector<double> & vehicle_circle_radiuses, const size_t sampling_num, const std::string & ns,
   const double r, const double g, const double b)
 {
   visualization_msgs::msg::MarkerArray msg;
@@ -651,7 +653,9 @@ visualization_msgs::msg::MarkerArray getVehicleCirclesMarkerArray(
     }
     const auto & mpt_traj_point = mpt_traj_points.at(i);
 
-    for (const double offset : vehicle_circle_longitudinal_offsets) {
+    for (size_t v_idx = 0; v_idx < vehicle_circle_longitudinal_offsets.size(); ++v_idx) {
+      const double offset = vehicle_circle_longitudinal_offsets.at(v_idx);
+
       auto marker = createDefaultMarker(
         "map", rclcpp::Clock().now(), ns, id, visualization_msgs::msg::Marker::LINE_STRIP,
         createMarkerScale(0.05, 0.0, 0.0), createMarkerColor(r, g, b, 0.8));
@@ -664,8 +668,8 @@ visualization_msgs::msg::MarkerArray getVehicleCirclesMarkerArray(
 
         const double edge_angle =
           static_cast<double>(e_idx) / static_cast<double>(circle_dividing_num) * 2.0 * M_PI;
-        edge_pos.x = vehicle_circle_radius * std::cos(edge_angle);
-        edge_pos.y = vehicle_circle_radius * std::sin(edge_angle);
+        edge_pos.x = vehicle_circle_radiuses.at(v_idx) * std::cos(edge_angle);
+        edge_pos.y = vehicle_circle_radiuses.at(v_idx) * std::sin(edge_angle);
 
         marker.points.push_back(edge_pos);
       }
@@ -754,7 +758,7 @@ visualization_msgs::msg::MarkerArray getDebugVisualizationMarker(
   // bounds
   appendMarkerArray(
     getBoundsLineMarkerArray(
-      debug_data_ptr->ref_points, 0.99, 0.99, 0.2, debug_data_ptr->vehicle_circle_radius,
+      debug_data_ptr->ref_points, 0.99, 0.99, 0.2, vehicle_param.width,
       debug_data_ptr->mpt_visualize_sampling_num),
     &vis_marker_array);
 
@@ -770,7 +774,7 @@ visualization_msgs::msg::MarkerArray getDebugVisualizationMarker(
   // vehicle circle line
   appendMarkerArray(
     getVehicleCircleLineMarkerArray(
-      debug_data_ptr->vehicle_circles_pose, debug_data_ptr->vehicle_circle_radius,
+      debug_data_ptr->vehicle_circles_pose, vehicle_param.width,
       debug_data_ptr->mpt_visualize_sampling_num, "vehicle_circle_lines", 0.99, 0.99, 0.2),
     &vis_marker_array);
 
@@ -785,14 +789,14 @@ visualization_msgs::msg::MarkerArray getDebugVisualizationMarker(
   appendMarkerArray(
     getCurrentVehicleCirclesMarkerArray(
       debug_data_ptr->current_ego_pose, debug_data_ptr->vehicle_circle_longitudinal_offsets,
-      debug_data_ptr->vehicle_circle_radius, "current_vehicle_circles", 1.0, 0.3, 0.3),
+      debug_data_ptr->vehicle_circle_radiuses, "current_vehicle_circles", 1.0, 0.3, 0.3),
     &vis_marker_array);
 
   // vehicle circles
   appendMarkerArray(
     getVehicleCirclesMarkerArray(
       debug_data_ptr->mpt_traj, debug_data_ptr->vehicle_circle_longitudinal_offsets,
-      debug_data_ptr->vehicle_circle_radius, debug_data_ptr->mpt_visualize_sampling_num,
+      debug_data_ptr->vehicle_circle_radiuses, debug_data_ptr->mpt_visualize_sampling_num,
       "vehicle_circles", 1.0, 0.3, 0.3),
     &vis_marker_array);
 

--- a/planning/obstacle_avoidance_planner/src/debug_visualization.cpp
+++ b/planning/obstacle_avoidance_planner/src/debug_visualization.cpp
@@ -544,8 +544,8 @@ visualization_msgs::msg::MarkerArray getBoundsLineMarkerArray(
 
 visualization_msgs::msg::MarkerArray getVehicleCircleLineMarkerArray(
   const std::vector<std::vector<geometry_msgs::msg::Pose>> & vehicle_circles_pose,
-  const double vehicle_width, const size_t sampling_num, const std::string & ns,
-  const double r, const double g, const double b)
+  const double vehicle_width, const size_t sampling_num, const std::string & ns, const double r,
+  const double g, const double b)
 {
   const auto current_time = rclcpp::Clock().now();
   visualization_msgs::msg::MarkerArray msg;
@@ -605,8 +605,8 @@ visualization_msgs::msg::MarkerArray getLateralErrorsLineMarkerArray(
 visualization_msgs::msg::MarkerArray getCurrentVehicleCirclesMarkerArray(
   const geometry_msgs::msg::Pose & current_ego_pose,
   const std::vector<double> & vehicle_circle_longitudinal_offsets,
-  const std::vector<double> & vehicle_circle_radiuses, const std::string & ns, const double r, const double g,
-  const double b)
+  const std::vector<double> & vehicle_circle_radiuses, const std::string & ns, const double r,
+  const double g, const double b)
 {
   visualization_msgs::msg::MarkerArray msg;
 
@@ -641,8 +641,8 @@ visualization_msgs::msg::MarkerArray getCurrentVehicleCirclesMarkerArray(
 visualization_msgs::msg::MarkerArray getVehicleCirclesMarkerArray(
   const std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & mpt_traj_points,
   const std::vector<double> & vehicle_circle_longitudinal_offsets,
-  const std::vector<double> & vehicle_circle_radiuses, const size_t sampling_num, const std::string & ns,
-  const double r, const double g, const double b)
+  const std::vector<double> & vehicle_circle_radiuses, const size_t sampling_num,
+  const std::string & ns, const double r, const double g, const double b)
 {
   visualization_msgs::msg::MarkerArray msg;
 

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -47,11 +47,12 @@ std::tuple<Eigen::VectorXd, Eigen::VectorXd> extractBounds(
   Eigen::VectorXd lb_vec(ref_points.size());
   for (size_t i = 0; i < ref_points.size(); ++i) {
     ub_vec(i) = ref_points.at(i).vehicle_bounds.at(l_idx).upper_bound + offset;
-    lb_vec(i) = ref_points.at(i).vehicle_bounds.at(l_idx).lower_bound + offset;
+    lb_vec(i) = ref_points.at(i).vehicle_bounds.at(l_idx).lower_bound - offset;
   }
   return {ub_vec, lb_vec};
 }
 
+/*
 Bounds findWidestBounds(const BoundsCandidates & front_bounds_candidates)
 {
   double max_width = std::numeric_limits<double>::min();
@@ -69,6 +70,33 @@ Bounds findWidestBounds(const BoundsCandidates & front_bounds_candidates)
     }
   }
   return front_bounds_candidates.at(max_width_index);
+}
+*/
+
+Bounds findNearestBounds(
+  const geometry_msgs::msg::Pose & bounds_pose, const BoundsCandidates & front_bounds_candidates,
+  const geometry_msgs::msg::Point & target_pos)
+{
+  double min_dist = std::numeric_limits<double>::max();
+  size_t min_dist_index = 0;
+  if (front_bounds_candidates.size() != 1) {
+    for (size_t candidate_idx = 0; candidate_idx < front_bounds_candidates.size();
+         ++candidate_idx) {
+      const auto & front_bounds_candidate = front_bounds_candidates.at(candidate_idx);
+
+      const double bound_center =
+        (front_bounds_candidate.upper_bound + front_bounds_candidate.lower_bound) / 2.0;
+      const auto center_pos =
+        tier4_autoware_utils::calcOffsetPose(bounds_pose, 0.0, bound_center, 0.0);
+      const double dist = tier4_autoware_utils::calcDistance2d(center_pos, target_pos);
+
+      if (dist < min_dist) {
+        min_dist_index = candidate_idx;
+        min_dist = dist;
+      }
+    }
+  }
+  return front_bounds_candidates.at(min_dist_index);
 }
 
 double calcOverlappedBoundsSignedLength(
@@ -352,7 +380,7 @@ std::vector<ReferencePoint> MPTOptimizer::getReferencePoints(
     ref_points = points_utils::clipForwardPoints(ref_points, 0, ref_length_with_margin);
 
     // set bounds information
-    calcBounds(ref_points, enable_avoidance, maps, debug_data_ptr);
+    calcBounds(ref_points, enable_avoidance, maps, prev_trajs, debug_data_ptr);
     calcVehicleBounds(ref_points, maps, debug_data_ptr, enable_avoidance);
 
     // set extra information (alpha and has_object_collision)
@@ -991,7 +1019,8 @@ MPTOptimizer::ConstraintMatrix MPTOptimizer::getConstraintMatrix(
     const Eigen::VectorXd CW = C_sparse_mat * mpt_mat.Wex + C_vec;
 
     // calculate bounds
-    const double bounds_offset = mpt_param_.vehicle_circle_radiuses.at(l_idx) - vehicle_param_.width / 2.0;
+    const double bounds_offset =
+      mpt_param_.vehicle_circle_radiuses.at(l_idx) - vehicle_param_.width / 2.0;
     const auto & [part_ub, part_lb] = extractBounds(ref_points, l_idx, bounds_offset);
 
     // soft constraints
@@ -1349,7 +1378,7 @@ void MPTOptimizer::addSteerWeightR(
 
 void MPTOptimizer::calcBounds(
   std::vector<ReferencePoint> & ref_points, const bool enable_avoidance, const CVMaps & maps,
-  std::shared_ptr<DebugData> debug_data_ptr) const
+  const std::unique_ptr<Trajectories> & prev_trajs, std::shared_ptr<DebugData> debug_data_ptr) const
 {
   stop_watch_.tic(__func__);
 
@@ -1368,8 +1397,19 @@ void MPTOptimizer::calcBounds(
 
     // extract only continuous bounds;
     if (i == 0) {  // TODO(murooka) use previous bounds, not widest bounds
-      const auto & widest_bounds = findWidestBounds(bounds_candidates);
-      ref_points.at(i).bounds = widest_bounds;
+      const auto target_pos = [&]() {
+        if (prev_trajs && !prev_trajs->mpt_ref_points.empty()) {
+          return prev_trajs->mpt_ref_points.front().p;
+        }
+        return current_ego_pose_.position;
+      }();
+
+      geometry_msgs::msg::Pose ref_pose;
+      ref_pose.position = ref_points.at(i).p;
+      ref_pose.orientation = tier4_autoware_utils::createQuaternionFromYaw(ref_points.at(i).yaw);
+
+      const auto & nearest_bounds = findNearestBounds(ref_pose, bounds_candidates, target_pos);
+      ref_points.at(i).bounds = nearest_bounds;
     } else {
       const auto & prev_ref_point = ref_points.at(i - 1);
       const auto & prev_continuous_bounds = prev_ref_point.bounds;
@@ -1633,8 +1673,7 @@ CollisionType MPTOptimizer::getCollisionType(
   const double min_soft_road_clearance = vehicle_param_.width / 2.0 +
                                          mpt_param_.soft_clearance_from_road +
                                          mpt_param_.extra_desired_clearance_from_road;
-  const double min_obj_clearance = vehicle_param_.width / 2.0 +
-                                   mpt_param_.clearance_from_object +
+  const double min_obj_clearance = vehicle_param_.width / 2.0 + mpt_param_.clearance_from_object +
                                    mpt_param_.soft_clearance_from_road;
 
   // calculate target position

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1515,7 +1515,7 @@ void MPTOptimizer::calcVehicleBounds(
 
       // interpolate bounds
       const double avoid_s = ref_points_spline_interpolation.getAccumulatedLength(p_idx) + d;
-      for (size_t cp_idx = p_idx; cp_idx < ref_points.size(); ++cp_idx) {
+      for (size_t cp_idx = 0; cp_idx < ref_points.size(); ++cp_idx) {
         const double current_s = ref_points_spline_interpolation.getAccumulatedLength(cp_idx);
         if (avoid_s <= current_s) {
           double prev_avoid_idx;

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1020,7 +1020,7 @@ MPTOptimizer::ConstraintMatrix MPTOptimizer::getConstraintMatrix(
 
     // calculate bounds
     const double bounds_offset =
-      mpt_param_.vehicle_circle_radiuses.at(l_idx) - vehicle_param_.width / 2.0;
+      vehicle_param_.width / 2.0 - mpt_param_.vehicle_circle_radiuses.at(l_idx);
     const auto & [part_ub, part_lb] = extractBounds(ref_points, l_idx, bounds_offset);
 
     // soft constraints

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -138,51 +138,29 @@ bool hasValidNearestPointFromEgo(
   return true;
 }
 
-std::tuple<double, std::vector<double>> calcVehicleCirclesInfo1(
-  const VehicleParam & vehicle_param, const size_t circle_num_for_constraints,
-  const size_t circle_num_for_radius, const double radius_ratio)
+std::tuple<std::vector<double>, std::vector<double>> calcVehicleCirclesInfo(
+  const VehicleParam & vehicle_param, const size_t circle_num,
+  const std::vector<double> & radius_ratios)
 {
-  const double radius = std::hypot(
-                          vehicle_param.length / static_cast<double>(circle_num_for_radius) / 2.0,
-                          vehicle_param.width / 2.0) *
-                        radius_ratio;
-
-  std::vector<double> longitudinal_offsets;
-  const double unit_lon_length = vehicle_param.length / static_cast<double>(circle_num_for_radius);
-  for (size_t i = 0; i < circle_num_for_constraints; ++i) {
-    longitudinal_offsets.push_back(
-      unit_lon_length / 2.0 +
-      (unit_lon_length * (circle_num_for_radius - 1)) /
-        static_cast<double>(circle_num_for_constraints - 1) * i -
-      vehicle_param.rear_overhang);
-  }
-
-  return {radius, longitudinal_offsets};
-}
-
-std::tuple<std::vector<double>, std::vector<double>> calcVehicleCirclesInfo2(
-  const VehicleParam & vehicle_param, const size_t circle_num_for_constraints,
-  const size_t circle_num_for_radius, const double radius_ratio)
-{
-  const double radius = std::hypot(
-                          vehicle_param.length / static_cast<double>(circle_num_for_radius) / 2.0,
-                          vehicle_param.width / 2.0) *
-                        radius_ratio;
-
   std::vector<double> longitudinal_offsets;
   std::vector<double> radiuses;
 
-  const double unit_lon_length = vehicle_param.length / static_cast<double>(circle_num_for_radius);
+  {  // 1st circle (rear)
+    longitudinal_offsets.push_back(-vehicle_param.rear_overhang);
+    radiuses.push_back(vehicle_param.width / 2.0 * radius_ratios.front());
+  }
 
-  longitudinal_offsets.push_back(
-    unit_lon_length / 2.0 +
-    (unit_lon_length * (circle_num_for_radius - 1)) /
-      static_cast<double>(circle_num_for_constraints - 1) * (circle_num_for_constraints - 1) -
-    vehicle_param.rear_overhang);
-  radiuses.push_back(radius);
+  {  // 2nd circle (front)
+    const double radius = std::hypot(
+      vehicle_param.length / static_cast<double>(circle_num) / 2.0, vehicle_param.width / 2.0);
 
-  longitudinal_offsets.push_back(-vehicle_param.rear_overhang);
-  radiuses.push_back(vehicle_param.width / 2.0);
+    const double unit_lon_length = vehicle_param.length / static_cast<double>(circle_num);
+    const double longitudinal_offset =
+      unit_lon_length / 2.0 + unit_lon_length * (circle_num - 1) - vehicle_param.rear_overhang;
+
+    longitudinal_offsets.push_back(longitudinal_offset);
+    radiuses.push_back(radius * radius_ratios.back());
+  }
 
   return {radiuses, longitudinal_offsets};
 }
@@ -282,41 +260,6 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
     is_showing_calculation_time_ = declare_parameter<bool>("option.is_showing_calculation_time");
     is_stopping_if_outside_drivable_area_ =
       declare_parameter<bool>("option.is_stopping_if_outside_drivable_area");
-
-    // drivability check
-    use_vehicle_circles_for_drivability_ =
-      declare_parameter<bool>("advanced.option.drivability_check.use_vehicle_circles");
-    if (use_vehicle_circles_for_drivability_) {
-      // vehicle_circles
-      // NOTE: Vehicle shape for drivability check is considered as a set of circles
-      use_manual_vehicle_circles_for_drivability_ = declare_parameter<bool>(
-        "advanced.option.drivability_check.vehicle_circles.use_manual_vehicle_circles");
-      vehicle_circle_constraints_num_for_drivability_ = declare_parameter<int>(
-        "advanced.option.drivability_check.vehicle_circles.num_for_constraints");
-      if (use_manual_vehicle_circles_for_drivability_) {  // vehicle circles are designated manually
-        vehicle_circle_longitudinal_offsets_for_drivability_ =
-          declare_parameter<std::vector<double>>(
-            "advanced.option.drivability_check.vehicle_circles.longitudinal_offsets");
-        vehicle_circle_radius_for_drivability_ =
-          declare_parameter<double>("advanced.option.drivability_check.vehicle_circles.radius");
-      } else {  // vehicle circles are calculated automatically with designated ratio
-        const int default_radius_num =
-          std::round(vehicle_param_.length / vehicle_param_.width * 1.5);
-
-        vehicle_circle_radius_num_for_drivability_ = declare_parameter<int>(
-          "advanced.option.drivability_check.vehicle_circles.num_for_radius", default_radius_num);
-        vehicle_circle_radius_ratio_for_drivability_ = declare_parameter<double>(
-          "advanced.option.drivability_check.vehicle_circles.radius_ratio");
-
-        std::tie(
-          vehicle_circle_radius_for_drivability_,
-          vehicle_circle_longitudinal_offsets_for_drivability_) =
-          calcVehicleCirclesInfo1(
-            vehicle_param_, vehicle_circle_constraints_num_for_drivability_,
-            vehicle_circle_radius_num_for_drivability_,
-            vehicle_circle_radius_ratio_for_drivability_);
-      }
-    }
 
     enable_avoidance_ = declare_parameter<bool>("option.enable_avoidance");
     enable_pre_smoothing_ = declare_parameter<bool>("option.enable_pre_smoothing");
@@ -451,22 +394,20 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
     // mpt_param_.two_step_soft_constraint =
     // declare_parameter<bool>("advanced.mpt.collision_free_constraints.option.two_step_soft_constraint");
 
-    // vehicle_circles
-    // NOTE: Vehicle shape for collision free constraints is considered as a set of circles
-    vehicle_circle_constraints_num_for_mpt_ = declare_parameter<int>(
-      "advanced.mpt.collision_free_constraints.vehicle_circles.num_for_constraints");
-    const int default_radius_num = std::round(vehicle_param_.length / vehicle_param_.width * 1.5);
+    {  // vehicle_circles
+       // NOTE: Vehicle shape for collision free constraints is considered as a set of circles
+      vehicle_circle_num_for_calculation_ = declare_parameter<int>(
+        "advanced.mpt.collision_free_constraints.vehicle_circles.num_for_calculation");
 
-    vehicle_circle_radius_num_for_mpt_ = declare_parameter<int>(
-      "advanced.mpt.collision_free_constraints.vehicle_circles.num_for_radius",
-      default_radius_num);
-    vehicle_circle_radius_ratio_for_mpt_ = declare_parameter<double>(
-      "advanced.mpt.collision_free_constraints.vehicle_circles.radius_ratio");
+      vehicle_circle_radius_ratios_.push_back(declare_parameter<double>(
+        "advanced.mpt.collision_free_constraints.vehicle_circles.rear_radius_ratio"));
+      vehicle_circle_radius_ratios_.push_back(declare_parameter<double>(
+        "advanced.mpt.collision_free_constraints.vehicle_circles.front_radius_ratio"));
 
-    std::tie(mpt_param_.vehicle_circle_radiuses, mpt_param_.vehicle_circle_longitudinal_offsets) =
-      calcVehicleCirclesInfo2(
-        vehicle_param_, vehicle_circle_constraints_num_for_mpt_,
-        vehicle_circle_radius_num_for_mpt_, vehicle_circle_radius_ratio_for_mpt_);
+      std::tie(mpt_param_.vehicle_circle_radiuses, mpt_param_.vehicle_circle_longitudinal_offsets) =
+        calcVehicleCirclesInfo(
+          vehicle_param_, vehicle_circle_num_for_calculation_, vehicle_circle_radius_ratios_);
+    }
 
     // clearance
     mpt_param_.hard_clearance_from_road =
@@ -559,44 +500,6 @@ rcl_interfaces::msg::SetParametersResult ObstacleAvoidancePlanner::paramCallback
     updateParam<bool>(
       parameters, "option.is_stopping_if_outside_drivable_area",
       is_stopping_if_outside_drivable_area_);
-
-    // drivability check
-    /*
-    updateParam<bool>(
-      parameters, "advanced.option.drivability_check.use_vehicle_circles",
-      use_vehicle_circles_for_drivability_);
-    if (use_vehicle_circles_for_drivability_) {
-      updateParam<bool>(
-        parameters, "advanced.option.drivability_check.vehicle_circles.use_manual_vehicle_circles",
-        use_manual_vehicle_circles_for_drivability_);
-      updateParam<int>(
-        parameters, "advanced.option.drivability_check.vehicle_circles.num_for_constraints",
-        vehicle_circle_constraints_num_for_drivability_);
-      if (use_manual_vehicle_circles_for_drivability_) {
-        updateParam<std::vector<double>>(
-          parameters, "advanced.option.drivability_check.vehicle_circles.longitudinal_offsets",
-          vehicle_circle_longitudinal_offsets_for_drivability_);
-        updateParam<double>(
-          parameters, "advanced.option.drivability_check.vehicle_circles.radius",
-          vehicle_circle_radius_for_drivability_);
-      } else {
-        updateParam<int>(
-          parameters, "advanced.option.drivability_check.vehicle_circles.num_for_radius",
-          vehicle_circle_radius_num_for_drivability_);
-        updateParam<double>(
-          parameters, "advanced.option.drivability_check.vehicle_circles.radius_ratio",
-          vehicle_circle_radius_ratio_for_drivability_);
-
-        std::tie(
-          vehicle_circle_radius_for_drivability_,
-          vehicle_circle_longitudinal_offsets_for_drivability_) =
-          calcVehicleCirclesInfo(
-            vehicle_param_, vehicle_circle_constraints_num_for_drivability_,
-            vehicle_circle_radius_num_for_drivability_,
-            vehicle_circle_radius_ratio_for_drivability_);
-      }
-    }
-    */
 
     updateParam<bool>(parameters, "option.enable_avoidance", enable_avoidance_);
     updateParam<bool>(parameters, "option.enable_pre_smoothing", enable_pre_smoothing_);
@@ -727,36 +630,27 @@ rcl_interfaces::msg::SetParametersResult ObstacleAvoidancePlanner::paramCallback
       parameters, "advanced.mpt.collision_free_constraints.option.hard_constraint",
       mpt_param_.hard_constraint);
 
-    // vehicle_circles
-    /*
-    updateParam<bool>(
-      parameters,
-      "advanced.mpt.collision_free_constraints.vehicle_circles.use_manual_vehicle_circles",
-      use_manual_vehicle_circles_for_mpt_);
-    updateParam<int>(
-      parameters, "advanced.mpt.collision_free_constraints.vehicle_circles.num_for_constraints",
-      vehicle_circle_constraints_num_for_mpt_);
-    if (use_manual_vehicle_circles_for_mpt_) {
-      updateParam<std::vector<double>>(
-        parameters, "advanced.mpt.collision_free_constraints.vehicle_circles.longitudinal_offsets",
-        mpt_param_.vehicle_circle_longitudinal_offsets);
-      updateParam<double>(
-        parameters, "advanced.mpt.collision_free_constraints.vehicle_circles.radius",
-        mpt_param_.vehicle_circle_radius);
-    } else {  // vehicle circles are calculated automatically with designated ratio
+    {  // vehicle_circles
       updateParam<int>(
-        parameters, "advanced.mpt.collision_free_constraints.vehicle_circles.num_for_radius",
-        vehicle_circle_radius_num_for_mpt_);
-      updateParam<double>(
-        parameters, "advanced.mpt.collision_free_constraints.vehicle_circles.radius_ratio",
-        vehicle_circle_radius_ratio_for_mpt_);
+        parameters, "advanced.mpt.collision_free_constraints.vehicle_circles.num_for_calculation",
+        vehicle_circle_num_for_calculation_);
 
-      std::tie(mpt_param_.vehicle_circle_radius, mpt_param_.vehicle_circle_longitudinal_offsets) =
+      double rear_radius_ratio;
+      updateParam<double>(
+        parameters, "advanced.mpt.collision_free_constraints.vehicle_circles.rear_radius_ratio",
+        rear_radius_ratio);
+      vehicle_circle_radius_ratios_.front() = rear_radius_ratio;
+
+      double front_radius_ratio;
+      updateParam<double>(
+        parameters, "advanced.mpt.collision_free_constraints.vehicle_circles.front_radius_ratio",
+        front_radius_ratio);
+      vehicle_circle_radius_ratios_.back() = front_radius_ratio;
+
+      std::tie(mpt_param_.vehicle_circle_radiuses, mpt_param_.vehicle_circle_longitudinal_offsets) =
         calcVehicleCirclesInfo(
-          vehicle_param_, vehicle_circle_constraints_num_for_mpt_,
-          vehicle_circle_radius_num_for_mpt_, vehicle_circle_radius_ratio_for_mpt_);
+          vehicle_param_, vehicle_circle_num_for_calculation_, vehicle_circle_radius_ratios_);
     }
-    */
 
     // clearance
     updateParam<double>(
@@ -889,8 +783,7 @@ void ObstacleAvoidancePlanner::pathCallback(
   debug_data_ptr_ = std::make_shared<DebugData>();
   debug_data_ptr_->init(
     is_showing_calculation_time_, mpt_visualize_sampling_num_, current_ego_pose_,
-    mpt_param_.vehicle_circle_radiuses,
-    mpt_param_.vehicle_circle_longitudinal_offsets);
+    mpt_param_.vehicle_circle_radiuses, mpt_param_.vehicle_circle_longitudinal_offsets);
 
   // generate optimized trajectory
   const auto optimized_traj_points = generateOptimizedTrajectory(*path_ptr);
@@ -1128,16 +1021,8 @@ void ObstacleAvoidancePlanner::insertZeroVelocityOutsideDrivableArea(
     const auto & traj_point = traj_points.at(i);
 
     // calculate the first point being outside drivable area
-    const bool is_outside = [&]() {
-      if (use_vehicle_circles_for_drivability_) {
-        return cv_drivable_area_utils::isOutsideDrivableAreaFromCirclesFootprint(
-          traj_point, road_clearance_map, map_info,
-          vehicle_circle_longitudinal_offsets_for_drivability_,
-          vehicle_circle_radius_for_drivability_);
-      }
-      return cv_drivable_area_utils::isOutsideDrivableAreaFromRectangleFootprint(
-        traj_point, road_clearance_map, map_info, vehicle_param_);
-    }();
+    const bool is_outside = cv_drivable_area_utils::isOutsideDrivableAreaFromRectangleFootprint(
+      traj_point, road_clearance_map, map_info, vehicle_param_);
 
     // only insert zero velocity to the first point outside drivable area
     if (is_outside) {


### PR DESCRIPTION
## Description

- Removed the option to check if the ego is outside the drivable area with **a set of circles**. (rectangle footprints are used instead).
    - This function was not used in any vehicle yet.
- fix boundary search
    - the first bounds will be nearest to the first bounds at the previous cycle, if it does not exist, nearest to the ego.
- use two circles for constraints of MPT.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
