### PR TITLE
chore(occupancy_grid): remove unecessary log

### DIFF
--- a/sensing/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/occupancy_grid_map.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/occupancy_grid_map.cpp
@@ -187,11 +187,9 @@ void OccupancyGridMap::raytraceFreespace(const PointCloud2 & pointcloud, const P
   const double ox{robot_pose.position.x};
   const double oy{robot_pose.position.y};
   if (!worldToMap(robot_pose.position.x, robot_pose.position.y, x0, y0)) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, clock_, 1000,
-      "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot "
-      "raytrace for it.",
-      ox, oy);
+    RCLCPP_DEBUG(
+      logger_, "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot "
+      "raytrace for it.", ox, oy);
     return;
   }
 

--- a/sensing/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/occupancy_grid_map.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/occupancy_grid_map.cpp
@@ -188,8 +188,10 @@ void OccupancyGridMap::raytraceFreespace(const PointCloud2 & pointcloud, const P
   const double oy{robot_pose.position.y};
   if (!worldToMap(robot_pose.position.x, robot_pose.position.y, x0, y0)) {
     RCLCPP_DEBUG(
-      logger_, "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot "
-      "raytrace for it.", ox, oy);
+      logger_,
+      "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot "
+      "raytrace for it.",
+      ox, oy);
     return;
   }
 

--- a/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
@@ -349,11 +349,9 @@ void OccupancyGridMap::raytrace(
   const double ox{source_x};
   const double oy{source_y};
   if (!worldToMap(ox, oy, x0, y0)) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, clock_, 1000,
-      "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot "
-      "raytrace for it.",
-      ox, oy);
+    RCLCPP_DEBUG(
+      logger_, "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot "
+      "raytrace for it.", ox, oy);
     return;
   }
 

--- a/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
@@ -350,8 +350,10 @@ void OccupancyGridMap::raytrace(
   const double oy{source_y};
   if (!worldToMap(ox, oy, x0, y0)) {
     RCLCPP_DEBUG(
-      logger_, "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot "
-      "raytrace for it.", ox, oy);
+      logger_,
+      "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot "
+      "raytrace for it.",
+      ox, oy);
     return;
   }
 


### PR DESCRIPTION
Signed-off-by: taikitanaka3 <ttatcoder@outlook.jp>

## Description


change this debug message from warn to debug
```
"The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot "
      "raytrace for it."
```
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
