### PR TITLE
fix(freespace_planner, mission_planner): null checking

### DIFF
--- a/planning/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
+++ b/planning/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
@@ -308,8 +308,6 @@ void FreespacePlannerNode::getAstarParam()
 
 void FreespacePlannerNode::onRoute(const HADMapRoute::ConstSharedPtr msg)
 {
-  if (scenario_ = nullptr) return;
-
   route_ = msg;
 
   goal_pose_.header = msg->header;

--- a/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
+++ b/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
@@ -162,7 +162,6 @@ bool MissionPlannerLanelet2::isRoutingGraphReady() const { return is_graph_ready
 void MissionPlannerLanelet2::visualizeRoute(
   const autoware_auto_planning_msgs::msg::HADMapRoute & route) const
 {
-  if (!route_handler_.isHandlerReady()) return;
   lanelet::ConstLanelets route_lanelets;
   lanelet::ConstLanelets end_lanelets;
   lanelet::ConstLanelets normal_lanelets;

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -311,6 +311,7 @@ void RouteHandler::setRouteLanelets(const lanelet::ConstLanelets & path_lanelets
   for (const auto & id : route_lanelets_id) {
     route_lanelets_.push_back(lanelet_map_ptr_->laneletLayer.get(id));
   }
+  is_handler_ready_ = true;
 }
 
 void RouteHandler::setLaneletsFromRouteMsg()


### PR DESCRIPTION
Signed-off-by: Shumpei Wakabayashi <shumpei.wakabayashi@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
Resolve https://github.com/autowarefoundation/autoware.universe/issues/1251.

This PR reverts some commits in [this PR](https://github.com/autowarefoundation/autoware.universe/pull/1155/files).

As for `freespace_planner`, I remove unnecessary nullptr checking.
As for `mission_planner`, it waits until `route_handler` is ready.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
