### PR TITLE
feat(planning): pass through for reverse driving

### DIFF
--- a/planning/behavior_velocity_planner/include/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/include/behavior_velocity_planner/node.hpp
@@ -113,6 +113,10 @@ private:
   // function
   geometry_msgs::msg::PoseStamped getCurrentPose();
   bool isDataReady(const PlannerData planner_data) const;
+  bool isBackwardPath(const autoware_auto_planning_msgs::msg::PathWithLaneId & planner_data) const;
+  autoware_auto_planning_msgs::msg::Path generatePath(
+    const autoware_auto_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg,
+    const PlannerData & planner_data);
 };
 }  // namespace behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -401,33 +401,8 @@ void BehaviorVelocityPlannerNode::onTrigger(
     return;
   }
 
-  Path output_path_msg;
-  if (std::any_of(
-        input_path_msg->points.begin(), input_path_msg->points.end(),
-        [&](const auto & p) { return p.point.longitudinal_velocity_mps < 0; })) {
-    RCLCPP_WARN(
-      get_logger(), "Negative velocity is detected, so just converting path_with_lane_id to path");
-    // just convert to path
-    output_path_msg = to_path(*input_path_msg);
-  } else {
-    // Plan path velocity
-    const auto velocity_planned_path = planner_manager_.planPathVelocity(
-      std::make_shared<const PlannerData>(planner_data), *input_path_msg);
-
-    // screening
-    const auto filtered_path = filterLitterPathPoint(to_path(velocity_planned_path));
-
-    // interpolation
-    const auto interpolated_path_msg = interpolatePath(filtered_path, forward_path_length_);
-
-    // check stop point
-    output_path_msg = filterStopPathPoint(interpolated_path_msg);
-  }
-  output_path_msg.header.frame_id = "map";
-  output_path_msg.header.stamp = this->now();
-
-  // TODO(someone): This must be updated in each scene module, but copy from input message for now.
-  output_path_msg.drivable_area = input_path_msg->drivable_area;
+  const autoware_auto_planning_msgs::msg::Path output_path_msg =
+    generatePath(input_path_msg, planner_data);
 
   path_pub_->publish(output_path_msg);
   stop_reason_diag_pub_->publish(planner_manager_.getStopReasonDiag());
