### PR TITLE
feat(tier4_autoware_utils): expand geometry and trajectory utility functions

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -26,7 +26,6 @@
 #include <Eigen/Geometry>
 
 #include <autoware_auto_planning_msgs/msg/path.hpp>
-#include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -72,13 +71,6 @@ inline geometry_msgs::msg::Point getPoint(const geometry_msgs::msg::PoseWithCova
 }
 
 template <>
-inline geometry_msgs::msg::Point getPoint(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
-{
-  return p.point.pose.position;
-}
-
-template <>
 inline geometry_msgs::msg::Point getPoint(const autoware_auto_planning_msgs::msg::PathPoint & p)
 {
   return p.pose.position;
@@ -117,13 +109,6 @@ inline geometry_msgs::msg::Pose getPose(const autoware_auto_planning_msgs::msg::
 }
 
 template <>
-inline geometry_msgs::msg::Pose getPose(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
-{
-  return p.point.pose;
-}
-
-template <>
 inline geometry_msgs::msg::Pose getPose(const autoware_auto_planning_msgs::msg::TrajectoryPoint & p)
 {
   return p.pose;
@@ -153,13 +138,6 @@ inline void setPose(
   const geometry_msgs::msg::Pose & pose, autoware_auto_planning_msgs::msg::PathPoint & p)
 {
   p.pose = pose;
-}
-
-template <>
-inline void setPose(
-  const geometry_msgs::msg::Pose & pose, autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
-{
-  p.point.pose = pose;
 }
 
 template <>

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -26,6 +26,7 @@
 #include <Eigen/Geometry>
 
 #include <autoware_auto_planning_msgs/msg/path.hpp>
+#include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -71,6 +72,13 @@ inline geometry_msgs::msg::Point getPoint(const geometry_msgs::msg::PoseWithCova
 }
 
 template <>
+inline geometry_msgs::msg::Point getPoint(
+  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
+{
+  return p.point.pose.position;
+}
+
+template <>
 inline geometry_msgs::msg::Point getPoint(const autoware_auto_planning_msgs::msg::PathPoint & p)
 {
   return p.pose.position;
@@ -109,9 +117,56 @@ inline geometry_msgs::msg::Pose getPose(const autoware_auto_planning_msgs::msg::
 }
 
 template <>
+inline geometry_msgs::msg::Pose getPose(
+  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
+{
+  return p.point.pose;
+}
+
+template <>
 inline geometry_msgs::msg::Pose getPose(const autoware_auto_planning_msgs::msg::TrajectoryPoint & p)
 {
   return p.pose;
+}
+
+template <class T>
+void setPose(const geometry_msgs::msg::Pose & pose, [[maybe_unused]] T & p)
+{
+  static_assert(sizeof(T) == 0, "Only specializations of getPose can be used.");
+  throw std::logic_error("Only specializations of getPose can be used.");
+}
+
+template <>
+inline void setPose(const geometry_msgs::msg::Pose & pose, geometry_msgs::msg::Pose & p)
+{
+  p = pose;
+}
+
+template <>
+inline void setPose(const geometry_msgs::msg::Pose & pose, geometry_msgs::msg::PoseStamped & p)
+{
+  p.pose = pose;
+}
+
+template <>
+inline void setPose(
+  const geometry_msgs::msg::Pose & pose, autoware_auto_planning_msgs::msg::PathPoint & p)
+{
+  p.pose = pose;
+}
+
+template <>
+inline void setPose(
+  const geometry_msgs::msg::Pose & pose, autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
+{
+  p.point.pose = pose;
+}
+
+template <>
+inline void setPose(
+  const geometry_msgs::msg::Pose & pose, autoware_auto_planning_msgs::msg::TrajectoryPoint & p)
+{
+  p.pose = pose;
 }
 
 inline geometry_msgs::msg::Point createPoint(const double x, const double y, const double z)

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/path_with_lane_id_geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/path_with_lane_id_geometry.hpp
@@ -1,0 +1,46 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TIER4_AUTOWARE_UTILS__GEOMETRY__PATH_WITH_LANE_ID_GEOMETRY_HPP_
+#define TIER4_AUTOWARE_UTILS__GEOMETRY__PATH_WITH_LANE_ID_GEOMETRY_HPP_
+
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+
+#include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
+
+namespace tier4_autoware_utils
+{
+template <>
+inline geometry_msgs::msg::Point getPoint(
+  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
+{
+  return p.point.pose.position;
+}
+
+template <>
+inline geometry_msgs::msg::Pose getPose(
+  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
+{
+  return p.point.pose;
+}
+
+template <>
+inline void setPose(
+  const geometry_msgs::msg::Pose & pose, autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
+{
+  p.point.pose = pose;
+}
+}  // namespace tier4_autoware_utils
+
+#endif  // TIER4_AUTOWARE_UTILS__GEOMETRY__PATH_WITH_LANE_ID_GEOMETRY_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/path_with_lane_id_geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/path_with_lane_id_geometry.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
@@ -17,6 +17,7 @@
 
 #include "tier4_autoware_utils/geometry/boost_geometry.hpp"
 #include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/geometry/path_with_lane_id_geometry.hpp"
 #include "tier4_autoware_utils/geometry/pose_deviation.hpp"
 #include "tier4_autoware_utils/math/constants.hpp"
 #include "tier4_autoware_utils/math/normalization.hpp"
@@ -32,6 +33,7 @@
 #include "tier4_autoware_utils/ros/update_param.hpp"
 #include "tier4_autoware_utils/ros/wait_for_param.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
+#include "tier4_autoware_utils/trajectory/path_with_lane_id.hpp"
 #include "tier4_autoware_utils/trajectory/trajectory.hpp"
 #include "tier4_autoware_utils/vehicle/vehicle_state_checker.hpp"
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/path_with_lane_id.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/path_with_lane_id.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/path_with_lane_id.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/path_with_lane_id.hpp
@@ -1,0 +1,148 @@
+// Copyright 2021 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TIER4_AUTOWARE_UTILS__TRAJECTORY__PATH_WITH_LANE_ID_HPP_
+#define TIER4_AUTOWARE_UTILS__TRAJECTORY__PATH_WITH_LANE_ID_HPP_
+
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/geometry/path_with_lane_id_geometry.hpp"
+#include "tier4_autoware_utils/trajectory/trajectory.hpp"
+
+#include <boost/optional.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace tier4_autoware_utils
+{
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param points points of trajectory, path, ...
+ * @param src_idx index of source point
+ * @param offset length of offset from source point
+ * @return offset point
+ */
+template <>
+inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
+  const size_t src_idx, const double offset)
+{
+  validateNonEmpty(points);
+
+  if (points.size() - 1 < src_idx) {
+    throw std::out_of_range("Invalid source index");
+  }
+
+  if (points.size() == 1) {
+    return {};
+  }
+
+  if (offset < 0.0) {
+    auto reverse_points = points;
+    std::reverse(reverse_points.begin(), reverse_points.end());
+    return calcLongitudinalOffsetPose(reverse_points, reverse_points.size() - src_idx - 1, -offset);
+  }
+
+  double dist_sum = 0.0;
+
+  for (size_t i = src_idx; i < points.size() - 1; ++i) {
+    const auto & p_front = points.at(i);
+    const auto & p_back = points.at(i + 1);
+
+    const auto dist_segment = calcDistance2d(p_front, p_back);
+    dist_sum += dist_segment;
+
+    const auto dist_res = offset - dist_sum;
+    if (dist_res <= 0.0) {
+      return calcInterpolatedPose(p_back, p_front, std::abs(dist_res / dist_segment));
+    }
+  }
+
+  return {};
+}
+
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param points points of trajectory, path, ...
+ * @param src_point source point
+ * @param offset length of offset from source point
+ * @return offset point
+ */
+template <>
+inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
+  const geometry_msgs::msg::Point & src_point, const double offset)
+{
+  validateNonEmpty(points);
+
+  if (offset < 0.0) {
+    auto reverse_points = points;
+    std::reverse(reverse_points.begin(), reverse_points.end());
+    return calcLongitudinalOffsetPose(reverse_points, src_point, -offset);
+  }
+
+  const size_t src_seg_idx = findNearestSegmentIndex(points, src_point);
+  const double signed_length_src_offset =
+    calcLongitudinalOffsetToSegment(points, src_seg_idx, src_point);
+
+  return calcLongitudinalOffsetPose(points, src_seg_idx, offset + signed_length_src_offset);
+}
+
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param seg_idx segment index of point at beginning of length
+ * @param p_target point to be inserted
+ * @param points output points of trajectory, path, ...
+ * @return index of insert point
+ */
+template <>
+inline size_t insertTargetPoint(
+  const size_t seg_idx, const geometry_msgs::msg::Point & p_target,
+  std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
+  const double overlap_threshold)
+{
+  validateNonEmpty(points);
+
+  const auto p_front = getPoint(points.at(seg_idx));
+  const auto p_back = getPoint(points.at(seg_idx + 1));
+  const auto yaw = calcAzimuthAngle(p_target, p_back);
+
+  validateNonSharpAngle(p_front, p_target, p_back);
+
+  const auto overlap_with_front = calcDistance2d(p_target, p_front) < overlap_threshold;
+  const auto overlap_with_back = calcDistance2d(p_target, p_back) < overlap_threshold;
+
+  geometry_msgs::msg::Pose target_pose;
+  target_pose.position = p_target;
+  target_pose.orientation = createQuaternionFromYaw(yaw);
+
+  auto p_insert = points.at(seg_idx);
+  setPose(target_pose, p_insert);
+
+  if (!overlap_with_front && !overlap_with_back) {
+    points.insert(points.begin() + seg_idx + 1, p_insert);
+    return seg_idx + 1;
+  }
+
+  if (overlap_with_back) {
+    return seg_idx + 1;
+  }
+
+  return seg_idx;
+}
+}  // namespace tier4_autoware_utils
+
+#endif  // TIER4_AUTOWARE_UTILS__TRAJECTORY__PATH_WITH_LANE_ID_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/path_with_lane_id.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/path_with_lane_id.hpp
@@ -36,6 +36,85 @@ namespace tier4_autoware_utils
  * @return offset point
  */
 template <>
+inline boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
+  const size_t src_idx, const double offset)
+{
+  validateNonEmpty(points);
+
+  if (points.size() - 1 < src_idx) {
+    throw std::out_of_range("Invalid source index");
+  }
+
+  if (points.size() == 1) {
+    return {};
+  }
+
+  if (src_idx + 1 == points.size() && offset == 0.0) {
+    return getPoint(points.at(src_idx));
+  }
+
+  if (offset < 0.0) {
+    auto reverse_points = points;
+    std::reverse(reverse_points.begin(), reverse_points.end());
+    return calcLongitudinalOffsetPoint(
+      reverse_points, reverse_points.size() - src_idx - 1, -offset);
+  }
+
+  double dist_sum = 0.0;
+
+  for (size_t i = src_idx; i < points.size() - 1; ++i) {
+    const auto & p_front = points.at(i);
+    const auto & p_back = points.at(i + 1);
+
+    const auto dist_segment = calcDistance2d(p_front, p_back);
+    dist_sum += dist_segment;
+
+    const auto dist_res = offset - dist_sum;
+    if (dist_res <= 0.0) {
+      return calcInterpolatedPoint(p_back, p_front, std::abs(dist_res / dist_segment));
+    }
+  }
+
+  // not found (out of range)
+  return {};
+}
+
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param points points of trajectory, path, ...
+ * @param src_point source point
+ * @param offset length of offset from source point
+ * @return offset point
+ */
+template <>
+inline boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
+  const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
+  const geometry_msgs::msg::Point & src_point, const double offset)
+{
+  validateNonEmpty(points);
+
+  if (offset < 0.0) {
+    auto reverse_points = points;
+    std::reverse(reverse_points.begin(), reverse_points.end());
+    return calcLongitudinalOffsetPoint(reverse_points, src_point, -offset);
+  }
+
+  const size_t src_seg_idx = findNearestSegmentIndex(points, src_point);
+  const double signed_length_src_offset =
+    calcLongitudinalOffsetToSegment(points, src_seg_idx, src_point);
+
+  return calcLongitudinalOffsetPoint(points, src_seg_idx, offset + signed_length_src_offset);
+}
+
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param points points of trajectory, path, ...
+ * @param src_idx index of source point
+ * @param offset length of offset from source point
+ * @return offset pose
+ */
+template <>
 inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const size_t src_idx, const double offset)
@@ -50,27 +129,46 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
     return {};
   }
 
+  if (src_idx + 1 == points.size() && offset == 0.0) {
+    return getPose(points.at(src_idx));
+  }
+
   if (offset < 0.0) {
     auto reverse_points = points;
     std::reverse(reverse_points.begin(), reverse_points.end());
-    return calcLongitudinalOffsetPose(reverse_points, reverse_points.size() - src_idx - 1, -offset);
-  }
 
-  double dist_sum = 0.0;
+    double dist_sum = 0.0;
 
-  for (size_t i = src_idx; i < points.size() - 1; ++i) {
-    const auto & p_front = points.at(i);
-    const auto & p_back = points.at(i + 1);
+    for (size_t i = reverse_points.size() - src_idx - 1; i < reverse_points.size() - 1; ++i) {
+      const auto & p_front = reverse_points.at(i);
+      const auto & p_back = reverse_points.at(i + 1);
 
-    const auto dist_segment = calcDistance2d(p_front, p_back);
-    dist_sum += dist_segment;
+      const auto dist_segment = calcDistance2d(p_front, p_back);
+      dist_sum += dist_segment;
 
-    const auto dist_res = offset - dist_sum;
-    if (dist_res <= 0.0) {
-      return calcInterpolatedPose(p_back, p_front, std::abs(dist_res / dist_segment));
+      const auto dist_res = -offset - dist_sum;
+      if (dist_res <= 0.0) {
+        return calcInterpolatedPose(p_back, p_front, std::abs(dist_res / dist_segment));
+      }
+    }
+  } else {
+    double dist_sum = 0.0;
+
+    for (size_t i = src_idx; i < points.size() - 1; ++i) {
+      const auto & p_front = points.at(i);
+      const auto & p_back = points.at(i + 1);
+
+      const auto dist_segment = calcDistance2d(p_front, p_back);
+      dist_sum += dist_segment;
+
+      const auto dist_res = offset - dist_sum;
+      if (dist_res <= 0.0) {
+        return calcInterpolatedPose(p_front, p_back, 1.0 - std::abs(dist_res / dist_segment));
+      }
     }
   }
 
+  // not found (out of range)
   return {};
 }
 
@@ -79,7 +177,7 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
  * @param points points of trajectory, path, ...
  * @param src_point source point
  * @param offset length of offset from source point
- * @return offset point
+ * @return offset pase
  */
 template <>
 inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
@@ -87,12 +185,6 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const geometry_msgs::msg::Point & src_point, const double offset)
 {
   validateNonEmpty(points);
-
-  if (offset < 0.0) {
-    auto reverse_points = points;
-    std::reverse(reverse_points.begin(), reverse_points.end());
-    return calcLongitudinalOffsetPose(reverse_points, src_point, -offset);
-  }
 
   const size_t src_seg_idx = findNearestSegmentIndex(points, src_point);
   const double signed_length_src_offset =
@@ -118,21 +210,39 @@ inline size_t insertTargetPoint(
 
   const auto p_front = getPoint(points.at(seg_idx));
   const auto p_back = getPoint(points.at(seg_idx + 1));
-  const auto yaw = calcAzimuthAngle(p_target, p_back);
 
-  validateNonSharpAngle(p_front, p_target, p_back);
+  try {
+    validateNonSharpAngle(p_front, p_target, p_back);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+  }
 
   const auto overlap_with_front = calcDistance2d(p_target, p_front) < overlap_threshold;
   const auto overlap_with_back = calcDistance2d(p_target, p_back) < overlap_threshold;
 
   geometry_msgs::msg::Pose target_pose;
-  target_pose.position = p_target;
-  target_pose.orientation = createQuaternionFromYaw(yaw);
+  {
+    const auto pitch = calcElevationAngle(p_target, p_back);
+    const auto yaw = calcAzimuthAngle(p_target, p_back);
+
+    target_pose.position = p_target;
+    target_pose.orientation = createQuaternionFromRPY(0.0, pitch, yaw);
+  }
 
   auto p_insert = points.at(seg_idx);
   setPose(target_pose, p_insert);
 
+  geometry_msgs::msg::Pose front_pose;
+  {
+    const auto pitch = calcElevationAngle(p_front, p_target);
+    const auto yaw = calcAzimuthAngle(p_front, p_target);
+
+    front_pose.position = getPoint(points.at(seg_idx));
+    front_pose.orientation = createQuaternionFromRPY(0.0, pitch, yaw);
+  }
+
   if (!overlap_with_front && !overlap_with_back) {
+    setPose(front_pose, points.at(seg_idx));
     points.insert(points.begin() + seg_idx + 1, p_insert);
     return seg_idx + 1;
   }

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
@@ -449,7 +449,7 @@ boost::optional<double> calcDistanceToForwardStopPoint(
  * @return offset point
  */
 template <class T>
-boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
+boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const T & points, const size_t src_idx, const double offset)
 {
   validateNonEmpty(points);
@@ -465,22 +465,21 @@ boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   if (offset < 0.0) {
     auto reverse_points = points;
     std::reverse(reverse_points.begin(), reverse_points.end());
-    return calcLongitudinalOffsetPoint(
-      reverse_points, reverse_points.size() - src_idx - 1, -offset);
+    return calcLongitudinalOffsetPose(reverse_points, reverse_points.size() - src_idx - 1, -offset);
   }
 
   double dist_sum = 0.0;
 
   for (size_t i = src_idx; i < points.size() - 1; ++i) {
-    const auto & p_front = getPoint(points.at(i));
-    const auto & p_back = getPoint(points.at(i + 1));
+    const auto & p_front = points.at(i);
+    const auto & p_back = points.at(i + 1);
 
     const auto dist_segment = calcDistance2d(p_front, p_back);
     dist_sum += dist_segment;
 
     const auto dist_res = offset - dist_sum;
     if (dist_res <= 0.0) {
-      return calcInterpolatedPoint(p_back, p_front, std::abs(dist_res / dist_segment));
+      return calcInterpolatedPose(p_back, p_front, std::abs(dist_res / dist_segment));
     }
   }
 
@@ -495,7 +494,7 @@ boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
  * @return offset point
  */
 template <class T>
-boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
+boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const T & points, const geometry_msgs::msg::Point & src_point, const double offset)
 {
   validateNonEmpty(points);
@@ -503,14 +502,14 @@ boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   if (offset < 0.0) {
     auto reverse_points = points;
     std::reverse(reverse_points.begin(), reverse_points.end());
-    return calcLongitudinalOffsetPoint(reverse_points, src_point, -offset);
+    return calcLongitudinalOffsetPose(reverse_points, src_point, -offset);
   }
 
   const size_t src_seg_idx = findNearestSegmentIndex(points, src_point);
   const double signed_length_src_offset =
     calcLongitudinalOffsetToSegment(points, src_seg_idx, src_point);
 
-  return calcLongitudinalOffsetPoint(points, src_seg_idx, offset + signed_length_src_offset);
+  return calcLongitudinalOffsetPose(points, src_seg_idx, offset + signed_length_src_offset);
 }
 
 /**

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
@@ -449,7 +449,7 @@ boost::optional<double> calcDistanceToForwardStopPoint(
  * @return offset point
  */
 template <class T>
-boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const T & points, const size_t src_idx, const double offset)
 {
   validateNonEmpty(points);
@@ -494,7 +494,7 @@ boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
  * @return offset point
  */
 template <class T>
-boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const T & points, const geometry_msgs::msg::Point & src_point, const double offset)
 {
   validateNonEmpty(points);
@@ -528,7 +528,7 @@ inline size_t insertTargetPoint(
 
   const auto p_front = getPoint(points.at(seg_idx));
   const auto p_back = getPoint(points.at(seg_idx + 1));
-  const auto yaw = calcAzimuthAngle(p_front, p_back);
+  const auto yaw = calcAzimuthAngle(p_target, p_back);
 
   validateNonSharpAngle(p_front, p_target, p_back);
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
@@ -17,12 +17,14 @@
 
 #include "tier4_autoware_utils/geometry/geometry.hpp"
 #include "tier4_autoware_utils/geometry/pose_deviation.hpp"
+#include "tier4_autoware_utils/math/constants.hpp"
 
 #include <boost/optional.hpp>
 
 #include <algorithm>
 #include <limits>
 #include <stdexcept>
+#include <vector>
 
 namespace tier4_autoware_utils
 {
@@ -31,6 +33,27 @@ void validateNonEmpty(const T & points)
 {
   if (points.empty()) {
     throw std::invalid_argument("Points is empty.");
+  }
+}
+
+template <class T>
+void validateNonSharpAngle(
+  const T & point1, const T & point2, const T & point3, const double angle_threshold = pi / 4)
+{
+  const auto p1 = getPoint(point1);
+  const auto p2 = getPoint(point2);
+  const auto p3 = getPoint(point3);
+
+  const std::vector vec_1to2 = {p2.x - p1.x, p2.y - p1.y, p2.z - p1.z};
+  const std::vector vec_3to2 = {p2.x - p3.x, p2.y - p3.y, p2.z - p3.z};
+  const auto product = std::inner_product(vec_1to2.begin(), vec_1to2.end(), vec_3to2.begin(), 0.0);
+
+  const auto dist_1to2 = calcDistance3d(p1, p2);
+  const auto dist_3to2 = calcDistance3d(p3, p2);
+
+  constexpr double epsilon = 1e-3;
+  if (std::cos(angle_threshold) < product / dist_1to2 / dist_3to2 + epsilon) {
+    throw std::invalid_argument("Invalid sharp angle.");
   }
 }
 
@@ -416,6 +439,120 @@ boost::optional<double> calcDistanceToForwardStopPoint(
   }
 
   return std::max(0.0, *closest_stop_dist);
+}
+
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param points points of trajectory, path, ...
+ * @param src_idx index of source point
+ * @param offset length of offset from source point
+ * @return offset point
+ */
+template <class T>
+boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
+  const T & points, const size_t src_idx, const double offset)
+{
+  validateNonEmpty(points);
+
+  if (points.size() - 1 < src_idx) {
+    throw std::out_of_range("Invalid source index");
+  }
+
+  if (points.size() == 1) {
+    return {};
+  }
+
+  if (offset < 0.0) {
+    auto reverse_points = points;
+    std::reverse(reverse_points.begin(), reverse_points.end());
+    return calcLongitudinalOffsetPoint(
+      reverse_points, reverse_points.size() - src_idx - 1, -offset);
+  }
+
+  double dist_sum = 0.0;
+
+  for (size_t i = src_idx; i < points.size() - 1; ++i) {
+    const auto & p_front = getPoint(points.at(i));
+    const auto & p_back = getPoint(points.at(i + 1));
+
+    const auto dist_segment = calcDistance2d(p_front, p_back);
+    dist_sum += dist_segment;
+
+    const auto dist_res = offset - dist_sum;
+    if (dist_res <= 0.0) {
+      return calcInterpolatePoint(p_back, p_front, std::abs(dist_res / dist_segment));
+    }
+  }
+
+  return {};
+}
+
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param points points of trajectory, path, ...
+ * @param src_point source point
+ * @param offset length of offset from source point
+ * @return offset point
+ */
+template <class T>
+boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
+  const T & points, const geometry_msgs::msg::Point & src_point, const double offset)
+{
+  validateNonEmpty(points);
+
+  if (offset < 0.0) {
+    auto reverse_points = points;
+    std::reverse(reverse_points.begin(), reverse_points.end());
+    return calcLongitudinalOffsetPoint(reverse_points, src_point, -offset);
+  }
+
+  const size_t src_seg_idx = findNearestSegmentIndex(points, src_point);
+  const double signed_length_src_offset =
+    calcLongitudinalOffsetToSegment(points, src_seg_idx, src_point);
+
+  return calcLongitudinalOffsetPoint(points, src_seg_idx, offset + signed_length_src_offset);
+}
+
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param seg_idx segment index of point at beginning of length
+ * @param p_target point to be inserted
+ * @param points output points of trajectory, path, ...
+ * @return index of insert point
+ */
+template <class T>
+inline size_t insertTargetPoint(
+  const size_t seg_idx, const geometry_msgs::msg::Point & p_target, T & points,
+  const double overlap_threshold = 1e-3)
+{
+  validateNonEmpty(points);
+
+  const auto p_front = getPoint(points.at(seg_idx));
+  const auto p_back = getPoint(points.at(seg_idx + 1));
+  const auto yaw = calcAzimuthAngle(p_front, p_back);
+
+  validateNonSharpAngle(p_front, p_target, p_back);
+
+  const auto overlap_with_front = calcDistance2d(p_target, p_front) < overlap_threshold;
+  const auto overlap_with_back = calcDistance2d(p_target, p_back) < overlap_threshold;
+
+  geometry_msgs::msg::Pose target_pose;
+  target_pose.position = p_target;
+  target_pose.orientation = createQuaternionFromYaw(yaw);
+
+  auto p_insert = points.at(seg_idx);
+  setPose(target_pose, p_insert);
+
+  if (!overlap_with_front && !overlap_with_back) {
+    points.insert(points.begin() + seg_idx + 1, p_insert);
+    return seg_idx + 1;
+  }
+
+  if (overlap_with_back) {
+    return seg_idx + 1;
+  }
+
+  return seg_idx;
 }
 }  // namespace tier4_autoware_utils
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
@@ -53,7 +53,7 @@ void validateNonSharpAngle(
 
   constexpr double epsilon = 1e-3;
   if (std::cos(angle_threshold) < product / dist_1to2 / dist_3to2 + epsilon) {
-    throw std::invalid_argument("Invalid sharp angle.");
+    throw std::invalid_argument("Sharp angle.");
   }
 }
 
@@ -449,7 +449,7 @@ boost::optional<double> calcDistanceToForwardStopPoint(
  * @return offset point
  */
 template <class T>
-inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+inline boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   const T & points, const size_t src_idx, const double offset)
 {
   validateNonEmpty(points);
@@ -462,10 +462,15 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
     return {};
   }
 
+  if (src_idx + 1 == points.size() && offset == 0.0) {
+    return getPoint(points.at(src_idx));
+  }
+
   if (offset < 0.0) {
     auto reverse_points = points;
     std::reverse(reverse_points.begin(), reverse_points.end());
-    return calcLongitudinalOffsetPose(reverse_points, reverse_points.size() - src_idx - 1, -offset);
+    return calcLongitudinalOffsetPoint(
+      reverse_points, reverse_points.size() - src_idx - 1, -offset);
   }
 
   double dist_sum = 0.0;
@@ -479,10 +484,11 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
 
     const auto dist_res = offset - dist_sum;
     if (dist_res <= 0.0) {
-      return calcInterpolatedPose(p_back, p_front, std::abs(dist_res / dist_segment));
+      return calcInterpolatedPoint(p_back, p_front, std::abs(dist_res / dist_segment));
     }
   }
 
+  // not found (out of range)
   return {};
 }
 
@@ -494,7 +500,7 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
  * @return offset point
  */
 template <class T>
-inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+inline boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   const T & points, const geometry_msgs::msg::Point & src_point, const double offset)
 {
   validateNonEmpty(points);
@@ -502,8 +508,92 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   if (offset < 0.0) {
     auto reverse_points = points;
     std::reverse(reverse_points.begin(), reverse_points.end());
-    return calcLongitudinalOffsetPose(reverse_points, src_point, -offset);
+    return calcLongitudinalOffsetPoint(reverse_points, src_point, -offset);
   }
+
+  const size_t src_seg_idx = findNearestSegmentIndex(points, src_point);
+  const double signed_length_src_offset =
+    calcLongitudinalOffsetToSegment(points, src_seg_idx, src_point);
+
+  return calcLongitudinalOffsetPoint(points, src_seg_idx, offset + signed_length_src_offset);
+}
+
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param points points of trajectory, path, ...
+ * @param src_idx index of source point
+ * @param offset length of offset from source point
+ * @return offset pose
+ */
+template <class T>
+inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+  const T & points, const size_t src_idx, const double offset)
+{
+  validateNonEmpty(points);
+
+  if (points.size() - 1 < src_idx) {
+    throw std::out_of_range("Invalid source index");
+  }
+
+  if (points.size() == 1) {
+    return {};
+  }
+
+  if (src_idx + 1 == points.size() && offset == 0.0) {
+    return getPose(points.at(src_idx));
+  }
+
+  if (offset < 0.0) {
+    auto reverse_points = points;
+    std::reverse(reverse_points.begin(), reverse_points.end());
+
+    double dist_sum = 0.0;
+
+    for (size_t i = reverse_points.size() - src_idx - 1; i < reverse_points.size() - 1; ++i) {
+      const auto & p_front = reverse_points.at(i);
+      const auto & p_back = reverse_points.at(i + 1);
+
+      const auto dist_segment = calcDistance2d(p_front, p_back);
+      dist_sum += dist_segment;
+
+      const auto dist_res = -offset - dist_sum;
+      if (dist_res <= 0.0) {
+        return calcInterpolatedPose(p_back, p_front, std::abs(dist_res / dist_segment));
+      }
+    }
+  } else {
+    double dist_sum = 0.0;
+
+    for (size_t i = src_idx; i < points.size() - 1; ++i) {
+      const auto & p_front = points.at(i);
+      const auto & p_back = points.at(i + 1);
+
+      const auto dist_segment = calcDistance2d(p_front, p_back);
+      dist_sum += dist_segment;
+
+      const auto dist_res = offset - dist_sum;
+      if (dist_res <= 0.0) {
+        return calcInterpolatedPose(p_front, p_back, 1.0 - std::abs(dist_res / dist_segment));
+      }
+    }
+  }
+
+  // not found (out of range)
+  return {};
+}
+
+/**
+ * @brief calculate the point offset from source point along the trajectory (or path)
+ * @param points points of trajectory, path, ...
+ * @param src_point source point
+ * @param offset length of offset from source point
+ * @return offset pase
+ */
+template <class T>
+inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
+  const T & points, const geometry_msgs::msg::Point & src_point, const double offset)
+{
+  validateNonEmpty(points);
 
   const size_t src_seg_idx = findNearestSegmentIndex(points, src_point);
   const double signed_length_src_offset =
@@ -528,21 +618,39 @@ inline size_t insertTargetPoint(
 
   const auto p_front = getPoint(points.at(seg_idx));
   const auto p_back = getPoint(points.at(seg_idx + 1));
-  const auto yaw = calcAzimuthAngle(p_target, p_back);
 
-  validateNonSharpAngle(p_front, p_target, p_back);
+  try {
+    validateNonSharpAngle(p_front, p_target, p_back);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+  }
 
   const auto overlap_with_front = calcDistance2d(p_target, p_front) < overlap_threshold;
   const auto overlap_with_back = calcDistance2d(p_target, p_back) < overlap_threshold;
 
   geometry_msgs::msg::Pose target_pose;
-  target_pose.position = p_target;
-  target_pose.orientation = createQuaternionFromYaw(yaw);
+  {
+    const auto pitch = calcElevationAngle(p_target, p_back);
+    const auto yaw = calcAzimuthAngle(p_target, p_back);
+
+    target_pose.position = p_target;
+    target_pose.orientation = createQuaternionFromRPY(0.0, pitch, yaw);
+  }
 
   auto p_insert = points.at(seg_idx);
   setPose(target_pose, p_insert);
 
+  geometry_msgs::msg::Pose front_pose;
+  {
+    const auto pitch = calcElevationAngle(p_front, p_target);
+    const auto yaw = calcAzimuthAngle(p_front, p_target);
+
+    front_pose.position = getPoint(points.at(seg_idx));
+    front_pose.orientation = createQuaternionFromRPY(0.0, pitch, yaw);
+  }
+
   if (!overlap_with_front && !overlap_with_back) {
+    setPose(front_pose, points.at(seg_idx));
     points.insert(points.begin() + seg_idx + 1, p_insert);
     return seg_idx + 1;
   }

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
@@ -480,7 +480,7 @@ boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
 
     const auto dist_res = offset - dist_sum;
     if (dist_res <= 0.0) {
-      return calcInterpolatePoint(p_back, p_front, std::abs(dist_res / dist_segment));
+      return calcInterpolatedPoint(p_back, p_front, std::abs(dist_res / dist_segment));
     }
   }
 

--- a/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
@@ -180,6 +180,25 @@ TEST(geometry, getPose)
   }
 
   {
+    autoware_auto_planning_msgs::msg::PathPointWithLaneId p;
+    p.point.pose.position.x = x_ans;
+    p.point.pose.position.y = y_ans;
+    p.point.pose.position.z = z_ans;
+    p.point.pose.orientation.x = q_x_ans;
+    p.point.pose.orientation.y = q_y_ans;
+    p.point.pose.orientation.z = q_z_ans;
+    p.point.pose.orientation.w = q_w_ans;
+    const geometry_msgs::msg::Pose p_out = getPose(p);
+    EXPECT_DOUBLE_EQ(p_out.position.x, x_ans);
+    EXPECT_DOUBLE_EQ(p_out.position.y, y_ans);
+    EXPECT_DOUBLE_EQ(p_out.position.z, z_ans);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, q_x_ans);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, q_y_ans);
+    EXPECT_DOUBLE_EQ(p_out.orientation.z, q_z_ans);
+    EXPECT_DOUBLE_EQ(p_out.orientation.w, q_w_ans);
+  }
+
+  {
     autoware_auto_planning_msgs::msg::TrajectoryPoint p;
     p.pose.position.x = x_ans;
     p.pose.position.y = y_ans;
@@ -196,6 +215,88 @@ TEST(geometry, getPose)
     EXPECT_DOUBLE_EQ(p_out.orientation.y, q_y_ans);
     EXPECT_DOUBLE_EQ(p_out.orientation.z, q_z_ans);
     EXPECT_DOUBLE_EQ(p_out.orientation.w, q_w_ans);
+  }
+}
+
+TEST(geometry, setPose)
+{
+  using tier4_autoware_utils::setPose;
+
+  const double x_ans = 1.0;
+  const double y_ans = 2.0;
+  const double z_ans = 3.0;
+  const double q_x_ans = 0.1;
+  const double q_y_ans = 0.2;
+  const double q_z_ans = 0.3;
+  const double q_w_ans = 0.4;
+
+  geometry_msgs::msg::Pose p;
+  p.position.x = x_ans;
+  p.position.y = y_ans;
+  p.position.z = z_ans;
+  p.orientation.x = q_x_ans;
+  p.orientation.y = q_y_ans;
+  p.orientation.z = q_z_ans;
+  p.orientation.w = q_w_ans;
+
+  {
+    geometry_msgs::msg::Pose p_out{};
+    setPose(p, p_out);
+    EXPECT_DOUBLE_EQ(p_out.position.x, x_ans);
+    EXPECT_DOUBLE_EQ(p_out.position.y, y_ans);
+    EXPECT_DOUBLE_EQ(p_out.position.z, z_ans);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, q_x_ans);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, q_y_ans);
+    EXPECT_DOUBLE_EQ(p_out.orientation.z, q_z_ans);
+    EXPECT_DOUBLE_EQ(p_out.orientation.w, q_w_ans);
+  }
+
+  {
+    geometry_msgs::msg::PoseStamped p_out{};
+    setPose(p, p_out);
+    EXPECT_DOUBLE_EQ(p_out.pose.position.x, x_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.position.y, y_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.position.z, z_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.x, q_x_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.y, q_y_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.z, q_z_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.w, q_w_ans);
+  }
+
+  {
+    autoware_auto_planning_msgs::msg::PathPoint p_out{};
+    setPose(p, p_out);
+    EXPECT_DOUBLE_EQ(p_out.pose.position.x, x_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.position.y, y_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.position.z, z_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.x, q_x_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.y, q_y_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.z, q_z_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.w, q_w_ans);
+  }
+
+  {
+    autoware_auto_planning_msgs::msg::PathPointWithLaneId p_out{};
+    setPose(p, p_out);
+    EXPECT_DOUBLE_EQ(p_out.point.pose.position.x, x_ans);
+    EXPECT_DOUBLE_EQ(p_out.point.pose.position.y, y_ans);
+    EXPECT_DOUBLE_EQ(p_out.point.pose.position.z, z_ans);
+    EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.x, q_x_ans);
+    EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.y, q_y_ans);
+    EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.z, q_z_ans);
+    EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.w, q_w_ans);
+  }
+
+  {
+    autoware_auto_planning_msgs::msg::TrajectoryPoint p_out{};
+    setPose(p, p_out);
+    EXPECT_DOUBLE_EQ(p_out.pose.position.x, x_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.position.y, y_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.position.z, z_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.x, q_x_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.y, q_y_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.z, q_z_ans);
+    EXPECT_DOUBLE_EQ(p_out.pose.orientation.w, q_w_ans);
   }
 }
 

