### PR TITLE
fix(obstacle_cruise_planner): compensate time delay for predicted object and fix stop condition

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/optimization_based_planner/optimization_based_planner.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/optimization_based_planner/optimization_based_planner.hpp
@@ -73,8 +73,7 @@ private:
   std::vector<double> createTimeVector();
 
   double getClosestStopDistance(
-    const ObstacleCruisePlannerData & planner_data, const TrajectoryData & ego_traj_data,
-    const std::vector<double> & resolutions);
+    const ObstacleCruisePlannerData & planner_data, const TrajectoryData & ego_traj_data);
 
   std::tuple<double, double> calcInitialMotion(
     const double current_vel, const Trajectory & input_traj, const size_t input_closest,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/optimization_based_planner/optimization_based_planner.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/optimization_based_planner/optimization_based_planner.hpp
@@ -115,7 +115,7 @@ private:
     const TargetObstacle & object, const rclcpp::Time & obj_base_time,
     const PredictedPath & predicted_path);
 
-  boost::optional<PredictedPath> resampledPredictedPath(
+  boost::optional<PredictedPath> resamplePredictedPath(
     const TargetObstacle & object, const rclcpp::Time & obj_base_time,
     const rclcpp::Time & current_time, const std::vector<double> & resolutions,
     const double horizon);

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/optimization_based_planner/resample.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/optimization_based_planner/resample.hpp
@@ -34,13 +34,6 @@ autoware_auto_perception_msgs::msg::PredictedPath resamplePredictedPath(
   const autoware_auto_perception_msgs::msg::PredictedPath & input_path,
   const std::vector<rclcpp::Duration> & rel_time_vec);
 
-geometry_msgs::msg::Pose lerpByPose(
-  const geometry_msgs::msg::Pose & p1, const geometry_msgs::msg::Pose & p2, const double t);
-
-boost::optional<geometry_msgs::msg::Pose> lerpByTimeStamp(
-  const autoware_auto_perception_msgs::msg::PredictedPath & path,
-  const rclcpp::Duration & rel_time);
-
 autoware_auto_planning_msgs::msg::Trajectory applyLinearInterpolation(
   const std::vector<double> & base_index,
   const autoware_auto_planning_msgs::msg::Trajectory & base_trajectory,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
@@ -78,7 +78,6 @@ private:
     boost::optional<CruiseObstacleInfo> & cruise_obstacle_info);
   double calcDistanceToObstacle(
     const ObstacleCruisePlannerData & planner_data, const TargetObstacle & obstacle);
-  bool isStopRequired(const TargetObstacle & obstacle);
 
   void planCruise(
     const ObstacleCruisePlannerData & planner_data, boost::optional<VelocityLimit> & vel_limit,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -167,6 +167,21 @@ public:
     return std::find(types.begin(), types.end(), label) != types.end();
   }
 
+  // Note: If stop planning is not required, cruise planning will be done instead.
+  bool isStopRequired(const TargetObstacle & obstacle)
+  {
+    const bool is_cruise_obstacle = isCruiseObstacle(obstacle.classification.label);
+    const bool is_stop_obstacle = isStopObstacle(obstacle.classification.label);
+
+    if (is_cruise_obstacle) {
+      return std::abs(obstacle.velocity) < obstacle_velocity_threshold_from_cruise_to_stop_;
+    } else if (is_stop_obstacle && !is_cruise_obstacle) {
+      return true;
+    }
+
+    return false;
+  }
+
 protected:
   // Parameters
   bool is_showing_debug_info_{false};

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_auto_perception_msgs/msg/object_classification.hpp"
+#include "autoware_auto_perception_msgs/msg/predicted_object.hpp"
 #include "autoware_auto_perception_msgs/msg/predicted_path.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/pose.hpp"
@@ -26,6 +27,7 @@
 #include <boost/optional.hpp>
 
 #include <string>
+#include <vector>
 
 namespace obstacle_cruise_utils
 {
@@ -41,8 +43,23 @@ boost::optional<geometry_msgs::msg::Pose> calcForwardPose(
   const autoware_auto_planning_msgs::msg::Trajectory & traj, const size_t nearest_idx,
   const double target_length);
 
+geometry_msgs::msg::Pose lerpByPose(
+  const geometry_msgs::msg::Pose & p1, const geometry_msgs::msg::Pose & p2, const double t);
+
+boost::optional<geometry_msgs::msg::Pose> lerpByTimeStamp(
+  const autoware_auto_perception_msgs::msg::PredictedPath & path,
+  const rclcpp::Duration & rel_time);
+
 boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
+  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time);
+
+boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
+  const std::vector<autoware_auto_perception_msgs::msg::PredictedPath> & predicted_paths,
+  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time);
+
+boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
+  const autoware_auto_perception_msgs::msg::PredictedObject & predicted_object,
   const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time);
 }  // namespace obstacle_cruise_utils
 

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
@@ -58,7 +58,7 @@ boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
   const std::vector<autoware_auto_perception_msgs::msg::PredictedPath> & predicted_paths,
   const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time);
 
-boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
+geometry_msgs::msg::Pose getCurrentObjectPoseFromPredictedPath(
   const autoware_auto_perception_msgs::msg::PredictedObject & predicted_object,
   const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time);
 }  // namespace obstacle_cruise_utils

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -519,7 +519,6 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
       continue;
     }
 
-    // const auto & object_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
     const auto object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPath(
       predicted_object, time_stamp, current_time);
     const auto & object_velocity =

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -524,7 +524,7 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
     const auto & object_velocity =
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x;
 
-    const bool is_front_obstacle = isFrontObstacle(traj, ego_idx, object_pose->position);
+    const bool is_front_obstacle = isFrontObstacle(traj, ego_idx, object_pose.position);
     if (!is_front_obstacle) {
       RCLCPP_INFO_EXPRESSION(
         get_logger(), is_showing_debug_info_, "Ignore obstacles since its not front obstacle.");
@@ -533,7 +533,7 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
 
     // rough detection area filtering without polygons
     const double dist_from_obstacle_to_traj = [&]() {
-      return tier4_autoware_utils::calcLateralOffset(decimated_traj.points, object_pose->position);
+      return tier4_autoware_utils::calcLateralOffset(decimated_traj.points, object_pose.position);
     }();
     if (dist_from_obstacle_to_traj > obstacle_filtering_param_.rough_detection_area_expand_width) {
       RCLCPP_INFO_EXPRESSION(
@@ -544,7 +544,7 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
 
     // calculate collision points
     const auto obstacle_polygon =
-      polygon_utils::convertObstacleToPolygon(*object_pose, predicted_object.shape);
+      polygon_utils::convertObstacleToPolygon(object_pose, predicted_object.shape);
     std::vector<geometry_msgs::msg::Point> collision_points;
     const auto first_within_idx = polygon_utils::getFirstCollisionIndex(
       decimated_traj_polygons, obstacle_polygon, collision_points);
@@ -558,7 +558,7 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
       debug_data.collision_points.push_back(nearest_collision_point);
 
       const bool is_angle_aligned = isAngleAlignedWithTrajectory(
-        decimated_traj, *object_pose,
+        decimated_traj, object_pose,
         obstacle_filtering_param_.crossing_obstacle_traj_angle_threshold);
       const double has_high_speed =
         std::abs(object_velocity) > obstacle_filtering_param_.crossing_obstacle_velocity_threshold;
@@ -598,7 +598,7 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
         obstacle_filtering_param_.max_prediction_time_for_collision_check);
 
       // TODO(murooka) think later
-      nearest_collision_point = object_pose->position;
+      nearest_collision_point = object_pose.position;
 
       if (!will_collide) {
         // Ignore condition 2

--- a/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -841,11 +841,8 @@ boost::optional<SBoundaries> OptimizationBasedPlanner::getSBoundaries(
     // Step3 search nearest obstacle to follow for rviz marker
     const double object_offset = obj.shape.dimensions.x / 2.0;
 
-    const auto predicted_path =
-      resampledPredictedPath(obj, obj_base_time, current_time, time_vec, max_time_horizon_);
-
     const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPath(
-      *predicted_path, obj_base_time, current_time);
+      obj.predicted_paths, obj_base_time, current_time);
 
     const double obj_vel = std::abs(obj.velocity);
     const double rss_dist = calcRSSDistance(planner_data.current_vel, obj_vel);
@@ -867,11 +864,8 @@ boost::optional<SBoundaries> OptimizationBasedPlanner::getSBoundaries(
   if (min_slow_down_idx) {
     const auto & obj = planner_data.target_obstacles.at(min_slow_down_idx.get());
 
-    const auto predicted_path =
-      resampledPredictedPath(obj, obj.time_stamp, current_time, time_vec, max_time_horizon_);
-
     const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPath(
-      *predicted_path, obj.time_stamp, current_time);
+      obj.predicted_paths, obj.time_stamp, current_time);
 
     const auto marker_pose = calcForwardPose(
       ego_traj_data.traj, planner_data.current_pose.position, min_slow_down_point_length);
@@ -906,7 +900,7 @@ boost::optional<SBoundaries> OptimizationBasedPlanner::getSBoundaries(
   // Get the predicted path, which has the most high confidence
   const double max_horizon = time_vec.back();
   const auto predicted_path =
-    resampledPredictedPath(object, obj_base_time, current_time, time_vec, max_horizon);
+    resamplePredictedPath(object, obj_base_time, current_time, time_vec, max_horizon);
   if (!predicted_path) {
     RCLCPP_DEBUG(
       rclcpp::get_logger("ObstacleCruisePlanner::OptimizationBasedPlanner"),
@@ -1105,7 +1099,7 @@ boost::optional<size_t> OptimizationBasedPlanner::getCollisionIdx(
   return boost::none;
 }
 
-boost::optional<PredictedPath> OptimizationBasedPlanner::resampledPredictedPath(
+boost::optional<PredictedPath> OptimizationBasedPlanner::resamplePredictedPath(
   const TargetObstacle & object, const rclcpp::Time & obj_base_time,
   const rclcpp::Time & current_time, const std::vector<double> & resolutions, const double horizon)
 {

--- a/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -475,12 +475,8 @@ double OptimizationBasedPlanner::getClosestStopDistance(
   for (const auto & obj : planner_data.target_obstacles) {
     const auto obj_base_time = obj.time_stamp;
 
-    // Step1. Ignore obstacles that are not vehicles
-    if (
-      obj.classification.label != ObjectClassification::CAR &&
-      obj.classification.label != ObjectClassification::TRUCK &&
-      obj.classification.label != ObjectClassification::BUS &&
-      obj.classification.label != ObjectClassification::MOTORCYCLE) {
+    // Step1. Ignore obstacles that are not required to stop
+    if (!isStopRequired(obj)) {
       continue;
     }
 
@@ -508,20 +504,17 @@ double OptimizationBasedPlanner::getClosestStopDistance(
 
     // Calculate Safety Distance
     const auto & safe_distance_margin = longitudinal_info_.safe_distance_margin;
-    const double ego_vehicle_offset = vehicle_info_.wheel_base_m + vehicle_info_.front_overhang_m;
+    const auto & ego_vehicle_offset = vehicle_info_.max_longitudinal_offset_m;
     const double object_offset = obj_data.length / 2.0;
     const double safety_distance = ego_vehicle_offset + object_offset + safe_distance_margin;
 
     // If the object is on the current ego trajectory,
     // we assume the object travels along ego trajectory
-    const double obj_vel = std::abs(obj.velocity);
-    if (dist_to_collision_point && obj_vel < obstacle_velocity_threshold_from_cruise_to_stop_) {
-      const double current_stop_point = std::max(*dist_to_collision_point - safety_distance, 0.0);
-      closest_stop_dist = std::min(current_stop_point, closest_stop_dist);
-    }
-
-    // Update Distance to the closest object on the ego trajectory
     if (dist_to_collision_point) {
+      const double stop_dist = std::max(*dist_to_collision_point - safety_distance, 0.0);
+      closest_stop_dist = std::min(stop_dist, closest_stop_dist);
+
+      // Update Distance to the closest object on the ego trajectory
       const double current_obj_distance = std::max(
         *dist_to_collision_point - safety_distance + safe_distance_margin, -safety_distance);
       closest_obj_distance = std::min(closest_obj_distance, current_obj_distance);
@@ -832,9 +825,13 @@ boost::optional<SBoundaries> OptimizationBasedPlanner::getSBoundaries(
   double min_slow_down_point_length = std::numeric_limits<double>::max();
   boost::optional<size_t> min_slow_down_idx = {};
   for (size_t o_idx = 0; o_idx < planner_data.target_obstacles.size(); ++o_idx) {
-    const auto obj_base_time = planner_data.target_obstacles.at(o_idx).time_stamp;
-
     const auto & obj = planner_data.target_obstacles.at(o_idx);
+    const auto obj_base_time = planner_data.target_obstacles.at(o_idx).time_stamp;
+    // Only see cruise obstacles
+    if (!isCruiseObstacle(obj.classification.label)) {
+      continue;
+    }
+
     // Step1 Get S boundary from the obstacle
     const auto obj_s_boundaries =
       getSBoundaries(planner_data.current_time, ego_traj_data, obj, obj_base_time, time_vec);

--- a/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -212,7 +212,7 @@ Trajectory OptimizationBasedPlanner::generateTrajectory(
   }
 
   // Get Closest Stop Point for static obstacles
-  double closest_stop_dist = getClosestStopDistance(planner_data, base_traj_data, time_vec);
+  double closest_stop_dist = getClosestStopDistance(planner_data, base_traj_data);
 
   // Compute maximum velocity
   double v_max = 0.0;
@@ -459,8 +459,7 @@ std::vector<double> OptimizationBasedPlanner::createTimeVector()
 }
 
 double OptimizationBasedPlanner::getClosestStopDistance(
-  const ObstacleCruisePlannerData & planner_data, const TrajectoryData & ego_traj_data,
-  const std::vector<double> & resolutions)
+  const ObstacleCruisePlannerData & planner_data, const TrajectoryData & ego_traj_data)
 {
   const auto & current_time = planner_data.current_time;
   double closest_stop_dist = ego_traj_data.s.back();
@@ -475,21 +474,14 @@ double OptimizationBasedPlanner::getClosestStopDistance(
   for (const auto & obj : planner_data.target_obstacles) {
     const auto obj_base_time = obj.time_stamp;
 
-    // Step1. Ignore obstacles that are not required to stop
+    // Ignore obstacles that are not required to stop
     if (!isStopRequired(obj)) {
-      continue;
-    }
-
-    // Get the predicted path, which has the most high confidence
-    const auto predicted_path =
-      resampledPredictedPath(obj, obj_base_time, current_time, resolutions, max_time_horizon_);
-    if (!predicted_path) {
       continue;
     }
 
     // Get current pose from object's predicted path
     const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPath(
-      *predicted_path, obj_base_time, current_time);
+      obj.predicted_paths, obj_base_time, current_time);
     if (!current_object_pose) {
       continue;
     }

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -297,21 +297,6 @@ double PIDBasedPlanner::calcDistanceToObstacle(
          offset;
 }
 
-// Note: If stop planning is not required, cruise planning will be done instead.
-bool PIDBasedPlanner::isStopRequired(const TargetObstacle & obstacle)
-{
-  const bool is_cruise_obstacle = isCruiseObstacle(obstacle.classification.label);
-  const bool is_stop_obstacle = isStopObstacle(obstacle.classification.label);
-
-  if (is_cruise_obstacle) {
-    return std::abs(obstacle.velocity) < obstacle_velocity_threshold_from_cruise_to_stop_;
-  } else if (is_stop_obstacle && !is_cruise_obstacle) {
-    return true;
-  }
-
-  return false;
-}
-
 Trajectory PIDBasedPlanner::planStop(
   const ObstacleCruisePlannerData & planner_data,
   const boost::optional<StopObstacleInfo> & stop_obstacle_info, DebugData & debug_data)

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -164,7 +164,7 @@ boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
   return getCurrentObjectPoseFromPredictedPath(*predicted_path, obj_base_time, current_time);
 }
 
-boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
+geometry_msgs::msg::Pose getCurrentObjectPoseFromPredictedPath(
   const autoware_auto_perception_msgs::msg::PredictedObject & predicted_object,
   const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time)
 {
@@ -175,7 +175,7 @@ boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
   const auto interpolated_pose =
     getCurrentObjectPoseFromPredictedPath(predicted_paths, obj_base_time, current_time);
 
-  return interpolated_pose ? interpolated_pose
+  return interpolated_pose ? interpolated_pose.value()
                            : predicted_object.kinematics.initial_pose_with_covariance.pose;
 }
 }  // namespace obstacle_cruise_utils

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -175,7 +175,12 @@ geometry_msgs::msg::Pose getCurrentObjectPoseFromPredictedPath(
   const auto interpolated_pose =
     getCurrentObjectPoseFromPredictedPath(predicted_paths, obj_base_time, current_time);
 
-  return interpolated_pose ? interpolated_pose.value()
-                           : predicted_object.kinematics.initial_pose_with_covariance.pose;
+  if (!interpolated_pose) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("ObstacleCruisePlanner"), "Failed to find the interpolated obstacle pose");
+    return predicted_object.kinematics.initial_pose_with_covariance.pose;
+  }
+
+  return interpolated_pose.value();
 }
 }  // namespace obstacle_cruise_utils

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -181,6 +181,6 @@ geometry_msgs::msg::Pose getCurrentObjectPoseFromPredictedPath(
     return predicted_object.kinematics.initial_pose_with_covariance.pose;
   }
 
-  return interpolated_pose.value();
+  return interpolated_pose.get();
 }
 }  // namespace obstacle_cruise_utils

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -90,22 +90,92 @@ boost::optional<geometry_msgs::msg::Pose> calcForwardPose(
   return target_pose;
 }
 
-boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
-  const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
-  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time)
+geometry_msgs::msg::Pose lerpByPose(
+  const geometry_msgs::msg::Pose & p1, const geometry_msgs::msg::Pose & p2, const double t)
 {
-  for (size_t i = 0; i < predicted_path.path.size(); ++i) {
-    const auto & obj_p = predicted_path.path.at(i);
+  tf2::Transform tf_transform1, tf_transform2;
+  tf2::fromMsg(p1, tf_transform1);
+  tf2::fromMsg(p2, tf_transform2);
+  const auto & tf_point = tf2::lerp(tf_transform1.getOrigin(), tf_transform2.getOrigin(), t);
+  const auto & tf_quaternion =
+    tf2::slerp(tf_transform1.getRotation(), tf_transform2.getRotation(), t);
 
-    const double object_time =
-      (obj_base_time + rclcpp::Duration(predicted_path.time_step) * static_cast<double>(i) -
-       current_time)
-        .seconds();
-    if (object_time >= 0) {
-      return obj_p;
+  geometry_msgs::msg::Pose pose;
+  {
+    pose.position.x = tf_point.x();
+    pose.position.y = tf_point.y();
+    pose.position.z = tf_point.z();
+  }
+  pose.orientation = tf2::toMsg(tf_quaternion);
+  return pose;
+}
+
+boost::optional<geometry_msgs::msg::Pose> lerpByTimeStamp(
+  const autoware_auto_perception_msgs::msg::PredictedPath & path, const rclcpp::Duration & rel_time)
+{
+  auto clock{rclcpp::Clock{RCL_ROS_TIME}};
+  if (
+    path.path.empty() || rel_time < rclcpp::Duration::from_seconds(0.0) ||
+    rel_time > rclcpp::Duration(path.time_step) * (static_cast<double>(path.path.size()) - 1)) {
+    return boost::none;
+  }
+
+  for (size_t i = 1; i < path.path.size(); ++i) {
+    const auto & pt = path.path.at(i);
+    const auto & prev_pt = path.path.at(i - 1);
+    if (rel_time <= rclcpp::Duration(path.time_step) * static_cast<double>(i)) {
+      const auto offset = rel_time - rclcpp::Duration(path.time_step) * static_cast<double>(i - 1);
+      const auto ratio = offset.seconds() / rclcpp::Duration(path.time_step).seconds();
+      return lerpByPose(prev_pt, pt, ratio);
     }
   }
 
   return boost::none;
+}
+
+boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
+  const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
+  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time)
+{
+  const auto rel_time = current_time - obj_base_time;
+  if (rel_time.seconds() < 0.0) {
+    return boost::none;
+  }
+
+  return lerpByTimeStamp(predicted_path, rel_time);
+}
+
+boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
+  const std::vector<autoware_auto_perception_msgs::msg::PredictedPath> & predicted_paths,
+  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time)
+{
+  if (predicted_paths.empty()) {
+    return boost::none;
+  }
+  // Get the most reliable path
+  const auto predicted_path = std::max_element(
+    predicted_paths.begin(), predicted_paths.end(),
+    [](
+      const autoware_auto_perception_msgs::msg::PredictedPath & a,
+      const autoware_auto_perception_msgs::msg::PredictedPath & b) {
+      return a.confidence < b.confidence;
+    });
+
+  return getCurrentObjectPoseFromPredictedPath(*predicted_path, obj_base_time, current_time);
+}
+
+boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
+  const autoware_auto_perception_msgs::msg::PredictedObject & predicted_object,
+  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time)
+{
+  std::vector<autoware_auto_perception_msgs::msg::PredictedPath> predicted_paths;
+  for (const auto & path : predicted_object.kinematics.predicted_paths) {
+    predicted_paths.push_back(path);
+  }
+  const auto interpolated_pose =
+    getCurrentObjectPoseFromPredictedPath(predicted_paths, obj_base_time, current_time);
+
+  return interpolated_pose ? interpolated_pose
+                           : predicted_object.kinematics.initial_pose_with_covariance.pose;
 }
 }  // namespace obstacle_cruise_utils


### PR DESCRIPTION
## Description
Currently obstacle filtering does not compensate position time delay for predicted object, which might cause serious problem like collisions with obstacles. In this PR, I made a compensate function to interpolate the current position of the obstacle.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed
PSim
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
