### PR TITLE
fix(behavior_path_planner): remove unnecessary functions

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -160,17 +160,11 @@ PredictedPath convertToPredictedPath(
   const PathWithLaneId & path, const Twist & vehicle_twist, const Pose & vehicle_pose,
   const double duration, const double resolution, const double acceleration);
 
-bool checkIfPositionIsOnTheLine(const double & linestring_length, const FrenetCoordinate3d & pose);
 FrenetCoordinate3d convertToFrenetCoordinate3d(
   const std::vector<Point> & linestring, const Point & search_point_geom);
 
-bool convertToFrenetCoordinate3d(
-  const PathWithLaneId & path, const Point & search_point_geom,
-  FrenetCoordinate3d * frenet_coordinate);
-
-bool convertToFrenetCoordinate3d(
-  const std::vector<Point> & linestring, const Point search_point_geom,
-  FrenetCoordinate3d * frenet_coordinate);
+FrenetCoordinate3d convertToFrenetCoordinate3d(
+  const PathWithLaneId & path, const Point & search_point_geom);
 
 std::vector<uint64_t> getIds(const lanelet::ConstLanelets & lanelets);
 

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -56,12 +56,7 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
   }
 
   // Get frenet coordinate of current_pose on path
-  util::FrenetCoordinate3d vehicle_pose_frenet;
-  if (!util::convertToFrenetCoordinate3d(path, current_pose.position, &vehicle_pose_frenet)) {
-    RCLCPP_DEBUG_THROTTLE(
-      logger_, clock, 5000, "failed to convert vehicle pose into frenet coordinate");
-    return std::make_pair(turn_signal, distance);
-  }
+  const auto vehicle_pose_frenet = util::convertToFrenetCoordinate3d(path, current_pose.position);
 
   // Get nearest intersection and decide turn signal
   double accumulated_distance = 0;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -230,18 +230,6 @@ double l2Norm(const Vector3 vector)
   return std::sqrt(std::pow(vector.x, 2) + std::pow(vector.y, 2) + std::pow(vector.z, 2));
 }
 
-bool checkIfPositionIsOnTheLine(
-  const double & linestring_length, const FrenetCoordinate3d & frenet_pose)
-{
-  const auto length_ratio =
-    frenet_pose.length / ((std::fabs(linestring_length) > 0) ? linestring_length : 1e-5);
-  const auto length_ratio_positive = !std::signbit(length_ratio);
-
-  bool found_on_line = (std::fabs(frenet_pose.distance) < 1e-3) && length_ratio_positive &&
-                       (std::fabs(length_ratio) < 1.0);
-  return found_on_line;
-}
-
 FrenetCoordinate3d convertToFrenetCoordinate3d(
   const std::vector<Point> & linestring, const Point & search_point_geom)
 {
@@ -260,30 +248,11 @@ FrenetCoordinate3d convertToFrenetCoordinate3d(
   return frenet_coordinate;
 }
 
-bool convertToFrenetCoordinate3d(
-  const PathWithLaneId & path, const Point & search_point_geom,
-  FrenetCoordinate3d * frenet_coordinate)
+FrenetCoordinate3d convertToFrenetCoordinate3d(
+  const PathWithLaneId & path, const Point & search_point_geom)
 {
   const auto linestring = convertToPointArray(path);
-  return convertToFrenetCoordinate3d(linestring, search_point_geom, frenet_coordinate);
-}
-
-// returns false when search point is off the linestring
-bool convertToFrenetCoordinate3d(
-  const std::vector<Point> & linestring, const Point search_point_geom,
-  FrenetCoordinate3d * frenet_coordinate)
-{
-  if (linestring.empty()) {
-    return false;
-  }
-
-  // get frenet coordinate based on points
-  // this is done because linestring is not differentiable at vertices
-  const auto linestring_length =
-    tier4_autoware_utils::calcSignedArcLength(linestring, 0, linestring.size() - 1);
-  *frenet_coordinate = convertToFrenetCoordinate3d(linestring, search_point_geom);
-
-  return checkIfPositionIsOnTheLine(linestring_length, *frenet_coordinate);
+  return convertToFrenetCoordinate3d(linestring, search_point_geom);
 }
 
 std::vector<Point> convertToGeometryPointArray(const PathWithLaneId & path)

--- a/planning/behavior_path_planner/test/test_utilities.cpp
+++ b/planning/behavior_path_planner/test/test_utilities.cpp
@@ -50,35 +50,3 @@ TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetOnDiagonalLin
   EXPECT_NEAR(vehicle_pose_frenet.distance, 0, 1e-2);
   EXPECT_NEAR(vehicle_pose_frenet.length, 0.1414f, 1e-2);
 }
-
-TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetWhenEgoIsOnPath)
-{
-  PathWithLaneId path =
-    behavior_path_planner::generateDiagonalSamplePathWithLaneId(0.0f, 1.0f, 10u);
-  std::vector<Point> geometry_points =
-    behavior_path_planner::util::convertToGeometryPointArray(path);
-  Pose vehicle_pose = behavior_path_planner::generateEgoSamplePose(0.1f, 0.1f, 0.0);
-
-  FrenetCoordinate3d vehicle_pose_frenet;
-
-  const bool is_on_path = behavior_path_planner::util::convertToFrenetCoordinate3d(
-    geometry_points, vehicle_pose.position, &vehicle_pose_frenet);
-
-  EXPECT_TRUE(is_on_path);
-}
-
-TEST(BehaviorPathPlanningUtilitiesBehaviorTest, vehiclePoseToFrenetWhenEgoIsNotOnPath)
-{
-  PathWithLaneId path =
-    behavior_path_planner::generateDiagonalSamplePathWithLaneId(0.0f, 1.0f, 10u);
-  std::vector<Point> geometry_points =
-    behavior_path_planner::util::convertToGeometryPointArray(path);
-  Pose vehicle_pose = behavior_path_planner::generateEgoSamplePose(-0.01f, -0.01f, 0.0);
-
-  FrenetCoordinate3d vehicle_pose_frenet;
-
-  const bool is_on_path = behavior_path_planner::util::convertToFrenetCoordinate3d(
-    geometry_points, vehicle_pose.position, &vehicle_pose_frenet);
-
-  EXPECT_FALSE(is_on_path);
-}


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description

By introducing https://github.com/autowarefoundation/autoware.universe/pull/1096 , `found_on_line` flag is no longer necessary.
In this PR, I remove unnecessary `bool convertToFrenetCoordinate3d` from `behavior_path_planner`.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
