### PR TITLE
fix(obstacle_cruise_planner): fix node dying

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/utils.hpp
@@ -96,8 +96,8 @@ size_t getIndexWithLongitudinalOffset(
         tier4_autoware_utils::calcDistance2d(points.at(i), points.at(i + 1));
       sum_length += segment_length;
       if (sum_length >= longitudinal_offset) {
-        const double front_length = segment_length;
         const double back_length = sum_length - longitudinal_offset;
+        const double front_length = segment_length - back_length;
         if (front_length < back_length) {
           return i;
         } else {
@@ -110,15 +110,15 @@ size_t getIndexWithLongitudinalOffset(
 
   for (size_t i = start_idx.get(); i > 0; --i) {
     const double segment_length =
-      tier4_autoware_utils::calcDistance2d(points.at(i), points.at(i + 1));
+      tier4_autoware_utils::calcDistance2d(points.at(i - 1), points.at(i));
     sum_length += segment_length;
     if (sum_length >= -longitudinal_offset) {
-      const double front_length = segment_length;
       const double back_length = sum_length + longitudinal_offset;
+      const double front_length = segment_length - back_length;
       if (front_length < back_length) {
         return i;
       } else {
-        return i + 1;
+        return i - 1;
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description
```
[component_container_mt-50] terminate called after throwing an instance of 'std::out_of_range'
[component_container_mt-50]   what():  vector::_M_range_check: __n (which is 146) >= this->size() (which is 146)
[ERROR] [component_container_mt-50]: process has died [pid 1812534, exit code -6, cmd '/opt/ros/galactic/lib/rclcpp_components/component_container_mt --ros-args -r __node:=motion_planning_container -r __ns:=/planning/scenario_planning/lane_driving/motion_planning --params-file /tmp/launch_params_tybtn0if'].
```

This is caused by invalid access of this code when *start_idx ==  points.size() - 1. 
```
tier4_autoware_utils::calcDistance2d(points.at(i), points.at(i + 1));
```

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
