### PR TITLE
fix(vehicle_cmd_gate): initialization handling for emergency state

### DIFF
--- a/control/vehicle_cmd_gate/include/vehicle_cmd_gate/vehicle_cmd_gate.hpp
+++ b/control/vehicle_cmd_gate/include/vehicle_cmd_gate/vehicle_cmd_gate.hpp
@@ -113,6 +113,9 @@ private:
   bool isHeartbeatTimeout(
     const std::shared_ptr<rclcpp::Time> & heartbeat_received_time, const double timeout);
 
+  // Check initialization
+  bool isDataReady();
+
   // Subscriber for auto
   Commands auto_commands_;
   rclcpp::Subscription<AckermannControlCommand>::SharedPtr auto_control_cmd_sub_;
@@ -182,10 +185,12 @@ private:
 
   // Timer / Event
   rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::TimerBase::SharedPtr timer_pub_status_;
 
   void onTimer();
   void publishControlCommands(const Commands & input_msg);
   void publishEmergencyStopControlCommands();
+  void publishStatus();
 
   // Diagnostics Updater
   diagnostic_updater::Updater updater_;


### PR DESCRIPTION
## Description

Fixed a problem that an emergency stop command is thrown when onTimer() runs before receiving emergency_state.

Publish emergency stop command ⇨ receives emergency_state and stops output of control commands ⇨ topic hz monitoring node makes an error.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

tested on psim.

1. run psim
2. set initialpose (no goal)
3. check if the `/control/command/control_cmd` is not published

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
