### PR TITLE
feat: update shape estiamtion param

### DIFF
--- a/perception/shape_estimation/include/shape_estimation/corrector/bus_corrector.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/bus_corrector.hpp
@@ -28,7 +28,7 @@ public:
   explicit BusCorrector(bool use_reference_yaw = false) : use_reference_yaw_(use_reference_yaw)
   {
     params_.min_width = 2.0;
-    params_.max_width = 2.9;
+    params_.max_width = 3.2;
     params_.avg_width = (params_.min_width + params_.max_width) * 0.5;
     params_.min_length = 5.0;
     params_.max_length = 17.0;

--- a/perception/shape_estimation/include/shape_estimation/corrector/truck_corrector.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/truck_corrector.hpp
@@ -28,7 +28,7 @@ public:
   explicit TruckCorrector(bool use_reference_yaw = false) : use_reference_yaw_(use_reference_yaw)
   {
     params_.min_width = 1.5;
-    params_.max_width = 2.9;
+    params_.max_width = 3.2;
     params_.avg_width = (params_.min_width + params_.max_width) * 0.5;
     params_.min_length = 4.0;
     params_.max_length = 7.9;

--- a/perception/shape_estimation/lib/filter/bus_filter.cpp
+++ b/perception/shape_estimation/lib/filter/bus_filter.cpp
@@ -19,7 +19,7 @@ bool BusFilter::filter(
   [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
 {
   constexpr float min_width = 2.0;
-  constexpr float max_width = 2.9;
+  constexpr float max_width = 3.2;
   constexpr float max_length = 17.0;
   return utils::filterVehicleBoundingBox(shape, min_width, max_width, max_length);
 }

--- a/perception/shape_estimation/lib/filter/truck_filter.cpp
+++ b/perception/shape_estimation/lib/filter/truck_filter.cpp
@@ -19,7 +19,7 @@ bool TruckFilter::filter(
   [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
 {
   constexpr float min_width = 1.5;
-  constexpr float max_width = 2.9;
+  constexpr float max_width = 3.2;
   constexpr float max_length = 7.9;
   return utils::filterVehicleBoundingBox(shape, min_width, max_width, max_length);
 }


### PR DESCRIPTION
Signed-off-by: Yukihiro Saito <yukky.saito@gmail.com>

## Description

change max width of BUS and TRUCK in shape estimation.
These parameters should be in a yaml file, but I want to merge them once.

before
white : clustering
blue : detection by tracker
![image (5)](https://user-images.githubusercontent.com/8327598/176986631-4b33d502-b6ad-4e7d-84db-493205550661.png)

after
white : clustering
blue : detection by tracker
![image (4)](https://user-images.githubusercontent.com/8327598/176986705-11bffa2d-b027-4df7-88fc-7d7d32ace5eb.png)


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
