### PR TITLE
feat(obstacle_cruise_planner): some minor updates

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -76,6 +76,8 @@
 
       min_cruise_target_vel: 0.0 # minimum target velocity during slow down [m/s]
 
+      lpf_cruise_gain: 0.2
+
     optimization_based_planner:
       resampling_s_interval: 2.0
       dense_resampling_time_interval: 0.1
@@ -85,11 +87,11 @@
       max_trajectory_length: 200.0
       velocity_margin: 0.1 #[m/s]
 
-      # Parameters for safe distance
+      # Parameters for safety distance limit time
       t_dangerous: 0.5
 
       # For initial Motion
-      replan_vel_deviation: 5.0         # velocity deviation to replan initial velocity [m/s]
+      replan_vel_deviation: 5.0          # velocity deviation to replan initial velocity [m/s]
       engage_velocity: 0.25              # engage velocity threshold [m/s] (if the trajectory velocity is higher than this value, use this velocity for engage vehicle speed)
       engage_acceleration: 0.1           # engage acceleration [m/ss] (use this acceleration when engagement)
       engage_exit_ratio: 0.5             # exit engage sequence to normal velocity planning when the velocity exceeds engage_exit_ratio x engage_velocity.

--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -76,6 +76,8 @@
 
       min_cruise_target_vel: 0.0 # minimum target velocity during slow down [m/s]
 
+      lpf_cruise_gain: 0.2
+
     optimization_based_planner:
       resampling_s_interval: 2.0
       dense_resampling_time_interval: 0.1

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -25,12 +25,25 @@
 
 #include <boost/optional.hpp>
 
+#include <string>
 #include <vector>
 
 using autoware_auto_perception_msgs::msg::ObjectClassification;
 using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_perception_msgs::msg::PredictedPath;
 using autoware_auto_perception_msgs::msg::Shape;
+
+namespace
+{
+std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
+{
+  std::stringstream ss;
+  for (auto i = 0; i < 16; ++i) {
+    ss << std::hex << std::setfill('0') << std::setw(2) << +id.uuid[i];
+  }
+  return ss.str();
+}
+}  // namespace
 
 struct TargetObstacle
 {
@@ -46,6 +59,7 @@ struct TargetObstacle
     is_classified = true;
     classification = object.classification.at(0);
     shape = object.shape;
+    uuid = toHexString(object.object_id);
 
     predicted_paths.clear();
     for (const auto & path : object.kinematics.predicted_paths) {
@@ -53,6 +67,7 @@ struct TargetObstacle
     }
 
     collision_point = arg_collision_point;
+    has_stopped = false;
   }
 
   rclcpp::Time time_stamp;
@@ -63,8 +78,10 @@ struct TargetObstacle
   bool is_classified;
   ObjectClassification classification;
   Shape shape;
+  std::string uuid;
   std::vector<PredictedPath> predicted_paths;
   geometry_msgs::msg::Point collision_point;
+  bool has_stopped;
 };
 
 struct ObstacleCruisePlannerData

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -98,6 +98,7 @@ private:
   double nearest_dist_deviation_threshold_;
   double nearest_yaw_deviation_threshold_;
   double obstacle_velocity_threshold_from_cruise_to_stop_;
+  double obstacle_velocity_threshold_from_stop_to_cruise_;
 
   // parameter callback result
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
@@ -41,15 +41,17 @@ public:
   {
     CruiseObstacleInfo(
       const TargetObstacle & obstacle_arg, const double dist_to_cruise_arg,
-      const double normalized_dist_to_cruise_arg)
+      const double normalized_dist_to_cruise_arg, double dist_to_obstacle_arg)
     : obstacle(obstacle_arg),
       dist_to_cruise(dist_to_cruise_arg),
-      normalized_dist_to_cruise(normalized_dist_to_cruise_arg)
+      normalized_dist_to_cruise(normalized_dist_to_cruise_arg),
+      dist_to_obstacle(dist_to_obstacle_arg)
     {
     }
     TargetObstacle obstacle;
     double dist_to_cruise;
     double normalized_dist_to_cruise;
