### PR TITLE
fix: path distance calculator

### DIFF
--- a/common/path_distance_calculator/src/path_distance_calculator.cpp
+++ b/common/path_distance_calculator/src/path_distance_calculator.cpp
@@ -47,6 +47,10 @@ PathDistanceCalculator::PathDistanceCalculator(const rclcpp::NodeOptions & optio
       RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "path empty");
     }
 
+    if (path->points.size() == 1) {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "too short path");
+    }
+
     const double distance = tier4_autoware_utils::calcSignedArcLength(
       path->points, pose->pose.position, path->points.size() - 1);
 


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description

When the size of path is 1, path distance calculator died with following messages.
```
[path_distance_calculator_node-42] terminate called after throwing an instance of 'std::out_of_range'
[path_distance_calculator_node-42]   what():  vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)
```
I fixed it.




<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
