### PR TITLE
feat(map_based_prediction): fix object yaw and velocity when necessary

### DIFF
--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -160,7 +160,7 @@ private:
     const lanelet::BasicPoint2d & search_point);
   float calculateLocalLikelihood(
     const lanelet::Lanelet & current_lanelet, const TrackedObject & object) const;
-  static double getObjectYaw(const TrackedObject & object);
+  void updateObjectData(TrackedObject & object);
 
   void updateObjectsHistory(
     const std_msgs::msg::Header & header, const TrackedObject & object,

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -620,7 +620,6 @@ void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
   if (
     object.kinematics.orientation_availability ==
     autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE) {
-    std::cerr << "Available" << std::endl;
     return;
   }
 

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -17,6 +17,8 @@
 #include <interpolation/linear_interpolation.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
+#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
 
@@ -385,6 +387,9 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
       label == ObjectClassification::CAR || label == ObjectClassification::BUS ||
       label == ObjectClassification::TRAILER || label == ObjectClassification::MOTORCYCLE ||
       label == ObjectClassification::TRUCK) {
+      // Update object yaw and velocity
+      updateObjectData(transformed_object);
+
       // Get Closest Lanelet
       const auto current_lanelets = getCurrentLanelets(transformed_object);
 
@@ -610,17 +615,33 @@ PredictedObject MapBasedPredictionNode::getPredictedObjectAsCrosswalkUser(
   return predicted_object;
 }
 
-double MapBasedPredictionNode::getObjectYaw(const TrackedObject & object)
+void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
 {
-  if (object.kinematics.orientation_availability) {
-    return tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
+  if (
+    object.kinematics.orientation_availability ==
+    autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE) {
+    return;
   }
 
+  // Compute yaw angle from the velocity and position of the object
+  const auto original_object_yaw =
+    tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
   const auto & object_pose = object.kinematics.pose_with_covariance.pose;
   const auto & object_twist = object.kinematics.twist_with_covariance.twist;
   const auto future_object_pose = tier4_autoware_utils::calcOffsetPose(
     object_pose, object_twist.linear.x * 0.1, object_twist.linear.y * 0.1, 0.0);
-  return tier4_autoware_utils::calcAzimuthAngle(object_pose.position, future_object_pose.position);
+  const auto updated_object_yaw =
+    tier4_autoware_utils::calcAzimuthAngle(object_pose.position, future_object_pose.position);
+
+  object.kinematics.pose_with_covariance.pose.orientation =
+    tier4_autoware_utils::createQuaternionFromYaw(updated_object_yaw);
+
+  // If the object yaw flips, we also flip the velocity
+  if (std::fabs(updated_object_yaw - original_object_yaw) > tier4_autoware_utils::pi / 2.0) {
+    object.kinematics.twist_with_covariance.twist.linear.x *= -1.0;
+  }
+
+  return;
 }
 
 void MapBasedPredictionNode::removeOldObjectsHistory(const double current_time)
@@ -731,7 +752,7 @@ bool MapBasedPredictionNode::checkCloseLaneletCondition(
   }
 
   // Step3. Calculate the angle difference between the lane angle and obstacle angle
-  const double object_yaw = getObjectYaw(object);
+  const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
   const double lane_yaw = lanelet::utils::getLaneletAngle(
     lanelet.second, object.kinematics.pose_with_covariance.pose.position);
   const double delta_yaw = object_yaw - lane_yaw;
@@ -758,7 +779,7 @@ float MapBasedPredictionNode::calculateLocalLikelihood(
   const auto & obj_point = object.kinematics.pose_with_covariance.pose.position;
 
   // compute yaw difference between the object and lane
-  const double obj_yaw = getObjectYaw(object);
+  const double obj_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
   const double lane_yaw = lanelet::utils::getLaneletAngle(current_lanelet, obj_point);
   const double delta_yaw = obj_yaw - lane_yaw;
   const double abs_norm_delta_yaw = std::fabs(tier4_autoware_utils::normalizeRadian(delta_yaw));
@@ -798,7 +819,7 @@ void MapBasedPredictionNode::updateObjectsHistory(
   single_object_data.current_lanelets = current_lanelets;
   single_object_data.future_possible_lanelets = current_lanelets;
   single_object_data.pose = object.kinematics.pose_with_covariance.pose;
-  const double object_yaw = getObjectYaw(object);
+  const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
   single_object_data.pose.orientation = tier4_autoware_utils::createQuaternionFromYaw(object_yaw);
   single_object_data.time_delay = std::fabs((this->get_clock()->now() - header.stamp).seconds());
   single_object_data.twist = object.kinematics.twist_with_covariance.twist;

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -624,20 +624,18 @@ void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
   }
 
   // Compute yaw angle from the velocity and position of the object
-  const auto original_object_yaw =
-    tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
   const auto & object_pose = object.kinematics.pose_with_covariance.pose;
   const auto & object_twist = object.kinematics.twist_with_covariance.twist;
   const auto future_object_pose = tier4_autoware_utils::calcOffsetPose(
     object_pose, object_twist.linear.x * 0.1, object_twist.linear.y * 0.1, 0.0);
-  const auto updated_object_yaw =
-    tier4_autoware_utils::calcAzimuthAngle(object_pose.position, future_object_pose.position);
 
-  object.kinematics.pose_with_covariance.pose.orientation =
-    tier4_autoware_utils::createQuaternionFromYaw(updated_object_yaw);
+  if (object.kinematics.twist_with_covariance.twist.linear.x < 0.0) {
+    const auto updated_object_yaw =
+      tier4_autoware_utils::calcAzimuthAngle(object_pose.position, future_object_pose.position);
 
-  // If the object yaw flips, we also flip the velocity
-  if (std::fabs(updated_object_yaw - original_object_yaw) > tier4_autoware_utils::pi / 2.0) {
+    object.kinematics.pose_with_covariance.pose.orientation =
+      tier4_autoware_utils::createQuaternionFromYaw(updated_object_yaw);
+
     object.kinematics.twist_with_covariance.twist.linear.x *= -1.0;
   }
 

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -620,6 +620,7 @@ void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
   if (
     object.kinematics.orientation_availability ==
     autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE) {
+    std::cerr << "Available" << std::endl;
     return;
   }
 
@@ -630,11 +631,21 @@ void MapBasedPredictionNode::updateObjectData(TrackedObject & object)
     object_pose, object_twist.linear.x * 0.1, object_twist.linear.y * 0.1, 0.0);
 
   if (object.kinematics.twist_with_covariance.twist.linear.x < 0.0) {
-    const auto updated_object_yaw =
-      tier4_autoware_utils::calcAzimuthAngle(object_pose.position, future_object_pose.position);
+    if (
+      object.kinematics.orientation_availability ==
+      autoware_auto_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN) {
+      const auto original_yaw =
+        tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
+      // flip the angle
+      object.kinematics.pose_with_covariance.pose.orientation =
+        tier4_autoware_utils::createQuaternionFromYaw(tier4_autoware_utils::pi + original_yaw);
+    } else {
+      const auto updated_object_yaw =
+        tier4_autoware_utils::calcAzimuthAngle(object_pose.position, future_object_pose.position);
 
-    object.kinematics.pose_with_covariance.pose.orientation =
-      tier4_autoware_utils::createQuaternionFromYaw(updated_object_yaw);
+      object.kinematics.pose_with_covariance.pose.orientation =
+        tier4_autoware_utils::createQuaternionFromYaw(updated_object_yaw);
+    }
 
     object.kinematics.twist_with_covariance.twist.linear.x *= -1.0;
   }


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
Currently, map based prediction has a serious issue that cannot handle the wrong yaw angle of the object. In order to fix this problem, I changed the condition and object yaw and velocity when necessary.

https://user-images.githubusercontent.com/43805014/179172812-37ebbfc5-b697-418a-ab87-10f12ff2590a.mp4



## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