@@ -435,6 +410,56 @@ void BehaviorVelocityPlannerNode::onTrigger(
   if (debug_viz_pub_->get_subscription_count() > 0) {
     publishDebugMarker(output_path_msg);
   }
+}
+
+bool BehaviorVelocityPlannerNode::isBackwardPath(
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path) const
+{
+  const bool has_negative_velocity = std::any_of(
+    path.points.begin(), path.points.end(),
+    [&](const auto & p) { return p.point.longitudinal_velocity_mps < 0; });
+
+  return has_negative_velocity;
+}
+
+autoware_auto_planning_msgs::msg::Path BehaviorVelocityPlannerNode::generatePath(
+  const autoware_auto_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg,
+  const PlannerData & planner_data)
+{
+  autoware_auto_planning_msgs::msg::Path output_path_msg;
+
+  // TODO(someone): support negative velocity
+  if (isBackwardPath(*input_path_msg)) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 3000,
+      "Negative velocity is NOT supported. just converting path_with_lane_id to path");
+    output_path_msg = to_path(*input_path_msg);
+    output_path_msg.header.frame_id = "map";
+    output_path_msg.header.stamp = this->now();
+    output_path_msg.drivable_area = input_path_msg->drivable_area;
+    return output_path_msg;
+  }
+
+  // Plan path velocity
+  const auto velocity_planned_path = planner_manager_.planPathVelocity(
+    std::make_shared<const PlannerData>(planner_data), *input_path_msg);
+
+  // screening
+  const auto filtered_path = filterLitterPathPoint(to_path(velocity_planned_path));
+
+  // interpolation
+  const auto interpolated_path_msg = interpolatePath(filtered_path, forward_path_length_);
+
+  // check stop point
+  output_path_msg = filterStopPathPoint(interpolated_path_msg);
+
+  output_path_msg.header.frame_id = "map";
+  output_path_msg.header.stamp = this->now();
+
+  // TODO(someone): This must be updated in each scene module, but copy from input message for now.
+  output_path_msg.drivable_area = input_path_msg->drivable_area;
+
+  return output_path_msg;
 }
 
 void BehaviorVelocityPlannerNode::publishDebugMarker(

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
@@ -237,10 +237,15 @@ private:
   void resetPlanning();
   void resetPrevOptimization();
 
+  bool isBackwardPath(const autoware_auto_planning_msgs::msg::Path & path) const;
+
   std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint> generateOptimizedTrajectory(
     const autoware_auto_planning_msgs::msg::Path & input_path);
 
   bool checkReplan(const std::vector<autoware_auto_planning_msgs::msg::PathPoint> & path_points);
+
+  autoware_auto_planning_msgs::msg::Trajectory generateTrajectory(
+    const autoware_auto_planning_msgs::msg::Path & path);
 
   Trajectories optimizeTrajectory(
     const autoware_auto_planning_msgs::msg::Path & path, const CVMaps & cv_maps);

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -867,26 +867,7 @@ void ObstacleAvoidancePlanner::pathCallback(
     is_showing_calculation_time_, mpt_visualize_sampling_num_, current_ego_pose_,
     mpt_param_.vehicle_circle_radiuses, mpt_param_.vehicle_circle_longitudinal_offsets);
 
-  autoware_auto_planning_msgs::msg::Trajectory output_traj_msg;
-  if (std::any_of(path_ptr->points.begin(), path_ptr->points.end(), [&](const auto & p) {
-        return p.longitudinal_velocity_mps < 0;
-      })) {
-    RCLCPP_WARN(
-      get_logger(),
-      "[ObstacleAvoidancePlanner] Negative velocity is detected, so just converting path to "
-      "trajectory");
-    // just convert to trajectory
-    const auto traj_points = points_utils::convertToTrajectoryPoints(path_ptr->points);
-    output_traj_msg = tier4_autoware_utils::convertToTrajectory(traj_points);
-  } else {
-    // generate optimized trajectory
-    const auto optimized_traj_points = generateOptimizedTrajectory(*path_ptr);
-    // generate post processed trajectory
-    const auto post_processed_traj_points =
-      generatePostProcessedTrajectory(path_ptr->points, optimized_traj_points);
-    output_traj_msg = tier4_autoware_utils::convertToTrajectory(post_processed_traj_points);
-  }
-  output_traj_msg.header = path_ptr->header;
+  autoware_auto_planning_msgs::msg::Trajectory output_traj_msg = generateTrajectory(*path_ptr);
 
   // publish debug data
   publishDebugDataInMain(*path_ptr);
@@ -906,6 +887,45 @@ void ObstacleAvoidancePlanner::pathCallback(
   prev_ego_pose_ptr_ = std::make_unique<geometry_msgs::msg::Pose>(current_ego_pose_);
 
   traj_pub_->publish(output_traj_msg);
+}
+
+autoware_auto_planning_msgs::msg::Trajectory ObstacleAvoidancePlanner::generateTrajectory(
+  const autoware_auto_planning_msgs::msg::Path & path)
+{
+  autoware_auto_planning_msgs::msg::Trajectory output_traj_msg;
+
+  // TODO(someone): support backward velocity
+  if (isBackwardPath(path)) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 3000,
+      "[ObstacleAvoidancePlanner] Negative velocity is NOT supported. Just converting path to "
+      "trajectory");
+    const auto traj_points = points_utils::convertToTrajectoryPoints(path.points);
+    output_traj_msg = tier4_autoware_utils::convertToTrajectory(traj_points);
+    output_traj_msg.header = path.header;
+
+    return output_traj_msg;
+  }
+
+  // generate optimized trajectory
+  const auto optimized_traj_points = generateOptimizedTrajectory(path);
+  // generate post processed trajectory
+  const auto post_processed_traj_points =
+    generatePostProcessedTrajectory(path.points, optimized_traj_points);
+  output_traj_msg = tier4_autoware_utils::convertToTrajectory(post_processed_traj_points);
+
+  output_traj_msg.header = path.header;
+  return output_traj_msg;
+}
+
+bool ObstacleAvoidancePlanner::isBackwardPath(
+  const autoware_auto_planning_msgs::msg::Path & path) const
+{
+  const bool has_negative_velocity = std::any_of(
+    path.points.begin(), path.points.end(),
+    [&](const auto & p) { return p.longitudinal_velocity_mps < 0; });
+
+  return has_negative_velocity;
 }
 
 std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -912,6 +912,8 @@ autoware_auto_planning_msgs::msg::Trajectory ObstacleAvoidancePlanner::generateT
   // generate post processed trajectory
   const auto post_processed_traj_points =
     generatePostProcessedTrajectory(path.points, optimized_traj_points);
