### PR TITLE
fix(behavior_path_planner): unsafe mutex operation

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -521,6 +521,8 @@ void BehaviorPathPlannerNode::run()
 
   // behavior_path_planner runs only in LANE DRIVING scenario.
   if (current_scenario_->current_scenario != Scenario::LANEDRIVING) {
+    mutex_bt_.unlock();  // for bt_manager_
+    mutex_pd_.unlock();  // for planner_data_
     return;
   }
 


### PR DESCRIPTION
Signed-off-by: NorahXiong <norah.xiong@autocore.ai>

## Description

<!-- Write a brief description of this PR. -->
Fix unsafe mutex operation in behavior_path_planner.
https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/src/behavior_path_planner_node.cpp#L516

If parking scenario is activated, the function will exit without unlocking the mutexes which belong to the class object. The program will try to lock the mutexes again when reentering the function and something unexpected will occur.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
Tested in planning simulator.

Before: no route is generated when scenario changing from parking to lane-driving because behavior_path_planner is stuck
![image](https://user-images.githubusercontent.com/103234047/171119629-e3a55670-0ed5-4275-aba9-9fe0cce00b4b.png)

After: route is generated after scenario changes from parking to lane-driving
![image](https://user-images.githubusercontent.com/103234047/171119934-cf5325e5-8e6f-448e-927f-d50c81bf4905.png)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
