### PR TITLE
feat(signal_processing): more flexible low pass filter

### DIFF
--- a/common/signal_processing/include/signal_processing/lowpass_filter_1d.hpp
+++ b/common/signal_processing/include/signal_processing/lowpass_filter_1d.hpp
@@ -15,6 +15,8 @@
 #ifndef SIGNAL_PROCESSING__LOWPASS_FILTER_1D_HPP_
 #define SIGNAL_PROCESSING__LOWPASS_FILTER_1D_HPP_
 
+#include <boost/optional.hpp>
+
 /**
  * @class First-order low-pass filter
  * @brief filtering values
@@ -22,15 +24,16 @@
 class LowpassFilter1d
 {
 private:
-  double x_;     //!< @brief current filtered value
-  double gain_;  //!< @brief gain value of first-order low-pass filter
+  boost::optional<double> x_;  //!< @brief current filtered value
+  double gain_;                //!< @brief gain value of first-order low-pass filter
 
 public:
-  LowpassFilter1d(const double x, const double gain);
+  explicit LowpassFilter1d(const double gain);
 
+  void reset();
   void reset(const double x);
 
-  double getValue() const;
+  boost::optional<double> getValue() const;
   double filter(const double u);
 };
 

--- a/common/signal_processing/src/lowpass_filter_1d.cpp
+++ b/common/signal_processing/src/lowpass_filter_1d.cpp
@@ -14,15 +14,22 @@
 
 #include "signal_processing/lowpass_filter_1d.hpp"
 
-LowpassFilter1d::LowpassFilter1d(const double x, const double gain) : x_(x), gain_(gain) {}
+LowpassFilter1d::LowpassFilter1d(const double gain) : gain_(gain) {}
+
+void LowpassFilter1d::reset() { x_ = {}; }
 
 void LowpassFilter1d::reset(const double x) { x_ = x; }
 
-double LowpassFilter1d::getValue() const { return x_; }
+boost::optional<double> LowpassFilter1d::getValue() const { return x_; }
 
 double LowpassFilter1d::filter(const double u)
 {
-  const double ret = gain_ * x_ + (1.0 - gain_) * u;
-  x_ = ret;
-  return ret;
+  if (x_) {
+    const double ret = gain_ * x_.get() + (1.0 - gain_) * u;
+    x_ = ret;
+    return x_.get();
+  }
+
+  x_ = u;
+  return x_.get();
 }

--- a/common/signal_processing/test/src/lowpass_filter_1d_test.cpp
+++ b/common/signal_processing/test/src/lowpass_filter_1d_test.cpp
@@ -20,22 +20,26 @@ constexpr double epsilon = 1e-6;
 
 TEST(lowpass_filter_1d, filter)
 {
-  LowpassFilter1d lowpass_filter_1d(0.0, 0.1);
+  LowpassFilter1d lowpass_filter_1d(0.1);
 
   // initial state
-  EXPECT_NEAR(lowpass_filter_1d.getValue(), 0.0, epsilon);
+  EXPECT_EQ(*lowpass_filter_1d.getValue(), {});
 
   // random filter
   EXPECT_NEAR(lowpass_filter_1d.filter(0.0), 0.0, epsilon);
   EXPECT_NEAR(lowpass_filter_1d.filter(1.0), 0.9, epsilon);
   EXPECT_NEAR(lowpass_filter_1d.filter(2.0), 1.89, epsilon);
-  EXPECT_NEAR(lowpass_filter_1d.getValue(), 1.89, epsilon);
+  EXPECT_NEAR(*lowpass_filter_1d.getValue(), 1.89, epsilon);
 
-  // reset
+  // reset without value
+  lowpass_filter_1d.reset();
+  EXPECT_EQ(*lowpass_filter_1d.getValue(), {});
+
+  // reset with value
   lowpass_filter_1d.reset(-1.1);
-  EXPECT_NEAR(lowpass_filter_1d.getValue(), -1.1, epsilon);
+  EXPECT_NEAR(*lowpass_filter_1d.getValue(), -1.1, epsilon);
   EXPECT_NEAR(lowpass_filter_1d.filter(0.0), -0.11, epsilon);
-  EXPECT_NEAR(lowpass_filter_1d.getValue(), -0.11, epsilon);
+  EXPECT_NEAR(*lowpass_filter_1d.getValue(), -0.11, epsilon);
 }
 
 int main(int argc, char * argv[])

--- a/localization/twist2accel/src/twist2accel.cpp
+++ b/localization/twist2accel/src/twist2accel.cpp
@@ -44,12 +44,12 @@ Twist2Accel::Twist2Accel(const std::string & node_name, const rclcpp::NodeOption
   accel_lowpass_gain_ = declare_parameter("accel_lowpass_gain", 0.5);
   use_odom_ = declare_parameter("use_odom", true);
 
-  lpf_alx_ptr_ = std::make_shared<LowpassFilter1d>(0.0, accel_lowpass_gain_);
-  lpf_aly_ptr_ = std::make_shared<LowpassFilter1d>(0.0, accel_lowpass_gain_);
-  lpf_alz_ptr_ = std::make_shared<LowpassFilter1d>(0.0, accel_lowpass_gain_);
-  lpf_aax_ptr_ = std::make_shared<LowpassFilter1d>(0.0, accel_lowpass_gain_);
-  lpf_aay_ptr_ = std::make_shared<LowpassFilter1d>(0.0, accel_lowpass_gain_);
-  lpf_aaz_ptr_ = std::make_shared<LowpassFilter1d>(0.0, accel_lowpass_gain_);
+  lpf_alx_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
+  lpf_aly_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
+  lpf_alz_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
+  lpf_aax_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
+  lpf_aay_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
+  lpf_aaz_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
 }
 
 void Twist2Accel::callbackOdometry(const nav_msgs::msg::Odometry::SharedPtr msg)

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -239,7 +239,7 @@ ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions &
 
   // low pass filter for ego acceleration
   const double lpf_gain_for_accel = declare_parameter<double>("common.lpf_gain_for_accel");
-  lpf_acc_ptr_ = std::make_shared<LowpassFilter1d>(0.0, lpf_gain_for_accel);
+  lpf_acc_ptr_ = std::make_shared<LowpassFilter1d>(lpf_gain_for_accel);
 
   {  // Obstacle filtering parameters
     obstacle_filtering_param_.rough_detection_area_expand_width =

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -452,7 +452,7 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
     p.max_velocity = declare_parameter("max_velocity", 20.0);
     p.hunting_threshold = declare_parameter("hunting_threshold", 0.5);
     p.lowpass_gain = declare_parameter("lowpass_gain", 0.9);
-    lpf_acc_ = std::make_shared<LowpassFilter1d>(0.0, p.lowpass_gain);
+    lpf_acc_ = std::make_shared<LowpassFilter1d>(p.lowpass_gain);
     const double max_yaw_deviation_deg = declare_parameter("max_yaw_deviation_deg", 90.0);
     p.max_yaw_deviation_rad = tier4_autoware_utils::deg2rad(max_yaw_deviation_deg);
   }


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

Just changed the interface of lowpass filter to be more flexible and changed its dependency (obstacle_stop_planner, twist2accel, obstacle_cruise_planner, ...) for the following usecase.
- The aim is to apply lpf to the front vehicle's position.
    - The front vehicle is recognized -> apply filtering (This filter function already exists without the PR)
    - Then, the front vehicle disappears -> do nothing
    - Then, the front vehicle is recognized again -> Assuming that this front vehicle is not the same as the previous front vehicle, we wanna forget the previous low-pass filtered value and apply filtering. (reset function (without arguments) and modified filter function in this PR enables this usecase)
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
