### PR TITLE
fix(behavior_path_planner): remove min max shift limit

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -465,8 +465,8 @@ AvoidPointArray AvoidanceModule::calcRawShiftPointsFromObjects(
   const auto & lat_collision_margin = parameters_.lateral_collision_margin;
   const auto & vehicle_width = planner_data_->parameters.vehicle_width;
   const auto & road_shoulder_safety_margin = parameters_.road_shoulder_safety_margin;
-  const auto max_allowable_lateral_distance =
-    lat_collision_safety_buffer + lat_collision_margin + vehicle_width;
+  const auto max_allowable_lateral_distance = lat_collision_safety_buffer + lat_collision_margin +
+                                              vehicle_width - road_shoulder_safety_margin;
 
   const auto avoid_margin =
     lat_collision_safety_buffer + lat_collision_margin + 0.5 * vehicle_width;
@@ -494,20 +494,9 @@ AvoidPointArray AvoidanceModule::calcRawShiftPointsFromObjects(
       continue;
     }
 
-    const auto max_shift_length =
-      o.to_road_shoulder_distance - road_shoulder_safety_margin - 0.5 * vehicle_width;
-
-    const auto max_left_shift_limit = [&max_shift_length, this]() noexcept {
-      return std::min(getLeftShiftBound(), max_shift_length);
-    };
-
-    const auto max_right_shift_limit = [&max_shift_length, this]() noexcept {
-      return std::max(getRightShiftBound(), -max_shift_length);
-    };
-
     const auto shift_length = isOnRight(o)
-                                ? std::min(o.overhang_dist + avoid_margin, max_left_shift_limit())
-                                : std::max(o.overhang_dist - avoid_margin, max_right_shift_limit());
+                                ? std::min(o.overhang_dist + avoid_margin, getLeftShiftBound())
+                                : std::max(o.overhang_dist - avoid_margin, getRightShiftBound());
     const auto avoiding_shift = shift_length - current_ego_shift;
     const auto return_shift = shift_length;
 


### PR DESCRIPTION
The shift limit generates improper shift that caused the maximum shift to be improper.
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

Previously, the code is tested mainly on Cars. 

The maximum shift point limit (based on the min/max of the online computed`max_shift_length` and parameterized value) was imposed to avoid a large shift during avoidance.

However, it actually introduces a bug since to avoid long object types (e.g., bus, truck, trailers), sometimes, large shift is needed. 

For example, if the necessary shift length to avoid bus is `shift_length = 3.5` and the current `max_shift_length=2.5`, the shift length will be limited to `2.5`. Therefore, it creates a path that collides with long objects such as buses, trucks, or trailers, as follows

![Screenshot from 2022-06-07 12-05-21](https://user-images.githubusercontent.com/93502286/172421026-9f0f6a77-c5df-472a-9c46-62999b85bede.png)

In the first place, the maximum shift point limit is unnecessary. Therefore to solve this issue, this PR removes the limitation check. It will not change very much of the current avoidance module behavior. The following is the result after the changes.
 
![Screenshot from 2022-06-08 00-16-29](https://user-images.githubusercontent.com/93502286/172421084-62a9c1de-87d9-418b-81f9-c0416a3655e3.png)
![Screenshot from 2022-06-08 00-21-36](https://user-images.githubusercontent.com/93502286/172421120-a5cb65be-f0c2-4459-bc6b-1682dfbb061e.png)


## Related links

#833
#934 
#1041 


## Tests performed

Use psim to test the conditions.
You can set either `lateral_collision_safety_margin: 0.0` or `lateral_collision_margin: 0.0` while testing.

## Notes for reviewers

This should solve #833 originally. However, #1041 is needed as it will complements with the future upgrades of the shift length computation.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
