### PR TITLE
fix(behavior_path_planner): rewrite convertToFrenetCoordinate3d

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -41,6 +41,16 @@ rclcpp_components_register_node(behavior_path_planner_node
   EXECUTABLE behavior_path_planner
 )
 
+if(BUILD_TESTING)
+  ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_utilities
+    test/input.cpp
+    test/test_utilities.cpp
+  )
+  target_link_libraries(test_${PROJECT_NAME}_utilities
+    behavior_path_planner_node
+  )
+endif()
+
 ament_auto_package(
   INSTALL_TO_SHARE
     config

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -161,7 +161,6 @@ PredictedPath convertToPredictedPath(
   const double duration, const double resolution, const double acceleration);
 
 bool checkIfPositionIsOnTheLine(const double & linestring_length, const FrenetCoordinate3d & pose);
-
 FrenetCoordinate3d convertToFrenetCoordinate3d(
   const std::vector<Point> & linestring, const Point & search_point_geom);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -160,6 +160,11 @@ PredictedPath convertToPredictedPath(
   const PathWithLaneId & path, const Twist & vehicle_twist, const Pose & vehicle_pose,
   const double duration, const double resolution, const double acceleration);
 
+bool checkIfPositionIsOnTheLine(const double & linestring_length, const FrenetCoordinate3d & pose);
+
+FrenetCoordinate3d convertToFrenetCoordinate3d(
+  const std::vector<Point> & linestring, const Point & search_point_geom);
+
 bool convertToFrenetCoordinate3d(
   const PathWithLaneId & path, const Point & search_point_geom,
   FrenetCoordinate3d * frenet_coordinate);
@@ -262,7 +267,8 @@ lanelet::ConstLineStrings3d getDrivableAreaForAllSharedLinestringLanelets(
 // goal management
 
 /**
- * @brief Modify the path points near the goal to smoothly connect the input path and the goal point
+ * @brief Modify the path points near the goal to smoothly connect the input path and the goal
+ * point
  * @details Remove the path points that are forward from the goal by the distance of
  * search_radius_range. Then insert the goal into the path. The previous goal point generated
  * from the goal posture information is also inserted for the smooth connection of the goal pose.

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -36,6 +36,7 @@
   <depend>vehicle_info_util</depend>
   <depend>visualization_msgs</depend>
 
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -230,78 +230,33 @@ double l2Norm(const Vector3 vector)
   return std::sqrt(std::pow(vector.x, 2) + std::pow(vector.y, 2) + std::pow(vector.z, 2));
 }
 
+bool checkIfPositionIsOnTheLine(
+  const double & linestring_length, const FrenetCoordinate3d & frenet_pose)
+{
+  const auto length_ratio =
+    frenet_pose.length / ((std::fabs(linestring_length) > 0) ? linestring_length : 1e-5);
+  const auto length_ratio_positive = !std::signbit(length_ratio);
+
+  bool found_on_line = (std::fabs(frenet_pose.distance) < 1e-3) && length_ratio_positive &&
+                       (std::fabs(length_ratio) < 1.0);
+  return found_on_line;
+}
+
 FrenetCoordinate3d convertToFrenetCoordinate3d(
   const std::vector<Point> & linestring, const Point & search_point_geom)
 {
   FrenetCoordinate3d frenet_coordinate;
-  const auto search_pt = tier4_autoware_utils::fromMsg(search_point_geom);
-  double min_distance = std::numeric_limits<double>::max();
 
-  // get frenet coordinate based on points
-  // this is done because linestring is not differentiable at vertices
-  {
-    double accumulated_length = 0;
+  const size_t nearest_segment_idx =
+    tier4_autoware_utils::findNearestSegmentIndex(linestring, search_point_geom);
+  const double longitudinal_length = tier4_autoware_utils::calcLongitudinalOffsetToSegment(
+    linestring, nearest_segment_idx, search_point_geom);
+  frenet_coordinate.length =
+    tier4_autoware_utils::calcSignedArcLength(linestring, 0, nearest_segment_idx) +
+    longitudinal_length;
+  frenet_coordinate.distance =
+    tier4_autoware_utils::calcLateralOffset(linestring, search_point_geom);
 
-    for (std::size_t i = 0; i < linestring.size(); i++) {
-      const auto geom_pt = linestring.at(i);
-      const auto current_pt = tier4_autoware_utils::fromMsg(geom_pt);
-      const auto current2search_pt = (search_pt - current_pt);
-      // update accumulated length
-      if (i != 0) {
-        const auto p1 = tier4_autoware_utils::fromMsg(linestring.at(i - 1));
-        const auto p2 = current_pt;
-        accumulated_length += (p2 - p1).norm();
-      }
-      // update frenet coordinate
-
-      const double tmp_distance = current2search_pt.norm();
-      if (tmp_distance < min_distance) {
-        min_distance = tmp_distance;
-        frenet_coordinate.distance = tmp_distance;
-        frenet_coordinate.length = accumulated_length;
-      } else {
-        break;
-      }
-    }
-  }
-
-  // get frenet coordinate based on lines
-  bool found_on_line = false;
-  {
-    auto prev_geom_pt = linestring.front();
-    double accumulated_length = 0;
-    for (const auto & geom_pt : linestring) {
-      const auto start_pt = tier4_autoware_utils::fromMsg(prev_geom_pt);
-      const auto end_pt = tier4_autoware_utils::fromMsg(geom_pt);
-
-      const auto line_segment = end_pt - start_pt;
-      const double line_segment_length = line_segment.norm();
-      const auto direction = line_segment / line_segment_length;
-      const auto start2search_pt = (search_pt - start_pt);
-
-      double tmp_length = direction.dot(start2search_pt);
-      if (tmp_length >= 0 && tmp_length <= line_segment_length) {
-        double tmp_distance = direction.cross(start2search_pt).norm();
-        if (tmp_distance < min_distance) {
-          min_distance = tmp_distance;
-          frenet_coordinate.distance = tmp_distance;
-          frenet_coordinate.length = accumulated_length + tmp_length;
-
-          if (found_on_line) {
-            break;
-          }
-
-          found_on_line = true;
-        } else if (found_on_line) {
-          break;
-        }
-      } else if (found_on_line) {
-        break;
-      }
-      accumulated_length += line_segment_length;
-      prev_geom_pt = geom_pt;
-    }
-  }
   return frenet_coordinate;
 }
 
@@ -313,7 +268,6 @@ bool convertToFrenetCoordinate3d(
   return convertToFrenetCoordinate3d(linestring, search_point_geom, frenet_coordinate);
 }
 
-
 // returns false when search point is off the linestring
 bool convertToFrenetCoordinate3d(
   const std::vector<Point> & linestring, const Point search_point_geom,
@@ -323,75 +277,13 @@ bool convertToFrenetCoordinate3d(
     return false;
   }
 
-  const auto search_pt = tier4_autoware_utils::fromMsg(search_point_geom);
-  double min_distance = std::numeric_limits<double>::max();
-
   // get frenet coordinate based on points
   // this is done because linestring is not differentiable at vertices
-  {
-    double accumulated_length = 0;
+  const auto linestring_length =
+    tier4_autoware_utils::calcSignedArcLength(linestring, 0, linestring.size() - 1);
+  *frenet_coordinate = convertToFrenetCoordinate3d(linestring, search_point_geom);
 
-    for (std::size_t i = 0; i < linestring.size(); i++) {
-      const auto geom_pt = linestring.at(i);
-      const auto current_pt = tier4_autoware_utils::fromMsg(geom_pt);
-      const auto current2search_pt = (search_pt - current_pt);
-      // update accumulated length
-      if (i != 0) {
-        const auto p1 = tier4_autoware_utils::fromMsg(linestring.at(i - 1));
-        const auto p2 = current_pt;
-        accumulated_length += (p2 - p1).norm();
-      }
-      // update frenet coordinate
-
-      const double tmp_distance = current2search_pt.norm();
-      if (tmp_distance < min_distance) {
-        min_distance = tmp_distance;
-        frenet_coordinate->distance = tmp_distance;
-        frenet_coordinate->length = accumulated_length;
-      } else {
-        break;
-      }
-    }
-  }
-
-  // get frenet coordinate based on lines
-  bool found_on_line = false;
-  {
-    auto prev_geom_pt = linestring.front();
-    double accumulated_length = 0;
-    for (const auto & geom_pt : linestring) {
-      const auto start_pt = tier4_autoware_utils::fromMsg(prev_geom_pt);
-      const auto end_pt = tier4_autoware_utils::fromMsg(geom_pt);
-
-      const auto line_segment = end_pt - start_pt;
-      const double line_segment_length = line_segment.norm();
-      const auto direction = line_segment / line_segment_length;
-      const auto start2search_pt = (search_pt - start_pt);
-
-      double tmp_length = direction.dot(start2search_pt);
-      if (tmp_length >= 0 && tmp_length <= line_segment_length) {
-        double tmp_distance = direction.cross(start2search_pt).norm();
-        if (tmp_distance < min_distance) {
-          min_distance = tmp_distance;
-          frenet_coordinate->distance = tmp_distance;
-          frenet_coordinate->length = accumulated_length + tmp_length;
-
-          if (found_on_line) {
-            break;
-          }
-
-          found_on_line = true;
-        } else if (found_on_line) {
-          break;
-        }
-      } else if (found_on_line) {
-        break;
-      }
-      accumulated_length += line_segment_length;
-      prev_geom_pt = geom_pt;
-    }
-  }
-  return found_on_line;
+  return checkIfPositionIsOnTheLine(linestring_length, *frenet_coordinate);
 }
 
 std::vector<Point> convertToGeometryPointArray(const PathWithLaneId & path)
@@ -439,8 +331,8 @@ PredictedPath convertToPredictedPath(
   }
 
   const auto & geometry_points = convertToGeometryPointArray(path);
-  FrenetCoordinate3d vehicle_pose_frenet;
-  convertToFrenetCoordinate3d(geometry_points, vehicle_pose.position, &vehicle_pose_frenet);
+  FrenetCoordinate3d vehicle_pose_frenet =
+    convertToFrenetCoordinate3d(geometry_points, vehicle_pose.position);
   auto clock{rclcpp::Clock{RCL_ROS_TIME}};
   rclcpp::Time start_time = clock.now();
   double vehicle_speed = std::abs(vehicle_twist.linear.x);

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -230,6 +230,81 @@ double l2Norm(const Vector3 vector)
   return std::sqrt(std::pow(vector.x, 2) + std::pow(vector.y, 2) + std::pow(vector.z, 2));
 }
 
+FrenetCoordinate3d convertToFrenetCoordinate3d(
+  const std::vector<Point> & linestring, const Point & search_point_geom)
+{
+  FrenetCoordinate3d frenet_coordinate;
+  const auto search_pt = tier4_autoware_utils::fromMsg(search_point_geom);
+  double min_distance = std::numeric_limits<double>::max();
+
+  // get frenet coordinate based on points
+  // this is done because linestring is not differentiable at vertices
+  {
+    double accumulated_length = 0;
+
+    for (std::size_t i = 0; i < linestring.size(); i++) {
+      const auto geom_pt = linestring.at(i);
+      const auto current_pt = tier4_autoware_utils::fromMsg(geom_pt);
+      const auto current2search_pt = (search_pt - current_pt);
+      // update accumulated length
+      if (i != 0) {
+        const auto p1 = tier4_autoware_utils::fromMsg(linestring.at(i - 1));
+        const auto p2 = current_pt;
+        accumulated_length += (p2 - p1).norm();
+      }
+      // update frenet coordinate
+
+      const double tmp_distance = current2search_pt.norm();
+      if (tmp_distance < min_distance) {
+        min_distance = tmp_distance;
+        frenet_coordinate.distance = tmp_distance;
+        frenet_coordinate.length = accumulated_length;
+      } else {
+        break;
+      }
+    }
+  }
+
+  // get frenet coordinate based on lines
+  bool found_on_line = false;
+  {
+    auto prev_geom_pt = linestring.front();
+    double accumulated_length = 0;
+    for (const auto & geom_pt : linestring) {
+      const auto start_pt = tier4_autoware_utils::fromMsg(prev_geom_pt);
+      const auto end_pt = tier4_autoware_utils::fromMsg(geom_pt);
+
+      const auto line_segment = end_pt - start_pt;
+      const double line_segment_length = line_segment.norm();
+      const auto direction = line_segment / line_segment_length;
+      const auto start2search_pt = (search_pt - start_pt);
+
+      double tmp_length = direction.dot(start2search_pt);
+      if (tmp_length >= 0 && tmp_length <= line_segment_length) {
+        double tmp_distance = direction.cross(start2search_pt).norm();
+        if (tmp_distance < min_distance) {
+          min_distance = tmp_distance;
+          frenet_coordinate.distance = tmp_distance;
+          frenet_coordinate.length = accumulated_length + tmp_length;
+
+          if (found_on_line) {
+            break;
+          }
+
+          found_on_line = true;
+        } else if (found_on_line) {
+          break;
+        }
+      } else if (found_on_line) {
+        break;
+      }
+      accumulated_length += line_segment_length;
+      prev_geom_pt = geom_pt;
+    }
+  }
+  return frenet_coordinate;
+}
+
 bool convertToFrenetCoordinate3d(
   const PathWithLaneId & path, const Point & search_point_geom,
   FrenetCoordinate3d * frenet_coordinate)
@@ -237,6 +312,7 @@ bool convertToFrenetCoordinate3d(
   const auto linestring = convertToPointArray(path);
   return convertToFrenetCoordinate3d(linestring, search_point_geom, frenet_coordinate);
 }
+
 
 // returns false when search point is off the linestring
 bool convertToFrenetCoordinate3d(

--- a/planning/behavior_path_planner/test/input.cpp
+++ b/planning/behavior_path_planner/test/input.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_path_planner/test/input.cpp
+++ b/planning/behavior_path_planner/test/input.cpp
@@ -1,0 +1,90 @@
+// Copyright 2022 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "input.hpp"
+
+namespace behavior_path_planner
+{
+using autoware_auto_planning_msgs::msg::PathPoint;
+using geometry_msgs::msg::Twist;
+PathWithLaneId generateStraightSamplePathWithLaneId(
+  float initial_pose_value, float pose_increment, size_t point_sample)
+{
+  PathWithLaneId path;
+  for (size_t idx = 0; idx < point_sample; ++idx) {
+    PathPoint point;
+    point.pose.position.x = std::exchange(initial_pose_value, initial_pose_value + pose_increment);
+    point.pose.position.y = 0.0;
+    point.pose.position.z = 0.0;
+    point.longitudinal_velocity_mps = 0.1;  // [m/s]
+    point.heading_rate_rps = 0.0;           // [rad/s]
+    point.is_final = (idx == point_sample - 1);
+
+    PathPointWithLaneId path_point_with_lane_id;
+    path_point_with_lane_id.point = point;
+    path_point_with_lane_id.lane_ids = std::vector<int64>();
+
+    path.header.frame_id = "map";
+    path.points.push_back(path_point_with_lane_id);
+  }
+
+  return path;
+}
+
+PathWithLaneId generateDiagonalSamplePathWithLaneId(
+  float initial_pose_value, float pose_increment, size_t point_sample)
+{
+  PathWithLaneId path;
+  for (size_t idx = 0; idx < point_sample; ++idx) {
+    PathPoint point;
+    point.pose.position.x = std::exchange(initial_pose_value, initial_pose_value + pose_increment);
+    point.pose.position.y = point.pose.position.x;
+    point.pose.position.z = 0.0;
+    point.longitudinal_velocity_mps = 0.1;  // [m/s]
+    point.heading_rate_rps = 0.0;           // [rad/s]
+    point.is_final = (idx == point_sample - 1);
+
+    PathPointWithLaneId path_point_with_lane_id;
+    path_point_with_lane_id.point = point;
+    path_point_with_lane_id.lane_ids = std::vector<int64>();
+
+    path.header.frame_id = "map";
+    path.points.push_back(path_point_with_lane_id);
+  }
+
+  return path;
+}
+
+Twist generateSampleEgoTwist(float && l_x, float && l_y, float && l_z)
+{
+  Twist twist;
+  twist.linear.x = l_x;
+  twist.linear.y = l_y;
+  twist.linear.z = l_z;
+
+  twist.angular.x = 0.0;
+  twist.angular.y = 0.0;
+  twist.angular.z = 0.0;
+
+  return twist;
+}
+
+Pose generateEgoSamplePose(float && p_x, float && p_y, float && p_z)
+{
+  Pose pose;
+  pose.position.x = p_x;
+  pose.position.y = p_y;
+  pose.position.z = p_z;
+  return pose;
+}
+}  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/test/input.hpp
+++ b/planning/behavior_path_planner/test/input.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_path_planner/test/input.hpp
+++ b/planning/behavior_path_planner/test/input.hpp
@@ -1,0 +1,40 @@
+// Copyright 2022 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INPUT_HPP_
+#define INPUT_HPP_
+
+#endif  // INPUT_HPP_
+#include "behavior_path_planner/behavior_tree_manager.hpp"
+#include "behavior_path_planner/utilities.hpp"
+
+#include "autoware_auto_planning_msgs/msg/path_point.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+#include <vector>
+
+namespace behavior_path_planner
+{
+using autoware_auto_planning_msgs::msg::PathPoint;
+using geometry_msgs::msg::Twist;
+PathWithLaneId generateStraightSamplePathWithLaneId(
+  float initial_pose_value, float pose_increment, size_t point_sample);
+
+PathWithLaneId generateDiagonalSamplePathWithLaneId(
+  float initial_pose_value, float pose_increment, size_t point_sample);
+
+Twist generateSampleEgoTwist(float && l_x, float && l_y, float && l_z);
+
+Pose generateEgoSamplePose(float && p_x, float && p_y, float && p_z);
+}  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/test/test_utilities.cpp
+++ b/planning/behavior_path_planner/test/test_utilities.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Tier IV, Inc.
+// Copyright 2022 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_path_planner/test/test_utilities.cpp
+++ b/planning/behavior_path_planner/test/test_utilities.cpp
@@ -1,0 +1,84 @@
+// Copyright 2022 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "input.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using behavior_path_planner::PathWithLaneId;
+using behavior_path_planner::Pose;
+using behavior_path_planner::util::FrenetCoordinate3d;
+using geometry_msgs::msg::Point;
+
+TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetOnStraightLine)
+{
+  PathWithLaneId path =
+    behavior_path_planner::generateStraightSamplePathWithLaneId(0.0f, 1.0f, 10u);
+  std::vector<Point> geometry_points =
+    behavior_path_planner::util::convertToGeometryPointArray(path);
+  Pose vehicle_pose = behavior_path_planner::generateEgoSamplePose(10.7f, -1.7f, 0.0);
+
+  FrenetCoordinate3d vehicle_pose_frenet = behavior_path_planner::util::convertToFrenetCoordinate3d(
+    geometry_points, vehicle_pose.position);
+
+  EXPECT_NEAR(vehicle_pose_frenet.distance, -1.7f, 1e-3);
+  EXPECT_NEAR(vehicle_pose_frenet.length, 10.7f, 1e-3);
+}
+
+TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetOnDiagonalLine)
+{
+  PathWithLaneId path =
+    behavior_path_planner::generateDiagonalSamplePathWithLaneId(0.0f, 1.0f, 10u);
+  std::vector<Point> geometry_points =
+    behavior_path_planner::util::convertToGeometryPointArray(path);
+  Pose vehicle_pose = behavior_path_planner::generateEgoSamplePose(0.1f, 0.1f, 0.0);
+
+  FrenetCoordinate3d vehicle_pose_frenet = behavior_path_planner::util::convertToFrenetCoordinate3d(
+    geometry_points, vehicle_pose.position);
+
+  EXPECT_NEAR(vehicle_pose_frenet.distance, 0, 1e-2);
+  EXPECT_NEAR(vehicle_pose_frenet.length, 0.1414f, 1e-2);
+}
+
+TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetWhenEgoIsOnPath)
+{
+  PathWithLaneId path =
+    behavior_path_planner::generateDiagonalSamplePathWithLaneId(0.0f, 1.0f, 10u);
+  std::vector<Point> geometry_points =
+    behavior_path_planner::util::convertToGeometryPointArray(path);
+  Pose vehicle_pose = behavior_path_planner::generateEgoSamplePose(0.1f, 0.1f, 0.0);
+
+  FrenetCoordinate3d vehicle_pose_frenet;
+
+  const bool is_on_path = behavior_path_planner::util::convertToFrenetCoordinate3d(
+    geometry_points, vehicle_pose.position, &vehicle_pose_frenet);
+
+  EXPECT_TRUE(is_on_path);
+}
+
+TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetWhenEgoIsNotOnPath)
+{
+  PathWithLaneId path =
+    behavior_path_planner::generateDiagonalSamplePathWithLaneId(0.0f, 1.0f, 10u);
+  std::vector<Point> geometry_points =
+    behavior_path_planner::util::convertToGeometryPointArray(path);
+  Pose vehicle_pose = behavior_path_planner::generateEgoSamplePose(-0.01f, -0.01f, 0.0);
+
+  FrenetCoordinate3d vehicle_pose_frenet;
+
+  const bool is_on_path = behavior_path_planner::util::convertToFrenetCoordinate3d(
+    geometry_points, vehicle_pose.position, &vehicle_pose_frenet);
+
+  EXPECT_FALSE(is_on_path);
+}


### PR DESCRIPTION
## Description

The function `convertToFreNetCoordinate3d` seems to be buggy.

Since that it is currently there is not way to visualize the result, `gmock` is used to verify the result.
The following is the unit test result with the current version 
```
❯ ./build/behavior_path_planner/test_behavior_path_planner_utilities
Running main() from gmock_main.cc
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from BehaviorPathPlanningUtilitiesBehaviorTest
[ RUN      ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetOnStraightLine
/home/name/workspace/autoware/src/autoware/universe/planning/behavior_path_planner/test/test_utilities.cpp:35: Failure
The difference between vehicle_pose_frenet.distance and -1.7f is 4.1041630025655467, which exceeds 1e-3, where
vehicle_pose_frenet.distance evaluates to 2.4041629548818308,
-1.7f evaluates to -1.7000000476837158, and
1e-3 evaluates to 0.001.
/home/name/workspace/autoware/src/autoware/universe/planning/behavior_path_planner/test/test_utilities.cpp:36: Failure
The difference between vehicle_pose_frenet.length and 10.7f is 1.6999998092651367, which exceeds 1e-3, where
vehicle_pose_frenet.length evaluates to 9,
10.7f evaluates to 10.699999809265137, and
1e-3 evaluates to 0.001.
[  FAILED  ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetOnStraightLine (1 ms)
[ RUN      ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetOnDiagonalLine
[       OK ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetOnDiagonalLine (0 ms)
[ RUN      ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetWhenEgoIsOnPath
[       OK ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetWhenEgoIsOnPath (0 ms)
[ RUN      ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetWhenEgoIsNotOnPath
[       OK ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetWhenEgoIsNotOnPath (0 ms)
[----------] 4 tests from BehaviorPathPlanningUtilitiesBehaviorTest (1 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetOnStraightLine
```

This PR aims to rewrite the function to get the correct value.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

### To test the original implementation of the function
```
git checkout 628257cebf42a1b6f7d62d80298e229d80f3d2ff
```
Note: the hash might be different after `git remote add` but, all you have to do is to checkout the **first** commit of this PR.

Then rebuilt autoware using following
```
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTING=ON --symlink-install --parallel-workers 6 --continue-on-error --packages-select=behavior_path_planner

colcon test --packages-select behavior_path_planner

colcon test-result --all --verbose

```
 
To check on the result, 
```
./build/behavior_path_planner/test_behavior_path_planner_utilities

```

### To the the new rewritten function
```
git checkout 1379511192553648f3d9f1939be45277358a6e5f
```
Note: the hash might be different after update of `git remote add` but, all you have to do is to checkout the **latest** commit of this PR.
Then rebuilt autoware using following
```
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTING=ON --symlink-install --parallel-workers 6 --continue-on-error --packages-select=behavior_path_planner

colcon test --packages-select behavior_path_planner

colcon test-result --all --verbose

```
 
To check on the result, 
```
./build/behavior_path_planner/test_behavior_path_planner_utilities

```

You should get the following result
```
❯ ./build/behavior_path_planner/test_behavior_path_planner_utilities
Running main() from gmock_main.cc
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from BehaviorPathPlanningUtilitiesBehaviorTest
[ RUN      ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetOnStraightLine
[       OK ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetOnStraightLine (0 ms)
[ RUN      ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetOnDiagonalLine
[       OK ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetOnDiagonalLine (0 ms)
[ RUN      ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetWhenEgoIsOnPath
[       OK ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetWhenEgoIsOnPath (0 ms)
[ RUN      ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetWhenEgoIsNotOnPath
[       OK ] BehaviorPathPlanningUtilitiesBehaviorTest.vehiclePoseToFrenetWhenEgoIsNotOnPath (0 ms)
[----------] 4 tests from BehaviorPathPlanningUtilitiesBehaviorTest (0 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 4 tests.
```

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
