### PR TITLE
fix(behavior_velocity_crosswalk): fix segfo at crosswalk is empty case

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -731,16 +731,18 @@ void CrosswalkModule::clampAttentionRangeByNeighborCrosswalks(
   boost::optional<lanelet::ConstLanelet> prev_crosswalk{boost::none};
   boost::optional<lanelet::ConstLanelet> next_crosswalk{boost::none};
 
-  for (size_t i = 0; i < crosswalks.size() - 1; ++i) {
-    const auto ll_front = crosswalks.at(i);
-    const auto ll_back = crosswalks.at(i + 1);
+  if (!crosswalks.empty()) {
+    for (size_t i = 0; i < crosswalks.size() - 1; ++i) {
+      const auto ll_front = crosswalks.at(i);
+      const auto ll_back = crosswalks.at(i + 1);
 
-    if (ll_front.id() == module_id_ && ll_back.id() != module_id_) {
-      next_crosswalk = ll_back;
-    }
+      if (ll_front.id() == module_id_ && ll_back.id() != module_id_) {
+        next_crosswalk = ll_back;
+      }
 
-    if (ll_front.id() != module_id_ && ll_back.id() == module_id_) {
-      prev_crosswalk = ll_front;
+      if (ll_front.id() != module_id_ && ll_back.id() == module_id_) {
+        prev_crosswalk = ll_front;
+      }
     }
   }
 


### PR DESCRIPTION
Note : range check for size_t (0 -1) is going to generate inf

Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

before
```
#7  0x00007fb8e21f64a8 in std::vector<lanelet::ConstLanelet, std::allocator<lanelet::ConstLanelet> >::_M_range_check(unsigned long) const
    (this=0x7fb9377f1010, __n=0)
    at /usr/include/c++/9/bits/stl_vector.h:1070
#8  0x00007fb8e21f372b in std::vector<lanelet::ConstLanelet, std::allocator<lanelet::ConstLanelet> >::at(unsigned long)
    (this=0x7fb9377f1010, __n=0)
    at /usr/include/c++/9/bits/stl_vector.h:1091
#9  0x00007fb8e21e9c1d in behavior_velocity_planner::CrosswalkModule::clampAttentionRangeByNeighborCrosswalks(autoware_auto_planning_msgs::msg::PathWithLaneId_<std::allocator<void> > const&, double&, double&)
--Type <RET> for more, q to quit, c to continue without paging--
   cb3238cfb0, ego_path=..., near_attention_range=@0x7fb9377f1b18: 15.890264344057147, far_attention_range=@0x7fb9377f1b20: 19.891459991938927)
    at /home/t4tanaka/workspace/debug_autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp:702
#10 0x00007fb8e21e8e67 in behavior_velocity_planner::CrosswalkModule::getAttentionRange(autoware_auto_planning_msgs::msg::PathWithLaneId_<std::allocator<void> > const&) (this=0x55cb3238cfb0, ego_path=...)
    at
```
![image (1)](https://user-images.githubusercontent.com/65527974/177924351-a97b7ab9-a515-4a30-80ce-cc05a0d2dd04.png)


after
![image](https://user-images.githubusercontent.com/65527974/177924129-3f193de7-77d1-46db-8a6d-55d0214cec38.png)


Fix crosswalk is empty case
I added guard for invalid range check 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
