### PR TITLE
fix: change codec of mp4 to h264

### DIFF
--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -110,7 +110,7 @@ void AutowareScreenCapturePanel::convertPNGImagesToMP4()
   if (!capture.isOpened()) {
     return;
   }
-  int fourcc = cv::VideoWriter::fourcc('m', 'p', '4', 'v');  // mp4
+  int fourcc = cv::VideoWriter::fourcc('h', '2', '6', '4');  // mp4
   cv::VideoWriter writer;
   cv::Size size = cv::Size(width_, height_);
   writer.open("capture/" + root_folder_ + ".mp4", fourcc, capture_hz_->value(), size);


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Change codec of mp4 from mp4v to h264 because videos with mp4v-codec cannot be played on many web-browsers such as chrome
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
