### PR TITLE
refactor(behavior_path_planner): reorganize debug visualization

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -11,6 +11,7 @@ ament_auto_add_library(behavior_path_planner_node SHARED
   src/behavior_tree_manager.cpp
   src/utilities.cpp
   src/path_utilities.cpp
+  src/debug_utilities.cpp
   src/path_shifter/path_shifter.cpp
   src/turn_signal_decider.cpp
   src/scene_module/scene_module_bt_node_interface.cpp

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -18,7 +18,6 @@
 #include "behavior_path_planner/behavior_tree_manager.hpp"
 #include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module.hpp"
-#include "behavior_path_planner/scene_module/avoidance/debug.hpp"
 #include "behavior_path_planner/scene_module/lane_change/lane_change_module.hpp"
 #include "behavior_path_planner/scene_module/lane_following/lane_following_module.hpp"
 #include "behavior_path_planner/scene_module/pull_out/pull_out_module.hpp"

--- a/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
@@ -40,23 +40,55 @@ using behavior_path_planner::ShiftPointArray;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Polygon;
 using geometry_msgs::msg::Pose;
+using geometry_msgs::msg::Vector3;
+using std_msgs::msg::ColorRGBA;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 
 inline int64_t bitShift(int64_t original_id) { return original_id << (sizeof(int32_t) * 8 / 2); }
 
-Marker initializeMarker(
-  std::string && frame_id, const std::string & ns, const Marker::_type_type & type);
+inline Marker createDefaultMarker(
+  const std::string & frame_id, const rclcpp::Time & now, const std::string & ns, const int32_t id,
+  const int & type, const Vector3 & scale, const ColorRGBA & color)
+{
+  Marker marker{};
 
-Marker initializeMarker(
-  std::string && frame_id, const std::string & ns, const int id, const Marker::_type_type & type);
+  marker.header.frame_id = frame_id;
+  marker.header.stamp = now;
+  marker.ns = ns;
+  marker.id = id;
+  marker.type = type;
+  marker.action = Marker::ADD;
+  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+
+  marker.scale = scale;
+  marker.color = color;
+
+  return marker;
+}
+
+inline Marker createDefaultMarker(
+  std::string && frame_id, const rclcpp::Time & now, std::string && ns, const int32_t id,
+  const int & type, const Vector3 & scale, const ColorRGBA & color)
+{
+  Marker marker{};
+
+  marker.header.frame_id = frame_id;
+  marker.header.stamp = now;
+  marker.ns = ns;
+  marker.id = id;
+  marker.type = type;
+  marker.action = Marker::ADD;
+  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+
+  marker.scale = scale;
+  marker.color = color;
+
+  return marker;
+}
 
 MarkerArray createPoseMarkerArray(
-  const Pose & pose, const std::string & ns, const int id, const float r, const float g,
-  const float b);
-
-MarkerArray createPoseLineMarkerArray(
-  const Pose & pose, const std::string & ns, const int64_t id, const float r, const float g,
+  const Pose & pose, const std::string & ns, const int32_t id, const float r, const float g,
   const float b);
 
 MarkerArray createPathMarkerArray(

--- a/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
@@ -1,0 +1,91 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef BEHAVIOR_PATH_PLANNER__DEBUG_UTILITIES_HPP_
+#define BEHAVIOR_PATH_PLANNER__DEBUG_UTILITIES_HPP_
+
+#include "behavior_path_planner/path_shifter/path_shifter.hpp"
+#include "behavior_path_planner/path_utilities.hpp"
+#include "behavior_path_planner/utilities.hpp"
+
+#include <tier4_autoware_utils/ros/marker_helper.hpp>
+
+#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
+#include <geometry_msgs/msg/polygon.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_routing/RoutingGraph.h>
+#include <tf2/utils.h>
+
+#include <string>
+#include <vector>
+
+namespace marker_utils
+{
+using autoware_auto_perception_msgs::msg::PredictedObjects;
+using autoware_auto_planning_msgs::msg::PathWithLaneId;
+using behavior_path_planner::ShiftPointArray;
+using geometry_msgs::msg::Point;
+using geometry_msgs::msg::Polygon;
+using geometry_msgs::msg::Pose;
+using visualization_msgs::msg::Marker;
+using visualization_msgs::msg::MarkerArray;
+
+inline int64_t bitShift(int64_t original_id) { return original_id << (sizeof(int32_t) * 8 / 2); }
+
+Marker initializeMarker(
+  std::string && frame_id, const std::string & ns, const Marker::_type_type & type);
+
+Marker initializeMarker(
+  std::string && frame_id, const std::string & ns, const int id, const Marker::_type_type & type);
+
+MarkerArray createPoseMarkerArray(
+  const Pose & pose, const std::string & ns, const int id, const float r, const float g,
+  const float b);
+
+MarkerArray createPoseLineMarkerArray(
+  const Pose & pose, const std::string & ns, const int64_t id, const float r, const float g,
+  const float b);
+
+MarkerArray createPathMarkerArray(
+  const PathWithLaneId & path, const std::string & ns, const int64_t lane_id, const float r,
+  const float g, const float b);
+
+MarkerArray createShiftPointMarkerArray(
+  const ShiftPointArray & shift_points, const double base_shift, const std::string & ns,
+  const float & r, const float & g, const float & b, const float & w);
+
+MarkerArray createShiftLengthMarkerArray(
+  const std::vector<double> & shift_distance,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & reference, const std::string & ns,
+  const float r, const float g, const float b);
+
+MarkerArray createLaneletsAreaMarkerArray(
+  const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns, const float r,
+  const float g, const float b);
+
+MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3d & linestrings);
+
+MarkerArray createPolygonMarkerArray(
+  const Polygon & polygon, const std::string & ns, const int64_t lane_id, const float r,
+  const float g, const float b);
+
+MarkerArray createObjectsMarkerArray(
+  const PredictedObjects & objects, const std::string & ns, const int64_t lane_id, const float r,
+  const float g, const float b);
+
+}  // namespace marker_utils
+
+#endif  // BEHAVIOR_PATH_PLANNER__DEBUG_UTILITIES_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
@@ -47,46 +47,6 @@ using visualization_msgs::msg::MarkerArray;
 
 inline int64_t bitShift(int64_t original_id) { return original_id << (sizeof(int32_t) * 8 / 2); }
 
-inline Marker createDefaultMarker(
-  const std::string & frame_id, const rclcpp::Time & now, const std::string & ns, const int32_t id,
-  const int & type, const Vector3 & scale, const ColorRGBA & color)
-{
-  Marker marker{};
-
-  marker.header.frame_id = frame_id;
-  marker.header.stamp = now;
-  marker.ns = ns;
-  marker.id = id;
-  marker.type = type;
-  marker.action = Marker::ADD;
-  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-
-  marker.scale = scale;
-  marker.color = color;
-
-  return marker;
-}
-
-inline Marker createDefaultMarker(
-  std::string && frame_id, const rclcpp::Time & now, std::string && ns, const int32_t id,
-  const int & type, const Vector3 & scale, const ColorRGBA & color)
-{
-  Marker marker{};
-
-  marker.header.frame_id = frame_id;
-  marker.header.stamp = now;
-  marker.ns = ns;
-  marker.id = id;
-  marker.type = type;
-  marker.action = Marker::ADD;
-  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-
-  marker.scale = scale;
-  marker.color = color;
-
-  return marker;
-}
-
 MarkerArray createPoseMarkerArray(
   const Pose & pose, std::string && ns, const int32_t & id, const float & r, const float & g,
   const float & b);

--- a/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
@@ -88,35 +88,35 @@ inline Marker createDefaultMarker(
 }
 
 MarkerArray createPoseMarkerArray(
-  const Pose & pose, const std::string & ns, const int32_t id, const float r, const float g,
-  const float b);
+  const Pose & pose, std::string && ns, const int32_t & id, const float & r, const float & g,
+  const float & b);
 
 MarkerArray createPathMarkerArray(
-  const PathWithLaneId & path, const std::string & ns, const int64_t lane_id, const float r,
-  const float g, const float b);
+  const PathWithLaneId & path, std::string && ns, const int64_t & lane_id, const float & r,
+  const float & g, const float & b);
 
 MarkerArray createShiftPointMarkerArray(
-  const ShiftPointArray & shift_points, const double base_shift, const std::string & ns,
+  const ShiftPointArray & shift_points, const double & base_shift, std::string && ns,
   const float & r, const float & g, const float & b, const float & w);
 
 MarkerArray createShiftLengthMarkerArray(
   const std::vector<double> & shift_distance,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & reference, const std::string & ns,
-  const float r, const float g, const float b);
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & reference, std::string && ns,
+  const float & r, const float & g, const float & b);
 
 MarkerArray createLaneletsAreaMarkerArray(
-  const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns, const float r,
-  const float g, const float b);
+  const std::vector<lanelet::ConstLanelet> & lanelets, std::string && ns, const float & r,
+  const float & g, const float & b);
 
 MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3d & linestrings);
 
 MarkerArray createPolygonMarkerArray(
-  const Polygon & polygon, const std::string & ns, const int64_t lane_id, const float r,
-  const float g, const float b);
+  const Polygon & polygon, std::string && ns, const int64_t & lane_id, const float & r,
+  const float & g, const float & b);
 
 MarkerArray createObjectsMarkerArray(
-  const PredictedObjects & objects, const std::string & ns, const int64_t lane_id, const float r,
-  const float g, const float b);
+  const PredictedObjects & objects, std::string && ns, const int64_t & lane_id, const float & r,
+  const float & g, const float & b);
 
 }  // namespace marker_utils
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -15,6 +15,7 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__DEBUG_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__DEBUG_HPP_
 
