### PR TITLE
feat(bluetooth_monitor): run bluetooth monitor with new parameter

### DIFF
--- a/system/bluetooth_monitor/include/bluetooth_monitor/service/l2ping.hpp
+++ b/system/bluetooth_monitor/include/bluetooth_monitor/service/l2ping.hpp
@@ -17,6 +17,7 @@
 
 #include "bluetooth_monitor/service/l2ping_interface.hpp"
 
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -35,6 +36,11 @@ public:
    * @brief Start ping thread
    */
   void run();
+
+  /**
+   * @brief Stop ping thread
+   */
+  void stop();
 
   /**
    * @brief Get status
@@ -82,6 +88,8 @@ protected:
   L2pingConfig config_;  //!< @brief Configuration of L2ping
   std::thread thread_;   //!< @brief Thread to L2ping
   L2pingStatus status_;  //!< @brief L2ping status
+  std::mutex mutex_;     //!< @brief mutex for stop flag
+  bool stop_;            //!< @brief Flag to stop thread
 };
 
 #endif  // BLUETOOTH_MONITOR__SERVICE__L2PING_HPP_

--- a/system/bluetooth_monitor/include/bluetooth_monitor/service/l2ping_interface.hpp
+++ b/system/bluetooth_monitor/include/bluetooth_monitor/service/l2ping_interface.hpp
@@ -20,6 +20,7 @@
 #include <boost/serialization/vector.hpp>
 
 #include <string>
+#include <tuple>
 #include <vector>
 
 // 7634-7647 Unassigned

--- a/system/bluetooth_monitor/include/bluetooth_monitor/service/l2ping_interface.hpp
+++ b/system/bluetooth_monitor/include/bluetooth_monitor/service/l2ping_interface.hpp
@@ -50,6 +50,26 @@ struct L2pingConfig
     ar & timeout;
     ar & rtt_warn;
   }
+
+  /**
+   * @brief Get struct reference without copying values of the members.
+   * @return Struct reference
+   */
+  inline auto tied() const { return std::tie(timeout, rtt_warn); }
+
+  /**
+   * @brief The equal comparison operator for struct.
+   * @param [in] right right hand side
+   * @return true on equal, false on not equal
+   */
+  inline bool operator==(const L2pingConfig & right) const { return (tied() == right.tied()); }
+
+  /**
+   * @brief The not equal comparison operator for struct.
+   * @param [in] right right hand side
+   * @return true on not equal, false on equal
+   */
+  inline bool operator!=(const L2pingConfig & right) const { return (tied() != right.tied()); }
 };
 
 /**
@@ -72,6 +92,32 @@ struct L2pingServiceConfig
   {
     ar & l2ping;
     ar & addresses;
+  }
+
+  /**
+   * @brief Get struct reference without copying values of the members.
+   * @return Struct reference
+   */
+  inline auto tied() const { return std::tie(l2ping, addresses); }
+
+  /**
+   * @brief The equal comparison operator for struct.
+   * @param [in] right right hand side
+   * @return true on equal, false on not equal
+   */
+  inline bool operator==(const L2pingServiceConfig & right) const
+  {
+    return (tied() == right.tied());
+  }
+
+  /**
+   * @brief The not equal comparison operator for struct.
+   * @param [in] right right hand side
+   * @return true on not equal, false on equal
+   */
+  inline bool operator!=(const L2pingServiceConfig & right) const
+  {
+    return (tied() != right.tied());
   }
 };
 

--- a/system/bluetooth_monitor/include/bluetooth_monitor/service/l2ping_service.hpp
+++ b/system/bluetooth_monitor/include/bluetooth_monitor/service/l2ping_service.hpp
@@ -58,6 +58,11 @@ protected:
   void setFunctionError(const std::string & function_name, const std::string & error_message);
 
   /**
+   * @brief Stop all ping threads
+   */
+  void stop();
+
+  /**
    * @brief Build device list to ping
    * @param [in] addresses List of bluetooth address
    * @return true on success, false on error

--- a/system/bluetooth_monitor/service/l2ping.cpp
+++ b/system/bluetooth_monitor/service/l2ping.cpp
@@ -66,12 +66,32 @@ bool L2ping::getDeviceInformation()
 void L2ping::run()
 {
   // Start thread loop
+  stop_ = false;
   thread_ = std::thread(&L2ping::thread, this);
+}
+
+void L2ping::stop()
+{
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stop_ = true;
+  }
+
+  thread_.join();
 }
 
 void L2ping::thread()
 {
   while (true) {
+    bool stop = false;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      stop = stop_;
+    }
+    if (stop) {
+       break;
+    }
+
     // Get device information if not provided
     if (status_.name.empty() || status_.manufacturer.empty()) {
       getDeviceInformation();

--- a/system/bluetooth_monitor/service/l2ping.cpp
+++ b/system/bluetooth_monitor/service/l2ping.cpp
@@ -89,7 +89,7 @@ void L2ping::thread()
       stop = stop_;
     }
     if (stop) {
-       break;
+      break;
     }
 
     // Get device information if not provided


### PR DESCRIPTION
Signed-off-by: ito-san <fumihito.ito@tier4.jp>

## Description

 Run bluetooth monitor with new parameters given without restarting l2ping daemon.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/1110

## Tests performed

1. Run `l2ping_service` and `bluetooth_monitor`.

   ```console
   ./build/bluetooth_monitor/l2ping_service
   ros2 launch bluetooth_monitor bluetooth_monitor.launch.xml
   ```

2. Change parameter such as rtt_warning from `0.00` to `30.00`(ms).
bluetooth_monitor.param.yaml
```yaml
/**:
  ros__parameters:
    port: 7640
    timeout: 5
    rtt_warn: 30.00
    addresses: ["82:82:AB:56:32:98"]
```

3. Observe RTT warning is reported.
![image](https://user-images.githubusercontent.com/57388357/173814031-53863f4b-ac5b-4fca-86c3-d50040c113a5.png)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
