### PR TITLE
feat(intersection_module): add option to change the stopline position

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -15,6 +15,7 @@
       min_predicted_path_confidence: 0.05
       collision_start_margin_time: 5.0 # [s]
       collision_end_margin_time: 2.0 # [s]
+      use_stuck_stopline: false # stopline generate before the intersection lanelet when is_stuck
 
     merge_from_private_road:
       stop_duration_sec: 1.0

--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -15,6 +15,7 @@
       min_predicted_path_confidence: 0.05
       collision_start_margin_time: 5.0 # [s]
       collision_end_margin_time: 2.0 # [s]
+      use_stuck_stopline: false # stopline generate before the intersection lanelet when is_stuck
 
     merge_from_private_road:
       stop_duration_sec: 1.0

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -122,6 +122,7 @@ public:
     double external_input_timeout;       //! used to disable external input
     double collision_start_margin_time;  //! start margin time to check collision
     double collision_end_margin_time;    //! end margin time to check collision
+    bool use_stuck_stopline;    //! stopline generate before the intersection lanelet when is_stuck.
   };
 
   IntersectionModule(

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -177,7 +177,7 @@ private:
   bool checkStuckVehicleInIntersection(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
-    const int stop_idx,
+    const int stop_idx, int * stuck_stop_idx,
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr) const;
 
   /**

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -122,7 +122,7 @@ public:
     double external_input_timeout;       //! used to disable external input
     double collision_start_margin_time;  //! start margin time to check collision
     double collision_end_margin_time;    //! end margin time to check collision
-    bool use_stuck_stopline;    //! stopline generate before the intersection lanelet when is_stuck.
+    bool use_stuck_stopline;  //! stopline generate before the intersection lanelet when is_stuck.
   };
 
   IntersectionModule(

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -178,7 +178,7 @@ private:
   bool checkStuckVehicleInIntersection(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
-    const int stop_idx, int * stuck_stop_idx,
+    const int stop_idx,
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr) const;
 
   /**

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -84,15 +84,16 @@ bool generateStopLine(
  * @brief If use_stuck_stopline is true, a stop line is generated before the intersection.
  * @param input_path      input path
  * @param output_path     output path
- * @param offset          ego longitudinal offset
  * @param stuck_stop_line_idx   generated stuck stop line index
+ * @param pass_judge_line_idx  generated pass judge line index
  * @return false when generation failed
  */
 bool generateStopLineBeforeIntersection(
   const int lane_id, lanelet::LaneletMapConstPtr lanelet_map_ptr,
+  const std::shared_ptr<const PlannerData> & planner_data,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path,
   autoware_auto_planning_msgs::msg::PathWithLaneId * output_path,
-  const double & offset, int * stuck_stop_line_idx,
+   int * stuck_stop_line_idx, int * pass_judge_line_idx,
   const rclcpp::Logger logger);
 
 /**

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -92,9 +92,8 @@ bool generateStopLineBeforeIntersection(
   const int lane_id, lanelet::LaneletMapConstPtr lanelet_map_ptr,
   const std::shared_ptr<const PlannerData> & planner_data,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path,
-  autoware_auto_planning_msgs::msg::PathWithLaneId * output_path,
-   int * stuck_stop_line_idx, int * pass_judge_line_idx,
-  const rclcpp::Logger logger);
+  autoware_auto_planning_msgs::msg::PathWithLaneId * output_path, int * stuck_stop_line_idx,
+  int * pass_judge_line_idx, const rclcpp::Logger logger);
 
 /**
  * @brief Calculate first path index that is in the polygon.

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -81,6 +81,21 @@ bool generateStopLine(
   int * pass_judge_line_idx, int * first_idx_inside_lane, const rclcpp::Logger logger);
 
 /**
+ * @brief If use_stuck_stopline is true, a stop line is generated before the intersection.
+ * @param input_path      input path
+ * @param output_path     output path
+ * @param offset          ego longitudinal offset
+ * @param stuck_stop_line_idx   generated stuck stop line index
+ * @return false when generation failed
+ */
+bool generateStopLineBeforeIntersection(
+  const int lane_id, lanelet::LaneletMapConstPtr lanelet_map_ptr,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path,
+  autoware_auto_planning_msgs::msg::PathWithLaneId * output_path,
+  const double & offset, int * stuck_stop_line_idx,
+  const rclcpp::Logger logger);
+
+/**
  * @brief Calculate first path index that is in the polygon.
  * @param path     target path
  * @param polygons target polygon

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -50,6 +50,7 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   ip.external_input_timeout = node.declare_parameter(ns + ".walkway.external_input_timeout", 1.0);
   ip.collision_start_margin_time = node.declare_parameter(ns + ".collision_start_margin_time", 5.0);
   ip.collision_end_margin_time = node.declare_parameter(ns + ".collision_end_margin_time", 2.0);
+  ip.use_stuck_stopline = node.declare_parameter(ns + ".use_stuck_stopline", true);
 }
 
 MergeFromPrivateModuleManager::MergeFromPrivateModuleManager(rclcpp::Node & node)

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -190,11 +190,12 @@ bool IntersectionModule::modifyPathVelocity(
 
   if (!isActivated()) {
     constexpr double v = 0.0;
-    if(planner_param_.use_stuck_stopline && is_stuck){
+    if (planner_param_.use_stuck_stopline && is_stuck) {
       int stuck_stop_line_idx = -1;
       int stuck_pass_judge_line_idx = -1;
-      if(util::generateStopLineBeforeIntersection(lane_id_, lanelet_map_ptr, planner_data_,
-            *path, path, &stuck_stop_line_idx, &stuck_pass_judge_line_idx, logger_.get_child("util"))){
+      if (util::generateStopLineBeforeIntersection(
+            lane_id_, lanelet_map_ptr, planner_data_, *path, path, &stuck_stop_line_idx,
+            &stuck_pass_judge_line_idx, logger_.get_child("util"))) {
         stop_line_idx = stuck_stop_line_idx;
         pass_judge_line_idx = stuck_pass_judge_line_idx;
       }

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -190,15 +190,13 @@ bool IntersectionModule::modifyPathVelocity(
 
   if (!isActivated()) {
     constexpr double v = 0.0;
-    if(planner_param_.use_stuck_stopline){
-      if(is_stuck){
-        int stuck_stop_line_idx = -1;
-        int stuck_pass_judge_line_idx = -1;
-        if(util::generateStopLineBeforeIntersection(lane_id_, lanelet_map_ptr, planner_data_,
-              *path, path, &stuck_stop_line_idx, &stuck_pass_judge_line_idx, logger_.get_child("util"))){
-          stop_line_idx = stuck_stop_line_idx;
-          pass_judge_line_idx = stuck_pass_judge_line_idx;
-        }
+    if(planner_param_.use_stuck_stopline && is_stuck){
+      int stuck_stop_line_idx = -1;
+      int stuck_pass_judge_line_idx = -1;
+      if(util::generateStopLineBeforeIntersection(lane_id_, lanelet_map_ptr, planner_data_,
+            *path, path, &stuck_stop_line_idx, &stuck_pass_judge_line_idx, logger_.get_child("util"))){
+        stop_line_idx = stuck_stop_line_idx;
+        pass_judge_line_idx = stuck_pass_judge_line_idx;
       }
     }
     util::setVelocityFrom(stop_line_idx, v, path);

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -189,7 +189,7 @@ bool IntersectionModule::modifyPathVelocity(
     input_path.points.at(stop_line_idx).point.pose.position));
 
   if (!isActivated()) {
-    const double v = 0.0;
+    constexpr double v = 0.0;
     util::setVelocityFrom(stop_line_idx, v, path);
 
     debug_data_.stop_required = true;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -193,10 +193,12 @@ bool IntersectionModule::modifyPathVelocity(
     if(planner_param_.use_stuck_stopline){
       if(is_stuck){
         int stuck_stop_line_idx = -1;
-        if(util::generateStopLineBeforeIntersection(lane_id_, lanelet_map_ptr, *path, path,
-              base_link2front, &stuck_stop_line_idx, logger_.get_child("util"))){
+        int stuck_pass_judge_line_idx = -1;
+        if(util::generateStopLineBeforeIntersection(lane_id_, lanelet_map_ptr, planner_data_,
+              *path, path, &stuck_stop_line_idx, &stuck_pass_judge_line_idx, logger_.get_child("util"))){
           stop_line_idx = stuck_stop_line_idx;
-        };
+          pass_judge_line_idx = stuck_pass_judge_line_idx;
+        }
       }
     }
     util::setVelocityFrom(stop_line_idx, v, path);

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -498,7 +498,11 @@ bool IntersectionModule::checkStuckVehicleInIntersection(
       for (size_t i = 0; i < path.points.size(); i++) {
         const auto & p = path.points.at(i).point.pose.position;
         if (p.x == lane_first_point.x() && p.y == lane_first_point.y()) {
-          *stuck_stop_idx = static_cast<int>(i);
+          /* set parameters */
+          constexpr double interval = 0.2;
+          const int base2front_idx_dist =
+            std::ceil(planner_data_->vehicle_info_.max_longitudinal_offset_m / interval);
+          *stuck_stop_idx = std::max(static_cast<int>(i) - base2front_idx_dist, 0);
         }
       }
       RCLCPP_DEBUG(logger_, "stuck vehicle found.");

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -501,5 +501,66 @@ lanelet::ConstLanelet generateOffsetLanelet(
   return std::move(lanelet_with_margin);
 }
 
