### PR TITLE
fix(system_monitor): move top command execution to a timer

### DIFF
--- a/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
@@ -110,6 +110,11 @@ protected:
     std::vector<std::shared_ptr<DiagTask>> * tasks, const std::string & message,
     const std::string & error_command, const std::string & content);
 
+  /**
+   * @brief timer callback to execute top command
+   */
+  void onTimer();
+
   diagnostic_updater::Updater updater_;  //!< @brief Updater class which advertises to /diagnostics
 
   char hostname_[HOST_NAME_MAX + 1];  //!< @brief host name
@@ -118,7 +123,11 @@ protected:
   std::vector<std::shared_ptr<DiagTask>>
     load_tasks_;  //!< @brief list of diagnostics tasks for high load procs
   std::vector<std::shared_ptr<DiagTask>>
-    memory_tasks_;  //!< @brief list of diagnostics tasks for high memory procs
+    memory_tasks_;                      //!< @brief list of diagnostics tasks for high memory procs
+  rclcpp::TimerBase::SharedPtr timer_;  //!< @brief timer to execute top command
+  std::string top_output_;              //!< @brief output from top command
+  bool is_top_error_;                   //!< @brief flag if an error occurs
+  float elapsed_ms_;                    //!< @brief Execution time of top command
 };
 
 #endif  // SYSTEM_MONITOR__PROCESS_MONITOR__PROCESS_MONITOR_HPP_

--- a/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
@@ -27,6 +27,7 @@
 #include <boost/process.hpp>
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -123,6 +124,8 @@ protected:
   std::string top_output_;              //!< @brief output from top command
   bool is_top_error_;                   //!< @brief flag if an error occurs
   double elapsed_ms_;                   //!< @brief Execution time of top command
+  std::mutex mutex_;                    //!< @brief mutex for output from top command
+  rclcpp::CallbackGroup::SharedPtr timer_callback_group_;  //!< @brief Callback Group
 };
 
 #endif  // SYSTEM_MONITOR__PROCESS_MONITOR__PROCESS_MONITOR_HPP_

--- a/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
@@ -41,11 +41,6 @@ public:
    */
   explicit ProcessMonitor(const rclcpp::NodeOptions & options);
 
-  /**
-   * @brief Update the diagnostic state
-   */
-  void update();
-
 protected:
   using DiagStatus = diagnostic_msgs::msg::DiagnosticStatus;
 

--- a/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
@@ -122,7 +122,7 @@ protected:
   rclcpp::TimerBase::SharedPtr timer_;  //!< @brief timer to execute top command
   std::string top_output_;              //!< @brief output from top command
   bool is_top_error_;                   //!< @brief flag if an error occurs
-  float elapsed_ms_;                    //!< @brief Execution time of top command
+  double elapsed_ms_;                   //!< @brief Execution time of top command
 };
 
 #endif  // SYSTEM_MONITOR__PROCESS_MONITOR__PROCESS_MONITOR_HPP_

--- a/system/system_monitor/package.xml
+++ b/system/system_monitor/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
+  <depend>tier4_autoware_utils</depend>
   <depend>tier4_external_api_msgs</depend>
 
   <exec_depend>chrony</exec_depend>

--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -57,8 +57,6 @@ ProcessMonitor::ProcessMonitor(const rclcpp::NodeOptions & options)
   timer_ = rclcpp::create_timer(this, get_clock(), 1s, std::bind(&ProcessMonitor::onTimer, this));
 }
 
-void ProcessMonitor::update() { updater_.force_update(); }
-
 void ProcessMonitor::monitorProcesses(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   std::string str = top_output_;

--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -21,6 +21,8 @@
 
 #include "system_monitor/system_monitor_utility.hpp"
 
+#include <tier4_autoware_utils/system/stop_watch.hpp>
+
 #include <fmt/format.h>
 
 #include <memory>
@@ -304,8 +306,9 @@ void ProcessMonitor::onTimer()
 {
   is_top_error_ = false;
 
-  // Remember start time to measure elapsed time
-  const auto t_start = std::chrono::high_resolution_clock::now();
+  // Start to measure elapsed time
+  tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
+  stop_watch.tic("execution_time");
 
   bp::ipstream is_err;
   bp::ipstream is_out;
@@ -324,8 +327,7 @@ void ProcessMonitor::onTimer()
   is_out >> os.rdbuf();
   top_output_ = os.str();
 
-  const auto t_end = std::chrono::high_resolution_clock::now();
-  elapsed_ms_ = std::chrono::duration<float, std::milli>(t_end - t_start).count();
+  elapsed_ms_ = stop_watch.toc("execution_time");
 }
 
 #include <rclcpp_components/register_node_macro.hpp>


### PR DESCRIPTION
## Description

Move the `top command` execution to another timer process instead of diagnostic timer.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/939

## Tests performed

1. Launch Autoware.
2. Run rqt_runtime_monitor.
    ```
    ros2 run rqt_runtime_monitor rqt_runtime_monitor
    ```
4. Verify all diagnostic topics related to process monitor are correctly published every 1 second. 

- process_monitor: Tasks Summary
- process_monitor: High-load Proc[0-4]
- process_monitor: High-mem Proc[0-4]

![image](https://user-images.githubusercontent.com/57388357/169737635-b0d487a7-30cd-4143-aef7-59a017f6f639.png)

## Notes for reviewers

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
