### PR TITLE
fix(obstacle_cruise_plannner): fix node dying bug

### DIFF
--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -101,10 +101,10 @@ Trajectory decimateTrajectory(const Trajectory & input, const double step_length
   double trajectory_length_sum = 0.0;
   double next_length = 0.0;
 
+  constexpr double epsilon = 1e-3;
   for (int i = 0; i < static_cast<int>(input.points.size()) - 1; ++i) {
     const auto & p_front = input.points.at(i);
     const auto & p_back = input.points.at(i + 1);
-    constexpr double epsilon = 1e-3;
 
     if (next_length <= trajectory_length_sum + epsilon) {
       const auto p_interpolate =
@@ -117,7 +117,12 @@ Trajectory decimateTrajectory(const Trajectory & input, const double step_length
     trajectory_length_sum += tier4_autoware_utils::calcDistance2d(p_front, p_back);
   }
 
-  output.points.push_back(input.points.back());
+  // avoid "Same points are given"
+  if (
+    !input.points.empty() && !output.points.empty() &&
+    epsilon < tier4_autoware_utils::calcDistance2d(input.points.back(), output.points.back())) {
+    output.points.push_back(input.points.back());
+  }
 
   return output;
 }


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

fix node dying in obstacle_cruise_planner
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
