### PR TITLE
fix: is_in_parking_lot check method

### DIFF
--- a/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -164,9 +164,10 @@ bool getLinkedParkingLot(
 bool getLinkedParkingLot(
   const lanelet::BasicPoint2d & current_position, const lanelet::ConstPolygons3d & all_parking_lots,
   lanelet::ConstPolygon3d * linked_parking_lot);
+// get linked parking lot from parking space
 bool getLinkedParkingLot(
-  const lanelet::ConstLineString3d & parking_space,
-  const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot);
+  const lanelet::ConstLineString3d & parking_space, const lanelet::ConstPolygons3d & all_parking_lots,
+  lanelet::ConstPolygon3d * linked_parking_lot);
 
 // query linked parking space from parking lot
 lanelet::ConstLineStrings3d getLinkedParkingSpaces(

--- a/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -166,8 +166,8 @@ bool getLinkedParkingLot(
   lanelet::ConstPolygon3d * linked_parking_lot);
 // get linked parking lot from parking space
 bool getLinkedParkingLot(
-  const lanelet::ConstLineString3d & parking_space, const lanelet::ConstPolygons3d & all_parking_lots,
-  lanelet::ConstPolygon3d * linked_parking_lot);
+  const lanelet::ConstLineString3d & parking_space,
+  const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot);
 
 // query linked parking space from parking lot
 lanelet::ConstLineStrings3d getLinkedParkingSpaces(

--- a/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -162,8 +162,8 @@ bool getLinkedParkingLot(
   lanelet::ConstPolygon3d * linked_parking_lot);
 // get linked parking lot from current pose of ego car
 bool getLinkedParkingLot(
-  const lanelet::BasicPoint2d & current_position,
-  const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot);
+  const lanelet::BasicPoint2d & current_position, const lanelet::ConstPolygons3d & all_parking_lots,
+  lanelet::ConstPolygon3d * linked_parking_lot);
 bool getLinkedParkingLot(
   const lanelet::ConstLineString3d & parking_space,
   const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot);

