### PR TITLE
feat(tier4_autoware_utils): add new orientation calculation

### DIFF
--- a/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
@@ -848,6 +848,7 @@ TEST(geometry, calcInterpolatedPose)
   using tier4_autoware_utils::createQuaternion;
   using tier4_autoware_utils::createQuaternionFromRPY;
   using tier4_autoware_utils::deg2rad;
+  const double epsilon = 1e-3;
 
   // Position Interpolation
   {
@@ -859,7 +860,6 @@ TEST(geometry, calcInterpolatedPose)
     dst_pose.position = createPoint(3.0, 0.0, 0.0);
     dst_pose.orientation = createQuaternion(0.0, 0.0, 0.0, 1.0);
 
-    const double epsilon = 1e-3;
     for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
       const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
 
@@ -873,78 +873,76 @@ TEST(geometry, calcInterpolatedPose)
     }
   }
 
-  // Quaternion Interpolation
-  {{geometry_msgs::msg::Pose src_pose;
-  src_pose.position = createPoint(0.0, 0.0, 0.0);
-  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+  // Quaternion Interpolation1
+  {
+    geometry_msgs::msg::Pose src_pose;
+    src_pose.position = createPoint(0.0, 0.0, 0.0);
+    src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
 
-  geometry_msgs::msg::Pose dst_pose;
-  dst_pose.position = createPoint(0.0, 0.0, 0.0);
-  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90));
+    geometry_msgs::msg::Pose dst_pose;
+    dst_pose.position = createPoint(0.0, 0.0, 0.0);
+    dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90));
 
-  const double epsilon = 1e-3;
-  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
-    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
+    for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+      const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
 
-    const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
-    EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
-    EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
-    EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
-    EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+      EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
+      EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
+      EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
+      EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+    }
   }
-}
 
-{
-  geometry_msgs::msg::Pose src_pose;
-  src_pose.position = createPoint(0.0, 0.0, 0.0);
-  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+  // Quaternion Interpolation2
+  {
+    geometry_msgs::msg::Pose src_pose;
+    src_pose.position = createPoint(0.0, 0.0, 0.0);
+    src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
 
-  geometry_msgs::msg::Pose dst_pose;
-  dst_pose.position = createPoint(1.0, 1.0, 0.0);
-  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(60));
+    geometry_msgs::msg::Pose dst_pose;
+    dst_pose.position = createPoint(1.0, 1.0, 0.0);
+    dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(60));
 
-  const double epsilon = 1e-3;
-  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
-    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
+    for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+      const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
 
-    const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(45));
-    EXPECT_DOUBLE_EQ(p_out.position.x, 1.0 * ratio);
-    EXPECT_DOUBLE_EQ(p_out.position.y, 1.0 * ratio);
-    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
-    EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
-    EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
-    EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(45));
+      EXPECT_DOUBLE_EQ(p_out.position.x, 1.0 * ratio);
+      EXPECT_DOUBLE_EQ(p_out.position.y, 1.0 * ratio);
+      EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
+      EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
+      EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
+      EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+    }
   }
-}
-}
 
-// Same points are given
-{
-  geometry_msgs::msg::Pose src_pose;
-  src_pose.position = createPoint(0.0, 0.0, 0.0);
-  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+  // Same points are given
+  {
+    geometry_msgs::msg::Pose src_pose;
+    src_pose.position = createPoint(0.0, 0.0, 0.0);
+    src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
 
-  geometry_msgs::msg::Pose dst_pose;
-  dst_pose.position = createPoint(0.0, 0.0, 0.0);
-  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+    geometry_msgs::msg::Pose dst_pose;
+    dst_pose.position = createPoint(0.0, 0.0, 0.0);
+    dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
 
-  const double epsilon = 1e-3;
-  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
-    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
+    for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+      const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
 
-    EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.x, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.y, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.z, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.w, 1.0);
+      EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.x, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.y, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.z, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.w, 1.0);
+    }
   }
-}
 }
 
 TEST(geometry, calcInterpolatedPose_with_Spherical_Interpolation)
@@ -954,6 +952,7 @@ TEST(geometry, calcInterpolatedPose_with_Spherical_Interpolation)
   using tier4_autoware_utils::createQuaternion;
   using tier4_autoware_utils::createQuaternionFromRPY;
   using tier4_autoware_utils::deg2rad;
+  const double epsilon = 1e-3;
 
   // Position Interpolation
   {
@@ -965,7 +964,6 @@ TEST(geometry, calcInterpolatedPose_with_Spherical_Interpolation)
     dst_pose.position = createPoint(3.0, 0.0, 0.0);
     dst_pose.orientation = createQuaternion(0.0, 0.0, 0.0, 1.0);
 
-    const double epsilon = 1e-3;
     for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
       const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
 
@@ -979,76 +977,74 @@ TEST(geometry, calcInterpolatedPose_with_Spherical_Interpolation)
     }
   }
 
