### PR TITLE
fix(run_out): fix uninitialized ptr

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -152,7 +152,7 @@ Polygons2d RunOutModule::createDetectionAreaPolygon(const PathWithLaneId & smoot
   da_range.min_longitudinal_distance =
     p.vehicle_param.base_to_front - p.detection_area.margin_behind;
   da_range.max_longitudinal_distance =
-    stop_distance + p.run_out.stop_margin + p.detection_area.margin_ahead;
+    *stop_dist + p.run_out.stop_margin + p.detection_area.margin_ahead;
   da_range.min_lateral_distance = p.vehicle_param.width / 2.0;
   da_range.max_lateral_distance = obstacle_vel_mps * p.dynamic_obstacle.max_prediction_time;
   Polygons2d detection_area_poly;

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -140,7 +140,9 @@ Polygons2d RunOutModule::createDetectionAreaPolygon(const PathWithLaneId & smoot
   auto stop_dist = run_out_utils::calcDecelDistWithJerkAndAccConstraints(
     initial_vel, target_vel, initial_acc, planning_dec, jerk_acc, jerk_dec);
 
-  const double stop_distance = !stop_dist ? 0 : *stop_dist;
+  if (!stop_dist) {
+    stop_dist = boost::make_optional<double>(0.0);
+  }
 
   // create detection area polygon
   DetectionRange da_range;

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -140,9 +140,7 @@ Polygons2d RunOutModule::createDetectionAreaPolygon(const PathWithLaneId & smoot
   auto stop_dist = run_out_utils::calcDecelDistWithJerkAndAccConstraints(
     initial_vel, target_vel, initial_acc, planning_dec, jerk_acc, jerk_dec);
 
-  if (!stop_dist) {
-    *stop_dist = 0;
-  }
+  const double stop_distance = !stop_dist ? 0 : *stop_dist;
 
   // create detection area polygon
   DetectionRange da_range;
@@ -152,7 +150,7 @@ Polygons2d RunOutModule::createDetectionAreaPolygon(const PathWithLaneId & smoot
   da_range.min_longitudinal_distance =
     p.vehicle_param.base_to_front - p.detection_area.margin_behind;
   da_range.max_longitudinal_distance =
-    *stop_dist + p.run_out.stop_margin + p.detection_area.margin_ahead;
+    stop_distance + p.run_out.stop_margin + p.detection_area.margin_ahead;
   da_range.min_lateral_distance = p.vehicle_param.width / 2.0;
   da_range.max_lateral_distance = obstacle_vel_mps * p.dynamic_obstacle.max_prediction_time;
   Polygons2d detection_area_poly;


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

fix this error when stop_dist is not initialized
``
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f20053ad859 in __GI_abort () at abort.c:79
#2  0x00007f20053ad729 in __assert_fail_base
    (fmt=0x7f2005543588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x7f1fca3ecbf1 "this->is_initialized()", file=0x7f1fca3ecbc8 "/usr/include/boost/optional/optional.hpp", line=1207, function=<optimized out>) at assert.c:92
#3  0x00007f20053befd6 in __GI___assert_fail
    (assertion=0x7f1fca3ecbf1 "this->is_initialized()", file=0x7f1fca3ecbc8 "/usr/include/boost/optional/optional.hpp", line=1207, function=0x7f1fca3ecb48 "boost::optional<T>::reference_type boost::optional<T>::get() [with T = double; boost::optional<T>::reference_type = double&]") at assert.c:101
#4  0x00007f1fc9f18757 in boost::optional<double>::get() (this=0x7f1fdfffbc60) at /usr/include/boost/optional/optional.hpp:1207
#5  0x00007f1fca3c3020 in boost::optional<double>::operator*() & (this=0x7f1fdfffbc60) at /usr/include/boost/optional/optional.hpp:1224
#6  0x00007f1fca3bbaf6 in behavior_velocity_planner::RunOutModule::createDetectionAreaPolygon (this=0x7f1fb40830d0, smoothed_path=...)
    at /home/t4tanaka/workspace/pilot-auto.x2_v0.4.0/src/autoware/universe/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp:144
144	    *stop_dist = 0;
``

After this PR this error didn't happen
![image](https://user-images.githubusercontent.com/65527974/177755910-b85bb9f0-f7dd-47e2-85cb-96cd35942b8d.png)



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
