### PR TITLE
feat(motion_utils): move marker helper to motion_utils

### DIFF
--- a/common/motion_utils/CMakeLists.txt
+++ b/common/motion_utils/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.14)
+project(motion_utils)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+find_package(Boost REQUIRED)
+
+ament_auto_add_library(motion_utils SHARED
+  src/motion_utils.cpp
+  src/marker/marker_helper.cpp
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_ros REQUIRED)
+
+  file(GLOB_RECURSE test_files test/**/*.cpp)
+
+  ament_add_ros_isolated_gtest(test_motion_utils ${test_files})
+
+  target_link_libraries(test_motion_utils
+    motion_utils
+  )
+endif()
+
+ament_auto_package()

--- a/common/motion_utils/include/motion_utils/marker/marker_helper.hpp
+++ b/common/motion_utils/include/motion_utils/marker/marker_helper.hpp
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TIER4_AUTOWARE_UTILS__PLANNING__PLANNING_MARKER_HELPER_HPP_
-#define TIER4_AUTOWARE_UTILS__PLANNING__PLANNING_MARKER_HELPER_HPP_
+#ifndef MOTION_UTILS__MARKER__MARKER_HELPER_HPP_
+#define MOTION_UTILS__MARKER__MARKER_HELPER_HPP_
 
 #include "tier4_autoware_utils/ros/marker_helper.hpp"
 
 #include <string>
 
-namespace tier4_autoware_utils
+namespace motion_utils
 {
 visualization_msgs::msg::MarkerArray createStopVirtualWallMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
@@ -32,6 +32,6 @@ visualization_msgs::msg::MarkerArray createSlowDownVirtualWallMarker(
 visualization_msgs::msg::MarkerArray createDeadLineVirtualWallMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
   const int32_t id);
-}  // namespace tier4_autoware_utils
+}  // namespace motion_utils
 
-#endif  // TIER4_AUTOWARE_UTILS__PLANNING__PLANNING_MARKER_HELPER_HPP_
+#endif  // MOTION_UTILS__MARKER__MARKER_HELPER_HPP_

--- a/common/motion_utils/include/motion_utils/motion_utils.hpp
+++ b/common/motion_utils/include/motion_utils/motion_utils.hpp
@@ -1,0 +1,20 @@
+// Copyright 2022 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTION_UTILS__MOTION_UTILS_HPP_
+#define MOTION_UTILS__MOTION_UTILS_HPP_
+
+#include "motion_utils/marker/marker_helper.hpp"
+
+#endif  // MOTION_UTILS__MOTION_UTILS_HPP_

--- a/common/motion_utils/package.xml
+++ b/common/motion_utils/package.xml
@@ -1,36 +1,27 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>accel_brake_map_calibrator</name>
+  <name>motion_utils</name>
   <version>0.1.0</version>
-  <description>The accel_brake_map_calibrator</description>
-  <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
+  <description>The motion_utils package</description>
+  <maintainer email="purewater0901@gmail.com">Yutaka Shimizu</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <build_depend>autoware_cmake</build_depend>
 
-  <depend>autoware_auto_vehicle_msgs</depend>
-  <depend>diagnostic_updater</depend>
+  <depend>autoware_auto_planning_msgs</depend>
+  <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <depend>motion_utils</depend>
-  <depend>raw_vehicle_cmd_converter</depend>
+  <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
-  <depend>std_srvs</depend>
+  <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
-  <depend>tier4_debug_msgs</depend>
-  <depend>tier4_external_api_msgs</depend>
-  <depend>tier4_vehicle_msgs</depend>
   <depend>visualization_msgs</depend>
 
-  <exec_depend>python3-matplotlib</exec_depend>
-  <exec_depend>python3-pandas</exec_depend>
-  <exec_depend>python3-scipy</exec_depend>
-
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/common/motion_utils/src/marker/marker_helper.cpp
+++ b/common/motion_utils/src/marker/marker_helper.cpp
@@ -14,6 +14,8 @@
 
 #include "motion_utils/marker/marker_helper.hpp"
 
+#include <string>
+
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerScale;

