### PR TITLE
fix: stop for wrong-way car

### DIFF
--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -803,12 +803,12 @@ void ObstacleCruisePlannerNode::updateHasStopped(std::vector<TargetObstacle> & t
         });
       const bool has_already_stopped = (itr != prev_target_obstacles_.end()) && itr->has_stopped;
       if (has_already_stopped) {
-        if (std::abs(obstacle.velocity) < obstacle_velocity_threshold_from_stop_to_cruise_) {
+        if (obstacle.velocity < obstacle_velocity_threshold_from_stop_to_cruise_) {
           obstacle.has_stopped = true;
           continue;
         }
       } else {
-        if (std::abs(obstacle.velocity) < obstacle_velocity_threshold_from_cruise_to_stop_) {
+        if (obstacle.velocity < obstacle_velocity_threshold_from_cruise_to_stop_) {
           obstacle.has_stopped = true;
           continue;
         }


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
With the current implementation of  `obstacle_cruise_planner`, the vehicle cruises for a wrong-way car by.

https://user-images.githubusercontent.com/59680180/178286969-0be4bf49-3b89-4d03-90ea-b908e2540d72.mp4

I fixed it to stop for a wrong-way car.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
