### PR TITLE
fix(behavior_velocity): remove inserting ego point in smoothPath

### DIFF
--- a/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
@@ -146,28 +146,9 @@ inline bool smoothPath(
   const auto traj_lateral_acc_filtered = smoother->applyLateralAccelerationFilter(trajectory);
   auto nearest_idx =
     tier4_autoware_utils::findNearestIndex(*traj_lateral_acc_filtered, current_pose.position);
-  const auto dist_to_nearest = tier4_autoware_utils::calcSignedArcLength(
-    *traj_lateral_acc_filtered, current_pose.position, nearest_idx);
 
-  // if trajectory has the almost same point as ego, don't insert the ego point
-  constexpr double epsilon = 1e-2;
-  TrajectoryPoints traj_with_ego_point_on_path = *traj_lateral_acc_filtered;
-  if (std::fabs(dist_to_nearest) > epsilon) {
-    // calc ego internal division point on path
-    const auto traj_with_ego_point_with_idx =
-      getLerpTrajectoryPointWithIdx(*traj_lateral_acc_filtered, current_pose.position);
-    if (traj_with_ego_point_with_idx == boost::none) return false;
-    TrajectoryPoint ego_point_on_path = traj_with_ego_point_with_idx->first;
-    const size_t nearest_seg_idx = traj_with_ego_point_with_idx->second;
-    //! insert ego projected pose on path so new nearest segment will be nearest_seg_idx + 1
-    traj_with_ego_point_on_path.insert(
-      traj_with_ego_point_on_path.begin() + nearest_seg_idx, ego_point_on_path);
-
-    // ego point inserted is new nearest point
-    nearest_idx = nearest_seg_idx + 1;
-  }
   // Resample trajectory with ego-velocity based interval distances
-  auto traj_resampled = smoother->resampleTrajectory(traj_with_ego_point_on_path, v0, nearest_idx);
+  auto traj_resampled = smoother->resampleTrajectory(*traj_lateral_acc_filtered, v0, nearest_idx);
   const auto traj_resampled_closest = findNearestIndex(*traj_resampled, current_pose, max, M_PI_4);
   if (!traj_resampled_closest) {
     return false;


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description
Inserting ego point is unnecessary since trajectory is resampled in `smoothPath` function.

I confirmed occlusion_spot and run_out module works well in PSim.
![image](https://user-images.githubusercontent.com/11865769/172832115-0578d9e3-4e24-481a-b90b-1ae3cd73b529.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
