### PR TITLE
fix(map_based_prediction): fix reversed vehicle prediction

### DIFF
--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -426,10 +426,12 @@ bool MapBasedPredictionNode::checkCloseLaneletCondition(
 
   // Step4. Check if the closest lanelet is valid, and add all
   // of the lanelets that are below max_dist and max_delta_yaw
+  const double object_vel = object.kinematics.twist_with_covariance.twist.linear.x;
+  const bool is_yaw_reversed =
+    M_PI - delta_yaw_threshold_for_searching_lanelet_ < abs_norm_delta && object_vel < 0.0;
   if (
     lanelet.first < dist_threshold_for_searching_lanelet_ &&
-    (M_PI - delta_yaw_threshold_for_searching_lanelet_ < abs_norm_delta ||
-     abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_)) {
+    (is_yaw_reversed || abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_)) {
     return true;
   }
 


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
Map-based prediction module generates weird predicted paths when the vehicle travels opposite direction of the lane. In this PR, I fixed the condition of the car which has reversed the yaw angle. 

- Before this PR
![image](https://user-images.githubusercontent.com/43805014/172527692-801bd58c-7675-4873-90bb-5544f53bcbcc.png)

- After this PR
![image](https://user-images.githubusercontent.com/43805014/172527632-d563d5a2-5d09-403d-869b-1ec99e79dfdf.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
