### PR TITLE
fix: avoid same name nodes in detection module

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -173,16 +173,19 @@
     <arg name="input/object0" value="$(var merger/input/objects)"/>
     <arg name="input/object1" value="clustering/camera_lidar_fusion/short_range_objects"/>
     <arg name="output/object" value="camera_lidar_fusion/objects"/>
+    <arg name="node_name" value="object_association_merger_camera_lidar_fusion" />
   </include>
   <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
     <arg name="input/object0" value="detection_by_tracker/objects"/>
     <arg name="input/object1" value="camera_lidar_fusion/objects"/>
     <arg name="output/object" value="temporary_merged_objects"/>
+    <arg name="node_name" value="object_association_merger_detection_by_tracker" />
   </include>
   <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
     <arg name="input/object0" value="temporary_merged_objects"/>
     <arg name="input/object1" value="clustering/objects"/>
     <arg name="output/object" value="objects_before_filter"/>
+    <arg name="node_name" value="object_association_merger_unknown_clustering" />
   </include>
 
   <!-- Filter -->

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -70,7 +70,7 @@
     <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
       <arg name="input" value="objects_with_feature"/>
       <arg name="output" value="objects"/>
-    <arg name="node_name" value="detected_object_feature_remover_clustering" />
+      <arg name="node_name" value="detected_object_feature_remover_clustering" />
     </include>
     <!-- Fusion camera-lidar to classify -->
     <include file="$(find-pkg-share image_projection_based_fusion)/launch/roi_cluster_fusion.launch.xml">

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -64,11 +64,13 @@
     <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
       <arg name="input/objects" value="clusters"/>
       <arg name="output/objects" value="objects_with_feature"/>
+      <arg name="node_name" value="shape_estimation_clustering" />
     </include>
     <!-- convert DynamicObjectsWithFeatureArray to DynamicObjects -->
     <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
       <arg name="input" value="objects_with_feature"/>
       <arg name="output" value="objects"/>
+    <arg name="node_name" value="detected_object_feature_remover_clustering" />
     </include>
     <!-- Fusion camera-lidar to classify -->
     <include file="$(find-pkg-share image_projection_based_fusion)/launch/roi_cluster_fusion.launch.xml">
@@ -103,11 +105,13 @@
     <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
       <arg name="input/objects" value="camera_lidar_fusion/clusters"/>
       <arg name="output/objects" value="camera_lidar_fusion/objects_with_feature"/>
+      <arg name="node_name" value="shape_estimation_camera_lidar_fusion" />
     </include>
     <!-- convert DynamicObjectsWithFeatureArray to DynamicObjects -->
     <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
       <arg name="input" value="camera_lidar_fusion/objects_with_feature"/>
       <arg name="output" value="camera_lidar_fusion/objects"/>
+    <arg name="node_name" value="detected_object_feature_camera_lidar_fusion" />
     </include>
     <include file="$(find-pkg-share object_range_splitter)/launch/object_range_splitter.launch.xml">
       <arg name="input/object" value="camera_lidar_fusion/objects"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -64,13 +64,13 @@
     <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
       <arg name="input/objects" value="clusters"/>
       <arg name="output/objects" value="objects_with_feature"/>
-      <arg name="node_name" value="shape_estimation_clustering" />
+      <arg name="node_name" value="shape_estimation_clustering"/>
     </include>
     <!-- convert DynamicObjectsWithFeatureArray to DynamicObjects -->
     <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
       <arg name="input" value="objects_with_feature"/>
       <arg name="output" value="objects"/>
-      <arg name="node_name" value="detected_object_feature_remover_clustering" />
+      <arg name="node_name" value="detected_object_feature_remover_clustering"/>
     </include>
     <!-- Fusion camera-lidar to classify -->
     <include file="$(find-pkg-share image_projection_based_fusion)/launch/roi_cluster_fusion.launch.xml">
@@ -105,13 +105,13 @@
     <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
       <arg name="input/objects" value="camera_lidar_fusion/clusters"/>
       <arg name="output/objects" value="camera_lidar_fusion/objects_with_feature"/>
-      <arg name="node_name" value="shape_estimation_camera_lidar_fusion" />
+      <arg name="node_name" value="shape_estimation_camera_lidar_fusion"/>
     </include>
     <!-- convert DynamicObjectsWithFeatureArray to DynamicObjects -->
     <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
       <arg name="input" value="camera_lidar_fusion/objects_with_feature"/>
       <arg name="output" value="camera_lidar_fusion/objects"/>
-      <arg name="node_name" value="detected_object_feature_camera_lidar_fusion" />
+      <arg name="node_name" value="detected_object_feature_camera_lidar_fusion"/>
     </include>
     <include file="$(find-pkg-share object_range_splitter)/launch/object_range_splitter.launch.xml">
       <arg name="input/object" value="camera_lidar_fusion/objects"/>
@@ -173,19 +173,19 @@
     <arg name="input/object0" value="$(var merger/input/objects)"/>
     <arg name="input/object1" value="clustering/camera_lidar_fusion/short_range_objects"/>
     <arg name="output/object" value="camera_lidar_fusion/objects"/>
-    <arg name="node_name" value="object_association_merger_camera_lidar_fusion" />
+    <arg name="node_name" value="object_association_merger_camera_lidar_fusion"/>
   </include>
   <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
     <arg name="input/object0" value="detection_by_tracker/objects"/>
     <arg name="input/object1" value="camera_lidar_fusion/objects"/>
     <arg name="output/object" value="temporary_merged_objects"/>
