### PR TITLE
feat(behavior_velocity_planner): consider jerk limit for generating pass judge line

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -169,10 +169,12 @@ bool generateStopLine(
 {
   /* set judge line dist */
   const double current_vel = planner_data->current_velocity->twist.linear.x;
+  const double current_acc = planner_data->current_accel.get();
   const double max_acc = planner_data->max_stop_acceleration_threshold;
+  const double max_jerk = planner_data->max_stop_jerk_threshold;
   const double delay_response_time = planner_data->delay_response_time;
-  const double pass_judge_line_dist =
-    planning_utils::calcJudgeLineDistWithAccLimit(current_vel, max_acc, delay_response_time);
+  const double pass_judge_line_dist = planning_utils::calcJudgeLineDistWithJerkLimit(
+    current_vel, current_acc, max_acc, max_jerk, delay_response_time);
 
   /* set parameters */
   constexpr double interval = 0.2;


### PR DESCRIPTION
Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

This PR changes pass judge line generation method in intersection module. By using jerk limit in addition to acceleration limit, the pass judge line is generated at closer position to the vehicle.

## Tests performed

I compared the pass judge line obtained from `calcJudgeDistWithJerkLimit` and `calcJudgeDistWithAccLimit` on Rviz. In the image the yellow and green lines are obtained from `calcJudgeDistWithJerkLimit` and `calcJudgeDistWithAccLimit` respectively (yellow one is closer to the vehicle, especially when the vehicle is driving).

![Screenshot from 2022-06-16 15-45-21](https://user-images.githubusercontent.com/28677420/174008800-0e7e1af8-54e3-4e4e-a1a1-0df4cd04a769.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
