### PR TITLE
feat(lane_departure_checker): add angle limitation to lane_departure_chacker

### DIFF
--- a/control/lane_departure_checker/config/lane_departure_checker.param.yaml
+++ b/control/lane_departure_checker/config/lane_departure_checker.param.yaml
@@ -12,4 +12,4 @@
     max_lateral_deviation: 2.0
     max_longitudinal_deviation: 2.0
     max_yaw_deviation_deg: 60.0
-    delta_yaw_threshold_for_closest_point: 90.0
+    delta_yaw_threshold_for_closest_point: 1.570 #M_PI/2.0, delta yaw thres for closest point

--- a/control/lane_departure_checker/config/lane_departure_checker.param.yaml
+++ b/control/lane_departure_checker/config/lane_departure_checker.param.yaml
@@ -12,3 +12,4 @@
     max_lateral_deviation: 2.0
     max_longitudinal_deviation: 2.0
     max_yaw_deviation_deg: 60.0
+    delta_yaw_threshold_for_closest_point: 90.0

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
@@ -18,6 +18,7 @@
 #include <rosidl_runtime_cpp/message_initialization.hpp>
 #include <tier4_autoware_utils/geometry/boost_geometry.hpp>
 #include <tier4_autoware_utils/geometry/pose_deviation.hpp>
+#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <autoware_auto_planning_msgs/msg/had_map_route.hpp>
@@ -55,6 +56,7 @@ struct Param
   double max_lateral_deviation;
   double max_longitudinal_deviation;
   double max_yaw_deviation_deg;
+  double delta_yaw_threshold_for_closest_point;
 };
 
 struct Input
@@ -98,7 +100,8 @@ private:
   std::shared_ptr<vehicle_info_util::VehicleInfo> vehicle_info_ptr_;
 
   static PoseDeviation calcTrajectoryDeviation(
-    const Trajectory & trajectory, const geometry_msgs::msg::Pose & pose);
+    const Trajectory & trajectory, const geometry_msgs::msg::Pose & pose,
+    const double yaw_threshold);
 
   //! This function assumes the input trajectory is sampled dense enough
   static TrajectoryPoints resampleTrajectory(const Trajectory & trajectory, const double interval);

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -62,8 +62,8 @@ size_t findNearestIndexWithSoftYawConstraints(
   const auto nearest_idx_optional = tier4_autoware_utils::findNearestIndex(
     trajectory.points, pose, std::numeric_limits<double>::max(), yaw_threshold);
   return nearest_idx_optional
-          ? *nearest_idx_optional
-          : tier4_autoware_utils::findNearestIndex(trajectory.points, pose.position);
+           ? *nearest_idx_optional
+           : tier4_autoware_utils::findNearestIndex(trajectory.points, pose.position);
 }
 
 LinearRing2d createHullFromFootprints(const std::vector<LinearRing2d> & footprints)
@@ -108,9 +108,9 @@ Output LaneDepartureChecker::update(const Input & input)
 
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
 
