### PR TITLE
fix(route_handler, ad_service_state_monitor): loading route error handling

### DIFF
--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -62,6 +62,16 @@ lanelet::ConstLanelets getRouteLanelets(
 
     for (const auto & primitive : route_sections.front().primitives) {
       const auto lane_id = primitive.id;
+      try {
+        lanelet_map.laneletLayer.get(lane_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("get_route_lanelets"),
+          "%s. Maybe the loaded route was created on a different Map from the current one. "
+          "Try to load the other Route again.",
+          e.what());
+        return route_lanelets;
+      }
       for (const auto & lanelet_sequence : lanelet::utils::query::getPrecedingLaneletSequences(
              routing_graph, lanelet_map.laneletLayer.get(lane_id), extension_length)) {
         for (const auto & preceding_lanelet : lanelet_sequence) {
@@ -74,6 +84,16 @@ lanelet::ConstLanelets getRouteLanelets(
   for (const auto & route_section : route_sections) {
     for (const auto & primitive : route_section.primitives) {
       const auto lane_id = primitive.id;
+      try {
+        lanelet_map.laneletLayer.get(lane_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("get_route_lanelets"),
+          "%s. Maybe the loaded route was created on a different Map from the current one. "
+          "Try to load the other Route again.",
+          e.what());
+        return route_lanelets;
+      }
       route_lanelets.push_back(lanelet_map.laneletLayer.get(lane_id));
     }
   }
@@ -84,6 +104,16 @@ lanelet::ConstLanelets getRouteLanelets(
 
     for (const auto & primitive : route_sections.back().primitives) {
       const auto lane_id = primitive.id;
+      try {
+        lanelet_map.laneletLayer.get(lane_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("get_route_lanelets"),
+          "%s. Maybe the loaded route was created on a different Map from the current one. "
+          "Try to load the other Route again.",
+          e.what());
+        return route_lanelets;
+      }
       for (const auto & lanelet_sequence : lanelet::utils::query::getSucceedingLaneletSequences(
              routing_graph, lanelet_map.laneletLayer.get(lane_id), extension_length)) {
         for (const auto & succeeding_lanelet : lanelet_sequence) {

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -549,7 +549,7 @@ void BehaviorPathPlannerNode::run()
   if (!clipped_path.points.empty()) {
     path_publisher_->publish(clipped_path);
   } else {
-    RCLCPP_ERROR(get_logger(), "behavior path output is empty! Stop publish.");
+    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "behavior path output is empty! Stop publish.");
   }
   path_candidate_publisher_->publish(util::toPath(*path_candidate));
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -549,7 +549,8 @@ void BehaviorPathPlannerNode::run()
   if (!clipped_path.points.empty()) {
     path_publisher_->publish(clipped_path);
   } else {
-    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "behavior path output is empty! Stop publish.");
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 5000, "behavior path output is empty! Stop publish.");
   }
   path_candidate_publisher_->publish(util::toPath(*path_candidate));
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -41,8 +41,10 @@ lanelet::ConstLanelets calcLaneAroundPose(
 
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(pose, &current_lane)) {
-    RCLCPP_ERROR(
+    RCLCPP_ERROR_THROTTLE(
       rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
+      *get_clock(),
+      5000,
       "failed to find closest lanelet within route!!!");
     return {};  // TODO(Horibe)
   }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -42,9 +42,7 @@ lanelet::ConstLanelets calcLaneAroundPose(
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(pose, &current_lane)) {
     RCLCPP_ERROR_THROTTLE(
-      rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
-      *get_clock(),
-      5000,
+      rclcpp::get_logger("behavior_path_planner").get_child("avoidance"), *get_clock(), 5000,
       "failed to find closest lanelet within route!!!");
     return {};  // TODO(Horibe)
   }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -277,7 +277,7 @@ lanelet::ConstLanelets LaneChangeModule::getCurrentLanes() const
 
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(current_pose, &current_lane)) {
-    RCLCPP_ERROR(getLogger(), "failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "failed to find closest lanelet within route!!!");
     return {};  // TODO(Horibe) what should be returned?
   }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -277,7 +277,8 @@ lanelet::ConstLanelets LaneChangeModule::getCurrentLanes() const
 
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(current_pose, &current_lane)) {
-    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 5000, "failed to find closest lanelet within route!!!");
     return {};  // TODO(Horibe) what should be returned?
   }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -81,7 +81,7 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
 
   lanelet::ConstLanelet current_lane;
   if (!planner_data_->route_handler->getClosestLaneletWithinRoute(current_pose, &current_lane)) {
-    RCLCPP_ERROR(getLogger(), "failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "failed to find closest lanelet within route!!!");
     return reference_path;  // TODO(Horibe)
   }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -81,7 +81,8 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
 
   lanelet::ConstLanelet current_lane;
   if (!planner_data_->route_handler->getClosestLaneletWithinRoute(current_pose, &current_lane)) {
-    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 5000, "failed to find closest lanelet within route!!!");
     return reference_path;  // TODO(Horibe)
   }
 

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -347,7 +347,7 @@ lanelet::ConstLanelets PullOutModule::getCurrentLanes() const
 
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(current_pose, &current_lane)) {
-    RCLCPP_ERROR(getLogger(), "failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR_THROTTLE(get_logger(), , 5000, "failed to find closest lanelet within route!!!");
     return {};  // TODO(Horibe) what should be returned?
   }
 
@@ -382,7 +382,7 @@ lanelet::ConstLanelets PullOutModule::getPullOutLanes(
       shoulder_lane, current_pose, pull_out_lane_length_, pull_out_lane_length_);
 
   } else {
-    RCLCPP_ERROR(getLogger(), "getPullOverTarget didn't work");
+    RCLCPP_ERROR_THROTTLE(get_logger(), clock, 5000, "getPullOverTarget didn't work");
     shoulder_lanes.clear();
   }
 

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -282,7 +282,8 @@ lanelet::ConstLanelets PullOverModule::getCurrentLanes() const
 
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(current_pose, &current_lane)) {
-    RCLCPP_ERROR_THROTTLE(get_logger(), clock, 5000, "failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), clock, 5000, "failed to find closest lanelet within route!!!");
     return {};  // TODO(Horibe) what should be returned?
   }
 

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -201,7 +201,7 @@ void PullOverModule::updatePullOverStatus()
     route_handler->setPullOverGoalPose(
       target_shoulder_lane, common_parameters.vehicle_width, parameters_.margin_from_boundary);
   } else {
-    RCLCPP_ERROR(getLogger(), "failed to get shoulder lane!!!");
+    RCLCPP_ERROR_THROTTLE(get_logger(), clock, 5000, "failed to get shoulder lane!!!");
   }
 
   // Get pull_over lanes
@@ -282,7 +282,7 @@ lanelet::ConstLanelets PullOverModule::getCurrentLanes() const
 
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(current_pose, &current_lane)) {
-    RCLCPP_ERROR(getLogger(), "failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR_THROTTLE(get_logger(), clock, 5000, "failed to find closest lanelet within route!!!");
     return {};  // TODO(Horibe) what should be returned?
   }
 

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -191,7 +191,8 @@ void SideShiftModule::updateData()
 
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(reference_pose.pose, &current_lane)) {
-    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 5000, "failed to find closest lanelet within route!!!");
   }
 
   // For current_lanes with desired length

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -191,7 +191,7 @@ void SideShiftModule::updateData()
 
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(reference_pose.pose, &current_lane)) {
-    RCLCPP_ERROR(getLogger(), "failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "failed to find closest lanelet within route!!!");
   }
 
   // For current_lanes with desired length

--- a/planning/freespace_planner/include/freespace_planner/freespace_planner_node.hpp
+++ b/planning/freespace_planner/include/freespace_planner/freespace_planner_node.hpp
@@ -48,6 +48,8 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
+#include <route_handler/route_handler.hpp>
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -56,7 +58,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <route_handler/route_handler.hpp>
 
 namespace freespace_planner
 {

--- a/planning/freespace_planner/include/freespace_planner/freespace_planner_node.hpp
+++ b/planning/freespace_planner/include/freespace_planner/freespace_planner_node.hpp
@@ -56,6 +56,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <route_handler/route_handler.hpp>
 
 namespace freespace_planner
 {
@@ -127,6 +128,7 @@ private:
   OccupancyGrid::ConstSharedPtr occupancy_grid_;
   Scenario::ConstSharedPtr scenario_;
   Odometry::ConstSharedPtr odom_;
+  std::shared_ptr<route_handler::RouteHandler> route_handler_;
 
   std::deque<Odometry::ConstSharedPtr> odom_buffer_;
 

--- a/planning/freespace_planner/package.xml
+++ b/planning/freespace_planner/package.xml
@@ -21,6 +21,7 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>route_handler</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
@@ -28,7 +29,6 @@
   <depend>tier4_planning_msgs</depend>
   <depend>vehicle_info_util</depend>
   <depend>visualization_msgs</depend>
-  <depend>route_handler</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/freespace_planner/package.xml
+++ b/planning/freespace_planner/package.xml
@@ -28,6 +28,7 @@
   <depend>tier4_planning_msgs</depend>
   <depend>vehicle_info_util</depend>
   <depend>visualization_msgs</depend>
+  <depend>route_handler</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
+++ b/planning/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
@@ -307,12 +307,14 @@ void FreespacePlannerNode::getAstarParam()
 
 void FreespacePlannerNode::onRoute(const HADMapRoute::ConstSharedPtr msg)
 {
-  route_ = msg;
+  if (scenario_ != nullptr) {
+    route_ = msg;
 
-  goal_pose_.header = msg->header;
-  goal_pose_.pose = msg->goal_pose;
+    goal_pose_.header = msg->header;
+    goal_pose_.pose = msg->goal_pose;
 
-  reset();
+    reset();
+  }
 }
 
 void FreespacePlannerNode::onOccupancyGrid(const OccupancyGrid::ConstSharedPtr msg)

--- a/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
+++ b/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
@@ -184,16 +184,16 @@ void MissionPlannerLanelet2::visualizeRoute(
       lanelet::visualization::laneletsBoundaryAsMarkerArray(route_lanelets, cl_ll_borders, false));
     insertMarkerArray(
       &route_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
-                            "route_lanelets", route_lanelets, cl_route));
+                             "route_lanelets", route_lanelets, cl_route));
     insertMarkerArray(
       &route_marker_array,
       lanelet::visualization::laneletsAsTriangleMarkerArray("end_lanelets", end_lanelets, cl_end));
     insertMarkerArray(
       &route_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
-                            "normal_lanelets", normal_lanelets, cl_normal));
+                             "normal_lanelets", normal_lanelets, cl_normal));
     insertMarkerArray(
-      &route_marker_array,
-      lanelet::visualization::laneletsAsTriangleMarkerArray("goal_lanelets", goal_lanelets, cl_goal));
+      &route_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
+                             "goal_lanelets", goal_lanelets, cl_goal));
     marker_publisher_->publish(route_marker_array);
   }
 }

