### PR TITLE
fix(tier4_autoware_utils): fix build error related to vehicle state checker

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
@@ -33,5 +33,6 @@
 #include "tier4_autoware_utils/ros/wait_for_param.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 #include "tier4_autoware_utils/trajectory/trajectory.hpp"
+#include "tier4_autoware_utils/vehicle/vehicle_state_checker.hpp"
 
 #endif  // TIER4_AUTOWARE_UTILS__TIER4_AUTOWARE_UTILS_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/vehicle/vehicle_state_checker.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/vehicle/vehicle_state_checker.hpp
@@ -36,7 +36,7 @@ class VehicleStopChecker
 public:
   explicit VehicleStopChecker(rclcpp::Node * node);
 
-  bool isVehicleStopped(const double stop_duration) const;
+  bool isVehicleStopped(const double stop_duration = 0.0) const;
 
   rclcpp::Logger getLogger() { return logger_; }
 
@@ -60,7 +60,7 @@ class VehicleArrivalChecker : public VehicleStopChecker
 public:
   explicit VehicleArrivalChecker(rclcpp::Node * node);
 
-  bool isVehicleStoppedAtStopPoint(const double stop_duration) const;
+  bool isVehicleStoppedAtStopPoint(const double stop_duration = 0.0) const;
 
 private:
   static constexpr double th_arrived_distance_m = 1.0;

--- a/common/tier4_autoware_utils/src/vehicle/vehicle_state_checker.cpp
+++ b/common/tier4_autoware_utils/src/vehicle/vehicle_state_checker.cpp
@@ -30,7 +30,7 @@ VehicleStopChecker::VehicleStopChecker(rclcpp::Node * node)
     std::bind(&VehicleStopChecker::onOdom, this, _1));
 }
 
-bool VehicleStopChecker::isVehicleStopped(const double stop_duration = 0.0) const
+bool VehicleStopChecker::isVehicleStopped(const double stop_duration) const
 {
   if (twist_buffer_.empty()) {
     return false;
@@ -93,7 +93,7 @@ VehicleArrivalChecker::VehicleArrivalChecker(rclcpp::Node * node) : VehicleStopC
     std::bind(&VehicleArrivalChecker::onTrajectory, this, _1));
 }
 
-bool VehicleArrivalChecker::isVehicleStoppedAtStopPoint(const double stop_duration = 0.0) const
+bool VehicleArrivalChecker::isVehicleStoppedAtStopPoint(const double stop_duration) const
 {
   if (!odometry_ptr_ || !trajectory_ptr_) {
     return false;

--- a/common/tier4_autoware_utils/test/src/vehicle/test_vehicle_state_checker.cpp
+++ b/common/tier4_autoware_utils/test/src/vehicle/test_vehicle_state_checker.cpp
@@ -142,7 +142,7 @@ TEST(vehicle_stop_checker, isVehicleStopped)
     auto manager = std::make_shared<PubManager>();
     EXPECT_GE(manager->pub_odom_->get_subscription_count(), 1U) << "topic is not connected.";
 
-    EXPECT_FALSE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
+    EXPECT_FALSE(checker->vehicle_stop_checker_->isVehicleStopped());
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(checker);
@@ -153,6 +153,7 @@ TEST(vehicle_stop_checker, isVehicleStopped)
 
     manager->publishStoppedOdometry(ODOMETRY_HISTORY_500_MS);
 
+    EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped());
     EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
     EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_200_MS));
     EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_400_MS));
@@ -171,7 +172,7 @@ TEST(vehicle_stop_checker, isVehicleStopped)
     auto manager = std::make_shared<PubManager>();
     EXPECT_GE(manager->pub_odom_->get_subscription_count(), 1U) << "topic is not connected.";
 
-    EXPECT_FALSE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
+    EXPECT_FALSE(checker->vehicle_stop_checker_->isVehicleStopped());
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(checker);
@@ -182,6 +183,7 @@ TEST(vehicle_stop_checker, isVehicleStopped)
 
     manager->publishStoppedOdometry(ODOMETRY_HISTORY_1000_MS);
 
+    EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped());
     EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
     EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_200_MS));
     EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_400_MS));
@@ -200,7 +202,7 @@ TEST(vehicle_stop_checker, isVehicleStopped)
     auto manager = std::make_shared<PubManager>();
     EXPECT_GE(manager->pub_odom_->get_subscription_count(), 1U) << "topic is not connected.";
 
-    EXPECT_FALSE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
+    EXPECT_FALSE(checker->vehicle_stop_checker_->isVehicleStopped());
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(checker);
@@ -211,6 +213,7 @@ TEST(vehicle_stop_checker, isVehicleStopped)
 
     manager->publishStoppingOdometry(ODOMETRY_HISTORY_1000_MS);
 
+    EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped());
     EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
     EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_200_MS));
     EXPECT_TRUE(checker->vehicle_stop_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_400_MS));
@@ -232,7 +235,7 @@ TEST(vehicle_arrival_checker, isVehicleStopped)
     auto manager = std::make_shared<PubManager>();
     EXPECT_GE(manager->pub_odom_->get_subscription_count(), 1U) << "topic is not connected.";
 
-    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
+    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStopped());
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(checker);
@@ -243,6 +246,7 @@ TEST(vehicle_arrival_checker, isVehicleStopped)
 
     manager->publishStoppedOdometry(ODOMETRY_HISTORY_500_MS);
 
+    EXPECT_TRUE(checker->vehicle_arrival_checker_->isVehicleStopped());
     EXPECT_TRUE(checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
     EXPECT_TRUE(
       checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_200_MS));
