### PR TITLE
fix(behavior_path_planner): fix intersection path is empty case

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1688,7 +1688,7 @@ bool checkLaneIsInIntersection(
   const RouteHandler & route_handler, const PathWithLaneId & reference_path,
   const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add)
 {
-  if (lanelet_sequence.size() < 2) {
+  if (lanelet_sequence.size() < 2 || reference_path.points.empty()) {
     return false;
   }
 


### PR DESCRIPTION
Signed-off-by: taikitanaka3 <ttatcoder@outlook.jp>

## Description

fix node dies at intersection path is empty case

```
#0  behavior_path_planner::util::checkLaneIsInIntersection (route_handler=..., reference_path=..., lanelet_sequence=std::vector of length 2, capacity 2 = {...}, additional_length_to_add=@0x7fe5e00222d0: 0)
    at /home/t4tanaka/workspace/humble_autoware/src/universe/autoware.universe/planning/behavior_path_planner/src/utilities.cpp:1696
1696	  auto end_of_route_pose = path_points.back().point.pose;

```
Note: it's very very hard to reproduce this error intensionaly, this is possible to reproduce using manual controller to go outside of lane.

But during the experiment with manual driving this can happen.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