--- a/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
+++ b/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
@@ -160,12 +160,20 @@ void MissionPlannerLanelet2::visualizeRoute(
 
   for (const auto & route_section : route.segments) {
     for (const auto & lane_id : route_section.primitives) {
-      auto lanelet = lanelet_map_ptr_->laneletLayer.get(lane_id.id);
-      route_lanelets.push_back(lanelet);
-      if (route_section.preferred_primitive_id == lane_id.id) {
-        goal_lanelets.push_back(lanelet);
-      } else {
-        end_lanelets.push_back(lanelet);
+      try {
+        auto lanelet = lanelet_map_ptr_->laneletLayer.get(lane_id.id);
+        route_lanelets.push_back(lanelet);
+        if (route_section.preferred_primitive_id == lane_id.id) {
+          goal_lanelets.push_back(lanelet);
+        } else {
+          end_lanelets.push_back(lanelet);
+        }
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(
+          get_logger(),
+          "%s. Maybe the loaded route was created on a different Map from the current one. "
+          "Try to load the other Route again.",
+          e.what());
       }
     }
   }

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -322,10 +322,19 @@ void RouteHandler::setLaneletsFromRouteMsg()
   for (const auto & route_section : route_msg_.segments) {
     for (const auto & primitive : route_section.primitives) {
       const auto id = primitive.id;
-      const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
-      route_lanelets_.push_back(llt);
-      if (id == route_section.preferred_primitive_id) {
-        preferred_lanelets_.push_back(llt);
+      try {
+        const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
+        route_lanelets_.push_back(llt);
+        if (id == route_section.preferred_primitive_id) {
+          preferred_lanelets_.push_back(llt);
+        }
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(
+          logger_,
+          "%s. Maybe the loaded route was created on a different Map from the current one. "
+          "Try to load the other Route again.",
+          e.what());
+        return;
       }
     }
   }

--- a/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
+++ b/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
@@ -39,6 +39,8 @@
 #include <memory>
 #include <string>
 
+#include <route_handler/route_handler.hpp>
+
 class ScenarioSelectorNode : public rclcpp::Node
 {
 public:
@@ -87,6 +89,7 @@ private:
   std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
   std::shared_ptr<lanelet::routing::RoutingGraph> routing_graph_ptr_;
   std::shared_ptr<lanelet::traffic_rules::TrafficRules> traffic_rules_ptr_;
+  std::shared_ptr<route_handler::RouteHandler> route_handler_;
 
   // Parameters
   double update_rate_;

--- a/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
+++ b/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
@@ -32,14 +32,14 @@
 #else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
+#include <route_handler/route_handler.hpp>
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <deque>
 #include <memory>
 #include <string>
-
-#include <route_handler/route_handler.hpp>
 
 class ScenarioSelectorNode : public rclcpp::Node
 {

--- a/planning/scenario_selector/package.xml
+++ b/planning/scenario_selector/package.xml
@@ -21,6 +21,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
+  <depend>route_handler</depend>
 
   <exec_depend>ros2cli</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/planning/scenario_selector/package.xml
+++ b/planning/scenario_selector/package.xml
@@ -17,11 +17,11 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>route_handler</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
-  <depend>route_handler</depend>
 
   <exec_depend>ros2cli</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -223,13 +223,17 @@ void ScenarioSelectorNode::onMap(
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
   lanelet::utils::conversion::fromBinMsg(
     *msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
+  route_handler_ = std::make_shared<route_handler::RouteHandler>(*msg);
 }
 
 void ScenarioSelectorNode::onRoute(
   const autoware_auto_planning_msgs::msg::HADMapRoute::ConstSharedPtr msg)
 {
-  route_ = msg;
-  current_scenario_ = tier4_planning_msgs::msg::Scenario::EMPTY;
+  route_handler_->setRoute(*msg);
+  if (route_handler_->isHandlerReady()) {
+    route_ = msg;
+    current_scenario_ = tier4_planning_msgs::msg::Scenario::EMPTY;
+  }
 }
 
 void ScenarioSelectorNode::onOdom(const nav_msgs::msg::Odometry::ConstSharedPtr msg)

--- a/system/ad_service_state_monitor/include/ad_service_state_monitor/ad_service_state_monitor_node.hpp
+++ b/system/ad_service_state_monitor/include/ad_service_state_monitor/ad_service_state_monitor_node.hpp
@@ -20,9 +20,11 @@
 #include "ad_service_state_monitor/state_machine.hpp"
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
+#include <lanelet2_extension/utility/query.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
+#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_auto_planning_msgs/msg/had_map_route.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
@@ -31,6 +33,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
+#include <lanelet2_core/LaneletMap.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -60,6 +63,10 @@ private:
   tf2_ros::TransformListener tf_listener_;
   geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
 
+  // Lanelet
+  std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
+  bool is_map_msg_ready_{false};
+
   // CallbackGroups
   rclcpp::CallbackGroup::SharedPtr callback_group_subscribers_;
   rclcpp::CallbackGroup::SharedPtr callback_group_services_;
@@ -69,11 +76,13 @@ private:
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
     sub_control_mode_;
   rclcpp::Subscription<autoware_auto_planning_msgs::msg::HADMapRoute>::SharedPtr sub_route_;
+  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_map_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
 
   void onAutowareEngage(const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void onVehicleControlMode(
     const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
+  void onMap(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
   void onRoute(const autoware_auto_planning_msgs::msg::HADMapRoute::ConstSharedPtr msg);
   void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
 

--- a/system/ad_service_state_monitor/launch/ad_service_state_monitor.launch.xml
+++ b/system/ad_service_state_monitor/launch/ad_service_state_monitor.launch.xml
@@ -1,33 +1,35 @@
 <launch>
   <!-- Input -->
-  <arg name="input_autoware_engage" default="/api/autoware/get/engage"/>
-  <arg name="input_control_mode" default="/vehicle/status/control_mode"/>
-  <arg name="input_route" default="/planning/mission_planning/route"/>
-  <arg name="input_odometry" default="/localization/kinematic_state"/>
+  <arg name="input_autoware_engage" default="/api/autoware/get/engage" />
+  <arg name="input_control_mode" default="/vehicle/status/control_mode" />
+  <arg name="input_map" default="/map/vector_map" />
+  <arg name="input_route" default="/planning/mission_planning/route" />
+  <arg name="input_odometry" default="/localization/kinematic_state" />
 
   <!-- Output -->
-  <arg name="output_autoware_state" default="/autoware/state"/>
-  <arg name="output_autoware_engage" default="/autoware/engage"/>
+  <arg name="output_autoware_state" default="/autoware/state" />
+  <arg name="output_autoware_engage" default="/autoware/engage" />
 
   <!-- Service -->
-  <arg name="service_shutdown" default="/autoware/shutdown"/>
-  <arg name="service_reset_route" default="/autoware/reset_route"/>
+  <arg name="service_shutdown" default="/autoware/shutdown" />
+  <arg name="service_reset_route" default="/autoware/reset_route" />
 
   <!-- Config -->
-  <arg name="config_file" default="$(find-pkg-share ad_service_state_monitor)/config/ad_service_state_monitor.param.yaml"/>
+  <arg name="config_file" default="$(find-pkg-share ad_service_state_monitor)/config/ad_service_state_monitor.param.yaml" />
 
   <!-- Parameter -->
-  <arg name="update_rate" default="10.0"/>
-  <arg name="th_arrived_distance_m" default="1.0"/>
-  <arg name="th_arrived_angle_deg" default="45.0"/>
-  <arg name="th_stopped_time_sec" default="1.0"/>
-  <arg name="th_stopped_velocity_mps" default="0.01"/>
-  <arg name="disengage_on_route" default="true"/>
-  <arg name="disengage_on_goal" default="true"/>
+  <arg name="update_rate" default="10.0" />
+  <arg name="th_arrived_distance_m" default="1.0" />
+  <arg name="th_arrived_angle_deg" default="45.0" />
+  <arg name="th_stopped_time_sec" default="1.0" />
+  <arg name="th_stopped_velocity_mps" default="0.01" />
+  <arg name="disengage_on_route" default="true" />
+  <arg name="disengage_on_goal" default="true" />
 
   <node pkg="ad_service_state_monitor" exec="ad_service_state_monitor" name="ad_service_state_monitor" output="screen">
     <remap from="input/autoware_engage" to="$(var input_autoware_engage)"/>
     <remap from="input/control_mode" to="$(var input_control_mode)"/>
+    <remap from="input/vector_map" to="$(var input_map)"/>
     <remap from="input/route" to="$(var input_route)"/>
     <remap from="input/odometry" to="$(var input_odometry)"/>
 
@@ -37,14 +39,14 @@
     <remap from="service/shutdown" to="$(var service_shutdown)"/>
     <remap from="service/reset_route" to="$(var service_reset_route)"/>
 
-    <param from="$(var config_file)"/>
+    <param from="$(var config_file)" />
 
-    <param name="update_rate" value="$(var update_rate)"/>
-    <param name="th_arrived_distance_m" value="$(var th_arrived_distance_m)"/>
-    <param name="th_arrived_angle_deg" value="$(var th_arrived_angle_deg)"/>
-    <param name="th_stopped_time_sec" value="$(var th_stopped_time_sec)"/>
-    <param name="th_stopped_velocity_mps" value="$(var th_stopped_velocity_mps)"/>
-    <param name="disengage_on_route" value="$(var disengage_on_route)"/>
-    <param name="disengage_on_goal" value="$(var disengage_on_goal)"/>
+    <param name="update_rate" value="$(var update_rate)" />
+    <param name="th_arrived_distance_m" value="$(var th_arrived_distance_m)" />
+    <param name="th_arrived_angle_deg" value="$(var th_arrived_angle_deg)" />
+    <param name="th_stopped_time_sec" value="$(var th_stopped_time_sec)" />
+    <param name="th_stopped_velocity_mps" value="$(var th_stopped_velocity_mps)" />
+    <param name="disengage_on_route" value="$(var disengage_on_route)" />
+    <param name="disengage_on_goal" value="$(var disengage_on_goal)" />
   </node>
 </launch>

--- a/system/ad_service_state_monitor/launch/ad_service_state_monitor.launch.xml
+++ b/system/ad_service_state_monitor/launch/ad_service_state_monitor.launch.xml
@@ -1,10 +1,10 @@
 <launch>
   <!-- Input -->
-  <arg name="input_autoware_engage" default="/api/autoware/get/engage" />
-  <arg name="input_control_mode" default="/vehicle/status/control_mode" />
-  <arg name="input_map" default="/map/vector_map" />
-  <arg name="input_route" default="/planning/mission_planning/route" />
-  <arg name="input_odometry" default="/localization/kinematic_state" />
+  <arg name="input_autoware_engage" default="/api/autoware/get/engage"/>
+  <arg name="input_control_mode" default="/vehicle/status/control_mode"/>
+  <arg name="input_map" default="/map/vector_map"/>
+  <arg name="input_route" default="/planning/mission_planning/route"/>
+  <arg name="input_odometry" default="/localization/kinematic_state"/>
 
   <!-- Output -->
   <arg name="output_autoware_state" default="/autoware/state" />

--- a/system/ad_service_state_monitor/launch/ad_service_state_monitor.launch.xml
+++ b/system/ad_service_state_monitor/launch/ad_service_state_monitor.launch.xml
@@ -7,24 +7,24 @@
   <arg name="input_odometry" default="/localization/kinematic_state"/>
 
   <!-- Output -->
-  <arg name="output_autoware_state" default="/autoware/state" />
-  <arg name="output_autoware_engage" default="/autoware/engage" />
+  <arg name="output_autoware_state" default="/autoware/state"/>
+  <arg name="output_autoware_engage" default="/autoware/engage"/>
 
   <!-- Service -->
-  <arg name="service_shutdown" default="/autoware/shutdown" />
-  <arg name="service_reset_route" default="/autoware/reset_route" />
+  <arg name="service_shutdown" default="/autoware/shutdown"/>
+  <arg name="service_reset_route" default="/autoware/reset_route"/>
 
   <!-- Config -->
-  <arg name="config_file" default="$(find-pkg-share ad_service_state_monitor)/config/ad_service_state_monitor.param.yaml" />
+  <arg name="config_file" default="$(find-pkg-share ad_service_state_monitor)/config/ad_service_state_monitor.param.yaml"/>
 
   <!-- Parameter -->
-  <arg name="update_rate" default="10.0" />
-  <arg name="th_arrived_distance_m" default="1.0" />
-  <arg name="th_arrived_angle_deg" default="45.0" />
-  <arg name="th_stopped_time_sec" default="1.0" />
-  <arg name="th_stopped_velocity_mps" default="0.01" />
-  <arg name="disengage_on_route" default="true" />
-  <arg name="disengage_on_goal" default="true" />
+  <arg name="update_rate" default="10.0"/>
+  <arg name="th_arrived_distance_m" default="1.0"/>
+  <arg name="th_arrived_angle_deg" default="45.0"/>
+  <arg name="th_stopped_time_sec" default="1.0"/>
+  <arg name="th_stopped_velocity_mps" default="0.01"/>
+  <arg name="disengage_on_route" default="true"/>
+  <arg name="disengage_on_goal" default="true"/>
 
   <node pkg="ad_service_state_monitor" exec="ad_service_state_monitor" name="ad_service_state_monitor" output="screen">
     <remap from="input/autoware_engage" to="$(var input_autoware_engage)"/>
@@ -39,14 +39,14 @@
     <remap from="service/shutdown" to="$(var service_shutdown)"/>
     <remap from="service/reset_route" to="$(var service_reset_route)"/>
 
-    <param from="$(var config_file)" />
+    <param from="$(var config_file)"/>
 
-    <param name="update_rate" value="$(var update_rate)" />
-    <param name="th_arrived_distance_m" value="$(var th_arrived_distance_m)" />
-    <param name="th_arrived_angle_deg" value="$(var th_arrived_angle_deg)" />
-    <param name="th_stopped_time_sec" value="$(var th_stopped_time_sec)" />
-    <param name="th_stopped_velocity_mps" value="$(var th_stopped_velocity_mps)" />
-    <param name="disengage_on_route" value="$(var disengage_on_route)" />
-    <param name="disengage_on_goal" value="$(var disengage_on_goal)" />
+    <param name="update_rate" value="$(var update_rate)"/>
+    <param name="th_arrived_distance_m" value="$(var th_arrived_distance_m)"/>
+    <param name="th_arrived_angle_deg" value="$(var th_arrived_angle_deg)"/>
+    <param name="th_stopped_time_sec" value="$(var th_stopped_time_sec)"/>
+    <param name="th_stopped_velocity_mps" value="$(var th_stopped_velocity_mps)"/>
+    <param name="disengage_on_route" value="$(var disengage_on_route)"/>
+    <param name="disengage_on_goal" value="$(var disengage_on_goal)"/>
   </node>
 </launch>

--- a/system/ad_service_state_monitor/package.xml
+++ b/system/ad_service_state_monitor/package.xml
@@ -18,6 +18,7 @@
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_extension</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
@@ -26,7 +27,6 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
-  <depend>lanelet2_extension</depend>
 
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>tier4_perception_msgs</exec_depend>

--- a/system/ad_service_state_monitor/package.xml
+++ b/system/ad_service_state_monitor/package.xml
@@ -26,6 +26,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
+  <depend>lanelet2_extension</depend>
 
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>tier4_perception_msgs</exec_depend>

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -16,8 +16,6 @@
 
 #include "lanelet2_extension/utility/message_conversion.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-
 #include <deque>
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
When loading the Route on a different Map from the current one, 
`behavior_path_planner` dies. 
This is because `behavior_path_planner` calls `route_handler` and it tries to mistakenly access the wrong route id in the map [here](https://github.com/autowarefoundation/autoware.universe/blob/800e815729618cd89b43cf00e193d88688043154/planning/route_handler/src/route_handler.cpp#L325).

With this PR, I add try/catch handling.
If you access the wrong route id in the map, it puts warning and skips accessing it without dying. 
This change is applyed to  
1. `route_handler` , which `behavior_path_planner` calls
2. `ad_service_state_monitor`, which manages "state".  Even when it subscribes the wrong route id, it will change the state from "WaitingForRoute" to "Planning". With this PR, it doesn't change the state at that time.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
I tested that even when I accessed the wrong route id, no nodes died and putted warning.  
If I chose the correct route id,  it successfully accessed the route id and it changed the "state".

## Notes for reviewers


<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
The way to handle  the error of  `ad_service_state_monitor` is the same as the `route_handler`, 
meaning that `ad_service_state_monitor`  can utilize the error handling function of `route_handler`.
However, in order to keep the modules independency,  `ad_service_state_monitor`  does not use `route_handler` function.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
