### PR TITLE
fix(tier4_autoware_utils): exception handling in tier4 autoware utils

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/path_with_lane_id.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/trajectory/path_with_lane_id.hpp
@@ -38,12 +38,22 @@ namespace tier4_autoware_utils
 template <>
 inline boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
-  const size_t src_idx, const double offset)
+  const size_t src_idx, const double offset, const bool throw_exception)
 {
-  validateNonEmpty(points);
+  try {
+    validateNonEmpty(points);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
 
   if (points.size() - 1 < src_idx) {
-    throw std::out_of_range("Invalid source index");
+    const auto e = std::out_of_range("Invalid source index");
+    if (throw_exception) {
+      throw e;
+    }
+    std::cerr << e.what() << std::endl;
+    return {};
   }
 
   if (points.size() == 1) {
@@ -92,7 +102,12 @@ inline boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Point & src_point, const double offset)
 {
-  validateNonEmpty(points);
+  try {
+    validateNonEmpty(points);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
 
   if (offset < 0.0) {
     auto reverse_points = points;
@@ -117,12 +132,22 @@ inline boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
 template <>
 inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
-  const size_t src_idx, const double offset)
+  const size_t src_idx, const double offset, const bool throw_exception)
 {
-  validateNonEmpty(points);
+  try {
+    validateNonEmpty(points);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
 
   if (points.size() - 1 < src_idx) {
-    throw std::out_of_range("Invalid source index");
+    const auto e = std::out_of_range("Invalid source index");
+    if (throw_exception) {
+      throw e;
+    }
+    std::cerr << e.what() << std::endl;
+    return {};
   }
 
   if (points.size() == 1) {
@@ -184,7 +209,12 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const geometry_msgs::msg::Point & src_point, const double offset)
 {
-  validateNonEmpty(points);
+  try {
+    validateNonEmpty(points);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
 
   const size_t src_seg_idx = findNearestSegmentIndex(points, src_point);
   const double signed_length_src_offset =
@@ -206,7 +236,12 @@ inline boost::optional<size_t> insertTargetPoint(
   std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
   const double overlap_threshold)
 {
-  validateNonEmpty(points);
+  try {
+    validateNonEmpty(points);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
 
   // invalid segment index
   if (seg_idx + 1 >= points.size()) {

--- a/common/tier4_autoware_utils/test/src/trajectory/test_path_with_lane_id.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_path_with_lane_id.cpp
@@ -72,12 +72,11 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex_PathWithLaneId)
   const auto total_length = calcArcLength(traj.points);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPoint(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
+  EXPECT_FALSE(calcLongitudinalOffsetPoint(PathWithLaneId{}.points, {}, {}));
 
   // Out of range
-  EXPECT_THROW(
-    calcLongitudinalOffsetPoint(traj.points, traj.points.size() + 1, 1.0), std::out_of_range);
-  EXPECT_THROW(calcLongitudinalOffsetPoint(traj.points, -1, 1.0), std::out_of_range);
+  EXPECT_FALSE(calcLongitudinalOffsetPoint(traj.points, traj.points.size() + 1, 1.0));
+  EXPECT_FALSE(calcLongitudinalOffsetPoint(traj.points, -1, 1.0));
 
   // Found Pose(forward)
   for (size_t i = 0; i < traj.points.size(); ++i) {
@@ -150,7 +149,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_PathWithLaneId)
   const auto total_length = calcArcLength(traj.points);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPoint(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
+  EXPECT_FALSE(calcLongitudinalOffsetPoint(PathWithLaneId{}.points, {}, {}));
 
   // Found Pose(forward)
   for (double x_start = 0.0; x_start < total_length + epsilon; x_start += 0.1) {
@@ -211,9 +210,8 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint_PathWithLaneId)
   // Out of range(Trajectory size is 1)
   {
     const auto one_point_traj = generateTestTrajectory(1, 1.0);
-    EXPECT_THROW(
-      calcLongitudinalOffsetPoint(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
-      std::out_of_range);
+    EXPECT_FALSE(
+      calcLongitudinalOffsetPoint(one_point_traj.points, geometry_msgs::msg::Point{}, {}));
   }
 }
 
@@ -228,12 +226,11 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_PathWithLaneId)
   const auto total_length = calcArcLength(traj.points);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
+  EXPECT_FALSE(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}));
 
   // Out of range
-  EXPECT_THROW(
-    calcLongitudinalOffsetPose(traj.points, traj.points.size() + 1, 1.0), std::out_of_range);
-  EXPECT_THROW(calcLongitudinalOffsetPose(traj.points, -1, 1.0), std::out_of_range);
+  EXPECT_FALSE(calcLongitudinalOffsetPose(traj.points, traj.points.size() + 1, 1.0));
+  EXPECT_FALSE(calcLongitudinalOffsetPose(traj.points, -1, 1.0));
 
   // Found Pose(forward)
   for (size_t i = 0; i < traj.points.size(); ++i) {
@@ -314,7 +311,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_PathWithLaneId)
   const auto total_length = calcArcLength(traj.points);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}), std::invalid_argument);
+  EXPECT_FALSE(calcLongitudinalOffsetPose(PathWithLaneId{}.points, {}, {}));
 
   // Found Pose(forward)
   for (double x_start = 0.0; x_start < total_length + epsilon; x_start += 0.1) {
@@ -383,9 +380,8 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_PathWithLaneId)
   // Out of range(Trajectory size is 1)
   {
     const auto one_point_traj = generateTestTrajectory(1, 1.0);
-    EXPECT_THROW(
-      calcLongitudinalOffsetPose(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
-      std::out_of_range);
+    EXPECT_FALSE(
+      calcLongitudinalOffsetPose(one_point_traj.points, geometry_msgs::msg::Point{}, {}));
   }
 }
 
@@ -604,9 +600,8 @@ TEST(trajectory, insertTargetPoint_PathWithLaneId)
   {
     auto empty_traj = generateTestTrajectory(0, 1.0);
     const size_t segment_idx = 0;
-    EXPECT_THROW(
-      insertTargetPoint(segment_idx, geometry_msgs::msg::Point{}, empty_traj.points),
-      std::invalid_argument);
+    EXPECT_FALSE(
+      insertTargetPoint(segment_idx, geometry_msgs::msg::Point{}, empty_traj.points));
   }
 }
 

--- a/common/tier4_autoware_utils/test/src/trajectory/test_path_with_lane_id.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_path_with_lane_id.cpp
@@ -600,8 +600,7 @@ TEST(trajectory, insertTargetPoint_PathWithLaneId)
   {
     auto empty_traj = generateTestTrajectory(0, 1.0);
     const size_t segment_idx = 0;
-    EXPECT_FALSE(
-      insertTargetPoint(segment_idx, geometry_msgs::msg::Point{}, empty_traj.points));
+    EXPECT_FALSE(insertTargetPoint(segment_idx, geometry_msgs::msg::Point{}, empty_traj.points));
   }
 }
 

--- a/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/tier4_autoware_utils/test/src/trajectory/test_trajectory.cpp
@@ -168,7 +168,7 @@ TEST(trajectory, searchZeroVelocityIndex)
   using tier4_autoware_utils::searchZeroVelocityIndex;
 
   // Empty
-  EXPECT_THROW(searchZeroVelocityIndex(Trajectory{}.points), std::invalid_argument);
+  EXPECT_FALSE(searchZeroVelocityIndex(Trajectory{}.points));
 
   // No zero velocity point
   {
@@ -290,8 +290,7 @@ TEST(trajectory, findNearestIndex_Pose_NoThreshold)
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(
-    findNearestIndex(Trajectory{}.points, geometry_msgs::msg::Pose{}, {}), std::invalid_argument);
+  EXPECT_FALSE(findNearestIndex(Trajectory{}.points, geometry_msgs::msg::Pose{}, {}));
 
   // Start point
   EXPECT_EQ(*findNearestIndex(traj.points, createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)), 0U);
@@ -404,26 +403,30 @@ TEST(trajectory, calcLongitudinalOffsetToSegment_StraightTrajectory)
   using tier4_autoware_utils::calcLongitudinalOffsetToSegment;
 
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+  const bool throw_exception = true;
 
   // Empty
   EXPECT_THROW(
-    calcLongitudinalOffsetToSegment(Trajectory{}.points, {}, geometry_msgs::msg::Point{}),
+    calcLongitudinalOffsetToSegment(
+      Trajectory{}.points, {}, geometry_msgs::msg::Point{}, throw_exception),
     std::invalid_argument);
 
   // Out of range
   EXPECT_THROW(
-    calcLongitudinalOffsetToSegment(traj.points, -1, geometry_msgs::msg::Point{}),
+    calcLongitudinalOffsetToSegment(traj.points, -1, geometry_msgs::msg::Point{}, throw_exception),
     std::out_of_range);
   EXPECT_THROW(
     calcLongitudinalOffsetToSegment(
-      traj.points, traj.points.size() - 1, geometry_msgs::msg::Point{}),
+      traj.points, traj.points.size() - 1, geometry_msgs::msg::Point{}, throw_exception),
     std::out_of_range);
 
   // Same close points in trajectory
   {
     const auto invalid_traj = generateTestTrajectory<Trajectory>(10, 0.0);
     const auto p = createPoint(3.0, 0.0, 0.0);
-    EXPECT_THROW(calcLongitudinalOffsetToSegment(invalid_traj.points, 3, p), std::runtime_error);
+    EXPECT_THROW(
+      calcLongitudinalOffsetToSegment(invalid_traj.points, 3, p, throw_exception),
+      std::runtime_error);
   }
 
   // Same point
@@ -462,23 +465,26 @@ TEST(trajectory, calcLateralOffset)
   using tier4_autoware_utils::calcLateralOffset;
 
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
+  const bool throw_exception = true;
 
   // Empty
   EXPECT_THROW(
-    calcLateralOffset(Trajectory{}.points, geometry_msgs::msg::Point{}), std::invalid_argument);
+    calcLateralOffset(Trajectory{}.points, geometry_msgs::msg::Point{}, throw_exception),
+    std::invalid_argument);
 
   // Trajectory size is 1
   {
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
     EXPECT_THROW(
-      calcLateralOffset(one_point_traj.points, geometry_msgs::msg::Point{}), std::out_of_range);
+      calcLateralOffset(one_point_traj.points, geometry_msgs::msg::Point{}, throw_exception),
+      std::runtime_error);
   }
 
   // Same close points in trajectory
   {
     const auto invalid_traj = generateTestTrajectory<Trajectory>(10, 0.0);
     const auto p = createPoint(3.0, 0.0, 0.0);
-    EXPECT_THROW(calcLateralOffset(invalid_traj.points, p), std::runtime_error);
+    EXPECT_THROW(calcLateralOffset(invalid_traj.points, p, throw_exception), std::runtime_error);
   }
 
   // Point on trajectory
