### PR TITLE
test(trajectory_follower_nodes): disable flaky test

### DIFF
--- a/control/trajectory_follower_nodes/test/test_longitudinal_controller_node.cpp
+++ b/control/trajectory_follower_nodes/test/test_longitudinal_controller_node.cpp
@@ -470,7 +470,8 @@ TEST_F(FakeNodeFixture, longitudinal_emergency)
   EXPECT_LT(cmd_msg->acceleration, 0.0f);
 }
 
-TEST_F(FakeNodeFixture, longitudinal_set_param_smoke_test)
+// TODO(Maxime CLEMENT): disabled as this test crashes in the CI but works locally
+TEST_F(FakeNodeFixture, DISABLED_longitudinal_set_param_smoke_test)
 {
   // Node
   std::shared_ptr<LongitudinalController> node = makeLongitudinalNode();


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@tier4.jp>

## Description

Disable test that sometimes fail.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
