### PR TITLE
fix(operation_mode_transition_manager): add required param

### DIFF
--- a/control/operation_mode_transition_manager/src/operation_mode_transition_manager.cpp
+++ b/control/operation_mode_transition_manager/src/operation_mode_transition_manager.cpp
@@ -211,7 +211,8 @@ bool OperationModeTransitionManager::checkEngageAvailable()
   const auto & param = engage_acceptable_param_;
 
   if (data_->trajectory.points.size() < 2) {
-    RCLCPP_WARN(get_logger(), "Engage unavailable: trajectory size must be > 2");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(
+      get_logger(), *get_clock(), 5000, "Engage unavailable: trajectory size must be > 2");
     debug_info_ = OperationModeTransitionManagerDebug{};  // all false
     return false;
   }

--- a/launch/tier4_control_launch/config/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
+++ b/launch/tier4_control_launch/config/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
@@ -2,6 +2,7 @@
   ros__parameters:
     frequency_hz: 10.0
     engage_acceptable_limits:
+      allow_autonomous_in_stopped: true  # no check if the velocity is zero, always allowed.
       dist_threshold: 1.5
       yaw_threshold: 0.524
       speed_upper_threshold: 10.0


### PR DESCRIPTION
## Description

`operation_mode_transition_manager` died when launched due to a missing param.

And, the warning message is modified for visibility convenience. 

Please check the `operation_mode_transtiion_manager` exists when launched by following command:
```
ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit map_path:=<YOUR MAP PATH>
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
