### PR TITLE
feat: visualize lane boundaries

### DIFF
--- a/map/lanelet2_extension/lib/visualization.cpp
+++ b/map/lanelet2_extension/lib/visualization.cpp
@@ -878,11 +878,13 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
   double lss_center = std::max(lss * 0.1, 0.02);
 
   std::unordered_set<lanelet::Id> added;
-  visualization_msgs::msg::Marker left_line_strip, right_line_strip, center_line_strip;
+  visualization_msgs::msg::Marker left_line_strip, right_line_strip, lane_bound_line_strip, center_line_strip;
   visualization::initLineStringMarker(
     &left_line_strip, "map", additional_namespace + "left_lane_bound", c);
   visualization::initLineStringMarker(
     &right_line_strip, "map", additional_namespace + "right_lane_bound", c);
+  visualization::initLineStringMarker(
+    &lane_bound_line_strip, "map", additional_namespace + "lane_bound", c);
   visualization::initLineStringMarker(
     &center_line_strip, "map", additional_namespace + "center_lane_line", c);
 
@@ -892,6 +894,11 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
     lanelet::ConstLineString3d left_ls = lll.leftBound();
     lanelet::ConstLineString3d right_ls = lll.rightBound();
     lanelet::ConstLineString3d center_ls = lll.centerline();
+    lanelet::LineString3d lane_bound_ls(lanelet::utils::getId());
+    lane_bound_ls.push_back(lanelet::Point3d(
+      lanelet::utils::getId(), left_ls.front().x(), left_ls.front().y(), left_ls.front().z()));
+    lane_bound_ls.push_back(lanelet::Point3d(
+      lanelet::utils::getId(), right_ls.front().x(), right_ls.front().y(), right_ls.front().z()));
 
     if (!exists(added, left_ls.id())) {
       visualization::pushLineStringMarker(&left_line_strip, left_ls, c, lss);
@@ -900,6 +907,10 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
     if (!exists(added, right_ls.id())) {
       visualization::pushLineStringMarker(&right_line_strip, right_ls, c, lss);
       added.insert(right_ls.id());
+    }
+    if (!exists(added, lane_bound_ls.id())) {
+      visualization::pushLineStringMarker(&lane_bound_line_strip, lane_bound_ls, c, lss);
+      added.insert(lane_bound_ls.id());
     }
     if (viz_centerline && !exists(added, center_ls.id())) {
       visualization::pushLineStringMarker(&center_line_strip, center_ls, c, lss_center);
@@ -916,6 +927,9 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
   }
   if (!center_line_strip.points.empty()) {
     marker_array.markers.push_back(center_line_strip);
+  }
+  if (!lane_bound_line_strip.points.empty()) {
+    marker_array.markers.push_back(lane_bound_line_strip);
   }
   return marker_array;
 }

--- a/map/lanelet2_extension/lib/visualization.cpp
+++ b/map/lanelet2_extension/lib/visualization.cpp
@@ -878,13 +878,13 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
   double lss_center = std::max(lss * 0.1, 0.02);
 
   std::unordered_set<lanelet::Id> added;
-  visualization_msgs::msg::Marker left_line_strip, right_line_strip, lane_bound_line_strip, center_line_strip;
+  visualization_msgs::msg::Marker left_line_strip, right_line_strip, start_bound_line_strip, center_line_strip;
   visualization::initLineStringMarker(
     &left_line_strip, "map", additional_namespace + "left_lane_bound", c);
   visualization::initLineStringMarker(
     &right_line_strip, "map", additional_namespace + "right_lane_bound", c);
   visualization::initLineStringMarker(
-    &lane_bound_line_strip, "map", additional_namespace + "lane_bound", c);
+    &start_bound_line_strip, "map", additional_namespace + "lane_start_bound", c);
   visualization::initLineStringMarker(
     &center_line_strip, "map", additional_namespace + "center_lane_line", c);
 
@@ -894,10 +894,10 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
     lanelet::ConstLineString3d left_ls = lll.leftBound();
     lanelet::ConstLineString3d right_ls = lll.rightBound();
     lanelet::ConstLineString3d center_ls = lll.centerline();
-    lanelet::LineString3d lane_bound_ls(lanelet::utils::getId());
-    lane_bound_ls.push_back(lanelet::Point3d(
+    lanelet::LineString3d start_bound_ls(lanelet::utils::getId());
+    start_bound_ls.push_back(lanelet::Point3d(
       lanelet::utils::getId(), left_ls.front().x(), left_ls.front().y(), left_ls.front().z()));
-    lane_bound_ls.push_back(lanelet::Point3d(
+    start_bound_ls.push_back(lanelet::Point3d(
       lanelet::utils::getId(), right_ls.front().x(), right_ls.front().y(), right_ls.front().z()));
 
     if (!exists(added, left_ls.id())) {
@@ -908,9 +908,9 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
       visualization::pushLineStringMarker(&right_line_strip, right_ls, c, lss);
       added.insert(right_ls.id());
     }
-    if (!exists(added, lane_bound_ls.id())) {
-      visualization::pushLineStringMarker(&lane_bound_line_strip, lane_bound_ls, c, lss);
-      added.insert(lane_bound_ls.id());
+    if (!exists(added, start_bound_ls.id())) {
+      visualization::pushLineStringMarker(&start_bound_line_strip, start_bound_ls, c, lss);
+      added.insert(start_bound_ls.id());
     }
     if (viz_centerline && !exists(added, center_ls.id())) {
       visualization::pushLineStringMarker(&center_line_strip, center_ls, c, lss_center);
@@ -928,8 +928,8 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
   if (!center_line_strip.points.empty()) {
     marker_array.markers.push_back(center_line_strip);
   }
-  if (!lane_bound_line_strip.points.empty()) {
-    marker_array.markers.push_back(lane_bound_line_strip);
+  if (!start_bound_line_strip.points.empty()) {
+    marker_array.markers.push_back(start_bound_line_strip);
   }
   return marker_array;
 }

--- a/map/lanelet2_extension/lib/visualization.cpp
+++ b/map/lanelet2_extension/lib/visualization.cpp
@@ -878,7 +878,8 @@ visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArra
   double lss_center = std::max(lss * 0.1, 0.02);
 
   std::unordered_set<lanelet::Id> added;
-  visualization_msgs::msg::Marker left_line_strip, right_line_strip, start_bound_line_strip, center_line_strip;
+  visualization_msgs::msg::Marker left_line_strip, right_line_strip, start_bound_line_strip,
+    center_line_strip;
   visualization::initLineStringMarker(
     &left_line_strip, "map", additional_namespace + "left_lane_bound", c);
   visualization::initLineStringMarker(


### PR DESCRIPTION
## Description

- visualize lane boundaries with namespace "lane_start_bound"

Before
![Before](https://user-images.githubusercontent.com/9547070/169005651-6a706e84-6025-490c-8370-2bec0c164e9c.png)

After
![After](https://user-images.githubusercontent.com/9547070/169005570-fffb4e33-27a0-4050-99c5-166aa1b121ef.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
