### PR TITLE
feat(obstacle_cruise_planner): deal with backward driving

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -92,6 +92,7 @@ struct ObstacleCruisePlannerData
   double current_vel;
   double current_acc;
   std::vector<TargetObstacle> target_obstacles;
+  bool is_driving_forward;
 };
 
 struct LongitudinalInfo

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -71,7 +71,6 @@ private:
   void onSmoothedTrajectory(const Trajectory::ConstSharedPtr msg);
 
   // member Functions
-  bool isDrivingForward(const Trajectory traj);
   ObstacleCruisePlannerData createCruiseData(
     const Trajectory & trajectory, const geometry_msgs::msg::Pose & current_pose,
     const std::vector<TargetObstacle> & obstacles, const bool is_driving_forward);

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -71,20 +71,21 @@ private:
   void onSmoothedTrajectory(const Trajectory::ConstSharedPtr msg);
 
   // member Functions
+  bool isDrivingForward(const Trajectory traj);
   ObstacleCruisePlannerData createCruiseData(
     const Trajectory & trajectory, const geometry_msgs::msg::Pose & current_pose,
-    const std::vector<TargetObstacle> & obstacles);
+    const std::vector<TargetObstacle> & obstacles, const bool is_driving_forward);
   ObstacleCruisePlannerData createStopData(
     const Trajectory & trajectory, const geometry_msgs::msg::Pose & current_pose,
-    const std::vector<TargetObstacle> & obstacles);
+    const std::vector<TargetObstacle> & obstacles, const bool is_driving_forward);
   double calcCurrentAccel() const;
   std::vector<TargetObstacle> getTargetObstacles(
     const Trajectory & trajectory, const geometry_msgs::msg::Pose & current_pose,
-    const double current_vel, DebugData & debug_data);
+    const double current_vel, const bool is_driving_forward, DebugData & debug_data);
   std::vector<TargetObstacle> filterObstacles(
     const PredictedObjects & predicted_objects, const Trajectory & traj,
     const geometry_msgs::msg::Pose & current_pose, const double current_vel,
-    DebugData & debug_data);
+    const bool is_driving_forward, DebugData & debug_data);
   void updateHasStopped(std::vector<TargetObstacle> & target_obstacles);
   void checkConsistency(
     const rclcpp::Time & current_time, const PredictedObjects & predicted_objects,
@@ -92,13 +93,14 @@ private:
   geometry_msgs::msg::Point calcNearestCollisionPoint(
     const size_t & first_within_idx,
     const std::vector<geometry_msgs::msg::Point> & collision_points,
-    const Trajectory & decimated_traj);
+    const Trajectory & decimated_traj, const bool is_driving_forward);
   double calcCollisionTimeMargin(
     const geometry_msgs::msg::Pose & current_pose, const double current_vel,
     const geometry_msgs::msg::Point & nearest_collision_point,
     const PredictedObject & predicted_object, const size_t first_within_idx,
     const Trajectory & decimated_traj,
-    const std::vector<tier4_autoware_utils::Polygon2d> & decimated_traj_polygons);
+    const std::vector<tier4_autoware_utils::Polygon2d> & decimated_traj_polygons,
+    const bool is_driving_forward);
   void publishVelocityLimit(const boost::optional<VelocityLimit> & vel_limit);
   void publishDebugData(const DebugData & debug_data) const;
   void publishCalculationTime(const double calculation_time) const;

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -493,7 +493,7 @@ void ObstacleCruisePlannerNode::onTrajectory(const Trajectory::ConstSharedPtr ms
 
   // Get Target Obstacles
   DebugData debug_data;
-  const bool is_driving_forward = isDrivingForward(*msg);
+  const bool is_driving_forward = motion_utils::isDrivingForward(msg->points);
   const auto target_obstacles = getTargetObstacles(
     *msg, current_pose_ptr->pose, current_twist_ptr_->twist.linear.x, is_driving_forward,
     debug_data);
@@ -541,32 +541,6 @@ bool ObstacleCruisePlannerNode::isStopObstacle(const uint8_t label)
 {
   const auto & types = stop_obstacle_types_;
   return std::find(types.begin(), types.end(), label) != types.end();
-}
-
-bool ObstacleCruisePlannerNode::isDrivingForward(const Trajectory traj)
-{
-  if (traj.points.size() < 2) {
-    return true;
-  }
-
-  const auto & first_traj_point = traj.points.at(0);
-  const auto & second_traj_point = traj.points.at(1);
-  if (
-    0.0 <= first_traj_point.longitudinal_velocity_mps &&
-    0.0 <= second_traj_point.longitudinal_velocity_mps) {
-    return true;
-  }
-
-  const double first_traj_yaw = tf2::getYaw(first_traj_point.pose.orientation);
-  const double driving_direction_yaw = tier4_autoware_utils::calcAzimuthAngle(
-    first_traj_point.pose.position, second_traj_point.pose.position);
-  if (
-    std::abs(tier4_autoware_utils::normalizeRadian(first_traj_yaw - driving_direction_yaw)) <
-    M_PI_2) {
-    return true;
-  }
-
-  return false;
 }
 
 ObstacleCruisePlannerData ObstacleCruisePlannerNode::createStopData(

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -930,13 +930,16 @@ geometry_msgs::msg::Point ObstacleCruisePlannerNode::calcNearestCollisionPoint(
   std::array<geometry_msgs::msg::Point, 2> segment_points;
   if (first_within_idx == 0) {
     const auto & traj_front_pose = decimated_traj.points.at(0).pose;
-    segment_points.at(0) = traj_front_pose.position;
-
-    const double signed_ego_offset = is_driving_forward ? vehicle_info_.max_longitudinal_offset_m
-                                                        : vehicle_info_.min_longitudinal_offset_m;
-    const auto ego_offset_pos =
-      tier4_autoware_utils::calcOffsetPose(traj_front_pose, signed_ego_offset, 0.0, 0.0).position;
-    segment_points.at(1) = ego_offset_pos;
+    const auto front_pos = tier4_autoware_utils::calcOffsetPose(
+                             traj_front_pose, vehicle_info_.max_longitudinal_offset_m, 0.0, 0.0)
+                             .position;
+    if (is_driving_forward) {
+      segment_points.at(0) = traj_front_pose.position;
+      segment_points.at(1) = front_pos;
+    } else {
+      segment_points.at(0) = front_pos;
+      segment_points.at(1) = traj_front_pose.position;
+    }
   } else {
     const size_t seg_idx = first_within_idx - 1;
     segment_points.at(0) = decimated_traj.points.at(seg_idx).pose.position;


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

obstacle cruise planner supports backward driving for pull over module
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
