### PR TITLE
refactor(ad_service_state_monitor): remove unused pointcloud_map param

### DIFF
--- a/system/ad_service_state_monitor/config/ad_service_state_monitor.param.yaml
+++ b/system/ad_service_state_monitor/config/ad_service_state_monitor.param.yaml
@@ -23,7 +23,6 @@
     topic_configs:
       names: [
         "/map/vector_map",
-        "/map/pointcloud_map",
         "/perception/obstacle_segmentation/pointcloud",
         "/initialpose3d",
         "/localization/pose_twist_fusion_filter/pose",
@@ -43,13 +42,6 @@
           timeout: 0.0
           warn_rate: 0.0
           type: "autoware_auto_mapping_msgs/msg/HADMapBin"
-          transient_local: True
-
-        /map/pointcloud_map:
-          module: "map"
-          timeout: 0.0
-          warn_rate: 0.0
-          type: "sensor_msgs/msg/PointCloud2"
           transient_local: True
 
         /perception/obstacle_segmentation/pointcloud:

--- a/system/ad_service_state_monitor/config/ad_service_state_monitor.planning_simulation.param.yaml
+++ b/system/ad_service_state_monitor/config/ad_service_state_monitor.planning_simulation.param.yaml
@@ -23,7 +23,6 @@
     topic_configs:
       names: [
         "/map/vector_map",
-        "/map/pointcloud_map",
         "/perception/object_recognition/objects",
         "/initialpose2d",
         "/planning/mission_planning/route",
@@ -41,13 +40,6 @@
           timeout: 0.0
           warn_rate: 0.0
           type: "autoware_auto_mapping_msgs/msg/HADMapBin"
-          transient_local: True
-
-        /map/pointcloud_map:
-          module: "map"
-          timeout: 0.0
-          warn_rate: 0.0
-          type: "sensor_msgs/msg/PointCloud2"
           transient_local: True
 
         /perception/object_recognition/objects:


### PR DESCRIPTION
Signed-off-by: Shumpei Wakabayashi <shumpei.wakabayashi@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
It seems `/map/pointcloud_map` config param is not used at `ad_service_state_monitor` so I remove it.
I tested planning_simulator and confirmed it works without it.
(I don't know who knows well about it, so I requested many people randomly to review this.)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
