### PR TITLE
feat: use THROTTLE to output log

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -231,7 +231,7 @@ bool StopLineModule::modifyPathVelocity(
 
   // If no collision found, do nothing
   if (!collision) {
-    RCLCPP_WARN(logger_, "is no collision");
+    RCLCPP_WARN_THROTTLE(logger_, *clock_, 5000 /* ms */, "is no collision");
     return true;
   }
 


### PR DESCRIPTION
## Description

When a lane has stopline but a path does not intersect with a stopline, the following log continues to output.
An example is the following image.
This PR suppreses its frequency.
```
[component_container_mt-45] [WARN 1653545859.549768965] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.stop_line_module] modifyPathVelocity(): is no collision
```

![image](https://user-images.githubusercontent.com/9547070/170910795-95f0c935-2bf7-493c-92a3-bdf0cefb445b.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
