### PR TITLE
fix(obstacle_cruise_planner): fix get index

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
@@ -108,17 +108,19 @@ size_t getIndexWithLongitudinalOffset(
     return points.size() - 1;
   }
 
-  for (size_t i = start_idx.get(); i > 0; --i) {
+  RCLCPP_ERROR_STREAM(rclcpp::get_logger("tmp"), *start_idx << ", " << points.size() - 1);
+
+  for (size_t i = start_idx.get(); i > 1; --i) {
     const double segment_length =
-      tier4_autoware_utils::calcDistance2d(points.at(i), points.at(i + 1));
+      tier4_autoware_utils::calcDistance2d(points.at(i), points.at(i - 1));
     sum_length += segment_length;
     if (sum_length >= -longitudinal_offset) {
       const double front_length = segment_length;
       const double back_length = sum_length + longitudinal_offset;
       if (front_length < back_length) {
-        return i;
+        return i - 1;
       } else {
-        return i + 1;
+        return i;
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
In such a case, 
![image](https://user-images.githubusercontent.com/59680180/178649625-723ddcc9-0413-4fdc-a14b-31a0aa12bb74.png)
obstacle_cruise_planner died with following message.
```
[component_container_mt-50] terminate called after throwing an instance of 'std::out_of_range'
[component_container_mt-50]   what():  vector::_M_range_check: __n (which is 146) >= this->size() (which is 146)
[ERROR] [component_container_mt-50]: process has died [pid 1812534, exit code -6, cmd '/opt/ros/galactic/lib/rclcpp_components/component_container_mt --ros-args -r __node:=motion_planning_container -r __ns:=/planning/scenario_planning/lane_driving/motion_planning --params-file /tmp/launch_params_tybtn0if'].
```

This is caused by invalid access in this code when *start_idx ==  points.size() - 1. 
```
tier4_autoware_utils::calcDistance2d(points.at(i), points.at(i + 1));
```

I fixed it.


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