--- a/common/motion_utils/src/marker/marker_helper.cpp
+++ b/common/motion_utils/src/marker/marker_helper.cpp
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "tier4_autoware_utils/planning/planning_marker_helper.hpp"
-
-#include <string>
+#include "motion_utils/marker/marker_helper.hpp"
 
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
@@ -59,7 +57,7 @@ inline visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
 
 }  // namespace
 
-namespace tier4_autoware_utils
+namespace motion_utils
 {
 visualization_msgs::msg::MarkerArray createStopVirtualWallMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
@@ -84,4 +82,4 @@ visualization_msgs::msg::MarkerArray createDeadLineVirtualWallMarker(
   return createVirtualWallMarkerArray(
     pose, module_name, "dead_line_", now, id, createMarkerColor(0.0, 1.0, 0.0, 0.5));
 }
-}  // namespace tier4_autoware_utils
+}  // namespace motion_utils

--- a/common/motion_utils/src/motion_utils.cpp
+++ b/common/motion_utils/src/motion_utils.cpp
@@ -1,0 +1,15 @@
+// Copyright 2022 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "motion_utils/motion_utils.hpp"

--- a/common/motion_utils/test/src/test_motion_utils.cpp
+++ b/common/motion_utils/test/src/test_motion_utils.cpp
@@ -1,0 +1,26 @@
+// Copyright 2022 TierIV
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "motion_utils/motion_utils.hpp"
+
+#include <gtest/gtest.h>
+
+int main(int argc, char * argv[])
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  bool result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/common/tier4_autoware_utils/CMakeLists.txt
+++ b/common/tier4_autoware_utils/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(Boost REQUIRED)
 
 ament_auto_add_library(tier4_autoware_utils SHARED
   src/tier4_autoware_utils.cpp
-  src/planning/planning_marker_helper.cpp
   src/vehicle/vehicle_state_checker.cpp
 )
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
@@ -23,7 +23,6 @@
 #include "tier4_autoware_utils/math/normalization.hpp"
 #include "tier4_autoware_utils/math/range.hpp"
 #include "tier4_autoware_utils/math/unit_conversion.hpp"
-#include "tier4_autoware_utils/planning/planning_marker_helper.hpp"
 #include "tier4_autoware_utils/ros/debug_publisher.hpp"
 #include "tier4_autoware_utils/ros/debug_traits.hpp"
 #include "tier4_autoware_utils/ros/marker_helper.hpp"

--- a/planning/behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/package.xml
@@ -25,6 +25,7 @@
   <depend>lanelet2_extension</depend>
   <depend>libboost-dev</depend>
   <depend>libopencv-dev</depend>
+  <depend>motion_utils</depend>
   <depend>motion_velocity_smoother</depend>
   <depend>nav_msgs</depend>
   <depend>nlohmann-json-dev</depend>

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <motion_utils/motion_utils.hpp>
 #include <scene_module/blind_spot/scene.hpp>
 #include <utilization/marker_helper.hpp>
 #include <utilization/util.hpp>
@@ -158,7 +159,7 @@ visualization_msgs::msg::MarkerArray BlindSpotModule::createVirtualWallMarkerArr
 
   if (!isActivated() && !is_over_pass_judge_line_) {
     appendMarkerArray(
-      tier4_autoware_utils::createStopVirtualWallMarker(
+      motion_utils::createStopVirtualWallMarker(
         debug_data_.virtual_wall_pose, "blind_spot", now, lane_id_),
       now, &wall_marker);
   }

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <motion_utils/motion_utils.hpp>
 #include <scene_module/crosswalk/scene_crosswalk.hpp>
 #include <scene_module/crosswalk/scene_walkway.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
@@ -22,14 +23,14 @@
 namespace behavior_velocity_planner
 {
 
+using motion_utils::createSlowDownVirtualWallMarker;
+using motion_utils::createStopVirtualWallMarker;
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerScale;
 using tier4_autoware_utils::createPoint;
-using tier4_autoware_utils::createSlowDownVirtualWallMarker;
-using tier4_autoware_utils::createStopVirtualWallMarker;
 using visualization_msgs::msg::Marker;
 
 namespace

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <motion_utils/motion_utils.hpp>
 #include <scene_module/detection_area/scene.hpp>
 #include <utilization/marker_helper.hpp>
 #include <utilization/util.hpp>
@@ -179,7 +180,7 @@ visualization_msgs::msg::MarkerArray DetectionAreaModule::createVirtualWallMarke
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      tier4_autoware_utils::createStopVirtualWallMarker(p_front, "detection_area", now, id++), now,
+      motion_utils::createStopVirtualWallMarker(p_front, "detection_area", now, id++), now,
       &wall_marker);
   }
 
