### PR TITLE
fix: behavior path drivable area

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1158,7 +1158,9 @@ OccupancyGrid generateDrivableArea(
       }
       cv_polygons.push_back(cv_polygon);
       // fill in drivable area and copy to occupancy grid
-      cv::fillPoly(cv_image, cv_polygons, cv::Scalar(free_space));
+      for (const auto & p : cv_polygons) {
+        cv::fillConvexPoly(cv_image, p, cv::Scalar(free_space));
+      }
     }
 
     // Closing


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/issues/1207
fillpoly generates wrong polygon for overlap area which might cause wrong drivable area(this doesn't happen in autoware drigvable area so I wonder why, but this may cause some errors for edge case)
![image](https://user-images.githubusercontent.com/65527974/176837160-64b1e93c-a843-4b32-a0ec-82eab8aa937f.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
