### PR TITLE
fix(obstacle_avoidance_planner): add error handling of empty reference point

### DIFF
--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -377,6 +377,9 @@ std::vector<ReferencePoint> MPTOptimizer::getReferencePoints(
       traj_param_.num_sampling_points * mpt_param_.delta_arc_length_for_mpt_points +
       tmp_ref_points_margin;
     ref_points = points_utils::clipForwardPoints(ref_points, 0, ref_length_with_margin);
+    if (ref_points.empty()) {
+      return std::vector<ReferencePoint>{};
+    }
 
     // set bounds information
     calcBounds(ref_points, enable_avoidance, maps, prev_trajs, debug_data_ptr);


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

add error handling of empty reference points
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
