### PR TITLE
feat(interpolation): add akima spline interpolation

### DIFF
--- a/common/interpolation/include/interpolation/spline_interpolation.hpp
+++ b/common/interpolation/include/interpolation/spline_interpolation.hpp
@@ -49,6 +49,9 @@ struct MultiSplineCoef
 std::vector<double> slerp(
   const std::vector<double> & base_keys, const std::vector<double> & base_values,
   const std::vector<double> & query_keys);
+std::vector<double> slerpByAkima(
+  const std::vector<double> & base_keys, const std::vector<double> & base_values,
+  const std::vector<double> & query_keys);
 }  // namespace interpolation
 
 // non-static 1-dimensional spline interpolation

--- a/common/interpolation/src/spline_interpolation.cpp
+++ b/common/interpolation/src/spline_interpolation.cpp
@@ -93,6 +93,80 @@ std::vector<double> slerp(
   // interpolate base_keys at query_keys
   return interpolator.getSplineInterpolatedValues(query_keys);
 }
+
+std::vector<double> slerpByAkima(
+  const std::vector<double> & base_keys, const std::vector<double> & base_values,
+  const std::vector<double> & query_keys)
+{
+  constexpr double epsilon = 1e-5;
+
+  // calculate m
+  std::vector<double> m_values;
+  for (size_t i = 0; i < base_keys.size() - 1; ++i) {
+    const double m_val =
+      (base_values.at(i + 1) - base_values.at(i)) / (base_keys.at(i + 1) - base_keys.at(i));
+    m_values.push_back(m_val);
+  }
+
+  // calculate s
+  std::vector<double> s_values;
+  for (size_t i = 0; i < base_keys.size(); ++i) {
+    if (i == 0) {
+      s_values.push_back(m_values.front());
+      continue;
+    } else if (i == 1 || i == base_keys.size() - 2) {
+      const double s_val = (m_values.at(i - 1) + m_values.at(i)) / 2.0;
+      s_values.push_back(s_val);
+      continue;
+    } else if (i == base_keys.size() - 1) {
+      s_values.push_back(m_values.back());
+      continue;
+    }
+
+    const double denom = std::abs(m_values.at(i + 1) - m_values.at(i)) +
+                         std::abs(m_values.at(i - 1) - m_values.at(i - 2));
+    if (std::abs(denom) < epsilon) {
+      const double s_val = (m_values.at(i - 1) + m_values.at(i)) / 2.0;
+      s_values.push_back(s_val);
+      continue;
+    }
+
+    const double s_val = (std::abs(m_values.at(i + 1) - m_values.at(i)) * m_values.at(i - 1) +
+                          std::abs(m_values.at(i - 1) - m_values.at(i - 2)) * m_values.at(i)) /
+                         denom;
+    s_values.push_back(s_val);
+  }
+
+  // calculate cubic coefficients
+  std::vector<double> a;
+  std::vector<double> b;
+  std::vector<double> c;
+  std::vector<double> d;
+  for (size_t i = 0; i < base_keys.size() - 1; ++i) {
+    a.push_back(
+      (s_values.at(i) + s_values.at(i + 1) - 2.0 * m_values.at(i)) /
+      std::pow(base_keys.at(i + 1) - base_keys.at(i), 2));
+    b.push_back(
+      (3.0 * m_values.at(i) - 2.0 * s_values.at(i) - s_values.at(i + 1)) /
+      (base_keys.at(i + 1) - base_keys.at(i)));
+    c.push_back(s_values.at(i));
+    d.push_back(base_values.at(i));
+  }
+
+  // interpolate
+  std::vector<double> res;
+  size_t j = 0;
+  for (const auto & query_key : query_keys) {
+    while (base_keys.at(j + 1) < query_key) {
+      ++j;
+    }
+
+    const double ds = query_key - base_keys.at(j);
+    res.push_back(d.at(j) + (c.at(j) + (b.at(j) + a.at(j) * ds) * ds) * ds);
+  }
+  return res;
+}
+
 }  // namespace interpolation
 
 void SplineInterpolation::calcSplineCoefficients(

--- a/common/interpolation/src/spline_interpolation.cpp
+++ b/common/interpolation/src/spline_interpolation.cpp
@@ -114,12 +114,12 @@ std::vector<double> slerpByAkima(
     if (i == 0) {
       s_values.push_back(m_values.front());
       continue;
+    } else if (i == base_keys.size() - 1) {
+      s_values.push_back(m_values.back());
+      continue;
     } else if (i == 1 || i == base_keys.size() - 2) {
       const double s_val = (m_values.at(i - 1) + m_values.at(i)) / 2.0;
       s_values.push_back(s_val);
-      continue;
-    } else if (i == base_keys.size() - 1) {
-      s_values.push_back(m_values.back());
       continue;
     }
 
@@ -166,7 +166,6 @@ std::vector<double> slerpByAkima(
   }
   return res;
 }
-
 }  // namespace interpolation
 
 void SplineInterpolation::calcSplineCoefficients(

--- a/common/interpolation/test/src/test_spline_interpolation.cpp
+++ b/common/interpolation/test/src/test_spline_interpolation.cpp
@@ -110,6 +110,93 @@ TEST(spline_interpolation, slerp)
   }
 }
 