@@ -266,7 +270,7 @@ TEST(vehicle_arrival_checker, isVehicleStopped)
     auto manager = std::make_shared<PubManager>();
     EXPECT_GE(manager->pub_odom_->get_subscription_count(), 1U) << "topic is not connected.";
 
-    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
+    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStopped());
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(checker);
@@ -277,6 +281,7 @@ TEST(vehicle_arrival_checker, isVehicleStopped)
 
     manager->publishStoppedOdometry(ODOMETRY_HISTORY_1000_MS);
 
+    EXPECT_TRUE(checker->vehicle_arrival_checker_->isVehicleStopped());
     EXPECT_TRUE(checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
     EXPECT_TRUE(
       checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_200_MS));
@@ -300,7 +305,7 @@ TEST(vehicle_arrival_checker, isVehicleStopped)
     auto manager = std::make_shared<PubManager>();
     EXPECT_GE(manager->pub_odom_->get_subscription_count(), 1U) << "topic is not connected.";
 
-    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
+    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStopped());
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(checker);
@@ -311,6 +316,7 @@ TEST(vehicle_arrival_checker, isVehicleStopped)
 
     manager->publishStoppingOdometry(ODOMETRY_HISTORY_1000_MS);
 
+    EXPECT_TRUE(checker->vehicle_arrival_checker_->isVehicleStopped());
     EXPECT_TRUE(checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
     EXPECT_TRUE(
       checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_200_MS));
@@ -337,7 +343,7 @@ TEST(vehicle_arrival_checker, isVehicleStoppedAtStopPoint)
     auto manager = std::make_shared<PubManager>();
     EXPECT_GE(manager->pub_odom_->get_subscription_count(), 1U) << "topic is not connected.";
 
-    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStopped(STOP_DURATION_THRESHOLD_0_MS));
+    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStopped());
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(checker);
@@ -357,6 +363,7 @@ TEST(vehicle_arrival_checker, isVehicleStoppedAtStopPoint)
     manager->pub_traj_->publish(generateTrajectoryWithStopPoint(goal_pose));
     manager->publishStoppedOdometry(odom_pose, ODOMETRY_HISTORY_500_MS);
 
+    EXPECT_TRUE(checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint());
     EXPECT_TRUE(
       checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint(STOP_DURATION_THRESHOLD_0_MS));
     EXPECT_TRUE(checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint(
@@ -381,8 +388,7 @@ TEST(vehicle_arrival_checker, isVehicleStoppedAtStopPoint)
     auto manager = std::make_shared<PubManager>();
     EXPECT_GE(manager->pub_odom_->get_subscription_count(), 1U) << "topic is not connected.";
 
-    EXPECT_FALSE(
-      checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint(STOP_DURATION_THRESHOLD_0_MS));
+    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint());
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(checker);
@@ -402,6 +408,7 @@ TEST(vehicle_arrival_checker, isVehicleStoppedAtStopPoint)
     manager->pub_traj_->publish(generateTrajectoryWithStopPoint(goal_pose));
     manager->publishStoppedOdometry(odom_pose, ODOMETRY_HISTORY_500_MS);
 
+    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint());
     EXPECT_FALSE(
       checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint(STOP_DURATION_THRESHOLD_0_MS));
     EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint(
@@ -426,8 +433,7 @@ TEST(vehicle_arrival_checker, isVehicleStoppedAtStopPoint)
     auto manager = std::make_shared<PubManager>();
     EXPECT_GE(manager->pub_odom_->get_subscription_count(), 1U) << "topic is not connected.";
 
-    EXPECT_FALSE(
-      checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint(STOP_DURATION_THRESHOLD_0_MS));
+    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint());
 
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(checker);
@@ -447,6 +453,7 @@ TEST(vehicle_arrival_checker, isVehicleStoppedAtStopPoint)
     manager->pub_traj_->publish(generateTrajectoryWithoutStopPoint(goal_pose));
     manager->publishStoppedOdometry(odom_pose, ODOMETRY_HISTORY_500_MS);
 
+    EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint());
     EXPECT_FALSE(
       checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint(STOP_DURATION_THRESHOLD_0_MS));
     EXPECT_FALSE(checker->vehicle_arrival_checker_->isVehicleStoppedAtStopPoint(


### PR DESCRIPTION
## Description

When I used vehicle_state_checker in planning modules, the following build error were shown.

```
In file included from /home/satoshi/pilot-auto.x2/src/autoware/universe/planning/surround_obstacle_checker/src/node.cpp:15:                                                                                    
/home/satoshi/pilot-auto.x2/src/autoware/universe/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp:53:29: error: ‘tier4_autoware_utils::VehicleStopChecker’ has not been declared 
   53 | using tier4_autoware_utils::VehicleStopChecker;   
```
-> I added `#include "tier4_autoware_utils/vehicle/vehicle_state_checker.hpp"` in tier4_autoware_utils.hpp.

```
/home/satoshi/pilot-auto.x2/src/autoware/universe/planning/surround_obstacle_checker/src/node.cpp: In member function ‘void surround_obstacle_checker::SurroundObstacleCheckerNode::onTimer()’:                
/home/satoshi/pilot-auto.x2/src/autoware/universe/planning/surround_obstacle_checker/src/node.cpp:211:75: error: no matching function for call to ‘tier4_autoware_utils::VehicleStopChecker::isVehicleStopped()
’                                                                                                                                                                                                              
  211 |   const auto is_vehicle_stopped = vehicle_stop_checker_->isVehicleStopped();
```
-> I fix member function's argument and set default value in header file. Additionally, I added test case of settitng no arguments.

**NOTE:** All unit test has been PASSED in my local env.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
