### PR TITLE
fix(behavior_path_planner): wrong avoidance for expanded lane case

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -42,13 +42,22 @@ rclcpp_components_register_node(behavior_path_planner_node
 )
 
 if(BUILD_TESTING)
-  ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_utilities
+  ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_utilities
     test/input.cpp
     test/test_utilities.cpp
   )
-  target_link_libraries(test_${PROJECT_NAME}_utilities
+  target_link_libraries(test_${CMAKE_PROJECT_NAME}_utilities
     behavior_path_planner_node
   )
+
+  ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_avoidance_module
+    test/test_avoidance_utils.cpp
+  )
+
+  target_link_libraries(test_${CMAKE_PROJECT_NAME}_avoidance_module
+    behavior_path_planner_node
+  )
+
 endif()
 
 ament_auto_package(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -137,6 +137,8 @@ private:
     AvoidPointArray & current_raw_shift_points, DebugData & debug) const;
 
   // shift point generation: generator
+  double getShiftLength(
+    const ObjectData & object, const bool & is_object_on_right, const double & avoid_margin) const;
   AvoidPointArray calcRawShiftPointsFromObjects(const ObjectDataArray & objects) const;
   double getRightShiftBound() const;
   double getLeftShiftBound() const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -15,6 +15,7 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__AVOIDANCE_UTILS_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__AVOIDANCE_UTILS_HPP_
 
+#include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp"
 
 #include <memory>
