### PR TITLE
fix(gnss_poser): added local coordinate system in UTM to gnss_poser

### DIFF
--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -33,6 +33,7 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 | `gnss_frame`         | string | "gnss"           | frame id                                                                                        |
 | `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                        |
 | `map_frame`          | string | "map"            | frame id                                                                                        |
+| `coordinate_system`  | int    | "4"              | id number of wanted coordinate system, 4 is a local coordinate system in UTM                    |
 | `use_ublox_receiver` | bool   | false            | flag to use ublox receiver                                                                      |
 | `plane_zone`         | int    | 9                | identification number of the plane rectangular coordinate systems (See, reference document [2]) |
 

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -28,12 +28,12 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 ### Core Parameters
 
 | Name                 | Type   | Default Value    | Description                                                                                                                                |
-| -------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| -------------------- | ------ | ---------------- |--------------------------------------------------------------------------------------------------------------------------------------------|
 | `base_frame`         | string | "base_link"      | frame d                                                                                                                                    |
 | `gnss_frame`         | string | "gnss"           | frame id                                                                                                                                   |
 | `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                                                                   |
 | `map_frame`          | string | "map"            | frame id                                                                                                                                   |
-| `coordinate_system`  | int    | "4"              | coordinate system enumeration; 1: UTM, 2: MGRS, 3: Plane, 4: WGS84 Local Coordinate System, 5: UTM Local Coordinate System                 |
+| `coordinate_system`  | int    | "4"              | coordinate system enumeration; 0: UTM, 1: MGRS, 2: Plane, 3: WGS84 Local Coordinate System, 4: UTM Local Coordinate System                 |
 | `use_ublox_receiver` | bool   | false            | flag to use ublox receiver                                                                                                                 |
 | `plane_zone`         | int    | 9                | identification number of the plane rectangular coordinate systems. [click here for more details](https://www.gsi.go.jp/LAW/heimencho.html) |
 

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -28,8 +28,8 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 ### Core Parameters
 
 | Name                 | Type   | Default Value    | Description                                                                                                                                |
-| -------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `base_frame`         | string | "base_link"      | frame d                                                                                                                                    |
+| -------------------- | ------ | ---------------- |--------------------------------------------------------------------------------------------------------------------------------------------|
+| `base_frame`         | string | "base_link"      | frame id                                                                                                                                   |
 | `gnss_frame`         | string | "gnss"           | frame id                                                                                                                                   |
 | `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                                                                   |
 | `map_frame`          | string | "map"            | frame id                                                                                                                                   |

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -10,15 +10,15 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 
 ### Input
 
-| Name             | Type                          | Description                                                                                     |
-| ---------------- | ----------------------------- | ----------------------------------------------------------------------------------------------- |
-| `~/input/fix`    | `sensor_msgs::msg::NavSatFix` | gnss status message                                                                             |
-| `~/input/navpvt` | `ublox_msgs::msg::NavPVT`     | position, velocity and time solution (You can see detail description in reference document [1]) |
+| Name             | Type                          | Description                                                                                                     |
+|------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `~/input/fix`    | `sensor_msgs::msg::NavSatFix` | gnss status message                                                                                             |
+| `~/input/navpvt` | `ublox_msgs::msg::NavPVT`     | position, velocity and time solution. [click here for more details](https://github.com/KumarRobotics/ublox.git) |
 
 ### Output
 
 | Name                     | Type                                            | Description                                                    |
-| ------------------------ | ----------------------------------------------- | -------------------------------------------------------------- |
+|--------------------------|-------------------------------------------------|----------------------------------------------------------------|
 | `~/output/pose`          | `geometry_msgs::msg::PoseStamped`               | vehicle pose calculated from gnss sensing data                 |
 | `~/output/gnss_pose_cov` | `geometry_msgs::msg::PoseWithCovarianceStamped` | vehicle pose with covariance calculated from gnss sensing data |
 | `~/output/gnss_fixed`    | `tier4_debug_msgs::msg::BoolStamped`            | gnss fix status                                                |
@@ -27,15 +27,15 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 
 ### Core Parameters
 
-| Name                 | Type   | Default Value    | Description                                                                                                                                           |
-| -------------------- | ------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `base_frame`         | string | "base_link"      | frame d                                                                                                                                               |
-| `gnss_frame`         | string | "gnss"           | frame id                                                                                                                                              |
-| `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                                                                              |
-| `map_frame`          | string | "map"            | frame id                                                                                                                                              |
-| `coordinate_system`  | int    | "4"              | id number of wanted coordinate system;<br/> 1: UTM <br/> 2: MGRS<br/>3: Plane<br/>4: WGS84 Local Coordinate System<br/>5: UTM Local Coordinate System |
-| `use_ublox_receiver` | bool   | false            | flag to use ublox receiver                                                                                                                            |
-| `plane_zone`         | int    | 9                | identification number of the plane rectangular coordinate systems (See, reference document [2])                                                       |
+| Name                 | Type   | Default Value    | Description                                                                                                                                |
+|----------------------|--------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `base_frame`         | string | "base_link"      | frame d                                                                                                                                    |
+| `gnss_frame`         | string | "gnss"           | frame id                                                                                                                                   |
+| `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                                                                   |
+| `map_frame`          | string | "map"            | frame id                                                                                                                                   |
+| `coordinate_system`  | int    | "4"              | coordinate system enumeration; 1: UTM, 2: MGRS, 3: Plane, 4: WGS84 Local Coordinate System, 5: UTM Local Coordinate System                 |
+| `use_ublox_receiver` | bool   | false            | flag to use ublox receiver                                                                                                                 |
+| `plane_zone`         | int    | 9                | identification number of the plane rectangular coordinate systems. [click here for more details](https://www.gsi.go.jp/LAW/heimencho.html) |
 
 ## Assumptions / Known limits
 
@@ -44,9 +44,5 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 ## (Optional) Performance characterization
 
 ## (Optional) References/External links
-
-[1] <https://github.com/KumarRobotics/ublox.git>
-
-[2] <https://www.gsi.go.jp/LAW/heimencho.html>
 
 ## (Optional) Future extensions / Unimplemented parts

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -28,7 +28,7 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 ### Core Parameters
 
 | Name                 | Type   | Default Value    | Description                                                                                                                                |
-| -------------------- | ------ | ---------------- |--------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `base_frame`         | string | "base_link"      | frame d                                                                                                                                    |
 | `gnss_frame`         | string | "gnss"           | frame id                                                                                                                                   |
 | `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                                                                   |

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -28,7 +28,7 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 ### Core Parameters
 
 | Name                 | Type   | Default Value    | Description                                                                                                                                           |
-| -------------------- | ------ | ---------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------- | ------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `base_frame`         | string | "base_link"      | frame d                                                                                                                                               |
 | `gnss_frame`         | string | "gnss"           | frame id                                                                                                                                              |
 | `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                                                                              |

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -27,15 +27,15 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 
 ### Core Parameters
 
-| Name                 | Type   | Default Value    | Description                                                                                     |
-| -------------------- | ------ | ---------------- | ----------------------------------------------------------------------------------------------- |
-| `base_frame`         | string | "base_link"      | frame d                                                                                         |
-| `gnss_frame`         | string | "gnss"           | frame id                                                                                        |
-| `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                        |
-| `map_frame`          | string | "map"            | frame id                                                                                        |
-| `coordinate_system`  | int    | "4"              | id number of wanted coordinate system, 4 is a local coordinate system in UTM                    |
-| `use_ublox_receiver` | bool   | false            | flag to use ublox receiver                                                                      |
-| `plane_zone`         | int    | 9                | identification number of the plane rectangular coordinate systems (See, reference document [2]) |
+| Name                 | Type   | Default Value    | Description                                                                                                                                           |
+| -------------------- | ------ | ---------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `base_frame`         | string | "base_link"      | frame d                                                                                                                                               |
+| `gnss_frame`         | string | "gnss"           | frame id                                                                                                                                              |
+| `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                                                                              |
+| `map_frame`          | string | "map"            | frame id                                                                                                                                              |
+| `coordinate_system`  | int    | "4"              | id number of wanted coordinate system;<br/> 1: UTM <br/> 2: MGRS<br/>3: Plane<br/>4: WGS84 Local Coordinate System<br/>5: UTM Local Coordinate System |
+| `use_ublox_receiver` | bool   | false            | flag to use ublox receiver                                                                                                                            |
+| `plane_zone`         | int    | 9                | identification number of the plane rectangular coordinate systems (See, reference document [2])                                                       |
 
 ## Assumptions / Known limits
 

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -28,7 +28,7 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 ### Core Parameters
 
 | Name                 | Type   | Default Value    | Description                                                                                                                                |
-| -------------------- | ------ | ---------------- |--------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `base_frame`         | string | "base_link"      | frame id                                                                                                                                   |
 | `gnss_frame`         | string | "gnss"           | frame id                                                                                                                                   |
 | `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                                                                   |

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -11,14 +11,14 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 ### Input
 
 | Name             | Type                          | Description                                                                                                     |
-|------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| ---------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `~/input/fix`    | `sensor_msgs::msg::NavSatFix` | gnss status message                                                                                             |
 | `~/input/navpvt` | `ublox_msgs::msg::NavPVT`     | position, velocity and time solution. [click here for more details](https://github.com/KumarRobotics/ublox.git) |
 
 ### Output
 
 | Name                     | Type                                            | Description                                                    |
-|--------------------------|-------------------------------------------------|----------------------------------------------------------------|
+| ------------------------ | ----------------------------------------------- | -------------------------------------------------------------- |
 | `~/output/pose`          | `geometry_msgs::msg::PoseStamped`               | vehicle pose calculated from gnss sensing data                 |
 | `~/output/gnss_pose_cov` | `geometry_msgs::msg::PoseWithCovarianceStamped` | vehicle pose with covariance calculated from gnss sensing data |
 | `~/output/gnss_fixed`    | `tier4_debug_msgs::msg::BoolStamped`            | gnss fix status                                                |
@@ -28,7 +28,7 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 ### Core Parameters
 
 | Name                 | Type   | Default Value    | Description                                                                                                                                |
-|----------------------|--------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `base_frame`         | string | "base_link"      | frame d                                                                                                                                    |
 | `gnss_frame`         | string | "gnss"           | frame id                                                                                                                                   |
 | `gnss_base_frame`    | string | "gnss_base_link" | frame id                                                                                                                                   |

--- a/sensing/gnss_poser/config/set_local_origin.param.yaml
+++ b/sensing/gnss_poser/config/set_local_origin.param.yaml
@@ -2,10 +2,10 @@
   ros__parameters:
 
     # Latitude of local origin
-    latitude: 40.816617984672746
+    latitude: 40.81187906
 
     # Longitude of local origin
-    longitude: 29.360491808334285
+    longitude: 29.35810110
 
     # Altitude of local origin
-    altitude: 52.251157145314075
+    altitude: 47.62

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -99,6 +99,41 @@ GNSSStat NavSatFix2UTM(
   }
   return utm;
 }
+bool is_utm_origin_initialized = false;
+GNSSStat utm_origin;
+GNSSStat utm_local;
+GNSSStat NavSatFix2UTMLocal(
+  const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
+  sensor_msgs::msg::NavSatFix nav_sat_fix_origin_, const rclcpp::Logger & logger)
+{
+  utm_origin.coordinate_system = CoordinateSystem::UTM;
+  utm_local.coordinate_system = CoordinateSystem::UTM;
+  double global_x;
+  double global_y;
+  try {
+    if (is_utm_origin_initialized == 0) {
+      GeographicLib::UTMUPS::Forward(
+        nav_sat_fix_origin_.latitude, nav_sat_fix_origin_.longitude, utm_origin.zone,
+        utm_origin.northup, utm_origin.x, utm_origin.y);
+      utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger);
+      is_utm_origin_initialized = true;
+    } else {
+      GeographicLib::UTMUPS::Forward(
+        nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
+        global_x, global_y);
+      utm_local.latitude = nav_sat_fix_msg.latitude;
+      utm_local.longitude = nav_sat_fix_msg.longitude;
+      utm_local.altitude = nav_sat_fix_msg.altitude;
+      utm_local.x = global_x - utm_origin.x;
+      utm_local.y = global_y - utm_origin.y;
+      utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
+    }
+  } catch (const GeographicLib::GeographicErr & err) {
+    RCLCPP_ERROR_STREAM(
+      logger, "Failed to convert from LLH to UTM in local coordinates" << err.what());
+  }
+  return utm_local;
+}
 
 GNSSStat UTM2MGRS(
   const GNSSStat & utm, const MGRSPrecision & precision, const rclcpp::Logger & logger)

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -113,15 +113,15 @@ GNSSStat NavSatFix2LocalCartesianUTM(
   double global_y;
   try {
     if (utm_origin_needs_init) {
-        GeographicLib::UTMUPS::Forward(
-                nav_sat_fix_origin_.latitude, nav_sat_fix_origin_.longitude, utm_origin.zone,
-                utm_origin.northup, utm_origin.x, utm_origin.y);
-        utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger);
-        utm_origin_needs_init = false;
+      GeographicLib::UTMUPS::Forward(
+        nav_sat_fix_origin_.latitude, nav_sat_fix_origin_.longitude, utm_origin.zone,
+        utm_origin.northup, utm_origin.x, utm_origin.y);
+      utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger);
+      utm_origin_needs_init = false;
     }
     GeographicLib::UTMUPS::Forward(
-            nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
-            global_x, global_y);
+      nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
+      global_x, global_y);
     utm_local.latitude = nav_sat_fix_msg.latitude;
     utm_local.longitude = nav_sat_fix_msg.longitude;
     utm_local.altitude = nav_sat_fix_msg.altitude;

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -103,19 +103,19 @@ GNSSStat NavSatFix2LocalCartesianUTM(
   const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
   sensor_msgs::msg::NavSatFix nav_sat_fix_origin, const rclcpp::Logger & logger)
 {
-  GNSSStat utm_origin;
   GNSSStat utm_local;
-  utm_origin.coordinate_system = CoordinateSystem::UTM;
   utm_local.coordinate_system = CoordinateSystem::UTM;
-  double global_x;
-  double global_y;
   try {
-    // origin of the local coordinate system in global
+    // origin of the local coordinate system in global frame
+    GNSSStat utm_origin;
+    utm_origin.coordinate_system = CoordinateSystem::UTM;
     GeographicLib::UTMUPS::Forward(
       nav_sat_fix_origin.latitude, nav_sat_fix_origin.longitude, utm_origin.zone,
       utm_origin.northup, utm_origin.x, utm_origin.y);
     utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_origin, logger);
     // individual coordinates of global coordinate system
+    double global_x = 0.0;
+    double global_y = 0.0;
     GeographicLib::UTMUPS::Forward(
       nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
       global_x, global_y);

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -100,37 +100,37 @@ GNSSStat NavSatFix2UTM(
   return utm;
 }
 GNSSStat NavSatFix2LocalCartesianUTM(
-        const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
-        sensor_msgs::msg::NavSatFix nav_sat_fix_origin, const rclcpp::Logger & logger)
+  const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
+  sensor_msgs::msg::NavSatFix nav_sat_fix_origin, const rclcpp::Logger & logger)
 {
-    GNSSStat utm_origin;
-    GNSSStat utm_local;
-    utm_origin.coordinate_system = CoordinateSystem::UTM;
-    utm_local.coordinate_system = CoordinateSystem::UTM;
-    double global_x;
-    double global_y;
-    try {
-        // origin of the local coordinate system in global
-        GeographicLib::UTMUPS::Forward(
-                nav_sat_fix_origin.latitude, nav_sat_fix_origin.longitude, utm_origin.zone,
-                utm_origin.northup, utm_origin.x, utm_origin.y);
-        utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_origin, logger);
-        // individual coordinates of global coordinate system
-        GeographicLib::UTMUPS::Forward(
-                nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
-                global_x, global_y);
-        utm_local.latitude = nav_sat_fix_msg.latitude;
-        utm_local.longitude = nav_sat_fix_msg.longitude;
-        utm_local.altitude = nav_sat_fix_msg.altitude;
-        // individual coordinates of local coordinate system
-        utm_local.x = global_x - utm_origin.x;
-        utm_local.y = global_y - utm_origin.y;
-        utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
-    } catch (const GeographicLib::GeographicErr & err) {
-        RCLCPP_ERROR_STREAM(
-                logger, "Failed to convert from LLH to UTM in local coordinates" << err.what());
-    }
-    return utm_local;
+  GNSSStat utm_origin;
+  GNSSStat utm_local;
+  utm_origin.coordinate_system = CoordinateSystem::UTM;
+  utm_local.coordinate_system = CoordinateSystem::UTM;
+  double global_x;
+  double global_y;
+  try {
+    // origin of the local coordinate system in global
+    GeographicLib::UTMUPS::Forward(
+      nav_sat_fix_origin.latitude, nav_sat_fix_origin.longitude, utm_origin.zone,
+      utm_origin.northup, utm_origin.x, utm_origin.y);
+    utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_origin, logger);
+    // individual coordinates of global coordinate system
+    GeographicLib::UTMUPS::Forward(
+      nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
+      global_x, global_y);
+    utm_local.latitude = nav_sat_fix_msg.latitude;
+    utm_local.longitude = nav_sat_fix_msg.longitude;
+    utm_local.altitude = nav_sat_fix_msg.altitude;
+    // individual coordinates of local coordinate system
+    utm_local.x = global_x - utm_origin.x;
+    utm_local.y = global_y - utm_origin.y;
+    utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
+  } catch (const GeographicLib::GeographicErr & err) {
+    RCLCPP_ERROR_STREAM(
+      logger, "Failed to convert from LLH to UTM in local coordinates" << err.what());
+  }
+  return utm_local;
 }
 GNSSStat UTM2MGRS(
   const GNSSStat & utm, const MGRSPrecision & precision, const rclcpp::Logger & logger)

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -99,7 +99,8 @@ GNSSStat NavSatFix2UTM(
   }
   return utm;
 }