+TEST(spline_interpolation, slerpByAkima)
+{
+  {  // straight: query_keys is same as base_keys
+    const std::vector<double> base_keys{0.0, 1.0, 2.0, 3.0, 4.0};
+    const std::vector<double> base_values{0.0, 1.5, 3.0, 4.5, 6.0};
+    const std::vector<double> query_keys = base_keys;
+    const std::vector<double> ans = base_values;
+
+    const auto query_values = interpolation::slerpByAkima(base_keys, base_values, query_keys);
+    for (size_t i = 0; i < query_values.size(); ++i) {
+      EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
+    }
+  }
+
+  {  // straight: query_keys is random
+    const std::vector<double> base_keys{0.0, 1.0, 2.0, 3.0, 4.0};
+    const std::vector<double> base_values{0.0, 1.5, 3.0, 4.5, 6.0};
+    const std::vector<double> query_keys{0.0, 0.7, 1.9, 4.0};
+    const std::vector<double> ans{0.0, 1.05, 2.85, 6.0};
+
+    const auto query_values = interpolation::slerpByAkima(base_keys, base_values, query_keys);
+    for (size_t i = 0; i < query_values.size(); ++i) {
+      EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
+    }
+  }
+
+  {  // curve: query_keys is same as base_keys
+    const std::vector<double> base_keys{-1.5, 1.0, 5.0, 10.0, 15.0, 20.0};
+    const std::vector<double> base_values{-1.2, 0.5, 1.0, 1.2, 2.0, 1.0};
+    const std::vector<double> query_keys = base_keys;
+    const std::vector<double> ans = base_values;
+
+    const auto query_values = interpolation::slerpByAkima(base_keys, base_values, query_keys);
+    for (size_t i = 0; i < query_values.size(); ++i) {
+      EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
+    }
+  }
+
+  {  // curve: query_keys is random
+    const std::vector<double> base_keys{-1.5, 1.0, 5.0, 10.0, 15.0, 20.0};
+    const std::vector<double> base_values{-1.2, 0.5, 1.0, 1.2, 2.0, 1.0};
+    const std::vector<double> query_keys{0.0, 8.0, 18.0};
+    const std::vector<double> ans{-0.0801, 1.110749, 1.4864};
+
+    const auto query_values = interpolation::slerpByAkima(base_keys, base_values, query_keys);
+    for (size_t i = 0; i < query_values.size(); ++i) {
+      EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
+    }
+  }
+
+  {  // straight: size of base_keys is 2 (edge case in the implementation)
+    const std::vector<double> base_keys{0.0, 1.0};
+    const std::vector<double> base_values{0.0, 1.5};
+    const std::vector<double> query_keys = base_keys;
+    const std::vector<double> ans = base_values;
+
+    const auto query_values = interpolation::slerpByAkima(base_keys, base_values, query_keys);
+    for (size_t i = 0; i < query_values.size(); ++i) {
+      EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
+    }
+  }
+
+  {  // straight: size of base_keys is 3 (edge case in the implementation)
+    const std::vector<double> base_keys{0.0, 1.0, 2.0};
+    const std::vector<double> base_values{0.0, 1.5, 3.0};
+    const std::vector<double> query_keys = base_keys;
+    const std::vector<double> ans = base_values;
+
+    const auto query_values = interpolation::slerpByAkima(base_keys, base_values, query_keys);
+    for (size_t i = 0; i < query_values.size(); ++i) {
+      EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
+    }
+  }
+
+  {  // curve: query_keys is random. size of base_keys is 3 (edge case in the implementation)
+    const std::vector<double> base_keys{-1.5, 1.0, 5.0};
+    const std::vector<double> base_values{-1.2, 0.5, 1.0};
+    const std::vector<double> query_keys{-1.0, 0.0, 4.0};
+    const std::vector<double> ans{-0.8378, -0.0801, 0.927031};
+
+    const auto query_values = interpolation::slerpByAkima(base_keys, base_values, query_keys);
+    for (size_t i = 0; i < query_values.size(); ++i) {
+      EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
+    }
+  }
+}
+
 TEST(spline_interpolation, slerpYawFromPoints)
 {
   using tier4_autoware_utils::createPoint;

--- a/common/interpolation/test/src/test_spline_interpolation.cpp
+++ b/common/interpolation/test/src/test_spline_interpolation.cpp
@@ -108,6 +108,18 @@ TEST(spline_interpolation, slerp)
       EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
     }
   }
