### PR TITLE
fix(behavior_velocity_planner): don't early return when it is not target object

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -142,6 +142,8 @@ private:
 
   bool isRedSignalForPedestrians() const;
 
+  bool isVehicle(const PredictedObject & object) const;
+
   bool isTargetType(const PredictedObject & object) const;
 
   bool isTargetExternalInputStatus(const int target_status) const;

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -468,8 +468,11 @@ boost::optional<std::pair<size_t, PathPointWithLaneId>> CrosswalkModule::findNea
     const auto & obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
     const auto obj_uuid = toHexString(object.object_id);
 
-    if (!isTargetType(object)) {
+    if (isVehicle(object)) {
       found_stuck_vehicle = found_stuck_vehicle || isStuckVehicle(ego_path, object);
+    }
+
+    if (!isTargetType(object)) {
       continue;
     }
 
@@ -989,6 +992,37 @@ bool CrosswalkModule::isRedSignalForPedestrians() const
         return true;
       }
     }
+  }
+
+  return false;
+}
+
+bool CrosswalkModule::isVehicle(const PredictedObject & object) const
+{
+  if (object.classification.empty()) {
+    return false;
+  }
+
+  const auto & label = object.classification.front().label;
+
+  if (label == ObjectClassification::CAR) {
+    return true;
+  }
+
+  if (label == ObjectClassification::TRUCK) {
+    return true;
+  }
+
+  if (label == ObjectClassification::BUS) {
+    return true;
+  }
+
+  if (label == ObjectClassification::TRAILER) {
+    return true;
+  }
+
+  if (label == ObjectClassification::MOTORCYCLE) {
+    return true;
   }
 
   return false;

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -925,15 +925,6 @@ CollisionPointState CrosswalkModule::getCollisionPointState(
 bool CrosswalkModule::isStuckVehicle(
   const PathWithLaneId & ego_path, const PredictedObject & object) const
 {
-  const auto & label = object.classification.at(0).label;
-  const auto is_target =
-    label == ObjectClassification::CAR || label == ObjectClassification::TRUCK ||
-    label == ObjectClassification::BUS || label == ObjectClassification::TRAILER ||
-    label == ObjectClassification::MOTORCYCLE;
-  if (!is_target) {
-    return false;
-  }
-
   const auto & obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
   if (planner_param_.stuck_vehicle_velocity < std::hypot(obj_vel.x, obj_vel.y)) {
     return false;


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

- Even if the object is target for crosswalk stop, the module checks whether the object is stuck or not.
- This module should checks each object not only as target object but also as stuck vehicle.
- **MOTORCYCLE** could be either target object or stuck vehicle.

before (the module **NOT** stop in front of the crosswalk.)

![rviz_screenshot_2022_07_12-19_37_14](https://user-images.githubusercontent.com/44889564/178472856-5643f5c1-dd90-42af-8a80-c387c69de7e1.png)


after (the module stop in front of the crosswalk.)

![rviz_screenshot_2022_07_12-19_32_31](https://user-images.githubusercontent.com/44889564/178473040-acae62c8-08ee-4782-a164-6b7bb99ff85e.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
