### PR TITLE
fix(ground_filter): expand range of cropped_box_filter

### DIFF
--- a/launch/tier4_perception_launch/config/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
+++ b/launch/tier4_perception_launch/config/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
@@ -20,4 +20,5 @@
         local_slope_max_angle_deg: 30.0
         split_points_distance_tolerance: 0.2
         split_height_distance: 0.3
+        minimum_detection_range: -0.2
         use_virtual_ground_point: True

--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -103,7 +103,8 @@ class GroundSegmentationPipeline:
                     ("output", f"{lidar_name}/pointcloud"),
                 ],
                 parameters=[
-                    self.ground_segmentation_param[f"{lidar_name}_ground_filter"]["parameters"]
+                    {"maximum_detection_range": self.vehicle_info["max_height_offset"]},
+                    self.ground_segmentation_param[f"{lidar_name}_ground_filter"]["parameters"],
                 ],
                 extra_arguments=[
                     {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
@@ -237,6 +238,7 @@ class GroundSegmentationPipeline:
                     ("output", output_topic),
                 ],
                 parameters=[
+                    {"maximum_detection_range": self.vehicle_info["max_height_offset"]},
                     self.ground_segmentation_param["common_ground_filter"]["parameters"],
                     self.vehicle_info,
                 ],

--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -57,7 +57,7 @@ class GroundSegmentationPipeline:
         p["max_longitudinal_offset"] = p["front_overhang"] + p["wheel_base"]
         p["min_lateral_offset"] = -(p["wheel_tread"] / 2.0 + p["right_overhang"])
         p["max_lateral_offset"] = p["wheel_tread"] / 2.0 + p["left_overhang"]
-        p["min_height_offset"] = -0.5
+        p["min_height_offset"] = -2.0
         p["max_height_offset"] = p["vehicle_height"]
         return p
 

--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -57,7 +57,7 @@ class GroundSegmentationPipeline:
         p["max_longitudinal_offset"] = p["front_overhang"] + p["wheel_base"]
         p["min_lateral_offset"] = -(p["wheel_tread"] / 2.0 + p["right_overhang"])
         p["max_lateral_offset"] = p["wheel_tread"] / 2.0 + p["left_overhang"]
-        p["min_height_offset"] = 0.0
+        p["min_height_offset"] = -0.5
         p["max_height_offset"] = p["vehicle_height"]
         return p
 

--- a/perception/ground_segmentation/docs/scan-ground-filter.md
+++ b/perception/ground_segmentation/docs/scan-ground-filter.md
@@ -36,6 +36,8 @@ This implementation inherits `pointcloud_preprocessor::Filter` class, please ref
 | `radial_divider_angle`            | double | 1.0           | The angle which divide the whole pointcloud to sliced group [deg]             |
 | `split_points_distance_tolerance` | double | 0.2           | The xy-distance threshold to to distinguishing far and near [m]               |
 | `split_height_distance`           | double | 0.2           | The height threshold to distinguishing far and near [m]                       |
+| `maximum_detection_range`         | float  | 2.5           | maximum of detection range from ground                                        |
+| `minimum_detection_range`         | float  | -0.2          | minimum of detection range from ground                                        |
 | `use_virtual_ground_point`        | bool   | true          | whether to use the ground center of front wheels as the virtual ground point. |
 
 ## Assumptions / Known limits

--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -113,6 +113,7 @@ private:
 
   std::string base_frame_;
   std::string sensor_frame_;
+  float non_ground_heigh_thresh_ = 2.5f;    // maximum height of non_ground object from ground
   double global_slope_max_angle_rad_;       // radians
   double local_slope_max_angle_rad_;        // radians
   double radial_divider_angle_rad_;         // distance in rads between dividers

--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -114,8 +114,8 @@ private:
 
   std::string base_frame_;
   std::string sensor_frame_;
-  float non_ground_height_max_ = 2.5f;      // maximum height of non_ground object from ground
-  float non_ground_height_min_ = 0.0f;      // mimimum height of non_ground object from ground
+  float maximum_detection_range_ = 2.5f;    // maximum height of non_ground object from ground
+  float minimum_detection_range_ = 0.0f;    // mimimum height of non_ground object from ground
   double global_slope_max_angle_rad_;       // radians
   double local_slope_max_angle_rad_;        // radians
   double radial_divider_angle_rad_;         // distance in rads between dividers

--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -54,6 +54,7 @@ private:
     POINT_FOLLOW,
     UNKNOWN,
     VIRTUAL_GROUND,
+    OUT_OF_RANGE
   };
   struct PointRef
   {

--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -114,8 +114,8 @@ private:
 
   std::string base_frame_;
   std::string sensor_frame_;
-  float maximum_detection_range_ = 2.5f;    // maximum height of non_ground object from ground
-  float minimum_detection_range_ = 0.0f;    // mimimum height of non_ground object from ground
+  float maximum_detection_range_ = 2.5f;    // maximum of detection range from ground
+  float minimum_detection_range_ = 0.0f;    // minimum of detection range from ground
   double global_slope_max_angle_rad_;       // radians
   double local_slope_max_angle_rad_;        // radians
   double radial_divider_angle_rad_;         // distance in rads between dividers

--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -113,7 +113,8 @@ private:
 
   std::string base_frame_;
   std::string sensor_frame_;
-  float non_ground_heigh_thresh_ = 2.5f;    // maximum height of non_ground object from ground
+  float non_ground_height_max_ = 2.5f;      // maximum height of non_ground object from ground
+  float non_ground_height_min_ = 0.0f;      // mimimum height of non_ground object from ground
   double global_slope_max_angle_rad_;       // radians
   double local_slope_max_angle_rad_;        // radians
   double radial_divider_angle_rad_;         // distance in rads between dividers

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -38,9 +38,11 @@ ScanGroundFilterComponent::ScanGroundFilterComponent(const rclcpp::NodeOptions &
   // set initial parameters
   {
     base_frame_ = declare_parameter("base_frame", "base_link");
-    non_ground_height_max_ = static_cast<float>(declare_parameter("non_ground_height_max", 2.5));
-    non_ground_height_min_ = static_cast<float>(declare_parameter("non_ground_height_min", -0.2));
-    // TODO(badai-nguyen) : adjust margin for non_ground_height_min_ based on the distance
+    maximum_detection_range_ =
+      static_cast<float>(declare_parameter("maximum_detection_range", 2.5));
+    minimum_detection_range_ =
+      static_cast<float>(declare_parameter("minimum_detection_range", -0.2));
+    // TODO(badai-nguyen) : adjust margin for minimum_detection_range_ based on the distance
     // from LiDAR to allow a down-slope
     global_slope_max_angle_rad_ = deg2rad(declare_parameter("global_slope_max_angle_deg", 8.0));
     local_slope_max_angle_rad_ = deg2rad(declare_parameter("local_slope_max_angle_deg", 6.0));
@@ -173,9 +175,9 @@ void ScanGroundFilterComponent::classifyPointCloud(
       float global_slope = std::atan2(p->orig_point->z, p->radius);
       // check points which is far enough from previous point
       if (
-        (height_from_gnd < non_ground_height_min_) ||
-        ((p->orig_point->z - ground_cluster.getAverageHeight()) < non_ground_height_min_) ||
-        (height_from_gnd > non_ground_height_max_)) {
+        (height_from_gnd < minimum_detection_range_) ||
+        ((p->orig_point->z - ground_cluster.getAverageHeight()) < minimum_detection_range_) ||
+        (height_from_gnd > maximum_detection_range_)) {
         // exclude pcl under ground or higher than limit
         p->point_state = PointLabel::OUT_OF_RANGE;
         calculate_slope = false;

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -38,8 +38,10 @@ ScanGroundFilterComponent::ScanGroundFilterComponent(const rclcpp::NodeOptions &
   // set initial parameters
   {
     base_frame_ = declare_parameter("base_frame", "base_link");
-    non_ground_heigh_thresh_ =
-      static_cast<float>(declare_parameter("non_ground_heigh_thresh", 2.5));
+    non_ground_height_max_ =
+      static_cast<float>(declare_parameter("non_ground_height_max", 2.5));
+    non_ground_height_min_ =
+      static_cast<float>(declare_parameter("non_ground_height_min", 0.0));
     global_slope_max_angle_rad_ = deg2rad(declare_parameter("global_slope_max_angle_deg", 8.0));
     local_slope_max_angle_rad_ = deg2rad(declare_parameter("local_slope_max_angle_deg", 6.0));
     radial_divider_angle_rad_ = deg2rad(declare_parameter("radial_divider_angle_deg", 1.0));
@@ -171,9 +173,9 @@ void ScanGroundFilterComponent::classifyPointCloud(
       float global_slope = std::atan2(p->orig_point->z, p->radius);
       // check points which is far enough from previous point
       if (
-        (height_from_gnd < -split_height_distance_) ||
-        ((p->orig_point->z - ground_cluster.getAverageHeight()) < -split_height_distance_) ||
-        (height_from_gnd > non_ground_heigh_thresh_)) {
+        (height_from_gnd < non_ground_height_min_) ||
+        ((p->orig_point->z - ground_cluster.getAverageHeight()) < non_ground_height_min_) ||
+        (height_from_gnd > non_ground_height_max_)) {
         // exclude pcl under ground or higher than limit
         calculate_slope = false;
       } else if (global_slope > global_slope_max_angle) {

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -39,7 +39,9 @@ ScanGroundFilterComponent::ScanGroundFilterComponent(const rclcpp::NodeOptions &
   {
     base_frame_ = declare_parameter("base_frame", "base_link");
     non_ground_height_max_ = static_cast<float>(declare_parameter("non_ground_height_max", 2.5));
-    non_ground_height_min_ = static_cast<float>(declare_parameter("non_ground_height_min", 0.0));
+    non_ground_height_min_ = static_cast<float>(declare_parameter("non_ground_height_min", -0.2));
+    // TODO(badai-nguyen) : adjust margin for non_ground_height_min_ based on the distance
+    // from LiDAR to allow a down-slope
     global_slope_max_angle_rad_ = deg2rad(declare_parameter("global_slope_max_angle_deg", 8.0));
     local_slope_max_angle_rad_ = deg2rad(declare_parameter("local_slope_max_angle_deg", 6.0));
     radial_divider_angle_rad_ = deg2rad(declare_parameter("radial_divider_angle_deg", 1.0));
@@ -175,6 +177,7 @@ void ScanGroundFilterComponent::classifyPointCloud(
         ((p->orig_point->z - ground_cluster.getAverageHeight()) < non_ground_height_min_) ||
         (height_from_gnd > non_ground_height_max_)) {
         // exclude pcl under ground or higher than limit
+        p->point_state = PointLabel::OUT_OF_RANGE;
         calculate_slope = false;
       } else if (global_slope > global_slope_max_angle) {
         p->point_state = PointLabel::NON_GROUND;

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -38,10 +38,8 @@ ScanGroundFilterComponent::ScanGroundFilterComponent(const rclcpp::NodeOptions &
   // set initial parameters
   {
     base_frame_ = declare_parameter("base_frame", "base_link");
-    non_ground_height_max_ =
-      static_cast<float>(declare_parameter("non_ground_height_max", 2.5));
-    non_ground_height_min_ =
-      static_cast<float>(declare_parameter("non_ground_height_min", 0.0));
+    non_ground_height_max_ = static_cast<float>(declare_parameter("non_ground_height_max", 2.5));
+    non_ground_height_min_ = static_cast<float>(declare_parameter("non_ground_height_min", 0.0));
     global_slope_max_angle_rad_ = deg2rad(declare_parameter("global_slope_max_angle_deg", 8.0));
     local_slope_max_angle_rad_ = deg2rad(declare_parameter("local_slope_max_angle_deg", 6.0));
     radial_divider_angle_rad_ = deg2rad(declare_parameter("radial_divider_angle_deg", 1.0));

--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -175,8 +175,9 @@ void ScanGroundFilterComponent::classifyPointCloud(
       float global_slope = std::atan2(p->orig_point->z, p->radius);
       // check points which is far enough from previous point
       if (
-        (height_from_gnd < minimum_detection_range_) ||
-        ((p->orig_point->z - ground_cluster.getAverageHeight()) < minimum_detection_range_) ||
+        ((p->orig_point->z < 0.0) &&
+         ((height_from_gnd < minimum_detection_range_) ||
+          (p->orig_point->z - ground_cluster.getAverageHeight() < minimum_detection_range_))) ||
         (height_from_gnd > maximum_detection_range_)) {
         // exclude pcl under ground or higher than limit
         p->point_state = PointLabel::OUT_OF_RANGE;


### PR DESCRIPTION
Signed-off-by: badai-nguyen <dai.nguyen@tier4.jp>

## Description

Current scan_ground_filter use the input from cropped_box_filter which limited from 0 < z < vehicle_height. Therefore, in case of uneven road or slope, the ground pcl might be filtered out and failure to initialize initial point cloud by scan_ground_filter. It could fixed by extending the cropped_box_filter range wider. This makes sure scan_ground_filter excludes the under ground point from non_ground point label when extending the range of cropped_box_filter. 

<!-- Write a brief description of this PR. -->


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
