### PR TITLE
fix(pointcloud_preprocessor): fix launch file

### DIFF
--- a/sensing/pointcloud_preprocessor/launch/preprocessor.launch.xml
+++ b/sensing/pointcloud_preprocessor/launch/preprocessor.launch.xml
@@ -4,14 +4,14 @@
      To subscribe multiple topics, write as:
      "['/points_raw0', '/points_raw1', '/points_raw2', ...]"
      This syntax is also available from command line -->
-  <arg name="input_points_raw_list" default="['/points_raw']" desc="define as string_array"/>
+  <arg name="input_points_raw_list" default="['/points_raw']" description="define as string_array"/>
 
-  <arg name="output_points_raw" default="/points_raw/cropbox/filtered" desc=""/>
-  <arg name="tf_output_frame" default="base_link" desc=""/>
+  <arg name="output_points_raw" default="/points_raw/cropbox/filtered" description=""/>
+  <arg name="tf_output_frame" default="base_link" description=""/>
 
   <include file="$(find-pkg-share pointcloud_preprocessor)/launch/preprocessor.launch.py">
-    <param name="input_points_raw_list" value="$(var input_points_raw_list)"/>
-    <param name="output_points_raw" value="$(var output_points_raw)"/>
-    <param name="tf_output_frame" value="$(var tf_output_frame)"/>
+    <arg name="input_points_raw_list" value="$(var input_points_raw_list)"/>
+    <arg name="output_points_raw" value="$(var output_points_raw)"/>
+    <arg name="tf_output_frame" value="$(var tf_output_frame)"/>
   </include>
 </launch>


### PR DESCRIPTION
Signed-off-by: Kaan Colak <kcolak@leodrive.ai>

## Description

When I tried to run some sensing/perception nodes standalone, I got a syntax error in preprocessor.launch.xml file. I created a PR with a few minor syntax fixes.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
