### PR TITLE
fix(behavior_velocity): use pose for min velocity if the object is stopped

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -55,7 +55,7 @@ bool RunOutModule::modifyPathVelocity(
   const auto current_acc = planner_data_->current_accel.get();
   const auto & current_pose = planner_data_->current_pose.pose;
 
-  // smooth velocity of the path to calcute time to collision accurately
+  // smooth velocity of the path to calculate time to collision accurately
   PathWithLaneId smoothed_path;
   if (!smoothPath(*path, smoothed_path, planner_data_)) {
     return true;

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -505,10 +505,15 @@ std::vector<geometry_msgs::msg::Point> RunOutModule::createBoundingBoxForRangedP
     tier4_autoware_utils::calcDistance2d(pose_with_range.pose_min, pose_with_range.pose_max);
 
   geometry_msgs::msg::Pose p_min_to_p_max;
-  const auto azimuth_angle = tier4_autoware_utils::calcAzimuthAngle(
-    pose_with_range.pose_min.position, pose_with_range.pose_max.position);
-  p_min_to_p_max.position = pose_with_range.pose_min.position;
-  p_min_to_p_max.orientation = tier4_autoware_utils::createQuaternionFromYaw(azimuth_angle);
+  if (dist_p1_p2 < std::numeric_limits<double>::epsilon()) {
+    // can't calculate the angle if two points are the same
+    p_min_to_p_max = pose_with_range.pose_min;
+  } else {
+    const auto azimuth_angle = tier4_autoware_utils::calcAzimuthAngle(
+      pose_with_range.pose_min.position, pose_with_range.pose_max.position);
+    p_min_to_p_max.position = pose_with_range.pose_min.position;
+    p_min_to_p_max.orientation = tier4_autoware_utils::createQuaternionFromYaw(azimuth_angle);
+  }
 
   std::vector<geometry_msgs::msg::Point> poly;
   poly.emplace_back(


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description

- fixed the calculation for bounding box of the obstacle when the obstacle is not moving.


### before this PR

Orientation of the obstacle was wrong and the obstacle beside the pass was considered to be collision.

![before](https://user-images.githubusercontent.com/11865769/172361325-f0299ae3-396e-4bb5-a6fb-a3186c16bf1b.png)

### after this PR
Orientation of the obstacle has been fixed.
![after](https://user-images.githubusercontent.com/11865769/172361336-eb4d99bf-d72b-477f-b689-3e3502958dd1.jpg)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
