### PR TITLE
fix(fault_injection): fix diag name

### DIFF
--- a/simulator/fault_injection/src/fault_injection_node/fault_injection_node.cpp
+++ b/simulator/fault_injection/src/fault_injection_node/fault_injection_node.cpp
@@ -62,7 +62,7 @@ FaultInjectionNode::FaultInjectionNode(rclcpp::NodeOptions node_options)
   for (const auto & diag : readEventDiagList()) {
     diagnostic_storage_.registerEvent(diag);
     updater_.add(
-      diag.sim_name, std::bind(&FaultInjectionNode::updateEventDiag, this, _1, diag.sim_name));
+      diag.diag_name, std::bind(&FaultInjectionNode::updateEventDiag, this, _1, diag.sim_name));
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>

## Description

<!-- Write a brief description of this PR. -->
Fixed diagnostic name. This change fixes a potential problem that depends on the order of initialization.

### How to reproduce the problem

* Terminal1
```
ros2 launch fault_injection fault_injection.launch.xml
```

* Terminal2
```
ros2 topic echo /diagnostics diagnostic_msgs/msg/DiagnosticArray
```

* Result
You will see messages with the event name stored in the `name`. After the modification, the correct diag name is used.
```
header:
  stamp:
    sec: 1653447541
    nanosec: 918962774
  frame_id: ''
status:
- level: "\0"
  name: 'fault_injection: map_version_is_different'
  message: Node starting up
  hardware_id: ''
  values: []
---
header:
  stamp:
    sec: 1653447541
    nanosec: 919001981
  frame_id: ''
status:
- level: "\0"
  name: 'fault_injection: trajectory_deviation_is_high'
  message: Node starting up
  hardware_id: ''
  values: []
---
header:
  stamp:
    sec: 1653447541
    nanosec: 919010033
  frame_id: ''
status:
- level: "\0"
  name: 'fault_injection: trajectory_is_invalid'
  message: Node starting up
  hardware_id: ''
  values: []
---
header:
  stamp:
    sec: 1653447541
    nanosec: 919016646
  frame_id: ''
status:
- level: "\0"
  name: 'fault_injection: vehicle_ecu_connection_is_lost'
  message: Node starting up
  hardware_id: ''
  values: []
---
header:
  stamp:
    sec: 1653447541
    nanosec: 919024601
  frame_id: ''
status:
- level: "\0"
  name: 'fault_injection: vehicle_error_occurred'
  message: Node starting up
  hardware_id: ''
  values: []
---
header:
  stamp:
    sec: 1653447541
    nanosec: 919032355
  frame_id: ''
status:
- level: "\0"
  name: 'fault_injection: vehicle_is_out_of_lane'
  message: Node starting up
  hardware_id: ''
  values: []
---
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
