### PR TITLE
fix(behavior_path_planner):  prevent modification of planning data while planner is running

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -58,14 +58,14 @@ std::vector<LaneChangePath> selectValidPaths(
 bool selectSafePath(
   const std::vector<LaneChangePath> & paths, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects, const Pose & current_pose,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const double vehicle_width,
   const behavior_path_planner::LaneChangeParameters & ros_parameters,
   LaneChangePath * selected_path);
 bool isLaneChangePathSafe(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects, const Pose & current_pose,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const double vehicle_width,
   const behavior_path_planner::LaneChangeParameters & ros_parameters, const bool use_buffer = true,
   const double acceleration = 0.0);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/util.hpp
@@ -66,14 +66,14 @@ std::vector<PullOutPath> selectValidPaths(
 bool selectSafePath(
   const std::vector<PullOutPath> & paths, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects, const Pose & current_pose,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const double vehicle_width,
   const behavior_path_planner::PullOutParameters & ros_parameters,
   const tier4_autoware_utils::LinearRing2d & vehicle_footprint, PullOutPath * selected_path);
 bool isPullOutPathSafe(
   const behavior_path_planner::PullOutPath & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects,
+  const PredictedObjects::ConstSharedPtr dynamic_objects,
   const behavior_path_planner::PullOutParameters & ros_parameters,
   const tier4_autoware_utils::LinearRing2d & vehicle_footprint, const bool use_buffer = true,
   const bool use_dynamic_object = false);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/util.hpp
@@ -58,13 +58,13 @@ std::vector<PullOverPath> selectValidPaths(
 bool selectSafePath(
   const std::vector<PullOverPath> & paths, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects, const Pose & current_pose,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const double vehicle_width,
   const behavior_path_planner::PullOverParameters & ros_parameters, PullOverPath * selected_path);
 bool isPullOverPathSafe(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects, const Pose & current_pose,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const double vehicle_width,
   const behavior_path_planner::PullOverParameters & ros_parameters, const bool use_buffer = true,
   const double acceleration = 0.0);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -527,10 +527,7 @@ void BehaviorPathPlannerNode::run()
   // update planner data
   planner_data_->self_pose = self_pose_listener_.getCurrentPose();
 
-  // NOTE: planner_data must not be referenced for multithreading
   const auto planner_data = planner_data_;
-  mutex_pd_.unlock();
-
   // run behavior planner
   const auto output = bt_manager_->run(planner_data);
 
@@ -539,7 +536,6 @@ void BehaviorPathPlannerNode::run()
   const auto path_candidate = getPathCandidate(output, planner_data);
 
   // update planner data
-  mutex_pd_.lock();  // for planner_data_
   planner_data_->prev_output_path = path;
   mutex_pd_.unlock();
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -271,7 +271,7 @@ std::vector<LaneChangePath> selectValidPaths(
 bool selectSafePath(
   const std::vector<LaneChangePath> & paths, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects, const Pose & current_pose,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const double vehicle_width,
   const LaneChangeParameters & ros_parameters, LaneChangePath * selected_path)
 {
@@ -329,7 +329,7 @@ bool hasEnoughDistance(
 bool isLaneChangePathSafe(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects, const Pose & current_pose,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const double vehicle_width,
   const LaneChangeParameters & ros_parameters, const bool use_buffer, const double acceleration)
 {

--- a/planning/behavior_path_planner/src/scene_module/pull_out/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/util.cpp
@@ -397,8 +397,7 @@ bool hasEnoughDistance(
 bool isPullOutPathSafe(
   const behavior_path_planner::PullOutPath & path, const lanelet::ConstLanelets & road_lanes,
   const lanelet::ConstLanelets & shoulder_lanes,
-  const PredictedObjects::ConstSharedPtr dynamic_objects,
-  const PullOutParameters & ros_parameters,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const PullOutParameters & ros_parameters,
   const tier4_autoware_utils::LinearRing2d & local_vehicle_footprint, const bool use_buffer,
   const bool use_dynamic_object)
 {

--- a/planning/behavior_path_planner/src/scene_module/pull_out/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/util.cpp
@@ -337,7 +337,7 @@ std::vector<PullOutPath> selectValidPaths(
 bool selectSafePath(
   const std::vector<PullOutPath> & paths, const lanelet::ConstLanelets & road_lanes,
   const lanelet::ConstLanelets & shoulder_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects,
+  const PredictedObjects::ConstSharedPtr dynamic_objects,
   [[maybe_unused]] const Pose & current_pose, [[maybe_unused]] const Twist & current_twist,
   [[maybe_unused]] const double vehicle_width, const PullOutParameters & ros_parameters,
   const tier4_autoware_utils::LinearRing2d & local_vehicle_footprint, PullOutPath * selected_path)
@@ -397,7 +397,7 @@ bool hasEnoughDistance(
 bool isPullOutPathSafe(
   const behavior_path_planner::PullOutPath & path, const lanelet::ConstLanelets & road_lanes,
   const lanelet::ConstLanelets & shoulder_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects,
+  const PredictedObjects::ConstSharedPtr dynamic_objects,
   const PullOutParameters & ros_parameters,
   const tier4_autoware_utils::LinearRing2d & local_vehicle_footprint, const bool use_buffer,
   const bool use_dynamic_object)

--- a/planning/behavior_path_planner/src/scene_module/pull_over/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/util.cpp
@@ -305,7 +305,7 @@ std::vector<PullOverPath> selectValidPaths(
 bool selectSafePath(
   const std::vector<PullOverPath> & paths, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects, const Pose & current_pose,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const double vehicle_width,
   const PullOverParameters & ros_parameters, PullOverPath * selected_path)
 {
@@ -363,7 +363,7 @@ bool hasEnoughDistance(
 bool isPullOverPathSafe(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const PredictedObjects::ConstSharedPtr & dynamic_objects, const Pose & current_pose,
+  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const double vehicle_width,
   const PullOverParameters & ros_parameters, const bool use_buffer, const double acceleration)
 {

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -653,7 +653,7 @@ std::vector<size_t> filterObjectsByLanelets(
   }
 
   for (size_t i = 0; i < objects.objects.size(); i++) {
-    const auto obj = objects.objects.at(i);
+    const auto & obj = objects.objects.at(i);
     // create object polygon
     Polygon2d obj_polygon;
     if (!calcObjectPolygon(obj, &obj_polygon)) {
@@ -687,7 +687,7 @@ std::vector<size_t> filterObjectsByLanelets(
 
   for (size_t i = 0; i < objects.objects.size(); i++) {
     // create object polygon
-    const auto obj = objects.objects.at(i);
+    const auto & obj = objects.objects.at(i);
     // create object polygon
     Polygon2d obj_polygon;
     if (!calcObjectPolygon(obj, &obj_polygon)) {


### PR DESCRIPTION
## Description

This PR prevents planning data from being modified while the `behavior_path_planner` is running, which could cause crashes.
Closes #1049 

The main issue is solved by keeping the mutex for planning data locked while running the planner.
Additional changes:
- Pass `ConstSharedPtr` by value rather than by reference.
- Avoid unnecessary copies when accessing vector elements.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