+
+  // convert to output msg type
   output_traj_msg = tier4_autoware_utils::convertToTrajectory(post_processed_traj_points);
 
   output_traj_msg.header = path.header;

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -867,15 +867,25 @@ void ObstacleAvoidancePlanner::pathCallback(
     is_showing_calculation_time_, mpt_visualize_sampling_num_, current_ego_pose_,
     mpt_param_.vehicle_circle_radiuses, mpt_param_.vehicle_circle_longitudinal_offsets);
 
-  // generate optimized trajectory
-  const auto optimized_traj_points = generateOptimizedTrajectory(*path_ptr);
-
-  // generate post processed trajectory
-  const auto post_processed_traj_points =
-    generatePostProcessedTrajectory(path_ptr->points, optimized_traj_points);
-
-  // convert to output msg type
-  auto output_traj_msg = tier4_autoware_utils::convertToTrajectory(post_processed_traj_points);
+  autoware_auto_planning_msgs::msg::Trajectory output_traj_msg;
+  if (std::any_of(path_ptr->points.begin(), path_ptr->points.end(), [&](const auto & p) {
+        return p.longitudinal_velocity_mps < 0;
+      })) {
+    RCLCPP_WARN(
+      get_logger(),
+      "[ObstacleAvoidancePlanner] Negative velocity is detected, so just converting path to "
+      "trajectory");
+    // just convert to trajectory
+    const auto traj_points = points_utils::convertToTrajectoryPoints(path_ptr->points);
+    output_traj_msg = tier4_autoware_utils::convertToTrajectory(traj_points);
+  } else {
+    // generate optimized trajectory
+    const auto optimized_traj_points = generateOptimizedTrajectory(*path_ptr);
+    // generate post processed trajectory
+    const auto post_processed_traj_points =
+      generatePostProcessedTrajectory(path_ptr->points, optimized_traj_points);
+    output_traj_msg = tier4_autoware_utils::convertToTrajectory(post_processed_traj_points);
+  }
   output_traj_msg.header = path_ptr->header;
 
   // publish debug data

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -217,6 +217,8 @@ private:
   void externalExpandStopRangeCallback(const ExpandStopRange::ConstSharedPtr input_msg);
 
 private:
+  bool isBackwardPath(const autoware_auto_planning_msgs::msg::Trajectory & trajectory) const;
+
   bool withinPolygon(
     const std::vector<cv::Point2d> & cv_polygon, const double radius, const Point2d & prev_point,
     const Point2d & next_point, pcl::PointCloud<pcl::PointXYZ>::Ptr candidate_points_ptr,

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -611,7 +611,6 @@ void ObstacleStopPlannerNode::pathCallback(const Trajectory::ConstSharedPtr inpu
     return;
   }
 
-  Trajectory trajectory;
   PlannerData planner_data{};
 
   getSelfPose(input_msg->header, tf_buffer_, planner_data.current_pose);
@@ -646,7 +645,7 @@ void ObstacleStopPlannerNode::pathCallback(const Trajectory::ConstSharedPtr inpu
     resetExternalVelocityLimit(current_acc);
   }
 
-  trajectory = tier4_autoware_utils::convertToTrajectory(output_trajectory_points);
+  auto trajectory = tier4_autoware_utils::convertToTrajectory(output_trajectory_points);
   publishDebugData(planner_data, current_acc);
 
   trajectory.header = input_msg->header;

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -603,44 +603,55 @@ void ObstacleStopPlannerNode::pathCallback(const Trajectory::ConstSharedPtr inpu
     }
   }
 
