### PR TITLE
fix: fix package missing without CUDA

### DIFF
--- a/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
@@ -154,4 +154,8 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
 
 else()
   message(STATUS "TrafficLightSSDFineDetector won't be built, CUDA and/or TensorRT were not found.")
+  # to avoid launch file missing without a gpu
+  ament_auto_package(INSTALL_TO_SHARE
+    launch
+  )
 endif()


### PR DESCRIPTION
Signed-off-by: h-ohta <hiroki.ota@tier4.jp>

## Description

Refer to following code, I fix package missing without CUDA.

https://github.com/tier4/autoware.universe/blob/tier4/main/perception/lidar_apollo_instance_segmentation/CMakeLists.txt#L163-L166


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