--- a/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -160,6 +160,10 @@ lanelet::ConstLanelets getLinkedLanelets(
 bool getLinkedParkingLot(
   const lanelet::ConstLanelet & lanelet, const lanelet::ConstPolygons3d & all_parking_lots,
   lanelet::ConstPolygon3d * linked_parking_lot);
+// get linked parking lot from current pose of ego car
+bool getLinkedParkingLot(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot);
 bool getLinkedParkingLot(
   const lanelet::ConstLineString3d & parking_space,
   const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot);

--- a/map/lanelet2_extension/lib/query.cpp
+++ b/map/lanelet2_extension/lib/query.cpp
@@ -452,6 +452,22 @@ bool query::getLinkedParkingLot(
 
 // get overlapping parking lot
 bool query::getLinkedParkingLot(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot)
+{
+  for (const auto & parking_lot : all_parking_lots) {
+    const double distance = boost::geometry::distance(
+      current_position, to2D(parking_lot).basicPolygon());
+    if (distance < std::numeric_limits<double>::epsilon()) {
+      *linked_parking_lot = parking_lot;
+      return true;
+    }
+  }
+  return false;
+}
+
+// get overlapping parking lot
+bool query::getLinkedParkingLot(
   const lanelet::ConstLineString3d & parking_space,
   const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot)
 {
@@ -465,6 +481,7 @@ bool query::getLinkedParkingLot(
   }
   return false;
 }
+
 
 lanelet::ConstLineStrings3d query::getLinkedParkingSpaces(
   const lanelet::ConstPolygon3d & parking_lot,

--- a/map/lanelet2_extension/lib/query.cpp
+++ b/map/lanelet2_extension/lib/query.cpp
@@ -452,12 +452,12 @@ bool query::getLinkedParkingLot(
 
 // get overlapping parking lot
 bool query::getLinkedParkingLot(
-  const lanelet::BasicPoint2d & current_position,
-  const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot)
+  const lanelet::BasicPoint2d & current_position, const lanelet::ConstPolygons3d & all_parking_lots,
+  lanelet::ConstPolygon3d * linked_parking_lot)
 {
   for (const auto & parking_lot : all_parking_lots) {
-    const double distance = boost::geometry::distance(
-      current_position, to2D(parking_lot).basicPolygon());
+    const double distance =
+      boost::geometry::distance(current_position, to2D(parking_lot).basicPolygon());
     if (distance < std::numeric_limits<double>::epsilon()) {
       *linked_parking_lot = parking_lot;
       return true;
@@ -481,7 +481,6 @@ bool query::getLinkedParkingLot(
   }
   return false;
 }
-
 
 lanelet::ConstLineStrings3d query::getLinkedParkingSpaces(
   const lanelet::ConstPolygon3d & parking_lot,

--- a/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
+++ b/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
@@ -93,21 +93,13 @@ geometry_msgs::msg::PoseStamped::ConstSharedPtr getCurrentPose(
 // copied from scenario selector
 std::shared_ptr<lanelet::ConstPolygon3d> findNearestParkinglot(
   const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr,
-  const lanelet::BasicPoint2d & search_point)
+  const lanelet::BasicPoint2d & current_position)
 {
-  std::vector<std::pair<double, lanelet::Lanelet>> nearest_lanelets =
-    lanelet::geometry::findNearest(lanelet_map_ptr->laneletLayer, search_point, 1);
-
-  if (nearest_lanelets.empty()) {
-    return {};
-  }
-
-  const auto nearest_lanelet = nearest_lanelets.front().second;
   const auto all_parking_lots = lanelet::utils::query::getAllParkingLots(lanelet_map_ptr);
 
   const auto linked_parking_lot = std::make_shared<lanelet::ConstPolygon3d>();
   const auto result = lanelet::utils::query::getLinkedParkingLot(
-    search_point, all_parking_lots, linked_parking_lot.get());
+    current_position, all_parking_lots, linked_parking_lot.get());
 
   if (result) {
     return linked_parking_lot;

--- a/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
+++ b/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
@@ -107,7 +107,7 @@ std::shared_ptr<lanelet::ConstPolygon3d> findNearestParkinglot(
 
   const auto linked_parking_lot = std::make_shared<lanelet::ConstPolygon3d>();
   const auto result = lanelet::utils::query::getLinkedParkingLot(
-    nearest_lanelet, all_parking_lots, linked_parking_lot.get());
+    search_point, all_parking_lots, linked_parking_lot.get());
 
   if (result) {
     return linked_parking_lot;

--- a/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<lanelet::ConstPolygon3d> findNearestParkinglot(
 
   const auto linked_parking_lot = std::make_shared<lanelet::ConstPolygon3d>();
   const auto result = lanelet::utils::query::getLinkedParkingLot(
-    nearest_lanelet, all_parking_lots, linked_parking_lot.get());
+    search_point, all_parking_lots, linked_parking_lot.get());
 
   if (result) {
     return linked_parking_lot;

--- a/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -39,21 +39,13 @@ void onData(const T & data, T * buffer)
 
 std::shared_ptr<lanelet::ConstPolygon3d> findNearestParkinglot(
   const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr,
-  const lanelet::BasicPoint2d & search_point)
+  const lanelet::BasicPoint2d & current_position)
 {
-  std::vector<std::pair<double, lanelet::Lanelet>> nearest_lanelets =
-    lanelet::geometry::findNearest(lanelet_map_ptr->laneletLayer, search_point, 1);
-
-  if (nearest_lanelets.empty()) {
-    return {};
-  }
-
-  const auto nearest_lanelet = nearest_lanelets.front().second;
   const auto all_parking_lots = lanelet::utils::query::getAllParkingLots(lanelet_map_ptr);
 
   const auto linked_parking_lot = std::make_shared<lanelet::ConstPolygon3d>();
   const auto result = lanelet::utils::query::getLinkedParkingLot(
-    search_point, all_parking_lots, linked_parking_lot.get());
+    current_position, all_parking_lots, linked_parking_lot.get());
 
   if (result) {
     return linked_parking_lot;


### PR DESCRIPTION
Signed-off-by: NorahXiong <norah.xiong@autocore.ai>

## Description

<!-- Write a brief description of this PR. -->
fix #941 
Use ego car position instead of the lanelet nearest to ego car to check if ego car is in a parking lot.

## Related links

<!-- Write the links related to this PR. -->
#941 

## Tests performed

<!-- Describe how you have tested this PR. -->
Tested in planning simulator.

Before fixing
![image](https://user-images.githubusercontent.com/103234047/170934143-2a4505ae-bb6e-4835-b5cd-fc161feff48b.png)

After fixing
![image](https://user-images.githubusercontent.com/103234047/170934157-a892d44c-8712-4e51-b26c-f1f4a42d54dc.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