@@ -187,8 +188,8 @@ visualization_msgs::msg::MarkerArray DetectionAreaModule::createVirtualWallMarke
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      tier4_autoware_utils::createDeadLineVirtualWallMarker(p_front, "detection_area", now, id++),
-      now, &wall_marker);
+      motion_utils::createDeadLineVirtualWallMarker(p_front, "detection_area", now, id++), now,
+      &wall_marker);
   }
 
   return wall_marker;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <motion_utils/motion_utils.hpp>
 #include <scene_module/intersection/scene_intersection.hpp>
 #include <scene_module/intersection/scene_merge_from_private_road.hpp>
 #include <utilization/marker_helper.hpp>
@@ -264,12 +265,12 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createVirtualWallMarker
 
   if (debug_data_.stop_required) {
     appendMarkerArray(
-      tier4_autoware_utils::createStopVirtualWallMarker(
+      motion_utils::createStopVirtualWallMarker(
         debug_data_.stop_wall_pose, "intersection", now, lane_id_),
       now, &wall_marker);
   } else if (state == IntersectionModule::State::STOP) {
     appendMarkerArray(
-      tier4_autoware_utils::createStopVirtualWallMarker(
+      motion_utils::createStopVirtualWallMarker(
         debug_data_.slow_wall_pose, "intersection", now, lane_id_),
       now, &wall_marker);
   }
@@ -302,7 +303,7 @@ visualization_msgs::msg::MarkerArray MergeFromPrivateRoadModule::createVirtualWa
   const auto now = this->clock_->now();
   if (state == MergeFromPrivateRoadModule::State::STOP) {
     appendMarkerArray(
-      tier4_autoware_utils::createStopVirtualWallMarker(
+      motion_utils::createStopVirtualWallMarker(
         debug_data_.virtual_wall_pose, "merge_from_private_road", now, lane_id_),
       now, &wall_marker);
   }

--- a/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/debug.cpp
@@ -16,7 +16,7 @@
 #include "utilization/marker_helper.hpp"
 #include "utilization/util.hpp"
 
-#include <tier4_autoware_utils/planning/planning_marker_helper.hpp>
+#include <motion_utils/motion_utils.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -216,8 +216,8 @@ visualization_msgs::msg::MarkerArray NoStoppingAreaModule::createVirtualWallMark
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      tier4_autoware_utils::createStopVirtualWallMarker(p_front, "no_stopping_area", now, id++),
-      now, &wall_marker);
+      motion_utils::createStopVirtualWallMarker(p_front, "no_stopping_area", now, id++), now,
+      &wall_marker);
   }
   return wall_marker;
 }

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/debug.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <motion_utils/motion_utils.hpp>
 #include <scene_module/occlusion_spot/occlusion_spot_utils.hpp>
 #include <scene_module/occlusion_spot/scene_occlusion_spot.hpp>
-#include <tier4_autoware_utils/planning/planning_marker_helper.hpp>
 #include <tier4_autoware_utils/ros/marker_helper.hpp>
 #include <utilization/marker_helper.hpp>
 #include <utilization/util.hpp>
@@ -273,7 +273,7 @@ MarkerArray OcclusionSpotModule::createVirtualWallMarkerArray()
     for (size_t id = 0; id < debug_data_.possible_collisions.size(); id++) {
       const auto & pose = debug_data_.possible_collisions.at(id).intersection_pose;
       appendMarkerArray(
-        tier4_autoware_utils::createSlowDownVirtualWallMarker(pose, module_name, current_time, id),
+        motion_utils::createSlowDownVirtualWallMarker(pose, module_name, current_time, id),
         current_time, &wall_marker);
     }
   }

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
@@ -16,6 +16,8 @@
 
 #include "scene_module/run_out/scene.hpp"
 
