### PR TITLE
fix(obstacle_avoidance_planner): empty points handling

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -1105,6 +1105,10 @@ void ObstacleAvoidancePlanner::insertZeroVelocityOutsideDrivableArea(
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> & traj_points,
   const CVMaps & cv_maps)
 {
+  if (traj_points.empty()) {
+    return;
+  }
+
   stop_watch_.tic(__func__);
 
   const auto & map_info = cv_maps.map_info;


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

Add error handling of empty points before using `findNearestIndex`
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
