### PR TITLE
fix(map_based_prediction): fix search dist

### DIFF
--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -814,7 +814,7 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
   const double object_detected_time)
 {
   const double delta_horizon = 1.0;
-  const double obj_vel = object.kinematics.twist_with_covariance.twist.linear.x;
+  const double obj_vel = std::fabs(object.kinematics.twist_with_covariance.twist.linear.x);
 
   std::vector<PredictedRefPath> all_ref_paths;
   for (const auto & current_lanelet_data : current_lanelets_data) {


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
In map_based_prediction, the searching distance of lanelet is calculated as following.
```
const double obj_vel = object.kinematics.twist_with_covariance.twist.linear.x;
const double search_dist = horizon * obj_vel + 10.0;
```

When twist.linear.x is negative, is not calculated correctly, and incorrectly very short predicted_paths are output.

https://user-images.githubusercontent.com/59680180/178973220-bf1664b6-fe98-45db-afc2-cd3fe43e7db5.mp4

I fixed it.


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
