### PR TITLE
fix(behavior_path_planner): revert road shoulder margin to zero

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -24,7 +24,7 @@
       min_nominal_avoidance_speed: 7.0  # [m/s]
       min_sharp_avoidance_speed: 1.0    # [m/s]
 
-      road_shoulder_safety_margin: 0.5 # [m]
+      road_shoulder_safety_margin: 0.0 # [m]
 
       max_right_shift_length: 5.0
       max_left_shift_length: 5.0

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -10,7 +10,7 @@
       enable_avoidance_over_same_direction: true
       enable_avoidance_over_opposite_direction: true
 
-      threshold_distance_object_is_on_center: 0.5 # [m]
+      threshold_distance_object_is_on_center: 1.0 # [m]
       threshold_speed_object_is_stopped: 1.0      # [m/s]
       object_check_forward_distance: 150.0        # [m]
       object_check_backward_distance: 2.0         # [m]

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -10,7 +10,7 @@
       enable_avoidance_over_same_direction: true
       enable_avoidance_over_opposite_direction: true
 
-      threshold_distance_object_is_on_center: 1.0 # [m]
+      threshold_distance_object_is_on_center: 0.5 # [m]
       threshold_speed_object_is_stopped: 1.0      # [m/s]
       object_check_forward_distance: 150.0        # [m]
       object_check_backward_distance: 2.0         # [m]

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -259,7 +259,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.min_nominal_avoidance_speed = dp("min_nominal_avoidance_speed", 5.0);
   p.min_sharp_avoidance_speed = dp("min_sharp_avoidance_speed", 1.0);
 
-  p.road_shoulder_safety_margin = dp("road_shoulder_safety_margin", 0.5);
+  p.road_shoulder_safety_margin = dp("road_shoulder_safety_margin", 0.0);
 
   p.max_right_shift_length = dp("max_right_shift_length", 1.5);
   p.max_left_shift_length = dp("max_left_shift_length", 1.5);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -245,7 +245,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.enable_avoidance_over_same_direction = dp("enable_avoidance_over_same_direction", true);
   p.enable_avoidance_over_opposite_direction = dp("enable_avoidance_over_opposite_direction", true);
 
-  p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 1.0);
+  p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 0.5);
   p.threshold_speed_object_is_stopped = dp("threshold_speed_object_is_stopped", 1.0);
   p.object_check_forward_distance = dp("object_check_forward_distance", 150.0);
   p.object_check_backward_distance = dp("object_check_backward_distance", 2.0);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -245,7 +245,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.enable_avoidance_over_same_direction = dp("enable_avoidance_over_same_direction", true);
   p.enable_avoidance_over_opposite_direction = dp("enable_avoidance_over_opposite_direction", true);
 
-  p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 0.5);
+  p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 1.0);
   p.threshold_speed_object_is_stopped = dp("threshold_speed_object_is_stopped", 1.0);
   p.object_check_forward_distance = dp("object_check_forward_distance", 150.0);
   p.object_check_backward_distance = dp("object_check_backward_distance", 2.0);


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

To reduce the number of parameters to be tune, it is decided to revert the road_shoulder_safety_margin to zero. The reason is that the parameter is dependent on the lanelet/ODD, therefore it might be different depending on the area.

Related links: 
road_shoulder_safety_margin: https://github.com/tier4/autoware_launch/pull/357
threshold_distance_object_is_on_center: https://github.com/tier4/autoware_launch/pull/397

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