+#include <motion_utils/motion_utils.hpp>
+
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::createDefaultMarker;
@@ -176,7 +178,7 @@ visualization_msgs::msg::MarkerArray RunOutDebug::createVirtualWallMarkerArray()
 
   for (const auto & p : stop_pose_) {
     appendMarkerArray(
-      tier4_autoware_utils::createStopVirtualWallMarker(p, "run_out", now, id++), &wall_marker);
+      motion_utils::createStopVirtualWallMarker(p, "run_out", now, id++), &wall_marker);
   }
 
   stop_pose_.clear();

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <motion_utils/motion_utils.hpp>
 #include <scene_module/stop_line/scene.hpp>
 #include <utilization/marker_helper.hpp>
 #include <utilization/util.hpp>
@@ -101,7 +102,7 @@ visualization_msgs::msg::MarkerArray StopLineModule::createVirtualWallMarkerArra
     *debug_data_.stop_pose, debug_data_.base_link2front, 0.0, 0.0);
   if (state_ == State::APPROACH) {
     appendMarkerArray(
-      tier4_autoware_utils::createStopVirtualWallMarker(p_front, "stopline", now, module_id_), now,
+      motion_utils::createStopVirtualWallMarker(p_front, "stopline", now, module_id_), now,
       &wall_marker);
   }
   return wall_marker;

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <motion_utils/motion_utils.hpp>
 #include <scene_module/traffic_light/scene.hpp>
 #include <utilization/marker_helper.hpp>
 #include <utilization/util.hpp>
@@ -41,15 +42,15 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      tier4_autoware_utils::createDeadLineVirtualWallMarker(p_front, "traffic_light", now, id++),
-      now, &wall_marker);
+      motion_utils::createDeadLineVirtualWallMarker(p_front, "traffic_light", now, id++), now,
+      &wall_marker);
   }
 
   for (const auto & p : debug_data_.stop_poses) {
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      tier4_autoware_utils::createStopVirtualWallMarker(p_front, "traffic_light", now, id++), now,
+      motion_utils::createStopVirtualWallMarker(p_front, "traffic_light", now, id++), now,
       &wall_marker);
   }
 

--- a/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/debug.cpp
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <motion_utils/motion_utils.hpp>
 #include <scene_module/virtual_traffic_light/scene.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
+using motion_utils::createStopVirtualWallMarker;
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerOrientation;
 using tier4_autoware_utils::createMarkerPosition;
 using tier4_autoware_utils::createMarkerScale;
-using tier4_autoware_utils::createStopVirtualWallMarker;
 using tier4_autoware_utils::toMsg;
 using namespace std::literals::string_literals;
 

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef OBSTACLE_CRUISE_PLANNER__PLANNER_INTERFACE_HPP_
 #define OBSTACLE_CRUISE_PLANNER__PLANNER_INTERFACE_HPP_
 
+#include "motion_utils/motion_utils.hpp"
 #include "obstacle_cruise_planner/common_structs.hpp"
 #include "obstacle_cruise_planner/utils.hpp"
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"

--- a/planning/obstacle_cruise_planner/package.xml
+++ b/planning/obstacle_cruise_planner/package.xml
@@ -17,6 +17,7 @@
   <depend>geometry_msgs</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
+  <depend>motion_utils</depend>
   <depend>nav_msgs</depend>
   <depend>osqp_interface</depend>
   <depend>rclcpp</depend>