+    double dist_to_obstacle;
   };
 
   struct StopObstacleInfo

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
@@ -18,6 +18,7 @@
 #include "obstacle_cruise_planner/pid_based_planner/debug_values.hpp"
 #include "obstacle_cruise_planner/pid_based_planner/pid_controller.hpp"
 #include "obstacle_cruise_planner/planner_interface.hpp"
+#include "signal_processing/lowpass_filter_1d.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 
 #include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
@@ -142,6 +143,8 @@ private:
   boost::optional<double> prev_target_vel_;
 
   DebugValues debug_values_;
+
+  std::shared_ptr<LowpassFilter1d> lpf_cruise_ptr_;
 };
 
 #endif  // OBSTACLE_CRUISE_PLANNER__PID_BASED_PLANNER__PID_BASED_PLANNER_HPP_

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -46,13 +46,14 @@ boost::optional<size_t> getFirstNonCollisionIndex(
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const autoware_auto_perception_msgs::msg::Shape & shape, const size_t start_idx);
 
-bool willCollideWithSurroundObstacle(
+boost::optional<size_t> willCollideWithSurroundObstacle(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,
   const std::vector<Polygon2d> & traj_polygons,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const autoware_auto_perception_msgs::msg::Shape & shape, const double max_dist,
   const double ego_obstacle_overlap_time_threshold,
-  const double max_prediction_time_for_collision_check);
+  const double max_prediction_time_for_collision_check,
+  std::vector<geometry_msgs::msg::Point> & collision_geom_points);
 
 std::vector<Polygon2d> createOneStepPolygons(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
@@ -60,7 +60,7 @@ boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPaths
 
 geometry_msgs::msg::Pose getCurrentObjectPose(
   const autoware_auto_perception_msgs::msg::PredictedObject & predicted_object,
-  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time, const bool use_predi);
+  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time, const bool use_prediction);
 }  // namespace obstacle_cruise_utils
 
 #endif  // OBSTACLE_CRUISE_PLANNER__UTILS_HPP_

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
@@ -54,13 +54,13 @@ boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time);
 
-boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
+boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPaths(
   const std::vector<autoware_auto_perception_msgs::msg::PredictedPath> & predicted_paths,
   const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time);
 
-geometry_msgs::msg::Pose getCurrentObjectPoseFromPredictedPath(
+geometry_msgs::msg::Pose getCurrentObjectPose(
   const autoware_auto_perception_msgs::msg::PredictedObject & predicted_object,
-  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time);
+  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time, const bool use_predi);
 }  // namespace obstacle_cruise_utils
 
 #endif  // OBSTACLE_CRUISE_PLANNER__UTILS_HPP_

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -529,8 +529,8 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
       continue;
     }
 
-    const auto object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPath(
-      predicted_object, time_stamp, current_time);
+    const auto object_pose = obstacle_cruise_utils::getCurrentObjectPose(
+      predicted_object, time_stamp, current_time, false);
     const auto & object_velocity =
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x;
 

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -316,9 +316,12 @@ ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions &
       declare_parameter<double>("common.nearest_yaw_deviation_threshold");
     obstacle_velocity_threshold_from_cruise_to_stop_ =
       declare_parameter<double>("common.obstacle_velocity_threshold_from_cruise_to_stop");
+    obstacle_velocity_threshold_from_stop_to_cruise_ =
+      declare_parameter<double>("common.obstacle_velocity_threshold_from_stop_to_cruise");
     planner_ptr_->setParams(
       is_showing_debug_info_, min_behavior_stop_margin_, nearest_dist_deviation_threshold_,
-      nearest_yaw_deviation_threshold_, obstacle_velocity_threshold_from_cruise_to_stop_);
+      nearest_yaw_deviation_threshold_, obstacle_velocity_threshold_from_cruise_to_stop_,
+      obstacle_velocity_threshold_from_stop_to_cruise_);
   }
 
   // wait for first self pose
