### PR TITLE
feat: add parameter argument for lanelet2_map_loader

### DIFF
--- a/map/map_loader/config/lanelet2_map_loader.param.yaml
+++ b/map/map_loader/config/lanelet2_map_loader.param.yaml
@@ -1,11 +1,7 @@
 /**:
   ros__parameters:
-    lanelet2_map_projector_type: MGRS
+    lanelet2_map_projector_type: MGRS   # Options: MGRS, UTM
+    latitude: 40.816617984672746        # Latitude of map_origin, using in UTM
+    longitude: 29.360491808334285       # Longitude of map_origin, using in UTM
 
-    # Latitude of map_origin, using in UTM
-    latitude: 40.816617984672746
-
-    # Longitude of map_origin, using in UTM
-    longitude: 29.360491808334285
-
-    center_line_resolution: 5.0
+    center_line_resolution: 5.0         # [m]

--- a/map/map_loader/config/lanelet2_map_loader.param.yaml
+++ b/map/map_loader/config/lanelet2_map_loader.param.yaml
@@ -1,8 +1,11 @@
 /**:
   ros__parameters:
+    lanelet2_map_projector_type: MGRS
 
-    # Latitude of map_origin
+    # Latitude of map_origin, using in UTM
     latitude: 40.816617984672746
 
-    # Longitude of map_origin
+    # Longitude of map_origin, using in UTM
     longitude: 29.360491808334285
+
+    center_line_resolution: 5.0


### PR DESCRIPTION
Signed-off-by: h-ohta <hiroki.ota@tier4.jp>

## Description

- The continuation of https://github.com/autowarefoundation/autoware.universe/pull/953
- add `lanelet2_map_loader_param_path` argument
- add centerline_resolution and lanelet2_map_projector_type in `lanelet2_map_loader.param.yam`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