@@ -513,7 +519,7 @@ TEST(trajectory, calcSignedArcLengthFromIndexToIndex)
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(calcSignedArcLength(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_DOUBLE_EQ(calcSignedArcLength(Trajectory{}.points, {}, {}), 0.0);
 
   // Out of range
   EXPECT_THROW(calcSignedArcLength(traj.points, -1, 1), std::out_of_range);
@@ -536,7 +542,7 @@ TEST(trajectory, calcSignedArcLengthFromPointToIndex)
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(calcSignedArcLength(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_DOUBLE_EQ(calcSignedArcLength(Trajectory{}.points, {}, {}), 0.0);
 
   // Same point
   EXPECT_NEAR(calcSignedArcLength(traj.points, createPoint(3.0, 0.0, 0.0), 3), 0, epsilon);
@@ -607,7 +613,7 @@ TEST(trajectory, calcSignedArcLengthFromIndexToPoint)
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(calcSignedArcLength(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_DOUBLE_EQ(calcSignedArcLength(Trajectory{}.points, {}, {}), 0.0);
 
   // Same point
   EXPECT_NEAR(calcSignedArcLength(traj.points, 3, createPoint(3.0, 0.0, 0.0)), 0, epsilon);
@@ -636,7 +642,7 @@ TEST(trajectory, calcSignedArcLengthFromPointToPoint)
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(calcSignedArcLength(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_DOUBLE_EQ(calcSignedArcLength(Trajectory{}.points, {}, {}), 0.0);
 
   // Same point
   {
@@ -699,7 +705,7 @@ TEST(trajectory, calcArcLength)
   const auto traj = generateTestTrajectory<Trajectory>(10, 1.0);
 
   // Empty
-  EXPECT_THROW(calcArcLength(Trajectory{}.points), std::invalid_argument);
+  EXPECT_DOUBLE_EQ(calcArcLength(Trajectory{}.points), 0.0);
 
   // Whole Length
   EXPECT_NEAR(calcArcLength(traj.points), 9.0, epsilon);
@@ -753,7 +759,7 @@ TEST(trajectory, calcDistanceToForwardStopPointFromIndex)
 
   // Empty
   {
-    EXPECT_THROW(calcDistanceToForwardStopPoint(Trajectory{}.points), std::invalid_argument);
+    EXPECT_FALSE(calcDistanceToForwardStopPoint(Trajectory{}.points));
   }
 
   // No Stop Point
@@ -811,9 +817,7 @@ TEST(trajectory, calcDistanceToForwardStopPointFromPose)
 
   // Empty
   {
-    EXPECT_THROW(
-      calcDistanceToForwardStopPoint(Trajectory{}.points, geometry_msgs::msg::Pose{}),
-      std::invalid_argument);
+    EXPECT_FALSE(calcDistanceToForwardStopPoint(Trajectory{}.points, geometry_msgs::msg::Pose{}));
   }
 
   // No Stop Point
@@ -995,12 +999,11 @@ TEST(trajectory, calcLongitudinalOffsetPointFromIndex)
   const auto total_length = calcArcLength(traj.points);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPoint(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_FALSE(calcLongitudinalOffsetPoint(Trajectory{}.points, {}, {}));
 
   // Out of range
-  EXPECT_THROW(
-    calcLongitudinalOffsetPoint(traj.points, traj.points.size() + 1, 1.0), std::out_of_range);
-  EXPECT_THROW(calcLongitudinalOffsetPoint(traj.points, -1, 1.0), std::out_of_range);
+  EXPECT_FALSE(calcLongitudinalOffsetPoint(traj.points, traj.points.size() + 1, 1.0));
+  EXPECT_FALSE(calcLongitudinalOffsetPoint(traj.points, -1, 1.0));
 
   // Found Pose(forward)
   for (size_t i = 0; i < traj.points.size(); ++i) {
@@ -1073,7 +1076,7 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
   const auto total_length = calcArcLength(traj.points);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPoint(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_FALSE(calcLongitudinalOffsetPoint(Trajectory{}.points, {}, {}));
 
   // Found Pose(forward)
   for (double x_start = 0.0; x_start < total_length + epsilon; x_start += 0.1) {
@@ -1134,9 +1137,8 @@ TEST(trajectory, calcLongitudinalOffsetPointFromPoint)
   // Out of range(Trajectory size is 1)
   {
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
-    EXPECT_THROW(
-      calcLongitudinalOffsetPoint(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
-      std::out_of_range);
+    EXPECT_FALSE(
+      calcLongitudinalOffsetPoint(one_point_traj.points, geometry_msgs::msg::Point{}, {}));
   }
 }
 
@@ -1151,12 +1153,11 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex)
   const auto total_length = calcArcLength(traj.points);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_FALSE(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}));
 
   // Out of range
-  EXPECT_THROW(
-    calcLongitudinalOffsetPose(traj.points, traj.points.size() + 1, 1.0), std::out_of_range);
-  EXPECT_THROW(calcLongitudinalOffsetPose(traj.points, -1, 1.0), std::out_of_range);
+  EXPECT_FALSE(calcLongitudinalOffsetPose(traj.points, traj.points.size() + 1, 1.0));
+  EXPECT_FALSE(calcLongitudinalOffsetPose(traj.points, -1, 1.0));
 
   // Found Pose(forward)
   for (size_t i = 0; i < traj.points.size(); ++i) {
@@ -1323,7 +1324,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
   const auto total_length = calcArcLength(traj.points);
 
   // Empty
-  EXPECT_THROW(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}), std::invalid_argument);
+  EXPECT_FALSE(calcLongitudinalOffsetPose(Trajectory{}.points, {}, {}));
 
   // Found Pose(forward)
   for (double x_start = 0.0; x_start < total_length + epsilon; x_start += 0.1) {
@@ -1392,9 +1393,8 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
   // Out of range(Trajectory size is 1)
   {
     const auto one_point_traj = generateTestTrajectory<Trajectory>(1, 1.0);
-    EXPECT_THROW(
-      calcLongitudinalOffsetPose(one_point_traj.points, geometry_msgs::msg::Point{}, {}),
-      std::out_of_range);
+    EXPECT_FALSE(
+      calcLongitudinalOffsetPose(one_point_traj.points, geometry_msgs::msg::Point{}, {}));
   }
 }
 
@@ -1687,9 +1687,7 @@ TEST(trajectory, insertTargetPoint)
   {
     auto empty_traj = generateTestTrajectory<Trajectory>(0, 1.0);
     const size_t segment_idx = 0;
-    EXPECT_THROW(
-      insertTargetPoint(segment_idx, geometry_msgs::msg::Point{}, empty_traj.points),
-      std::invalid_argument);
+    EXPECT_FALSE(insertTargetPoint(segment_idx, geometry_msgs::msg::Point{}, empty_traj.points));
   }
 }
 

--- a/control/trajectory_follower/src/longitudinal_controller_utils.cpp
+++ b/control/trajectory_follower/src/longitudinal_controller_utils.cpp
@@ -77,7 +77,7 @@ float64_t calcStopDistance(
   const float64_t signed_length_src_offset = tier4_autoware_utils::calcLongitudinalOffsetToSegment(
     traj.points, *seg_idx, current_pose.position);
 
-  if(std::isnan(signed_length_src_offset)) {
+  if (std::isnan(signed_length_src_offset)) {
     return 0.0;
   }
 

--- a/control/trajectory_follower/src/longitudinal_controller_utils.cpp
+++ b/control/trajectory_follower/src/longitudinal_controller_utils.cpp
@@ -77,6 +77,10 @@ float64_t calcStopDistance(
   const float64_t signed_length_src_offset = tier4_autoware_utils::calcLongitudinalOffsetToSegment(
     traj.points, *seg_idx, current_pose.position);
 
+  if(std::isnan(signed_length_src_offset)) {
+    return 0.0;
+  }
+
   // If no zero velocity point, return the length between current_pose to the end of trajectory.
   if (!stop_idx_opt) {
     float64_t signed_length_on_traj =

--- a/control/trajectory_follower/test/test_longitudinal_controller_utils.cpp
+++ b/control/trajectory_follower/test/test_longitudinal_controller_utils.cpp
@@ -68,8 +68,8 @@ TEST(TestLongitudinalControllerUtils, calcStopDistance)
   point.pose.position.y = 0.0;
   point.longitudinal_velocity_mps = 0.0;
   traj.points.push_back(point);
-  EXPECT_THROW(
-    longitudinal_utils::calcStopDistance(current_pose, traj, max_dist, max_yaw), std::out_of_range);
+  EXPECT_DOUBLE_EQ(
+    longitudinal_utils::calcStopDistance(current_pose, traj, max_dist, max_yaw), 0.0);
   traj.points.clear();
   // non stopping trajectory: stop distance = trajectory length
   point.pose.position.x = 0.0;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Before change, planning_modules often dies due to the exception from tier4_autoware_utils.
In this PR, to avoid dying planning modules, I changed utilities for trajectory like following:

- Make some functions to throw exception as an option
- If the output is `boost::optional`, make the functions not to throw exception and return `boost::none`
- Fix the test code to suit the changes

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Test performed by gtest.
Furthermore, I checked by running planning_simulator.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
