### PR TITLE
fix(behavior_velocity_planner): fix safety status in intersection module

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -185,7 +185,7 @@ bool IntersectionModule::modifyPathVelocity(
   const bool is_stop_required = is_stuck || !has_traffic_light_ || turn_direction_ != "straight";
   const double base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
 
-  setSafe(!(is_stop_required && is_entry_prohibited) || (state_machine_.getState() == State::GO));
+  setSafe(!(is_stop_required && is_entry_prohibited));
   setDistance(tier4_autoware_utils::calcSignedArcLength(
     input_path.points, planner_data_->current_pose.pose.position,
     input_path.points.at(stop_line_idx).point.pose.position));


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
I fixed the problem that the intersection module does not work with rtc_auto_approver.

The state of intersection module is kept to `State::GO` if rtc_auto_apprver approves once.
So, I remove the state condition from safety status.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
