### PR TITLE
fix(obstacle_cruise_planner): use absolute value in lateraloffset to filter on obstacles

### DIFF
--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -533,7 +533,7 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
     const double dist_from_obstacle_to_traj = [&]() {
       return tier4_autoware_utils::calcLateralOffset(decimated_traj.points, object_pose.position);
     }();
-    if (dist_from_obstacle_to_traj > obstacle_filtering_param_.rough_detection_area_expand_width) {
+    if (std::fabs(dist_from_obstacle_to_traj) > obstacle_filtering_param_.rough_detection_area_expand_width) {
       RCLCPP_INFO_EXPRESSION(
         get_logger(), is_showing_debug_info_,
         "Ignore obstacles since it is far from the trajectory.");

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -533,7 +533,9 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
     const double dist_from_obstacle_to_traj = [&]() {
       return tier4_autoware_utils::calcLateralOffset(decimated_traj.points, object_pose.position);
     }();
-    if (std::fabs(dist_from_obstacle_to_traj) > obstacle_filtering_param_.rough_detection_area_expand_width) {
+    if (
+      std::fabs(dist_from_obstacle_to_traj) >
+      obstacle_filtering_param_.rough_detection_area_expand_width) {
       RCLCPP_INFO_EXPRESSION(
         get_logger(), is_showing_debug_info_,
         "Ignore obstacles since it is far from the trajectory.");


### PR DESCRIPTION
Signed-off-by: jack.song <jack.song@autocore.ai>
## Description
In obstacle_cruise_planner,During obstacle filtering, the absolute value should be taken for comparison with the parameters after calculating the horizontal distance of the obstacle, because the offset distance is positive or negative.
The current code is as follows:
![2022-06-13 14-20-51屏幕截图](https://user-images.githubusercontent.com/102840938/173292315-26c1a9fc-3d50-4d94-9030-dc9a21bc9868.png)


The "dist_from_obstacle_to_traj" should be changed  to "std::fabs(dist_from_obstacle_to_traj)".








<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
