### PR TITLE
feat(motion_velocity_smoother): improve the velocity calculation of trajectory w.r.t. lateral acceleration limit

### DIFF
--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -33,6 +33,8 @@
 #include "tier4_autoware_utils/trajectory/tmp_conversion.hpp"
 #include "tier4_autoware_utils/trajectory/trajectory.hpp"
 
+#include <vehicle_info_util/vehicle_info_util.hpp>
+
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -57,6 +59,7 @@ using nav_msgs::msg::Odometry;
 using tier4_debug_msgs::msg::Float32Stamped;        // temporary
 using tier4_planning_msgs::msg::StopSpeedExceeded;  // temporary
 using tier4_planning_msgs::msg::VelocityLimit;      // temporary
+using vehicle_info_util::VehicleInfoUtil;
 
 class MotionVelocitySmootherNode : public rclcpp::Node
 {
@@ -82,6 +85,7 @@ private:
   double max_velocity_with_deceleration_;          // maximum velocity with deceleration
                                                    // for external velocity limit
   double external_velocity_limit_dist_{0.0};       // distance to set external velocity limit
+  double wheelbase_;                               // wheelbase
 
   TrajectoryPoints prev_output_;                           // previously published trajectory
   boost::optional<TrajectoryPoint> prev_closest_point_{};  // previous trajectory point

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
@@ -47,6 +47,7 @@ public:
     double min_curve_velocity;           // min velocity at curve [m/s]
     double decel_distance_before_curve;  // distance before slow down for lateral acc at a curve
     double decel_distance_after_curve;   // distance after slow down for lateral acc at a curve
+    double wheel_base;                   // wheel base [m]
     resampling::ResampleParam resample_param;
   };
 

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/trajectory_utils.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/trajectory_utils.hpp
@@ -53,6 +53,9 @@ std::vector<double> calcTrajectoryIntervalDistance(const TrajectoryPoints & traj
 boost::optional<std::vector<double>> calcTrajectoryCurvatureFrom3Points(
   const TrajectoryPoints & trajectory, const size_t & idx_dist);
 
+boost::optional<std::vector<double>> calcTrajectoryCurvatureFromFrontSteeringAngle(
+  const TrajectoryPoints & trajectory, const double & wheelbase);
+
 void setZeroVelocity(TrajectoryPoints & trajectory);
 
 double getMaxVelocity(const TrajectoryPoints & trajectory);

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/trajectory_utils.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/trajectory_utils.hpp
@@ -52,9 +52,14 @@ std::vector<double> calcTrajectoryIntervalDistance(const TrajectoryPoints & traj
 
 boost::optional<std::vector<double>> calcTrajectoryCurvatureFrom3Points(
   const TrajectoryPoints & trajectory, const size_t & idx_dist);
-
+/**
+ * This function takes the trajectory points that include the steering angle, and wheelbase
+ * as an input and calculates the curvature array by using steering angles.
+ *
+ * @return Curvature array.
+ */
 boost::optional<std::vector<double>> calcTrajectoryCurvatureFromFrontSteeringAngle(
-  const TrajectoryPoints & trajectory, const double & wheelbase);
+  const TrajectoryPoints & trajectory, const double wheelbase);
 
 void setZeroVelocity(TrajectoryPoints & trajectory);
 

--- a/planning/motion_velocity_smoother/package.xml
+++ b/planning/motion_velocity_smoother/package.xml
@@ -26,6 +26,7 @@
   <depend>tier4_autoware_utils</depend>
   <depend>tier4_debug_msgs</depend>
   <depend>tier4_planning_msgs</depend>
+  <depend>vehicle_info_util</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -38,6 +38,8 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
 
   // set common params
   initCommonParam();
+  const auto vehicle_info = VehicleInfoUtil(*this).getVehicleInfo();
+  wheelbase_ = vehicle_info.wheel_base_m;
   over_stop_velocity_warn_thr_ =
     declare_parameter("over_stop_velocity_warn_thr", tier4_autoware_utils::kmph2mps(5.0));
 
@@ -72,6 +74,10 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
     default:
       throw std::domain_error("[MotionVelocitySmootherNode] invalid algorithm");
   }
+  // Initialize the wheelbase
+  auto p = smoother_->getBaseParam();
+  p.wheel_base = wheelbase_;
+  smoother_->setParam(p);
 
   // publishers, subscribers
   pub_trajectory_ = create_publisher<Trajectory>("~/output/trajectory", 1);

