### PR TITLE
fix(imu_corrector): correct sign of offset in imu_corrector

### DIFF
--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -4,12 +4,15 @@
 
 `imu_corrector_node` is a node that correct imu data.
 
-1. Correct yaw rate offset by reading the parameter.
-2. Correct yaw rate standard deviation by reading the parameter.
+1. Correct yaw rate offset $b$ by reading the parameter.
+2. Correct yaw rate standard deviation $\sigma$ by reading the parameter.
 
+Mathematically, we assume the following equation:
 $$
-\tilde{\omega} = \omega + b
+\tilde{\omega}(t) = \omega(t) + b(t) + n(t)
 $$
+where $\tilde{\omega}$ denotes observed angular velocity, $\omega$ denotes true angular velocity, $b$ denotes an offset, and $n$ denotes a gaussian noise.
+We also assume that $n\sim\mathcal{N}(0, \sigma^2)$.
 <!-- TODO(TIER IV): Make this repository public or change the link. -->
 <!-- Use the value estimated by [deviation_estimator](https://github.com/tier4/calibration_tools/tree/main/localization/deviation_estimation_tools) as the parameters for this node. -->
 

--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -8,9 +8,11 @@
 2. Correct yaw rate standard deviation $\sigma$ by reading the parameter.
 
 Mathematically, we assume the following equation:
+
 $$
 \tilde{\omega}(t) = \omega(t) + b(t) + n(t)
 $$
+
 where $\tilde{\omega}$ denotes observed angular velocity, $\omega$ denotes true angular velocity, $b$ denotes an offset, and $n$ denotes a gaussian noise.
 We also assume that $n\sim\mathcal{N}(0, \sigma^2)$.
 <!-- TODO(TIER IV): Make this repository public or change the link. -->

--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -7,6 +7,9 @@
 1. Correct yaw rate offset by reading the parameter.
 2. Correct yaw rate standard deviation by reading the parameter.
 
+$$
+\tilde{\omega} = \omega + b
+$$
 <!-- TODO(TIER IV): Make this repository public or change the link. -->
 <!-- Use the value estimated by [deviation_estimator](https://github.com/tier4/calibration_tools/tree/main/localization/deviation_estimation_tools) as the parameters for this node. -->
 

--- a/sensing/imu_corrector/src/imu_corrector_core.cpp
+++ b/sensing/imu_corrector/src/imu_corrector_core.cpp
@@ -38,9 +38,9 @@ void ImuCorrector::callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_m
   sensor_msgs::msg::Imu imu_msg;
   imu_msg = *imu_msg_ptr;
 
-  imu_msg.angular_velocity.x += angular_velocity_offset_x_;
-  imu_msg.angular_velocity.y += angular_velocity_offset_y_;
-  imu_msg.angular_velocity.z += angular_velocity_offset_z_;
+  imu_msg.angular_velocity.x -= angular_velocity_offset_x_;
+  imu_msg.angular_velocity.y -= angular_velocity_offset_y_;
+  imu_msg.angular_velocity.z -= angular_velocity_offset_z_;
 
   imu_msg.angular_velocity_covariance[0 * 3 + 0] =
     angular_velocity_stddev_xx_ * angular_velocity_stddev_xx_;


### PR DESCRIPTION
## Description
Changed a sign of offset in imu_corrector.

Previously:

$$
\tilde{\omega}(t) = \omega(t) - b(t)
$$

Now:

$$
\tilde{\omega}(t) = \omega(t) + b(t)
$$

where $\tilde{\omega}$ denotes observed angular velocity, $\omega$ denotes true angular velocity, and $b$ denotes an offset.


I have also added an equation to clarify our model assumption.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
