### PR TITLE
fix: add  vehicle_status topic checking

### DIFF
--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
@@ -34,25 +34,29 @@
 #include <tf2_ros/transform_listener.h>
 
 // Include tier4 autoware utils
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
 #include <deque>
 #include <memory>
 #include <string>
-
 namespace pointcloud_preprocessor
 {
 using autoware_auto_vehicle_msgs::msg::VelocityReport;
 using rcl_interfaces::msg::SetParametersResult;
 using sensor_msgs::msg::PointCloud2;
 
+using diagnostic_updater::DiagnosticStatusWrapper;
+using diagnostic_updater::Updater;
 class DistortionCorrectorComponent : public rclcpp::Node
 {
 public:
   explicit DistortionCorrectorComponent(const rclcpp::NodeOptions & options);
 
 private:
+  void VehicleReportCheck(DiagnosticStatusWrapper & stat);
+  Updater updater_{this};
   void onPointCloud(PointCloud2::UniquePtr points_msg);
   void onVelocityReport(const VelocityReport::ConstSharedPtr velocity_report_msg);
   bool getTransform(


### PR DESCRIPTION
Signed-off-by: badai-nguyen <dai.nguyen@tier4.jp>

## Description
To solve this issue #1102 
Since the other simulation might needed on run failed cases so only warning is added into.

Warning status in case no velocity report topic is published:
 
![image](https://user-images.githubusercontent.com/94814556/174518740-09b63d8b-224e-4815-9f18-6ee2ea8bda59.png)

Status in case velocity report topic is published:  
![image](https://user-images.githubusercontent.com/94814556/174518946-db272e91-acb3-47e7-8e5b-eef287e833fd.png)



<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
