### PR TITLE
fix(behavior_velocity_planner): output stop reason when RTC sends deactivate command

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -107,10 +107,10 @@ private:
   int64_t module_id_;
 
   boost::optional<std::pair<size_t, PathPointWithLaneId>> findRTCStopPoint(
-    const PathWithLaneId & ego_path);
+    const PathWithLaneId & ego_path, StopFactor & stop_factor);
 
   boost::optional<std::pair<size_t, PathPointWithLaneId>> findNearestStopPoint(
-    const PathWithLaneId & ego_path, StopReason & stop_reason);
+    const PathWithLaneId & ego_path, StopFactor & stop_factor);
 
   boost::optional<std::pair<double, geometry_msgs::msg::Point>> getStopLine(
     const PathWithLaneId & ego_path) const;

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -354,8 +354,10 @@ bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
     logger_, planner_param_.show_processing_time, "- step2: %f ms",
     stop_watch_.toc("total_processing_time", false));
 
-  const auto nearest_stop_point = findNearestStopPoint(ego_path, *stop_reason);
-  const auto rtc_stop_point = findRTCStopPoint(ego_path);
+  StopFactor stop_factor{};
+
+  const auto nearest_stop_point = findNearestStopPoint(ego_path, stop_factor);
+  const auto rtc_stop_point = findRTCStopPoint(ego_path, stop_factor);
 
   RCLCPP_INFO_EXPRESSION(
     logger_, planner_param_.show_processing_time, "- step3: %f ms",
@@ -381,6 +383,8 @@ bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   } else if (rtc_stop_point) {
     insertDecelPoint(rtc_stop_point.get(), 0.0, *path);
   }
+
+  planning_utils::appendStopReason(stop_factor, stop_reason);
 
   RCLCPP_INFO_EXPRESSION(
     logger_, planner_param_.show_processing_time, "- step4: %f ms",
@@ -419,7 +423,7 @@ boost::optional<std::pair<double, geometry_msgs::msg::Point>> CrosswalkModule::g
 }
 
 boost::optional<std::pair<size_t, PathPointWithLaneId>> CrosswalkModule::findRTCStopPoint(
-  const PathWithLaneId & ego_path)
+  const PathWithLaneId & ego_path, StopFactor & stop_factor)
 {
   const auto & base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
 
@@ -435,14 +439,15 @@ boost::optional<std::pair<size_t, PathPointWithLaneId>> CrosswalkModule::findRTC
   const auto residual_length = calcLongitudinalOffsetToSegment(ego_path.points, base_idx, p_stop);
   const auto update_margin = margin - residual_length + base_link2front;
 
-  return getBackwardInsertPointFromBasePoint(base_idx, ego_path, update_margin);
+  const auto stop_point = getBackwardInsertPointFromBasePoint(base_idx, ego_path, update_margin);
+  stop_factor.stop_pose = stop_point.get().second.point.pose;
+
+  return stop_point;
 }
 
 boost::optional<std::pair<size_t, PathPointWithLaneId>> CrosswalkModule::findNearestStopPoint(
-  const PathWithLaneId & ego_path, StopReason & stop_reason)
+  const PathWithLaneId & ego_path, StopFactor & stop_factor)
 {
-  StopFactor stop_factor{};
-
   bool found_pedestrians = false;
   bool found_stuck_vehicle = false;
 
@@ -565,7 +570,6 @@ boost::optional<std::pair<size_t, PathPointWithLaneId>> CrosswalkModule::findNea
 
   const auto stop_point = getBackwardInsertPointFromBasePoint(base_idx, ego_path, update_margin);
   stop_factor.stop_pose = stop_point.get().second.point.pose;
-  planning_utils::appendStopReason(stop_factor, &stop_reason);
 
   return stop_point;
 }


### PR DESCRIPTION

Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

- output stop reason when RTC sends deactivate command

`ros2 topic echo /planning/scenario_planning/status/stop_reasons`

```
---
header:
  stamp:
    sec: 1658221677
    nanosec: 711467350
  frame_id: map
stop_reasons:
- reason: Intersection
  stop_factors:
  - stop_pose:
      position:
        x: 3754.9432961549437
        y: 73740.62173834527
        z: 19.3106380794887
      orientation:
        x: 0.0
        y: 0.0
        z: 0.2380742115708329
        w: 0.971246966422509
    dist_to_stop_pose: 0.0
    stop_factor_points: []
---
header:
  stamp:
    sec: 1658221677
    nanosec: 809301484
  frame_id: map
stop_reasons:
- reason: Crosswalk
  stop_factors:
  - stop_pose:
      position:
        x: 3749.9866513537954
        y: 73738.0350989553
        z: 19.331237636895924
      orientation:
        x: 0.0
        y: 0.0
        z: 0.23841642053532994
        w: 0.971163019487007
    dist_to_stop_pose: 0.0
    stop_factor_points: []
- reason: Crosswalk
  stop_factors:
  - stop_pose:
      position:
        x: 3763.2795473148863
        y: 73744.96954579547
        z: 19.309074249208603
      orientation:
        x: 0.0
        y: 0.0
        z: 0.23813417865428801
        w: 0.9712322651954308
    dist_to_stop_pose: 0.0
    stop_factor_points: []
---
header:
  stamp:
    sec: 1658221677
    nanosec: 808069794
  frame_id: map
stop_reasons:
- reason: TrafficLight
  stop_factors:
  - stop_pose:
      position:
        x: 3752.009294224483
        y: 73739.09148076354
        z: 19.322499999999998
      orientation:
        x: 0.0
        y: 0.0
        z: 0.23806562726459893
        w: 0.9712490705864861
    dist_to_stop_pose: 0.0
    stop_factor_points:
    - x: 0.0
      y: 0.0
      z: 0.0
---

```

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
