### PR TITLE
fix(emergency_handler): publish gear

### DIFF
--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -141,10 +141,14 @@ void EmergencyHandler::publishControlCommands()
   pub_hazard_cmd_->publish(createHazardCmdMsg());
 
   // Publish gear
-  if (param_.use_parking_after_stopped && isStopped()) {
+  {
     GearCommand msg;
     msg.stamp = stamp;
-    msg.command = GearCommand::PARK;
+    if (param_.use_parking_after_stopped && isStopped()) {
+      msg.command = GearCommand::PARK;
+    } else {
+      msg.command = GearCommand::DRIVE;
+    }
     pub_gear_cmd_->publish(msg);
   }
 


### PR DESCRIPTION
Signed-off-by: Shinnosuke Hirakawa <shinnosuke.hirakawa@tier4.jp>

## Description
The current emergency handler does not publish GearCommand in default. When Autoware becomes emergency, the gear is not explicitly determined. The vehicle_cmd gate adopts [the default value](https://github.com/autowarefoundation/autoware.universe/blob/main/control/vehicle_cmd_gate/include/vehicle_cmd_gate/vehicle_cmd_gate.hpp#L64-L74) and immediately shift from Drive to Park.
This PR attempts to solve the issue by publishing GearCommand of Drive 

## Related links

<!-- Write the links related to this PR. -->

## Tests performed
1. Drive a car in planning simulator
2. Cause emergency by reconfiguring some dummy_diag_publisher
3. Check `/system/emergency/gear_cmd` and `/control/command/gear_cmd`

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
