### PR TITLE
feat(behavior_path_planner): lane change revised visualization

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -22,6 +22,7 @@ ament_auto_add_library(behavior_path_planner_node SHARED
   src/scene_module/lane_following/lane_following_module.cpp
   src/scene_module/lane_change/lane_change_module.cpp
   src/scene_module/lane_change/util.cpp
+  src/scene_module/lane_change/debug.cpp
   src/scene_module/pull_over/pull_over_module.cpp
   src/scene_module/pull_over/util.cpp
   src/scene_module/pull_out/pull_out_module.cpp

--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -16,4 +16,4 @@
       enable_collision_check_at_prepare_phase: true
       use_predicted_path_outside_lanelet: true
       use_all_predicted_path: true
-      publish_debug_marker: true
+      publish_debug_marker: false

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -148,6 +148,10 @@ private:
   // debug
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_drivable_area_lanelets_publisher_;
   rclcpp::Publisher<AvoidanceDebugMsgArray>::SharedPtr debug_avoidance_msg_array_publisher_;
+  /**
+   * @brief check path if it is unsafe or forced
+   */
+  bool isForcedCandidatePath() const;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
@@ -15,10 +15,12 @@
 #define BEHAVIOR_PATH_PLANNER__DEBUG_UTILITIES_HPP_
 
 #include "behavior_path_planner/scene_module/utils/path_shifter.hpp"
+#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 
 #include <tier4_autoware_utils/ros/marker_helper.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_auto_perception_msgs/msg/predicted_path.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
@@ -31,15 +33,51 @@
 namespace marker_utils
 {
 using autoware_auto_perception_msgs::msg::PredictedObjects;
+using autoware_auto_perception_msgs::msg::PredictedPath;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using behavior_path_planner::ShiftPointArray;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Polygon;
 using geometry_msgs::msg::Pose;
+using geometry_msgs::msg::Twist;
 using geometry_msgs::msg::Vector3;
 using std_msgs::msg::ColorRGBA;
+using tier4_autoware_utils::Polygon2d;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
+
+struct CollisionCheckDebug
+{
+  std::string failed_reason;
+  std::size_t lane_id{0};
+  Pose current_pose{};
+  Twist current_twist{};
+  Pose expected_ego_pose{};
+  Pose expected_obj_pose{};
+  Pose relative_to_ego{};
+  bool is_front{false};
+  bool allow_lane_change{false};
+  std::vector<Pose> lerped_path;
+  std::vector<PredictedPath> ego_predicted_path{};
+  Polygon2d ego_polygon{};
+  Polygon2d obj_polygon{};
+};
+
+constexpr std::array<std::array<float, 3>, 10> colorsList()
+{
+  constexpr std::array<float, 3> red = {1., 0., 0.};
+  constexpr std::array<float, 3> green = {0., 1., 0.};
+  constexpr std::array<float, 3> blue = {0., 0., 1.};
+  constexpr std::array<float, 3> yellow = {1., 1., 0.};
+  constexpr std::array<float, 3> aqua = {0., 1., 1.};
+  constexpr std::array<float, 3> magenta = {1., 0., 1.};
+  constexpr std::array<float, 3> medium_orchid = {0.729, 0.333, 0.827};
+  constexpr std::array<float, 3> light_pink = {1, 0.713, 0.756};
+  constexpr std::array<float, 3> light_yellow = {1, 1, 0.878};
+  constexpr std::array<float, 3> light_steel_blue = {0.690, 0.768, 0.870};
+  return {red,     green,         blue,       yellow,       aqua,
+          magenta, medium_orchid, light_pink, light_yellow, light_steel_blue};
+}
 
 inline int64_t bitShift(int64_t original_id) { return original_id << (sizeof(int32_t) * 8 / 2); }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/debug.hpp
@@ -1,0 +1,43 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__DEBUG_HPP_
+#define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__DEBUG_HPP_
+
+#include "behavior_path_planner/debug_utilities.hpp"
+#include "behavior_path_planner/scene_module/lane_change/lane_change_path.hpp"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace marker_utils::lane_change_markers
+{
+using behavior_path_planner::LaneChangePath;
+using marker_utils::CollisionCheckDebug;
+using visualization_msgs::msg::MarkerArray;
+MarkerArray showObjectInfo(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns);
+MarkerArray showAllValidLaneChangePath(
+  const std::vector<LaneChangePath> & lanes, std::string && ns);
+MarkerArray showLerpedPose(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns);
+MarkerArray showEgoPredictedPaths(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns);
+MarkerArray showPolygon(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns);
+MarkerArray showPolygonPose(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns);
+}  // namespace marker_utils::lane_change_markers
+#endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__DEBUG_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -15,6 +15,7 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__LANE_CHANGE_MODULE_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__LANE_CHANGE_MODULE_HPP_
 
+#include "behavior_path_planner/scene_module/lane_change/debug.hpp"
 #include "behavior_path_planner/scene_module/lane_change/lane_change_path.hpp"
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 
@@ -25,12 +26,14 @@
 #include <tf2/utils.h>
 
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace behavior_path_planner
 {
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
+using marker_utils::CollisionCheckDebug;
 
 struct LaneChangeParameters
 {
@@ -49,6 +52,7 @@ struct LaneChangeParameters
   bool enable_collision_check_at_prepare_phase;
   bool use_predicted_path_outside_lanelet;
   bool use_all_predicted_path;
+  bool publish_debug_marker;
 };
 
 struct LaneChangeStatus
@@ -166,6 +170,10 @@ private:
   bool isCurrentSpeedLow() const;
   bool isAbortConditionSatisfied() const;
   bool hasFinishedLaneChange() const;
+
+  void setObjectDebugVisualization() const;
+  mutable std::unordered_map<std::string, CollisionCheckDebug> object_debug_;
+  mutable std::vector<LaneChangePath> debug_valid_path_;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -29,6 +29,8 @@
 #include <lanelet2_core/primitives/Primitive.h>
 
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace behavior_path_planner::lane_change_utils
@@ -65,13 +67,16 @@ bool selectSafePath(
   const lanelet::ConstLanelets & target_lanes,
   const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const BehaviorPathPlannerParameters & common_parameters,
-  const LaneChangeParameters & ros_parameters, LaneChangePath * selected_path);
+  const behavior_path_planner::LaneChangeParameters & ros_parameters,
+  LaneChangePath * selected_path,
+  std::unordered_map<std::string, CollisionCheckDebug> & debug_data);
 bool isLaneChangePathSafe(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
   const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const BehaviorPathPlannerParameters & common_parameters,
-  const LaneChangeParameters & lane_change_parameters, const bool use_buffer = true,
+  const behavior_path_planner::LaneChangeParameters & lane_change_parameters,
+  std::unordered_map<std::string, CollisionCheckDebug> & debug_data, const bool use_buffer = true,
   const double acceleration = 0.0);
 bool hasEnoughDistance(
   const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_bt_node_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_bt_node_interface.hpp
@@ -29,6 +29,7 @@ struct SceneModuleStatus
   explicit SceneModuleStatus(const std::string & n) : module_name(n) {}
   std::string module_name;  // TODO(Horibe) should be const
   bool is_requested{false};
+  bool is_execution_ready{false};
   bool is_waiting_approval{false};
   BT::NodeStatus status{BT::NodeStatus::IDLE};
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -16,6 +16,7 @@
 #define BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_
 
 #include "behavior_path_planner/data_manager.hpp"
+#include "behavior_path_planner/debug_utilities.hpp"
 #include "behavior_path_planner/scene_module/pull_out/pull_out_path.hpp"
 
 #include <opencv2/opencv.hpp>
@@ -72,6 +73,7 @@ using tier4_autoware_utils::Point2d;
 using tier4_autoware_utils::Polygon2d;
 namespace bg = boost::geometry;
 using geometry_msgs::msg::Pose;
+using marker_utils::CollisionCheckDebug;
 
 struct FrenetCoordinate3d
 {
@@ -313,6 +315,8 @@ Polygon2d convertCylindricalObjectToGeometryPolygon(
 
 Polygon2d convertPolygonObjectToGeometryPolygon(const Pose & current_pose, const Shape & obj_shape);
 
+std::string getUuidStr(const PredictedObject & obj);
+
 std::vector<PredictedPath> getPredictedPathFromObj(
   const PredictedObject & obj, const bool & is_use_all_predicted_path);
 
@@ -347,7 +351,7 @@ bool isLongitudinalDistanceEnough(
 bool hasEnoughDistance(
   const Pose & expected_ego_pose, const Twist & ego_current_twist,
   const Pose & expected_object_pose, const Twist & object_current_twist,
-  const BehaviorPathPlannerParameters & param);
+  const BehaviorPathPlannerParameters & param, CollisionCheckDebug & debug);
 
 bool isLateralDistanceEnough(
   const double & relative_lateral_distance, const double & lateral_distance_threshold);
@@ -357,15 +361,15 @@ bool isSafeInLaneletCollisionCheck(
   const PredictedPath & ego_predicted_path, const double & ego_vehicle_length,
   const double & ego_vehicle_width, const double & check_start_time, const double & check_end_time,
   const double & check_time_resolution, const PredictedObject & target_object,
-  const PredictedPath & target_object_path,
-  const BehaviorPathPlannerParameters & common_parameters);
+  const PredictedPath & target_object_path, const BehaviorPathPlannerParameters & common_parameters,
+  CollisionCheckDebug & debug);
 
 bool isSafeInFreeSpaceCollisionCheck(
   const Pose & ego_current_pose, const Twist & ego_current_twist,
   const PredictedPath & ego_predicted_path, const double & ego_vehicle_length,
   const double & ego_vehicle_width, const double & check_start_time, const double & check_end_time,
   const double & check_time_resolution, const PredictedObject & target_object,
-  const BehaviorPathPlannerParameters & common_parameters);
+  const BehaviorPathPlannerParameters & common_parameters, CollisionCheckDebug & debug);
 }  // namespace behavior_path_planner::util
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -329,7 +329,8 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.enable_abort_lane_change = dp("enable_abort_lane_change", true);
   p.enable_collision_check_at_prepare_phase = dp("enable_collision_check_at_prepare_phase", true);
   p.use_predicted_path_outside_lanelet = dp("use_predicted_path_outside_lanelet", true);
-  p.use_all_predicted_path = dp("use_all_predicted_path", false);
+  p.use_all_predicted_path = dp("use_all_predicted_path", true);
+  p.publish_debug_marker = dp("publish_debug_marker", false);
 
   // validation of parameters
   if (p.lane_change_sampling_num < 1) {
@@ -552,18 +553,19 @@ void BehaviorPathPlannerNode::run()
 
   // path handling
   const auto path = getPath(output, planner_data);
-  const auto path_candidate = getPathCandidate(output, planner_data);
 
   // update planner data
   planner_data_->prev_output_path = path;
   mutex_pd_.unlock();
 
   PathWithLaneId clipped_path;
-  if (skipSmoothGoalConnection(bt_manager_->getModulesStatus())) {
+  const auto module_status_ptr_vec = bt_manager_->getModulesStatus();
+  if (skipSmoothGoalConnection(module_status_ptr_vec)) {
     clipped_path = *path;
   } else {
     clipped_path = modifyPathForSmoothGoalConnection(*path);
   }
+
   clipPathLength(clipped_path);
   if (!clipped_path.points.empty()) {
     path_publisher_->publish(clipped_path);
@@ -572,6 +574,7 @@ void BehaviorPathPlannerNode::run()
       get_logger(), *get_clock(), 5000, "behavior path output is empty! Stop publish.");
   }
 
+  const auto path_candidate = getPathCandidate(output, planner_data);
   path_candidate_publisher_->publish(util::toPath(*path_candidate));
 
   // for turn signal
@@ -627,12 +630,39 @@ PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPathCandidate(
 {
   auto path_candidate =
     bt_output.path_candidate ? bt_output.path_candidate : std::make_shared<PathWithLaneId>();
+
+  if (isForcedCandidatePath()) {
+    for (auto & path_point : path_candidate->points) {
+      path_point.point.longitudinal_velocity_mps = 1.0;
+    }
+  }
+
   path_candidate->header = planner_data->route_handler->getRouteHeader();
   path_candidate->header.stamp = this->now();
   RCLCPP_DEBUG(
     get_logger(), "BehaviorTreeManager: path candidate is %s.",
     bt_output.path_candidate ? "FOUND" : "NOT FOUND");
   return path_candidate;
+}
+
+bool BehaviorPathPlannerNode::isForcedCandidatePath() const
+{
+  const auto & module_status_ptr_vec = bt_manager_->getModulesStatus();
+  for (const auto & module_status_ptr : module_status_ptr_vec) {
+    if (!module_status_ptr) {
+      continue;
+    }
+    if (module_status_ptr->module_name != "LaneChange") {
+      continue;
+    }
+    const auto & is_waiting_approval = module_status_ptr->is_waiting_approval;
+    const auto & is_execution_ready = module_status_ptr->is_execution_ready;
+    if (is_waiting_approval && !is_execution_ready) {
+      return true;
+    }
+    break;
+  }
+  return false;
 }
 
 bool BehaviorPathPlannerNode::skipSmoothGoalConnection(

--- a/planning/behavior_path_planner/src/scene_module/lane_change/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/debug.cpp
@@ -1,0 +1,237 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "behavior_path_planner/scene_module/utils/path_shifter.hpp"
+
+#include <behavior_path_planner/scene_module/lane_change/debug.hpp>
+#include <tier4_autoware_utils/ros/marker_helper.hpp>
+
+#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
+
+#include <cstdlib>
+#include <iomanip>
+#include <string>
+#include <vector>
+
+namespace marker_utils::lane_change_markers
+{
+using geometry_msgs::msg::Point;
+using tier4_autoware_utils::createDefaultMarker;
+using tier4_autoware_utils::createMarkerColor;
+using tier4_autoware_utils::createMarkerScale;
+
+MarkerArray showObjectInfo(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns)
+{
+  Marker marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::TEXT_VIEW_FACING,
+    createMarkerScale(0.5, 0.5, 0.5), createMarkerColor(0.0, 1.0, 1.0, 0.999));
+
+  MarkerArray marker_array;
+  int32_t id{0};
+
+  marker_array.markers.reserve(obj_debug_vec.size());
+
+  for (const auto & [uuid, info] : obj_debug_vec) {
+    marker.id = ++id;
+    marker.pose = info.current_pose;
+
+    std::ostringstream ss;
+
+    ss << info.failed_reason << "\nLon: " << std::setprecision(4) << info.relative_to_ego.position.x
+       << "\nLat: " << info.relative_to_ego.position.y;
+
+    marker.text = ss.str();
+
+    marker_array.markers.push_back(marker);
+  }
+  return marker_array;
+}
+
+MarkerArray showAllValidLaneChangePath(const std::vector<LaneChangePath> & lanes, std::string && ns)
+{
+  if (lanes.empty()) {
+    return MarkerArray{};
+  }
+
+  MarkerArray marker_array;
+  int32_t id{0};
+  const auto current_time{rclcpp::Clock{RCL_ROS_TIME}.now()};
+
+  constexpr auto colors = colorsList();
+  const auto loop_size = std::min(lanes.size(), colors.size());
+  marker_array.markers.reserve(loop_size);
+
+  for (std::size_t idx = 0; idx < loop_size; ++idx) {
+    if (lanes.at(idx).path.points.empty()) {
+      continue;
+    }
+
+    const auto & color = colors.at(idx);
+    Marker marker = createDefaultMarker(
+      "map", current_time, ns, ++id, Marker::LINE_STRIP, createMarkerScale(0.1, 0.1, 0.0),
+      createMarkerColor(color[0], color[1], color[2], 0.9));
+    marker.points.reserve(lanes.at(idx).path.points.size());
+
+    for (const auto & point : lanes.at(idx).path.points) {
+      marker.points.push_back(point.point.pose.position);
+    }
+
+    marker_array.markers.push_back(marker);
+  }
+  return marker_array;
+}
+
+MarkerArray showLerpedPose(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns)
+{
+  MarkerArray marker_array;
+  int32_t id{0};
+  const auto current_time{rclcpp::Clock{RCL_ROS_TIME}.now()};
+  marker_array.markers.reserve(obj_debug_vec.size());
+
+  for (const auto & [uuid, info] : obj_debug_vec) {
+    Marker marker = createDefaultMarker(
+      "map", current_time, ns, ++id, Marker::POINTS, createMarkerScale(0.3, 0.3, 0.3),
+      createMarkerColor(1.0, 0.3, 1.0, 0.9));
+    marker.points.reserve(info.lerped_path.size());
+
+    for (const auto & point : info.lerped_path) {
+      marker.points.push_back(point.position);
+    }
+
+    marker_array.markers.push_back(marker);
+  }
+  return marker_array;
+}
+
+MarkerArray showEgoPredictedPaths(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns)
+{
+  if (obj_debug_vec.empty()) {
+    return MarkerArray{};
+  }
+
+  MarkerArray marker_array;
+  constexpr auto colors = colorsList();
+  constexpr float scale_val = 0.2;
+  const auto current_time{rclcpp::Clock{RCL_ROS_TIME}.now()};
+  marker_array.markers.reserve(obj_debug_vec.size());
+
+  int32_t id{0};
+  for (const auto & [uuid, info] : obj_debug_vec) {
+    const auto loop_size = std::min(info.ego_predicted_path.size(), colors.size());
+
+    for (std::size_t idx = 0; idx < loop_size; ++idx) {
+      const auto & path = info.ego_predicted_path.at(idx).path;
+      const auto & color = colors.at(idx);
+
+      Marker marker = createDefaultMarker(
+        "map", current_time, ns, ++id, Marker::LINE_STRIP,
+        createMarkerScale(scale_val, scale_val, scale_val),
+        createMarkerColor(color[0], color[1], color[2], 0.9));
+
+      marker.points.reserve(path.size());
+
+      for (const auto & point : path) {
+        marker.points.push_back(point.position);
+      }
+
+      marker_array.markers.push_back(marker);
+    }
+  }
+  return marker_array;
+}
+
+MarkerArray showPolygon(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns)
+{
+  if (obj_debug_vec.empty()) {
+    return MarkerArray{};
+  }
+
+  constexpr float scale_val{0.2};
+  int32_t id{0};
+  Marker ego_marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, id, Marker::LINE_STRIP,
+    createMarkerScale(scale_val, scale_val, scale_val), createMarkerColor(1.0, 1.0, 1.0, 0.9));
+  Marker obj_marker = ego_marker;
+  MarkerArray marker_array;
+
+  constexpr auto colors = colorsList();
+  const auto loop_size = std::min(obj_debug_vec.size(), colors.size());
+
+  marker_array.markers.reserve(loop_size * 2);
+  size_t idx{0};
+
+  for (const auto & [uuid, info] : obj_debug_vec) {
+    if (idx >= loop_size) {
+      break;
+    }
+    const auto & color = colors.at(idx);
+    const auto & ego_polygon = info.ego_polygon.outer();
+    ego_marker.id = ++id;
+    ego_marker.color = createMarkerColor(color[0], color[1], color[2], 0.8);
+    ego_marker.points.reserve(ego_polygon.size());
+    for (const auto & p : ego_polygon) {
+      ego_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), 0.0));
+    }
+    marker_array.markers.push_back(ego_marker);
+
+    const auto & obj_polygon = info.obj_polygon.outer();
+    obj_marker.id = ++id;
+    obj_marker.color = createMarkerColor(color[0], color[1], color[2], 0.8);
+    obj_marker.points.reserve(obj_polygon.size());
+    for (const auto & p : obj_polygon) {
+      obj_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), 0.0));
+    }
+    marker_array.markers.push_back(obj_marker);
+    ++idx;
+    ego_marker.points.clear();
+    obj_marker.points.clear();
+  }
+
+  return marker_array;
+}
+
+MarkerArray showPolygonPose(
+  const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns)
+{
+  constexpr auto colors = colorsList();
+  const auto loop_size = std::min(colors.size(), obj_debug_vec.size());
+  MarkerArray marker_array;
+  int32_t id{0};
+  size_t idx{0};
+  const auto current_time{rclcpp::Clock{RCL_ROS_TIME}.now()};
+  marker_array.markers.reserve(obj_debug_vec.size());
+
+  for (const auto & [uuid, info] : obj_debug_vec) {
+    const auto & color = colors.at(idx);
+    Marker marker = createDefaultMarker(
+      "map", current_time, ns, ++id, Marker::POINTS, createMarkerScale(0.2, 0.2, 0.2),
+      createMarkerColor(color[0], color[1], color[2], 0.999));
+    marker.points.reserve(2);
+    marker.points.push_back(info.expected_ego_pose.position);
+    marker.points.push_back(info.expected_obj_pose.position);
+    marker_array.markers.push_back(marker);
+    ++idx;
+    if (idx >= loop_size) {
+      break;
+    }
+  }
+
+  return marker_array;
+}
+}  // namespace marker_utils::lane_change_markers

