### PR TITLE
feat(obstacle_avoidance_planner): dealt with close lane change

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -960,7 +960,8 @@ bool ObstacleAvoidancePlanner::checkReplan(
         current_ego_pose_, path_points, prev_path_points_ptr_, max_mpt_length,
         max_path_shape_change_dist_for_replan_,
         traj_param_.delta_yaw_threshold_for_closest_point)) {
-    RCLCPP_INFO(get_logger(), "Replan since path shape was changed.");
+    RCLCPP_INFO(get_logger(), "Replan with resetting optimization since path shape was changed.");
+    resetPrevOptimization();
     return true;
   }
 

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -82,7 +82,7 @@ bool isPathShapeChanged(
   // calculate lateral deviations between truncated path_points and prev_path_points
   for (const auto & prev_point : truncated_prev_points) {
     const double dist =
-      tier4_autoware_utils::calcLateralOffset(truncated_points, prev_point.pose.position);
+      std::abs(tier4_autoware_utils::calcLateralOffset(truncated_points, prev_point.pose.position));
     if (dist > max_path_shape_change_dist) {
       return true;
     }


### PR DESCRIPTION
## Description

Add reset function (forget the previous optimization result) when the path shape changes because of lane change or avoidance.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
