### PR TITLE
feat(tier4_autoware_utils): add calculator to the closest stop point

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/trajectory.hpp
@@ -364,6 +364,41 @@ double calcArcLength(const T & points)
 
   return calcSignedArcLength(points, 0, points.size() - 1);
 }
+
+/**
+ * @brief Calculate distance to the closest stop point ahead of the pose
+ */
+template <class T>
+boost::optional<double> calcDistanceToStopPoint(
+  const T & points_with_twist, const geometry_msgs::msg::Pose & pose, const size_t dst_idx,
+  const double max_dist = std::numeric_limits<double>::max(),
+  const double max_yaw = std::numeric_limits<double>::max())
+{
+  validateNonEmpty(points_with_twist);
+
+  const auto nearest_segment_idx =
+    tier4_autoware_utils::findNearestSegmentIndex(points_with_twist, pose, max_dist, max_yaw);
+
+  if (!nearest_segment_idx) {
+    return boost::none;
+  }
+
+  const auto stop_idx = tier4_autoware_utils::searchZeroVelocityIndex(
+    points_with_twist, *nearest_segment_idx + 1, points_with_twist.size());
+
+  if (!stop_idx) {
+    return boost::none;
+  }
+
+  const auto closest_stop_dist = tier4_autoware_utils::calcSignedArcLength(
+    points_with_twist, pose, *stop_idx, max_dist, max_yaw);
+
+  if (!closest_stop_dist) {
+    return boost::none;
+  }
+
+  return std::max(0.0, *closest_stop_dist);
+}
 }  // namespace tier4_autoware_utils
 
 #endif  // TIER4_AUTOWARE_UTILS__TRAJECTORY__TRAJECTORY_HPP_


### PR DESCRIPTION
## Description
Add a distance calculator to the closest stop point on the trajectory. We assume the stop point is ahead of the current pose, and ignore the pose behind the current pose. 

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
