### PR TITLE
feat(behavior_path_planner): behavior path planner parameter server

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -129,7 +129,7 @@ private:
   void onForceApproval(const PathChangeModule::ConstSharedPtr msg);
   void onMap(const HADMapBin::ConstSharedPtr map_msg);
   void onRoute(const HADMapRoute::ConstSharedPtr route_msg);
-  SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & parameters);
+  SetParametersResult onSetParam(const std::vector<rclcpp::Parameter> & parameters);
 
   /**
    * @brief Modify the path points near the goal to smoothly connect the lanelet and the goal point.

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -46,6 +46,18 @@
 #include <string>
 #include <vector>
 
+template <typename T>
+inline void update_param(
+  const std::vector<rclcpp::Parameter> & parameters, const std::string & name, T & value)
+{
+  const auto it = std::find_if(
+    parameters.cbegin(), parameters.cend(),
+    [&name](const rclcpp::Parameter & parameter) { return parameter.get_name() == name; });
+  if (it != parameters.cend()) {
+    value = static_cast<T>(it->template get_value<T>());
+  }
+}
+
 namespace behavior_path_planner
 {
 using ApprovalMsg = tier4_planning_msgs::msg::Approval;
@@ -59,6 +71,7 @@ using autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand;
 using geometry_msgs::msg::TwistStamped;
 using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
+using rcl_interfaces::msg::SetParametersResult;
 using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
 using tier4_planning_msgs::msg::PathChangeModule;
 using tier4_planning_msgs::msg::Scenario;
@@ -113,12 +126,15 @@ private:
   void onForceApproval(const PathChangeModule::ConstSharedPtr msg);
   void onMap(const HADMapBin::ConstSharedPtr map_msg);
   void onRoute(const HADMapRoute::ConstSharedPtr route_msg);
+  SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & parameters);
+  std::shared_ptr<LaneChangeParameters> lane_change_param_ptr;
 
   /**
    * @brief Modify the path points near the goal to smoothly connect the lanelet and the goal point.
    */
   PathWithLaneId modifyPathForSmoothGoalConnection(
     const PathWithLaneId & path) const;  // (TODO) move to util