--- a/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
@@ -180,25 +180,6 @@ TEST(geometry, getPose)
   }
 
   {
-    autoware_auto_planning_msgs::msg::PathPointWithLaneId p;
-    p.point.pose.position.x = x_ans;
-    p.point.pose.position.y = y_ans;
-    p.point.pose.position.z = z_ans;
-    p.point.pose.orientation.x = q_x_ans;
-    p.point.pose.orientation.y = q_y_ans;
-    p.point.pose.orientation.z = q_z_ans;
-    p.point.pose.orientation.w = q_w_ans;
-    const geometry_msgs::msg::Pose p_out = getPose(p);
-    EXPECT_DOUBLE_EQ(p_out.position.x, x_ans);
-    EXPECT_DOUBLE_EQ(p_out.position.y, y_ans);
-    EXPECT_DOUBLE_EQ(p_out.position.z, z_ans);
-    EXPECT_DOUBLE_EQ(p_out.orientation.x, q_x_ans);
-    EXPECT_DOUBLE_EQ(p_out.orientation.y, q_y_ans);
-    EXPECT_DOUBLE_EQ(p_out.orientation.z, q_z_ans);
-    EXPECT_DOUBLE_EQ(p_out.orientation.w, q_w_ans);
-  }
-
-  {
     autoware_auto_planning_msgs::msg::TrajectoryPoint p;
     p.pose.position.x = x_ans;
     p.pose.position.y = y_ans;
@@ -273,18 +254,6 @@ TEST(geometry, setPose)
     EXPECT_DOUBLE_EQ(p_out.pose.orientation.y, q_y_ans);
     EXPECT_DOUBLE_EQ(p_out.pose.orientation.z, q_z_ans);
     EXPECT_DOUBLE_EQ(p_out.pose.orientation.w, q_w_ans);
-  }
-
-  {
-    autoware_auto_planning_msgs::msg::PathPointWithLaneId p_out{};
-    setPose(p, p_out);
-    EXPECT_DOUBLE_EQ(p_out.point.pose.position.x, x_ans);
-    EXPECT_DOUBLE_EQ(p_out.point.pose.position.y, y_ans);
-    EXPECT_DOUBLE_EQ(p_out.point.pose.position.z, z_ans);
-    EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.x, q_x_ans);
-    EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.y, q_y_ans);
-    EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.z, q_z_ans);
-    EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.w, q_w_ans);
   }
 
   {

--- a/common/tier4_autoware_utils/test/src/geometry/test_path_with_lane_id_geometry.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_path_with_lane_id_geometry.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/tier4_autoware_utils/test/src/geometry/test_path_with_lane_id_geometry.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_path_with_lane_id_geometry.cpp
@@ -1,0 +1,97 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tier4_autoware_utils/geometry/path_with_lane_id_geometry.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(geometry, getPoint_PathWithLaneId)
+{
+  using tier4_autoware_utils::getPoint;
+
+  const double x_ans = 1.0;
+  const double y_ans = 2.0;
+  const double z_ans = 3.0;
+
+  autoware_auto_planning_msgs::msg::PathPointWithLaneId p;
+  p.point.pose.position.x = x_ans;
+  p.point.pose.position.y = y_ans;
+  p.point.pose.position.z = z_ans;
+  const geometry_msgs::msg::Point p_out = getPoint(p);
+  EXPECT_DOUBLE_EQ(p_out.x, x_ans);
+  EXPECT_DOUBLE_EQ(p_out.y, y_ans);
+  EXPECT_DOUBLE_EQ(p_out.z, z_ans);
+}
+
+TEST(geometry, getPose_PathWithLaneId)
+{
+  using tier4_autoware_utils::getPose;
+
+  const double x_ans = 1.0;
+  const double y_ans = 2.0;
+  const double z_ans = 3.0;
+  const double q_x_ans = 0.1;
+  const double q_y_ans = 0.2;
+  const double q_z_ans = 0.3;
+  const double q_w_ans = 0.4;
+
+  autoware_auto_planning_msgs::msg::PathPointWithLaneId p;
+  p.point.pose.position.x = x_ans;
+  p.point.pose.position.y = y_ans;
+  p.point.pose.position.z = z_ans;
+  p.point.pose.orientation.x = q_x_ans;
+  p.point.pose.orientation.y = q_y_ans;
+  p.point.pose.orientation.z = q_z_ans;
+  p.point.pose.orientation.w = q_w_ans;
+  const geometry_msgs::msg::Pose p_out = getPose(p);
+  EXPECT_DOUBLE_EQ(p_out.position.x, x_ans);
+  EXPECT_DOUBLE_EQ(p_out.position.y, y_ans);
+  EXPECT_DOUBLE_EQ(p_out.position.z, z_ans);
+  EXPECT_DOUBLE_EQ(p_out.orientation.x, q_x_ans);
+  EXPECT_DOUBLE_EQ(p_out.orientation.y, q_y_ans);
+  EXPECT_DOUBLE_EQ(p_out.orientation.z, q_z_ans);
+  EXPECT_DOUBLE_EQ(p_out.orientation.w, q_w_ans);
+}
+
+TEST(geometry, setPose_PathWithLaneId)
+{
+  using tier4_autoware_utils::setPose;
+
+  const double x_ans = 1.0;
+  const double y_ans = 2.0;
+  const double z_ans = 3.0;
+  const double q_x_ans = 0.1;
+  const double q_y_ans = 0.2;
+  const double q_z_ans = 0.3;
+  const double q_w_ans = 0.4;
+
+  geometry_msgs::msg::Pose p;
+  p.position.x = x_ans;
+  p.position.y = y_ans;
+  p.position.z = z_ans;
+  p.orientation.x = q_x_ans;
+  p.orientation.y = q_y_ans;
+  p.orientation.z = q_z_ans;
+  p.orientation.w = q_w_ans;
+
+  autoware_auto_planning_msgs::msg::PathPointWithLaneId p_out{};
+  setPose(p, p_out);
+  EXPECT_DOUBLE_EQ(p_out.point.pose.position.x, x_ans);
+  EXPECT_DOUBLE_EQ(p_out.point.pose.position.y, y_ans);
+  EXPECT_DOUBLE_EQ(p_out.point.pose.position.z, z_ans);
+  EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.x, q_x_ans);
+  EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.y, q_y_ans);
+  EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.z, q_z_ans);
+  EXPECT_DOUBLE_EQ(p_out.point.pose.orientation.w, q_w_ans);
+}

