### PR TITLE
fix(behavior_path_planner): change the condition of skip_smooth_goal_connection

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -650,7 +650,6 @@ bool BehaviorPathPlannerNode::skipSmoothGoalConnection(
   const std::vector<std::shared_ptr<SceneModuleStatus>> & statuses) const
 {
   const auto target_module = "PullOver";
-
   for (auto & status : statuses) {
     if (status->status == BT::NodeStatus::RUNNING) {
       if (target_module == status->module_name) {

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -652,7 +652,7 @@ bool BehaviorPathPlannerNode::skipSmoothGoalConnection(
   const auto target_module = "PullOver";
 
   for (auto & status : statuses) {
-    if (status->is_waiting_approval || status->status == BT::NodeStatus::RUNNING) {
+    if (status->status == BT::NodeStatus::RUNNING) {
       if (target_module == status->module_name) {
         return true;
       }


### PR DESCRIPTION
Signed-off-by: jack.song <jack.song@autocore.ai>

## Description
The intention of the "skipSmoothGoalConnection" is that the connection target point is not used in the "PullOver" scenario.
The current judgment condition will make the “pullover” scenario tenable as long as it is registered (whether the pullover scenario is running or not). Because the variable "is_waiting_approval" will be true after all models are registered. Therefore, when the pullover scenario is registered, other scenarios cannot have the "modifypathforsmoothgoalconnection" function.
![flowing](https://user-images.githubusercontent.com/102840938/178457241-b0a505b0-75b8-4591-87a3-3e45b056725c.png)
![lanechange](https://user-images.githubusercontent.com/102840938/178457313-83cc3f02-ba06-49db-b714-dbb3fd7c12f6.png)

After changing conditions：
 
![flowing_c](https://user-images.githubusercontent.com/102840938/178457513-b59ba3c9-853d-4e1d-8c18-2ededb774808.png)

![lanchange_c](https://user-images.githubusercontent.com/102840938/178457534-9d57f2e4-6c04-4a12-83fa-8d92b093e8a2.png)





<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