-  output.trajectory_deviation =
-    calcTrajectoryDeviation(*input.reference_trajectory,
-    input.current_pose->pose, param_.delta_yaw_threshold_for_closest_point);
+  output.trajectory_deviation = calcTrajectoryDeviation(
+    *input.reference_trajectory, input.current_pose->pose,
+    param_.delta_yaw_threshold_for_closest_point);
   output.processing_time_map["calcTrajectoryDeviation"] = stop_watch.toc(true);
 
   {
@@ -147,8 +147,7 @@ Output LaneDepartureChecker::update(const Input & input)
 PoseDeviation LaneDepartureChecker::calcTrajectoryDeviation(
   const Trajectory & trajectory, const geometry_msgs::msg::Pose & pose, const double yaw_threshold)
 {
-  const auto nearest_idx = findNearestIndexWithSoftYawConstraints(
-    trajectory, pose, yaw_threshold);
+  const auto nearest_idx = findNearestIndexWithSoftYawConstraints(trajectory, pose, yaw_threshold);
   return tier4_autoware_utils::calcPoseDeviation(trajectory.points.at(nearest_idx).pose, pose);
 }
 

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -56,22 +56,14 @@ bool isInAnyLane(const lanelet::ConstLanelets & candidate_lanelets, const Point2
   return false;
 }
 
-size_t findNearestIndex(const Trajectory & trajectory, const geometry_msgs::msg::Pose & pose)
+size_t findNearestIndexWithSoftYawConstraints(
+  const Trajectory & trajectory, const geometry_msgs::msg::Pose & pose, const double yaw_threshold)
 {
-  std::vector<double> distances;
-  distances.reserve(trajectory.points.size());
-  std::transform(
-    trajectory.points.cbegin(), trajectory.points.cend(), std::back_inserter(distances),
-    [&](const TrajectoryPoint & p) {
-      const auto p1 = tier4_autoware_utils::fromMsg(p.pose.position).to_2d();
-      const auto p2 = tier4_autoware_utils::fromMsg(pose.position).to_2d();
-      return boost::geometry::distance(p1, p2);
-    });
-
-  const auto min_itr = std::min_element(distances.cbegin(), distances.cend());
-  const auto min_idx = static_cast<size_t>(std::distance(distances.cbegin(), min_itr));
-
-  return min_idx;
+  const auto nearest_idx_optional = tier4_autoware_utils::findNearestIndex(
+    trajectory.points, pose, std::numeric_limits<double>::max(), yaw_threshold);
+  return nearest_idx_optional
+          ? *nearest_idx_optional
+          : tier4_autoware_utils::findNearestIndex(trajectory.points, pose.position);
 }
 
 LinearRing2d createHullFromFootprints(const std::vector<LinearRing2d> & footprints)
@@ -117,7 +109,8 @@ Output LaneDepartureChecker::update(const Input & input)
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
 
   output.trajectory_deviation =
-    calcTrajectoryDeviation(*input.reference_trajectory, input.current_pose->pose);
+    calcTrajectoryDeviation(*input.reference_trajectory,
+    input.current_pose->pose, param_.delta_yaw_threshold_for_closest_point);
   output.processing_time_map["calcTrajectoryDeviation"] = stop_watch.toc(true);
 
   {
@@ -152,9 +145,10 @@ Output LaneDepartureChecker::update(const Input & input)
 }
 
 PoseDeviation LaneDepartureChecker::calcTrajectoryDeviation(
-  const Trajectory & trajectory, const geometry_msgs::msg::Pose & pose)
+  const Trajectory & trajectory, const geometry_msgs::msg::Pose & pose, const double yaw_threshold)
 {
-  const auto nearest_idx = findNearestIndex(trajectory, pose);
+  const auto nearest_idx = findNearestIndexWithSoftYawConstraints(
+    trajectory, pose, yaw_threshold);
   return tier4_autoware_utils::calcPoseDeviation(trajectory.points.at(nearest_idx).pose, pose);
 }
 

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -135,8 +135,7 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   param_.max_longitudinal_deviation = declare_parameter("max_longitudinal_deviation", 1.0);
   param_.max_yaw_deviation_deg = declare_parameter("max_yaw_deviation_deg", 30.0);
   param_.delta_yaw_threshold_for_closest_point =
-  declare_parameter("delta_yaw_threshold_for_closest_point", 90.0);
-
+    declare_parameter("delta_yaw_threshold_for_closest_point", 90.0);
 
   // Parameter Callback
   set_param_res_ =

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -134,6 +134,9 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   param_.max_lateral_deviation = declare_parameter("max_lateral_deviation", 1.0);
   param_.max_longitudinal_deviation = declare_parameter("max_longitudinal_deviation", 1.0);
   param_.max_yaw_deviation_deg = declare_parameter("max_yaw_deviation_deg", 30.0);
+  param_.delta_yaw_threshold_for_closest_point =
+  declare_parameter("delta_yaw_threshold_for_closest_point", 90.0);
+
 
   // Parameter Callback
   set_param_res_ =

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -96,9 +96,11 @@ visualization_msgs::msg::MarkerArray StopLineModule::createVirtualWallMarkerArra
   visualization_msgs::msg::MarkerArray wall_marker;
   const auto p_front = tier4_autoware_utils::calcOffsetPose(
     *debug_data_.stop_pose, debug_data_.base_link2front, 0.0, 0.0);
-  appendMarkerArray(
-    tier4_autoware_utils::createStopVirtualWallMarker(p_front, "stopline", now, module_id_), now,
-    &wall_marker);
+  if (state_ == State::APPROACH) {
+    appendMarkerArray(
+      tier4_autoware_utils::createStopVirtualWallMarker(p_front, "stopline", now, module_id_), now,
+      &wall_marker);
+  }
   return wall_marker;
 }
 }  // namespace behavior_velocity_planner


### PR DESCRIPTION
Signed-off-by: kyoichi sugahara <kyoichi.sugahara@tier4.jp>

## Description

add angle limitation to the nearest point search in trajectory in lane_departure_checker.

## Background

In the current implementation, when the route intersects, there is a possibility that the nearest point of the own vehicle will be calculated incorrectly. I fixed it by adding angle limitation to search the nearest point.

Lane_departure_checker module’s one of the criteria for judging whether the ego vehicle has deviated from the lane is to check whether the angle between the own vehicle and the nearest  point on the trajectory is significantly different.
However, since the module searches for the nearest point based on the distance between each point on the route and the ego vehicle, in the case of a U-turn, a point on the route that has turned around has possibility to be judged as the nearest point, and a deviation may be judged based on the large angle difference.

## Pre-review checklist for the PR author
The PR author must check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers
The PR reviewers must check the checkboxes below before approval.

- [ ]  The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ]  The PR has been reviewed by the code owners.

## Post-review checklist for the PR author
The PR author must check the checkboxes below before merging.

- [ ]  There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
