### PR TITLE
feat(behavior_velocity_planner): use grid_map_utils::PolygonIterator

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/grid_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/grid_utils.hpp
@@ -17,8 +17,8 @@
 
 #include <grid_map_core/GridMap.hpp>
 #include <grid_map_core/iterators/LineIterator.hpp>
-#include <grid_map_core/iterators/PolygonIterator.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
+#include <grid_map_utils/polygon_iterator.hpp>
 #include <opencv2/opencv.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <tier4_autoware_utils/math/normalization.hpp>

--- a/planning/behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/package.xml
@@ -19,6 +19,7 @@
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>grid_map_ros</depend>
+  <depend>grid_map_utils</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
   <depend>libboost-dev</depend>

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/grid_utils.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/grid_utils.cpp
@@ -68,7 +68,7 @@ void addObjectsToGridMap(const std::vector<PredictedObject> & objs, grid_map::Gr
       for (const auto & point : foot_print_polygon.outer()) {
         grid_polygon.addVertex({point.x(), point.y()});
       }
-      for (grid_map::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd();
+      for (grid_map_utils::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd();
            ++iterator) {
         const grid_map::Index & index = *iterator;
         if (!grid.isValid(index)) continue;
@@ -89,7 +89,8 @@ void findOcclusionSpots(
   for (const auto & point : polygon.outer()) {
     grid_polygon.addVertex({point.x(), point.y()});
   }
-  for (grid_map::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd(); ++iterator) {
+  for (grid_map_utils::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd();
+       ++iterator) {
     const grid_map::Index & index = *iterator;
     if (grid_data(index.x(), index.y()) == grid_utils::occlusion_cost_value::UNKNOWN) {
       grid_map::Position occlusion_spot_position;
@@ -115,7 +116,7 @@ bool isCollisionFree(
       for (const auto & point : polygon.outer()) {
         grid_polygon.addVertex({point.x(), point.y()});
       }
-      for (grid_map::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd();
+      for (grid_map_utils::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd();
            ++iterator) {
         const grid_map::Index & index = *iterator;
         if (grid_data(index.x(), index.y()) == grid_utils::occlusion_cost_value::OCCUPIED) {

--- a/planning/behavior_velocity_planner/test/src/test_grid_utils.cpp
+++ b/planning/behavior_velocity_planner/test/src/test_grid_utils.cpp
@@ -99,7 +99,7 @@ TEST(compareTime, polygon_vs_line_iterator)
         for (const auto & point : polygon.outer()) {
           grid_polygon.addVertex({point.x(), point.y()});
         }
-        for (grid_map::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd();
+        for (grid_map_utils::PolygonIterator iterator(grid, grid_polygon); !iterator.isPastEnd();
              ++iterator) {
           const grid_map::Index & index = *iterator;
           if (grid_data(index.x(), index.y()) == OCCUPIED) {


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@tier4.jp>

## Description

Switch to the faster `grid_map_utils::PolygonIterator` (added in https://github.com/autowarefoundation/autoware.universe/pull/943)  in the occlusion spot module of the `behavior_velocity_planner`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
