### PR TITLE
fix(trajectory_follower_nodes): change control running order to keep stopped state

### DIFF
--- a/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
@@ -131,6 +131,9 @@ private:
   //!< @brief previous control command
   autoware_auto_control_msgs::msg::AckermannLateralCommand m_ctrl_cmd_prev;
 
+  //!< @brief flag whether the first trajectory has been received
+  bool m_has_received_first_trajectory = false;
+
   //!< @brief buffer for transforms
   tf2::BufferCore m_tf_buffer{tf2::BUFFER_CORE_DEFAULT_CACHE_TIME};
   tf2_ros::TransformListener m_tf_listener{m_tf_buffer};

--- a/control/trajectory_follower/src/mpc_lateral_controller.cpp
+++ b/control/trajectory_follower/src/mpc_lateral_controller.cpp
@@ -225,7 +225,7 @@ bool MpcLateralController::isSteerConverged(
 {
   // wait for a while to propagate the trajectory shape to the output command when the trajectory
   // shape is changed.
-  if (isTrajectoryShapeChanged()) {
+  if (!m_has_received_first_trajectory || isTrajectoryShapeChanged()) {
     return false;
   }
 
@@ -300,7 +300,12 @@ void MpcLateralController::setTrajectory(
   while (rclcpp::ok()) {
     const auto time_diff = rclcpp::Time(m_trajectory_buffer.back().header.stamp) -
                            rclcpp::Time(m_trajectory_buffer.front().header.stamp);
-    if (time_diff.seconds() < m_new_traj_duration_time) {
+
+    const float64_t first_trajectory_duration_time = 5.0;
+    const float64_t duration_time =
+      m_has_received_first_trajectory ? m_new_traj_duration_time : first_trajectory_duration_time;
+    if (time_diff.seconds() < duration_time) {
+      m_has_received_first_trajectory = true;
       break;
     }
     m_trajectory_buffer.pop_front();


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- fix keep stopped until the steer is converged when the new trajectory is received.
- steer convergence is checked in the lateral controller for a new trajectory.  In order to pass it immediately to the longitudinal controller, the lateral controller must run first then the longitudinal. 
  - If two are executed at the same time, the longitudinal controller uses the steer convergence information of the trajectory one step earlier and can not keep stopped. 

## Related links

<!-- Write the links related to this PR. -->
https://github.com/autowarefoundation/autoware.universe/pull/901

## Tests performed

<!-- Describe how you have tested this PR. -->
checked keeping stopped state until steer is converged when receiving a new trajectory.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
