### PR TITLE
fix(map_based_prediction): fix prediction logic for crosswalk user

### DIFF
--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -542,26 +542,29 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
   } else if (withinRoadLanelet(object, lanelet_map_ptr_)) {
     lanelet::ConstLanelet closest_crosswalk{};
     const auto & obj_pose = object.kinematics.pose_with_covariance.pose;
-    lanelet::utils::query::getClosestLanelet(crosswalks_, obj_pose, &closest_crosswalk);
+    const auto found_closest_crosswalk =
+      lanelet::utils::query::getClosestLanelet(crosswalks_, obj_pose, &closest_crosswalk);
 
-    const auto entry_point = getCrosswalkEntryPoint(closest_crosswalk);
+    if (found_closest_crosswalk) {
+      const auto entry_point = getCrosswalkEntryPoint(closest_crosswalk);
 
-    if (hasPotentialToReach(
-          object, entry_point.first, std::numeric_limits<double>::max(),
-          min_velocity_for_map_based_prediction_)) {
-      PredictedPath predicted_path =
-        path_generator_->generatePathToTargetPoint(object, entry_point.first);
-      predicted_path.confidence = 1.0;
-      predicted_object.kinematics.predicted_paths.push_back(predicted_path);
-    }
+      if (hasPotentialToReach(
+            object, entry_point.first, std::numeric_limits<double>::max(),
+            min_velocity_for_map_based_prediction_)) {
+        PredictedPath predicted_path =
+          path_generator_->generatePathToTargetPoint(object, entry_point.first);
+        predicted_path.confidence = 1.0;
+        predicted_object.kinematics.predicted_paths.push_back(predicted_path);
+      }
 
-    if (hasPotentialToReach(
-          object, entry_point.first, std::numeric_limits<double>::max(),
-          min_velocity_for_map_based_prediction_)) {
-      PredictedPath predicted_path =
-        path_generator_->generatePathToTargetPoint(object, entry_point.second);
-      predicted_path.confidence = 1.0;
-      predicted_object.kinematics.predicted_paths.push_back(predicted_path);
+      if (hasPotentialToReach(
+            object, entry_point.first, std::numeric_limits<double>::max(),
+            min_velocity_for_map_based_prediction_)) {
+        PredictedPath predicted_path =
+          path_generator_->generatePathToTargetPoint(object, entry_point.second);
+        predicted_path.confidence = 1.0;
+        predicted_object.kinematics.predicted_paths.push_back(predicted_path);
+      }
     }
 
   } else {

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -549,7 +549,7 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
       const auto entry_point = getCrosswalkEntryPoint(closest_crosswalk);
 
       if (hasPotentialToReach(
-            object, entry_point.first, std::numeric_limits<double>::max(),
+            object, entry_point.first, prediction_time_horizon_ * 2.0,
             min_velocity_for_map_based_prediction_)) {
         PredictedPath predicted_path =
           path_generator_->generatePathToTargetPoint(object, entry_point.first);
@@ -558,7 +558,7 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
       }
 
       if (hasPotentialToReach(
-            object, entry_point.first, std::numeric_limits<double>::max(),
+            object, entry_point.first, prediction_time_horizon_ * 2.0,
             min_velocity_for_map_based_prediction_)) {
         PredictedPath predicted_path =
           path_generator_->generatePathToTargetPoint(object, entry_point.second);

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -558,7 +558,7 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
       }
 
       if (hasPotentialToReach(
-            object, entry_point.first, prediction_time_horizon_ * 2.0,
+            object, entry_point.second, prediction_time_horizon_ * 2.0,
             min_velocity_for_map_based_prediction_)) {
         PredictedPath predicted_path =
           path_generator_->generatePathToTargetPoint(object, entry_point.second);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

fix prediction policy for crosswalk user (PEDESTRIAN, BICYCLE)

- If the object is within crosswalk, the module outputs prediction path toward **both** side of the crosswalk at **all time.**
- If the object is within road, the module outputs prediction path toward **both** side of the **nearest** crosswalk at **all time.**

befor(the module does **NOT** output prediction path toward exit side)

https://user-images.githubusercontent.com/44889564/179123309-31ed0a0b-086b-4a59-b644-a5aa042a1f7d.mp4

afterr(the module outputs prediction path toward exit side)

https://user-images.githubusercontent.com/44889564/179123402-233885dc-f79f-4f71-90c3-525fe3d80684.mp4


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
