### PR TITLE
fix(behavior_velociry_planner): change virtual wall color in slow down condition

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -638,7 +638,12 @@ void CrosswalkModule::insertDecelPoint(
   setDistance(stop_point_distance);
 
   debug_data_.first_stop_pose = stop_point.second.point.pose;
-  debug_data_.stop_poses.push_back(stop_point.second.point.pose);
+
+  if (std::abs(target_velocity) < 1e-3) {
+    debug_data_.stop_poses.push_back(stop_point.second.point.pose);
+  } else {
+    debug_data_.slow_poses.push_back(stop_point.second.point.pose);
+  }
 }
 
 float CrosswalkModule::calcTargetVelocity(


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

change virtual wall color in slow down condition

test with foa(RTC)

https://user-images.githubusercontent.com/44889564/179164100-a85ee5ca-49ab-4010-a6a1-64400ee3a6fb.mp4

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
