### PR TITLE
fix(motion_velocity_smoother): prevent sudden deceleration in the lateral acceleration filtering process

### DIFF
--- a/planning/motion_velocity_smoother/README.md
+++ b/planning/motion_velocity_smoother/README.md
@@ -30,8 +30,10 @@ This function is used to approach near the obstacle or improve the accuracy of s
 #### Apply lateral acceleration limit
 
 It applies the velocity limit to decelerate at the curve.
-It calculate the velocity limit from the curvature of the reference trajectory and the maximum lateral acceleration `max_lateral_accel`.
+It calculates the velocity limit from the curvature of the reference trajectory and the maximum lateral acceleration `max_lateral_accel`.
 The velocity limit is set as not to fall under `min_curve_velocity`.
+
+Note: velocity limit that requests larger than `nominal.jerk` is not applied. In other words, even if a sharp curve is planned just in front of the ego, no deceleration is performed.
 
 #### Resample trajectory
 

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -157,7 +157,9 @@ private:
 
   TrajectoryPoints calcTrajectoryVelocity(const TrajectoryPoints & input) const;
 
-  bool smoothVelocity(const TrajectoryPoints & input, TrajectoryPoints & traj_smoothed) const;
+  bool smoothVelocity(
+    const TrajectoryPoints & input, const size_t input_closest,
+    TrajectoryPoints & traj_smoothed) const;
 
   std::tuple<double, double, InitializeType> calcInitialMotion(
     const TrajectoryPoints & input_traj, const size_t input_closest,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -75,7 +75,9 @@ public:
     const TrajectoryPoints & input, const double v_current, const int closest_id) const override;
 
   boost::optional<TrajectoryPoints> applyLateralAccelerationFilter(
-    const TrajectoryPoints & input) const override;
+    const TrajectoryPoints & input, [[maybe_unused]] const double v0,
+    [[maybe_unused]] const double a0,
+    [[maybe_unused]] const bool enable_smooth_limit) const override;
 
   void setParam(const Param & param);
   Param getParam() const;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
@@ -60,7 +60,9 @@ public:
     const TrajectoryPoints & input, const double v_current, const int closest_id) const = 0;
 
   virtual boost::optional<TrajectoryPoints> applyLateralAccelerationFilter(
-    const TrajectoryPoints & input) const;
+    const TrajectoryPoints & input, [[maybe_unused]] const double v0 = 0.0,
+    [[maybe_unused]] const double a0 = 0.0,
+    [[maybe_unused]] const bool enable_smooth_limit = false) const;
 
   double getMaxAccel() const;
   double getMinDecel() const;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/trajectory_utils.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/trajectory_utils.hpp
@@ -85,6 +85,10 @@ boost::optional<TrajectoryPoints> applyDecelFilterWithJerkConstraint(
 boost::optional<std::tuple<double, double, double, double>> updateStateWithJerkConstraint(
   const double v0, const double a0, const std::map<double, double> & jerk_profile, const double t);
 
+std::vector<double> calcVelocityProfileWithConstantJerkAndAccelerationLimit(
+  const TrajectoryPoints & trajectory, const double v0, const double a0, const double jerk,
+  const double acc_max, const double acc_min);
+
 }  // namespace trajectory_utils
 }  // namespace motion_velocity_smoother
 

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -513,6 +513,11 @@ bool MotionVelocitySmootherNode::smoothVelocity(
   const auto traj_pre_resampled_closest = motion_utils::findNearestIndex(
     *traj_lateral_acc_filtered, current_pose_ptr_->pose, std::numeric_limits<double>::max(),
     node_param_.delta_yaw_threshold);
+  if (!traj_pre_resampled_closest) {
+    RCLCPP_WARN(
+      get_logger(), "Cannot find closest waypoint for traj_lateral_acc_filtered trajectory");
+    return false;
+  }
   auto traj_resampled = smoother_->resampleTrajectory(
     *traj_lateral_acc_filtered, current_odometry_ptr_->twist.twist.linear.x,
     *traj_pre_resampled_closest);

--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -273,7 +273,8 @@ boost::optional<TrajectoryPoints> AnalyticalJerkConstrainedSmoother::resampleTra
 }
 
 boost::optional<TrajectoryPoints> AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilter(
-  const TrajectoryPoints & input) const
+  const TrajectoryPoints & input, [[maybe_unused]] const double v0,
+  [[maybe_unused]] const double a0, [[maybe_unused]] const bool enable_smooth_limit) const
 {
   if (input.empty()) {
     return boost::none;

--- a/planning/motion_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/motion_velocity_smoother/src/trajectory_utils.cpp
@@ -639,5 +639,32 @@ boost::optional<std::tuple<double, double, double, double>> updateStateWithJerkC
   return {};
 }
 
+std::vector<double> calcVelocityProfileWithConstantJerkAndAccelerationLimit(
+  const TrajectoryPoints & trajectory, const double v0, const double a0, const double jerk,
+  const double acc_max, const double acc_min)
+{
+  if (trajectory.empty()) return {};
+
+  std::vector<double> velocities(trajectory.size());
+  velocities.at(0) = v0;
+  auto curr_v = v0;
+  auto curr_a = a0;
+
+  const auto intervals = calcTrajectoryIntervalDistance(trajectory);
+
+  if (intervals.size() + 1 != trajectory.size()) {
+    throw std::logic_error("interval calculation result has unexpected array size.");
+  }
+
+  for (size_t i = 0; i < intervals.size(); ++i) {
+    const auto t = intervals.at(i) / std::max(velocities.at(i), 1.0e-5);
+    curr_v = integ_v(curr_v, curr_a, jerk, t);
+    velocities.at(i + 1) = curr_v;
+    curr_a = std::clamp(integ_a(curr_a, jerk, t), acc_min, acc_max);
+  }
+
+  return velocities;
+}
+
 }  // namespace trajectory_utils
 }  // namespace motion_velocity_smoother


### PR DESCRIPTION
## Description

- Add minimum velocity filter to prevent sudden deceleration in the lateral acceleration filtering process.
- Add guard for optional variable


## Related links

<!-- Write the links related to this PR. -->

## Tests performed

- Checked if the lateral acc limit works as it was in Odaiba-map
- No strong deceleration occurs in noisy path planning

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

pls check the deceleration on curve still work well

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
