### PR TITLE
feat: add line_width property to object display

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -80,7 +80,7 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::Sha
 get_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-  const std_msgs::msg::ColorRGBA & color_rgba);
+  const std_msgs::msg::ColorRGBA & color_rgba, const double line_width = 0.03);
 
 /// \brief Convert the given polygon into a marker representing the shape in 3d
 /// \param centroid Centroid position of the shape in Object.header.frame_id frame

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -75,6 +75,7 @@ const std::map<
 /// \param centroid Centroid position of the shape in Object.header.frame_id frame
 /// \param orientation Orientation of the shape in Object.header.frame_id frame
 /// \param color_rgba Color and alpha values to use for the marker
+/// \param line_width Line thickness around the object
 /// \return Marker ptr. Id and header will have to be set by the caller
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_shape_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -80,7 +80,7 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::Sha
 get_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-  const std_msgs::msg::ColorRGBA & color_rgba, const double line_width = 0.03);
+  const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width);
 
 /// \brief Convert the given polygon into a marker representing the shape in 3d
 /// \param centroid Centroid position of the shape in Object.header.frame_id frame

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -134,6 +134,7 @@ protected:
   /// \param centroid Centroid position of the shape in Object.header.frame_id frame
   /// \param orientation Orientation of the shape in Object.header.frame_id frame
   /// \param labels List of ObjectClassificationMsg objects
+  /// \param line_width Line thickness around the object
   /// \return Marker ptr. Id and header will have to be set by the caller
   template <typename ClassificationContainerT>
   std::optional<Marker::SharedPtr> get_shape_marker_ptr(

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -139,7 +139,7 @@ protected:
   std::optional<Marker::SharedPtr> get_shape_marker_ptr(
     const autoware_auto_perception_msgs::msg::Shape & shape_msg,
     const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-    const ClassificationContainerT & labels, const double line_width = 0.03) const
+    const ClassificationContainerT & labels, const double & line_width) const
   {
     const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
 

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -74,6 +74,7 @@ public:
     m_display_path_confidence_property{
       "Display Predicted Path Confidence", true, "Enable/disable predicted paths visualization",
       this},
+    m_line_width_property{"Line Width", 0.03, "Line width of object-shape", this},
     m_default_topic{default_topic}
   {
     // iterate over default values to create and initialize the properties.
@@ -138,12 +139,12 @@ protected:
   std::optional<Marker::SharedPtr> get_shape_marker_ptr(
     const autoware_auto_perception_msgs::msg::Shape & shape_msg,
     const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-    const ClassificationContainerT & labels) const
+    const ClassificationContainerT & labels, const double line_width = 0.03) const
   {
     const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
 
     if (m_display_3d_property.getBool()) {
-      return detail::get_shape_marker_ptr(shape_msg, centroid, orientation, color_rgba);
+      return detail::get_shape_marker_ptr(shape_msg, centroid, orientation, color_rgba, line_width);
     } else {
       return std::nullopt;
     }
@@ -335,6 +336,8 @@ protected:
     colors.push_back(sample_color);  // spring green
   }
 
+  double get_line_width() { return m_line_width_property.getFloat(); }
+
 private:
   // All rviz plugins should have this. Should be initialized with pointer to this class
   MarkerCommon m_marker_common;
@@ -358,6 +361,8 @@ private:
   rviz_common::properties::BoolProperty m_display_predicted_paths_property;
   // Property to enable/disable predicted path confidence visualization
   rviz_common::properties::BoolProperty m_display_path_confidence_property;
+  // Property to decide line width of object shape
+  rviz_common::properties::FloatProperty m_line_width_property;
   // Default topic name to be visualized
   std::string m_default_topic;
 

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_display.cpp
@@ -34,7 +34,8 @@ void DetectedObjectsDisplay::processMessage(DetectedObjects::ConstSharedPtr msg)
     // Get marker for shape
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.pose_with_covariance.pose.position,
-      object.kinematics.pose_with_covariance.pose.orientation, object.classification);
+      object.kinematics.pose_with_covariance.pose.orientation, object.classification,
+      get_line_width());
     if (shape_marker) {
       auto shape_marker_ptr = shape_marker.value();
       shape_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -212,7 +212,7 @@ visualization_msgs::msg::Marker::SharedPtr get_label_marker_ptr(
 visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-  const std_msgs::msg::ColorRGBA & color_rgba)
+  const std_msgs::msg::ColorRGBA & color_rgba, const double line_width)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->ns = std::string("shape");
@@ -235,7 +235,7 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose = to_pose(centroid, orientation);
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
-  marker_ptr->scale.x = 0.03;
+  marker_ptr->scale.x = line_width;
   marker_ptr->color = color_rgba;
 
   return marker_ptr;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -212,7 +212,7 @@ visualization_msgs::msg::Marker::SharedPtr get_label_marker_ptr(
 visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape_msg,
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
-  const std_msgs::msg::ColorRGBA & color_rgba, const double line_width)
+  const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width)
 {
   auto marker_ptr = std::make_shared<Marker>();
   marker_ptr->ns = std::string("shape");

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -33,7 +33,8 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
     // Get marker for shape
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.initial_pose_with_covariance.pose.position,
-      object.kinematics.initial_pose_with_covariance.pose.orientation, object.classification);
+      object.kinematics.initial_pose_with_covariance.pose.orientation, object.classification,
+      get_line_width());
     if (shape_marker) {
       auto shape_marker_ptr = shape_marker.value();
       shape_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -35,7 +35,8 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
     // Get marker for shape
     auto shape_marker = get_shape_marker_ptr(
       object.shape, object.kinematics.pose_with_covariance.pose.position,
-      object.kinematics.pose_with_covariance.pose.orientation, object.classification);
+      object.kinematics.pose_with_covariance.pose.orientation, object.classification,
+      get_line_width());
     if (shape_marker) {
       auto shape_marker_ptr = shape_marker.value();
       shape_marker_ptr->header = msg->header;


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Add a line with property to object display
![image](https://user-images.githubusercontent.com/59680180/176816381-4328fc16-7884-46a3-a621-283d2a2a5be3.png)

<!-- Write a brief description of this PR. -->

## Related links
https://github.com/tier4/autoware_launch/pull/378

<!-- Write the links related to this PR. -->

## Review procedure
Check that the line width of object-shape changes depending on the value of line witdh property on rviz.

(with https://github.com/tier4/autoware_launch/pull/378 )

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
