### PR TITLE
fix(tier4_vehicle_rviz_plugin): initialization vehicle rivz plugin

### DIFF
--- a/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
@@ -86,10 +86,9 @@ void ConsoleMeterDisplay::update(float wall_dt, float ros_dt)
   double linear_x = 0;
   {
     std::lock_guard<std::mutex> message_lock(mutex_);
-    if (!last_msg_ptr_) {
-      return;
+    if (last_msg_ptr_) {
+      linear_x = last_msg_ptr_->longitudinal_velocity;
     }
-    linear_x = last_msg_ptr_->longitudinal_velocity;
   }
 
   QColor background_color;

--- a/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -96,10 +96,9 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   double steering = 0;
   {
     std::lock_guard<std::mutex> message_lock(mutex_);
-    if (!last_msg_ptr_) {
-      return;
+    if (last_msg_ptr_) {
+      steering = last_msg_ptr_->steering_tire_angle;
     }
-    steering = last_msg_ptr_->steering_tire_angle;
   }
 
   QColor background_color;

--- a/common/tier4_vehicle_rviz_plugin/src/tools/turn_signal.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/turn_signal.cpp
@@ -92,7 +92,7 @@ void TurnSignalDisplay::update(float wall_dt, float ros_dt)
   (void)wall_dt;
   (void)ros_dt;
 
-  unsigned int signal_type;
+  unsigned int signal_type = 0;
   {
     std::lock_guard<std::mutex> message_lock(mutex_);
     if (last_msg_ptr_) {

--- a/common/tier4_vehicle_rviz_plugin/src/tools/turn_signal.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/turn_signal.cpp
@@ -95,10 +95,9 @@ void TurnSignalDisplay::update(float wall_dt, float ros_dt)
   unsigned int signal_type;
   {
     std::lock_guard<std::mutex> message_lock(mutex_);
-    if (!last_msg_ptr_) {
-      return;
+    if (last_msg_ptr_) {
+      signal_type = last_msg_ptr_->report;
     }
-    signal_type = last_msg_ptr_->report;
   }
 
   QColor background_color;


### PR DESCRIPTION
Signed-off-by: Takeshi Miura <m.takeshi1995@gmail.com>

## Description
Fixed a problem with initialization at rviz startup not working in environments without nvidia driver.

Before
![Screenshot from 2022-07-20 13-55-29](https://user-images.githubusercontent.com/57553950/179905185-ce0175c1-a6be-4b69-81ea-13e2f0b1a98e.png)

After
![image](https://user-images.githubusercontent.com/57553950/179905381-53653852-6fed-49b1-91ca-d1128d9a2c2c.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