--- a/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -719,11 +719,11 @@ boost::optional<SBoundaries> OptimizationBasedPlanner::getSBoundaries(
       visualization_msgs::msg::MarkerArray wall_msg;
 
       if (obj.has_stopped) {
-        const auto markers = tier4_autoware_utils::createStopVirtualWallMarker(
+        const auto markers = motion_utils::createStopVirtualWallMarker(
           marker_pose.get(), "obstacle to follow", current_time, 0);
         tier4_autoware_utils::appendMarkerArray(markers, &wall_msg);
       } else {
-        const auto markers = tier4_autoware_utils::createSlowDownVirtualWallMarker(
+        const auto markers = motion_utils::createSlowDownVirtualWallMarker(
           marker_pose.get(), "obstacle to follow", current_time, 0);
         tier4_autoware_utils::appendMarkerArray(markers, &wall_msg);
       }

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -244,7 +244,7 @@ VelocityLimit PIDBasedPlanner::doCruise(
   const size_t wall_idx = obstacle_cruise_utils::getIndexWithLongitudinalOffset(
     planner_data.traj.points, dist_to_rss_wall, ego_idx);
 
-  const auto markers = tier4_autoware_utils::createSlowDownVirtualWallMarker(
+  const auto markers = motion_utils::createSlowDownVirtualWallMarker(
     planner_data.traj.points.at(wall_idx).pose, "obstacle cruise", planner_data.current_time, 0);
   tier4_autoware_utils::appendMarkerArray(markers, &debug_wall_marker);
 

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -138,7 +138,7 @@ Trajectory PlannerInterface::generateStopTrajectory(
 
   // virtual wall marker for stop obstacle
   const auto marker_pose = planner_data.traj.points.at(wall_idx).pose;
-  const auto markers = tier4_autoware_utils::createStopVirtualWallMarker(
+  const auto markers = motion_utils::createStopVirtualWallMarker(
     marker_pose, "obstacle stop", planner_data.current_time, 0);
   tier4_autoware_utils::appendMarkerArray(markers, &debug_data.stop_wall_marker);
   debug_data.obstacles_to_stop.push_back(*closest_stop_obstacle);

--- a/planning/obstacle_stop_planner/package.xml
+++ b/planning/obstacle_stop_planner/package.xml
@@ -14,6 +14,7 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>motion_utils</depend>
   <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>

--- a/planning/obstacle_stop_planner/src/debug_marker.cpp
+++ b/planning/obstacle_stop_planner/src/debug_marker.cpp
@@ -14,6 +14,7 @@
 
 #include "obstacle_stop_planner/debug_marker.hpp"
 
+#include <motion_utils/motion_utils.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
@@ -25,6 +26,8 @@
 #include <memory>
 #include <vector>
 
+using motion_utils::createSlowDownVirtualWallMarker;
+using motion_utils::createStopVirtualWallMarker;
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::createDefaultMarker;
@@ -32,8 +35,6 @@ using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerOrientation;
 using tier4_autoware_utils::createMarkerScale;
 using tier4_autoware_utils::createPoint;
-using tier4_autoware_utils::createSlowDownVirtualWallMarker;
-using tier4_autoware_utils::createStopVirtualWallMarker;
 
 namespace motion_planning
 {

--- a/planning/surround_obstacle_checker/package.xml
+++ b/planning/surround_obstacle_checker/package.xml
@@ -18,6 +18,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>libpcl-all-dev</depend>
+  <depend>motion_utils</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/surround_obstacle_checker/src/debug_marker.cpp
@@ -14,6 +14,7 @@
 
 #include "surround_obstacle_checker/debug_marker.hpp"
 
+#include <motion_utils/motion_utils.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -26,13 +27,13 @@
 namespace surround_obstacle_checker
 {
 
+using motion_utils::createStopVirtualWallMarker;
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerScale;
 using tier4_autoware_utils::createPoint;
-using tier4_autoware_utils::createStopVirtualWallMarker;
 
 SurroundObstacleCheckerDebugNode::SurroundObstacleCheckerDebugNode(
   const double base_link2front, const rclcpp::Clock::SharedPtr clock, rclcpp::Node & node)

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
@@ -29,8 +29,9 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #endif
 
-#include "tier4_autoware_utils/planning/planning_marker_helper.hpp"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
+
+#include <motion_utils/motion_utils.hpp>
 
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/velocity_report.hpp"


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description

Add motion utils packages in this PR. Motion utils will contain motion related utility functions, and this time I move the planning directory under the tier4_autoware_utils to motion utils directory.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
