### PR TITLE
fix(behavior_velocity_planner): lerp stop point z coordinate

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -229,11 +229,13 @@ PathPointWithLaneId getBackwardPointFromBasePoint(
   PathPointWithLaneId output;
   const double dx = p_to.point.pose.position.x - p_from.point.pose.position.x;
   const double dy = p_to.point.pose.position.y - p_from.point.pose.position.y;
-  const double norm = std::hypot(dx, dy);
+  const double dz = p_to.point.pose.position.z - p_from.point.pose.position.z;
+  const double norm = std::hypot(dx, dy, dz);
 
   output = p_base;
   output.point.pose.position.x += backward_length * dx / norm;
   output.point.pose.position.y += backward_length * dy / norm;
+  output.point.pose.position.z += backward_length * dz / norm;
 
   return output;
 }


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

- fix stop point z position (use lerp)

Before (use z position of the front point)

![image](https://user-images.githubusercontent.com/44889564/179696705-d2042807-431a-48ac-b20d-1854c3cbc23f.png)

After (lerp z position)

![rviz_screenshot_2022_07_19-16_45_37](https://user-images.githubusercontent.com/44889564/179696930-c98db0fa-44aa-4337-95c9-0d42f484c190.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
