### PR TITLE
fix(behavior_velocity_planner): fix condition to show virtual wall

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
@@ -126,6 +126,7 @@ private:
   int64_t lane_id_;
   TurnDirection turn_direction_;
   bool has_traffic_light_;
+  bool is_over_pass_judge_line_;
 
   // Parameter
   PlannerParam planner_param_;

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
@@ -156,7 +156,7 @@ visualization_msgs::msg::MarkerArray BlindSpotModule::createVirtualWallMarkerArr
 
   const auto now = this->clock_->now();
 
-  if (!isActivated()) {
+  if (!isActivated() && !is_over_pass_judge_line_) {
     appendMarkerArray(
       tier4_autoware_utils::createStopVirtualWallMarker(
         debug_data_.virtual_wall_pose, "blind_spot", now, lane_id_),


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description

Before change, it keeps to show virtual wall of blind_spot module if the pass judge line condition satisfied.
To fix this problem, I fixed the condition to add virtual wall in blind_spot module.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Performed in planning_simulator.

https://user-images.githubusercontent.com/10190493/178200987-05ac27c3-acc2-447e-b8ee-ee4d59eceb5e.mp4

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