-    <arg name="node_name" value="object_association_merger_detection_by_tracker" />
+    <arg name="node_name" value="object_association_merger_detection_by_tracker"/>
   </include>
   <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
     <arg name="input/object0" value="temporary_merged_objects"/>
     <arg name="input/object1" value="clustering/objects"/>
     <arg name="output/object" value="objects_before_filter"/>
-    <arg name="node_name" value="object_association_merger_unknown_clustering" />
+    <arg name="node_name" value="object_association_merger_unknown_clustering"/>
   </include>
 
   <!-- Filter -->

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -111,7 +111,7 @@
     <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
       <arg name="input" value="camera_lidar_fusion/objects_with_feature"/>
       <arg name="output" value="camera_lidar_fusion/objects"/>
-    <arg name="node_name" value="detected_object_feature_camera_lidar_fusion" />
+      <arg name="node_name" value="detected_object_feature_camera_lidar_fusion" />
     </include>
     <include file="$(find-pkg-share object_range_splitter)/launch/object_range_splitter.launch.xml">
       <arg name="input/object" value="camera_lidar_fusion/objects"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -96,11 +96,13 @@
       <arg name="input/object0" value="$(var merger/input/objects)"/>
       <arg name="input/object1" value="clustering/objects"/>
       <arg name="output/object" value="temporary_merged_objects"/>
+      <arg name="node_name" value="object_association_merger_unknown_clustering" />
     </include>
     <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
       <arg name="input/object0" value="temporary_merged_objects"/>
       <arg name="input/object1" value="detection_by_tracker/objects"/>
       <arg name="output/object" value="objects_before_filter"/>
+    <arg name="node_name" value="object_association_merger_detection_by_tracker" />
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -96,13 +96,13 @@
       <arg name="input/object0" value="$(var merger/input/objects)"/>
       <arg name="input/object1" value="clustering/objects"/>
       <arg name="output/object" value="temporary_merged_objects"/>
-      <arg name="node_name" value="object_association_merger_unknown_clustering" />
+      <arg name="node_name" value="object_association_merger_unknown_clustering"/>
     </include>
     <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
       <arg name="input/object0" value="temporary_merged_objects"/>
       <arg name="input/object1" value="detection_by_tracker/objects"/>
       <arg name="output/object" value="objects_before_filter"/>
-      <arg name="node_name" value="object_association_merger_detection_by_tracker" />
+      <arg name="node_name" value="object_association_merger_detection_by_tracker"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -102,7 +102,7 @@
       <arg name="input/object0" value="temporary_merged_objects"/>
       <arg name="input/object1" value="detection_by_tracker/objects"/>
       <arg name="output/object" value="objects_before_filter"/>
-    <arg name="node_name" value="object_association_merger_detection_by_tracker" />
+      <arg name="node_name" value="object_association_merger_detection_by_tracker" />
     </include>
   </group>
 

--- a/perception/detected_object_feature_remover/launch/detected_object_feature_remover.launch.xml
+++ b/perception/detected_object_feature_remover/launch/detected_object_feature_remover.launch.xml
@@ -3,7 +3,6 @@
   <arg name="output"/>
   <arg name="node_name" default="detected_object_feature_remover"/>
 
-
   <node pkg="detected_object_feature_remover" exec="detected_object_feature_remover" name="$(var node_name)" output="screen">
     <remap from="~/input" to="$(var input)"/>
     <remap from="~/output" to="$(var output)"/>

--- a/perception/detected_object_feature_remover/launch/detected_object_feature_remover.launch.xml
+++ b/perception/detected_object_feature_remover/launch/detected_object_feature_remover.launch.xml
@@ -1,8 +1,10 @@
 <launch>
   <arg name="input"/>
   <arg name="output"/>
+  <arg name="node_name" default="detected_object_feature_remover"/>
 
-  <node pkg="detected_object_feature_remover" exec="detected_object_feature_remover" name="$(anon detected_object_feature_remover)" output="screen">
+
+  <node pkg="detected_object_feature_remover" exec="detected_object_feature_remover" name="$(var node_name)" output="screen">
     <remap from="~/input" to="$(var input)"/>
     <remap from="~/output" to="$(var output)"/>
   </node>

--- a/perception/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_merger/launch/object_association_merger.launch.xml
@@ -4,8 +4,10 @@
   <arg name="input/object1" default="object1"/>
   <arg name="output/object" default="merged_object"/>
   <arg name="data_association_matrix_path" default="$(find-pkg-share object_merger)/config/data_association_matrix.param.yaml"/>
+  <arg name="node_name" default="object_association_merger"/>
 
-  <node pkg="object_merger" exec="object_association_merger_node" name="$(anon object_association_merger)" output="screen">
+
+  <node pkg="object_merger" exec="object_association_merger_node" name="$(var node_name)" output="screen">
     <remap from="input/object0" to="$(var input/object0)"/>
     <remap from="input/object1" to="$(var input/object1)"/>
     <remap from="output/object" to="$(var output/object)"/>

--- a/perception/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_merger/launch/object_association_merger.launch.xml
@@ -6,7 +6,6 @@
   <arg name="data_association_matrix_path" default="$(find-pkg-share object_merger)/config/data_association_matrix.param.yaml"/>
   <arg name="node_name" default="object_association_merger"/>
 
-
   <node pkg="object_merger" exec="object_association_merger_node" name="$(var node_name)" output="screen">
     <remap from="input/object0" to="$(var input/object0)"/>
     <remap from="input/object1" to="$(var input/object1)"/>


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
avoid to launch duplicated-named nodes in detection module.
```
/perception/object_recognition/detection/clustering/detected_object_feature_remover_($ anon)
/perception/object_recognition/detection/clustering/shape_estimation 
/perception/object_recognition/detection/object_association_merger_($ anon)
```

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
