### PR TITLE
fix(obstacle_avoidance_planner): edge case for path size is lower than nearest index + 1

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -1136,7 +1136,7 @@ void ObstacleAvoidancePlanner::calcVelocity(
     }();
 
     // add this line not to exceeds max index size
-    const size_t max_idx = std::min(nearest_seg_idx + 1, path_points.size() - 1); 
+    const size_t max_idx = std::min(nearest_seg_idx + 1, path_points.size() - 1);
     // NOTE: std::max, not std::min, is used here since traj_points' sampling width may be longer
     // than path_points' sampling width. A zero velocity point is guaranteed to be inserted in an
     // output trajectory in the alignVelocity function

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -1135,12 +1135,14 @@ void ObstacleAvoidancePlanner::calcVelocity(
         path_points, traj_points.at(i).pose.position);
     }();
 
+    // add this line not to exceeds max index size
+    const size_t max_idx = std::min(nearest_seg_idx + 1, path_points.size() - 1); 
     // NOTE: std::max, not std::min, is used here since traj_points' sampling width may be longer
     // than path_points' sampling width. A zero velocity point is guaranteed to be inserted in an
     // output trajectory in the alignVelocity function
     traj_points.at(i).longitudinal_velocity_mps = std::max(
       path_points.at(nearest_seg_idx).longitudinal_velocity_mps,
-      path_points.at(nearest_seg_idx + 1).longitudinal_velocity_mps);
+      path_points.at(max_idx).longitudinal_velocity_mps);
   }
 }
 

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -1135,7 +1135,7 @@ void ObstacleAvoidancePlanner::calcVelocity(
         path_points, traj_points.at(i).pose.position);
     }();
 
-    // add this line not to exceeds max index size
+    // add this line not to exceed max index size
     const size_t max_idx = std::min(nearest_seg_idx + 1, path_points.size() - 1);
     // NOTE: std::max, not std::min, is used here since traj_points' sampling width may be longer
     // than path_points' sampling width. A zero velocity point is guaranteed to be inserted in an


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description


related to https://github.com/autowarefoundation/autoware.universe/issues/1297


Because 
- path size = trajectory size
- if path size = 1 nearest index = 0 

node dies below

```
    traj_points.at(i).longitudinal_velocity_mps = std::max(
      path_points.at(nearest_seg_idx).longitudinal_velocity_mps,
      path_points.at(nearest_seg_idx+1).longitudinal_velocity_mps);
```
before
```
#7  0x00007f33e423e458 in ObstacleAvoidancePlanner::calcVelocity(std::vector<autoware_auto_planning_msgs::msg::PathPoint_<std::allocator<void> >, std::allocator<autoware_auto_planning_msgs::msg::PathPoint_<std::allocator<void> > > > const&, std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint_<std::allocator<void> >, std::allocator<autoware_auto_planning_msgs::msg::TrajectoryPoint_<std::allocator<void> > > >&) const ()
   from /home/t4tanaka/workspace/autoware/install/obstacle_avoidance_planner/lib/libobstacle_avoidance_planner.so
#8  0x00007f33e424a0fe in ObstacleAvoidancePlanner::generateOptimizedTrajectory(autoware_auto_planning_msgs::msg::Path_<std::allocator<void> > const&) ()
   from /home/t4tanaka/workspace/autoware/install/obstacle_avoidance_planner/lib/libobstacle_avoidance_planner.so


[component_container_mt-16] [INFO] [1657620327.665149088] [planning.scenario_planning.lane_driving.motion_planning.obstacle_avoidance_planner]: Replan with resetting optimization since valid nearest trajectory point from ego was not found.
[component_container_mt-16] terminate called after throwing an instance of 'std::out_of_range'
[component_container_mt-16]   what():  vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)
[component_container-19] [ERROR] [1657620327.772353358] [control.trajectory_follower.lane_departure_checker_node]: predicted_trajectory is empty. Not expected!
[ERROR] [component_container_mt-16]: process has died [pid 116049, exit code -6, cmd '/opt/ros/galactic/lib/rclcpp_components/component_container_mt --ros-args -r __node:=motion_planning_container -r __ns:=/planning/scenario_planning/lane_driving/motion_planning --params-file /tmp/launch_params_vm0cqaa1'].
```
after
[Screencast from 2022年07月12日 22時04分44秒.webm](https://user-images.githubusercontent.com/65527974/178496839-cd17afdd-04c6-40fc-9518-9b1723a69ff4.webm)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
