### PR TITLE
fix(behavior_velocity_planner): keep FINALIZED state in vtl module

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/scene.cpp
@@ -372,7 +372,7 @@ bool VirtualTrafficLightModule::modifyPathVelocity(
   }
 
   // Do nothing if vehicle is after any end line
-  if (isAfterAnyEndLine()) {
+  if (isAfterAnyEndLine() || state_ == State::FINALIZED) {
     RCLCPP_DEBUG(logger_, "after end_line");
     state_ = State::FINALIZED;
     updateInfrastructureCommand();


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Keep FINALIZED after end line.
This fix bug of returning to REQUESTING state after end line and inserting stop point.
![image](https://user-images.githubusercontent.com/39142679/173775486-97ed5399-f637-4c3f-a871-3fcc2bb8aa87.png)


## Related links

<!-- Write the links related to this PR. -->
porting mistake of https://github.com/tier4/autoware.iv/pull/2413#discussion_r783701590

## Tests performed

<!-- Describe how you have tested this PR. -->
check in psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