@@ -350,7 +353,8 @@ rcl_interfaces::msg::SetParametersResult ObstacleCruisePlannerNode::onParam(
     parameters, "common.is_showing_debug_info", is_showing_debug_info_);
   planner_ptr_->setParams(
     is_showing_debug_info_, min_behavior_stop_margin_, nearest_dist_deviation_threshold_,
-    nearest_yaw_deviation_threshold_, obstacle_velocity_threshold_from_cruise_to_stop_);
+    nearest_yaw_deviation_threshold_, obstacle_velocity_threshold_from_cruise_to_stop_,
+    obstacle_velocity_threshold_from_stop_to_cruise_);
 
   // obstacle_filtering
   tier4_autoware_utils::updateParam<double>(

--- a/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -477,7 +477,7 @@ double OptimizationBasedPlanner::getClosestStopDistance(
     }
 
     // Get current pose from object's predicted path
-    const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPath(
+    const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPaths(
       obj.predicted_paths, obj_base_time, current_time);
     if (!current_object_pose) {
       continue;
@@ -841,7 +841,7 @@ boost::optional<SBoundaries> OptimizationBasedPlanner::getSBoundaries(
     // Step3 search nearest obstacle to follow for rviz marker
     const double object_offset = obj.shape.dimensions.x / 2.0;
 
-    const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPath(
+    const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPaths(
       obj.predicted_paths, obj_base_time, current_time);
 
     const double obj_vel = std::abs(obj.velocity);
@@ -864,7 +864,7 @@ boost::optional<SBoundaries> OptimizationBasedPlanner::getSBoundaries(
   if (min_slow_down_idx) {
     const auto & obj = planner_data.target_obstacles.at(min_slow_down_idx.get());
 
-    const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPath(
+    const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPaths(
       obj.predicted_paths, obj.time_stamp, current_time);
 
     const auto marker_pose = calcForwardPose(

--- a/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -34,15 +34,6 @@ constexpr double CLOSE_S_DIST_THRESHOLD = 1e-3;
 // TODO(shimizu) Is is ok to use planner_data.current_time instead of get_clock()->now()?
 namespace
 {
-[[maybe_unused]] std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
-{
-  std::stringstream ss;
-  for (auto i = 0; i < 16; ++i) {
-    ss << std::hex << std::setfill('0') << std::setw(2) << +id.uuid[i];
-  }
-  return ss.str();
-}
-
 inline void convertEulerAngleToMonotonic(std::vector<double> & a)
 {
   for (unsigned int i = 1; i < a.size(); ++i) {
@@ -180,6 +171,9 @@ Trajectory OptimizationBasedPlanner::generateTrajectory(
   [[maybe_unused]] boost::optional<VelocityLimit> & vel_limit,
   [[maybe_unused]] DebugData & debug_data)
 {
+  // TODO(shimizu) refactor obstacle stop;
+  prev_target_obstacles_.clear();
+
   // Create Time Vector defined by resampling time interval
   const std::vector<double> time_vec = createTimeVector();
   if (time_vec.size() < 2) {
@@ -461,6 +455,8 @@ std::vector<double> OptimizationBasedPlanner::createTimeVector()
 double OptimizationBasedPlanner::getClosestStopDistance(
   const ObstacleCruisePlannerData & planner_data, const TrajectoryData & ego_traj_data)
 {
+  auto modified_target_obstacles = planner_data.target_obstacles;
+
   const auto & current_time = planner_data.current_time;
   double closest_stop_dist = ego_traj_data.s.back();
   const auto closest_stop_id =
@@ -471,11 +467,12 @@ double OptimizationBasedPlanner::getClosestStopDistance(
 
   double closest_obj_distance = ego_traj_data.s.back();
   boost::optional<TargetObstacle> closest_obj;
-  for (const auto & obj : planner_data.target_obstacles) {
+  for (size_t o_idx = 0; o_idx < planner_data.target_obstacles.size(); ++o_idx) {
+    const auto & obj = planner_data.target_obstacles.at(o_idx);
     const auto obj_base_time = obj.time_stamp;
 
     // Ignore obstacles that are not required to stop
-    if (!isStopRequired(obj)) {
+    if (!isStopRequired(obj, modified_target_obstacles.at(o_idx))) {
       continue;
     }
 
@@ -513,6 +510,9 @@ double OptimizationBasedPlanner::getClosestStopDistance(
       closest_obj = obj;
     }
   }
+
+  // TODO(shimizu) refactor obstacle stop;
+  prev_target_obstacles_ = modified_target_obstacles;
 
   // Publish distance from the ego vehicle to the object which is on the trajectory
   if (closest_obj && closest_obj_distance < ego_traj_data.s.back()) {

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -357,11 +357,11 @@ boost::optional<size_t> PIDBasedPlanner::doStop(
   std::vector<TargetObstacle> & debug_obstacles_to_stop,
   visualization_msgs::msg::MarkerArray & debug_wall_marker) const
 {
-  const size_t ego_idx = findExtendedNearestIndex(planner_data.traj, planner_data.current_pose);
+  // const size_t ego_idx = findExtendedNearestIndex(planner_data.traj, planner_data.current_pose);
 
   // TODO(murooka) use interpolation to calculate stop point and marker pose
   const auto modified_stop_info = [&]() -> boost::optional<std::pair<size_t, size_t>> {
-    const double dist_to_stop = stop_obstacle_info.dist_to_stop;
+    // const double dist_to_stop = stop_obstacle_info.dist_to_stop;
 
     const size_t collision_idx = tier4_autoware_utils::findNearestIndex(
       planner_data.traj.points, stop_obstacle_info.obstacle.collision_point);

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -231,7 +231,7 @@ void PIDBasedPlanner::calcObstaclesToCruiseAndStop(
       const double error_dist = dist_to_obstacle - longitudinal_info_.safe_distance_margin;
       if (stop_obstacle_info) {
         if (error_dist > stop_obstacle_info->dist_to_stop) {
-          return;
+          continue;
         }
       }
       stop_obstacle_info = StopObstacleInfo(obstacle, error_dist);
@@ -253,7 +253,7 @@ void PIDBasedPlanner::calcObstaclesToCruiseAndStop(
       const double error_dist = dist_to_obstacle - rss_dist;
       if (cruise_obstacle_info) {
         if (error_dist > cruise_obstacle_info->dist_to_cruise) {
-          return;
+          continue;
         }
       }
       const double normalized_dist_to_cruise = error_dist / dist_to_obstacle;
@@ -400,7 +400,6 @@ boost::optional<size_t> PIDBasedPlanner::doStop(
   const auto marker_pose = obstacle_cruise_utils::calcForwardPose(
     planner_data.traj, ego_idx, modified_dist_to_stop + vehicle_info_.max_longitudinal_offset_m);
   if (marker_pose) {
-    visualization_msgs::msg::MarkerArray wall_msg;
     const auto markers = tier4_autoware_utils::createStopVirtualWallMarker(
       marker_pose.get(), "obstacle stop", planner_data.current_time, 0);
     tier4_autoware_utils::appendMarkerArray(markers, &debug_wall_marker);

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -284,24 +284,6 @@ void PIDBasedPlanner::calcObstaclesToCruiseAndStop(
 double PIDBasedPlanner::calcDistanceToObstacle(
   const ObstacleCruisePlannerData & planner_data, const TargetObstacle & obstacle)
 {
-  // TODO(murooka) enable this option considering collision_point (precise obstacle point to measure
-  // distance) if (use_predicted_obstacle_pose_) {
-  //   // interpolate current obstacle pose from predicted path
-  //   const auto current_interpolated_obstacle_pose =
-  //     obstacle_cruise_utils::getCurrentObjectPoseFromPredictedPath(
-  //       obstacle.predicted_paths.at(0), obstacle.time_stamp, planner_data.current_time);
-  //   if (current_interpolated_obstacle_pose) {
-  //     return tier4_autoware_utils::calcSignedArcLength(
-  //       planner_data.traj.points, planner_data.current_pose.position,
-  //       current_interpolated_obstacle_pose->position) - offset;
-  //   }
-  //
-  //   RCLCPP_INFO_EXPRESSION(
-  //     rclcpp::get_logger("ObstacleCruisePlanner::PIDBasedPlanner"), true,
-  //     "Failed to interpolated obstacle pose from predicted path. Use non-interpolated obstacle
-  //     pose.");
-  // }
-
   const size_t ego_segment_idx =
     findExtendedNearestSegmentIndex(planner_data.traj, planner_data.current_pose);
   const double segment_offset = std::max(

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -220,12 +220,16 @@ void PIDBasedPlanner::calcObstaclesToCruiseAndStop(
   debug_values_.setValues(DebugValues::TYPE::CURRENT_VELOCITY, planner_data.current_vel);
   debug_values_.setValues(DebugValues::TYPE::CURRENT_ACCELERATION, planner_data.current_acc);
 
+  auto modified_target_obstacles = planner_data.target_obstacles;
+
   // search highest probability obstacle for stop and cruise
-  for (const auto & obstacle : planner_data.target_obstacles) {
+  for (size_t o_idx = 0; o_idx < planner_data.target_obstacles.size(); ++o_idx) {
+    const auto & obstacle = planner_data.target_obstacles.at(o_idx);
+
     // NOTE: from ego's front to obstacle's back
     const double dist_to_obstacle = calcDistanceToObstacle(planner_data, obstacle);
 
-    const bool is_stop_required = isStopRequired(obstacle);
+    const bool is_stop_required = isStopRequired(obstacle, modified_target_obstacles.at(o_idx));
     if (is_stop_required) {  // stop
       // calculate error distance (= distance to stop)
       const double error_dist = dist_to_obstacle - longitudinal_info_.safe_distance_margin;
@@ -266,6 +270,9 @@ void PIDBasedPlanner::calcObstaclesToCruiseAndStop(
       debug_values_.setValues(DebugValues::TYPE::CRUISE_ERROR_OBJECT_DISTANCE, error_dist);
     }
   }
+
+  // TODO(shimizu) refactor obstacle stop;
+  prev_target_obstacles_ = modified_target_obstacles;
 }
 
 double PIDBasedPlanner::calcDistanceToObstacle(

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -35,7 +35,6 @@ visualization_msgs::msg::Marker getObjectMarker(
     tier4_autoware_utils::createMarkerScale(2.0, 2.0, 2.0),
     tier4_autoware_utils::createMarkerColor(r, g, b, 0.8));
 
-  marker.lifetime = rclcpp::Duration::from_seconds(0.8);
   marker.pose = obstacle_pose;
 
   return marker;

--- a/planning/obstacle_cruise_planner/src/utils.cpp
+++ b/planning/obstacle_cruise_planner/src/utils.cpp
@@ -144,7 +144,7 @@ boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
   return lerpByTimeStamp(predicted_path, rel_time);
 }
 
-boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
+boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPaths(
   const std::vector<autoware_auto_perception_msgs::msg::PredictedPath> & predicted_paths,
   const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time)
 {
@@ -163,16 +163,20 @@ boost::optional<geometry_msgs::msg::Pose> getCurrentObjectPoseFromPredictedPath(
   return getCurrentObjectPoseFromPredictedPath(*predicted_path, obj_base_time, current_time);
 }
 
-geometry_msgs::msg::Pose getCurrentObjectPoseFromPredictedPath(
+geometry_msgs::msg::Pose getCurrentObjectPose(
   const autoware_auto_perception_msgs::msg::PredictedObject & predicted_object,
-  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time)
+  const rclcpp::Time & obj_base_time, const rclcpp::Time & current_time, const bool use_prediction)
 {
+  if (!use_prediction) {
+    return predicted_object.kinematics.initial_pose_with_covariance.pose;
+  }
+
   std::vector<autoware_auto_perception_msgs::msg::PredictedPath> predicted_paths;
   for (const auto & path : predicted_object.kinematics.predicted_paths) {
     predicted_paths.push_back(path);
   }
   const auto interpolated_pose =
-    getCurrentObjectPoseFromPredictedPath(predicted_paths, obj_base_time, current_time);
+    getCurrentObjectPoseFromPredictedPaths(predicted_paths, obj_base_time, current_time);
 
   if (!interpolated_pose) {
     RCLCPP_WARN(


### PR DESCRIPTION
## Description

- common
    - add hysteresis to remove chattering between cruise and stop
    - fix isFrontVehicle function
    - calculate collision points between ego and obstacles outside the trajectory based on polygon collision
    - fix min_behavior_stop_margin behavior
- pid based planner
    - apply lpf to cruise distance. Depend on https://github.com/autowarefoundation/autoware.universe/pull/1135

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