+#include "behavior_path_planner/debug_utilities.hpp"
 #include "behavior_path_planner/path_shifter/path_shifter.hpp"
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp"
 
@@ -31,61 +32,23 @@
 #include <string>
 #include <vector>
 
-namespace marker_utils
+namespace marker_utils::avoidance_marker
 {
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
-using behavior_path_planner::AvoidPoint;
 using behavior_path_planner::AvoidPointArray;
-using behavior_path_planner::ShiftPoint;
 using behavior_path_planner::ShiftPointArray;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Polygon;
 using geometry_msgs::msg::Pose;
 using visualization_msgs::msg::MarkerArray;
 
-MarkerArray createShiftLengthMarkerArray(
-  const std::vector<double> shift_distance, const PathWithLaneId & reference,
-  const std::string & ns, const double r, const double g, const double b);
-
 MarkerArray createAvoidPointMarkerArray(
-  const AvoidPointArray & shift_points, const std::string & ns, const double r, const double g,
-  const double b, const double w);
-
-MarkerArray createShiftPointMarkerArray(
-  const ShiftPointArray & shift_points, const double base_shift, const std::string & ns,
-  const double r, const double g, const double b, const double w);
-
-MarkerArray createLaneletsAreaMarkerArray(
-  const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns, const double r,
-  const double g, const double b);
-
-MarkerArray createLaneletPolygonsMarkerArray(
-  const std::vector<lanelet::CompoundPolygon3d> & polygons, const std::string & ns,
-  const int64_t lane_id);
-
-MarkerArray createPolygonMarkerArray(
-  const Polygon & polygon, const std::string & ns, const int64_t lane_id, const double r,
-  const double g, const double b);
-
-MarkerArray createObjectsMarkerArray(
-  const PredictedObjects & objects, const std::string & ns, const int64_t lane_id, const double r,
-  const double g, const double b);
+  const AvoidPointArray & shift_points, const std::string & ns, const float r, const float g,
+  const float b, const double w);
 
 MarkerArray createAvoidanceObjectsMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects, const std::string & ns);
-
-MarkerArray createPathMarkerArray(
-  const PathWithLaneId & path, const std::string & ns, const int64_t lane_id, const double r,
-  const double g, const double b);
-
-MarkerArray createPoseLineMarkerArray(
-  const Pose & pose, const std::string & ns, const int64_t id, const double r, const double g,
-  const double b);
-
-MarkerArray createPoseMarkerArray(
-  const Pose & pose, const std::string & ns, const int64_t id, const double r, const double g,
-  const double b);
 
 MarkerArray makeOverhangToRoadShoulderMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects);
@@ -94,8 +57,7 @@ MarkerArray createOverhangFurthestLineStringMarkerArray(
   const lanelet::ConstLineStrings3d & linestrings, const std::string & ns, const double r,
   const double g, const double b);
 
-MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3d & linestrings);
-}  // namespace marker_utils
+}  // namespace marker_utils::avoidance_marker
 
 std::string toStrInfo(const behavior_path_planner::ShiftPointArray & sp_arr);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -44,18 +44,18 @@ using geometry_msgs::msg::Pose;
 using visualization_msgs::msg::MarkerArray;
 
 MarkerArray createAvoidPointMarkerArray(
-  const AvoidPointArray & shift_points, const std::string & ns, const float r, const float g,
-  const float b, const double w);
+  const AvoidPointArray & shift_points, std::string && ns, const float & r, const float & g,
+  const float & b, const double & w);
 
 MarkerArray createAvoidanceObjectsMarkerArray(
-  const behavior_path_planner::ObjectDataArray & objects, const std::string & ns);
+  const behavior_path_planner::ObjectDataArray & objects, std::string && ns);
 
 MarkerArray makeOverhangToRoadShoulderMarkerArray(
-  const behavior_path_planner::ObjectDataArray & objects);
+  const behavior_path_planner::ObjectDataArray & objects, std::string && ns);
 
 MarkerArray createOverhangFurthestLineStringMarkerArray(
-  const lanelet::ConstLineStrings3d & linestrings, std::string && ns, const float r, const float g,
-  const float b);
+  const lanelet::ConstLineStrings3d & linestrings, std::string && ns, const float & r,
+  const float & g, const float & b);
 
 }  // namespace marker_utils::avoidance_marker
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -54,8 +54,8 @@ MarkerArray makeOverhangToRoadShoulderMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects);
 
 MarkerArray createOverhangFurthestLineStringMarkerArray(
-  const lanelet::ConstLineStrings3d & linestrings, const std::string & ns, const double r,
-  const double g, const double b);
+  const lanelet::ConstLineStrings3d & linestrings, std::string && ns, const float r, const float g,
+  const float b);
 
 }  // namespace marker_utils::avoidance_marker
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -14,6 +14,7 @@
 
 #include "behavior_path_planner/behavior_path_planner_node.hpp"
 
+#include "behavior_path_planner/debug_utilities.hpp"
 #include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module.hpp"
 #include "behavior_path_planner/scene_module/lane_change/lane_change_module.hpp"

--- a/planning/behavior_path_planner/src/debug_utilities.cpp
+++ b/planning/behavior_path_planner/src/debug_utilities.cpp
@@ -19,76 +19,24 @@ namespace marker_utils
 using behavior_path_planner::ShiftPoint;
 using behavior_path_planner::util::calcPathArcLengthArray;
 using behavior_path_planner::util::shiftPose;
+using std_msgs::msg::ColorRGBA;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerOrientation;
 using tier4_autoware_utils::createMarkerScale;
+using tier4_autoware_utils::createPoint;
 using visualization_msgs::msg::Marker;
 
-Marker initializeMarker(
-  std::string && frame_id, const std::string & ns, const Marker::_type_type & type)
-{
-  Marker marker{};
-  marker.header.frame_id = frame_id;
-  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-  marker.ns = ns;
-  marker.type = type;
-  return marker;
-}
-
-Marker initializeMarker(
-  std::string && frame_id, const std::string & ns, const int id, const Marker::_type_type & type)
-{
-  Marker marker = initializeMarker(std::move(frame_id), ns, type);
-  marker.id = id;
-  return marker;
-}
-
 MarkerArray createPoseMarkerArray(
-  const Pose & pose, const std::string & ns, const int id, const float r, const float g,
+  const Pose & pose, const std::string & ns, const int32_t id, const float r, const float g,
   const float b)
 {
   MarkerArray msg;
 
-  Marker marker = initializeMarker("map", ns, id, Marker::ARROW);
-  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
-  marker.action = Marker::ADD;
+  Marker marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, id, Marker::ARROW,
+    createMarkerScale(0.7, 0.3, 0.3), createMarkerColor(r, g, b, 0.999));
   marker.pose = pose;
-  marker.scale = createMarkerScale(0.7, 0.3, 0.3);
-  marker.color = createMarkerColor(r, g, b, 0.999);
   msg.markers.push_back(marker);
-
-  return msg;
-}
-
-MarkerArray createPoseLineMarkerArray(
-  const Pose & pose, const std::string & ns, const int64_t id, const float r, const float g,
-  const float b)
-{
-  Marker marker_line = initializeMarker("map", ns + "_line", id, Marker::LINE_STRIP);
-  marker_line.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
-  marker_line.action = Marker::ADD;
-  marker_line.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-  marker_line.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
-  marker_line.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
-
-  const double yaw = tf2::getYaw(pose.orientation);
-
-  const double a = 3.0;
-  Point p0;
-  p0.x = pose.position.x - a * std::sin(yaw);
-  p0.y = pose.position.y + a * std::cos(yaw);
-  p0.z = pose.position.z;
-  marker_line.points.push_back(p0);
-
-  Point p1;
-  p1.x = pose.position.x + a * std::sin(yaw);
-  p1.y = pose.position.y - a * std::cos(yaw);
-  p1.z = pose.position.z;
-  marker_line.points.push_back(p1);
-
-  MarkerArray msg;
-
-  msg.markers.push_back(marker_line);
 
   return msg;
 }
