### PR TITLE
fix(behavior_velocity): stop line search ego index at returning path case

### DIFF
--- a/planning/behavior_velocity_planner/include/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/util.hpp
@@ -222,6 +222,7 @@ PointWithSearchRangeIndex findFirstNearSearchRangeIndex(
   tier4_autoware_utils::validateNonEmpty(points);
 
   bool min_idx_found = false;
+  bool max_idx_found = false;
   PointWithSearchRangeIndex point_with_range = {point, {static_cast<size_t>(0), points.size() - 1}};
   for (size_t i = 0; i < points.size(); i++) {
     const auto & p = points.at(i).point.pose.position;
@@ -231,7 +232,10 @@ PointWithSearchRangeIndex findFirstNearSearchRangeIndex(
         point_with_range.index.min_idx = i;
         min_idx_found = true;
       }
-      point_with_range.index.max_idx = i;
+      if (!max_idx_found) point_with_range.index.max_idx = i;
+    } else if (min_idx_found) {
+      // found close index and farther than distance_thresh, stop update max index
+      max_idx_found = true;
     }
   }
   return point_with_range;


### PR DESCRIPTION
## Description

- bug fix 


## review procedure

fix bug to search ego closest index in returning type path(not autoware support type path)

ego index jumps to in bound path index because max index was updated after exceeding distance.

![image](https://user-images.githubusercontent.com/65527974/171094734-a494a40d-8a75-4682-ad9e-cd08c3e7ff8f.png)
![image](https://user-images.githubusercontent.com/65527974/171098575-5c96b1a3-de86-4dee-b578-2bd9f159e0dd.png)



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
