### PR TITLE
fix: stop_line visualization

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -96,9 +96,11 @@ visualization_msgs::msg::MarkerArray StopLineModule::createVirtualWallMarkerArra
   visualization_msgs::msg::MarkerArray wall_marker;
   const auto p_front = tier4_autoware_utils::calcOffsetPose(
     *debug_data_.stop_pose, debug_data_.base_link2front, 0.0, 0.0);
-  appendMarkerArray(
-    tier4_autoware_utils::createStopVirtualWallMarker(p_front, "stopline", now, module_id_), now,
-    &wall_marker);
+  if (state_ == State::APPROACH) {
+    appendMarkerArray(
+      tier4_autoware_utils::createStopVirtualWallMarker(p_front, "stopline", now, module_id_), now,
+      &wall_marker);
+  }
   return wall_marker;
 }
 }  // namespace behavior_velocity_planner


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Fix stop line visualization.

![image](https://user-images.githubusercontent.com/59680180/171618995-09eadf45-e806-46fc-abe1-61891559b441.png)
In the original implementation, the stop line was visualized even after stopping at the stop line.

I fixed it.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