@@ -100,16 +48,14 @@ MarkerArray createPathMarkerArray(
   const auto arclength = calcPathArcLengthArray(path);
   const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
   MarkerArray msg;
-  int32_t uid = bitShift(lane_id);
-  int32_t i = 0;
-  int32_t idx = 0;
+  const int32_t uid = bitShift(lane_id);
+  int32_t i{0};
+  int32_t idx{0};
   for (const auto & p : path.points) {
-    Marker marker = initializeMarker("map", ns, uid + i++, Marker::ARROW);
-    marker.header.stamp = current_time;
-    marker.action = Marker::ADD;
+    Marker marker = createDefaultMarker(
+      "map", current_time, ns, uid + i++, Marker::ARROW, createMarkerScale(0.2, 0.1, 0.3),
+      createMarkerColor(r, g, b, 0.999));
     marker.pose = p.point.pose;
-    marker.scale = tier4_autoware_utils::createMarkerScale(0.2, 0.1, 0.3);
-    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
     msg.markers.push_back(marker);
     if (idx % 10 == 0) {
       auto marker_text = marker;
@@ -143,29 +89,27 @@ MarkerArray createShiftPointMarkerArray(
   double current_shift = base_shift;
   for (const auto & sp : shift_points_local) {
     // ROS_ERROR("sp: s = (%f, %f), g = (%f, %f)", sp.start.x, sp.start.y, sp.end.x, sp.end.y);
-    Marker marker = initializeMarker("map", ns, Marker::CUBE);
-    marker.header.stamp = current_time;
-    marker.action = Marker::ADD;
-    marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
-    marker.scale = createMarkerScale(0.5, 0.5, 0.5);
-    marker.color = createMarkerColor(r, g, b, 0.5);
+    Marker basic_marker = createDefaultMarker(
+      "map", current_time, ns, 0L, Marker::CUBE, createMarkerScale(0.5, 0.5, 0.5),
+      createMarkerColor(r, g, b, 0.5));
+    basic_marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
     {
       // start point
-      auto marker_s = marker;
+      auto marker_s = basic_marker;
       marker_s.id = id++;
       marker_s.pose = sp.start;
       shiftPose(&marker_s.pose, current_shift);  // old
       msg.markers.push_back(marker_s);
 
       // end point
-      auto marker_e = marker;
+      auto marker_e = basic_marker;
       marker_e.id = id++;
       marker_e.pose = sp.end;
       shiftPose(&marker_e.pose, sp.length);
       msg.markers.push_back(marker_e);
 
       // start-to-end line
-      auto marker_l = marker;
+      auto marker_l = basic_marker;
       marker_l.id = id++;
       marker_l.type = Marker::LINE_STRIP;
       marker_l.scale = createMarkerScale(w, 0.0, 0.0);
@@ -184,18 +128,16 @@ MarkerArray createShiftLengthMarkerArray(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & reference, const std::string & ns,
   const float r, const float g, const float b)
 {
-  MarkerArray msg;
-
   if (shift_distance.size() != reference.points.size()) {
-    return msg;
+    return MarkerArray{};
   }
 
-  Marker marker = initializeMarker("map", ns, Marker::LINE_STRIP);
-  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
-  marker.action = Marker::ADD;
+  MarkerArray msg;
+
+  Marker marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::LINE_STRIP,
+    createMarkerScale(0.1, 0.0, 0.0), createMarkerColor(r, g, b, 0.9));
   marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-  marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
-  marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.9);
 
   for (size_t i = 0; i < shift_distance.size(); ++i) {
     auto p = reference.points.at(i).point.pose;
@@ -215,22 +157,18 @@ MarkerArray createLaneletsAreaMarkerArray(
   MarkerArray msg;
 
   for (const auto & lanelet : lanelets) {
-    Marker marker = initializeMarker("map", ns, lanelet.id(), Marker::LINE_STRIP);
-    marker.header.stamp = current_time;
-    marker.action = Marker::ADD;
+    Marker marker = createDefaultMarker(
+      "map", current_time, ns, static_cast<int32_t>(lanelet.id()), Marker::LINE_STRIP,
+      createMarkerScale(0.1, 0.0, 0.0), createMarkerColor(r, g, b, 0.999));
     marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-    marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
-    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
     for (const auto & p : lanelet.polygon3d()) {
-      Point point;
-      point.x = p.x();
-      point.y = p.y();
-      point.z = p.z();
-      marker.points.push_back(point);
+      marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
     }
+
     if (!marker.points.empty()) {
       marker.points.push_back(marker.points.front());
     }
+
     msg.markers.push_back(marker);
   }
 
@@ -243,14 +181,10 @@ MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3
     return MarkerArray();
   }
 
-  MarkerArray msg;
-
-  Marker marker = initializeMarker("map", "shared_linestring_lanelets", Marker::LINE_STRIP);
-  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
-  marker.action = Marker::ADD;
+  Marker marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "shared_linestring_lanelets", 0L, Marker::LINE_STRIP,
+    createMarkerScale(0.3, 0.0, 0.0), createMarkerColor(0.996, 0.658, 0.466, 0.999));
   marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-  marker.scale = tier4_autoware_utils::createMarkerScale(0.3, 0.0, 0.0);
-  marker.color = tier4_autoware_utils::createMarkerColor(0.996, 0.658, 0.466, 0.999);
 
   const auto reserve_size = linestrings.size() / 2;
   lanelet::ConstLineStrings3d lefts;
@@ -264,61 +198,49 @@ MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3
 
   const auto & first_ls = lefts.front().basicLineString();
   for (const auto & ls : first_ls) {
-    Point p;
-    p.x = ls.x();
-    p.y = ls.y();
-    p.z = ls.z();
-    marker.points.push_back(p);
+    marker.points.push_back(createPoint(ls.x(), ls.y(), ls.z()));
   }
 
   for (auto idx = lefts.cbegin() + 1; idx != lefts.cend(); ++idx) {
+    Point front = createPoint(
+      idx->basicLineString().front().x(), idx->basicLineString().front().y(),
+      idx->basicLineString().front().z());
+    Point front_inverted = createPoint(
+      idx->invert().basicLineString().front().x(), idx->invert().basicLineString().front().y(),
+      idx->invert().basicLineString().front().z());
+
     const auto & marker_back = marker.points.back();
-    Point front;
-    front.x = idx->basicLineString().front().x();
-    front.y = idx->basicLineString().front().y();
-    front.z = idx->basicLineString().front().z();
-    Point front_inverted;
-    front_inverted.x = idx->invert().basicLineString().front().x();
-    front_inverted.y = idx->invert().basicLineString().front().y();
-    front_inverted.z = idx->invert().basicLineString().front().z();
     const bool isFrontNear = tier4_autoware_utils::calcDistance2d(marker_back, front) <
                              tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
     const auto & left_ls = (isFrontNear) ? idx->basicLineString() : idx->invert().basicLineString();
     for (auto ls = left_ls.cbegin(); ls != left_ls.cend(); ++ls) {
-      Point p;
-      p.x = ls->x();
-      p.y = ls->y();
-      p.z = ls->z();
-      marker.points.push_back(p);
+      marker.points.push_back(createPoint(ls->x(), ls->y(), ls->z()));
     }
   }
 
   for (auto idx = rights.crbegin(); idx != rights.crend(); ++idx) {
+    Point front = createPoint(
+      idx->basicLineString().front().x(), idx->basicLineString().front().y(),
+      idx->basicLineString().front().z());
+    Point front_inverted = createPoint(
+      idx->invert().basicLineString().front().x(), idx->invert().basicLineString().front().y(),
+      idx->invert().basicLineString().front().z());
+
     const auto & marker_back = marker.points.back();
-    Point front;
-    front.x = idx->basicLineString().front().x();
-    front.y = idx->basicLineString().front().y();
-    front.z = idx->basicLineString().front().z();
-    Point front_inverted;
-    front_inverted.x = idx->invert().basicLineString().front().x();
-    front_inverted.y = idx->invert().basicLineString().front().y();
-    front_inverted.z = idx->invert().basicLineString().front().z();
     const bool isFrontFurther = tier4_autoware_utils::calcDistance2d(marker_back, front) >
                                 tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
     const auto & right_ls =
       (isFrontFurther) ? idx->basicLineString() : idx->invert().basicLineString();
     for (auto ls = right_ls.crbegin(); ls != right_ls.crend(); ++ls) {
-      Point p;
-      p.x = ls->x();
-      p.y = ls->y();
-      p.z = ls->z();
-      marker.points.push_back(p);
+      marker.points.push_back(createPoint(ls->x(), ls->y(), ls->z()));
     }
   }
 
   if (!marker.points.empty()) {
     marker.points.push_back(marker.points.front());
   }
+
+  MarkerArray msg;
 
   msg.markers.push_back(marker);
   return msg;
@@ -328,25 +250,20 @@ MarkerArray createPolygonMarkerArray(
   const Polygon & polygon, const std::string & ns, const int64_t lane_id, const float r,
   const float g, const float b)
 {
-  Marker marker = initializeMarker("map", ns, lane_id, Marker::LINE_STRIP);
+  Marker marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, static_cast<int32_t>(lane_id), Marker::LINE_STRIP,
+    createMarkerScale(0.3, 0.0, 0.0), createMarkerColor(r, g, b, 0.8));
 
-  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
-  marker.action = Marker::ADD;
   marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-  marker.scale = tier4_autoware_utils::createMarkerScale(0.3, 0.0, 0.0);
-  marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.8);
 
-  MarkerArray msg;
   for (const auto & p : polygon.points) {
-    Point point;
-    point.x = p.x;
-    point.y = p.y;
-    point.z = p.z;
-    marker.points.push_back(point);
+    marker.points.push_back(createPoint(p.x, p.y, p.z));
   }
   if (!marker.points.empty()) {
     marker.points.push_back(marker.points.front());
   }
+
+  MarkerArray msg;
   msg.markers.push_back(marker);
 
   return msg;
@@ -356,9 +273,9 @@ MarkerArray createObjectsMarkerArray(
   const PredictedObjects & objects, const std::string & ns, const int64_t lane_id, const float r,
   const float g, const float b)
 {
-  Marker marker = initializeMarker("map", ns, Marker::CUBE);
-  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
-  marker.ns = ns;
+  Marker marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE,
+    createMarkerScale(3.0, 1.0, 1.0), createMarkerColor(r, g, b, 0.8));
 
   int32_t uid = bitShift(lane_id);
   int32_t i{0};
@@ -366,11 +283,7 @@ MarkerArray createObjectsMarkerArray(
   MarkerArray msg;
   for (const auto & object : objects.objects) {
     marker.id = uid + i++;
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.action = Marker::ADD;
     marker.pose = object.kinematics.initial_pose_with_covariance.pose;
-    marker.scale = tier4_autoware_utils::createMarkerScale(3.0, 1.0, 1.0);
-    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.8);
     msg.markers.push_back(marker);
   }
 

--- a/planning/behavior_path_planner/src/debug_utilities.cpp
+++ b/planning/behavior_path_planner/src/debug_utilities.cpp
@@ -1,0 +1,379 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "behavior_path_planner/debug_utilities.hpp"
+
+namespace marker_utils
+{
+using behavior_path_planner::ShiftPoint;
+using behavior_path_planner::util::calcPathArcLengthArray;
+using behavior_path_planner::util::shiftPose;
+using tier4_autoware_utils::createMarkerColor;
+using tier4_autoware_utils::createMarkerOrientation;
+using tier4_autoware_utils::createMarkerScale;
+using visualization_msgs::msg::Marker;
+
+Marker initializeMarker(
+  std::string && frame_id, const std::string & ns, const Marker::_type_type & type)
+{
+  Marker marker{};
+  marker.header.frame_id = frame_id;
+  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker.ns = ns;
+  marker.type = type;
+  return marker;
+}
+
+Marker initializeMarker(
+  std::string && frame_id, const std::string & ns, const int id, const Marker::_type_type & type)
+{
+  Marker marker = initializeMarker(std::move(frame_id), ns, type);
+  marker.id = id;
+  return marker;
+}
+
+MarkerArray createPoseMarkerArray(
+  const Pose & pose, const std::string & ns, const int id, const float r, const float g,
+  const float b)
+{
+  MarkerArray msg;
+
+  Marker marker = initializeMarker("map", ns, id, Marker::ARROW);
+  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
+  marker.action = Marker::ADD;
+  marker.pose = pose;
+  marker.scale = createMarkerScale(0.7, 0.3, 0.3);
+  marker.color = createMarkerColor(r, g, b, 0.999);
+  msg.markers.push_back(marker);
+
+  return msg;
+}
+
+MarkerArray createPoseLineMarkerArray(
+  const Pose & pose, const std::string & ns, const int64_t id, const float r, const float g,
+  const float b)
+{
+  Marker marker_line = initializeMarker("map", ns + "_line", id, Marker::LINE_STRIP);
+  marker_line.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
+  marker_line.action = Marker::ADD;
+  marker_line.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
+  marker_line.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
+  marker_line.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
+
+  const double yaw = tf2::getYaw(pose.orientation);
+
+  const double a = 3.0;
+  Point p0;
+  p0.x = pose.position.x - a * std::sin(yaw);
+  p0.y = pose.position.y + a * std::cos(yaw);
+  p0.z = pose.position.z;
+  marker_line.points.push_back(p0);
+
+  Point p1;
+  p1.x = pose.position.x + a * std::sin(yaw);
+  p1.y = pose.position.y - a * std::cos(yaw);
+  p1.z = pose.position.z;
+  marker_line.points.push_back(p1);
+
+  MarkerArray msg;
+
+  msg.markers.push_back(marker_line);
+
+  return msg;
+}
+
+MarkerArray createPathMarkerArray(
+  const PathWithLaneId & path, const std::string & ns, const int64_t lane_id, const float r,
+  const float g, const float b)
+{
+  const auto arclength = calcPathArcLengthArray(path);
+  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+  MarkerArray msg;
+  int32_t uid = bitShift(lane_id);
+  int32_t i = 0;
+  int32_t idx = 0;
+  for (const auto & p : path.points) {
+    Marker marker = initializeMarker("map", ns, uid + i++, Marker::ARROW);
+    marker.header.stamp = current_time;
+    marker.action = Marker::ADD;
+    marker.pose = p.point.pose;
+    marker.scale = tier4_autoware_utils::createMarkerScale(0.2, 0.1, 0.3);
+    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
+    msg.markers.push_back(marker);
+    if (idx % 10 == 0) {
+      auto marker_text = marker;
+      marker_text.id = uid + i++;
+      marker_text.type = Marker::TEXT_VIEW_FACING;
+      std::stringstream ss;
+      ss << std::fixed << std::setprecision(1) << "i=" << idx << "\ns=" << arclength.at(idx);
+      marker_text.text = ss.str();
+      marker_text.color = tier4_autoware_utils::createMarkerColor(1, 1, 1, 0.999);
+      msg.markers.push_back(marker_text);
+    }
+    ++idx;
+  }
+
+  return msg;
+}
+MarkerArray createShiftPointMarkerArray(
+  const ShiftPointArray & shift_points, const double base_shift, const std::string & ns,
+  const float & r, const float & g, const float & b, const float & w)
+{
+  ShiftPointArray shift_points_local = shift_points;
+  if (shift_points_local.empty()) {
+    shift_points_local.push_back(ShiftPoint());
+  }
+
+  MarkerArray msg;
+  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+  int id{0};
+
+  // TODO(Horibe) now assuming the shift point is aligned in longitudinal distance order
+  double current_shift = base_shift;
+  for (const auto & sp : shift_points_local) {
+    // ROS_ERROR("sp: s = (%f, %f), g = (%f, %f)", sp.start.x, sp.start.y, sp.end.x, sp.end.y);
+    Marker marker = initializeMarker("map", ns, Marker::CUBE);
+    marker.header.stamp = current_time;
+    marker.action = Marker::ADD;
+    marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
+    marker.scale = createMarkerScale(0.5, 0.5, 0.5);
+    marker.color = createMarkerColor(r, g, b, 0.5);
+    {
+      // start point
+      auto marker_s = marker;
+      marker_s.id = id++;
+      marker_s.pose = sp.start;
+      shiftPose(&marker_s.pose, current_shift);  // old
+      msg.markers.push_back(marker_s);
+
+      // end point
+      auto marker_e = marker;
+      marker_e.id = id++;
+      marker_e.pose = sp.end;
+      shiftPose(&marker_e.pose, sp.length);
+      msg.markers.push_back(marker_e);
+
+      // start-to-end line
+      auto marker_l = marker;
+      marker_l.id = id++;
+      marker_l.type = Marker::LINE_STRIP;
+      marker_l.scale = createMarkerScale(w, 0.0, 0.0);
+      marker_l.points.push_back(marker_s.pose.position);
+      marker_l.points.push_back(marker_e.pose.position);
+      msg.markers.push_back(marker_l);
+    }
+    current_shift = sp.length;
+  }
+
+  return msg;
+}
+
+MarkerArray createShiftLengthMarkerArray(
+  const std::vector<double> & shift_distance,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & reference, const std::string & ns,
+  const float r, const float g, const float b)
+{
+  MarkerArray msg;
+
+  if (shift_distance.size() != reference.points.size()) {
+    return msg;
+  }
+
+  Marker marker = initializeMarker("map", ns, Marker::LINE_STRIP);
+  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
+  marker.action = Marker::ADD;
+  marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
+  marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
+  marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.9);
+
+  for (size_t i = 0; i < shift_distance.size(); ++i) {
+    auto p = reference.points.at(i).point.pose;
+    shiftPose(&p, shift_distance.at(i));
+    marker.points.push_back(p.position);
+  }
+
+  msg.markers.push_back(marker);
+  return msg;
+}
+
+MarkerArray createLaneletsAreaMarkerArray(
+  const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns, const float r,
+  const float g, const float b)
+{
+  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+  MarkerArray msg;
+
+  for (const auto & lanelet : lanelets) {
+    Marker marker = initializeMarker("map", ns, lanelet.id(), Marker::LINE_STRIP);
+    marker.header.stamp = current_time;
+    marker.action = Marker::ADD;
+    marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
+    marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
+    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
+    for (const auto & p : lanelet.polygon3d()) {
+      Point point;
+      point.x = p.x();
+      point.y = p.y();
+      point.z = p.z();
+      marker.points.push_back(point);
+    }
+    if (!marker.points.empty()) {
+      marker.points.push_back(marker.points.front());
+    }
+    msg.markers.push_back(marker);
+  }
+
+  return msg;
+}
+
+MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3d & linestrings)
+{
+  if (linestrings.empty()) {
+    return MarkerArray();
+  }
+
+  MarkerArray msg;
+
+  Marker marker = initializeMarker("map", "shared_linestring_lanelets", Marker::LINE_STRIP);
+  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
+  marker.action = Marker::ADD;
+  marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
+  marker.scale = tier4_autoware_utils::createMarkerScale(0.3, 0.0, 0.0);
+  marker.color = tier4_autoware_utils::createMarkerColor(0.996, 0.658, 0.466, 0.999);
+
+  const auto reserve_size = linestrings.size() / 2;
+  lanelet::ConstLineStrings3d lefts;
+  lanelet::ConstLineStrings3d rights;
+  lefts.reserve(reserve_size);
+  rights.reserve(reserve_size);
+  for (size_t idx = 1; idx < linestrings.size(); idx += 2) {
+    rights.emplace_back(linestrings.at(idx - 1));
+    lefts.emplace_back(linestrings.at(idx));
+  }
+
+  const auto & first_ls = lefts.front().basicLineString();
+  for (const auto & ls : first_ls) {
+    Point p;
+    p.x = ls.x();
+    p.y = ls.y();
+    p.z = ls.z();
+    marker.points.push_back(p);
+  }
+
+  for (auto idx = lefts.cbegin() + 1; idx != lefts.cend(); ++idx) {
+    const auto & marker_back = marker.points.back();
+    Point front;
+    front.x = idx->basicLineString().front().x();
+    front.y = idx->basicLineString().front().y();
+    front.z = idx->basicLineString().front().z();
+    Point front_inverted;
+    front_inverted.x = idx->invert().basicLineString().front().x();
+    front_inverted.y = idx->invert().basicLineString().front().y();
+    front_inverted.z = idx->invert().basicLineString().front().z();
+    const bool isFrontNear = tier4_autoware_utils::calcDistance2d(marker_back, front) <
+                             tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
+    const auto & left_ls = (isFrontNear) ? idx->basicLineString() : idx->invert().basicLineString();
+    for (auto ls = left_ls.cbegin(); ls != left_ls.cend(); ++ls) {
+      Point p;
+      p.x = ls->x();
+      p.y = ls->y();
+      p.z = ls->z();
+      marker.points.push_back(p);
+    }
+  }
+
+  for (auto idx = rights.crbegin(); idx != rights.crend(); ++idx) {
+    const auto & marker_back = marker.points.back();
+    Point front;
+    front.x = idx->basicLineString().front().x();
+    front.y = idx->basicLineString().front().y();
+    front.z = idx->basicLineString().front().z();
+    Point front_inverted;
+    front_inverted.x = idx->invert().basicLineString().front().x();
+    front_inverted.y = idx->invert().basicLineString().front().y();
+    front_inverted.z = idx->invert().basicLineString().front().z();
+    const bool isFrontFurther = tier4_autoware_utils::calcDistance2d(marker_back, front) >
+                                tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
+    const auto & right_ls =
+      (isFrontFurther) ? idx->basicLineString() : idx->invert().basicLineString();
+    for (auto ls = right_ls.crbegin(); ls != right_ls.crend(); ++ls) {
+      Point p;
+      p.x = ls->x();
+      p.y = ls->y();
+      p.z = ls->z();
+      marker.points.push_back(p);
+    }
+  }
+
+  if (!marker.points.empty()) {
+    marker.points.push_back(marker.points.front());
+  }
+
+  msg.markers.push_back(marker);
+  return msg;
+}
+
+MarkerArray createPolygonMarkerArray(
+  const Polygon & polygon, const std::string & ns, const int64_t lane_id, const float r,
+  const float g, const float b)
+{
+  Marker marker = initializeMarker("map", ns, lane_id, Marker::LINE_STRIP);
+
+  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
+  marker.action = Marker::ADD;
+  marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
+  marker.scale = tier4_autoware_utils::createMarkerScale(0.3, 0.0, 0.0);
+  marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.8);
+
+  MarkerArray msg;
+  for (const auto & p : polygon.points) {
+    Point point;
+    point.x = p.x;
+    point.y = p.y;
+    point.z = p.z;
+    marker.points.push_back(point);
+  }
+  if (!marker.points.empty()) {
+    marker.points.push_back(marker.points.front());
+  }
+  msg.markers.push_back(marker);
+
+  return msg;
+}
+
+MarkerArray createObjectsMarkerArray(
+  const PredictedObjects & objects, const std::string & ns, const int64_t lane_id, const float r,
+  const float g, const float b)
+{
+  Marker marker = initializeMarker("map", ns, Marker::CUBE);
+  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
+  marker.ns = ns;
+
+  int32_t uid = bitShift(lane_id);
+  int32_t i{0};
+
+  MarkerArray msg;
+  for (const auto & object : objects.objects) {
+    marker.id = uid + i++;
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.action = Marker::ADD;
+    marker.pose = object.kinematics.initial_pose_with_covariance.pose;
+    marker.scale = tier4_autoware_utils::createMarkerScale(3.0, 1.0, 1.0);
+    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.8);
+    msg.markers.push_back(marker);
+  }
+
+  return msg;
+}
+}  // namespace marker_utils

