### PR TITLE
fix(behavior_velocity): fix intersection last point

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -76,8 +76,7 @@ bool IntersectionModule::modifyPathVelocity(
   *stop_reason =
     planning_utils::initializeStopReason(tier4_planning_msgs::msg::StopReason::INTERSECTION);
 
-  const auto input_path = *path;
-  debug_data_.path_raw = input_path;
+  debug_data_.path_raw = *path;
 
   State current_state = state_machine_.getState();
   RCLCPP_DEBUG(logger_, "lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
@@ -142,7 +141,7 @@ bool IntersectionModule::modifyPathVelocity(
 
   /* calc closest index */
   int closest_idx = -1;
-  if (!planning_utils::calcClosestIndex(input_path, current_pose.pose, closest_idx)) {
+  if (!planning_utils::calcClosestIndex(*path, current_pose.pose, closest_idx)) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000 /* ms */, "calcClosestIndex fail");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
@@ -159,8 +158,8 @@ bool IntersectionModule::modifyPathVelocity(
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     setSafe(true);
     setDistance(tier4_autoware_utils::calcSignedArcLength(
-      input_path.points, planner_data_->current_pose.pose.position,
-      input_path.points.at(stop_line_idx).point.pose.position));
+      path->points, planner_data_->current_pose.pose.position,
+      path->points.at(stop_line_idx).point.pose.position));
     return true;  // no plan needed.
   }
 
@@ -185,8 +184,8 @@ bool IntersectionModule::modifyPathVelocity(
 
   setSafe(!is_entry_prohibited);
   setDistance(tier4_autoware_utils::calcSignedArcLength(
-    input_path.points, planner_data_->current_pose.pose.position,
-    input_path.points.at(stop_line_idx).point.pose.position));
+    path->points, planner_data_->current_pose.pose.position,
+    path->points.at(stop_line_idx).point.pose.position));
 
   if (!isActivated()) {
     const double v = 0.0;


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

fix intersection dies insert stop point at the end
because input path size and *path size is different

I confirmed normal case and intersection module won't die for inserting last stop index point
(Note: test case won't be enough but this won't happen for normal use)

cc: @VRichardJP 

## Related links

resolve
https://github.com/autowarefoundation/autoware.universe/issues/1247

## Tests performed

by psim

https://user-images.githubusercontent.com/65527974/177935298-24dad101-c24b-4708-b79f-ff2a21ba9d5a.mp4


## Notes for reviewers

This PR  has not been tested enough.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