@@ -24,7 +25,13 @@
 
 namespace behavior_path_planner
 {
+using behavior_path_planner::PlannerData;
 bool isOnRight(const ObjectData & obj);
+
+double calcShiftLength(
+  const bool & is_object_on_right, const double & overhang_dist, const double & avoid_margin);
+
+bool isSameDirectionShift(const bool & is_object_on_right, const double & shift_length);
 
 lanelet::ConstLanelets calcLaneAroundPose(
   const std::shared_ptr<const PlannerData> & planner_data, const Pose & pose,

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -497,6 +497,14 @@ AvoidPointArray AvoidanceModule::calcRawShiftPointsFromObjects(
     const auto shift_length = isOnRight(o)
                                 ? std::min(o.overhang_dist + avoid_margin, getLeftShiftBound())
                                 : std::max(o.overhang_dist - avoid_margin, getRightShiftBound());
+
+    if (
+      std::fabs(shift_length) <
+      std::fabs(o.overhang_dist) - vehicle_width - lat_collision_safety_buffer) {
+      avoidance_debug_array_false_and_push_back("TooShortShift");
+      continue;
+    }
+
     const auto avoiding_shift = shift_length - current_ego_shift;
     const auto return_shift = shift_length;
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -500,7 +500,7 @@ AvoidPointArray AvoidanceModule::calcRawShiftPointsFromObjects(
 
     if (
       std::fabs(shift_length) <
-      std::fabs(o.overhang_dist) - vehicle_width - lat_collision_safety_buffer) {
+      std::fabs(o.overhang_dist) - 0.5 * vehicle_width - lat_collision_safety_buffer) {
       avoidance_debug_array_false_and_push_back("TooShortShift");
       continue;
     }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -446,6 +446,14 @@ void AvoidanceModule::registerRawShiftPoints(const AvoidPointArray & future)
   DEBUG_PRINT("registered object size: %lu -> %lu", old_size, registered_raw_shift_points_.size());
 }
 
+double AvoidanceModule::getShiftLength(
+  const ObjectData & object, const bool & is_object_on_right, const double & avoid_margin) const
+{
+  const auto shift_length =
+    behavior_path_planner::calcShiftLength(is_object_on_right, object.overhang_dist, avoid_margin);
+  return is_object_on_right ? std::min(shift_length, getLeftShiftBound())
+                            : std::max(shift_length, getRightShiftBound());
+}
 /**
  * calcRawShiftPointsFromObjects
  *
@@ -494,14 +502,10 @@ AvoidPointArray AvoidanceModule::calcRawShiftPointsFromObjects(
       continue;
     }
 
-    const auto shift_length = isOnRight(o)
-                                ? std::min(o.overhang_dist + avoid_margin, getLeftShiftBound())
-                                : std::max(o.overhang_dist - avoid_margin, getRightShiftBound());
-
-    if (
-      std::fabs(shift_length) <
-      std::fabs(o.overhang_dist) - 0.5 * vehicle_width - lat_collision_safety_buffer) {
-      avoidance_debug_array_false_and_push_back("TooShortShift");
+    const auto is_object_on_right = isOnRight(o);
+    const auto shift_length = getShiftLength(o, is_object_on_right, avoid_margin);
+    if (isSameDirectionShift(is_object_on_right, shift_length)) {
+      avoidance_debug_array_false_and_push_back("IgnoreSameDirectionShift");
       continue;
     }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -14,6 +14,7 @@
 
 #include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module.hpp"
+#include "behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp"
 #include "behavior_path_planner/utilities.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
@@ -31,6 +32,19 @@
 namespace behavior_path_planner
 {
 bool isOnRight(const ObjectData & obj) { return obj.lateral < 0.0; }
+
+double calcShiftLength(
+  const bool & is_object_on_right, const double & overhang_dist, const double & avoid_margin)
+{
+  const auto shift_length =
+    is_object_on_right ? (overhang_dist + avoid_margin) : (overhang_dist - avoid_margin);
+  return std::fabs(shift_length) > 1e-3 ? shift_length : 0.0;
+}
+
+bool isSameDirectionShift(const bool & is_object_on_right, const double & shift_length)
+{
+  return (is_object_on_right == std::signbit(shift_length));
+}
 
 lanelet::ConstLanelets calcLaneAroundPose(
   const std::shared_ptr<const PlannerData> & planner_data, const geometry_msgs::msg::Pose & pose,

--- a/planning/behavior_path_planner/test/test_avoidance_utils.cpp
+++ b/planning/behavior_path_planner/test/test_avoidance_utils.cpp
@@ -1,0 +1,42 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp"
+#include "behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using behavior_path_planner::isOnRight;
+using behavior_path_planner::isSameDirectionShift;
+using behavior_path_planner::ObjectData;
+
+TEST(BehaviorPathPlanningAvoidanceUtilsTest, shiftLengthDirectionTest)
+{
+  ObjectData right_obj;
+  right_obj.lateral = -0.3;
+  const double negative_shift_length = -1.0;
+  const double positive_shift_length = 1.0;
+
+  ASSERT_TRUE(isSameDirectionShift(isOnRight(right_obj), negative_shift_length));
+  ASSERT_FALSE(isSameDirectionShift(isOnRight(right_obj), positive_shift_length));
+
+  ObjectData left_obj;
+  left_obj.lateral = 0.3;
+  ASSERT_TRUE(isSameDirectionShift(isOnRight(left_obj), positive_shift_length));
+  ASSERT_FALSE(isSameDirectionShift(isOnRight(left_obj), negative_shift_length));
+
+  const double zero_shift_length = 0.0;
+  ASSERT_TRUE(isSameDirectionShift(isOnRight(left_obj), zero_shift_length));
+  ASSERT_FALSE(isSameDirectionShift(isOnRight(right_obj), zero_shift_length));
+}


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

The current avoidance module doesn't consider shift_length that can be ignored. This causes wrong avoidance behavior is some areas for example wide lanes where the width is not the standard. This PR attempts to solve the issue by ignoring the shift length.

![ignoring_shift_point drawio](https://user-images.githubusercontent.com/93502286/174950289-747b246a-d42d-466e-aba0-fada6d67c9f5.png)


## Related links

#1076 

## Tests performed

1. Adjust the value `detection_area_right_expand` in `avoidance.param.yaml`
2. Load map with road width wider than standard in planning simulator.
3. Place the obstacle outside of the ego current lane, but within the expanded lane.
4. The result is avoidance should not happen.

![Evidence](https://user-images.githubusercontent.com/93502286/174158957-e7ad8d52-3fe7-4d37-abb9-9a82b817e54c.png)

## Notes for reviewers

Reviewer should also confirm that the solution will not break the normal avoidance behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
