### PR TITLE
fix(behavior_velocity): avoid zero division in pcl

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/run_out/dynamic_obstacle.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/dynamic_obstacle.cpp
@@ -197,6 +197,12 @@ std::vector<DynamicObstacle> DynamicObstacleCreatorForPoints::createDynamicObsta
 void DynamicObstacleCreatorForPoints::onCompareMapFilteredPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+  if (msg->data.empty()) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    dynamic_obstacle_data_.compare_map_filtered_pointcloud.clear();
+    return;
+  }
+
   geometry_msgs::msg::TransformStamped transform;
   try {
     transform = tf_buffer_.lookupTransform(

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/dynamic_obstacle.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/dynamic_obstacle.cpp
@@ -61,7 +61,6 @@ pcl::PointCloud<pcl::PointXYZ> applyVoxelGridFilter(
     p.z = 0.0;
   }
 
-  // use boost::makeshared instead of std beacause filter.setInputCloud requires boost shared ptr
   pcl::VoxelGrid<pcl::PointXYZ> filter;
   filter.setInputCloud(pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(no_height_points));
   filter.setLeafSize(0.05f, 0.05f, 100000.0f);


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description

Fixed zero division caused by passing empty pointcloud.
```
#0  0x00007f4f59e5b05d in pcl::PointCloud<pcl::PointXYZ>::assign<__gnu_cxx::__normal_iterator<pcl::PointXYZ const*, std::vector<pcl::PointXYZ, Eigen::aligned_allocator<pcl::PointXYZ> > > > (this=0x7f4f4c1c78b0, first=..., last=..., new_width=0) at /usr/include/pcl-1.12/pcl/point_cloud.h:600
600	        height = size() / width;
[Current thread is 1 (Thread 0x7f4f697e9640 (LWP 10155))]
(gdb) bt
#0  0x00007f4f59e5b05d in pcl::PointCloud<pcl::PointXYZ>::assign<__gnu_cxx::__normal_iterator<pcl::PointXYZ const*, std::vector<pcl::PointXYZ, Eigen::aligned_allocator<pcl::PointXYZ> > > >(__gnu_cxx::__normal_iterator<pcl::PointXYZ const*, std::vector<pcl::PointXYZ, Eigen::aligned_allocator<pcl::PointXYZ> > >, __gnu_cxx::__normal_iterator<pcl::PointXYZ const*, std::vector<pcl::PointXYZ, Eigen::aligned_allocator<pcl::PointXYZ> > >, int)
    (this=0x7f4f4c1c78b0, first=non-dereferenceable iterator for std::vector, last=non-dereferenceable iterator for std::vector, new_width=0)
    at /usr/include/pcl-1.12/pcl/point_cloud.h:600
#1  0x00007f4f59e4723e in pcl::transformPointCloud<pcl::PointXYZ, float>(pcl::PointCloud<pcl::PointXYZ> const&, pcl::PointCloud<pcl::PointXYZ>&, Eigen::Matrix<float, 4, 4, 0, 4, 4> const&, bool) (cloud_in=..., cloud_out=..., transform=..., copy_all_fields=true)
    at /usr/include/pcl-1.12/pcl/common/impl/transforms.hpp:232
#2  0x00007f4f59e3ad02 in pcl::transformPointCloud<pcl::PointXYZ>(pcl::PointCloud<pcl::PointXYZ> const&, pcl::PointCloud<pcl::PointXYZ>&, Eigen::Transform<float, 3, 2, 0> const&, bool) (cloud_in=..., cloud_out=..., transform=..., copy_all_fields=true) at /usr/include/pcl-1.12/pcl/common/transforms.h:74
#3  0x00007f4f5a346bba in behavior_velocity_planner::DynamicObstacleCreatorForPoints::onCompareMapFilteredPointCloud(std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>)
    (this=0x7f4f18731d20, msg=std::shared_ptr<const sensor_msgs::msg::PointCloud2_<std::allocator<void> >> (use count 4, weak count 0) = {...})
    at /home/tomohitoando/workspace/pilot-auto.x2/src/autoware/universe/planning/behavior_velocity_planner/src/scene_module/run_out/dynamic_obstacle.cpp:214
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
