### PR TITLE
feat: reduce calc cost of occ grid outlier filter

### DIFF
--- a/perception/occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_nodelet.cpp
+++ b/perception/occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_nodelet.cpp
@@ -131,7 +131,8 @@ void RadiusSearch2dfilter::filter(
     const int min_points_threshold = std::min(
       std::max(static_cast<int>(min_points_and_distance_ratio_ / distance + 0.5f), min_points_),
       max_points_);
-    const int points_num = kd_tree_->radiusSearch(i, search_radius_, k_indices, k_dists);
+    const int points_num =
+      kd_tree_->radiusSearch(i, search_radius_, k_indices, k_dists, min_points_threshold);
 
     if (min_points_threshold <= points_num) {
       output.points.push_back(xyz_cloud.points.at(i));
@@ -167,7 +168,8 @@ void RadiusSearch2dfilter::filter(
     const int min_points_threshold = std::min(
       std::max(static_cast<int>(min_points_and_distance_ratio_ / distance + 0.5f), min_points_),
       max_points_);
-    const int points_num = kd_tree_->radiusSearch(i, search_radius_, k_indices, k_dists);
+    const int points_num =
+      kd_tree_->radiusSearch(i, search_radius_, k_indices, k_dists, min_points_threshold);
 
     if (min_points_threshold <= points_num) {
       output.points.push_back(low_conf_xyz_cloud.points.at(i));


### PR DESCRIPTION
Signed-off-by: Yukihiro Saito <yukky.saito@gmail.com>

## Description

Sometimes the execution time of the occupancy grid map based outlier filter node is long.
After analysis, radiusSearch was dominant.
In this PR, it is reduced calc cost of occ grid outlier filter.

With sample code, the result is shown in the following
https://pointclouds.org/documentation/classpcl_1_1search_1_1_kd_tree.html
```
max_nn == 10: 20msec
max_nn == 100: 100msec
max_nn == none : 2329msec
```

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
