### PR TITLE
fix(behavior_velocity_planner): fix rtc behavior in crosswalk module

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
@@ -10,7 +10,7 @@
       stop_position_threshold: 1.0 # [m] threshold for check whether the vehicle stop in front of crosswalk
 
       # param for ego velocity
-      slow_velocity: 2.78 # [m/s] target vehicle velocity when module receive slow down command from FOA (2.78 m/s = 10.0 kmph)
+      min_slow_down_velocity: 2.78 # [m/s] target vehicle velocity when module receive slow down command from FOA (2.78 m/s = 10.0 kmph)
       max_slow_down_jerk: -1.5 # [m/sss] minimum jerk deceleration for safe brake
       max_slow_down_accel: -2.5 # [m/ss] minimum accel deceleration for safe brake
       no_relax_velocity: 2.78 # [m/s] if the current velocity is less than X m/s, ego always stops at the stop position(not relax deceleration constraints 2.78 m/s = 10 kmph)

--- a/planning/behavior_velocity_planner/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_planner/config/crosswalk.param.yaml
@@ -10,7 +10,7 @@
       stop_position_threshold: 1.0 # [m] threshold for check whether the vehicle stop in front of crosswalk
 
       # param for ego velocity
-      slow_velocity: 2.78 # [m/s] target vehicle velocity when module receive slow down command from FOA (2.78 m/s = 10.0 kmph)
+      min_slow_down_velocity: 2.78 # [m/s] target vehicle velocity when module receive slow down command from FOA (2.78 m/s = 10.0 kmph)
       max_slow_down_jerk: -1.5 # [m/sss] minimum jerk deceleration for safe brake
       max_slow_down_accel: -2.5 # [m/ss] minimum accel deceleration for safe brake
       no_relax_velocity: 2.78 # [m/s] if the current velocity is less than X m/s, ego always stops at the stop position(not relax deceleration constraints 2.78 m/s = 10 kmph)

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -68,7 +68,7 @@ public:
     double stop_line_margin;
     double stop_position_threshold;
     // param for ego velocity
-    double slow_velocity;
+    float min_slow_down_velocity;
     double max_slow_down_jerk;
     double max_slow_down_accel;
     double no_relax_velocity;

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
@@ -103,7 +103,7 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
   cp.stop_position_threshold = node.declare_parameter(ns + ".stop_position_threshold", 1.0);
 
   // param for ego velocity
-  cp.slow_velocity = node.declare_parameter(ns + ".slow_velocity", 5.0 / 3.6);
+  cp.min_slow_down_velocity = node.declare_parameter(ns + ".min_slow_down_velocity", 5.0 / 3.6);
   cp.max_slow_down_jerk = node.declare_parameter(ns + ".max_slow_down_jerk", -0.7);
   cp.max_slow_down_accel = node.declare_parameter(ns + ".max_slow_down_accel", -2.5);
   cp.no_relax_velocity = node.declare_parameter(ns + ".no_relax_velocity", 2.78);


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

- fix RTC behavior in crosswalk module
- add param for minimium velocity in **Activate** condition
- remove crosswalk stop / slowdown / go
- https://github.com/tier4/autoware_launch/pull/401

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
