### PR TITLE
feat(rviz_plugin): add side shift control to state panel

### DIFF
--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -97,10 +97,20 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   pub_velocity_limit_input_->setSingleStep(5.0);
   connect(velocity_limit_button_ptr_, SIGNAL(clicked()), this, SLOT(onClickVelocityLimit()));
 
+  // for side shift
+  lateral_offset_slider_ptr_ = new QSlider(Qt::Horizontal, this);
+  lateral_offset_slider_ptr_->setRange(-8.0, 8.0);
+  lateral_offset_slider_ptr_->setValue(0.0);
+  pub_velocity_limit_input_->setSingleStep(1.0);
+  lateral_offset_value_ptr_ = new QLabel();
+  connect(
+    lateral_offset_slider_ptr_, SIGNAL(valueChanged(int)), this, SLOT(onClickLateralOffset()));
+
   // Layout
   auto * v_layout = new QVBoxLayout;
   auto * gate_mode_path_change_approval_layout = new QHBoxLayout;
   auto * velocity_limit_layout = new QHBoxLayout();
+  auto * lateral_offset_slider_layout = new QHBoxLayout;
   v_layout->addLayout(gate_layout);
   v_layout->addLayout(selector_layout);
   v_layout->addLayout(state_layout);
@@ -115,6 +125,11 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   velocity_limit_layout->addWidget(pub_velocity_limit_input_);
   velocity_limit_layout->addWidget(new QLabel("  [km/h]"));
   v_layout->addLayout(velocity_limit_layout);
+  lateral_offset_slider_layout->addWidget(new QLabel("Side Shift "));
+  lateral_offset_slider_layout->addWidget(lateral_offset_slider_ptr_);
+  lateral_offset_slider_layout->addWidget(lateral_offset_value_ptr_);
+  lateral_offset_slider_layout->addWidget(new QLabel("  [m]"));
+  v_layout->addLayout(lateral_offset_slider_layout);
   setLayout(v_layout);
 }
 
@@ -153,6 +168,22 @@ void AutowareStatePanel::onInitialize()
     "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/"
     "path_change_approval",
     rclcpp::QoS(1));
+
+  pub_lateral_offset_ = raw_node_->create_publisher<LateralOffset>(
+    "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/input/"
+    "lateral_offset",
+    rclcpp::QoS(1));
+}
+
+void AutowareStatePanel::onClickLateralOffset()
+{
+  const double shift_step = -0.5;
+  lateral_offset_ = lateral_offset_slider_ptr_->sliderPosition() * shift_step;
+  const QString lateral_offset_string = QString::fromStdString(std::to_string(lateral_offset_));
+  lateral_offset_value_ptr_->setText(lateral_offset_string);
+  pub_lateral_offset_->publish(tier4_planning_msgs::build<LateralOffset>()
+                                 .stamp(raw_node_->now())
+                                 .lateral_offset(lateral_offset_));
 }
 
 void AutowareStatePanel::onGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg)

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -19,6 +19,7 @@
 
 #include <QLabel>
 #include <QPushButton>
+#include <QSlider>
 #include <QSpinBox>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
@@ -30,10 +31,12 @@
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
 #include <tier4_planning_msgs/msg/approval.hpp>
+#include <tier4_planning_msgs/msg/lateral_offset.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 
 namespace rviz_plugins
 {
+using tier4_planning_msgs::msg::LateralOffset;
 class AutowareStatePanel : public rviz_common::Panel
 {
   Q_OBJECT
@@ -47,6 +50,7 @@ public Q_SLOTS:
   void onClickVelocityLimit();
   void onClickGateMode();
   void onClickPathChangeApproval();
+  void onClickLateralOffset();
 
 protected:
   void onGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg);
@@ -70,6 +74,7 @@ protected:
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
   rclcpp::Publisher<tier4_control_msgs::msg::GateMode>::SharedPtr pub_gate_mode_;
   rclcpp::Publisher<tier4_planning_msgs::msg::Approval>::SharedPtr pub_path_change_approval_;
+  rclcpp::Publisher<LateralOffset>::SharedPtr pub_lateral_offset_;
 
   QLabel * gate_mode_label_ptr_;
   QLabel * selector_mode_label_ptr_;
@@ -82,7 +87,12 @@ protected:
   QPushButton * path_change_approval_button_ptr_;
   QSpinBox * pub_velocity_limit_input_;
 
+  // for side shift
+  QSlider * lateral_offset_slider_ptr_;
+  QLabel * lateral_offset_value_ptr_;
+
   bool current_engage_;
+  double lateral_offset_ = {0.0};
 };
 
 }  // namespace rviz_plugins


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

currently there is no good way to develop side shift for open source user so I added side shift control as rviz plugin

https://user-images.githubusercontent.com/65527974/173217705-afc8e3fb-b0d7-47c3-8476-2e7a7d081253.mp4

![image](https://user-images.githubusercontent.com/65527974/173217720-d83696e8-2835-40a9-b124-a07f012c844a.png)

## Related links


## Tests performed

by Psim
shift param below is going to make smooth shift path
```
      shift_request_time_limit: 0.0
```

## Notes for reviewers

run psim

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
