### PR TITLE
chore(behavior_velocity): refactor debug marker

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/debug.cpp
@@ -14,6 +14,7 @@
 
 #include <scene_module/occlusion_spot/occlusion_spot_utils.hpp>
 #include <scene_module/occlusion_spot/scene_occlusion_spot.hpp>
+#include <tier4_autoware_utils/planning/planning_marker_helper.hpp>
 #include <tier4_autoware_utils/ros/marker_helper.hpp>
 #include <utilization/marker_helper.hpp>
 #include <utilization/util.hpp>
@@ -28,111 +29,74 @@ namespace
 {
 using builtin_interfaces::msg::Time;
 using BasicPolygons = std::vector<lanelet::BasicPolygon2d>;
+using occlusion_spot_utils::PossibleCollisionInfo;
+using visualization_msgs::msg::Marker;
+using visualization_msgs::msg::MarkerArray;
 
-visualization_msgs::msg::Marker makeArrowMarker(
-  const occlusion_spot_utils::PossibleCollisionInfo & possible_collision, const int id)
+std::vector<Marker> makeDebugInfoMarker(
+  const PossibleCollisionInfo & possible_collision, const int id, const bool show_text)
 {
-  visualization_msgs::msg::Marker debug_marker;
+  std::vector<Marker> debug_markers;
+  Marker debug_marker;
   debug_marker.header.frame_id = "map";
-  debug_marker.ns = "occlusion spot arrow";
-  debug_marker.id = planning_utils::bitShift(id);
-  debug_marker.type = visualization_msgs::msg::Marker::ARROW;
+  debug_marker.id = id;
+  debug_marker.action = Marker::ADD;
+  debug_marker.pose.position = tier4_autoware_utils::createMarkerPosition(0.0, 0.0, 0.0);
   debug_marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
-  debug_marker.scale = tier4_autoware_utils::createMarkerScale(0.05, 0.2, 0.5);
-  debug_marker.color = tier4_autoware_utils::createMarkerColor(0.1, 0.1, 0.1, 0.5);
   debug_marker.lifetime = rclcpp::Duration::from_seconds(0.5);
-  geometry_msgs::msg::Point obs_point, intersection_point{};
-  obs_point = possible_collision.obstacle_info.position;
-  obs_point.z += 1;
-  intersection_point = possible_collision.intersection_pose.position, intersection_point.z += 1;
-  debug_marker.points = {obs_point, intersection_point};
-  return debug_marker;
-}
-
-std::vector<visualization_msgs::msg::Marker> makeSlowDownMarkers(
-  const occlusion_spot_utils::PossibleCollisionInfo & possible_collision,
-  const std::string detection_type, const int id)
-{
-  // virtual wall
-  std::vector<visualization_msgs::msg::Marker> debug_markers;
-  visualization_msgs::msg::Marker wall_marker;
-  wall_marker.header.frame_id = "map";
-  wall_marker.ns = "occlusion spot slow down";
-  wall_marker.lifetime = rclcpp::Duration::from_seconds(0.5);
-  wall_marker.type = visualization_msgs::msg::Marker::CUBE;
-  wall_marker.action = visualization_msgs::msg::Marker::ADD;
-  wall_marker.id = planning_utils::bitShift(id);
-  // cylinder at collision point
-  wall_marker.pose = possible_collision.intersection_pose;
-  wall_marker.pose.position.z += 1.0;
-  wall_marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 5.0, 2.0);
-  wall_marker.color = tier4_autoware_utils::createMarkerColor(1.0, 1.0, 0.0, 0.5);
-
-  wall_marker.lifetime = rclcpp::Duration::from_seconds(0.5);
-  debug_markers.emplace_back(wall_marker);
-
-  // slow down reason marker
-  visualization_msgs::msg::Marker slowdown_reason_marker;
-  slowdown_reason_marker.header.frame_id = "map";
-  slowdown_reason_marker.ns = "slow factor_text";
-  slowdown_reason_marker.id = planning_utils::bitShift(id);
-  slowdown_reason_marker.lifetime = rclcpp::Duration::from_seconds(0.5);
-  slowdown_reason_marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
-  slowdown_reason_marker.action = visualization_msgs::msg::Marker::ADD;
-  slowdown_reason_marker.pose = possible_collision.intersection_pose;
-  slowdown_reason_marker.scale = tier4_autoware_utils::createMarkerScale(0.0, 0.0, 1.0);
-  slowdown_reason_marker.color = tier4_autoware_utils::createMarkerColor(1.0, 1.0, 1.0, 0.999);
-  slowdown_reason_marker.text = "occlusion spot";
-  debug_markers.emplace_back(slowdown_reason_marker);
-  slowdown_reason_marker.scale = tier4_autoware_utils::createMarkerScale(0.0, 0.0, 0.5);
-  slowdown_reason_marker.id = id + 100;
-  slowdown_reason_marker.text = "\n \n" + detection_type;
-  debug_markers.emplace_back(slowdown_reason_marker);
-  debug_markers.push_back(makeArrowMarker(possible_collision, id));
-  return debug_markers;
-}
-
-std::vector<visualization_msgs::msg::Marker> makeCollisionMarkers(
-  const occlusion_spot_utils::PossibleCollisionInfo & possible_collision, const int id,
-  const bool show_text)
-{
-  std::vector<visualization_msgs::msg::Marker> debug_markers;
-  visualization_msgs::msg::Marker debug_marker;
-  debug_marker.header.frame_id = "map";
-  debug_marker.ns = "collision_point";
-  debug_marker.id = planning_utils::bitShift(id);
-  // cylinder at collision with margin point
-  debug_marker.type = visualization_msgs::msg::Marker::CYLINDER;
-  debug_marker.pose = possible_collision.collision_with_margin.pose;
-  debug_marker.scale = tier4_autoware_utils::createMarkerScale(0.5, 0.5, 0.5);
-  debug_marker.color = tier4_autoware_utils::createMarkerColor(1.0, 0.0, 0.0, 0.5);
-  debug_marker.lifetime = rclcpp::Duration::from_seconds(0.5);
-  debug_markers.push_back(debug_marker);
-  debug_marker.id++;
+  const auto & pc = possible_collision;
+  // for collision point with margin
+  {
+    debug_marker.ns = "collision_point";
+    debug_marker.type = Marker::CYLINDER;
+    debug_marker.pose = pc.collision_with_margin.pose;
+    debug_marker.scale = tier4_autoware_utils::createMarkerScale(0.5, 0.5, 0.5);
+    debug_marker.color = tier4_autoware_utils::createMarkerColor(1.0, 0.0, 0.0, 0.5);
+    debug_markers.push_back(debug_marker);
+  }
   // cylinder at collision_point point
-  debug_marker.pose = possible_collision.collision_pose;
-  debug_marker.color = tier4_autoware_utils::createMarkerColor(1.0, 0.5, 0.0, 0.5);
-  debug_markers.push_back(debug_marker);
+  {
+    debug_marker.ns = "collision_point_with_margin";
+    debug_marker.type = Marker::CYLINDER;
+    debug_marker.pose = pc.collision_pose;
+    debug_marker.scale = tier4_autoware_utils::createMarkerScale(0.5, 0.5, 0.5);
+    debug_marker.color = tier4_autoware_utils::createMarkerColor(1.0, 0.5, 0.0, 0.5);
+    debug_markers.push_back(debug_marker);
+  }
+
   // cylinder at obstacle point
-  debug_marker.ns = "obstacle";
-  debug_marker.type = visualization_msgs::msg::Marker::CYLINDER;
-  debug_marker.pose.position = possible_collision.obstacle_info.position;
-  debug_marker.color = tier4_autoware_utils::createMarkerColor(0.5, 0.5, 0.5, 0.5);
-  debug_marker.scale = tier4_autoware_utils::createMarkerScale(1.0, 1.0, 1.0);
-  debug_markers.push_back(debug_marker);
+  {
+    debug_marker.ns = "obstacle";
+    debug_marker.type = Marker::CYLINDER;
+    debug_marker.pose.position = pc.obstacle_info.position;
+    debug_marker.color = tier4_autoware_utils::createMarkerColor(0.5, 0.5, 0.5, 0.5);
+    debug_marker.scale = tier4_autoware_utils::createMarkerScale(0.8, 0.8, 1.5);
+    debug_markers.push_back(debug_marker);
+  }
+
+  // arrow marker
+  {
+    debug_marker.ns = "from_obj_to_collision";
+    debug_marker.type = Marker::ARROW;
+    debug_marker.scale = tier4_autoware_utils::createMarkerScale(0.05, 0.2, 0.5);
+    debug_marker.color = tier4_autoware_utils::createMarkerColor(0.1, 0.1, 0.1, 0.5);
+    debug_marker.points = {pc.obstacle_info.position, pc.intersection_pose.position};
+    debug_markers.push_back(debug_marker);
+  }
+
   if (show_text) {
     // info text at obstacle point
-    debug_marker.ns = "info_obstacle";
-    debug_marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
-    debug_marker.pose = possible_collision.collision_with_margin.pose;
+    debug_marker.ns = "info";
+    debug_marker.type = Marker::TEXT_VIEW_FACING;
+    debug_marker.pose = pc.collision_with_margin.pose;
     debug_marker.scale.z = 1.0;
     debug_marker.color = tier4_autoware_utils::createMarkerColor(1.0, 1.0, 0.0, 1.0);
     std::ostringstream string_stream;
     auto r = [](const double v) { return std::round(v * 100.0) / 100.0; };
-    const double len = r(possible_collision.arc_lane_dist_at_collision.length);
-    const double dist = r(possible_collision.arc_lane_dist_at_collision.distance);
-    const double vel = r(possible_collision.obstacle_info.safe_motion.safe_velocity);
-    const double margin = r(possible_collision.obstacle_info.safe_motion.stop_dist);
+    const double len = r(pc.arc_lane_dist_at_collision.length);
+    const double dist = r(pc.arc_lane_dist_at_collision.distance);
+    const double vel = r(pc.obstacle_info.safe_motion.safe_velocity);
+    const double margin = r(pc.obstacle_info.safe_motion.stop_dist);
     string_stream << "(s,d,v,m)=(" << len << " , " << dist << " , " << vel << " , " << margin
                   << " )";
     debug_marker.text = string_stream.str();
@@ -141,16 +105,34 @@ std::vector<visualization_msgs::msg::Marker> makeCollisionMarkers(
   return debug_markers;
 }
 
-visualization_msgs::msg::MarkerArray makePolygonMarker(
+template <class T>
+MarkerArray makeDebugInfoMarkers(T & debug_data)
+{
+  // add slow down markers for occlusion spot
+  MarkerArray debug_markers;
+  auto & possible_collisions = debug_data.possible_collisions;
+  size_t id = 0;
+  // draw obstacle collision
+  for (const auto & pc : possible_collisions) {
+    // debug marker
+    std::vector<Marker> collision_markers = makeDebugInfoMarker(pc, id, true);
+    debug_markers.markers.insert(
+      debug_markers.markers.end(), collision_markers.begin(), collision_markers.end());
+    id++;
+  }
+  return debug_markers;
+}
+
+MarkerArray makePolygonMarker(
   const BasicPolygons & polygons, const std::string ns, const int id, const double z)
 {
-  visualization_msgs::msg::MarkerArray debug_markers;
-  visualization_msgs::msg::Marker debug_marker;
+  MarkerArray debug_markers;
+  Marker debug_marker;
   debug_marker.header.frame_id = "map";
   debug_marker.header.stamp = rclcpp::Time(0);
   debug_marker.id = planning_utils::bitShift(id);
-  debug_marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
-  debug_marker.action = visualization_msgs::msg::Marker::ADD;
+  debug_marker.type = Marker::LINE_STRIP;
+  debug_marker.action = Marker::ADD;
   debug_marker.pose.position = tier4_autoware_utils::createMarkerPosition(0.0, 0.0, 0);
   debug_marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
   debug_marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.1, 0.1);
@@ -170,16 +152,16 @@ visualization_msgs::msg::MarkerArray makePolygonMarker(
   return debug_markers;
 }
 
-visualization_msgs::msg::MarkerArray makeSlicePolygonMarker(
+MarkerArray makeSlicePolygonMarker(
   const Polygons2d & slices, const std::string ns, const int id, const double z)
 {
-  visualization_msgs::msg::MarkerArray debug_markers;
-  visualization_msgs::msg::Marker debug_marker;
+  MarkerArray debug_markers;
+  Marker debug_marker;
   debug_marker.header.frame_id = "map";
   debug_marker.header.stamp = rclcpp::Time(0);
   debug_marker.id = planning_utils::bitShift(id);
-  debug_marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
-  debug_marker.action = visualization_msgs::msg::Marker::ADD;
+  debug_marker.type = Marker::LINE_STRIP;
+  debug_marker.action = Marker::ADD;
   debug_marker.pose.position = tier4_autoware_utils::createMarkerPosition(0.0, 0.0, 0);
   debug_marker.pose.orientation = tier4_autoware_utils::createMarkerOrientation(0, 0, 0, 1.0);
   debug_marker.scale = tier4_autoware_utils::createMarkerScale(0.1, 0.1, 0.1);
@@ -198,21 +180,21 @@ visualization_msgs::msg::MarkerArray makeSlicePolygonMarker(
   return debug_markers;
 }
 
-visualization_msgs::msg::MarkerArray createPathMarkerArray(
+MarkerArray createPathMarkerArray(
   const PathWithLaneId & path, const std::string & ns, const int64_t lane_id, const double r,
   const double g, const double b)
 {
-  visualization_msgs::msg::MarkerArray msg;
+  MarkerArray msg;
   int32_t uid = planning_utils::bitShift(lane_id);
   int32_t i = 0;
   for (const auto & p : path.points) {
-    visualization_msgs::msg::Marker marker{};
+    Marker marker{};
     marker.header.frame_id = "map";
     marker.ns = ns;
     marker.id = uid + i++;
     marker.lifetime = rclcpp::Duration::from_seconds(0.3);
-    marker.type = visualization_msgs::msg::Marker::ARROW;
-    marker.action = visualization_msgs::msg::Marker::ADD;
+    marker.type = Marker::ARROW;
+    marker.action = Marker::ADD;
     marker.pose = p.point.pose;
     marker.scale = createMarkerScale(0.6, 0.3, 0.3);
     if (std::find(p.lane_ids.begin(), p.lane_ids.end(), lane_id) != p.lane_ids.end()) {
@@ -227,47 +209,14 @@ visualization_msgs::msg::MarkerArray createPathMarkerArray(
   return msg;
 }
 
-template <class T>
-visualization_msgs::msg::MarkerArray createPossibleCollisionMarkers(
-  T & debug_data, [[maybe_unused]] const int64_t module_id_)
-{
-  // add slow down markers for occlusion spot
-  visualization_msgs::msg::MarkerArray occlusion_spot_slowdown_markers;
-  auto & possible_collisions = debug_data.possible_collisions;
-
-  // draw virtual wall markers
-  int id = planning_utils::bitShift(module_id_);
-  for (const auto & possible_collision : possible_collisions) {
-    std::vector<visualization_msgs::msg::Marker> collision_markers =
-      makeSlowDownMarkers(possible_collision, debug_data.detection_type, id++);
-    occlusion_spot_slowdown_markers.markers.insert(
-      occlusion_spot_slowdown_markers.markers.end(), collision_markers.begin(),
-      collision_markers.end());
-  }
-
-  // draw obstacle collision
-  id = planning_utils::bitShift(module_id_);
-  for (const auto & possible_collision : possible_collisions) {
-    // debug marker
-    std::vector<visualization_msgs::msg::Marker> collision_markers =
-      makeCollisionMarkers(possible_collision, id++, true);
-    occlusion_spot_slowdown_markers.markers.insert(
-      occlusion_spot_slowdown_markers.markers.end(), collision_markers.begin(),
-      collision_markers.end());
-    id++;
-  }
-  return occlusion_spot_slowdown_markers;
-}
-
-visualization_msgs::msg::MarkerArray createOcclusionMarkerArray(
+MarkerArray createOcclusionMarkerArray(
   const std::vector<geometry_msgs::msg::Point> & occlusion_points, const int64_t module_id)
 {
-  visualization_msgs::msg::MarkerArray msg;
+  MarkerArray msg;
   {
     const Time now = rclcpp::Time(0);
     auto marker = createDefaultMarker(
-      "map", now, "occlusion", 0, visualization_msgs::msg::Marker::SPHERE,
-      createMarkerColor(1.0, 0.0, 0.0, 0.999));
+      "map", now, "occlusion", 0, Marker::SPHERE, createMarkerColor(1.0, 0.0, 0.0, 0.999));
     marker.scale = createMarkerScale(0.5, 0.5, 0.5);
     marker.lifetime = rclcpp::Duration::from_seconds(0.1);
     for (size_t i = 0; i < occlusion_points.size(); ++i) {
@@ -280,12 +229,13 @@ visualization_msgs::msg::MarkerArray createOcclusionMarkerArray(
 }
 }  // namespace
 
-visualization_msgs::msg::MarkerArray OcclusionSpotModule::createDebugMarkerArray()
+MarkerArray OcclusionSpotModule::createDebugMarkerArray()
 {
   const auto current_time = this->clock_->now();
-
-  visualization_msgs::msg::MarkerArray debug_marker_array;
-
+  MarkerArray debug_marker_array;
+  if (!debug_data_.possible_collisions.empty()) {
+    appendMarkerArray(makeDebugInfoMarkers(debug_data_), current_time, &debug_marker_array);
+  }
   if (!debug_data_.detection_area_polygons.empty()) {
     appendMarkerArray(
       makeSlicePolygonMarker(
@@ -313,14 +263,19 @@ visualization_msgs::msg::MarkerArray OcclusionSpotModule::createDebugMarkerArray
   return debug_marker_array;
 }
 
-visualization_msgs::msg::MarkerArray OcclusionSpotModule::createVirtualWallMarkerArray()
+MarkerArray OcclusionSpotModule::createVirtualWallMarkerArray()
 {
   const auto current_time = this->clock_->now();
 
-  visualization_msgs::msg::MarkerArray wall_marker;
+  MarkerArray wall_marker;
+  std::string module_name = "occlusion_spot";
   if (!debug_data_.possible_collisions.empty()) {
-    appendMarkerArray(
-      createPossibleCollisionMarkers(debug_data_, module_id_), current_time, &wall_marker);
+    for (size_t id = 0; id < debug_data_.possible_collisions.size(); id++) {
+      const auto & pose = debug_data_.possible_collisions.at(id).intersection_pose;
+      appendMarkerArray(
+        tier4_autoware_utils::createSlowDownVirtualWallMarker(pose, module_name, current_time, id),
+        current_time, &wall_marker);
+    }
   }
   return wall_marker;
 }


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

move occlusion spot debug marker which is included in virtual wall marker to debug marker name space

![image](https://user-images.githubusercontent.com/65527974/173969401-3780c943-0f5f-45f1-b4e6-59086bb7d2d9.png)

after this  PR default view is as follows
![image](https://user-images.githubusercontent.com/65527974/173970358-89173c15-acaa-4500-8cdf-a439517a5d31.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