-  // Quaternion Interpolation
-  {{geometry_msgs::msg::Pose src_pose;
-  src_pose.position = createPoint(0.0, 0.0, 0.0);
-  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+  // Quaternion Interpolation1
+  {
+    geometry_msgs::msg::Pose src_pose;
+    src_pose.position = createPoint(0.0, 0.0, 0.0);
+    src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
 
-  geometry_msgs::msg::Pose dst_pose;
-  dst_pose.position = createPoint(0.0, 0.0, 0.0);
-  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90));
+    geometry_msgs::msg::Pose dst_pose;
+    dst_pose.position = createPoint(0.0, 0.0, 0.0);
+    dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90));
 
-  const double epsilon = 1e-3;
-  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
-    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
+    for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+      const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
 
-    const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90 * ratio));
-    EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
-    EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
-    EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
-    EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90 * ratio));
+      EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
+      EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
+      EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
+      EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+    }
   }
-}
 
-{
-  geometry_msgs::msg::Pose src_pose;
-  src_pose.position = createPoint(0.0, 0.0, 0.0);
-  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+  // Quaternion Interpolation2
+  {
+    geometry_msgs::msg::Pose src_pose;
+    src_pose.position = createPoint(0.0, 0.0, 0.0);
+    src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
 
-  geometry_msgs::msg::Pose dst_pose;
-  dst_pose.position = createPoint(1.0, 1.0, 0.0);
-  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(60));
+    geometry_msgs::msg::Pose dst_pose;
+    dst_pose.position = createPoint(1.0, 1.0, 0.0);
+    dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(60));
 
-  const double epsilon = 1e-3;
-  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
-    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
+    for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+      const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
 
-    const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(60 * ratio));
-    EXPECT_DOUBLE_EQ(p_out.position.x, 1.0 * ratio);
-    EXPECT_DOUBLE_EQ(p_out.position.y, 1.0 * ratio);
-    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
-    EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
-    EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
-    EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+      const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(60 * ratio));
+      EXPECT_DOUBLE_EQ(p_out.position.x, 1.0 * ratio);
+      EXPECT_DOUBLE_EQ(p_out.position.y, 1.0 * ratio);
+      EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
+      EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
+      EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
+      EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+    }
   }
-}
-}
 
-// Same points are given
-{
-  geometry_msgs::msg::Pose src_pose;
-  src_pose.position = createPoint(0.0, 0.0, 0.0);
-  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+  // Same points are given
+  {
+    geometry_msgs::msg::Pose src_pose;
+    src_pose.position = createPoint(0.0, 0.0, 0.0);
+    src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
 
-  geometry_msgs::msg::Pose dst_pose;
-  dst_pose.position = createPoint(0.0, 0.0, 0.0);
-  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+    geometry_msgs::msg::Pose dst_pose;
+    dst_pose.position = createPoint(0.0, 0.0, 0.0);
+    dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
 
-  const double epsilon = 1e-3;
-  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
-    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
+    for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+      const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
 
-    EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.x, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.y, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.z, 0.0);
-    EXPECT_DOUBLE_EQ(p_out.orientation.w, 1.0);
+      EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.x, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.y, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.z, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.orientation.w, 1.0);
+    }
   }
-}
 }

--- a/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
@@ -874,45 +874,102 @@ TEST(geometry, calcInterpolatedPose)
   }
 
   // Quaternion Interpolation
-  {
-    geometry_msgs::msg::Pose src_pose;
-    src_pose.position = createPoint(0.0, 0.0, 0.0);
-    src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+  {{geometry_msgs::msg::Pose src_pose;
+  src_pose.position = createPoint(0.0, 0.0, 0.0);
+  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
 
-    geometry_msgs::msg::Pose dst_pose;
-    dst_pose.position = createPoint(0.0, 0.0, 0.0);
-    dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90));
+  geometry_msgs::msg::Pose dst_pose;
+  dst_pose.position = createPoint(0.0, 0.0, 0.0);
+  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90));
 
-    const double epsilon = 1e-3;
-    for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
-      const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
+  const double epsilon = 1e-3;
+  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
 
-      const auto result_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90 * ratio));
-      EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
-      EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
-      EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
-      EXPECT_DOUBLE_EQ(p_out.orientation.x, result_quat.x);
-      EXPECT_DOUBLE_EQ(p_out.orientation.y, result_quat.y);
-      EXPECT_DOUBLE_EQ(p_out.orientation.z, result_quat.z);
-      EXPECT_DOUBLE_EQ(p_out.orientation.w, result_quat.w);
-    }
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+    EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
+    EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
+    EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
   }
+}
 