-  PlannerData planner_data{};
+  Trajectory trajectory;
+  if (std::any_of(input_msg->points.begin(), input_msg->points.end(), [&](const auto & p) {
+        return p.longitudinal_velocity_mps < 0;
+      })) {
+    RCLCPP_WARN(
+      get_logger(), "Negative velocity is detected, so let the input trajectory pass through");
+    trajectory = *input_msg;
+  } else {
+    PlannerData planner_data{};
 
-  getSelfPose(input_msg->header, tf_buffer_, planner_data.current_pose);
+    getSelfPose(input_msg->header, tf_buffer_, planner_data.current_pose);
 
-  Trajectory output_trajectory = *input_msg;
-  TrajectoryPoints output_trajectory_points =
-    tier4_autoware_utils::convertToTrajectoryPointArray(*input_msg);
+    Trajectory output_trajectory = *input_msg;
+    TrajectoryPoints output_trajectory_points =
+      tier4_autoware_utils::convertToTrajectoryPointArray(*input_msg);
 
-  // trim trajectory from self pose
-  const auto base_trajectory = trimTrajectoryWithIndexFromSelfPose(
-    tier4_autoware_utils::convertToTrajectoryPointArray(*input_msg), planner_data.current_pose,
-    planner_data.trajectory_trim_index);
-  // extend trajectory to consider obstacles after the goal
-  const auto extend_trajectory = extendTrajectory(base_trajectory, stop_param.extend_distance);
-  // decimate trajectory for calculation cost
-  const auto decimate_trajectory = decimateTrajectory(
-    extend_trajectory, stop_param.step_length, planner_data.decimate_trajectory_index_map);
+    // trim trajectory from self pose
+    const auto base_trajectory = trimTrajectoryWithIndexFromSelfPose(
+      tier4_autoware_utils::convertToTrajectoryPointArray(*input_msg), planner_data.current_pose,
+      planner_data.trajectory_trim_index);
+    // extend trajectory to consider obstacles after the goal
+    const auto extend_trajectory = extendTrajectory(base_trajectory, stop_param.extend_distance);
+    // decimate trajectory for calculation cost
+    const auto decimate_trajectory = decimateTrajectory(
+      extend_trajectory, stop_param.step_length, planner_data.decimate_trajectory_index_map);
 
-  // search obstacles within slow-down/collision area
-  searchObstacle(
-    decimate_trajectory, output_trajectory_points, planner_data, input_msg->header, vehicle_info,
-    stop_param, obstacle_ros_pointcloud_ptr);
-  // insert slow-down-section/stop-point
-  insertVelocity(
-    output_trajectory_points, planner_data, input_msg->header, vehicle_info, current_acc,
-    stop_param);
+    // search obstacles within slow-down/collision area
+    searchObstacle(
+      decimate_trajectory, output_trajectory_points, planner_data, input_msg->header, vehicle_info,
+      stop_param, obstacle_ros_pointcloud_ptr);
+    // insert slow-down-section/stop-point
+    insertVelocity(
+      output_trajectory_points, planner_data, input_msg->header, vehicle_info, current_acc,
+      stop_param);
 
-  const auto no_slow_down_section = !planner_data.slow_down_require && !latest_slow_down_section_;
-  const auto no_hunting = (rclcpp::Time(input_msg->header.stamp) - last_detection_time_).seconds() >
-                          node_param_.hunting_threshold;
-  if (node_param_.enable_slow_down && no_slow_down_section && set_velocity_limit_ && no_hunting) {
-    resetExternalVelocityLimit(current_acc);
+    const auto no_slow_down_section = !planner_data.slow_down_require && !latest_slow_down_section_;
+    const auto no_hunting =
+      (rclcpp::Time(input_msg->header.stamp) - last_detection_time_).seconds() >
+      node_param_.hunting_threshold;
+    if (node_param_.enable_slow_down && no_slow_down_section && set_velocity_limit_ && no_hunting) {
+      resetExternalVelocityLimit(current_acc);
+    }
+
+    trajectory = tier4_autoware_utils::convertToTrajectory(output_trajectory_points);
+    publishDebugData(planner_data, current_acc);
   }
 
-  auto trajectory = tier4_autoware_utils::convertToTrajectory(output_trajectory_points);
   trajectory.header = input_msg->header;
   path_pub_->publish(trajectory);
-  publishDebugData(planner_data, current_acc);
 }
 
 void ObstacleStopPlannerNode::searchObstacle(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Each module does not support negative speeds, so the path is then passed directly to the next module.
Therefore, note that each module does not work when reverse driving.

TODO: support reverse driving in the following modules
- behavior_velocity_planner
- obstalce_avoidance_planner
- obstacle_stop_planner

## Related links

<!-- Write the links related to this PR. -->
This is the part of https://github.com/autowarefoundation/autoware.universe/pull/873

## Tests performed

<!-- Describe how you have tested this PR. -->
checked reverse driving is possible with psim and real vehicle
https://user-images.githubusercontent.com/39142679/177542658-66c9cfde-2f88-484b-bc6e-af35f85a7e3e.mp4

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