-bool is_utm_origin_initialized = false;
+
+bool utm_origin_needs_init = true;
 GNSSStat utm_origin;
 GNSSStat utm_local;
 GNSSStat NavSatFix2LocalCartesianUTM(
@@ -111,23 +112,22 @@ GNSSStat NavSatFix2LocalCartesianUTM(
   double global_x;
   double global_y;
   try {
-    if (is_utm_origin_initialized == 0) {
-      GeographicLib::UTMUPS::Forward(
-        nav_sat_fix_origin_.latitude, nav_sat_fix_origin_.longitude, utm_origin.zone,
-        utm_origin.northup, utm_origin.x, utm_origin.y);
-      utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger);
-      is_utm_origin_initialized = true;
-    } else {
-      GeographicLib::UTMUPS::Forward(
-        nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
-        global_x, global_y);
-      utm_local.latitude = nav_sat_fix_msg.latitude;
-      utm_local.longitude = nav_sat_fix_msg.longitude;
-      utm_local.altitude = nav_sat_fix_msg.altitude;
-      utm_local.x = global_x - utm_origin.x;
-      utm_local.y = global_y - utm_origin.y;
-      utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
+    if (utm_origin_needs_init) {
+        GeographicLib::UTMUPS::Forward(
+                nav_sat_fix_origin_.latitude, nav_sat_fix_origin_.longitude, utm_origin.zone,
+                utm_origin.northup, utm_origin.x, utm_origin.y);
+        utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger);
+        utm_origin_needs_init = false;
     }
+    GeographicLib::UTMUPS::Forward(
+            nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
+            global_x, global_y);
+    utm_local.latitude = nav_sat_fix_msg.latitude;
+    utm_local.longitude = nav_sat_fix_msg.longitude;
+    utm_local.altitude = nav_sat_fix_msg.altitude;
+    utm_local.x = global_x - utm_origin.x;
+    utm_local.y = global_y - utm_origin.y;
+    utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
   } catch (const GeographicLib::GeographicErr & err) {
     RCLCPP_ERROR_STREAM(
       logger, "Failed to convert from LLH to UTM in local coordinates" << err.what());

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -57,12 +57,12 @@ double EllipsoidHeight2OrthometricHeight(
   }
   return OrthometricHeight;
 }
-GNSSStat NavSatFix2LocalCartesian(
+GNSSStat NavSatFix2LocalCartesianWGS84(
   const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
   sensor_msgs::msg::NavSatFix nav_sat_fix_origin_, const rclcpp::Logger & logger)
 {
   GNSSStat local_cartesian;
-  local_cartesian.coordinate_system = CoordinateSystem::LOCAL_CARTESIAN;
+  local_cartesian.coordinate_system = CoordinateSystem::LOCAL_CARTESIAN_WGS84;
 
   try {
     GeographicLib::LocalCartesian localCartesian_origin(
@@ -102,7 +102,7 @@ GNSSStat NavSatFix2UTM(
 bool is_utm_origin_initialized = false;
 GNSSStat utm_origin;
 GNSSStat utm_local;
-GNSSStat NavSatFix2UTMLocal(
+GNSSStat NavSatFix2LocalCartesianUTM(
   const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
   sensor_msgs::msg::NavSatFix nav_sat_fix_origin_, const rclcpp::Logger & logger)
 {

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -99,42 +99,39 @@ GNSSStat NavSatFix2UTM(
   }
   return utm;
 }
-
-bool utm_origin_needs_init = true;
-GNSSStat utm_origin;
-GNSSStat utm_local;
 GNSSStat NavSatFix2LocalCartesianUTM(
-  const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
-  sensor_msgs::msg::NavSatFix nav_sat_fix_origin_, const rclcpp::Logger & logger)
+        const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
+        sensor_msgs::msg::NavSatFix nav_sat_fix_origin, const rclcpp::Logger & logger)
 {
-  utm_origin.coordinate_system = CoordinateSystem::UTM;
-  utm_local.coordinate_system = CoordinateSystem::UTM;
-  double global_x;
-  double global_y;
-  try {
-    if (utm_origin_needs_init) {
-      GeographicLib::UTMUPS::Forward(
-        nav_sat_fix_origin_.latitude, nav_sat_fix_origin_.longitude, utm_origin.zone,
-        utm_origin.northup, utm_origin.x, utm_origin.y);
-      utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger);
-      utm_origin_needs_init = false;
+    GNSSStat utm_origin;
+    GNSSStat utm_local;
+    utm_origin.coordinate_system = CoordinateSystem::UTM;
+    utm_local.coordinate_system = CoordinateSystem::UTM;
+    double global_x;
+    double global_y;
+    try {
+        // origin of the local coordinate system in global
+        GeographicLib::UTMUPS::Forward(
+                nav_sat_fix_origin.latitude, nav_sat_fix_origin.longitude, utm_origin.zone,
+                utm_origin.northup, utm_origin.x, utm_origin.y);
+        utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_origin, logger);
+        // individual coordinates of global coordinate system
+        GeographicLib::UTMUPS::Forward(
+                nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
+                global_x, global_y);
+        utm_local.latitude = nav_sat_fix_msg.latitude;
+        utm_local.longitude = nav_sat_fix_msg.longitude;
+        utm_local.altitude = nav_sat_fix_msg.altitude;
+        // individual coordinates of local coordinate system
+        utm_local.x = global_x - utm_origin.x;
+        utm_local.y = global_y - utm_origin.y;
+        utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
+    } catch (const GeographicLib::GeographicErr & err) {
+        RCLCPP_ERROR_STREAM(
+                logger, "Failed to convert from LLH to UTM in local coordinates" << err.what());
     }
-    GeographicLib::UTMUPS::Forward(
-      nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm_origin.zone, utm_origin.northup,
-      global_x, global_y);
-    utm_local.latitude = nav_sat_fix_msg.latitude;
-    utm_local.longitude = nav_sat_fix_msg.longitude;
-    utm_local.altitude = nav_sat_fix_msg.altitude;
-    utm_local.x = global_x - utm_origin.x;
-    utm_local.y = global_y - utm_origin.y;
-    utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
-  } catch (const GeographicLib::GeographicErr & err) {
-    RCLCPP_ERROR_STREAM(
-      logger, "Failed to convert from LLH to UTM in local coordinates" << err.what());
-  }
-  return utm_local;
+    return utm_local;
 }
-
 GNSSStat UTM2MGRS(
   const GNSSStat & utm, const MGRSPrecision & precision, const rclcpp::Logger & logger)
 {

--- a/sensing/gnss_poser/include/gnss_poser/gnss_stat.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/gnss_stat.hpp
@@ -20,7 +20,8 @@ enum class CoordinateSystem {
   UTM = 0,
   MGRS = 1,
   PLANE = 2,
-  LOCAL_CARTESIAN = 3,
+  LOCAL_CARTESIAN_WGS84 = 3,
+  LOCAL_CARTESIAN_UTM = 4
 };
 
 struct GNSSStat

--- a/sensing/gnss_poser/launch/gnss_poser.launch.xml
+++ b/sensing/gnss_poser/launch/gnss_poser.launch.xml
@@ -13,7 +13,7 @@
   <arg name="gnss_frame" default="gnss"/>
   <arg name="map_frame" default="map"/>
 
-  <arg name="coordinate_system" default="1" description="0:UTM, 1:MGRS, 2:PLANE, 3:LocalCartesian"/>
+  <arg name="coordinate_system" default="4" description="0:UTM, 1:MGRS, 2:PLANE, 3:LocalCartesianWGS84, 4:LocalCartesianUTM"/>
   <arg name="buff_epoch" default="1"/>
   <arg name="use_gnss_ins_orientation" default="true"/>
   <arg name="plane_zone" default="9"/>

--- a/sensing/gnss_poser/launch/gnss_poser.launch.xml
+++ b/sensing/gnss_poser/launch/gnss_poser.launch.xml
@@ -13,7 +13,7 @@
   <arg name="gnss_frame" default="gnss"/>
   <arg name="map_frame" default="map"/>
 
-  <arg name="coordinate_system" default="4" description="0:UTM, 1:MGRS, 2:PLANE, 3:LocalCartesianWGS84, 4:LocalCartesianUTM"/>
+  <arg name="coordinate_system" default="0" description="0:UTM, 1:MGRS, 2:PLANE, 3:LocalCartesianWGS84, 4:LocalCartesianUTM"/>
   <arg name="buff_epoch" default="1"/>
   <arg name="use_gnss_ins_orientation" default="true"/>
   <arg name="plane_zone" default="9"/>

--- a/sensing/gnss_poser/launch/gnss_poser.launch.xml
+++ b/sensing/gnss_poser/launch/gnss_poser.launch.xml
@@ -13,7 +13,7 @@
   <arg name="gnss_frame" default="gnss"/>
   <arg name="map_frame" default="map"/>
 
-  <arg name="coordinate_system" default="0" description="0:UTM, 1:MGRS, 2:PLANE, 3:LocalCartesianWGS84, 4:LocalCartesianUTM"/>
+  <arg name="coordinate_system" default="4" description="0:UTM, 1:MGRS, 2:PLANE, 3:LocalCartesianWGS84, 4:LocalCartesianUTM"/>
   <arg name="buff_epoch" default="1"/>
   <arg name="use_gnss_ins_orientation" default="true"/>
   <arg name="plane_zone" default="9"/>

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -185,13 +185,15 @@ GNSSStat GNSSPoser::convert(
   if (coordinate_system == CoordinateSystem::UTM) {
     gnss_stat = NavSatFix2UTM(nav_sat_fix_msg, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_UTM) {
-    gnss_stat = NavSatFix2LocalCartesianUTM(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
+    gnss_stat =
+      NavSatFix2LocalCartesianUTM(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::MGRS) {
     gnss_stat = NavSatFix2MGRS(nav_sat_fix_msg, MGRSPrecision::_100MICRO_METER, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::PLANE) {
     gnss_stat = NavSatFix2PLANE(nav_sat_fix_msg, plane_zone_, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_WGS84) {
-    gnss_stat = NavSatFix2LocalCartesianWGS84(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
+    gnss_stat =
+      NavSatFix2LocalCartesianWGS84(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
   } else {
     RCLCPP_ERROR_STREAM_THROTTLE(
       this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -184,11 +184,13 @@ GNSSStat GNSSPoser::convert(
   GNSSStat gnss_stat;
   if (coordinate_system == CoordinateSystem::UTM) {
     gnss_stat = NavSatFix2UTM(nav_sat_fix_msg, this->get_logger());
+  } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_UTM) {
+    gnss_stat = NavSatFix2UTMLocal(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::MGRS) {
     gnss_stat = NavSatFix2MGRS(nav_sat_fix_msg, MGRSPrecision::_100MICRO_METER, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::PLANE) {
     gnss_stat = NavSatFix2PLANE(nav_sat_fix_msg, plane_zone_, this->get_logger());
-  } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN) {
+  } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_WGS84) {
     gnss_stat = NavSatFix2LocalCartesian(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
   } else {
     RCLCPP_ERROR_STREAM_THROTTLE(

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -185,13 +185,13 @@ GNSSStat GNSSPoser::convert(
   if (coordinate_system == CoordinateSystem::UTM) {
     gnss_stat = NavSatFix2UTM(nav_sat_fix_msg, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_UTM) {
-    gnss_stat = NavSatFix2UTMLocal(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
+    gnss_stat = NavSatFix2LocalCartesianUTM(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::MGRS) {
     gnss_stat = NavSatFix2MGRS(nav_sat_fix_msg, MGRSPrecision::_100MICRO_METER, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::PLANE) {
     gnss_stat = NavSatFix2PLANE(nav_sat_fix_msg, plane_zone_, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_WGS84) {
-    gnss_stat = NavSatFix2LocalCartesian(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
+    gnss_stat = NavSatFix2LocalCartesianWGS84(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
   } else {
     RCLCPP_ERROR_STREAM_THROTTLE(
       this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),


### PR DESCRIPTION
Signed-off-by: ataparlar [ataparlar@leodrive.ai](mailto:ataparlar@leodrive.ai)

## Description

In the gnss_poser package, there was no option for working in a local coordinate system for UTM. Added a function to ```convert.hpp``` and added "**UTMLocal**" parameter to the ```gnss_poser.launch.xml``` .

## Related links

Related with this issue: [#1122](https://github.com/autowarefoundation/autoware.universe/issues/1122)

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