-  // Same points are given
+{
+  geometry_msgs::msg::Pose src_pose;
+  src_pose.position = createPoint(0.0, 0.0, 0.0);
+  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+
+  geometry_msgs::msg::Pose dst_pose;
+  dst_pose.position = createPoint(1.0, 1.0, 0.0);
+  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(60));
+
+  const double epsilon = 1e-3;
+  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
+
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(45));
+    EXPECT_DOUBLE_EQ(p_out.position.x, 1.0 * ratio);
+    EXPECT_DOUBLE_EQ(p_out.position.y, 1.0 * ratio);
+    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
+    EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
+    EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+  }
+}
+}
+
+// Same points are given
+{
+  geometry_msgs::msg::Pose src_pose;
+  src_pose.position = createPoint(0.0, 0.0, 0.0);
+  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+
+  geometry_msgs::msg::Pose dst_pose;
+  dst_pose.position = createPoint(0.0, 0.0, 0.0);
+  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+
+  const double epsilon = 1e-3;
+  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
+
+    EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.z, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.w, 1.0);
+  }
+}
+}
+
+TEST(geometry, calcInterpolatedPose_with_Spherical_Interpolation)
+{
+  using tier4_autoware_utils::calcInterpolatedPose;
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::createQuaternion;
+  using tier4_autoware_utils::createQuaternionFromRPY;
+  using tier4_autoware_utils::deg2rad;
+
+  // Position Interpolation
   {
     geometry_msgs::msg::Pose src_pose;
     src_pose.position = createPoint(0.0, 0.0, 0.0);
-    src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+    src_pose.orientation = createQuaternion(0.0, 0.0, 0.0, 1.0);
 
     geometry_msgs::msg::Pose dst_pose;
-    dst_pose.position = createPoint(0.0, 0.0, 0.0);
-    dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+    dst_pose.position = createPoint(3.0, 0.0, 0.0);
+    dst_pose.orientation = createQuaternion(0.0, 0.0, 0.0, 1.0);
 
     const double epsilon = 1e-3;
     for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
-      const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio);
+      const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
 
-      EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
+      EXPECT_DOUBLE_EQ(p_out.position.x, 3.0 * ratio);
       EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
       EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
       EXPECT_DOUBLE_EQ(p_out.orientation.x, 0.0);
@@ -921,4 +978,77 @@ TEST(geometry, calcInterpolatedPose)
       EXPECT_DOUBLE_EQ(p_out.orientation.w, 1.0);
     }
   }
+
+  // Quaternion Interpolation
+  {{geometry_msgs::msg::Pose src_pose;
+  src_pose.position = createPoint(0.0, 0.0, 0.0);
+  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+
+  geometry_msgs::msg::Pose dst_pose;
+  dst_pose.position = createPoint(0.0, 0.0, 0.0);
+  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90));
+
+  const double epsilon = 1e-3;
+  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
+
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(90 * ratio));
+    EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
+    EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
+    EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+  }
+}
+
+{
+  geometry_msgs::msg::Pose src_pose;
+  src_pose.position = createPoint(0.0, 0.0, 0.0);
+  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+
+  geometry_msgs::msg::Pose dst_pose;
+  dst_pose.position = createPoint(1.0, 1.0, 0.0);
+  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(60));
+
+  const double epsilon = 1e-3;
+  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
+
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(60 * ratio));
+    EXPECT_DOUBLE_EQ(p_out.position.x, 1.0 * ratio);
+    EXPECT_DOUBLE_EQ(p_out.position.y, 1.0 * ratio);
+    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, ans_quat.x);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, ans_quat.y);
+    EXPECT_DOUBLE_EQ(p_out.orientation.z, ans_quat.z);
+    EXPECT_DOUBLE_EQ(p_out.orientation.w, ans_quat.w);
+  }
+}
+}
+
+// Same points are given
+{
+  geometry_msgs::msg::Pose src_pose;
+  src_pose.position = createPoint(0.0, 0.0, 0.0);
+  src_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+
+  geometry_msgs::msg::Pose dst_pose;
+  dst_pose.position = createPoint(0.0, 0.0, 0.0);
+  dst_pose.orientation = createQuaternionFromRPY(deg2rad(0), deg2rad(0), deg2rad(0));
+
+  const double epsilon = 1e-3;
+  for (double ratio = 0.0; ratio < 1.0 + epsilon; ratio += 0.1) {
+    const auto p_out = calcInterpolatedPose(src_pose, dst_pose, ratio, false);
+
+    EXPECT_DOUBLE_EQ(p_out.position.x, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.position.y, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.position.z, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.x, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.y, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.z, 0.0);
+    EXPECT_DOUBLE_EQ(p_out.orientation.w, 1.0);
+  }
+}
 }


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
Add a new option to calculate the interpolated pose orientation
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
