### PR TITLE
fix(behavior_velocity): add guard for empty stop pose

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -94,6 +94,9 @@ visualization_msgs::msg::MarkerArray StopLineModule::createVirtualWallMarkerArra
 {
   const auto now = this->clock_->now();
   visualization_msgs::msg::MarkerArray wall_marker;
+  if (!debug_data_.stop_pose) {
+    return wall_marker;
+  }
   const auto p_front = tier4_autoware_utils::calcOffsetPose(
     *debug_data_.stop_pose, debug_data_.base_link2front, 0.0, 0.0);
   if (state_ == State::APPROACH) {


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description
I added the guard to prevent stop_line module from dying by referring to an empty boost::optional value.
This happens when the goal pose was set behind the stop sign, and no stop pose were generated.
```
>>> bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f420bb4b859 in __GI_abort () at abort.c:79
#2  0x00007f420bb4b729 in __assert_fail_base (fmt=0x7f420bce1588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x7f41abc38ed1 "this->is_initialized()", file=0x7f41abc38ea8 "/usr/include/boost/optional/optional.hpp", line=1207, function=<optimized out>) at assert.c:92
#3  0x00007f420bb5cfd6 in __GI___assert_fail (assertion=0x7f41abc38ed1 "this->is_initialized()", file=0x7f41abc38ea8 "/usr/include/boost/optional/optional.hpp", line=1207, function=0x7f41abc38dd0 "boost::optional<T>::reference_type boost::optional<T>::get() [with T = geometry_msgs::msg::Pose_<std::allocator<void> >; boost::optional<T>::reference_type = geometry_msgs::msg::Pose_<std::allocator<v"...) at assert.c:101
#4  0x00007f41ab9fd95d in boost::optional<geometry_msgs::msg::Pose_<std::allocator<void> > >::get() (this=0x7f41c4795470) at /usr/include/boost/optional/optional.hpp:1207
#5  0x00007f41ab9fd8c4 in boost::optional<geometry_msgs::msg::Pose_<std::allocator<void> > >::operator*() & (this=0x7f41c4795470) at /usr/include/boost/optional/optional.hpp:1224
#6  0x00007f41ab9fd2fc in behavior_velocity_planner::StopLineModule::createVirtualWallMarkerArray() (this=0x7f41c4795350) at /home/tomohitoando/workspace/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp:101
```

```
>>> f 6
#6  0x00007f41ab9fd2fc in behavior_velocity_planner::StopLineModule::createVirtualWallMarkerArray (this=0x7f41c4795350) at /home/tomohitoando/workspace/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp:101
101	    *debug_data_.stop_pose, debug_data_.base_link2front, 0.0, 0.0);
>>> p debug_data_
$1 = {
  base_link2front = 3.79,
  stop_pose = boost::optional<geometry_msgs::msg::Pose_<std::allocator<void> > > is not initialized,
  search_segments = std::vector of length 0, capacity 0,
  search_stopline = {
    <std::vector<boost::geometry::model::d2::point_xy<double, boost::geometry::cs::cartesian>, std::allocator<boost::geometry::model::d2::point_xy<double, boost::geometry::cs::cartesian> > >> = std::vector of length 0, capacity 0, <No data fields>}
}
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