--- a/planning/behavior_path_planner/src/scene_module/scene_module_bt_node_interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/scene_module_bt_node_interface.cpp
@@ -45,6 +45,7 @@ BT::NodeStatus SceneModuleBTNodeInterface::tick()
 
   scene_module_->onEntry();
   module_status_->is_waiting_approval = scene_module_->isWaitingApproval();
+  module_status_->is_execution_ready = scene_module_->isExecutionReady();
 
   const bool is_lane_following = scene_module_->name() == "LaneFollowing";
 
@@ -59,6 +60,7 @@ BT::NodeStatus SceneModuleBTNodeInterface::tick()
         RCLCPP_ERROR_STREAM(scene_module_->getLogger(), "setOutput() failed : " << res.error());
       }
       module_status_->is_waiting_approval = scene_module_->isWaitingApproval();
+      module_status_->is_execution_ready = scene_module_->isExecutionReady();
     } catch (const std::exception & e) {
       RCLCPP_ERROR_STREAM(
         scene_module_->getLogger(), "behavior module has failed with exception: " << e.what());
@@ -81,6 +83,7 @@ BT::NodeStatus SceneModuleBTNodeInterface::tick()
       // for data output
       module_status_->status = current_status;
       module_status_->is_waiting_approval = scene_module_->isWaitingApproval();
+      module_status_->is_execution_ready = scene_module_->isExecutionReady();
     } catch (const std::exception & e) {
       RCLCPP_ERROR_STREAM(
         scene_module_->getLogger(), "behavior module has failed with exception: " << e.what());


### PR DESCRIPTION
## Description

Previous lane change logic checks the distance between ego to the object using l2Norm. However, some information lost might occurs for example the object is on the left or right etc.

The lane change module is currently revised internally to better handle the dynamic environment. Instead of using l2norm, the distance is separated into lateral distance evaluation and longitudinal distance evaluation. the longitudinal distance evaluation takes into account of collision via predicted path.

This PR aims to provide visualization for debugging the module. Note that for the purpose of this PR, the parameter will be turn on by default. 

## Related links

For configuration, cherry-pick/pull the following https://github.com/tier4/autoware_launch/pull/355
For the implementation PR: #1139 
Using parameter server to change the value on runtime: #1152 

## Tests performed

2. Run the PSIM.
3. Place ego starting position and goal. Goal must be on the adjacent lane to simulate lane change process.
4. Place an object on the target lane.
![Screenshot from 2022-06-21 13-40-31](https://user-images.githubusercontent.com/93502286/174717952-d6b0a44c-4751-431d-9a2d-ba7df5a9f181.png)
5. If ego is within object vicinity and there is potential of collision via predicted path comparison, no path appears. Marker will also be shown together.


![Screenshot from 2022-07-19 15-30-15](https://user-images.githubusercontent.com/93502286/179681555-f03ea4a2-5142-4768-8fc3-c9a3fc29b92f.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