--- a/planning/behavior_path_planner/src/debug_utilities.cpp
+++ b/planning/behavior_path_planner/src/debug_utilities.cpp
@@ -27,13 +27,13 @@ using tier4_autoware_utils::createPoint;
 using visualization_msgs::msg::Marker;
 
 MarkerArray createPoseMarkerArray(
-  const Pose & pose, const std::string & ns, const int32_t id, const float r, const float g,
-  const float b)
+  const Pose & pose, std::string && ns, const int32_t & id, const float & r, const float & g,
+  const float & b)
 {
   MarkerArray msg;
 
   Marker marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, id, Marker::ARROW,
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), std::move(ns), id, Marker::ARROW,
     createMarkerScale(0.7, 0.3, 0.3), createMarkerColor(r, g, b, 0.999));
   marker.pose = pose;
   msg.markers.push_back(marker);
@@ -42,8 +42,8 @@ MarkerArray createPoseMarkerArray(
 }
 
 MarkerArray createPathMarkerArray(
-  const PathWithLaneId & path, const std::string & ns, const int64_t lane_id, const float r,
-  const float g, const float b)
+  const PathWithLaneId & path, std::string && ns, const int64_t & lane_id, const float & r,
+  const float & g, const float & b)
 {
   const auto arclength = calcPathArcLengthArray(path);
   const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
@@ -73,7 +73,7 @@ MarkerArray createPathMarkerArray(
   return msg;
 }
 MarkerArray createShiftPointMarkerArray(
-  const ShiftPointArray & shift_points, const double base_shift, const std::string & ns,
+  const ShiftPointArray & shift_points, const double & base_shift, std::string && ns,
   const float & r, const float & g, const float & b, const float & w)
 {
   ShiftPointArray shift_points_local = shift_points;
@@ -90,27 +90,27 @@ MarkerArray createShiftPointMarkerArray(
   for (const auto & sp : shift_points_local) {
     // ROS_ERROR("sp: s = (%f, %f), g = (%f, %f)", sp.start.x, sp.start.y, sp.end.x, sp.end.y);
     Marker basic_marker = createDefaultMarker(
-      "map", current_time, ns, 0L, Marker::CUBE, createMarkerScale(0.5, 0.5, 0.5),
+      "map", current_time, std::move(ns), 0L, Marker::CUBE, createMarkerScale(0.5, 0.5, 0.5),
       createMarkerColor(r, g, b, 0.5));
     basic_marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
     {
       // start point
       auto marker_s = basic_marker;
-      marker_s.id = id++;
+      marker_s.id = ++id;
       marker_s.pose = sp.start;
       shiftPose(&marker_s.pose, current_shift);  // old
       msg.markers.push_back(marker_s);
 
       // end point
       auto marker_e = basic_marker;
-      marker_e.id = id++;
+      marker_e.id = ++id;
       marker_e.pose = sp.end;
       shiftPose(&marker_e.pose, sp.length);
       msg.markers.push_back(marker_e);
 
       // start-to-end line
       auto marker_l = basic_marker;
-      marker_l.id = id++;
+      marker_l.id = ++id;
       marker_l.type = Marker::LINE_STRIP;
       marker_l.scale = createMarkerScale(w, 0.0, 0.0);
       marker_l.points.push_back(marker_s.pose.position);
@@ -125,8 +125,8 @@ MarkerArray createShiftPointMarkerArray(
 
 MarkerArray createShiftLengthMarkerArray(
   const std::vector<double> & shift_distance,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & reference, const std::string & ns,
-  const float r, const float g, const float b)
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & reference, std::string && ns,
+  const float & r, const float & g, const float & b)
 {
   if (shift_distance.size() != reference.points.size()) {
     return MarkerArray{};
@@ -135,7 +135,7 @@ MarkerArray createShiftLengthMarkerArray(
   MarkerArray msg;
 
   Marker marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::LINE_STRIP,
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), std::move(ns), 0L, Marker::LINE_STRIP,
     createMarkerScale(0.1, 0.0, 0.0), createMarkerColor(r, g, b, 0.9));
   marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
 
@@ -150,15 +150,15 @@ MarkerArray createShiftLengthMarkerArray(
 }
 
 MarkerArray createLaneletsAreaMarkerArray(
-  const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns, const float r,
-  const float g, const float b)
+  const std::vector<lanelet::ConstLanelet> & lanelets, std::string && ns, const float & r,
+  const float & g, const float & b)
 {
   const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
   MarkerArray msg;
 
   for (const auto & lanelet : lanelets) {
     Marker marker = createDefaultMarker(
-      "map", current_time, ns, static_cast<int32_t>(lanelet.id()), Marker::LINE_STRIP,
+      "map", current_time, std::move(ns), static_cast<int32_t>(lanelet.id()), Marker::LINE_STRIP,
       createMarkerScale(0.1, 0.0, 0.0), createMarkerColor(r, g, b, 0.999));
     marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
     for (const auto & p : lanelet.polygon3d()) {
@@ -247,12 +247,12 @@ MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3
 }
 
 MarkerArray createPolygonMarkerArray(
-  const Polygon & polygon, const std::string & ns, const int64_t lane_id, const float r,
-  const float g, const float b)
+  const Polygon & polygon, std::string && ns, const int64_t & lane_id, const float & r,
+  const float & g, const float & b)
 {
   Marker marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, static_cast<int32_t>(lane_id), Marker::LINE_STRIP,
-    createMarkerScale(0.3, 0.0, 0.0), createMarkerColor(r, g, b, 0.8));
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), std::move(ns), static_cast<int32_t>(lane_id),
+    Marker::LINE_STRIP, createMarkerScale(0.3, 0.0, 0.0), createMarkerColor(r, g, b, 0.8));
 
   marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
 
@@ -270,11 +270,11 @@ MarkerArray createPolygonMarkerArray(
 }
 
 MarkerArray createObjectsMarkerArray(
-  const PredictedObjects & objects, const std::string & ns, const int64_t lane_id, const float r,
-  const float g, const float b)
+  const PredictedObjects & objects, std::string && ns, const int64_t & lane_id, const float & r,
+  const float & g, const float & b)
 {
   Marker marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE,
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), std::move(ns), 0L, Marker::CUBE,
     createMarkerScale(3.0, 1.0, 1.0), createMarkerColor(r, g, b, 0.8));
 
   int32_t uid = bitShift(lane_id);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2625,16 +2625,16 @@ double AvoidanceModule::getCurrentLinearShift() const
 
 void AvoidanceModule::setDebugData(const PathShifter & shifter, const DebugData & debug)
 {
-  using marker_utils::createAvoidanceObjectsMarkerArray;
-  using marker_utils::createAvoidPointMarkerArray;
   using marker_utils::createLaneletsAreaMarkerArray;
   using marker_utils::createObjectsMarkerArray;
-  using marker_utils::createOverhangFurthestLineStringMarkerArray;
   using marker_utils::createPathMarkerArray;
   using marker_utils::createPoseMarkerArray;
   using marker_utils::createShiftLengthMarkerArray;
   using marker_utils::createShiftPointMarkerArray;
-  using marker_utils::makeOverhangToRoadShoulderMarkerArray;
+  using marker_utils::avoidance_marker::createAvoidanceObjectsMarkerArray;
+  using marker_utils::avoidance_marker::createAvoidPointMarkerArray;
+  using marker_utils::avoidance_marker::createOverhangFurthestLineStringMarkerArray;
+  using marker_utils::avoidance_marker::makeOverhangToRoadShoulderMarkerArray;
 
   debug_marker_.markers.clear();
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2552,7 +2552,7 @@ void AvoidanceModule::initVariables()
 
   debug_avoidance_msg_array_ptr_.reset();
   debug_data_ = DebugData();
-
+  debug_marker_.markers.clear();
   registered_raw_shift_points_ = {};
   current_raw_shift_points_ = {};
   original_unique_id = 0;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2661,7 +2661,7 @@ void AvoidanceModule::setDebugData(const PathShifter & shifter, const DebugData 
   add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
   add(createLaneletsAreaMarkerArray(*debug.expanded_lanelets, "expanded_lanelet", 0.8, 0.8, 0.0));
   add(createAvoidanceObjectsMarkerArray(avoidance_data_.objects, "avoidance_object"));
-  add(makeOverhangToRoadShoulderMarkerArray(avoidance_data_.objects));
+  add(makeOverhangToRoadShoulderMarkerArray(avoidance_data_.objects, "overhang"));
   add(createOverhangFurthestLineStringMarkerArray(
     *debug.farthest_linestring_from_overhang, "farthest_linestring_from_overhang", 1.0, 0.0, 1.0));
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -26,6 +26,7 @@ namespace marker_utils::avoidance_marker
 {
 using behavior_path_planner::AvoidPoint;
 using behavior_path_planner::util::shiftPose;
+using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerScale;
 using tier4_autoware_utils::createPoint;
@@ -47,7 +48,7 @@ MarkerArray createAvoidPointMarkerArray(
   for (const auto & sp : shift_points_local) {
     // ROS_ERROR("sp: s = (%f, %f), g = (%f, %f)", sp.start.x, sp.start.y, sp.end.x, sp.end.y);
     Marker basic_marker = createDefaultMarker(
-      "map", current_time, std::move(ns), 0L, Marker::CUBE, createMarkerScale(0.5, 0.5, 0.5),
+      "map", current_time, ns, 0L, Marker::CUBE, createMarkerScale(0.5, 0.5, 0.5),
       createMarkerColor(r, g, b, 0.9));
     basic_marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
     {
@@ -88,7 +89,7 @@ MarkerArray createAvoidanceObjectsMarkerArray(
   const auto disappearing_color = tier4_autoware_utils::createMarkerColor(0.9, 0.5, 0.9, 0.6);
 
   Marker marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), std::move(ns), 0L, Marker::CUBE,
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE,
     createMarkerScale(3.0, 1.5, 1.5), normal_color);
   int32_t i{0};
   MarkerArray msg;
@@ -106,7 +107,7 @@ MarkerArray makeOverhangToRoadShoulderMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects, std::string && ns)
 {
   Marker marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), std::move(ns), 0L, Marker::TEXT_VIEW_FACING,
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::TEXT_VIEW_FACING,
     createMarkerScale(1.0, 1.0, 1.0), createMarkerColor(1.0, 1.0, 0.0, 1.0));
 
   int32_t i{0};

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -22,75 +22,33 @@
 #include <string>
 #include <vector>
 
-namespace marker_utils
+namespace marker_utils::avoidance_marker
 {
-using behavior_path_planner::util::calcPathArcLengthArray;
+using behavior_path_planner::AvoidPoint;
 using behavior_path_planner::util::shiftPose;
 using visualization_msgs::msg::Marker;
 
-inline int64_t bitShift(int64_t original_id) { return original_id << (sizeof(int32_t) * 8 / 2); }
-
-MarkerArray createShiftLengthMarkerArray(
-  const std::vector<double> shift_distance,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & reference, const std::string & ns,
-  const double r, const double g, const double b)
-{
-  MarkerArray ma;
-
-  if (shift_distance.size() != reference.points.size()) {
-    return ma;
-  }
-
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-
-  Marker marker{};
-  marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
-  marker.ns = ns;
-  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-  marker.action = Marker::ADD;
-  marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-  marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
-  marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.9);
-  marker.type = Marker::LINE_STRIP;
-
-  for (size_t i = 0; i < shift_distance.size(); ++i) {
-    auto p = reference.points.at(i).point.pose;
-    shiftPose(&p, shift_distance.at(i));
-    marker.points.push_back(p.position);
-  }
-
-  ma.markers.push_back(marker);
-  return ma;
-}
-
 MarkerArray createAvoidPointMarkerArray(
-  const AvoidPointArray & shift_points, const std::string & ns, const double r, const double g,
-  const double b, const double w)
+  const AvoidPointArray & shift_points, const std::string & ns, const float r, const float g,
+  const float b, const double w)
 {
-  int32_t id = 0;
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
   AvoidPointArray shift_points_local = shift_points;
   if (shift_points_local.empty()) {
     shift_points_local.push_back(AvoidPoint());
   }
+  int32_t id = 0;
+  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+  MarkerArray msg;
 
   for (const auto & sp : shift_points_local) {
     // ROS_ERROR("sp: s = (%f, %f), g = (%f, %f)", sp.start.x, sp.start.y, sp.end.x, sp.end.y);
-    Marker marker{};
-    marker.header.frame_id = "map";
+    Marker marker = initializeMarker("map", ns, Marker::CUBE);
     marker.header.stamp = current_time;
-    marker.ns = ns;
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
     marker.action = Marker::ADD;
     marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
     marker.scale = tier4_autoware_utils::createMarkerScale(0.5, 0.5, 0.5);
     marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.9);
     {
-      marker.type = Marker::CUBE;
-
       // start point
       auto marker_s = marker;
       marker_s.id = id++;
@@ -121,219 +79,19 @@ MarkerArray createAvoidPointMarkerArray(
   return msg;
 }
 
-MarkerArray createShiftPointMarkerArray(
-  const ShiftPointArray & shift_points, const double base_shift, const std::string & ns,
-  const double r, const double g, const double b, const double w)
-{
-  int32_t id = 0;
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
-  ShiftPointArray shift_points_local = shift_points;
-  if (shift_points_local.empty()) {
-    shift_points_local.push_back(ShiftPoint());
-  }
-
-  // TODO(Horibe) now assuming the shift point is aligned in longitudinal distance order
-  double current_shift = base_shift;
-  for (const auto & sp : shift_points_local) {
-    // ROS_ERROR("sp: s = (%f, %f), g = (%f, %f)", sp.start.x, sp.start.y, sp.end.x, sp.end.y);
-    Marker marker{};
-    marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
-    marker.ns = ns;
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.action = Marker::ADD;
-    marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-    marker.scale = tier4_autoware_utils::createMarkerScale(0.5, 0.5, 0.5);
-    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.5);
-    {
-      marker.type = Marker::CUBE;
-
-      // start point
-      auto marker_s = marker;
-      marker_s.id = id++;
-      marker_s.pose = sp.start;
-      shiftPose(&marker_s.pose, current_shift);  // old
-      msg.markers.push_back(marker_s);
-
-      // end point
-      auto marker_e = marker;
-      marker_e.id = id++;
-      marker_e.pose = sp.end;
-      shiftPose(&marker_e.pose, sp.length);
-      msg.markers.push_back(marker_e);
-
-      // start-to-end line
-      auto marker_l = marker;
-      marker_l.id = id++;
-      marker_l.type = Marker::LINE_STRIP;
-      marker_l.scale = tier4_autoware_utils::createMarkerScale(w, 0.0, 0.0);
-      marker_l.points.push_back(marker_s.pose.position);
-      marker_l.points.push_back(marker_e.pose.position);
-      msg.markers.push_back(marker_l);
-    }
-    current_shift = sp.length;
-  }
-
-  return msg;
-}
-
-MarkerArray createLaneletsAreaMarkerArray(
-  const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns, const double r,
-  const double g, const double b)
-{
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
-  for (const auto & lanelet : lanelets) {
-    Marker marker{};
-    marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
-
-    marker.ns = ns;
-    marker.id = lanelet.id();
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.type = Marker::LINE_STRIP;
-    marker.action = Marker::ADD;
-    marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-    marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
-    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
-    for (const auto & p : lanelet.polygon3d()) {
-      Point point;
-      point.x = p.x();
-      point.y = p.y();
-      point.z = p.z();
-      marker.points.push_back(point);
-    }
-    if (!marker.points.empty()) {
-      marker.points.push_back(marker.points.front());
-    }
-    msg.markers.push_back(marker);
-  }
-
-  return msg;
-}
-
-MarkerArray createLaneletPolygonsMarkerArray(
-  const std::vector<lanelet::CompoundPolygon3d> & polygons, const std::string & ns,
-  const int64_t lane_id)
-{
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
-  int32_t i = 0;
-  int32_t uid = bitShift(lane_id);
-  for (const auto & polygon : polygons) {
-    Marker marker{};
-    marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
-
-    marker.ns = ns;
-    marker.id = uid + i++;
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.type = Marker::LINE_STRIP;
-    marker.action = Marker::ADD;
-    marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-    marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
-    marker.color = tier4_autoware_utils::createMarkerColor(0.0, 1.0, 0.0, 0.999);
-    for (const auto & p : polygon) {
-      Point point;
-      point.x = p.x();
-      point.y = p.y();
-      point.z = p.z();
-      marker.points.push_back(point);
-    }
-    if (!marker.points.empty()) {
-      marker.points.push_back(marker.points.front());
-    }
-    msg.markers.push_back(marker);
-  }
-
-  return msg;
-}
-
-MarkerArray createPolygonMarkerArray(
-  const Polygon & polygon, const std::string & ns, const int64_t lane_id, const double r,
-  const double g, const double b)
-{
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
-  Marker marker{};
-  marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
-
-  marker.ns = ns;
-  marker.id = lane_id;
-  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-  marker.type = Marker::LINE_STRIP;
-  marker.action = Marker::ADD;
-  marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-  marker.scale = tier4_autoware_utils::createMarkerScale(0.3, 0.0, 0.0);
-  marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.8);
-  for (const auto & p : polygon.points) {
-    Point point;
-    point.x = p.x;
-    point.y = p.y;
-    point.z = p.z;
-    marker.points.push_back(point);
-  }
-  if (!marker.points.empty()) {
-    marker.points.push_back(marker.points.front());
-  }
-  msg.markers.push_back(marker);
-
-  return msg;
-}
-
-MarkerArray createObjectsMarkerArray(
-  const PredictedObjects & objects, const std::string & ns, const int64_t lane_id, const double r,
-  const double g, const double b)
-{
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
-  Marker marker{};
-  marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
-  marker.ns = ns;
-
-  int32_t uid = bitShift(lane_id);
-  int32_t i = 0;
-  for (const auto & object : objects.objects) {
-    marker.id = uid + i++;
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.type = Marker::CUBE;
-    marker.action = Marker::ADD;
-    marker.pose = object.kinematics.initial_pose_with_covariance.pose;
-    marker.scale = tier4_autoware_utils::createMarkerScale(3.0, 1.0, 1.0);
-    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.8);
-    msg.markers.push_back(marker);
-  }
-
-  return msg;
-}
-
 MarkerArray createAvoidanceObjectsMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects, const std::string & ns)
 {
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
-  Marker marker{};
-  marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
-  marker.ns = ns;
+  Marker marker = initializeMarker("map", ns, Marker::CUBE);
+  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
 
   const auto normal_color = tier4_autoware_utils::createMarkerColor(0.9, 0.0, 0.0, 0.8);
   const auto disappearing_color = tier4_autoware_utils::createMarkerColor(0.9, 0.5, 0.9, 0.6);
 
   int32_t i = 0;
+  MarkerArray msg;
   for (const auto & object : objects) {
     marker.id = i++;
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.type = Marker::CUBE;
     marker.action = Marker::ADD;
     marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
     marker.scale = tier4_autoware_utils::createMarkerScale(3.0, 1.5, 1.5);
@@ -344,124 +102,18 @@ MarkerArray createAvoidanceObjectsMarkerArray(
   return msg;
 }
 
-MarkerArray createPathMarkerArray(
-  const PathWithLaneId & path, const std::string & ns, const int64_t lane_id, const double r,
-  const double g, const double b)
-{
-  const auto arclength = calcPathArcLengthArray(path);
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-  int32_t uid = bitShift(lane_id);
-  int32_t i = 0;
-  int32_t idx = 0;
-  for (const auto & p : path.points) {
-    Marker marker{};
-    marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
-    marker.ns = ns;
-    marker.id = uid + i++;
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.type = Marker::ARROW;
-    marker.action = Marker::ADD;
-    marker.pose = p.point.pose;
-    marker.scale = tier4_autoware_utils::createMarkerScale(0.2, 0.1, 0.3);
-    marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
-    msg.markers.push_back(marker);
-    if (idx % 10 == 0) {
-      auto marker_text = marker;
-      marker_text.id = uid + i++;
-      marker_text.type = Marker::TEXT_VIEW_FACING;
-      std::stringstream ss;
-      ss << std::fixed << std::setprecision(1) << "i=" << idx << "\ns=" << arclength.at(idx);
-      marker_text.text = ss.str();
-      marker_text.color = tier4_autoware_utils::createMarkerColor(1, 1, 1, 0.999);
-      msg.markers.push_back(marker_text);
-    }
-    ++idx;
-  }
-
-  return msg;
-}
-
-MarkerArray createPoseLineMarkerArray(
-  const Pose & pose, const std::string & ns, const int64_t id, const double r, const double g,
-  const double b)
-{
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
-  Marker marker_line{};
-  marker_line.header.frame_id = "map";
-  marker_line.header.stamp = current_time;
-  marker_line.ns = ns + "_line";
-  marker_line.id = id;
-  marker_line.lifetime = rclcpp::Duration::from_seconds(0.2);
-  marker_line.type = Marker::LINE_STRIP;
-  marker_line.action = Marker::ADD;
-  marker_line.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-  marker_line.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0);
-  marker_line.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
-
-  const double yaw = tf2::getYaw(pose.orientation);
-
-  const double a = 3.0;
-  Point p0;
-  p0.x = pose.position.x - a * std::sin(yaw);
-  p0.y = pose.position.y + a * std::cos(yaw);
-  p0.z = pose.position.z;
-  marker_line.points.push_back(p0);
-
-  Point p1;
-  p1.x = pose.position.x + a * std::sin(yaw);
-  p1.y = pose.position.y - a * std::cos(yaw);
-  p1.z = pose.position.z;
-  marker_line.points.push_back(p1);
-
-  msg.markers.push_back(marker_line);
-
-  return msg;
-}
-
-MarkerArray createPoseMarkerArray(
-  const Pose & pose, const std::string & ns, const int64_t id, const double r, const double g,
-  const double b)
-{
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
-  Marker marker{};
-  marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
-  marker.ns = ns;
-  marker.id = id;
-  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-  marker.type = Marker::ARROW;
-  marker.action = Marker::ADD;
-  marker.pose = pose;
-  marker.scale = tier4_autoware_utils::createMarkerScale(0.7, 0.3, 0.3);
-  marker.color = tier4_autoware_utils::createMarkerColor(r, g, b, 0.999);
-  msg.markers.push_back(marker);
-
-  return msg;
-}
 MarkerArray makeOverhangToRoadShoulderMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects)
 {
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-  MarkerArray msg;
-
-  Marker marker{};
-  marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
-  marker.ns = "overhang";
+  Marker marker = initializeMarker("map", "overhang", Marker::TEXT_VIEW_FACING);
+  marker.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
 
   const auto normal_color = tier4_autoware_utils::createMarkerColor(1.0, 1.0, 0.0, 1.0);
 
   int32_t i = 0;
+  MarkerArray msg;
   for (const auto & object : objects) {
     marker.id = i++;
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.type = Marker::TEXT_VIEW_FACING;
     // marker.action = Marker::ADD;
     marker.pose = object.overhang_pose;
     marker.scale = tier4_autoware_utils::createMarkerScale(1.0, 1.0, 1.0);
@@ -483,14 +135,9 @@ MarkerArray createOverhangFurthestLineStringMarkerArray(
   MarkerArray msg;
 
   for (const auto & linestring : linestrings) {
-    Marker marker{};
-    marker.header.frame_id = "map";
+    Marker marker = initializeMarker("map", ns, linestring.id(), Marker::LINE_STRIP);
     marker.header.stamp = current_time;
 
-    marker.ns = ns;
-    marker.id = linestring.id();
-    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.type = Marker::LINE_STRIP;
     marker.action = Marker::ADD;
     marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
     marker.scale = tier4_autoware_utils::createMarkerScale(0.4, 0.0, 0.0);
@@ -520,99 +167,7 @@ MarkerArray createOverhangFurthestLineStringMarkerArray(
 
   return msg;
 }
-
-MarkerArray createFurthestLineStringMarkerArray(const lanelet::ConstLineStrings3d & linestrings)
-{
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-
-  MarkerArray msg;
-  if (linestrings.empty()) {
-    return msg;
-  }
-
-  Marker marker{};
-  marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
-  marker.ns = "shared_linestring_lanelets";
-  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-  marker.type = Marker::LINE_STRIP;
-  marker.action = Marker::ADD;
-  marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-  marker.scale = tier4_autoware_utils::createMarkerScale(0.3, 0.0, 0.0);
-  marker.color = tier4_autoware_utils::createMarkerColor(0.996, 0.658, 0.466, 0.999);
-
-  const auto reserve_size = linestrings.size() / 2;
-  lanelet::ConstLineStrings3d lefts;
-  lanelet::ConstLineStrings3d rights;
-  lefts.reserve(reserve_size);
-  rights.reserve(reserve_size);
-  for (size_t idx = 1; idx < linestrings.size(); idx += 2) {
-    rights.emplace_back(linestrings.at(idx - 1));
-    lefts.emplace_back(linestrings.at(idx));
-  }
-
-  const auto & first_ls = lefts.front().basicLineString();
-  for (const auto & ls : first_ls) {
-    Point p;
-    p.x = ls.x();
-    p.y = ls.y();
-    p.z = ls.z();
-    marker.points.push_back(p);
-  }
-
-  for (auto idx = lefts.cbegin() + 1; idx != lefts.cend(); ++idx) {
-    const auto & marker_back = marker.points.back();
-    Point front;
-    front.x = idx->basicLineString().front().x();
-    front.y = idx->basicLineString().front().y();
-    front.z = idx->basicLineString().front().z();
-    Point front_inverted;
-    front_inverted.x = idx->invert().basicLineString().front().x();
-    front_inverted.y = idx->invert().basicLineString().front().y();
-    front_inverted.z = idx->invert().basicLineString().front().z();
-    const bool isFrontNear = tier4_autoware_utils::calcDistance2d(marker_back, front) <
-                             tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
-    const auto & left_ls = (isFrontNear) ? idx->basicLineString() : idx->invert().basicLineString();
-    for (auto ls = left_ls.cbegin(); ls != left_ls.cend(); ++ls) {
-      Point p;
-      p.x = ls->x();
-      p.y = ls->y();
-      p.z = ls->z();
-      marker.points.push_back(p);
-    }
-  }
-
-  for (auto idx = rights.crbegin(); idx != rights.crend(); ++idx) {
-    const auto & marker_back = marker.points.back();
-    Point front;
-    front.x = idx->basicLineString().front().x();
-    front.y = idx->basicLineString().front().y();
-    front.z = idx->basicLineString().front().z();
-    Point front_inverted;
-    front_inverted.x = idx->invert().basicLineString().front().x();
-    front_inverted.y = idx->invert().basicLineString().front().y();
-    front_inverted.z = idx->invert().basicLineString().front().z();
-    const bool isFrontFurther = tier4_autoware_utils::calcDistance2d(marker_back, front) >
-                                tier4_autoware_utils::calcDistance2d(marker_back, front_inverted);
-    const auto & right_ls =
-      (isFrontFurther) ? idx->basicLineString() : idx->invert().basicLineString();
-    for (auto ls = right_ls.crbegin(); ls != right_ls.crend(); ++ls) {
-      Point p;
-      p.x = ls->x();
-      p.y = ls->y();
-      p.z = ls->z();
-      marker.points.push_back(p);
-    }
-  }
-
-  if (!marker.points.empty()) {
-    marker.points.push_back(marker.points.front());
-  }
-
-  msg.markers.push_back(marker);
-  return msg;
-}
-}  // namespace marker_utils
+}  // namespace marker_utils::avoidance_marker
 
 std::string toStrInfo(const behavior_path_planner::ShiftPointArray & sp_arr)
 {

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -32,8 +32,8 @@ using tier4_autoware_utils::createPoint;
 using visualization_msgs::msg::Marker;
 
 MarkerArray createAvoidPointMarkerArray(
-  const AvoidPointArray & shift_points, const std::string & ns, const float r, const float g,
-  const float b, const double w)
+  const AvoidPointArray & shift_points, std::string && ns, const float & r, const float & g,
+  const float & b, const double & w)
 {
   AvoidPointArray shift_points_local = shift_points;
   if (shift_points_local.empty()) {
@@ -47,7 +47,7 @@ MarkerArray createAvoidPointMarkerArray(
   for (const auto & sp : shift_points_local) {
     // ROS_ERROR("sp: s = (%f, %f), g = (%f, %f)", sp.start.x, sp.start.y, sp.end.x, sp.end.y);
     Marker basic_marker = createDefaultMarker(
-      "map", current_time, ns, 0L, Marker::CUBE, createMarkerScale(0.5, 0.5, 0.5),
+      "map", current_time, std::move(ns), 0L, Marker::CUBE, createMarkerScale(0.5, 0.5, 0.5),
       createMarkerColor(r, g, b, 0.9));
     basic_marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
     {
@@ -82,18 +82,18 @@ MarkerArray createAvoidPointMarkerArray(
 }
 
 MarkerArray createAvoidanceObjectsMarkerArray(
-  const behavior_path_planner::ObjectDataArray & objects, const std::string & ns)
+  const behavior_path_planner::ObjectDataArray & objects, std::string && ns)
 {
   const auto normal_color = tier4_autoware_utils::createMarkerColor(0.9, 0.0, 0.0, 0.8);
   const auto disappearing_color = tier4_autoware_utils::createMarkerColor(0.9, 0.5, 0.9, 0.6);
 
   Marker marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE,
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), std::move(ns), 0L, Marker::CUBE,
     createMarkerScale(3.0, 1.5, 1.5), normal_color);
   int32_t i{0};
   MarkerArray msg;
   for (const auto & object : objects) {
-    marker.id = i++;
+    marker.id = ++i;
     marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
     marker.color = object.lost_count == 0 ? normal_color : disappearing_color;
     msg.markers.push_back(marker);
@@ -103,16 +103,16 @@ MarkerArray createAvoidanceObjectsMarkerArray(
 }
 
 MarkerArray makeOverhangToRoadShoulderMarkerArray(
-  const behavior_path_planner::ObjectDataArray & objects)
+  const behavior_path_planner::ObjectDataArray & objects, std::string && ns)
 {
   Marker marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "overhang", 0L, Marker::TEXT_VIEW_FACING,
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), std::move(ns), 0L, Marker::TEXT_VIEW_FACING,
     createMarkerScale(1.0, 1.0, 1.0), createMarkerColor(1.0, 1.0, 0.0, 1.0));
 
   int32_t i{0};
   MarkerArray msg;
   for (const auto & object : objects) {
-    marker.id = i++;
+    marker.id = ++i;
     marker.pose = object.overhang_pose;
     std::ostringstream string_stream;
     string_stream << "(to_road_shoulder_distance = " << object.to_road_shoulder_distance << " [m])";
@@ -124,8 +124,8 @@ MarkerArray makeOverhangToRoadShoulderMarkerArray(
 }
 
 MarkerArray createOverhangFurthestLineStringMarkerArray(
-  const lanelet::ConstLineStrings3d & linestrings, std::string && ns, const float r, const float g,
-  const float b)
+  const lanelet::ConstLineStrings3d & linestrings, std::string && ns, const float & r,
+  const float & g, const float & b)
 {
   const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
   MarkerArray msg;


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

The `marker_utils` for behavior_path_planner is currently under `avoidance` module. 
Since other `scene_module` under `behavior_path_planner` might reuse the function, it is better to reorganize the `marker_utils` to separate the between reusable markers and `scene_module` specific marker.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

The test is conducted using planning simulator.

To test this PR, simply set the `publish_debug_marker` to `true` and insert the debug marker in the `rviz2`. Then try the avoidance scenario and check to see if all the debug marker works or not.

## Notes for reviewers

There is no behavior changes is expected.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
