### PR TITLE
fix(behavior_velocity): don't insert a stop point ahead of the goal

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -673,7 +673,9 @@ void RunOutModule::insertStopPoint(
   auto insert_idx = nearest_seg_idx + 1;
 
   // if stop point is ahead of the end of the path, don't insert
-  if (planning_utils::isAheadOf(*stop_point, path.points.at(insert_idx).point.pose)) {
+  if (
+    insert_idx == path.points.size() - 1 &&
+    planning_utils::isAheadOf(*stop_point, path.points.at(insert_idx).point.pose)) {
     return;
   }
 

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -672,6 +672,11 @@ void RunOutModule::insertStopPoint(
     tier4_autoware_utils::findNearestSegmentIndex(path.points, stop_point->position);
   auto insert_idx = nearest_seg_idx + 1;
 
+  // if stop point is ahead of the end of the path, don't insert
+  if (planning_utils::isAheadOf(*stop_point, path.points.at(insert_idx).point.pose)) {
+    return;
+  }
+
   // to PathPointWithLaneId
   autoware_auto_planning_msgs::msg::PathPointWithLaneId stop_point_with_lane_id;
   stop_point_with_lane_id = path.points.at(nearest_seg_idx);


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description
Fixed the case that run_out module inserted the stop point after the goal, and the index of the path was incorrect.
I confirmed these scenarios are successful.
- UC-F-10-00002-001
- UC-F-11-00004-001

### before
This bug caused the strange optimized path.

https://user-images.githubusercontent.com/11865769/177063297-43ebcaae-6802-4474-8770-3a72d1d473a3.mp4

### after
The bug mentioned above doesn't happen. (The ego vehicle stops because I used the rosbag that the bug happened.)

https://user-images.githubusercontent.com/11865769/177063302-7d54fcc5-d489-44a4-8279-ac90ae156436.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
