### PR TITLE
fix(route_handler): dereference to null cause avoidance module crash

### DIFF
--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -938,6 +938,9 @@ lanelet::ConstLanelets RouteHandler::getAllLeftSharedLinestringLanelets(
   while (lanelet_at_left) {
     linestring_shared.push_back(lanelet_at_left.get());
     lanelet_at_left = getLeftLanelet(lanelet_at_left.get());
+    if (!lanelet_at_left) {
+      break;
+    }
     lanelet_at_left_opposite = getLeftOppositeLanelets(lanelet_at_left.get());
   }
 
@@ -961,6 +964,9 @@ lanelet::ConstLanelets RouteHandler::getAllRightSharedLinestringLanelets(
   while (lanelet_at_right) {
     linestring_shared.push_back(lanelet_at_right.get());
     lanelet_at_right = getRightLanelet(lanelet_at_right.get());
+    if (!lanelet_at_right) {
+      break;
+    }
     lanelet_at_right_opposite = getRightOppositeLanelets(lanelet_at_right.get());
   }
 


### PR DESCRIPTION
This crash will not appear unless drivable area boundary is added.

Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

Currently there is a possibility of behavior_path_planner crashes, due to improper  use of`get` function for `boost::optional` in the route handler's lanelet getter. To avoid this issue, it is essential to check for `nullptr` before get the data.

This will not affect any behavior of the module.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
