### PR TITLE
fix: launch missing rosbridge_server

### DIFF
--- a/common/web_controller/launch/web_controller.launch.xml
+++ b/common/web_controller/launch/web_controller.launch.xml
@@ -2,4 +2,5 @@
 <launch>
   <!-- Web Controller -->
   <executable cmd="python3 -m http.server 8085" cwd="$(find-pkg-share web_controller)/www" name="web_server"/>
+  <node pkg="rosbridge_server" exec="rosbridge_websocket" name="rosbridge_server_node"/>
 </launch>


### PR DESCRIPTION
## Description

Add missing rosbridge_server to the web_controller launch file
Without it, the web controller view only displays 'Disconnected'

Same than original architecture proposal launch file: https://github.com/tier4/AutowareArchitectureProposal.iv/blob/use-autoware-auto-msgs/common/util/web_controller/autoware_web_controller/launch/autoware_web_controller.launch.xml

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
