### PR TITLE
feat: add twist information for detected object on rviz

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -52,6 +52,28 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
       label_marker_ptr->id = id++;
       add_marker(label_marker_ptr);
     }
+
+    // Get marker for velocity text
+    geometry_msgs::msg::Point vel_vis_position;
+    vel_vis_position.x = object.kinematics.pose_with_covariance.pose.position.x;
+    vel_vis_position.y = object.kinematics.pose_with_covariance.pose.position.y - 1.0;
+    vel_vis_position.z = object.kinematics.pose_with_covariance.pose.position.z - 1.0;
+    auto velocity_text_marker = get_velocity_text_marker_ptr(
+      object.kinematics.twist_with_covariance.twist, vel_vis_position, object.classification);
+    if (velocity_text_marker) {
+      auto velocity_text_marker_ptr = velocity_text_marker.value();
+      velocity_text_marker_ptr->header = msg->header;
+      add_marker(velocity_text_marker_ptr);
+    }
+
+    // Get marker for twist
+    auto twist_marker = get_twist_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance);
+    if (twist_marker) {
+      auto twist_marker_ptr = twist_marker.value();
+      twist_marker_ptr->header = msg->header;
+      add_marker(twist_marker_ptr);
+    }
   }
 }
 

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -54,8 +54,8 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
 
     // Get marker for id
     geometry_msgs::msg::Point uuid_vis_position;
-    uuid_vis_position.x = object.kinematics.initial_pose_with_covariance.pose.position.x - 0.5;
-    uuid_vis_position.y = object.kinematics.initial_pose_with_covariance.pose.position.y;
+    uuid_vis_position.x = object.kinematics.initial_pose_with_covariance.pose.position.x;
+    uuid_vis_position.y = object.kinematics.initial_pose_with_covariance.pose.position.y - 0.5;
     uuid_vis_position.z = object.kinematics.initial_pose_with_covariance.pose.position.z - 0.5;
 
     auto id_marker =
@@ -79,8 +79,8 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
 
     // Get marker for velocity text
     geometry_msgs::msg::Point vel_vis_position;
-    vel_vis_position.x = uuid_vis_position.x - 0.5;
-    vel_vis_position.y = uuid_vis_position.y;
+    vel_vis_position.x = uuid_vis_position.x;
+    vel_vis_position.y = uuid_vis_position.y - 0.5;
     vel_vis_position.z = uuid_vis_position.z - 0.5;
     auto velocity_text_marker = get_velocity_text_marker_ptr(
       object.kinematics.initial_twist_with_covariance.twist, vel_vis_position,

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -56,8 +56,8 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for id
     geometry_msgs::msg::Point uuid_vis_position;
-    uuid_vis_position.x = object.kinematics.pose_with_covariance.pose.position.x - 0.5;
-    uuid_vis_position.y = object.kinematics.pose_with_covariance.pose.position.y;
+    uuid_vis_position.x = object.kinematics.pose_with_covariance.pose.position.x;
+    uuid_vis_position.y = object.kinematics.pose_with_covariance.pose.position.y - 0.5;
     uuid_vis_position.z = object.kinematics.pose_with_covariance.pose.position.z - 0.5;
 
     auto id_marker =
@@ -81,8 +81,8 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for velocity text
     geometry_msgs::msg::Point vel_vis_position;
-    vel_vis_position.x = uuid_vis_position.x - 0.5;
-    vel_vis_position.y = uuid_vis_position.y;
+    vel_vis_position.x = uuid_vis_position.x;
+    vel_vis_position.y = uuid_vis_position.y - 0.5;
     vel_vis_position.z = uuid_vis_position.z - 0.5;
     auto velocity_text_marker = get_velocity_text_marker_ptr(
       object.kinematics.twist_with_covariance.twist, vel_vis_position, object.classification);


### PR DESCRIPTION
## Description

Add twist information for detected object on rviz.

![Screenshot from 2022-05-31 00-39-22](https://user-images.githubusercontent.com/16330533/171310228-554175f5-63ba-492a-8161-dbd7040954df.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