+
+  {  // When the query keys changes suddenly (edge case of spline interpolation).
+    const std::vector<double> base_keys = {0.0, 1.0, 1.0001, 2.0, 3.0, 4.0};
+    const std::vector<double> base_values = {0.0, 0.0, 0.1, 0.1, 0.1, 0.1};
+    const std::vector<double> query_keys = {0.0, 1.0, 1.5, 2.0, 3.0, 4.0};
+    const std::vector<double> ans = {0.0, 0.0, 137.591789, 0.1, 0.1, 0.1};
+
+    const auto query_values = interpolation::slerp(base_keys, base_values, query_keys);
+    for (size_t i = 0; i < query_values.size(); ++i) {
+      EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
+    }
+  }
 }
 
 TEST(spline_interpolation, slerpByAkima)
@@ -189,6 +201,18 @@ TEST(spline_interpolation, slerpByAkima)
     const std::vector<double> base_values{-1.2, 0.5, 1.0};
     const std::vector<double> query_keys{-1.0, 0.0, 4.0};
     const std::vector<double> ans{-0.8378, -0.0801, 0.927031};
+
+    const auto query_values = interpolation::slerpByAkima(base_keys, base_values, query_keys);
+    for (size_t i = 0; i < query_values.size(); ++i) {
+      EXPECT_NEAR(query_values.at(i), ans.at(i), epsilon);
+    }
+  }
+
+  {  // When the query keys changes suddenly (edge case of spline interpolation).
+    const std::vector<double> base_keys = {0.0, 1.0, 1.0001, 2.0, 3.0, 4.0};
+    const std::vector<double> base_values = {0.0, 0.0, 0.1, 0.1, 0.1, 0.1};
+    const std::vector<double> query_keys = {0.0, 1.0, 1.5, 2.0, 3.0, 4.0};
+    const std::vector<double> ans = {0.0, 0.0, 0.1, 0.1, 0.1, 0.1};
 
     const auto query_values = interpolation::slerpByAkima(base_keys, base_values, query_keys);
     for (size_t i = 0; i < query_values.size(); ++i) {


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

**No behavior changes** since this is not used in any package.
Implemented akima spline interpolation according to https://en.wikipedia.org/wiki/Akima_spline

e.g.) when using akima spline interpolation in behavior velocity planner.
thin path and path footprint of the output of behavior velocity planner are visualized.
before
![image](https://user-images.githubusercontent.com/20228327/178473687-2b493a88-7820-4dcf-a9b0-804f5a918ae1.png)

after
![image](https://user-images.githubusercontent.com/20228327/178472118-eaa2cb07-2d09-43e6-901b-23c6ee8a584a.png)

**TODO (after this PR merged)**
when the ego is running along the road, the first several path points are unstable (path points moves laterally).
In order to always use akima spline instead of normal spline, we have to fix this issue.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