+bool generateStopLineBeforeIntersection(
+  const int lane_id, lanelet::LaneletMapConstPtr lanelet_map_ptr,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path,
+  autoware_auto_planning_msgs::msg::PathWithLaneId * output_path,
+  const double & offset, int * stuck_stop_line_idx,
+  const rclcpp::Logger logger)
+{
+  /* set parameters */
+  constexpr double interval = 0.2;
+  const int base2front_idx_dist = std::ceil(offset / interval);
+
+  /* spline interpolation */
+  autoware_auto_planning_msgs::msg::PathWithLaneId path_ip;
+  if (!splineInterpolate(input_path, interval, &path_ip, logger)) {
+    return false;
+  }
+  const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id);
+  for (size_t i = 0; i < path_ip.points.size(); i++) {
+    const auto & p = path_ip.points.at(i).point.pose;
+    if (lanelet::utils::isInLanelet(p, assigned_lanelet, 0.1)) {
+      if (static_cast<int>(i) == -1) {
+        RCLCPP_DEBUG(logger, "generate stopline, but no within lanelet.");
+        return false;
+      }
+      if (static_cast<int>(i) == 0) {
+        RCLCPP_DEBUG(logger, "stuck stop point is path[0].");
+        *stuck_stop_line_idx = 0;
+        return true;
+      }
+      int stop_idx_ip;               // stop point index for interpolated path.
+      stop_idx_ip = std::max(static_cast<int>(i) - base2front_idx_dist, 0);
+
+      /* insert stop_point */
+      const auto inserted_stop_point = path_ip.points.at(stop_idx_ip).point.pose;
+
+      // if path has too close (= duplicated) point to the stop point, do not insert it
+      // and consider the index of the duplicated point as *stuck_stop_line_idx
+      if (!util::hasDuplicatedPoint(*output_path, inserted_stop_point.position, stuck_stop_line_idx)) {
+        *stuck_stop_line_idx = util::insertPoint(inserted_stop_point, output_path);
+        std::cerr << "insert stuck stop point" << std::endl;
+      }
+
+      /* if another stop point exist before intersection stop_line, disable judge_line. */
+      bool has_prior_stopline = false;
+      for (int i = 0; i < *stuck_stop_line_idx; ++i) {
+        if (std::fabs(output_path->points.at(i).point.longitudinal_velocity_mps) < 0.1) {
+          has_prior_stopline = true;
+          break;
+        }
+      }
+
+      RCLCPP_DEBUG(
+        logger,
+        "generateStopLine() : stuck_stop_line_idx = %d, stop_idx_ip = %d, has_prior_stopline = %d",
+        * stuck_stop_line_idx, stop_idx_ip, has_prior_stopline);
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace util
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -503,14 +503,26 @@ lanelet::ConstLanelet generateOffsetLanelet(
 
 bool generateStopLineBeforeIntersection(
   const int lane_id, lanelet::LaneletMapConstPtr lanelet_map_ptr,
+  const std::shared_ptr<const PlannerData> & planner_data,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path,
   autoware_auto_planning_msgs::msg::PathWithLaneId * output_path,
-  const double & offset, int * stuck_stop_line_idx,
+  int * stuck_stop_line_idx, int * pass_judge_line_idx,
   const rclcpp::Logger logger)
 {
+  /* set judge line dist */
+  const double current_vel = planner_data->current_velocity->twist.linear.x;
+  const double current_acc = planner_data->current_accel.get();
+  const double max_acc = planner_data->max_stop_acceleration_threshold;
+  const double max_jerk = planner_data->max_stop_jerk_threshold;
+  const double delay_response_time = planner_data->delay_response_time;
+  const double pass_judge_line_dist = planning_utils::calcJudgeLineDistWithJerkLimit(
+    current_vel, current_acc, max_acc, max_jerk, delay_response_time);
+
   /* set parameters */
   constexpr double interval = 0.2;
-  const int base2front_idx_dist = std::ceil(offset / interval);
+  const int base2front_idx_dist =
+    std::ceil(planner_data->vehicle_info_.max_longitudinal_offset_m / interval);
+  const int pass_judge_idx_dist = std::ceil(pass_judge_line_dist / interval);
 
   /* spline interpolation */
   autoware_auto_planning_msgs::msg::PathWithLaneId path_ip;
@@ -521,26 +533,19 @@ bool generateStopLineBeforeIntersection(
   for (size_t i = 0; i < path_ip.points.size(); i++) {
     const auto & p = path_ip.points.at(i).point.pose;
     if (lanelet::utils::isInLanelet(p, assigned_lanelet, 0.1)) {
-      if (static_cast<int>(i) == -1) {
+      if (static_cast<int>(i) <= 0) {
         RCLCPP_DEBUG(logger, "generate stopline, but no within lanelet.");
         return false;
-      }
-      if (static_cast<int>(i) == 0) {
-        RCLCPP_DEBUG(logger, "stuck stop point is path[0].");
-        *stuck_stop_line_idx = 0;
-        return true;
       }
       int stop_idx_ip;               // stop point index for interpolated path.
       stop_idx_ip = std::max(static_cast<int>(i) - base2front_idx_dist, 0);
 
       /* insert stop_point */
       const auto inserted_stop_point = path_ip.points.at(stop_idx_ip).point.pose;
-
       // if path has too close (= duplicated) point to the stop point, do not insert it
       // and consider the index of the duplicated point as *stuck_stop_line_idx
       if (!util::hasDuplicatedPoint(*output_path, inserted_stop_point.position, stuck_stop_line_idx)) {
         *stuck_stop_line_idx = util::insertPoint(inserted_stop_point, output_path);
-        std::cerr << "insert stuck stop point" << std::endl;
       }
 
       /* if another stop point exist before intersection stop_line, disable judge_line. */
@@ -552,10 +557,27 @@ bool generateStopLineBeforeIntersection(
         }
       }
 
+      /* insert judge point */
+      const int pass_judge_idx_ip = std::min(
+        static_cast<int>(path_ip.points.size()) - 1, std::max(stop_idx_ip - pass_judge_idx_dist, 0));
+      if (has_prior_stopline || stop_idx_ip == pass_judge_idx_ip) {
+        *pass_judge_line_idx = *stuck_stop_line_idx;
+      } else {
+        const auto inserted_pass_judge_point = path_ip.points.at(pass_judge_idx_ip).point.pose;
+        // if path has too close (= duplicated) point to the pass judge point, do not insert it
+        // and consider the index of the duplicated point as pass_judge_line_idx
+        if (!util::hasDuplicatedPoint(
+              *output_path, inserted_pass_judge_point.position, pass_judge_line_idx)) {
+          *pass_judge_line_idx = util::insertPoint(inserted_pass_judge_point, output_path);
+          ++(*stuck_stop_line_idx);  // stop index is incremented by judge line insertion
+        }
+      }
+
       RCLCPP_DEBUG(
         logger,
-        "generateStopLine() : stuck_stop_line_idx = %d, stop_idx_ip = %d, has_prior_stopline = %d",
-        * stuck_stop_line_idx, stop_idx_ip, has_prior_stopline);
+        "generateStopLineBeforeIntersection() : stuck_stop_line_idx = %d, pass_judge_idx = %d,"
+        "stop_idx_ip = %d, pass_judge_idx_ip = %d, has_prior_stopline = %d",
+        * stuck_stop_line_idx, *pass_judge_line_idx, stop_idx_ip, pass_judge_idx_ip, has_prior_stopline);
       return true;
     }
   }

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -505,9 +505,8 @@ bool generateStopLineBeforeIntersection(
   const int lane_id, lanelet::LaneletMapConstPtr lanelet_map_ptr,
   const std::shared_ptr<const PlannerData> & planner_data,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path,
-  autoware_auto_planning_msgs::msg::PathWithLaneId * output_path,
-  int * stuck_stop_line_idx, int * pass_judge_line_idx,
-  const rclcpp::Logger logger)
+  autoware_auto_planning_msgs::msg::PathWithLaneId * output_path, int * stuck_stop_line_idx,
+  int * pass_judge_line_idx, const rclcpp::Logger logger)
 {
   /* set judge line dist */
   const double current_vel = planner_data->current_velocity->twist.linear.x;
@@ -537,14 +536,15 @@ bool generateStopLineBeforeIntersection(
         RCLCPP_DEBUG(logger, "generate stopline, but no within lanelet.");
         return false;
       }
-      int stop_idx_ip;               // stop point index for interpolated path.
+      int stop_idx_ip;  // stop point index for interpolated path.
       stop_idx_ip = std::max(static_cast<int>(i) - base2front_idx_dist, 0);
 
       /* insert stop_point */
       const auto inserted_stop_point = path_ip.points.at(stop_idx_ip).point.pose;
       // if path has too close (= duplicated) point to the stop point, do not insert it
       // and consider the index of the duplicated point as *stuck_stop_line_idx
-      if (!util::hasDuplicatedPoint(*output_path, inserted_stop_point.position, stuck_stop_line_idx)) {
+      if (!util::hasDuplicatedPoint(
+            *output_path, inserted_stop_point.position, stuck_stop_line_idx)) {
         *stuck_stop_line_idx = util::insertPoint(inserted_stop_point, output_path);
       }
 
@@ -559,7 +559,8 @@ bool generateStopLineBeforeIntersection(
 
       /* insert judge point */
       const int pass_judge_idx_ip = std::min(
-        static_cast<int>(path_ip.points.size()) - 1, std::max(stop_idx_ip - pass_judge_idx_dist, 0));
+        static_cast<int>(path_ip.points.size()) - 1,
+        std::max(stop_idx_ip - pass_judge_idx_dist, 0));
       if (has_prior_stopline || stop_idx_ip == pass_judge_idx_ip) {
         *pass_judge_line_idx = *stuck_stop_line_idx;
       } else {
@@ -577,7 +578,8 @@ bool generateStopLineBeforeIntersection(
         logger,
         "generateStopLineBeforeIntersection() : stuck_stop_line_idx = %d, pass_judge_idx = %d,"
         "stop_idx_ip = %d, pass_judge_idx_ip = %d, has_prior_stopline = %d",
-        * stuck_stop_line_idx, *pass_judge_line_idx, stop_idx_ip, pass_judge_idx_ip, has_prior_stopline);
+        *stuck_stop_line_idx, *pass_judge_line_idx, stop_idx_ip, pass_judge_idx_ip,
+        has_prior_stopline);
       return true;
     }
   }


### PR DESCRIPTION
## Description
Addition of an option to change the position of the stop line to before the intersection when a stack vehicle is detected.
## Related links

## Tests performed
use_stuck_stopline = true
![image](https://user-images.githubusercontent.com/57553950/179648626-a6064d5d-5fb5-49f6-bbbb-ac02f2b8208d.png)

use_stuck_stopline = false
![image](https://user-images.githubusercontent.com/57553950/179648800-080ad0e5-4c55-448e-8417-929c57728b54.png)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
