### PR TITLE
fix(tier4_perception_launch): fix apollo pipeline in detection module

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -142,15 +142,19 @@
     <group>
       <include file="$(find-pkg-share lidar_apollo_instance_segmentation)/launch/lidar_apollo_instance_segmentation.launch.xml">
         <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
+        <arg name="output/objects" value="labeled_clusters"/>
       </include>
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
+        <arg name="input/objects" value="labeled_clusters"/>
         <arg name="output/objects" value="objects_with_feature"/>
         <arg name="use_vehicle_reference_yaw" value="true"/>
+        <arg name="node_name" value="shape_estimation_apollo"/>
       </include>
       <!-- convert DynamicObjectsWithFeatureArray to DynamicObjects -->
       <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
         <arg name="input" value="objects_with_feature"/>
         <arg name="output" value="objects"/>
+        <arg name="node_name" value="detected_object_feature_remover_apollo"/>
       </include>
     </group>
   </group>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -34,11 +34,13 @@
     <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
       <arg name="input/objects" value="clusters"/>
       <arg name="output/objects" value="objects_with_feature"/>
+      <arg name="node_name" value="shape_estimation_clustering"/>
     </include>
     <!-- convert DynamicObjectsWithFeatureArray to DynamicObjects -->
     <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
       <arg name="input" value="objects_with_feature"/>
       <arg name="output" value="objects"/>
+      <arg name="node_name" value="detected_object_feature_remover_clustering"/>
     </include>
   </group>
 
@@ -64,15 +66,19 @@
     <group>
       <include file="$(find-pkg-share lidar_apollo_instance_segmentation)/launch/lidar_apollo_instance_segmentation.launch.xml">
         <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
+        <arg name="output/objects" value="labeled_clusters"/>
       </include>
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
+        <arg name="input/objects" value="labeled_clusters"/>
         <arg name="output/objects" value="objects_with_feature"/>
         <arg name="use_vehicle_reference_yaw" value="true"/>
+        <arg name="node_name" value="shape_estimation_apollo"/>
       </include>
       <!-- convert DynamicObjectsWithFeatureArray to DynamicObjects -->
       <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
         <arg name="input" value="objects_with_feature"/>
         <arg name="output" value="objects"/>
+        <arg name="node_name" value="detected_object_feature_remover_apollo"/>
       </include>
     </group>
   </group>


### PR DESCRIPTION
Signed-off-by: yukke42 <yusuke.muramatsu@tier4.jp>

## Description

Related Link: https://github.com/autowarefoundation/autoware.universe/pull/1301

If the `lidar_detection_model` is changed to `apollo`, there are no perception outputs in rviz. And when launching `logging.simulator.launch.xml`, there are warnings below.

```
[WARNING] [detected_object_feature_remover-27]: there are now at least 2 nodes with the name /perception/object_recognition/detection/clustering/shape_estimation created within this launch context
[WARNING] [detected_object_feature_remover-31]: there are now at least 2 nodes with the name /perception/object_recognition/detection/apollo/shape_estimation created within this launch context
```

### Before

https://user-images.githubusercontent.com/24660808/178674625-3878d77e-c20b-4711-ace6-2b1f58f2ee13.mp4


```
❯ ros2 node list | grep apollo
WARNING: Be aware that are nodes in the graph that share an exact name, this can have unintended side effects.
/perception/object_recognition/detection/apollo/lidar_apollo_instance_segmentation
/perception/object_recognition/detection/apollo/shape_estimation
/perception/object_recognition/detection/apollo/shape_estimation
/perception/object_recognition/detection/apollo/transform_listener_impl_55d1d39df298

❯ ros2 node info /perception/object_recognition/detection/apollo/lidar_apollo_instance_segmentation
/perception/object_recognition/detection/apollo/lidar_apollo_instance_segmentation
  Subscribers:
    /clock: rosgraph_msgs/msg/Clock
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /sensing/lidar/concatenated/pointcloud: sensor_msgs/msg/PointCloud2
  Publishers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/object_recognition/detection/apollo/debug/instance_pointcloud: sensor_msgs/msg/PointCloud2
    /perception/object_recognition/detection/apollo/objects: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /rosout: rcl_interfaces/msg/Log
...

❯ ros2 node info /perception/object_recognition/detection/apollo/shape_estimation
There are 2 nodes in the graph with the exact name "/perception/object_recognition/detection/apollo/shape_estimation". You are seeing information about only one of them.
/perception/object_recognition/detection/apollo/shape_estimation
  Subscribers:
    /clock: rosgraph_msgs/msg/Clock
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/object_recognition/detection/apollo/labeled_clusters: tier4_perception_msgs/msg/DetectedObjectsWithFeature
  Publishers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/object_recognition/detection/apollo/objects_with_feature: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /rosout: rcl_interfaces/msg/Log
...
```


### After

https://user-images.githubusercontent.com/24660808/178676714-2cb7395f-c85a-4e88-bfbb-05b970e48847.mp4


```
❯ ros2 node list | grep apollo
/perception/object_recognition/detection/apollo/detected_object_feature_remover_apollo
/perception/object_recognition/detection/apollo/lidar_apollo_instance_segmentation
/perception/object_recognition/detection/apollo/shape_estimation_apollo
/perception/object_recognition/detection/apollo/transform_listener_impl_559ee6ffb518

❯ ros2 node info /perception/object_recognition/detection/apollo/lidar_apollo_instance_segmentation
/perception/object_recognition/detection/apollo/lidar_apollo_instance_segmentation
  Subscribers:
    /clock: rosgraph_msgs/msg/Clock
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /sensing/lidar/concatenated/pointcloud: sensor_msgs/msg/PointCloud2
  Publishers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/object_recognition/detection/apollo/debug/instance_pointcloud: sensor_msgs/msg/PointCloud2
    /perception/object_recognition/detection/apollo/labeled_clusters: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /perception/object_recognition/detection/apollo/lidar_apollo_instance_segmentation/debug/cyclic_time_ms: tier4_debug_msgs/msg/Float64Stamped
    /perception/object_recognition/detection/apollo/lidar_apollo_instance_segmentation/debug/processing_time_ms: tier4_debug_msgs/msg/Float64Stamped
    /rosout: rcl_interfaces/msg/Log

❯ ros2 node info /perception/object_recognition/detection/apollo/shape_estimation_apollo 
/perception/object_recognition/detection/apollo/shape_estimation_apollo
  Subscribers:
    /clock: rosgraph_msgs/msg/Clock
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/object_recognition/detection/apollo/labeled_clusters: tier4_perception_msgs/msg/DetectedObjectsWithFeature
  Publishers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/object_recognition/detection/apollo/objects_with_feature: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /rosout: rcl_interfaces/msg/Log
...
```


## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