+  OnSetParametersCallbackHandle::SharedPtr m_set_param_res;
 
   /**
    * @brief Execute behavior tree and publish planned data.

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -109,6 +109,9 @@ private:
   bool isDataReady();
 
   // parameters
+  std::shared_ptr<AvoidanceParameters> avoidance_param_ptr;
+  std::shared_ptr<LaneChangeParameters> lane_change_param_ptr;
+
   BehaviorPathPlannerParameters getCommonParam();
   BehaviorTreeManagerParam getBehaviorTreeManagerParam();
   SideShiftParameters getSideShiftParam();
@@ -127,7 +130,6 @@ private:
   void onMap(const HADMapBin::ConstSharedPtr map_msg);
   void onRoute(const HADMapRoute::ConstSharedPtr route_msg);
   SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & parameters);
-  std::shared_ptr<LaneChangeParameters> lane_change_param_ptr;
 
   /**
    * @brief Modify the path points near the goal to smoothly connect the lanelet and the goal point.

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -40,7 +40,7 @@ class AvoidanceModule : public SceneModuleInterface
 
 public:
   AvoidanceModule(
-    const std::string & name, rclcpp::Node & node, const AvoidanceParameters & parameters);
+    const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters);
 
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
@@ -69,10 +69,8 @@ public:
     return false;
   }
 
-  void setParameters(const AvoidanceParameters & parameters);
-
 private:
-  AvoidanceParameters parameters_;
+  std::shared_ptr<AvoidanceParameters> parameters_;
 
   AvoidancePlanningData avoidance_data_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -25,6 +25,7 @@
 
 #include <tf2/utils.h>
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -71,7 +72,8 @@ class LaneChangeModule : public SceneModuleInterface
 {
 public:
   LaneChangeModule(
-    const std::string & name, rclcpp::Node & node, const LaneChangeParameters & parameters);
+    const std::string & name, rclcpp::Node & node,
+    std::shared_ptr<LaneChangeParameters> parameters);
 
   BehaviorModuleOutput run() override;
 
@@ -101,10 +103,8 @@ public:
     return false;
   }
 
-  void setParameters(const LaneChangeParameters & parameters);
-
 private:
-  LaneChangeParameters parameters_;
+  std::shared_ptr<LaneChangeParameters> parameters_;
   LaneChangeStatus status_;
   PathShifter path_shifter_;
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -105,7 +105,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
   lane_change_param_ptr = std::make_shared<LaneChangeParameters>(getLaneChangeParam());
 
   m_set_param_res = this->add_on_set_parameters_callback(
-    std::bind(&BehaviorPathPlannerNode::paramCallback, this, std::placeholders::_1));
+    std::bind(&BehaviorPathPlannerNode::onSetParam, this, std::placeholders::_1));
   // behavior tree manager
   {
     mutex_bt_.lock();
@@ -745,7 +745,7 @@ void BehaviorPathPlannerNode::onRoute(const HADMapRoute::ConstSharedPtr msg)
   }
 }
 
-SetParametersResult BehaviorPathPlannerNode::paramCallback(
+SetParametersResult BehaviorPathPlannerNode::onSetParam(
   const std::vector<rclcpp::Parameter> & parameters)
 {
   rcl_interfaces::msg::SetParametersResult result;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -101,6 +101,10 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     "~/input/route", qos_transient_local, std::bind(&BehaviorPathPlannerNode::onRoute, this, _1),
     createSubscriptionOptions(this));
 
+  lane_change_param_ptr = std::make_shared<LaneChangeParameters>(getLaneChangeParam());
+
+  m_set_param_res = this->add_on_set_parameters_callback(
+    std::bind(&BehaviorPathPlannerNode::paramCallback, this, std::placeholders::_1));
   // behavior tree manager
   {
     mutex_bt_.lock();
@@ -119,10 +123,8 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       std::make_shared<LaneFollowingModule>("LaneFollowing", *this, getLaneFollowingParam());
     bt_manager_->registerSceneModule(lane_following_module);
 
-    const auto lane_change_param = getLaneChangeParam();
-
     auto lane_change_module =
-      std::make_shared<LaneChangeModule>("LaneChange", *this, lane_change_param);
+      std::make_shared<LaneChangeModule>("LaneChange", *this, lane_change_param_ptr);
     bt_manager_->registerSceneModule(lane_change_module);
 
     auto pull_over_module = std::make_shared<PullOverModule>("PullOver", *this, getPullOverParam());
@@ -740,6 +742,31 @@ void BehaviorPathPlannerNode::onRoute(const HADMapRoute::ConstSharedPtr msg)
     RCLCPP_DEBUG(get_logger(), "new route is received. reset behavior tree.");
     bt_manager_->resetBehaviorTree();
   }
+}
+
+SetParametersResult BehaviorPathPlannerNode::paramCallback(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+
+  if (!lane_change_param_ptr) {
+    result.successful = false;
+    result.reason = "param not initialized";
+    return result;
+  }
+
+  result.successful = true;
+  result.reason = "success";
+
+  try {
+    update_param(
+      parameters, "lane_change.publish_debug_marker", lane_change_param_ptr->publish_debug_marker);
+  } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
+    result.successful = false;
+    result.reason = e.what();
+  }
+
+  return result;
 }
 
 PathWithLaneId BehaviorPathPlannerNode::modifyPathForSmoothGoalConnection(

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -35,7 +35,7 @@
 // set as macro so that calling function name will be printed.
 // debug print is heavy. turn on only when debugging.
 #define DEBUG_PRINT(...) \
-  RCLCPP_DEBUG_EXPRESSION(getLogger(), parameters_.print_debug_info, __VA_ARGS__)
+  RCLCPP_DEBUG_EXPRESSION(getLogger(), parameters_->print_debug_info, __VA_ARGS__)
 #define printShiftPoints(p, msg) DEBUG_PRINT("[%s] %s", msg, toStrInfo(p).c_str())
 
 namespace behavior_path_planner
@@ -47,9 +47,9 @@ using tier4_autoware_utils::calcLateralDeviation;
 using tier4_planning_msgs::msg::AvoidanceDebugFactor;
 
 AvoidanceModule::AvoidanceModule(
-  const std::string & name, rclcpp::Node & node, const AvoidanceParameters & parameters)
+  const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters)
 : SceneModuleInterface{name, node},
-  parameters_{parameters},
+  parameters_{std::move(parameters)},
   rtc_interface_left_(&node, "avoidance_left"),
   rtc_interface_right_(&node, "avoidance_right"),
   uuid_left_{generateUUID()},
@@ -134,7 +134,7 @@ AvoidancePlanningData AvoidanceModule::calcAvoidancePlanningData(DebugData & deb
 
   // reference path
   data.reference_path =
-    util::resamplePathWithSpline(center_path, parameters_.resample_interval_for_planning);
+    util::resamplePathWithSpline(center_path, parameters_->resample_interval_for_planning);
   if (data.reference_path.points.size() < 2) {
     // if the resampled path has only 1 point, use original path.
     data.reference_path = center_path;
@@ -173,14 +173,14 @@ ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
 
   // velocity filter: only for stopped vehicle
   const auto objects_candidate = util::filterObjectsByVelocity(
-    *planner_data_->dynamic_object, parameters_.threshold_speed_object_is_stopped);
+    *planner_data_->dynamic_object, parameters_->threshold_speed_object_is_stopped);
 
   // detection area filter
   // when expanding lanelets, right_offset must be minus.
   // This is because y axis is positive on the left.
   const auto expanded_lanelets = lanelet::utils::getExpandedLanelets(
-    current_lanes, parameters_.detection_area_left_expand_dist,
-    parameters_.detection_area_right_expand_dist * (-1.0));
+    current_lanes, parameters_->detection_area_left_expand_dist,
+    parameters_->detection_area_right_expand_dist * (-1.0));
   const auto lane_filtered_objects_index =
     util::filterObjectsByLanelets(objects_candidate, expanded_lanelets);
 
@@ -224,11 +224,11 @@ ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
     avoidance_debug_msg.longitudinal_distance = object_data.longitudinal;
 
     // object is behind ego or too far.
-    if (object_data.longitudinal < -parameters_.object_check_backward_distance) {
+    if (object_data.longitudinal < -parameters_->object_check_backward_distance) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_IS_BEHIND_THRESHOLD);
       continue;
     }
-    if (object_data.longitudinal > parameters_.object_check_forward_distance) {
+    if (object_data.longitudinal > parameters_->object_check_forward_distance) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_IS_IN_FRONT_THRESHOLD);
       continue;
     }
@@ -260,13 +260,13 @@ ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
         object_data.overhang_pose.position.x, object_data.overhang_pose.position.y,
         object_data.overhang_pose.position.z);
       const bool get_left =
-        isOnRight(object_data) && parameters_.enable_avoidance_over_same_direction;
+        isOnRight(object_data) && parameters_->enable_avoidance_over_same_direction;
       const bool get_right =
-        !isOnRight(object_data) && parameters_.enable_avoidance_over_same_direction;
+        !isOnRight(object_data) && parameters_->enable_avoidance_over_same_direction;
 
       const auto target_lines = rh->getFurthestLinestring(
         overhang_lanelet, get_right, get_left,
-        parameters_.enable_avoidance_over_opposite_direction);
+        parameters_->enable_avoidance_over_opposite_direction);
 
       if (isOnRight(object_data)) {
         object_data.to_road_shoulder_distance =
@@ -287,7 +287,7 @@ ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
 
     // Object is on center line -> ignore.
     avoidance_debug_msg.lateral_distance_from_centerline = object_data.lateral;
-    if (std::abs(object_data.lateral) < parameters_.threshold_distance_object_is_on_center) {
+    if (std::abs(object_data.lateral) < parameters_->threshold_distance_object_is_on_center) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE);
       continue;
     }
@@ -472,10 +472,10 @@ AvoidPointArray AvoidanceModule::calcRawShiftPointsFromObjects(
   // To be consistent with changes in the ego position, the current shift length is considered.
   const auto current_ego_shift = getCurrentShift();
   // // implement lane detection here.
-  const auto & lat_collision_safety_buffer = parameters_.lateral_collision_safety_buffer;
-  const auto & lat_collision_margin = parameters_.lateral_collision_margin;
+  const auto & lat_collision_safety_buffer = parameters_->lateral_collision_safety_buffer;
+  const auto & lat_collision_margin = parameters_->lateral_collision_margin;
   const auto & vehicle_width = planner_data_->parameters.vehicle_width;
-  const auto & road_shoulder_safety_margin = parameters_.road_shoulder_safety_margin;
+  const auto & road_shoulder_safety_margin = parameters_->road_shoulder_safety_margin;
 
   const auto avoid_margin =
     lat_collision_safety_buffer + lat_collision_margin + 0.5 * vehicle_width;
@@ -544,8 +544,8 @@ AvoidPointArray AvoidanceModule::calcRawShiftPointsFromObjects(
       const auto required_jerk = path_shifter_.calcJerkFromLatLonDistance(
         avoiding_shift, remaining_distance, getSharpAvoidanceEgoSpeed());
       avoidance_debug_msg.required_jerk = required_jerk;
-      avoidance_debug_msg.maximum_jerk = parameters_.max_lateral_jerk;
-      if (required_jerk > parameters_.max_lateral_jerk) {
+      avoidance_debug_msg.maximum_jerk = parameters_->max_lateral_jerk;
+      if (required_jerk > parameters_->max_lateral_jerk) {
         avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::TOO_LARGE_JERK);
         continue;
       }
@@ -556,7 +556,7 @@ AvoidPointArray AvoidanceModule::calcRawShiftPointsFromObjects(
     DEBUG_PRINT(
       "nominal_lateral_jerk = %f, getNominalAvoidanceEgoSpeed() = %f, prepare_distance = %f, "
       "has_enough_distance = %d",
-      parameters_.nominal_lateral_jerk, getNominalAvoidanceEgoSpeed(), prepare_distance,
+      parameters_->nominal_lateral_jerk, getNominalAvoidanceEgoSpeed(), prepare_distance,
       has_enough_distance);
 
     AvoidPoint ap_avoid;
@@ -1451,7 +1451,7 @@ void AvoidanceModule::trimTooSharpShift(AvoidPointArray & avoid_points) const
   const auto isInJerkLimit = [this](const auto & ap) {
     const auto required_jerk = path_shifter_.calcJerkFromLatLonDistance(
       ap.getRelativeLength(), ap.getRelativeLongitudinal(), getSharpAvoidanceEgoSpeed());
-    return std::fabs(required_jerk) < parameters_.max_lateral_jerk;
+    return std::fabs(required_jerk) < parameters_->max_lateral_jerk;
   };
 
   for (size_t i = 0; i < avoid_points_orig.size(); ++i) {
@@ -1685,13 +1685,13 @@ void AvoidanceModule::addReturnShiftPointFromEgo(
 double AvoidanceModule::getRightShiftBound() const
 {
   // TODO(Horibe) write me. Real lane boundary must be considered here.
-  return -parameters_.max_right_shift_length;
+  return -parameters_->max_right_shift_length;
 }
 
 double AvoidanceModule::getLeftShiftBound() const
 {
   // TODO(Horibe) write me. Real lane boundary must be considered here.
-  return parameters_.max_left_shift_length;
+  return parameters_->max_left_shift_length;
 }
 
 // TODO(murooka) judge when and which way to extend drivable area. current implementation is keep
@@ -1706,13 +1706,13 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
   lanelet::ConstLanelets extended_lanelets = current_lanes;
 
   for (const auto & current_lane : current_lanes) {
-    if (!parameters_.enable_avoidance_over_opposite_direction) {
+    if (!parameters_->enable_avoidance_over_opposite_direction) {
       break;
     }
 
     const auto extend_from_current_lane = std::invoke(
       [this, &route_handler](const lanelet::ConstLanelet & lane) {
-        const auto ignore_opposite = !parameters_.enable_avoidance_over_opposite_direction;
+        const auto ignore_opposite = !parameters_->enable_avoidance_over_opposite_direction;
         if (ignore_opposite) {
           return route_handler->getAllSharedLineStringLanelets(lane, true, true, ignore_opposite);
         }
@@ -1825,8 +1825,8 @@ void AvoidanceModule::modifyPathVelocityToPreventAccelerationOnAvoidance(Shifted
     if (t < NO_ACCEL_TIME_THR) {
       insert_idx = i;
       vmax = std::max(
-        parameters_.min_avoidance_speed_for_acc_prevention,
-        std::sqrt(v0 * v0 + 2.0 * s * parameters_.max_avoidance_acceleration));
+        parameters_->min_avoidance_speed_for_acc_prevention,
+        std::sqrt(v0 * v0 + 2.0 * s * parameters_->max_avoidance_acceleration));
       break;
     }
   }
@@ -1840,7 +1840,7 @@ void AvoidanceModule::modifyPathVelocityToPreventAccelerationOnAvoidance(Shifted
 
   DEBUG_PRINT(
     "s: %f, t: %f, v0: %f, a: %f, vmax: %f, ego_i: %lu, target_i: %lu", s_from_ego, t_from_ego, v0,
-    parameters_.max_avoidance_acceleration, vmax, ego_idx, target_idx);
+    parameters_->max_avoidance_acceleration, vmax, ego_idx, target_idx);
 }
 
 // TODO(Horibe) clean up functions: there is a similar code in util as well.
@@ -2029,8 +2029,10 @@ BehaviorModuleOutput AvoidanceModule::plan()
     prev_linear_shift_path_ = toShiftedPath(avoidance_data_.reference_path);
     path_shifter_.generate(&prev_linear_shift_path_, true, SHIFT_TYPE::LINEAR);
     prev_reference_ = avoidance_data_.reference_path;
-    if (parameters_.publish_debug_marker) {
+    if (parameters_->publish_debug_marker) {
       setDebugData(path_shifter_, debug_data_);
+    } else {
+      debug_marker_.markers.clear();
     }
   }
 
@@ -2039,7 +2041,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
   // sparse resampling for computational cost
   {
     avoidance_path.path =
-      util::resamplePathWithSpline(avoidance_path.path, parameters_.resample_interval_for_output);
+      util::resamplePathWithSpline(avoidance_path.path, parameters_->resample_interval_for_output);
   }
   output.path = std::make_shared<PathWithLaneId>(avoidance_path.path);
 
@@ -2240,9 +2242,9 @@ boost::optional<AvoidPointArray> AvoidanceModule::findNewShiftPoint(
     // TODO(Horibe) test fails with this print. why?
     // DEBUG_PRINT("%s, shift current: %f, candidate: %f", pfx, current_shift, candidate.length);
 
-    const auto new_point_threshold = parameters_.avoidance_execution_lateral_threshold;
+    const auto new_point_threshold = parameters_->avoidance_execution_lateral_threshold;
     if (std::abs(candidate.length - current_shift) > new_point_threshold) {
-      if (calcJerk(candidate) > parameters_.max_lateral_jerk) {
+      if (calcJerk(candidate) > parameters_->max_lateral_jerk) {
         DEBUG_PRINT(
           "%s, Failed to find new shift: jerk limit over (%f).", pfx, calcJerk(candidate));
         break;
@@ -2266,11 +2268,11 @@ double AvoidanceModule::getEgoSpeed() const
 
 double AvoidanceModule::getNominalAvoidanceEgoSpeed() const
 {
-  return std::max(getEgoSpeed(), parameters_.min_nominal_avoidance_speed);
+  return std::max(getEgoSpeed(), parameters_->min_nominal_avoidance_speed);
 }
 double AvoidanceModule::getSharpAvoidanceEgoSpeed() const
 {
-  return std::max(getEgoSpeed(), parameters_.min_sharp_avoidance_speed);
+  return std::max(getEgoSpeed(), parameters_->min_sharp_avoidance_speed);
 }
 
 Point AvoidanceModule::getEgoPosition() const { return planner_data_->self_pose->pose.position; }
@@ -2301,25 +2303,25 @@ double AvoidanceModule::getNominalAvoidanceDistance(const double shift_length) c
 {
   const auto & p = parameters_;
   const auto distance_by_jerk = path_shifter_.calcLongitudinalDistFromJerk(
-    shift_length, parameters_.nominal_lateral_jerk, getNominalAvoidanceEgoSpeed());
+    shift_length, parameters_->nominal_lateral_jerk, getNominalAvoidanceEgoSpeed());
 
-  return std::max(p.min_avoidance_distance, distance_by_jerk);
+  return std::max(p->min_avoidance_distance, distance_by_jerk);
 }
 
 double AvoidanceModule::getSharpAvoidanceDistance(const double shift_length) const
 {
   const auto & p = parameters_;
   const auto distance_by_jerk = path_shifter_.calcLongitudinalDistFromJerk(
-    shift_length, parameters_.max_lateral_jerk, getSharpAvoidanceEgoSpeed());
+    shift_length, parameters_->max_lateral_jerk, getSharpAvoidanceEgoSpeed());
 
-  return std::max(p.min_avoidance_distance, distance_by_jerk);
+  return std::max(p->min_avoidance_distance, distance_by_jerk);
 }
 
 double AvoidanceModule::getNominalPrepareDistance() const
 {
   const auto & p = parameters_;
   const auto epsilon_m = 0.01;  // for floating error to pass "has_enough_distance" check.
-  const auto nominal_distance = std::max(getEgoSpeed() * p.prepare_time, p.min_prepare_distance);
+  const auto nominal_distance = std::max(getEgoSpeed() * p->prepare_time, p->min_prepare_distance);
   return nominal_distance + epsilon_m;
 }
 
@@ -2425,7 +2427,7 @@ void AvoidanceModule::updateRegisteredObject(const ObjectDataArray & now_objects
     }
 
     // lost count exceeds threshold. remove object from register.
-    if (r.lost_time > parameters_.object_last_seen_threshold) {
+    if (r.lost_time > parameters_->object_last_seen_threshold) {
       registered_objects_.erase(registered_objects_.begin() + i);
     }
   }
@@ -2484,11 +2486,6 @@ void AvoidanceModule::onExit()
   removeRTCStatus();
 }
 
-void AvoidanceModule::setParameters(const AvoidanceParameters & parameters)
-{
-  parameters_ = parameters;
-}
-
 void AvoidanceModule::initVariables()
 {
   prev_output_ = ShiftedPath();
@@ -2511,14 +2508,14 @@ bool AvoidanceModule::isTargetObjectType(const PredictedObject & object) const
   using autoware_auto_perception_msgs::msg::ObjectClassification;
   const auto t = util::getHighestProbLabel(object.classification);
   const auto is_object_type =
-    ((t == ObjectClassification::CAR && parameters_.avoid_car) ||
-     (t == ObjectClassification::TRUCK && parameters_.avoid_truck) ||
-     (t == ObjectClassification::BUS && parameters_.avoid_bus) ||
-     (t == ObjectClassification::TRAILER && parameters_.avoid_trailer) ||
-     (t == ObjectClassification::UNKNOWN && parameters_.avoid_unknown) ||
-     (t == ObjectClassification::BICYCLE && parameters_.avoid_bicycle) ||
-     (t == ObjectClassification::MOTORCYCLE && parameters_.avoid_motorcycle) ||
-     (t == ObjectClassification::PEDESTRIAN && parameters_.avoid_pedestrian));
+    ((t == ObjectClassification::CAR && parameters_->avoid_car) ||
+     (t == ObjectClassification::TRUCK && parameters_->avoid_truck) ||
+     (t == ObjectClassification::BUS && parameters_->avoid_bus) ||
+     (t == ObjectClassification::TRAILER && parameters_->avoid_trailer) ||
+     (t == ObjectClassification::UNKNOWN && parameters_->avoid_unknown) ||
+     (t == ObjectClassification::BICYCLE && parameters_->avoid_bicycle) ||
+     (t == ObjectClassification::MOTORCYCLE && parameters_->avoid_motorcycle) ||
+     (t == ObjectClassification::PEDESTRIAN && parameters_->avoid_pedestrian));
   return is_object_type;
 }
 


### PR DESCRIPTION
## Description

Whether we want the debug marker but forgot to enable them in param, or we don't want them but forgot to disable, it is time consuming to terminate autoware and edit and re-run autoware.

Therefore, this PR aims to use `rclcpp::Param` to enable the `publish_debug_marker`. Currrently only Avoidance and Lane Change are supported.

## Related links

## Tests performed

1. Ensure [publish debug marker](https://github.com/tier4/autoware_launch/blob/awf-latest/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml#:~:text=publish_debug_marker%3A%20false) is set to false.
2. Run the PSIM.
3. Place ego starting position and goal. Goal must be on the adjacent lane to simulate lane change process.
4. Place an object on the target lane.
5. If ego is within object vicinity and there is potential of collision via predicted path comparison, no path appears. Marker will also be shown together.
6. On the separate terminal, source autoware folder
7. run the following command. The debug marker should turned off.

**For lane change module**
```
ros2 param set /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner lane_change.publish_debug_marker true
```

https://user-images.githubusercontent.com/93502286/187595811-0fd5a8f2-31c5-430e-ada7-97a83161eed6.mp4

**For avoidance module**

```
ros2 param set /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner avoidance.publish_debug_marker true
```

https://user-images.githubusercontent.com/93502286/187603744-e36db697-d33c-44cf-a322-2aae37bea7e9.mp4

## Notes for reviewers
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
