### PR TITLE
fix(obstacle_avoidance,obstacle_stop): null ptr check

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -520,8 +520,6 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
   // TODO(murooka) tune this param when avoiding with obstacle_avoidance_planner
   traj_param_.center_line_width = vehicle_param_.width;
 
-  objects_ptr_ = std::make_unique<autoware_auto_perception_msgs::msg::PredictedObjects>();
-
   // set parameter callback
   set_param_res_ = this->add_on_set_parameters_callback(
     std::bind(&ObstacleAvoidancePlanner::paramCallback, this, std::placeholders::_1));
@@ -855,7 +853,9 @@ void ObstacleAvoidancePlanner::pathCallback(
 {
   stop_watch_.tic(__func__);
 
-  if (path_ptr->points.empty() || path_ptr->drivable_area.data.empty() || !current_twist_ptr_) {
+  if (
+    path_ptr->points.empty() || path_ptr->drivable_area.data.empty() || !current_twist_ptr_ ||
+    !objects_ptr_) {
     return;
   }
 

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -668,7 +668,6 @@ void ObstacleStopPlannerNode::searchObstacle(
   const VehicleInfo & vehicle_info, const StopParam & stop_param,
   const sensor_msgs::msg::PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr)
 {
-  if (!object_ptr_) return;
   // search candidate obstacle pointcloud
   pcl::PointCloud<pcl::PointXYZ>::Ptr slow_down_pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_candidate_pointcloud_ptr(

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -668,6 +668,7 @@ void ObstacleStopPlannerNode::searchObstacle(
   const VehicleInfo & vehicle_info, const StopParam & stop_param,
   const sensor_msgs::msg::PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr)
 {
+  if (!object_ptr_) return;
   // search candidate obstacle pointcloud
   pcl::PointCloud<pcl::PointXYZ>::Ptr slow_down_pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_candidate_pointcloud_ptr(


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

Fix null ptr check


This line can delete subscribed object 
```
objects_ptr_ = std::make_unique<autoware_auto_perception_msgs::msg::PredictedObjects>();
```

object_ptr_ is not checked if it's not empty or not.
```
insertAdaptiveCruiseVelocity(
          decimate_trajectory, planner_data.decimate_trajectory_collision_index,
          planner_data.current_pose, planner_data.nearest_collision_point,
          planner_data.nearest_collision_point_time, object_ptr_, current_velocity_ptr_,
          &planner_data.stop_require, &output, trajectory_header);
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