--- a/common/tier4_autoware_utils/test/src/trajectory/test_path_with_lane_id.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_path_with_lane_id.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/tier4_autoware_utils/test/src/trajectory/test_path_with_lane_id.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_path_with_lane_id.cpp
@@ -1,0 +1,490 @@
+// Copyright 2021 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/trajectory/path_with_lane_id.hpp"
+
+#include <gtest/gtest.h>
+#include <tf2/LinearMath/Quaternion.h>
+
+#include <limits>
+#include <vector>
+
+namespace
+{
+using autoware_auto_planning_msgs::msg::PathPointWithLaneId;
+using autoware_auto_planning_msgs::msg::PathWithLaneId;
+using tier4_autoware_utils::createPoint;
+using tier4_autoware_utils::createQuaternionFromRPY;
+using tier4_autoware_utils::transformPoint;
+
+constexpr double epsilon = 1e-6;
+
+geometry_msgs::msg::Pose createPose(
+  double x, double y, double z, double roll, double pitch, double yaw)
+{
+  geometry_msgs::msg::Pose p;
+  p.position = createPoint(x, y, z);
+  p.orientation = createQuaternionFromRPY(roll, pitch, yaw);
+  return p;
+}
+
+PathWithLaneId generateTestTrajectory(
+  const size_t num_points, const double point_interval, const double vel = 0.0,
+  const double init_theta = 0.0, const double delta_theta = 0.0)
+{
+  PathWithLaneId path_with_lane_id;
+  for (size_t i = 0; i < num_points; ++i) {
+    const double theta = init_theta + i * delta_theta;
+    const double x = i * point_interval * std::cos(theta);
+    const double y = i * point_interval * std::sin(theta);
+
+    PathPointWithLaneId p;
+    p.point.pose = createPose(x, y, 0.0, 0.0, 0.0, theta);
+    p.point.longitudinal_velocity_mps = vel;
+    path_with_lane_id.points.push_back(p);
+  }
+
+  return path_with_lane_id;
+}
+}  // namespace
+
+TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_PathWithLaneId)
+{
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
+
+  const auto path_with_lane_id = generateTestTrajectory(10, 1.0);
+
+  // Empty
+  EXPECT_THROW(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
+
+  // Out of range
+  EXPECT_THROW(
+    calcLongitudinalOffsetPose(path_with_lane_id.points, path_with_lane_id.points.size() + 1, 1.0),
+    std::out_of_range);
+  EXPECT_THROW(calcLongitudinalOffsetPose(path_with_lane_id.points, -1, 1.0), std::out_of_range);
+
+  // Same Point
+  {
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 3, 0.0);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Whole length
+  {
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 0, 9.0);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Whole length
+  {
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 9, -9.0);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Forward offset
+  {
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 3, 2.25);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 5.25, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Backward offset
+  {
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 3, -2.25);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 0.75, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // No found
+  {
+    const auto p_out = calcLongitudinalOffsetPose(
+      path_with_lane_id.points, 0, calcArcLength(path_with_lane_id.points) + 1.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // No found
+  {
+    const auto p_out = calcLongitudinalOffsetPose(
+      path_with_lane_id.points, 9, -calcArcLength(path_with_lane_id.points) - 1.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // No found(Trajectory size is 1)
+  {
+    const auto one_point_path = generateTestTrajectory(1, 1.0);
+    const auto p_out = calcLongitudinalOffsetPose(one_point_path.points, 0.0, 0.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+}
+
+TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_PathWithLaneId)
+{
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
+  using tier4_autoware_utils::createPoint;
+
+  const auto path_with_lane_id = generateTestTrajectory(10, 1.0);
+
+  // Empty
+  EXPECT_THROW(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
+
+  // Same Point
+  {
+    const auto p_src = createPoint(3.0, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 0.0);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Whole length
+  {
+    const auto p_src = createPoint(0.0, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 9.0);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Whole length
+  {
+    const auto p_src = createPoint(9.0, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, -9.0);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Forward offset(No lateral deviation)
+  {
+    const auto p_src = createPoint(1.25, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 2.25);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 3.5, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Forward offset(Lateral deviation)
+  {
+    const auto p_src = createPoint(-1.25, 1.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 4.25);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Backward offset
+  {
+    const auto p_src = createPoint(6.25, 1.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, -2.25);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 4.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // Backward offset(Lateral deviation)
+  {
+    const auto p_src = createPoint(6.25, -1.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, -4.25);
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 2.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+  }
+
+  // No found
+  {
+    const auto p_src = createPoint(0.0, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(
+      path_with_lane_id.points, p_src, calcArcLength(path_with_lane_id.points) + 1.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // No found
+  {
+    const auto p_src = createPoint(9.0, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(
+      path_with_lane_id.points, p_src, -calcArcLength(path_with_lane_id.points) - 1.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // Out of range(Trajectory size is 1)
+  {
+    const auto one_point_path = generateTestTrajectory(1, 1.0);
+    EXPECT_THROW(
+      calcLongitudinalOffsetPose(one_point_path.points, geometry_msgs::msg::Point{}, {}),
+      std::out_of_range);
+  }
+}
+
+TEST(trajectory, insertTargetPoint_PathWithLaneId)
+{
+  using tier4_autoware_utils::calcDistance2d;
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+  using tier4_autoware_utils::getPoint;
+  using tier4_autoware_utils::insertTargetPoint;
+
+  const auto path_with_lane_id = generateTestTrajectory(10, 1.0);
+
+  // Insert between trajectory front and back
+  {
+    auto path_out = path_with_lane_id;
+
+    const auto p_target = createPoint(3.5, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
+    const auto insert_idx = insertTargetPoint(base_idx, p_target, path_out.points);
+
+    EXPECT_EQ(insert_idx, 4U);
+    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size() + 1);
+
+    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
+      const auto & p_front = getPoint(path_out.points.at(i));
+      const auto & p_back = getPoint(path_out.points.at(i + 1));
+      EXPECT_TRUE(calcDistance2d(p_front, p_back) > 1e-3);
+    }
+
+    const auto & p_insert = getPoint(path_out.points.at(insert_idx));
+    EXPECT_EQ(p_insert.x, p_target.x);
+    EXPECT_EQ(p_insert.y, p_target.y);
+    EXPECT_EQ(p_insert.z, p_target.z);
+  }
+
+  // Overlap base_idx point
+  {
+    auto path_out = path_with_lane_id;
+
+    const auto p_target = createPoint(3.0, 0.0, 0.0);
+    const auto insert_idx = insertTargetPoint(3, p_target, path_out.points);
+
+    EXPECT_EQ(insert_idx, 3U);
+    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size());
+
+    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
+      const auto & p_front = getPoint(path_out.points.at(i));
+      const auto & p_back = getPoint(path_out.points.at(i + 1));
+      EXPECT_TRUE(calcDistance2d(p_front, p_back) > 1e-3);
+    }
+  }
+
+  // Overlap base_idx + 1 point
+  {
+    auto path_out = path_with_lane_id;
+
+    const auto p_target = createPoint(4.0, 0.0, 0.0);
+    const auto insert_idx = insertTargetPoint(3, p_target, path_out.points);
+
+    EXPECT_EQ(insert_idx, 4U);
+    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size());
+
+    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
+      const auto & p_front = getPoint(path_out.points.at(i));
+      const auto & p_back = getPoint(path_out.points.at(i + 1));
+      EXPECT_TRUE(calcDistance2d(p_front, p_back) > 1e-3);
+    }
+  }
+
+  // Invalid target point(In front of begin point)
+  {
+    auto path_out = path_with_lane_id;
+
+    const auto p_target = createPoint(-1.0, 0.0, 0.0);
+    EXPECT_THROW(insertTargetPoint(0, p_target, path_out.points), std::invalid_argument);
+  }
+
+  // Invalid target point(Behind of end point)
+  {
+    auto path_out = path_with_lane_id;
+
+    const auto p_target = createPoint(10.0, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
+    EXPECT_THROW(insertTargetPoint(base_idx, p_target, path_out.points), std::invalid_argument);
+  }
+
+  // Invalid target point(Huge lateral offset)
+  {
+    auto path_out = path_with_lane_id;
+
+    const auto p_target = createPoint(4.0, 10.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
+    EXPECT_THROW(insertTargetPoint(base_idx, p_target, path_out.points), std::invalid_argument);
+  }
+
+  // Empty
+  {
+    auto empty_traj = generateTestTrajectory(0, 1.0);
+    EXPECT_THROW(
+      insertTargetPoint({}, geometry_msgs::msg::Point{}, empty_traj.points), std::invalid_argument);
+  }
+}
+
+TEST(trajectory, insertTargetPoint_OverlapThreshold_PathWithLaneId)
+{
+  using tier4_autoware_utils::calcDistance2d;
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+  using tier4_autoware_utils::getPoint;
+  using tier4_autoware_utils::insertTargetPoint;
+
+  constexpr double overlap_threshold = 1e-4;
+  const auto path_with_lane_id = generateTestTrajectory(10, 1.0);
+
+  // Insert between trajectory front and back
+  {
+    auto path_out = path_with_lane_id;
+
+    const auto p_target = createPoint(3.0001, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
+    const auto insert_idx =
+      insertTargetPoint(base_idx, p_target, path_out.points, overlap_threshold);
+
+    EXPECT_EQ(insert_idx, 4U);
+    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size() + 1);
+
+    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
+      const auto & p_front = getPoint(path_out.points.at(i));
+      const auto & p_back = getPoint(path_out.points.at(i + 1));
+      EXPECT_TRUE(calcDistance2d(p_front, p_back) > overlap_threshold);
+    }
+
+    const auto & p_insert = getPoint(path_out.points.at(insert_idx));
+    EXPECT_EQ(p_insert.x, p_target.x);
+    EXPECT_EQ(p_insert.y, p_target.y);
+    EXPECT_EQ(p_insert.z, p_target.z);
+  }
+
+  // Overlap base_idx point
+  {
+    auto path_out = path_with_lane_id;
+
+    const auto p_target = createPoint(3.00001, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
+    const auto insert_idx =
+      insertTargetPoint(base_idx, p_target, path_out.points, overlap_threshold);
+
+    EXPECT_EQ(insert_idx, 3U);
+    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size());
+
+    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
+      const auto & p_front = getPoint(path_out.points.at(i));
+      const auto & p_back = getPoint(path_out.points.at(i + 1));
+      EXPECT_TRUE(calcDistance2d(p_front, p_back) > overlap_threshold);
+    }
+  }
+
+  // Overlap base_idx + 1 point
+  {
+    auto path_out = path_with_lane_id;
+
+    const auto p_target = createPoint(3.99999, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
+    const auto insert_idx =
+      insertTargetPoint(base_idx, p_target, path_out.points, overlap_threshold);
+
+    EXPECT_EQ(insert_idx, 4U);
+    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size());
+
+    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
+      const auto & p_front = getPoint(path_out.points.at(i));
+      const auto & p_back = getPoint(path_out.points.at(i + 1));
+      EXPECT_TRUE(calcDistance2d(p_front, p_back) > overlap_threshold);
+    }
+  }
+}

--- a/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
@@ -18,6 +18,7 @@
 #include "tier4_autoware_utils/trajectory/trajectory.hpp"
 
 #include <gtest/gtest.h>
+#include <gtest/internal/gtest-port.h>
 #include <tf2/LinearMath/Quaternion.h>
 
 #include <limits>
@@ -931,627 +932,6 @@ TEST(trajectory, calcDistanceToForwardStopPoint_DistThreshold)
   }
 }
 
-TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
-{
-  using tier4_autoware_utils::calcArcLength;
-  using tier4_autoware_utils::calcLongitudinalOffsetPose;
-
-  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
-
-  // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}), std::invalid_argument);
-
-  // Out of range
-  EXPECT_THROW(
-    calcLongitudinalOffsetPose(traj.points, traj.points.size() + 1, 1.0), std::out_of_range);
-  EXPECT_THROW(calcLongitudinalOffsetPose(traj.points, -1, 1.0), std::out_of_range);
-
-  // Same Point
-  {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 3, 0.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, 9.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 9, -9.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Forward offset
-  {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 3, 2.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 5.25, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Backward offset
-  {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 3, -2.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.75, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // No found
-  {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, calcArcLength(traj.points) + 1.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-
-  // No found
-  {
-    const auto p_out =
-      calcLongitudinalOffsetPose(traj.points, 9, -calcArcLength(traj.points) - 1.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-
-  // No found(Trajectory size is 1)
-  {
-    const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
-    const auto p_out = calcLongitudinalOffsetPose(one_point_traj.points, 0.0, 0.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-}
-
-TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_CurveTrajectory)
-{
-  using autoware_auto_planning_msgs::msg::TrajectoryPoint;
-  using tier4_autoware_utils::calcLongitudinalOffsetPose;
-
-  Trajectory curve_traj{};
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(1.0, 1.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(2.0, 1.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(3.0, 2.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  // Whole length
-  {
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, 0, 4.41421356237309505);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 2.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, 4, -4.41421356237309505);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Forward offset
-  {
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, 1, 3.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 2.707106781186547524, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.707106781186547524, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Backward offset
-  {
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, 4, -4.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.41421356237309505, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-}
-
-TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
-{
-  using tier4_autoware_utils::calcArcLength;
-  using tier4_autoware_utils::calcLongitudinalOffsetPose;
-  using tier4_autoware_utils::createPoint;
-
-  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
-
-  // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}), std::invalid_argument);
-
-  // Same Point
-  {
-    const auto p_src = createPoint(3.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, 0.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, 9.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_src = createPoint(9.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, -9.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Forward offset(No lateral deviation)
-  {
-    const auto p_src = createPoint(1.25, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, 2.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.5, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Forward offset(Lateral deviation)
-  {
-    const auto p_src = createPoint(-1.25, 1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, 4.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Backward offset
-  {
-    const auto p_src = createPoint(6.25, 1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, -2.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 4.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // Backward offset(Lateral deviation)
-  {
-    const auto p_src = createPoint(6.25, -1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, -4.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 2.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
-  }
-
-  // No found
-  {
-    const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out =
-      calcLongitudinalOffsetPose(traj.points, p_src, calcArcLength(traj.points) + 1.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-
-  // No found
-  {
-    const auto p_src = createPoint(9.0, 0.0, 0.0);
-    const auto p_out =
-      calcLongitudinalOffsetPose(traj.points, p_src, -calcArcLength(traj.points) - 1.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-
-  // Out of range(Trajectory size is 1)
-  {
-    const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
-    EXPECT_THROW(
-      calcLongitudinalOffsetPose(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
-      std::out_of_range);
-  }
-}
-
-TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_CurveTrajectory)
-{
-  using autoware_auto_planning_msgs::msg::TrajectoryPoint;
-  using tier4_autoware_utils::calcLongitudinalOffsetPose;
-
-  Trajectory curve_traj{};
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(1.0, 1.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(2.0, 1.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  {
-    TrajectoryPoint p;
-    p.pose = createPose(3.0, 2.0, 0.0, 0.0, 0.0, 0.0);
-    p.longitudinal_velocity_mps = 0.0;
-    curve_traj.points.push_back(p);
-  }
-
-  // Whole length
-  {
-    const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, 4.41421356237309505);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 2.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_src = createPoint(3.0, 2.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, -4.41421356237309505);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Forward offset(No lateral deviation)
-  {
-    const auto p_src = createPoint(1.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, 3.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 2.707106781186547524, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.707106781186547524, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Forward offset(Lateral deviation)
-  {
-    const auto p_src = createPoint(0.75, 0.25, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, 1.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.25, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Backward offset(No lateral deviation)
-  {
-    const auto p_src = createPoint(3.0, 2.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, -4.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.41421356237309505, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Backward offset(No lateral deviation)
-  {
-    const auto p_src = createPoint(1.75, 1.25, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, -1.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.75, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-}
-
-TEST(trajectory, insertTargetPoint)
-{
-  using tier4_autoware_utils::calcDistance2d;
-  using tier4_autoware_utils::createPoint;
-  using tier4_autoware_utils::findNearestSegmentIndex;
-  using tier4_autoware_utils::getPoint;
-  using tier4_autoware_utils::insertTargetPoint;
-
-  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
-
-  // Insert between trajectory front and back
-  {
-    auto traj_out = traj;
-
-    const auto p_target = createPoint(3.5, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
-    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
-
-    EXPECT_EQ(insert_idx, 4U);
-    EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
-
-    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(traj_out.points.at(i));
-      const auto & p_back = getPoint(traj_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > 1e-3);
-    }
-
-    const auto & p_insert = getPoint(traj_out.points.at(insert_idx));
-    EXPECT_EQ(p_insert.x, p_target.x);
-    EXPECT_EQ(p_insert.y, p_target.y);
-    EXPECT_EQ(p_insert.z, p_target.z);
-  }
-
-  // Overlap base_idx point
-  {
-    auto traj_out = traj;
-
-    const auto p_target = createPoint(3.0001, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
-    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
-
-    EXPECT_EQ(insert_idx, 3U);
-    EXPECT_EQ(traj_out.points.size(), traj.points.size());
-
-    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(traj_out.points.at(i));
-      const auto & p_back = getPoint(traj_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > 1e-3);
-    }
-  }
-
-  // Overlap base_idx + 1 point
-  {
-    auto traj_out = traj;
-
-    const auto p_target = createPoint(3.9999, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
-    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
-
-    EXPECT_EQ(insert_idx, 4U);
-    EXPECT_EQ(traj_out.points.size(), traj.points.size());
-
-    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(traj_out.points.at(i));
-      const auto & p_back = getPoint(traj_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > 1e-3);
-    }
-  }
-
-  // Invalid target point(In front of begin point)
-  {
-    auto traj_out = traj;
-
-    const auto p_target = createPoint(-1.0, 0.0, 0.0);
-    EXPECT_THROW(insertTargetPoint(0, p_target, traj_out.points), std::invalid_argument);
-  }
-
-  // Invalid target point(Behind of end point)
-  {
-    auto traj_out = traj;
-
-    const auto p_target = createPoint(10.0, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
-    EXPECT_THROW(insertTargetPoint(base_idx, p_target, traj_out.points), std::invalid_argument);
-  }
-
-  // Invalid target point(Huge lateral offset)
-  {
-    auto traj_out = traj;
-
-    const auto p_target = createPoint(4.0, 10.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
-    EXPECT_THROW(insertTargetPoint(base_idx, p_target, traj_out.points), std::invalid_argument);
-  }
-
-  // Empty
-  {
-    auto empty_traj = generateTestTrajectory<Trajectory>(0, 1.0);
-    EXPECT_THROW(
-      insertTargetPoint({}, geometry_msgs::msg::Point{}, empty_traj.points), std::invalid_argument);
-  }
-}
-
-TEST(trajectory, insertTargetPoint_OverlapThreshold)
-{
-  using tier4_autoware_utils::calcDistance2d;
-  using tier4_autoware_utils::createPoint;
-  using tier4_autoware_utils::findNearestSegmentIndex;
-  using tier4_autoware_utils::getPoint;
-  using tier4_autoware_utils::insertTargetPoint;
-
-  constexpr double overlap_threshold = 1e-4;
-  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
-
-  // Insert between trajectory front and back
-  {
-    auto traj_out = traj;
-
-    const auto p_target = createPoint(3.0001, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
-    const auto insert_idx =
-      insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
-
-    EXPECT_EQ(insert_idx, 4U);
-    EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
-
-    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(traj_out.points.at(i));
-      const auto & p_back = getPoint(traj_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > overlap_threshold);
-    }
-
-    const auto & p_insert = getPoint(traj_out.points.at(insert_idx));
-    EXPECT_EQ(p_insert.x, p_target.x);
-    EXPECT_EQ(p_insert.y, p_target.y);
-    EXPECT_EQ(p_insert.z, p_target.z);
-  }
-
-  // Overlap base_idx point
-  {
-    auto traj_out = traj;
-
-    const auto p_target = createPoint(3.00001, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
-    const auto insert_idx =
-      insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
-
-    EXPECT_EQ(insert_idx, 3U);
-    EXPECT_EQ(traj_out.points.size(), traj.points.size());
-
-    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(traj_out.points.at(i));
-      const auto & p_back = getPoint(traj_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > overlap_threshold);
-    }
-  }
-
-  // Overlap base_idx + 1 point
-  {
-    auto traj_out = traj;
-
-    const auto p_target = createPoint(3.99999, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
-    const auto insert_idx =
-      insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
-
-    EXPECT_EQ(insert_idx, 4U);
-    EXPECT_EQ(traj_out.points.size(), traj.points.size());
-
-    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(traj_out.points.at(i));
-      const auto & p_back = getPoint(traj_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > overlap_threshold);
-    }
-  }
-}
-
 TEST(trajectory, calcDistanceToForwardStopPoint_YawThreshold)
 {
   using tier4_autoware_utils::calcDistanceToForwardStopPoint;
@@ -1600,6 +980,802 @@ TEST(trajectory, calcDistanceToForwardStopPoint_YawThreshold)
       const auto dist =
         calcDistanceToForwardStopPoint(traj_input.points, pose, max_d, deg2rad(10.0));
       EXPECT_FALSE(dist);
+    }
+  }
+}
+
+TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
+{
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcLongitudinalOffsetPoint;
+  using tier4_autoware_utils::calcSignedArcLength;
+  using tier4_autoware_utils::getPoint;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+  const auto total_length = calcArcLength(traj.points);
+
+  // Empty
+  EXPECT_THROW(calcLongitudinalOffsetPoint(Trajectory{}.points, {}, {}), std::invalid_argument);
+
+  // Out of range
+  EXPECT_THROW(
+    calcLongitudinalOffsetPoint(traj.points, traj.points.size() + 1, 1.0), std::out_of_range);
+  EXPECT_THROW(calcLongitudinalOffsetPoint(traj.points, -1, 1.0), std::out_of_range);
+
+  // Found Pose(forward)
+  for (size_t i = 0; i < traj.points.size(); ++i) {
+    double x_ans = getPoint(traj.points.at(i)).x;
+
+    const auto d_back = calcSignedArcLength(traj.points, i, traj.points.size() - 1);
+
+    for (double len = 0.0; len < d_back + epsilon; len += 0.1) {
+      const auto p_out = calcLongitudinalOffsetPoint(traj.points, i, std::min(len, d_back));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(p_out.get().x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+
+      x_ans += 0.1;
+    }
+  }
+
+  // Found Pose(backward)
+  for (size_t i = 0; i < traj.points.size(); ++i) {
+    double x_ans = getPoint(traj.points.at(i)).x;
+
+    const auto d_front = calcSignedArcLength(traj.points, i, 0);
+
+    for (double len = 0.0; d_front - epsilon < len; len -= 0.1) {
+      const auto p_out = calcLongitudinalOffsetPoint(traj.points, i, std::max(len, d_front));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(p_out.get().x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+
+      x_ans -= 0.1;
+    }
+  }
+
+  // No found
+  {
+    const auto p_out = calcLongitudinalOffsetPoint(traj.points, 0, total_length + epsilon);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // No found
+  {
+    const auto p_out = calcLongitudinalOffsetPoint(traj.points, 9, -total_length - epsilon);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // No found(Trajectory size is 1)
+  {
+    const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
+    const auto p_out = calcLongitudinalOffsetPoint(one_point_traj.points, 0.0, 0.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+}
+
+TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
+{
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcLongitudinalOffsetPoint;
+  using tier4_autoware_utils::calcSignedArcLength;
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::getPoint;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+  const auto total_length = calcArcLength(traj.points);
+
+  // Empty
+  EXPECT_THROW(calcLongitudinalOffsetPoint(Trajectory{}.points, {}, {}), std::invalid_argument);
+
+  // Found Pose(forward)
+  for (double x_start = 0.0; x_start < total_length + epsilon; x_start += 0.1) {
+    constexpr double lateral_deviation = 0.5;
+    double x_ans = x_start;
+
+    const auto p_src = createPoint(x_start, lateral_deviation, 0.0);
+    const auto d_back = calcSignedArcLength(traj.points, p_src, traj.points.size() - 1);
+
+    for (double len = 0.0; len < d_back + epsilon; len += 0.1) {
+      const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, std::min(len, d_back));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(p_out.get().x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+
+      x_ans += 0.1;
+    }
+  }
+
+  // Found Pose(backward)
+  for (double x_start = 0.0; x_start < total_length + epsilon; x_start += 0.1) {
+    constexpr double lateral_deviation = 0.5;
+    double x_ans = x_start;
+
+    const auto p_src = createPoint(x_start, lateral_deviation, 0.0);
+    const auto d_front = calcSignedArcLength(traj.points, p_src, 0);
+
+    for (double len = 0.0; d_front - epsilon < len; len -= 0.1) {
+      const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, std::max(len, d_front));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(p_out.get().x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+
+      x_ans -= 0.1;
+    }
+  }
+
+  // No found
+  {
+    const auto p_src = createPoint(0.0, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, total_length + 1.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // No found
+  {
+    const auto p_src = createPoint(9.0, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, -total_length - 1.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // Out of range(Trajectory size is 1)
+  {
+    const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
+    EXPECT_THROW(
+      calcLongitudinalOffsetPoint(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
+      std::out_of_range);
+  }
+}
+
+TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
+{
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
+  using tier4_autoware_utils::calcSignedArcLength;
+  using tier4_autoware_utils::getPoint;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+  const auto total_length = calcArcLength(traj.points);
+
+  // Empty
+  EXPECT_THROW(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}), std::invalid_argument);
+
+  // Out of range
+  EXPECT_THROW(
+    calcLongitudinalOffsetPose(traj.points, traj.points.size() + 1, 1.0), std::out_of_range);
+  EXPECT_THROW(calcLongitudinalOffsetPose(traj.points, -1, 1.0), std::out_of_range);
+
+  // Found Pose(forward)
+  for (size_t i = 0; i < traj.points.size(); ++i) {
+    double x_ans = getPoint(traj.points.at(i)).x;
+
+    const auto d_back = calcSignedArcLength(traj.points, i, traj.points.size() - 1);
+
+    for (double len = 0.0; len < d_back + epsilon; len += 0.1) {
+      const auto p_out = calcLongitudinalOffsetPose(traj.points, i, std::min(len, d_back));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(p_out.get().position.x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+
+      x_ans += 0.1;
+    }
+  }
+
+  // Found Pose(backward)
+  for (size_t i = 0; i < traj.points.size(); ++i) {
+    double x_ans = getPoint(traj.points.at(i)).x;
+
+    const auto d_front = calcSignedArcLength(traj.points, i, 0);
+
+    for (double len = 0.0; d_front - epsilon < len; len -= 0.1) {
+      const auto p_out = calcLongitudinalOffsetPose(traj.points, i, std::max(len, d_front));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(p_out.get().position.x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+
+      x_ans -= 0.1;
+    }
+  }
+
+  // No found
+  {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, total_length + epsilon);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // No found
+  {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 9, -total_length - epsilon);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // No found(Trajectory size is 1)
+  {
+    const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
+    const auto p_out = calcLongitudinalOffsetPose(one_point_traj.points, 0.0, 0.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+}
+
+TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatInterpolation)
+{
+  using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
+  using tier4_autoware_utils::deg2rad;
+
+  Trajectory traj{};
+
+  {
+    TrajectoryPoint p;
+    p.pose = createPose(0.0, 0.0, 0.0, deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
+    p.longitudinal_velocity_mps = 0.0;
+    traj.points.push_back(p);
+  }
+
+  {
+    TrajectoryPoint p;
+    p.pose = createPose(1.0, 1.0, 0.0, deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+    p.longitudinal_velocity_mps = 0.0;
+    traj.points.push_back(p);
+  }
+
+  const auto total_length = calcArcLength(traj.points);
+
+  // Found pose(forward)
+  for (double len = 0.0; len < total_length; len += 0.1) {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, len);
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, len * std::cos(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.get().position.y, len * std::sin(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+
+  // Found pose(backward)
+  for (double len = total_length; 0.0 < len; len -= 0.1) {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, -len);
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 1.0 - len * std::cos(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.0 - len * std::sin(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+
+  // Boundary condition
+  {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, total_length);
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+
+  // Boundary condition
+  {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, 0.0);
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+}
+
+TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
+{
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
+  using tier4_autoware_utils::calcSignedArcLength;
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::getPoint;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+  const auto total_length = calcArcLength(traj.points);
+
+  // Empty
+  EXPECT_THROW(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}), std::invalid_argument);
+
+  // Found Pose(forward)
+  for (double x_start = 0.0; x_start < total_length + epsilon; x_start += 0.1) {
+    constexpr double lateral_deviation = 0.5;
+    double x_ans = x_start;
+
+    const auto p_src = createPoint(x_start, lateral_deviation, 0.0);
+    const auto d_back = calcSignedArcLength(traj.points, p_src, traj.points.size() - 1);
+
+    for (double len = 0.0; len < d_back + epsilon; len += 0.1) {
+      const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, std::min(len, d_back));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(p_out.get().position.x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+
+      x_ans += 0.1;
+    }
+  }
+
+  // Found Pose(backward)
+  for (double x_start = 0.0; x_start < total_length + epsilon; x_start += 0.1) {
+    constexpr double lateral_deviation = 0.5;
+    double x_ans = x_start;
+
+    const auto p_src = createPoint(x_start, lateral_deviation, 0.0);
+    const auto d_front = calcSignedArcLength(traj.points, p_src, 0);
+
+    for (double len = 0.0; d_front - epsilon < len; len -= 0.1) {
+      const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, std::max(len, d_front));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(p_out.get().position.x, x_ans, epsilon);
+      EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
+
+      x_ans -= 0.1;
+    }
+  }
+
+  // No found
+  {
+    const auto p_src = createPoint(0.0, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, total_length + 1.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // No found
+  {
+    const auto p_src = createPoint(9.0, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, -total_length - 1.0);
+
+    EXPECT_EQ(p_out, boost::none);
+  }
+
+  // Out of range(Trajectory size is 1)
+  {
+    const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
+    EXPECT_THROW(
+      calcLongitudinalOffsetPose(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
+      std::out_of_range);
+  }
+}
+
+TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatInterpolation)
+{
+  using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
+  using tier4_autoware_utils::calcLongitudinalOffsetToSegment;
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::deg2rad;
+
+  Trajectory traj{};
+
+  {
+    TrajectoryPoint p;
+    p.pose = createPose(0.0, 0.0, 0.0, deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
+    p.longitudinal_velocity_mps = 0.0;
+    traj.points.push_back(p);
+  }
+
+  {
+    TrajectoryPoint p;
+    p.pose = createPose(1.0, 1.0, 0.0, deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+    p.longitudinal_velocity_mps = 0.0;
+    traj.points.push_back(p);
+  }
+
+  const auto total_length = calcArcLength(traj.points);
+
+  // Found pose
+  for (double len_start = 0.0; len_start < total_length; len_start += 0.1) {
+    constexpr double deviation = 0.1;
+
+    const auto p_src = createPoint(
+      len_start * std::cos(deg2rad(45.0)) + deviation,
+      len_start * std::sin(deg2rad(45.0)) - deviation, 0.0);
+    const auto src_offset = calcLongitudinalOffsetToSegment(traj.points, 0, p_src);
+
+    for (double len = -src_offset; len < total_length - src_offset; len += 0.1) {
+      const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, len);
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(
+        p_out.get().position.x, p_src.x + len * std::cos(deg2rad(45.0)) - deviation, epsilon);
+      EXPECT_NEAR(
+        p_out.get().position.y, p_src.y + len * std::sin(deg2rad(45.0)) + deviation, epsilon);
+      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    }
+  }
+
+  // Boundary condition
+  {
+    constexpr double deviation = 0.1;
+
+    const auto p_src = createPoint(1.0 + deviation, 1.0 - deviation, 0.0);
+    const auto src_offset = calcLongitudinalOffsetToSegment(traj.points, 0, p_src);
+
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, total_length - src_offset);
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+}
+
+TEST(trajectory, insertTargetPoint)
+{
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcDistance2d;
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::deg2rad;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+  using tier4_autoware_utils::getPose;
+  using tier4_autoware_utils::insertTargetPoint;
+
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+  const auto total_length = calcArcLength(traj.points);
+
+  // Insert
+  for (double x_start = 0.5; x_start < total_length; x_start += 1.0) {
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(x_start, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
+
+    EXPECT_EQ(insert_idx, base_idx + 1);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
+    }
+
+    {
+      const auto p_insert = getPose(traj_out.points.at(insert_idx));
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+      EXPECT_EQ(p_insert.position.x, p_target.x);
+      EXPECT_EQ(p_insert.position.y, p_target.y);
+      EXPECT_EQ(p_insert.position.z, p_target.z);
+      EXPECT_NEAR(p_insert.orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_insert.orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_insert.orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_insert.orientation.w, ans_quat.w, epsilon);
+    }
+
+    {
+      const auto p_base = getPose(traj_out.points.at(base_idx));
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+      EXPECT_NEAR(p_base.orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_base.orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_base.orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_base.orientation.w, ans_quat.w, epsilon);
+    }
+  }
+
+  // Insert(Boundary condition)
+  for (double x_start = 0.0; x_start < total_length; x_start += 1.0) {
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(x_start + 1.1e-3, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
+
+    EXPECT_EQ(insert_idx, base_idx + 1);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
+    }
+
+    {
+      const auto p_insert = getPose(traj_out.points.at(insert_idx));
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+      EXPECT_EQ(p_insert.position.x, p_target.x);
+      EXPECT_EQ(p_insert.position.y, p_target.y);
+      EXPECT_EQ(p_insert.position.z, p_target.z);
+      EXPECT_NEAR(p_insert.orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_insert.orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_insert.orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_insert.orientation.w, ans_quat.w, epsilon);
+    }
+
+    {
+      const auto p_base = getPose(traj_out.points.at(base_idx));
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+      EXPECT_NEAR(p_base.orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_base.orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_base.orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_base.orientation.w, ans_quat.w, epsilon);
+    }
+  }
+
+  // Insert(Quaternion interpolation)
+  for (double x_start = 0.25; x_start < total_length; x_start += 1.0) {
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(x_start, 0.25 * std::tan(deg2rad(60.0)), 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
+
+    EXPECT_EQ(insert_idx, base_idx + 1);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
+    }
+
+    {
+      const auto p_insert = getPose(traj_out.points.at(insert_idx));
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(-30.0));
+      EXPECT_EQ(p_insert.position.x, p_target.x);
+      EXPECT_EQ(p_insert.position.y, p_target.y);
+      EXPECT_EQ(p_insert.position.z, p_target.z);
+      EXPECT_NEAR(p_insert.orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_insert.orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_insert.orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_insert.orientation.w, ans_quat.w, epsilon);
+    }
+
+    {
+      const auto p_base = getPose(traj_out.points.at(base_idx));
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(60.0));
+      EXPECT_NEAR(p_base.orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_base.orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_base.orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_base.orientation.w, ans_quat.w, epsilon);
+    }
+  }
+
+  // Not insert(Overlap base_idx point)
+  for (double x_start = 0.0; x_start < total_length - 1.0 + epsilon; x_start += 1.0) {
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(x_start + 1e-4, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
+
+    EXPECT_EQ(insert_idx, base_idx);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size());
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
+    }
+  }
+
+  // Not insert(Overlap base_idx + 1 point)
+  for (double x_start = 1.0; x_start < total_length + epsilon; x_start += 1.0) {
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(x_start - 1e-4, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
+
+    EXPECT_EQ(insert_idx, base_idx + 1);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size());
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
+    }
+  }
+
+  // Invalid target point(In front of begin point)
+  {
+    testing::internal::CaptureStderr();
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(-1.0, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
+
+    EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
+    EXPECT_EQ(insert_idx, base_idx + 1);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
+    }
+  }
+
+  // Invalid target point(Behind of end point)
+  {
+    testing::internal::CaptureStderr();
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(10.0, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
+
+    EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
+    EXPECT_EQ(insert_idx, base_idx + 1);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
+    }
+  }
+
+  // Invalid target point(Huge lateral offset)
+  {
+    testing::internal::CaptureStderr();
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(4.0, 10.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx = insertTargetPoint(base_idx, p_target, traj_out.points);
+
+    EXPECT_STREQ(testing::internal::GetCapturedStderr().c_str(), "Sharp angle.\n");
+    EXPECT_EQ(insert_idx, base_idx + 1);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > 1e-3);
+    }
+  }
+
+  // Empty
+  {
+    auto empty_traj = generateTestTrajectory<Trajectory>(0, 1.0);
+    EXPECT_THROW(
+      insertTargetPoint({}, geometry_msgs::msg::Point{}, empty_traj.points), std::invalid_argument);
+  }
+}
+
+TEST(trajectory, insertTargetPoint_OverlapThreshold)
+{
+  using tier4_autoware_utils::calcArcLength;
+  using tier4_autoware_utils::calcDistance2d;
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::deg2rad;
+  using tier4_autoware_utils::findNearestSegmentIndex;
+  using tier4_autoware_utils::getPose;
+  using tier4_autoware_utils::insertTargetPoint;
+
+  constexpr double overlap_threshold = 1e-4;
+  const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+  const auto total_length = calcArcLength(traj.points);
+
+  // Insert(Boundary condition)
+  for (double x_start = 0.0; x_start < total_length; x_start += 1.0) {
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(x_start + 1.1e-4, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx =
+      insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
+
+    EXPECT_EQ(insert_idx, base_idx + 1);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size() + 1);
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(
+        calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > overlap_threshold);
+    }
+
+    {
+      const auto p_insert = getPose(traj_out.points.at(insert_idx));
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+      EXPECT_EQ(p_insert.position.x, p_target.x);
+      EXPECT_EQ(p_insert.position.y, p_target.y);
+      EXPECT_EQ(p_insert.position.z, p_target.z);
+      EXPECT_NEAR(p_insert.orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_insert.orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_insert.orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_insert.orientation.w, ans_quat.w, epsilon);
+    }
+
+    {
+      const auto p_base = getPose(traj_out.points.at(base_idx));
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+      EXPECT_NEAR(p_base.orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_base.orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_base.orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_base.orientation.w, ans_quat.w, epsilon);
+    }
+  }
+
+  // Not insert(Overlap base_idx point)
+  for (double x_start = 0.0; x_start < total_length - 1.0 + epsilon; x_start += 1.0) {
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(x_start + 1e-5, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx =
+      insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
+
+    EXPECT_EQ(insert_idx, base_idx);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size());
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(
+        calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > overlap_threshold);
+    }
+  }
+
+  // Not insert(Overlap base_idx + 1 point)
+  for (double x_start = 1.0; x_start < total_length + epsilon; x_start += 1.0) {
+    auto traj_out = traj;
+
+    const auto p_target = createPoint(x_start - 1e-5, 0.0, 0.0);
+    const size_t base_idx = findNearestSegmentIndex(traj.points, p_target);
+    const auto insert_idx =
+      insertTargetPoint(base_idx, p_target, traj_out.points, overlap_threshold);
+
+    EXPECT_EQ(insert_idx, base_idx + 1);
+    EXPECT_EQ(traj_out.points.size(), traj.points.size());
+
+    for (size_t i = 0; i < traj_out.points.size() - 1; ++i) {
+      EXPECT_TRUE(
+        calcDistance2d(traj_out.points.at(i), traj_out.points.at(i + 1)) > overlap_threshold);
     }
   }
 }

--- a/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
@@ -125,7 +125,7 @@ TEST(trajectory, validateNonEmpty)
   EXPECT_NO_THROW(validateNonEmpty(traj.points));
 }
 
-TEST(trajectory, validateNonSharpAngle_DefaltThreshold)
+TEST(trajectory, validateNonSharpAngle_DefaultThreshold)
 {
   using autoware_auto_planning_msgs::msg::TrajectoryPoint;
   using tier4_autoware_utils::validateNonSharpAngle;
@@ -998,7 +998,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
     EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
   }
 
-  // Foward offset
+  // Forward offset
   {
     const auto p_out = calcLongitudinalOffsetPoint(traj.points, 3, 2.25);
 
@@ -1089,7 +1089,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex_PathWithLaneId)
     EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
   }
 
-  // Foward offset
+  // Forward offset
   {
     const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, 3, 2.25);
 
@@ -1139,46 +1139,46 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex_CurveTrajectory)
   using autoware_auto_planning_msgs::msg::TrajectoryPoint;
   using tier4_autoware_utils::calcLongitudinalOffsetPoint;
 
-  Trajectory curv_traj{};
+  Trajectory curve_traj{};
 
   {
     TrajectoryPoint p;
     p.pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   {
     TrajectoryPoint p;
     p.pose = createPose(1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   {
     TrajectoryPoint p;
     p.pose = createPose(1.0, 1.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   {
     TrajectoryPoint p;
     p.pose = createPose(2.0, 1.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   {
     TrajectoryPoint p;
     p.pose = createPose(3.0, 2.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   // Whole length
   {
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, 0, 4.41421356237309505);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, 0, 4.41421356237309505);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
@@ -1188,7 +1188,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex_CurveTrajectory)
 
   // Whole length
   {
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, 4, -4.41421356237309505);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, 4, -4.41421356237309505);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 0.0, epsilon);
@@ -1196,9 +1196,9 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex_CurveTrajectory)
     EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
   }
 
-  // Foward offset
+  // Forward offset
   {
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, 1, 3.0);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, 1, 3.0);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 2.707106781186547524, epsilon);
@@ -1208,7 +1208,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex_CurveTrajectory)
 
   // Backward offset
   {
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, 4, -4.0);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, 4, -4.0);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 0.41421356237309505, epsilon);
@@ -1263,7 +1263,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
     EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
   }
 
-  // Foward offset(No lateral deviation)
+  // Forward offset(No lateral deviation)
   {
     const auto p_src = createPoint(1.25, 0.0, 0.0);
     const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, 2.25);
@@ -1274,7 +1274,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
     EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
   }
 
-  // Foward offset(Lateral deviation)
+  // Forward offset(Lateral deviation)
   {
     const auto p_src = createPoint(-1.25, 1.0, 0.0);
     const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, 4.25);
@@ -1380,7 +1380,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_PathWithLaneId)
     EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
   }
 
-  // Foward offset(No lateral deviation)
+  // Forward offset(No lateral deviation)
   {
     const auto p_src = createPoint(1.25, 0.0, 0.0);
     const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, p_src, 2.25);
@@ -1391,7 +1391,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_PathWithLaneId)
     EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
   }
 
-  // Foward offset(Lateral deviation)
+  // Forward offset(Lateral deviation)
   {
     const auto p_src = createPoint(-1.25, 1.0, 0.0);
     const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, p_src, 4.25);
@@ -1456,47 +1456,47 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_CurveTrajectory)
   using autoware_auto_planning_msgs::msg::TrajectoryPoint;
   using tier4_autoware_utils::calcLongitudinalOffsetPoint;
 
-  Trajectory curv_traj{};
+  Trajectory curve_traj{};
 
   {
     TrajectoryPoint p;
     p.pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   {
     TrajectoryPoint p;
     p.pose = createPose(1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   {
     TrajectoryPoint p;
     p.pose = createPose(1.0, 1.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   {
     TrajectoryPoint p;
     p.pose = createPose(2.0, 1.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   {
     TrajectoryPoint p;
     p.pose = createPose(3.0, 2.0, 0.0, 0.0, 0.0, 0.0);
     p.longitudinal_velocity_mps = 0.0;
-    curv_traj.points.push_back(p);
+    curve_traj.points.push_back(p);
   }
 
   // Whole length
   {
     const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, p_src, 4.41421356237309505);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, 4.41421356237309505);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
@@ -1507,7 +1507,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_CurveTrajectory)
   // Whole length
   {
     const auto p_src = createPoint(3.0, 2.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, p_src, -4.41421356237309505);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, -4.41421356237309505);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 0.0, epsilon);
@@ -1515,10 +1515,10 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_CurveTrajectory)
     EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
   }
 
-  // Foward offset(No lateral deviation)
+  // Forward offset(No lateral deviation)
   {
     const auto p_src = createPoint(1.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, p_src, 3.0);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, 3.0);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 2.707106781186547524, epsilon);
@@ -1526,10 +1526,10 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_CurveTrajectory)
     EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
   }
 
-  // Foward offset(Lateral deviation)
+  // Forward offset(Lateral deviation)
   {
     const auto p_src = createPoint(0.75, 0.25, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, p_src, 1.0);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, 1.0);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 1.25, epsilon);
@@ -1540,7 +1540,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_CurveTrajectory)
   // Backward offset(No lateral deviation)
   {
     const auto p_src = createPoint(3.0, 2.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, p_src, -4.0);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, -4.0);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 0.41421356237309505, epsilon);
@@ -1551,7 +1551,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_CurveTrajectory)
   // Backward offset(No lateral deviation)
   {
     const auto p_src = createPoint(1.75, 1.25, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curv_traj.points, p_src, -1.0);
+    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, -1.0);
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().x, 1.0, epsilon);
@@ -1570,7 +1570,7 @@ TEST(trajectory, insertTargetPoint)
 
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
-  // Insert betweet trajectory front and back
+  // Insert between trajectory front and back
   {
     auto traj_out = traj;
 
@@ -1629,7 +1629,7 @@ TEST(trajectory, insertTargetPoint)
     }
   }
 
-  // Invalid target point(Infront of begin point)
+  // Invalid target point(In front of begin point)
   {
     auto traj_out = traj;
 
@@ -1674,7 +1674,7 @@ TEST(trajectory, insertTargetPoint_OverlapThreshold)
   constexpr double overlap_threshold = 1e-4;
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
-  // Insert betweet trajectory front and back
+  // Insert between trajectory front and back
   {
     auto traj_out = traj;
 
@@ -1799,7 +1799,7 @@ TEST(trajectory, insertTargetPoint_PathWithLaneId)
 
   const auto path_with_lane_id = generateTestTrajectory<PathWithLaneId>(10, 1.0);
 
-  // Insert betweet trajectory front and back
+  // Insert between trajectory front and back
   {
     auto path_out = path_with_lane_id;
 
@@ -1856,7 +1856,7 @@ TEST(trajectory, insertTargetPoint_PathWithLaneId)
     }
   }
 
-  // Invalid target point(Infront of begin point)
+  // Invalid target point(In front of begin point)
   {
     auto path_out = path_with_lane_id;
 
@@ -1901,7 +1901,7 @@ TEST(trajectory, insertTargetPoint_OverlapThreshold_PathWithLaneId)
   constexpr double overlap_threshold = 1e-4;
   const auto path_with_lane_id = generateTestTrajectory<PathWithLaneId>(10, 1.0);
 
-  // Insert betweet trajectory front and back
+  // Insert between trajectory front and back
   {
     auto path_out = path_with_lane_id;
 

--- a/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
@@ -953,75 +953,74 @@ TEST(trajectory, calcDistanceToForwardStopPoint_DistThreshold)
   }
 }
 
-TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
+TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
 {
   using tier4_autoware_utils::calcArcLength;
-  using tier4_autoware_utils::calcLongitudinalOffsetPoint;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
 
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPoint(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_THROW(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}), std::invalid_argument);
 
   // Out of range
   EXPECT_THROW(
-    calcLongitudinalOffsetPoint(traj.points, traj.points.size() + 1, 1.0), std::out_of_range);
-  EXPECT_THROW(calcLongitudinalOffsetPoint(traj.points, -1, 1.0), std::out_of_range);
+    calcLongitudinalOffsetPose(traj.points, traj.points.size() + 1, 1.0), std::out_of_range);
+  EXPECT_THROW(calcLongitudinalOffsetPose(traj.points, -1, 1.0), std::out_of_range);
 
   // Same Point
   {
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, 3, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 3, 0.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, 0, 9.0);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, 9.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 9.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, 9, -9.0);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 9, -9.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Forward offset
   {
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, 3, 2.25);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 3, 2.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 5.25, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 5.25, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Backward offset
   {
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, 3, -2.25);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 3, -2.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 0.75, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.75, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // No found
   {
-    const auto p_out =
-      calcLongitudinalOffsetPoint(traj.points, 0, calcArcLength(traj.points) + 1.0);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, calcArcLength(traj.points) + 1.0);
 
     EXPECT_EQ(p_out, boost::none);
   }
@@ -1029,7 +1028,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
   // No found
   {
     const auto p_out =
-      calcLongitudinalOffsetPoint(traj.points, 9, -calcArcLength(traj.points) - 1.0);
+      calcLongitudinalOffsetPose(traj.points, 9, -calcArcLength(traj.points) - 1.0);
 
     EXPECT_EQ(p_out, boost::none);
   }
@@ -1037,81 +1036,81 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
   // No found(Trajectory size is 1)
   {
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
-    const auto p_out = calcLongitudinalOffsetPoint(one_point_traj.points, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(one_point_traj.points, 0.0, 0.0);
 
     EXPECT_EQ(p_out, boost::none);
   }
 }
 
-TEST(trajectory, calcLongitudinalOffsetPointFromIndex_PathWithLaneId)
+TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_PathWithLaneId)
 {
   using tier4_autoware_utils::calcArcLength;
-  using tier4_autoware_utils::calcLongitudinalOffsetPoint;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
 
   const auto path_with_lane_id = generateTestTrajectory<PathWithLaneId>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPoint(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
+  EXPECT_THROW(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
 
   // Out of range
   EXPECT_THROW(
-    calcLongitudinalOffsetPoint(path_with_lane_id.points, path_with_lane_id.points.size() + 1, 1.0),
+    calcLongitudinalOffsetPose(path_with_lane_id.points, path_with_lane_id.points.size() + 1, 1.0),
     std::out_of_range);
-  EXPECT_THROW(calcLongitudinalOffsetPoint(path_with_lane_id.points, -1, 1.0), std::out_of_range);
+  EXPECT_THROW(calcLongitudinalOffsetPose(path_with_lane_id.points, -1, 1.0), std::out_of_range);
 
   // Same Point
   {
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, 3, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 3, 0.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, 0, 9.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 0, 9.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 9.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, 9, -9.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 9, -9.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Forward offset
   {
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, 3, 2.25);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 3, 2.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 5.25, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 5.25, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Backward offset
   {
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, 3, -2.25);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 3, -2.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 0.75, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.75, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // No found
   {
-    const auto p_out = calcLongitudinalOffsetPoint(
+    const auto p_out = calcLongitudinalOffsetPose(
       path_with_lane_id.points, 0, calcArcLength(path_with_lane_id.points) + 1.0);
 
     EXPECT_EQ(p_out, boost::none);
@@ -1119,7 +1118,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex_PathWithLaneId)
 
   // No found
   {
-    const auto p_out = calcLongitudinalOffsetPoint(
+    const auto p_out = calcLongitudinalOffsetPose(
       path_with_lane_id.points, 9, -calcArcLength(path_with_lane_id.points) - 1.0);
 
     EXPECT_EQ(p_out, boost::none);
@@ -1128,16 +1127,16 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex_PathWithLaneId)
   // No found(Trajectory size is 1)
   {
     const auto one_point_path = generateTestTrajectory<PathWithLaneId>(1, 1.0);
-    const auto p_out = calcLongitudinalOffsetPoint(one_point_path.points, 0.0, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(one_point_path.points, 0.0, 0.0);
 
     EXPECT_EQ(p_out, boost::none);
   }
 }
 
-TEST(trajectory, calcLongitudinalOffsetPointFromIndex_CurveTrajectory)
+TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_CurveTrajectory)
 {
   using autoware_auto_planning_msgs::msg::TrajectoryPoint;
-  using tier4_autoware_utils::calcLongitudinalOffsetPoint;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
 
   Trajectory curve_traj{};
 
@@ -1178,140 +1177,138 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex_CurveTrajectory)
 
   // Whole length
   {
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, 0, 4.41421356237309505);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, 0, 4.41421356237309505);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 2.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 2.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, 4, -4.41421356237309505);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, 4, -4.41421356237309505);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Forward offset
   {
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, 1, 3.0);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, 1, 3.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 2.707106781186547524, epsilon);
-    EXPECT_NEAR(p_out.get().y, 1.707106781186547524, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 2.707106781186547524, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.707106781186547524, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Backward offset
   {
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, 4, -4.0);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, 4, -4.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 0.41421356237309505, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.41421356237309505, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 }
 
-TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
+TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
 {
   using tier4_autoware_utils::calcArcLength;
-  using tier4_autoware_utils::calcLongitudinalOffsetPoint;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
   using tier4_autoware_utils::createPoint;
 
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPoint(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_THROW(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}), std::invalid_argument);
 
   // Same Point
   {
     const auto p_src = createPoint(3.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, 0.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
     const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, 9.0);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, 9.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_EQ(p_out.get(), createPoint(9.0, 0.0, 0.0));
-    EXPECT_NEAR(p_out.get().x, 9.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
     const auto p_src = createPoint(9.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, -9.0);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, -9.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_EQ(p_out.get(), createPoint(0.0, 0.0, 0.0));
-    EXPECT_NEAR(p_out.get().x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Forward offset(No lateral deviation)
   {
     const auto p_src = createPoint(1.25, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, 2.25);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, 2.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.5, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.5, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Forward offset(Lateral deviation)
   {
     const auto p_src = createPoint(-1.25, 1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, 4.25);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, 4.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Backward offset
   {
     const auto p_src = createPoint(6.25, 1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, -2.25);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, -2.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 4.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 4.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Backward offset(Lateral deviation)
   {
     const auto p_src = createPoint(6.25, -1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(traj.points, p_src, -4.25);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, -4.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 2.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 2.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // No found
   {
     const auto p_src = createPoint(0.0, 0.0, 0.0);
     const auto p_out =
-      calcLongitudinalOffsetPoint(traj.points, p_src, calcArcLength(traj.points) + 1.0);
+      calcLongitudinalOffsetPose(traj.points, p_src, calcArcLength(traj.points) + 1.0);
 
     EXPECT_EQ(p_out, boost::none);
   }
@@ -1320,7 +1317,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
   {
     const auto p_src = createPoint(9.0, 0.0, 0.0);
     const auto p_out =
-      calcLongitudinalOffsetPoint(traj.points, p_src, -calcArcLength(traj.points) - 1.0);
+      calcLongitudinalOffsetPose(traj.points, p_src, -calcArcLength(traj.points) - 1.0);
 
     EXPECT_EQ(p_out, boost::none);
   }
@@ -1329,105 +1326,103 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
   {
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
     EXPECT_THROW(
-      calcLongitudinalOffsetPoint(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
+      calcLongitudinalOffsetPose(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
       std::out_of_range);
   }
 }
 
-TEST(trajectory, calcLongitudinalOffsetPointFromPoint_PathWithLaneId)
+TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_PathWithLaneId)
 {
   using tier4_autoware_utils::calcArcLength;
-  using tier4_autoware_utils::calcLongitudinalOffsetPoint;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
   using tier4_autoware_utils::createPoint;
 
   const auto path_with_lane_id = generateTestTrajectory<PathWithLaneId>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPoint(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
+  EXPECT_THROW(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
 
   // Same Point
   {
     const auto p_src = createPoint(3.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, p_src, 0.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 0.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
     const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, p_src, 9.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 9.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_EQ(p_out.get(), createPoint(9.0, 0.0, 0.0));
-    EXPECT_NEAR(p_out.get().x, 9.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
     const auto p_src = createPoint(9.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, p_src, -9.0);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, -9.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_EQ(p_out.get(), createPoint(0.0, 0.0, 0.0));
-    EXPECT_NEAR(p_out.get().x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Forward offset(No lateral deviation)
   {
     const auto p_src = createPoint(1.25, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, p_src, 2.25);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 2.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.5, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.5, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Forward offset(Lateral deviation)
   {
     const auto p_src = createPoint(-1.25, 1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, p_src, 4.25);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 4.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Backward offset
   {
     const auto p_src = createPoint(6.25, 1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, p_src, -2.25);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, -2.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 4.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 4.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Backward offset(Lateral deviation)
   {
     const auto p_src = createPoint(6.25, -1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(path_with_lane_id.points, p_src, -4.25);
+    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, -4.25);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 2.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 2.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // No found
   {
     const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(
+    const auto p_out = calcLongitudinalOffsetPose(
       path_with_lane_id.points, p_src, calcArcLength(path_with_lane_id.points) + 1.0);
 
     EXPECT_EQ(p_out, boost::none);
@@ -1436,7 +1431,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_PathWithLaneId)
   // No found
   {
     const auto p_src = createPoint(9.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(
+    const auto p_out = calcLongitudinalOffsetPose(
       path_with_lane_id.points, p_src, -calcArcLength(path_with_lane_id.points) - 1.0);
 
     EXPECT_EQ(p_out, boost::none);
@@ -1446,15 +1441,15 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_PathWithLaneId)
   {
     const auto one_point_path = generateTestTrajectory<PathWithLaneId>(1, 1.0);
     EXPECT_THROW(
-      calcLongitudinalOffsetPoint(one_point_path.points, geometry_msgs::msg::Point{}, {}),
+      calcLongitudinalOffsetPose(one_point_path.points, geometry_msgs::msg::Point{}, {}),
       std::out_of_range);
   }
 }
 
-TEST(trajectory, calcLongitudinalOffsetPointFromPoint_CurveTrajectory)
+TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_CurveTrajectory)
 {
   using autoware_auto_planning_msgs::msg::TrajectoryPoint;
-  using tier4_autoware_utils::calcLongitudinalOffsetPoint;
+  using tier4_autoware_utils::calcLongitudinalOffsetPose;
 
   Trajectory curve_traj{};
 
@@ -1496,67 +1491,67 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_CurveTrajectory)
   // Whole length
   {
     const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, 4.41421356237309505);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, 4.41421356237309505);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 2.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 2.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Whole length
   {
     const auto p_src = createPoint(3.0, 2.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, -4.41421356237309505);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, -4.41421356237309505);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Forward offset(No lateral deviation)
   {
     const auto p_src = createPoint(1.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, 3.0);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, 3.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 2.707106781186547524, epsilon);
-    EXPECT_NEAR(p_out.get().y, 1.707106781186547524, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 2.707106781186547524, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.707106781186547524, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Forward offset(Lateral deviation)
   {
     const auto p_src = createPoint(0.75, 0.25, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, 1.0);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, 1.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 1.25, epsilon);
-    EXPECT_NEAR(p_out.get().y, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 1.25, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Backward offset(No lateral deviation)
   {
     const auto p_src = createPoint(3.0, 2.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, -4.0);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, -4.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 0.41421356237309505, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 0.41421356237309505, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 
   // Backward offset(No lateral deviation)
   {
     const auto p_src = createPoint(1.75, 1.25, 0.0);
-    const auto p_out = calcLongitudinalOffsetPoint(curve_traj.points, p_src, -1.0);
+    const auto p_out = calcLongitudinalOffsetPose(curve_traj.points, p_src, -1.0);
 
     EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().x, 1.0, epsilon);
-    EXPECT_NEAR(p_out.get().y, 0.75, epsilon);
-    EXPECT_NEAR(p_out.get().z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 0.75, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
   }
 }
 

--- a/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
@@ -25,8 +25,6 @@
 
 namespace
 {
-using autoware_auto_planning_msgs::msg::PathPointWithLaneId;
-using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using TrajectoryPointArray = std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>;
 using tier4_autoware_utils::createPoint;
@@ -64,26 +62,6 @@ T generateTestTrajectory(
   }
 
   return traj;
-}
-
-template <>
-PathWithLaneId generateTestTrajectory(
-  const size_t num_points, const double point_interval, const double vel, const double init_theta,
-  const double delta_theta)
-{
-  PathWithLaneId path_with_lane_id;
-  for (size_t i = 0; i < num_points; ++i) {
-    const double theta = init_theta + i * delta_theta;
-    const double x = i * point_interval * std::cos(theta);
-    const double y = i * point_interval * std::sin(theta);
-
-    PathPointWithLaneId p;
-    p.point.pose = createPose(x, y, 0.0, 0.0, 0.0, theta);
-    p.point.longitudinal_velocity_mps = vel;
-    path_with_lane_id.points.push_back(p);
-  }
-
-  return path_with_lane_id;
 }
 
 TrajectoryPointArray generateTestTrajectoryPointArray(
@@ -976,6 +954,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
     EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Whole length
@@ -986,6 +968,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
     EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Whole length
@@ -996,6 +982,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
     EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Forward offset
@@ -1006,6 +996,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
     EXPECT_NEAR(p_out.get().position.x, 5.25, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Backward offset
@@ -1016,6 +1010,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
     EXPECT_NEAR(p_out.get().position.x, 0.75, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // No found
@@ -1037,97 +1035,6 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
   {
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
     const auto p_out = calcLongitudinalOffsetPose(one_point_traj.points, 0.0, 0.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-}
-
-TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_PathWithLaneId)
-{
-  using tier4_autoware_utils::calcArcLength;
-  using tier4_autoware_utils::calcLongitudinalOffsetPose;
-
-  const auto path_with_lane_id = generateTestTrajectory<PathWithLaneId>(10, 1.0);
-
-  // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
-
-  // Out of range
-  EXPECT_THROW(
-    calcLongitudinalOffsetPose(path_with_lane_id.points, path_with_lane_id.points.size() + 1, 1.0),
-    std::out_of_range);
-  EXPECT_THROW(calcLongitudinalOffsetPose(path_with_lane_id.points, -1, 1.0), std::out_of_range);
-
-  // Same Point
-  {
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 3, 0.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 0, 9.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 9, -9.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Forward offset
-  {
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 3, 2.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 5.25, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Backward offset
-  {
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, 3, -2.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.75, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // No found
-  {
-    const auto p_out = calcLongitudinalOffsetPose(
-      path_with_lane_id.points, 0, calcArcLength(path_with_lane_id.points) + 1.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-
-  // No found
-  {
-    const auto p_out = calcLongitudinalOffsetPose(
-      path_with_lane_id.points, 9, -calcArcLength(path_with_lane_id.points) - 1.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-
-  // No found(Trajectory size is 1)
-  {
-    const auto one_point_path = generateTestTrajectory<PathWithLaneId>(1, 1.0);
-    const auto p_out = calcLongitudinalOffsetPose(one_point_path.points, 0.0, 0.0);
 
     EXPECT_EQ(p_out, boost::none);
   }
@@ -1236,6 +1143,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Whole length
@@ -1247,6 +1158,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Whole length
@@ -1258,6 +1173,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Forward offset(No lateral deviation)
@@ -1269,6 +1188,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     EXPECT_NEAR(p_out.get().position.x, 3.5, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Forward offset(Lateral deviation)
@@ -1280,6 +1203,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Backward offset
@@ -1291,6 +1218,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     EXPECT_NEAR(p_out.get().position.x, 4.0, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // Backward offset(Lateral deviation)
@@ -1302,6 +1233,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     EXPECT_NEAR(p_out.get().position.x, 2.0, epsilon);
     EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
     EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, 1.0, epsilon);
   }
 
   // No found
@@ -1327,121 +1262,6 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
     EXPECT_THROW(
       calcLongitudinalOffsetPose(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
-      std::out_of_range);
-  }
-}
-
-TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_PathWithLaneId)
-{
-  using tier4_autoware_utils::calcArcLength;
-  using tier4_autoware_utils::calcLongitudinalOffsetPose;
-  using tier4_autoware_utils::createPoint;
-
-  const auto path_with_lane_id = generateTestTrajectory<PathWithLaneId>(10, 1.0);
-
-  // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
-
-  // Same Point
-  {
-    const auto p_src = createPoint(3.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 0.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 9.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 9.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Whole length
-  {
-    const auto p_src = createPoint(9.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, -9.0);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Forward offset(No lateral deviation)
-  {
-    const auto p_src = createPoint(1.25, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 2.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.5, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Forward offset(Lateral deviation)
-  {
-    const auto p_src = createPoint(-1.25, 1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, 4.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 3.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Backward offset
-  {
-    const auto p_src = createPoint(6.25, 1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, -2.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 4.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // Backward offset(Lateral deviation)
-  {
-    const auto p_src = createPoint(6.25, -1.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(path_with_lane_id.points, p_src, -4.25);
-
-    EXPECT_NE(p_out, boost::none);
-    EXPECT_NEAR(p_out.get().position.x, 2.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.y, 0.0, epsilon);
-    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
-  }
-
-  // No found
-  {
-    const auto p_src = createPoint(0.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(
-      path_with_lane_id.points, p_src, calcArcLength(path_with_lane_id.points) + 1.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-
-  // No found
-  {
-    const auto p_src = createPoint(9.0, 0.0, 0.0);
-    const auto p_out = calcLongitudinalOffsetPose(
-      path_with_lane_id.points, p_src, -calcArcLength(path_with_lane_id.points) - 1.0);
-
-    EXPECT_EQ(p_out, boost::none);
-  }
-
-  // Out of range(Trajectory size is 1)
-  {
-    const auto one_point_path = generateTestTrajectory<PathWithLaneId>(1, 1.0);
-    EXPECT_THROW(
-      calcLongitudinalOffsetPose(one_point_path.points, geometry_msgs::msg::Point{}, {}),
       std::out_of_range);
   }
 }
@@ -1780,181 +1600,6 @@ TEST(trajectory, calcDistanceToForwardStopPoint_YawThreshold)
       const auto dist =
         calcDistanceToForwardStopPoint(traj_input.points, pose, max_d, deg2rad(10.0));
       EXPECT_FALSE(dist);
-    }
-  }
-}
-
-TEST(trajectory, insertTargetPoint_PathWithLaneId)
-{
-  using tier4_autoware_utils::calcDistance2d;
-  using tier4_autoware_utils::createPoint;
-  using tier4_autoware_utils::findNearestSegmentIndex;
-  using tier4_autoware_utils::getPoint;
-  using tier4_autoware_utils::insertTargetPoint;
-
-  const auto path_with_lane_id = generateTestTrajectory<PathWithLaneId>(10, 1.0);
-
-  // Insert between trajectory front and back
-  {
-    auto path_out = path_with_lane_id;
-
-    const auto p_target = createPoint(3.5, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
-    const auto insert_idx = insertTargetPoint(base_idx, p_target, path_out.points);
-
-    EXPECT_EQ(insert_idx, 4U);
-    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size() + 1);
-
-    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(path_out.points.at(i));
-      const auto & p_back = getPoint(path_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > 1e-3);
-    }
-
-    const auto & p_insert = getPoint(path_out.points.at(insert_idx));
-    EXPECT_EQ(p_insert.x, p_target.x);
-    EXPECT_EQ(p_insert.y, p_target.y);
-    EXPECT_EQ(p_insert.z, p_target.z);
-  }
-
-  // Overlap base_idx point
-  {
-    auto path_out = path_with_lane_id;
-
-    const auto p_target = createPoint(3.0, 0.0, 0.0);
-    const auto insert_idx = insertTargetPoint(3, p_target, path_out.points);
-
-    EXPECT_EQ(insert_idx, 3U);
-    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size());
-
-    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(path_out.points.at(i));
-      const auto & p_back = getPoint(path_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > 1e-3);
-    }
-  }
-
-  // Overlap base_idx + 1 point
-  {
-    auto path_out = path_with_lane_id;
-
-    const auto p_target = createPoint(4.0, 0.0, 0.0);
-    const auto insert_idx = insertTargetPoint(3, p_target, path_out.points);
-
-    EXPECT_EQ(insert_idx, 4U);
-    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size());
-
-    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(path_out.points.at(i));
-      const auto & p_back = getPoint(path_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > 1e-3);
-    }
-  }
-
-  // Invalid target point(In front of begin point)
-  {
-    auto path_out = path_with_lane_id;
-
-    const auto p_target = createPoint(-1.0, 0.0, 0.0);
-    EXPECT_THROW(insertTargetPoint(0, p_target, path_out.points), std::invalid_argument);
-  }
-
-  // Invalid target point(Behind of end point)
-  {
-    auto path_out = path_with_lane_id;
-
-    const auto p_target = createPoint(10.0, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
-    EXPECT_THROW(insertTargetPoint(base_idx, p_target, path_out.points), std::invalid_argument);
-  }
-
-  // Invalid target point(Huge lateral offset)
-  {
-    auto path_out = path_with_lane_id;
-
-    const auto p_target = createPoint(4.0, 10.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
-    EXPECT_THROW(insertTargetPoint(base_idx, p_target, path_out.points), std::invalid_argument);
-  }
-
-  // Empty
-  {
-    auto empty_traj = generateTestTrajectory<Trajectory>(0, 1.0);
-    EXPECT_THROW(
-      insertTargetPoint({}, geometry_msgs::msg::Point{}, empty_traj.points), std::invalid_argument);
-  }
-}
-
-TEST(trajectory, insertTargetPoint_OverlapThreshold_PathWithLaneId)
-{
-  using tier4_autoware_utils::calcDistance2d;
-  using tier4_autoware_utils::createPoint;
-  using tier4_autoware_utils::findNearestSegmentIndex;
-  using tier4_autoware_utils::getPoint;
-  using tier4_autoware_utils::insertTargetPoint;
-
-  constexpr double overlap_threshold = 1e-4;
-  const auto path_with_lane_id = generateTestTrajectory<PathWithLaneId>(10, 1.0);
-
-  // Insert between trajectory front and back
-  {
-    auto path_out = path_with_lane_id;
-
-    const auto p_target = createPoint(3.0001, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
-    const auto insert_idx =
-      insertTargetPoint(base_idx, p_target, path_out.points, overlap_threshold);
-
-    EXPECT_EQ(insert_idx, 4U);
-    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size() + 1);
-
-    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(path_out.points.at(i));
-      const auto & p_back = getPoint(path_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > overlap_threshold);
-    }
-
-    const auto & p_insert = getPoint(path_out.points.at(insert_idx));
-    EXPECT_EQ(p_insert.x, p_target.x);
-    EXPECT_EQ(p_insert.y, p_target.y);
-    EXPECT_EQ(p_insert.z, p_target.z);
-  }
-
-  // Overlap base_idx point
-  {
-    auto path_out = path_with_lane_id;
-
-    const auto p_target = createPoint(3.00001, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
-    const auto insert_idx =
-      insertTargetPoint(base_idx, p_target, path_out.points, overlap_threshold);
-
-    EXPECT_EQ(insert_idx, 3U);
-    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size());
-
-    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(path_out.points.at(i));
-      const auto & p_back = getPoint(path_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > overlap_threshold);
-    }
-  }
-
-  // Overlap base_idx + 1 point
-  {
-    auto path_out = path_with_lane_id;
-
-    const auto p_target = createPoint(3.99999, 0.0, 0.0);
-    const size_t base_idx = findNearestSegmentIndex(path_with_lane_id.points, p_target);
-    const auto insert_idx =
-      insertTargetPoint(base_idx, p_target, path_out.points, overlap_threshold);
-
-    EXPECT_EQ(insert_idx, 4U);
-    EXPECT_EQ(path_out.points.size(), path_with_lane_id.points.size());
-
-    for (size_t i = 0; i < path_out.points.size() - 1; ++i) {
-      const auto & p_front = getPoint(path_out.points.at(i));
-      const auto & p_back = getPoint(path_out.points.at(i + 1));
-      EXPECT_TRUE(calcDistance2d(p_front, p_back) > overlap_threshold);
     }
   }
 }

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -57,23 +57,6 @@
 #include <string>
 #include <vector>
 
-namespace tier4_autoware_utils
-{
-template <>
-inline geometry_msgs::msg::Point getPoint(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
-{
-  return p.point.pose.position;
-}
-
-template <>
-inline geometry_msgs::msg::Pose getPose(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
-{
-  return p.point.pose;
-}
-}  // namespace tier4_autoware_utils
-
 namespace tf2
 {
 inline void fromMsg(const geometry_msgs::msg::PoseStamped & msg, tf2::Stamped<tf2::Transform> & out)

--- a/planning/behavior_velocity_planner/include/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/util.hpp
@@ -53,22 +53,6 @@
 #include <utility>
 #include <vector>
 
-namespace tier4_autoware_utils
-{
-template <>
-inline geometry_msgs::msg::Point getPoint(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
-{
-  return p.point.pose.position;
-}
-template <>
-inline geometry_msgs::msg::Pose getPose(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
-{
-  return p.point.pose;
-}
-}  // namespace tier4_autoware_utils
-
 namespace behavior_velocity_planner
 {
 struct SearchRangeIndex

--- a/planning/behavior_velocity_planner/include/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/util.hpp
@@ -16,8 +16,7 @@
 #define UTILIZATION__UTIL_HPP_
 
 #include <lanelet2_extension/utility/query.hpp>
-#include <tier4_autoware_utils/geometry/geometry.hpp>
-#include <tier4_autoware_utils/trajectory/trajectory.hpp>
+#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 #include <utilization/boost_geometry_helper.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_object.hpp>


### PR DESCRIPTION
## Description

In this PR, I expanded geometry and trajectory utility functions:

### geometry

#### support `autoware_auto_planning_msgs::msg::PathWithLaneId`

```c++
template <>
inline geometry_msgs::msg::Point getPoint(
  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p);

template <>
inline geometry_msgs::msg::Pose getPose(
  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p);
```

#### add new utility functions

- `setPose()`

```c++
template <class T>
void setPose(const geometry_msgs::msg::Pose & pose, [[maybe_unused]] T & p);

template <>
inline void setPose(const geometry_msgs::msg::Pose & pose, geometry_msgs::msg::Pose & p);

template <>
inline void setPose(const geometry_msgs::msg::Pose & pose, geometry_msgs::msg::PoseStamped & p);

template <>
inline void setPose(
  const geometry_msgs::msg::Pose & pose, autoware_auto_planning_msgs::msg::PathPoint & p);

template <>
inline void setPose(
  const geometry_msgs::msg::Pose & pose, autoware_auto_planning_msgs::msg::PathPointWithLaneId & p);

template <>
inline void setPose(
  const geometry_msgs::msg::Pose & pose, autoware_auto_planning_msgs::msg::TrajectoryPoint & p);
```

### trajectory

#### add new utility functions

- `calcLongitudinalOffsetPoint()`
```c++
/**
 * @brief calculate the point offset from source point along the trajectory (or path)
 * @param points points of trajectory, path, ...
 * @param src_idx index of source point
 * @param offset length of offset from source point
 * @return offset point
 */
template <class T>
boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
  const T & points, const size_t src_idx, const double offset);

/**
 * @brief calculate the point offset from source point along the trajectory (or path)
 * @param points points of trajectory, path, ...
 * @param src_point source point
 * @param offset length of offset from source point
 * @return offset point
 */
template <class T>
boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
  const T & points, const geometry_msgs::msg::Point & src_point, const double offset);
```
- `calcLongitudinalOffsetPose()`
```c++
/**
 * @brief calculate the point offset from source point along the trajectory (or path)
 * @param points points of trajectory, path, ...
 * @param src_idx index of source point
 * @param offset length of offset from source point
 * @return offset pose
 */
template <class T>
boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPose(
  const T & points, const size_t src_idx, const double offset);

/**
 * @brief calculate the point offset from source point along the trajectory (or path)
 * @param points points of trajectory, path, ...
 * @param src_point source point
 * @param offset length of offset from source point
 * @return offset pose
 */
template <class T>
boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
  const T & points, const geometry_msgs::msg::Point & src_point, const double offset);
```
- `insertTargetPoint()`
```c++
/**
 * @brief calculate the point offset from source point along the trajectory (or path)
 * @param seg_idx segment index of point at beginning of length
 * @param p_target point to be inserted
 * @param points output points of trajectory, path, ...
 * @return index of insert point
 */
template <class T>
inline size_t insertTargetPoint(
  const size_t seg_idx, const geometry_msgs::msg::Point & p_target, T & points,
  const double overlap_threshold = 1e-3)
```

<!-- Write a brief description of this PR. -->

## Related links

- https://github.com/autowarefoundation/autoware.universe/issues/596

<!-- Write the links related to this PR. -->

## Tests performed

- please check whether unit test is valid.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

### Example usage

Insert a stop point 5.0m before the obstacle.

```c++
...
auto output_trajectory = input_trajectory;

const auto obstacle_poisition = ... (geometry_msgs::msg::Point)
const auto target_point = calcLongitudinalOffsetPoint(input_trajectory.points, obstacle_position, -5.0);
const size_t base_idx = findNearestSegmetnIndex(input_trajectory.points, obstacle_position);
const size_t insert_idx = insertTargetPoint(base_idx, target_point, output_trajectory.points);

for (size_t i = insert_idx; i < output_trajectory.points.size(); ++i)
{
  output_trajectory.points.at(i).longitudinal_velocity_mps = 0.0;
}
...
```

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
