### PR TITLE
chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check

### DIFF
--- a/planning/behavior_velocity_planner/config/stop_line.param.yaml
+++ b/planning/behavior_velocity_planner/config/stop_line.param.yaml
@@ -4,3 +4,5 @@
       stop_margin: 0.0
       stop_check_dist: 2.0
       stop_duration_sec: 1.0
+      debug:
+        show_stopline_collision_check: false            # [-] whether to show stopline collision

--- a/planning/behavior_velocity_planner/include/scene_module/stop_line/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/stop_line/scene.hpp
@@ -63,6 +63,8 @@ public:
   {
     double base_link2front;
     boost::optional<geometry_msgs::msg::Pose> stop_pose;
+    std::vector<LineString2d> search_segments;
+    LineString2d search_stopline;
   };
 
   struct PlannerParam
@@ -70,6 +72,7 @@ public:
     double stop_margin;
     double stop_check_dist;
     double stop_duration_sec;
+    bool show_stopline_collision_check;
   };
 
 public:

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -87,6 +87,63 @@ visualization_msgs::msg::MarkerArray createMarkers(
   return msg;
 }
 
+visualization_msgs::msg::MarkerArray createStopLineCollisionCheck(
+  const DebugData & debug_data, const int64_t module_id)
+{
+  visualization_msgs::msg::MarkerArray msg;
+
+  // Search Segments
+  {
+    visualization_msgs::msg::Marker marker;
+    marker.header.frame_id = "map";
+    marker.ns = "search_segments";
+    marker.id = module_id;
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
+    marker.type = visualization_msgs::msg::Marker::SPHERE_LIST;
+    marker.action = visualization_msgs::msg::Marker::ADD;
+    for (const auto & e : debug_data.search_segments) {
+      marker.points.push_back(
+        geometry_msgs::build<geometry_msgs::msg::Point>().x(e.at(0).x()).y(e.at(0).y()).z(0.0));
+      marker.points.push_back(
+        geometry_msgs::build<geometry_msgs::msg::Point>().x(e.at(1).x()).y(e.at(1).y()).z(0.0));
+    }
+    marker.scale.x = 0.1;
+    marker.scale.y = 0.1;
+    marker.color.a = 0.999;  // Don't forget to set the alpha!
+    marker.color.r = 0.0;
+    marker.color.g = 0.0;
+    marker.color.b = 1.0;
+    msg.markers.push_back(marker);
+  }
+
+  // Search stopline
+  {
+    visualization_msgs::msg::Marker marker;
+    marker.header.frame_id = "map";
+    marker.ns = "search_stopline";
+    marker.id = module_id;
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
+    const auto p0 = debug_data.search_stopline.at(0);
+    marker.points.push_back(
+      geometry_msgs::build<geometry_msgs::msg::Point>().x(p0.x()).y(p0.y()).z(0.0));
+    const auto p1 = debug_data.search_stopline.at(1);
+    marker.points.push_back(
+      geometry_msgs::build<geometry_msgs::msg::Point>().x(p1.x()).y(p1.y()).z(0.0));
+
+    marker.scale.x = 0.1;
+    marker.scale.y = 0.1;
+    marker.color.a = 0.999;  // Don't forget to set the alpha!
+    marker.color.r = 1.0;
+    marker.color.g = 0.0;
+    marker.color.b = 0.0;
+    msg.markers.push_back(marker);
+  }
+
+  return msg;
+}
+
 }  // namespace
 
 visualization_msgs::msg::MarkerArray StopLineModule::createDebugMarkerArray()
@@ -95,6 +152,12 @@ visualization_msgs::msg::MarkerArray StopLineModule::createDebugMarkerArray()
 
   appendMarkerArray(
     createMarkers(debug_data_, module_id_), this->clock_->now(), &debug_marker_array);
+
+  if (planner_param_.show_stopline_collision_check) {
+    appendMarkerArray(
+      createStopLineCollisionCheck(debug_data_, module_id_), this->clock_->now(),
+      &debug_marker_array);
+  }
 
   return debug_marker_array;
 }

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -107,12 +107,8 @@ visualization_msgs::msg::MarkerArray createStopLineCollisionCheck(
       marker.points.push_back(
         geometry_msgs::build<geometry_msgs::msg::Point>().x(e.at(1).x()).y(e.at(1).y()).z(0.0));
     }
-    marker.scale.x = 0.1;
-    marker.scale.y = 0.1;
-    marker.color.a = 0.999;  // Don't forget to set the alpha!
-    marker.color.r = 0.0;
-    marker.color.g = 0.0;
-    marker.color.b = 1.0;
+    marker.scale = createMarkerScale(0.1, 0.1, 0.1);
+    marker.color = createMarkerColor(0.0, 0.0, 1.0, 0.999);
     msg.markers.push_back(marker);
   }
 
@@ -132,12 +128,8 @@ visualization_msgs::msg::MarkerArray createStopLineCollisionCheck(
     marker.points.push_back(
       geometry_msgs::build<geometry_msgs::msg::Point>().x(p1.x()).y(p1.y()).z(0.0));
 
-    marker.scale.x = 0.1;
-    marker.scale.y = 0.1;
-    marker.color.a = 0.999;  // Don't forget to set the alpha!
-    marker.color.r = 1.0;
-    marker.color.g = 0.0;
-    marker.color.b = 0.0;
+    marker.scale = createMarkerScale(0.1, 0.1, 0.1);
+    marker.color = createMarkerColor(1.0, 0.0, 0.0, 0.999);
     msg.markers.push_back(marker);
   }
 

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
@@ -93,6 +93,9 @@ StopLineModuleManager::StopLineModuleManager(rclcpp::Node & node)
   p.stop_margin = node.declare_parameter(ns + ".stop_margin", 0.0);
   p.stop_check_dist = node.declare_parameter(ns + ".stop_check_dist", 2.0);
   p.stop_duration_sec = node.declare_parameter(ns + ".stop_duration_sec", 1.0);
+  // debug
+  p.show_stopline_collision_check =
+    node.declare_parameter(ns + ".debug.show_stopline_collision_check", false);
 }
 
 void StopLineModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -109,6 +109,18 @@ boost::optional<StopLineModule::SegmentIndexWithPoint2d> StopLineModule::findCol
 {
   const size_t min_search_index = std::max(static_cast<size_t>(0), search_index.min_idx);
   const size_t max_search_index = std::min(search_index.max_idx, path.points.size() - 1);
+
+  // for creating debug marker
+  if (planner_param_.show_stopline_collision_check) {
+    debug_data_.search_stopline = stop_line;
+    for (size_t i = min_search_index; i < max_search_index; ++i) {
+      const auto & p_front = path.points.at(i).point.pose.position;
+      const auto & p_back = path.points.at(i + 1).point.pose.position;
+      const LineString2d path_segment = {{p_front.x, p_front.y}, {p_back.x, p_back.y}};
+      debug_data_.search_segments.push_back(path_segment);
+    }
+  }
+
   for (size_t i = min_search_index; i < max_search_index; ++i) {
     const auto & p_front = path.points.at(i).point.pose.position;
     const auto & p_back = path.points.at(i + 1).point.pose.position;


### PR DESCRIPTION
## Related link

https://github.com/autowarefoundation/autoware.universe/pull/917

## Description

- add debug marker for stopline collision check
- You can choose marker visualization by rosparam 
![2022-05-19_14-47](https://user-images.githubusercontent.com/9547070/169219433-6f4cefc9-f3cc-4a3c-a1d2-7d53aa792c6b.png)



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