--- a/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
@@ -93,20 +93,13 @@ boost::optional<TrajectoryPoints> SmootherBase::applyLateralAccelerationFilter(
    *
    */
 
-  for (size_t i = 0; output->size() > i; i++) {
-    if (i < output->size() - 1) {
+  for (size_t i = 0; i < output->size() - 1; i++) {
       output->at(i).front_wheel_angle_rad = static_cast<float>(std::atan(
         (tf2::getYaw(output->at(i + 1).pose.orientation) -
          tf2::getYaw(output->at(i).pose.orientation)) *
         base_param_.wheel_base / (points_interval)));
-    } else {
-      output->at(i).front_wheel_angle_rad = 0.0;
-    }
   }
-
-  //  constexpr double curvature_calc_dist = 5.0;  // [m] calc curvature with 5m away points
-  //  const size_t idx_dist =
-  //    static_cast<size_t>(std::max(static_cast<int>((curvature_calc_dist) / points_interval), 1));
+  output->back().front_wheel_angle_rad = 0.0;
 
   // Calculate curvature assuming the trajectory points interval is constant
   const auto curvature_v = trajectory_utils::calcTrajectoryCurvatureFromFrontSteeringAngle(

--- a/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
@@ -93,7 +93,7 @@ boost::optional<TrajectoryPoints> SmootherBase::applyLateralAccelerationFilter(
    *
    */
 
-  for (size_t i = 0; i < output->size() - 1; i++) {
+  for (size_t i = 0; i + 1 < output->size(); i++) {
     output->at(i).front_wheel_angle_rad = static_cast<float>(std::atan(
       (tf2::getYaw(output->at(i + 1).pose.orientation) -
        tf2::getYaw(output->at(i).pose.orientation)) *

--- a/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
@@ -94,10 +94,10 @@ boost::optional<TrajectoryPoints> SmootherBase::applyLateralAccelerationFilter(
    */
 
   for (size_t i = 0; i < output->size() - 1; i++) {
-      output->at(i).front_wheel_angle_rad = static_cast<float>(std::atan(
-        (tf2::getYaw(output->at(i + 1).pose.orientation) -
-         tf2::getYaw(output->at(i).pose.orientation)) *
-        base_param_.wheel_base / (points_interval)));
+    output->at(i).front_wheel_angle_rad = static_cast<float>(std::atan(
+      (tf2::getYaw(output->at(i + 1).pose.orientation) -
+       tf2::getYaw(output->at(i).pose.orientation)) *
+      base_param_.wheel_base / (points_interval)));
   }
   output->back().front_wheel_angle_rad = 0.0;
 

--- a/planning/motion_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/motion_velocity_smoother/src/trajectory_utils.cpp
@@ -239,6 +239,36 @@ boost::optional<std::vector<double>> calcTrajectoryCurvatureFrom3Points(
   return boost::optional<std::vector<double>>(k_arr);
 }
 
+boost::optional<std::vector<double>> calcTrajectoryCurvatureFromFrontSteeringAngle(
+  const TrajectoryPoints & trajectory, const double & wheelbase)
+{
+  std::vector<double> k_arr;
+  if (trajectory.size() < 2) {
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("motion_velocity_smoother").get_child("trajectory_utils"),
+      "cannot calc curvature from steering angle, trajectory.size() = %lu", trajectory.size());
+    return {};
+  }
+
+  // calculate curvature by desired front wheel steering angle
+
+  for (size_t i = 0; i < trajectory.size(); ++i) {
+    const double steering_angle = trajectory.at(i).front_wheel_angle_rad;
+    const double curvature = tan(steering_angle) / wheelbase;
+    k_arr.push_back(curvature);
+  }
+
+  // for debug
+  if (k_arr.empty()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("motion_velocity_smoother").get_child("trajectory_utils"),
+      "k_arr.size() = 0, something wrong. pls check.");
+    return {};
+  }
+
+  return boost::optional<std::vector<double>>(k_arr);
+}
+
 void setZeroVelocity(TrajectoryPoints & trajectory)
 {
   for (auto & tp : trajectory) {

--- a/planning/motion_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/motion_velocity_smoother/src/trajectory_utils.cpp
@@ -240,30 +240,21 @@ boost::optional<std::vector<double>> calcTrajectoryCurvatureFrom3Points(
 }
 
 boost::optional<std::vector<double>> calcTrajectoryCurvatureFromFrontSteeringAngle(
-  const TrajectoryPoints & trajectory, const double & wheelbase)
+  const TrajectoryPoints & trajectory, const double wheelbase)
 {
-  std::vector<double> k_arr;
-  if (trajectory.size() < 2) {
+  if (trajectory.empty()) {
     RCLCPP_DEBUG(
       rclcpp::get_logger("motion_velocity_smoother").get_child("trajectory_utils"),
-      "cannot calc curvature from steering angle, trajectory.size() = %lu", trajectory.size());
+      "cannot calculate the curvature from steering angle, trajectory is empty.");
     return {};
   }
+  std::vector<double> k_arr;
 
   // calculate curvature by desired front wheel steering angle
-
-  for (size_t i = 0; i < trajectory.size(); ++i) {
-    const double steering_angle = trajectory.at(i).front_wheel_angle_rad;
+  for (const auto & trajectory_point: trajectory){
+    const double steering_angle = trajectory_point.front_wheel_angle_rad;
     const double curvature = tan(steering_angle) / wheelbase;
     k_arr.push_back(curvature);
-  }
-
-  // for debug
-  if (k_arr.empty()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("motion_velocity_smoother").get_child("trajectory_utils"),
-      "k_arr.size() = 0, something wrong. pls check.");
-    return {};
   }
 
   return boost::optional<std::vector<double>>(k_arr);

--- a/planning/motion_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/motion_velocity_smoother/src/trajectory_utils.cpp
@@ -251,7 +251,7 @@ boost::optional<std::vector<double>> calcTrajectoryCurvatureFromFrontSteeringAng
   std::vector<double> k_arr;
 
   // calculate curvature by desired front wheel steering angle
-  for (const auto & trajectory_point: trajectory){
+  for (const auto & trajectory_point : trajectory) {
     const double steering_angle = trajectory_point.front_wheel_angle_rad;
     const double curvature = tan(steering_angle) / wheelbase;
     k_arr.push_back(curvature);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

In current implementation of lateral acceleration filtering in trajectory, we are estimating the curvature by selecting three point. Then, we are calculating the lateral acceleration with this curvature estimation. See [here](https://github.com/autowarefoundation/autoware.universe/blob/main/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp#L61)!

I want to suggest a new approach to estimate the curvature in trajectory points. We can estimate the curvature by using the orientation of trajectory points. I think orientation can give more accurate results because it is output of optimization.

We can calculate the desired steering angle with following equation:
![desired_steering_angle_eq](https://user-images.githubusercontent.com/45468306/173042936-fca51004-0e18-4789-a1f9-f8878d93b39b.svg)

After calculate the desired steering angles, `tan(steering_angle) / wheelbase` will give us the curvature of the trajectory point. We can set the velocities w.r.t. this calculation. 
 

## Related links
Closes #1163
[Discussion](https://github.com/orgs/autowarefoundation/discussions/412)
Related issue [#567](https://github.com/autowarefoundation/autoware.universe/issues/567) 
<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

I tested the both approach with `control_performance_analysis`.

**Results (Before is current implementation, after is implementation with new approach):**
| Series                                                                               | Min Before  | Min After  | Max Before   | Max After   | Average Before | Average After |
|--------------------------------------------------------------------------------------|-------------|------------|--------------|-------------|----------------|---------------|
| /control_performance/driving_status/lateral_acceleration/data                        | -0.414748   | -0.404385  | 0.587819     | 0.570642    | 0.028891       | 0.025944      |
| /control_performance/driving_status/lateral_jerk/data                                | -4.37723    | -3.515305  | 2.620279     | 2.488174    | 0.001978       | -0.002855     |
| /control_performance/driving_status/longitudinal_acceleration/data                   | -0.912165   | -0.992638  | 1.171741     | 1.169503    | -0.00547       | -0.001894     |
| /control_performance/driving_status/longitudinal_jerk/data                           | -37.579326  | -38.59962  | 50.363508    | 64.01396    | -0.043433      | 0.003336      |
| /control_performance/performance_vars/error/control_effort_energy                    | 1E-06       | 3E-06      | 3.751512     | 3.640998    | 0.548236       | 0.517991      |
| /control_performance/performance_vars/error/curvature_estimate                       | -0.196328   | -0.15474   | 0.147634     | 0.14805     | 0.012307       | 0.011465      |
| /control_performance/performance_vars/error/curvature_estimate_pp                    | -0.685987   | -0.659468  | 0.857495     | 0.864488    | 0.0036         | 0.016651      |
| /control_performance/performance_vars/error/error_energy                             | 3E-06       | 3E-06      | 725.076238   | 744.538529  | 16.453592      | 14.461468     |
| /control_performance/performance_vars/error/heading_error                            | -3.935703   | -3.6235    | 0.131046     | 0.089199    | -0.138134      | -0.130147     |
| /control_performance/performance_vars/error/heading_error_velocity                   | -0.228567   | -0.232441  | 0.357787     | 0.351656    | 0.013681       | 0.012888      |
| /control_performance/performance_vars/error/lateral_error                            | -0.201026   | -0.203656  | 25.594785    | 24.925392   | 0.763545       | 0.690954      |
| /control_performance/performance_vars/error/lateral_error_acceleration               | -0.677725   | -0.646119  | 0.977959     | 0.961904    | 0.020453       | 0.020365      |
| /control_performance/performance_vars/error/lateral_error_velocity                   | -0.263545   | -0.231912  | 3.613527     | 3.311932    | 0.080852       | 0.070448      |
| /control_performance/performance_vars/error/longitudinal_error                       | -1.416918   | -1.687636  | 0.415556     | 0.557804    | -0.02788       | -0.024898     |
| /control_performance/performance_vars/error/longitudinal_error_acceleration          | -0.879877   | -0.888177  | 0.731259     | 0.756286    | 0.009436       | 0.000694      |
| /control_performance/performance_vars/error/longitudinal_error_velocity              | -4.887811   | -4.10775   | 0.486414     | 0.093616    | -0.102476      | -0.100788     |
| /control_performance/performance_vars/error/tracking_curvature_discontinuity_ability | 0           | 0          | 0.194609     | 0.149417    | 0.002406       | 0.002328      |
| /control_performance/performance_vars/error/value_approximation                      | 4E-06       | 2E-06      | 1157.290071  | 1141.501573 | 22.946368      | 20.431148     |
| /control_performance/performance_vars/error/vehicle_velocity_error                   | -0.25       | -0.34384   | 4.550888     | 4.419915    | 0.089122       | 0.073407      |
| iae_heading_error                                                                    | 0.070968    | 0.036298   | 2140.478331  | 1845.584953 | 1439.086766    | 1231.35816    |
| iae_heading_velocity_error                                                           | 0.260451    | 0.140809   | 839.786466   | 780.52647   | 438.247896     | 396.277805    |
| iae_lateral_acceleration_error                                                       | 0.062105    | 0.033544   | 2175.340398  | 2000.631767 | 1234.263002    | 1106.525029   |
| iae_lateral_error                                                                    | 1211.975957 | 646.071468 | 11887.734163 | 9804.156735 | 8798.502473    | 7032.961661   |
| iae_lateral_velocity_error                                                           | 4.9E-05     | 1.5E-05    | 1779.449632  | 1556.360706 | 1223.726301    | 1037.138146   |
| iae_longitudina_velocity_error                                                       | 891.871092  | 475.582655 | 2458.981641  | 1861.455609 | 1950.962988    | 1390.603746   |
| iae_longitudinal_acceleration_error                                                  | 176.916485  | 93.702997  | 2746.845968  | 2458.832042 | 1752.962301    | 1549.778308   |
| iae_longitudinal_error                                                               | 0.00567     | 0.002785   | 447.159208   | 366.669203  | 306.049465     | 253.690967    |
| iae_tracking_curvature_discontinuity_ability                                         | 0.000405    | 9E-06      | 31.055063    | 28.275924   | 14.034673      | 13.055478     |
| rms_heading_error                                                                    | 0.070968    | 0.036298   | 2140.478331  | 1845.584953 | 1439.086766    | 1231.35816    |
| rms_heading_velocity_error                                                           | 0.260451    | 0.140809   | 839.786466   | 780.52647   | 438.247896     | 396.277805    |
| rms_lateral_acceleration_error                                                       | 0.062105    | 0.033544   | 2175.340398  | 2000.631767 | 1234.263002    | 1106.525029   |
| rms_lateral_error                                                                    | 1211.975957 | 646.071468 | 11887.734163 | 9804.156735 | 8798.502473    | 7032.961661   |
| rms_lateral_velocity_error                                                           | 4.9E-05     | 1.5E-05    | 1779.449632  | 1556.360706 | 1223.726301    | 1037.138146   |
| rms_longitudinal_acceleration_error                                                  | 176.916485  | 93.702997  | 2746.845968  | 2458.832042 | 1752.962301    | 1549.778308   |
| rms_longitudinal_error                                                               | 0.00567     | 0.002785   | 447.159208   | 366.669203  | 306.049465     | 253.690967    |
| rms_longitudinal_velocity_error                                                      | 891.871092  | 475.582655 | 2458.981641  | 1861.455609 | 1950.962988    | 1390.603746   |
| rms_tracking_curvature_discontinuity_ability                                         | 0.000405    | 9E-06      | 31.055063    | 28.275924   | 14.034673      | 13.055478     |


---
**With new approach, maximum, total, average lateral errors decreased.** 



## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

You can test the PR with `control_performance_analysis` tool. For further information please read the [readme](https://github.com/autowarefoundation/autoware.universe/blob/main/control/control_performance_analysis/README.md)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
