### PR TITLE
fix: fix overlap of tracked objects information on rviz

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -54,8 +54,8 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
 
     // Get marker for id
     geometry_msgs::msg::Point uuid_vis_position;
-    uuid_vis_position.x = object.kinematics.initial_pose_with_covariance.pose.position.x - 0.5;
-    uuid_vis_position.y = object.kinematics.initial_pose_with_covariance.pose.position.y;
+    uuid_vis_position.x = object.kinematics.initial_pose_with_covariance.pose.position.x;
+    uuid_vis_position.y = object.kinematics.initial_pose_with_covariance.pose.position.y - 0.5;
     uuid_vis_position.z = object.kinematics.initial_pose_with_covariance.pose.position.z - 0.5;
 
     auto id_marker =
@@ -79,8 +79,8 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
 
     // Get marker for velocity text
     geometry_msgs::msg::Point vel_vis_position;
-    vel_vis_position.x = uuid_vis_position.x - 0.5;
-    vel_vis_position.y = uuid_vis_position.y;
+    vel_vis_position.x = uuid_vis_position.x;
+    vel_vis_position.y = uuid_vis_position.y - 0.5;
     vel_vis_position.z = uuid_vis_position.z - 0.5;
     auto velocity_text_marker = get_velocity_text_marker_ptr(
       object.kinematics.initial_twist_with_covariance.twist, vel_vis_position,

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -56,8 +56,8 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for id
     geometry_msgs::msg::Point uuid_vis_position;
-    uuid_vis_position.x = object.kinematics.pose_with_covariance.pose.position.x - 0.5;
-    uuid_vis_position.y = object.kinematics.pose_with_covariance.pose.position.y;
+    uuid_vis_position.x = object.kinematics.pose_with_covariance.pose.position.x;
+    uuid_vis_position.y = object.kinematics.pose_with_covariance.pose.position.y - 0.5;
     uuid_vis_position.z = object.kinematics.pose_with_covariance.pose.position.z - 0.5;
 
     auto id_marker =
@@ -81,8 +81,8 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
 
     // Get marker for velocity text
     geometry_msgs::msg::Point vel_vis_position;
-    vel_vis_position.x = uuid_vis_position.x - 0.5;
-    vel_vis_position.y = uuid_vis_position.y;
+    vel_vis_position.x = uuid_vis_position.x;
+    vel_vis_position.y = uuid_vis_position.y - 0.5;
     vel_vis_position.z = uuid_vis_position.z - 0.5;
     auto velocity_text_marker = get_velocity_text_marker_ptr(
       object.kinematics.twist_with_covariance.twist, vel_vis_position, object.classification);


### PR DESCRIPTION
## Description

Fix rviz overlap of tracked objects information on rviz.

- before

![Screenshot from 2022-05-31 00-32-45](https://user-images.githubusercontent.com/16330533/171310962-b64b5275-b5c6-4b8d-b042-d44de5366d24.png)

- after

![Screenshot from 2022-05-31 00-21-05](https://user-images.githubusercontent.com/16330533/171310984-796bac34-5798-49c3-ab56-307620ec535f.png)

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
