### PR TITLE
fix(behavior_velocity): fix segfo at for unstable subscriber

### DIFF
--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -303,7 +303,10 @@ void BehaviorVelocityPlannerNode::onVehicleVelocity(
     }
 
     // Remove old data
-    planner_data_.velocity_buffer.pop_back();
+    if (!planner_data_.velocity_buffer.empty())
+      planner_data_.velocity_buffer.pop_back();
+    else
+      break;
   }
 }
 

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -302,7 +302,7 @@ void BehaviorVelocityPlannerNode::onVehicleVelocity(
       break;
     }
 
-    if (!planner_data_.velocity_buffer.empty()) {
+    if (planner_data_.velocity_buffer.empty()) {
       break;
     }
     // Remove old data

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -302,11 +302,11 @@ void BehaviorVelocityPlannerNode::onVehicleVelocity(
       break;
     }
 
-    // Remove old data
-    if (!planner_data_.velocity_buffer.empty())
-      planner_data_.velocity_buffer.pop_back();
-    else
+    if (!planner_data_.velocity_buffer.empty()) {
       break;
+    }
+    // Remove old data
+    planner_data_.velocity_buffer.pop_back();
   }
 }
 


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description
related to https://github.com/autowarefoundation/autoware.universe/issues/1297
for unstable clock velocity buffer can be zero and that can cause segmentation fault
before this PR
```
[openscenario_interpreter_node-3] [component_container_mt-44] ERROR time_diff : 45.2335 velocity_buffer size: 2
[openscenario_interpreter_node-3] [component_container_mt-44] ERROR time_diff : 45.2283 velocity_buffer size: 1
[openscenario_interpreter_node-3] [component_container_mt-44] ERROR time_diff : 1.65752e+09 velocity_buffer size: 0
[openscenario_interpreter_node-3] [component_container_mt-44] ERROR time_diff : 1.65752e+09 velocity_buffer size: 18446744073709551615
```
-> segmenation fault

after this PR

https://user-images.githubusercontent.com/65527974/178202317-697fe1e3-15aa-4b48-becb-00bd7decb51b.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
