### PR TITLE
feat(motion_veloctiy_smoother): allow usage as solver library

### DIFF
--- a/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
+++ b/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
@@ -89,7 +89,7 @@ struct PlannerData
   tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr virtual_traffic_light_states;
 
   // velocity smoother
-  std::shared_ptr<motion_velocity_smoother::SmootherBase> velocity_smoother_;
+  std::shared_ptr<motion_velocity_smoother::SolverBase> velocity_smoother_;
   // route handler
   std::shared_ptr<route_handler::RouteHandler> route_handler_;
   // parameters

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -313,7 +313,7 @@ void BehaviorVelocityPlannerNode::onVehicleVelocity(
 void BehaviorVelocityPlannerNode::onParam()
 {
   planner_data_.velocity_smoother_ =
-    std::make_unique<motion_velocity_smoother::AnalyticalJerkConstrainedSmoother>(*this);
+    std::make_unique<motion_velocity_smoother::AnalyticalJerkConstrainedSolver>(*this);
   return;
 }
 

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -128,7 +128,7 @@ private:
     AlgorithmType algorithm_type;  // Option : JerkFiltered, Linf, L2
   } node_param_{};
 
-  std::shared_ptr<SmootherBase> smoother_;
+  std::shared_ptr<SolverBase> smoother_;
 
   bool publish_debug_trajs_;  // publish planned trajectories
 

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -30,7 +30,7 @@
 
 namespace motion_velocity_smoother
 {
-class AnalyticalJerkConstrainedSmoother : public SmootherBase
+class AnalyticalJerkConstrainedSolver : public SolverBase
 {
 public:
   struct Param
@@ -65,7 +65,7 @@ public:
     } backward;
   };
 
-  explicit AnalyticalJerkConstrainedSmoother(rclcpp::Node & node);
+  explicit AnalyticalJerkConstrainedSolver(rclcpp::Node & node);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -84,8 +84,6 @@ public:
 
 private:
   Param smoother_param_;
-  // rclcpp::Logger logger_{
-  //  rclcpp::get_logger("smoother").get_child("analytical_jerk_constrained_smoother")};
 
   bool searchDecelTargetIndices(
     const TrajectoryPoints & trajectory, const size_t closest_index,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -84,8 +84,8 @@ public:
 
 private:
   Param smoother_param_;
-  rclcpp::Logger logger_{
-    rclcpp::get_logger("smoother").get_child("analytical_jerk_constrained_smoother")};
+  // rclcpp::Logger logger_{
+  //  rclcpp::get_logger("smoother").get_child("analytical_jerk_constrained_smoother")};
 
   bool searchDecelTargetIndices(
     const TrajectoryPoints & trajectory, const size_t closest_index,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -65,6 +65,7 @@ public:
     } backward;
   };
 
+  AnalyticalJerkConstrainedSolver();
   explicit AnalyticalJerkConstrainedSolver(rclcpp::Node & node);
 
   bool apply(
@@ -80,6 +81,7 @@ public:
     [[maybe_unused]] const bool enable_smooth_limit) const override;
 
   void setParam(const Param & param);
+  Param getParam(rclcpp::Node & node) const;
   Param getParam() const;
 
 private:

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -40,6 +40,7 @@ public:
     double jerk_filter_ds;
   };
 
+  JerkFilteredSolver();
   explicit JerkFilteredSolver(rclcpp::Node & node);
 
   bool apply(
@@ -50,6 +51,7 @@ public:
     const TrajectoryPoints & input, const double v_current, const int closest_id) const override;
 
   void setParam(const Param & param);
+  Param getParam(rclcpp::Node & node) const;
   Param getParam() const;
 
 private:

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -55,7 +55,7 @@ public:
 private:
   Param smoother_param_;
   autoware::common::osqp::OSQPInterface qp_solver_;
-  rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("jerk_filtered_smoother")};
+  // rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("jerk_filtered_smoother")};
 
   TrajectoryPoints forwardJerkFilter(
     const double v0, const double a0, const double a_max, const double a_stop, const double j_max,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -28,7 +28,7 @@
 
 namespace motion_velocity_smoother
 {
-class JerkFilteredSmoother : public SmootherBase
+class JerkFilteredSolver : public SolverBase
 {
 public:
   struct Param
@@ -40,7 +40,7 @@ public:
     double jerk_filter_ds;
   };
 
-  explicit JerkFilteredSmoother(rclcpp::Node & node);
+  explicit JerkFilteredSolver(rclcpp::Node & node);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -55,7 +55,6 @@ public:
 private:
   Param smoother_param_;
   autoware::common::osqp::OSQPInterface qp_solver_;
-  // rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("jerk_filtered_smoother")};
 
   TrajectoryPoints forwardJerkFilter(
     const double v0, const double a0, const double a_max, const double a_stop, const double j_max,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -53,7 +53,7 @@ public:
 private:
   Param smoother_param_;
   autoware::common::osqp::OSQPInterface qp_solver_;
-  rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("l2_pseudo_jerk_smoother")};
+  // rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("l2_pseudo_jerk_smoother")};
 };
 }  // namespace motion_velocity_smoother
 

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -28,7 +28,7 @@
 
 namespace motion_velocity_smoother
 {
-class L2PseudoJerkSmoother : public SmootherBase
+class L2PseudoJerkSolver : public SolverBase
 {
 public:
   struct Param
@@ -38,7 +38,7 @@ public:
     double over_a_weight;
   };
 
-  explicit L2PseudoJerkSmoother(rclcpp::Node & node);
+  explicit L2PseudoJerkSolver(rclcpp::Node & node);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -53,7 +53,6 @@ public:
 private:
   Param smoother_param_;
   autoware::common::osqp::OSQPInterface qp_solver_;
-  // rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("l2_pseudo_jerk_smoother")};
 };
 }  // namespace motion_velocity_smoother
 

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -38,6 +38,7 @@ public:
     double over_a_weight;
   };
 
+  L2PseudoJerkSolver();
   explicit L2PseudoJerkSolver(rclcpp::Node & node);
 
   bool apply(
@@ -48,6 +49,7 @@ public:
     const TrajectoryPoints & input, const double v_current, const int closest_id) const override;
 
   void setParam(const Param & smoother_param);
+  Param getParam(rclcpp::Node & node) const;
   Param getParam() const;
 
 private:

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -53,7 +53,6 @@ public:
 private:
   Param smoother_param_;
   autoware::common::osqp::OSQPInterface qp_solver_;
-  // rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("linf_pseudo_jerk_smoother")};
 };
 }  // namespace motion_velocity_smoother
 

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -38,6 +38,7 @@ public:
     double over_a_weight;
   };
 
+  LinfPseudoJerkSolver();
   explicit LinfPseudoJerkSolver(rclcpp::Node & node);
 
   bool apply(
@@ -48,6 +49,7 @@ public:
     const TrajectoryPoints & input, const double v_current, const int closest_id) const override;
 
   void setParam(const Param & smoother_param);
+  Param getParam(rclcpp::Node & node) const;
   Param getParam() const;
 
 private:

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -53,7 +53,7 @@ public:
 private:
   Param smoother_param_;
   autoware::common::osqp::OSQPInterface qp_solver_;
-  rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("linf_pseudo_jerk_smoother")};
+  // rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("linf_pseudo_jerk_smoother")};
 };
 }  // namespace motion_velocity_smoother
 

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -28,7 +28,7 @@
 
 namespace motion_velocity_smoother
 {
-class LinfPseudoJerkSmoother : public SmootherBase
+class LinfPseudoJerkSolver : public SolverBase
 {
 public:
   struct Param
@@ -38,7 +38,7 @@ public:
     double over_a_weight;
   };
 
-  explicit LinfPseudoJerkSmoother(rclcpp::Node & node);
+  explicit LinfPseudoJerkSolver(rclcpp::Node & node);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
@@ -50,6 +50,7 @@ public:
     resampling::ResampleParam resample_param;
   };
 
+  SolverBase() {}
   explicit SolverBase(rclcpp::Node & node);
   virtual ~SolverBase() = default;
   virtual bool apply(
@@ -70,11 +71,13 @@ public:
   double getMinJerk() const;
 
   void setParam(const BaseParam & param);
+  BaseParam getBaseParam(rclcpp::Node & node) const;
   BaseParam getBaseParam() const;
 
 protected:
   BaseParam base_param_;
 };
+
 }  // namespace motion_velocity_smoother
 
 #endif  // MOTION_VELOCITY_SMOOTHER__SMOOTHER__SMOOTHER_BASE_HPP_

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
@@ -33,7 +33,7 @@ namespace motion_velocity_smoother
 using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 
-class SmootherBase
+class SolverBase
 {
 public:
   struct BaseParam
@@ -50,8 +50,8 @@ public:
     resampling::ResampleParam resample_param;
   };
 
-  explicit SmootherBase(rclcpp::Node & node);
-  virtual ~SmootherBase() = default;
+  explicit SolverBase(rclcpp::Node & node);
+  virtual ~SolverBase() = default;
   virtual bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
     TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories) = 0;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
@@ -74,7 +74,6 @@ public:
 
 protected:
   BaseParam base_param_;
-  rclcpp::Logger logger_{rclcpp::get_logger("smoother")};
 };
 }  // namespace motion_velocity_smoother
 

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
@@ -74,6 +74,7 @@ public:
 
 protected:
   BaseParam base_param_;
+  rclcpp::Logger logger_{rclcpp::get_logger("smoother")};
 };
 }  // namespace motion_velocity_smoother
 

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -44,7 +44,7 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
   // create smoother
   switch (node_param_.algorithm_type) {
     case AlgorithmType::JERK_FILTERED: {
-      smoother_ = std::make_shared<JerkFilteredSmoother>(*this);
+      smoother_ = std::make_shared<JerkFilteredSolver>(*this);
 
       // Set Publisher for jerk filtered algorithm
       pub_forward_filtered_trajectory_ =
@@ -58,15 +58,15 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
       break;
     }
     case AlgorithmType::L2: {
-      smoother_ = std::make_shared<L2PseudoJerkSmoother>(*this);
+      smoother_ = std::make_shared<L2PseudoJerkSolver>(*this);
       break;
     }
     case AlgorithmType::LINF: {
-      smoother_ = std::make_shared<LinfPseudoJerkSmoother>(*this);
+      smoother_ = std::make_shared<LinfPseudoJerkSolver>(*this);
       break;
     }
     case AlgorithmType::ANALYTICAL: {
-      smoother_ = std::make_shared<AnalyticalJerkConstrainedSmoother>(*this);
+      smoother_ = std::make_shared<AnalyticalJerkConstrainedSolver>(*this);
       break;
     }
     default:
@@ -174,33 +174,33 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
 
   switch (node_param_.algorithm_type) {
     case AlgorithmType::JERK_FILTERED: {
-      auto p = std::dynamic_pointer_cast<JerkFilteredSmoother>(smoother_)->getParam();
+      auto p = std::dynamic_pointer_cast<JerkFilteredSolver>(smoother_)->getParam();
       update_param("jerk_weight", p.jerk_weight);
       update_param("over_v_weight", p.over_v_weight);
       update_param("over_a_weight", p.over_a_weight);
       update_param("over_j_weight", p.over_j_weight);
       update_param("jerk_filter_ds", p.jerk_filter_ds);
-      std::dynamic_pointer_cast<JerkFilteredSmoother>(smoother_)->setParam(p);
+      std::dynamic_pointer_cast<JerkFilteredSolver>(smoother_)->setParam(p);
       break;
     }
     case AlgorithmType::L2: {
-      auto p = std::dynamic_pointer_cast<L2PseudoJerkSmoother>(smoother_)->getParam();
+      auto p = std::dynamic_pointer_cast<L2PseudoJerkSolver>(smoother_)->getParam();
       update_param("pseudo_jerk_weight", p.pseudo_jerk_weight);
       update_param("over_v_weight", p.over_v_weight);
       update_param("over_a_weight", p.over_a_weight);
-      std::dynamic_pointer_cast<L2PseudoJerkSmoother>(smoother_)->setParam(p);
+      std::dynamic_pointer_cast<L2PseudoJerkSolver>(smoother_)->setParam(p);
       break;
     }
     case AlgorithmType::LINF: {
-      auto p = std::dynamic_pointer_cast<LinfPseudoJerkSmoother>(smoother_)->getParam();
+      auto p = std::dynamic_pointer_cast<LinfPseudoJerkSolver>(smoother_)->getParam();
       update_param("pseudo_jerk_weight", p.pseudo_jerk_weight);
       update_param("over_v_weight", p.over_v_weight);
       update_param("over_a_weight", p.over_a_weight);
-      std::dynamic_pointer_cast<LinfPseudoJerkSmoother>(smoother_)->setParam(p);
+      std::dynamic_pointer_cast<LinfPseudoJerkSolver>(smoother_)->setParam(p);
       break;
     }
     case AlgorithmType::ANALYTICAL: {
-      auto p = std::dynamic_pointer_cast<AnalyticalJerkConstrainedSmoother>(smoother_)->getParam();
+      auto p = std::dynamic_pointer_cast<AnalyticalJerkConstrainedSolver>(smoother_)->getParam();
       update_param("resample.delta_yaw_threshold", p.resample.delta_yaw_threshold);
       update_param(
         "latacc.constant_velocity_dist_threshold", p.latacc.constant_velocity_dist_threshold);
@@ -215,7 +215,7 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
       update_param("backward.min_acc_mild_stop", p.backward.min_acc_mild_stop);
       update_param("backward.min_acc", p.backward.min_acc);
       update_param("backward.span_jerk", p.backward.span_jerk);
-      std::dynamic_pointer_cast<AnalyticalJerkConstrainedSmoother>(smoother_)->setParam(p);
+      std::dynamic_pointer_cast<AnalyticalJerkConstrainedSolver>(smoother_)->setParam(p);
       break;
     }
     default:

--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -20,6 +20,30 @@
 #include <utility>
 #include <vector>
 
+static double get_parameter_or(
+  rclcpp::Node & node, const std::string & param_name, const double & default_value)
+{
+  rclcpp::Parameter param;
+  node.get_parameter_or(param_name, param, rclcpp::Parameter(param_name, default_value));
+  return param.as_double();
+}
+
+static int get_parameter_or(
+  rclcpp::Node & node, const std::string & param_name, const int & default_value)
+{
+  rclcpp::Parameter param;
+  node.get_parameter_or(param_name, param, rclcpp::Parameter(param_name, default_value));
+  return param.as_double();
+}
+
+static bool get_parameter_or(
+  rclcpp::Node & node, const std::string & param_name, const bool & default_value)
+{
+  rclcpp::Parameter param;
+  node.get_parameter_or(param_name, param, rclcpp::Parameter(param_name, default_value));
+  return param.as_bool();
+}
+
 namespace
 {
 using TrajectoryPoints = std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>;
@@ -62,33 +86,43 @@ bool applyMaxVelocity(
 
 namespace motion_velocity_smoother
 {
+
+AnalyticalJerkConstrainedSolver::AnalyticalJerkConstrainedSolver() : SolverBase() {}
 AnalyticalJerkConstrainedSolver::AnalyticalJerkConstrainedSolver(rclcpp::Node & node)
 : SolverBase(node)
 {
-  auto & p = smoother_param_;
-  p.resample.ds_resample = node.declare_parameter("resample.ds_resample", 0.1);
-  p.resample.num_resample = node.declare_parameter("resample.num_resample", 1);
-  p.resample.delta_yaw_threshold = node.declare_parameter("resample.delta_yaw_threshold", 0.785);
-  p.latacc.enable_constant_velocity_while_turning =
-    node.declare_parameter("latacc.enable_constant_velocity_while_turning", false);
-  p.latacc.constant_velocity_dist_threshold =
-    node.declare_parameter("latacc.constant_velocity_dist_threshold", 2.0);
-  p.forward.max_acc = node.declare_parameter("forward.max_acc", 1.0);
-  p.forward.min_acc = node.declare_parameter("forward.min_acc", -1.0);
-  p.forward.max_jerk = node.declare_parameter("forward.max_jerk", 0.3);
-  p.forward.min_jerk = node.declare_parameter("forward.min_jerk", -0.3);
-  p.forward.kp = node.declare_parameter("forward.kp", 0.3);
-  p.backward.start_jerk = node.declare_parameter("backward.start_jerk", -0.1);
-  p.backward.min_jerk_mild_stop = node.declare_parameter("backward.min_jerk_mild_stop", -0.3);
-  p.backward.min_jerk = node.declare_parameter("backward.min_jerk", -1.5);
-  p.backward.min_acc_mild_stop = node.declare_parameter("backward.min_acc_mild_stop", -1.0);
-  p.backward.min_acc = node.declare_parameter("backward.min_acc", -2.5);
-  p.backward.span_jerk = node.declare_parameter("backward.span_jerk", -0.01);
+  smoother_param_ = getParam(node);
 }
 
 void AnalyticalJerkConstrainedSolver::setParam(const Param & smoother_param)
 {
   smoother_param_ = smoother_param;
+}
+
+AnalyticalJerkConstrainedSolver::Param AnalyticalJerkConstrainedSolver::getParam(
+  rclcpp::Node & node) const
+{
+  AnalyticalJerkConstrainedSolver::Param smoother_param;
+  auto & p = smoother_param;
+  p.resample.ds_resample = get_parameter_or(node, "resample.ds_resample", 0.1);
+  p.resample.num_resample = get_parameter_or(node, "resample.num_resample", 1);
+  p.resample.delta_yaw_threshold = get_parameter_or(node, "resample.delta_yaw_threshold", 0.785);
+  p.latacc.enable_constant_velocity_while_turning =
+    get_parameter_or(node, "latacc.enable_constant_velocity_while_turning", false);
+  p.latacc.constant_velocity_dist_threshold =
+    get_parameter_or(node, "latacc.constant_velocity_dist_threshold", 2.0);
+  p.forward.max_acc = get_parameter_or(node, "forward.max_acc", 1.0);
+  p.forward.min_acc = get_parameter_or(node, "forward.min_acc", -1.0);
+  p.forward.max_jerk = get_parameter_or(node, "forward.max_jerk", 0.3);
+  p.forward.min_jerk = get_parameter_or(node, "forward.min_jerk", -0.3);
+  p.forward.kp = get_parameter_or(node, "forward.kp", 0.3);
+  p.backward.start_jerk = get_parameter_or(node, "backward.start_jerk", -0.1);
+  p.backward.min_jerk_mild_stop = get_parameter_or(node, "backward.min_jerk_mild_stop", -0.3);
+  p.backward.min_jerk = get_parameter_or(node, "backward.min_jerk", -1.5);
+  p.backward.min_acc_mild_stop = get_parameter_or(node, "backward.min_acc_mild_stop", -1.0);
+  p.backward.min_acc = get_parameter_or(node, "backward.min_acc", -2.5);
+  p.backward.span_jerk = get_parameter_or(node, "backward.span_jerk", -0.01);
+  return smoother_param;
 }
 
 AnalyticalJerkConstrainedSolver::Param AnalyticalJerkConstrainedSolver::getParam() const

--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -33,7 +33,7 @@ static int get_parameter_or(
 {
   rclcpp::Parameter param;
   node.get_parameter_or(param_name, param, rclcpp::Parameter(param_name, default_value));
-  return param.as_double();
+  return param.as_int();
 }
 
 static bool get_parameter_or(

--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -62,8 +62,8 @@ bool applyMaxVelocity(
 
 namespace motion_velocity_smoother
 {
-AnalyticalJerkConstrainedSmoother::AnalyticalJerkConstrainedSmoother(rclcpp::Node & node)
-: SmootherBase(node)
+AnalyticalJerkConstrainedSolver::AnalyticalJerkConstrainedSolver(rclcpp::Node & node)
+: SolverBase(node)
 {
   auto & p = smoother_param_;
   p.resample.ds_resample = node.declare_parameter("resample.ds_resample", 0.1);
@@ -86,17 +86,17 @@ AnalyticalJerkConstrainedSmoother::AnalyticalJerkConstrainedSmoother(rclcpp::Nod
   p.backward.span_jerk = node.declare_parameter("backward.span_jerk", -0.01);
 }
 
-void AnalyticalJerkConstrainedSmoother::setParam(const Param & smoother_param)
+void AnalyticalJerkConstrainedSolver::setParam(const Param & smoother_param)
 {
   smoother_param_ = smoother_param;
 }
 
-AnalyticalJerkConstrainedSmoother::Param AnalyticalJerkConstrainedSmoother::getParam() const
+AnalyticalJerkConstrainedSolver::Param AnalyticalJerkConstrainedSolver::getParam() const
 {
   return smoother_param_;
 }
 
-bool AnalyticalJerkConstrainedSmoother::apply(
+bool AnalyticalJerkConstrainedSolver::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
   TrajectoryPoints & output, [[maybe_unused]] std::vector<TrajectoryPoints> & debug_trajectories)
 {
@@ -228,7 +228,7 @@ bool AnalyticalJerkConstrainedSmoother::apply(
   return true;
 }
 
-boost::optional<TrajectoryPoints> AnalyticalJerkConstrainedSmoother::resampleTrajectory(
+boost::optional<TrajectoryPoints> AnalyticalJerkConstrainedSolver::resampleTrajectory(
   const TrajectoryPoints & input, [[maybe_unused]] const double v_current,
   [[maybe_unused]] const int closest_id) const
 {
@@ -272,7 +272,7 @@ boost::optional<TrajectoryPoints> AnalyticalJerkConstrainedSmoother::resampleTra
   return boost::optional<TrajectoryPoints>(output);
 }
 
-boost::optional<TrajectoryPoints> AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilter(
+boost::optional<TrajectoryPoints> AnalyticalJerkConstrainedSolver::applyLateralAccelerationFilter(
   const TrajectoryPoints & input, [[maybe_unused]] const double v0,
   [[maybe_unused]] const double a0, [[maybe_unused]] const bool enable_smooth_limit) const
 {
@@ -381,7 +381,7 @@ boost::optional<TrajectoryPoints> AnalyticalJerkConstrainedSmoother::applyLatera
   return output;
 }
 
-bool AnalyticalJerkConstrainedSmoother::searchDecelTargetIndices(
+bool AnalyticalJerkConstrainedSolver::searchDecelTargetIndices(
   const TrajectoryPoints & trajectory, const size_t closest_index,
   std::vector<std::pair<size_t, double>> & decel_target_indices) const
 {
@@ -423,7 +423,7 @@ bool AnalyticalJerkConstrainedSmoother::searchDecelTargetIndices(
   return true;
 }
 
-bool AnalyticalJerkConstrainedSmoother::applyForwardJerkFilter(
+bool AnalyticalJerkConstrainedSolver::applyForwardJerkFilter(
   const TrajectoryPoints & base_trajectory, const size_t start_index, const double initial_vel,
   const double initial_acc, const Param & params, TrajectoryPoints & output_trajectory) const
 {
@@ -456,7 +456,7 @@ bool AnalyticalJerkConstrainedSmoother::applyForwardJerkFilter(
   return true;
 }
 
-bool AnalyticalJerkConstrainedSmoother::applyBackwardDecelFilter(
+bool AnalyticalJerkConstrainedSolver::applyBackwardDecelFilter(
   const std::vector<size_t> & start_indices, const size_t decel_target_index,
   const double decel_target_vel, const Param & params, TrajectoryPoints & output_trajectory) const
 {
@@ -556,7 +556,7 @@ bool AnalyticalJerkConstrainedSmoother::applyBackwardDecelFilter(
   return true;
 }
 
-bool AnalyticalJerkConstrainedSmoother::calcEnoughDistForDecel(
+bool AnalyticalJerkConstrainedSolver::calcEnoughDistForDecel(
   const TrajectoryPoints & trajectory, const size_t start_index, const double decel_target_vel,
   const double planning_jerk, const Param & params, const std::vector<double> & dist_to_target,
   bool & is_enough_dist, int & type, std::vector<double> & times, double & stop_dist) const
@@ -599,7 +599,7 @@ bool AnalyticalJerkConstrainedSmoother::calcEnoughDistForDecel(
   return false;
 }
 
-bool AnalyticalJerkConstrainedSmoother::applyDecelVelocityFilter(
+bool AnalyticalJerkConstrainedSolver::applyDecelVelocityFilter(
   const size_t decel_start_index, const double decel_target_vel, const double planning_jerk,
   const Param & params, const int type, const std::vector<double> & times,
   TrajectoryPoints & output_trajectory) const
@@ -625,7 +625,7 @@ bool AnalyticalJerkConstrainedSmoother::applyDecelVelocityFilter(
   return true;
 }
 
-std::string AnalyticalJerkConstrainedSmoother::strTimes(const std::vector<double> & times) const
+std::string AnalyticalJerkConstrainedSolver::strTimes(const std::vector<double> & times) const
 {
   std::stringstream ss;
   unsigned int i = 0;
@@ -636,7 +636,7 @@ std::string AnalyticalJerkConstrainedSmoother::strTimes(const std::vector<double
   return ss.str();
 }
 
-std::string AnalyticalJerkConstrainedSmoother::strStartIndices(
+std::string AnalyticalJerkConstrainedSolver::strStartIndices(
   const std::vector<size_t> & start_indices) const
 {
   std::stringstream ss;

--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -53,10 +53,11 @@ bool JerkFilteredSolver::apply(
   const double v0, const double a0, const TrajectoryPoints & input, TrajectoryPoints & output,
   std::vector<TrajectoryPoints> & debug_trajectories)
 {
+  auto logger = rclcpp::get_logger("smoother").get_child("jerk_filtered_smoother");
   output = input;
 
   if (input.empty()) {
-    RCLCPP_WARN(logger_, "Input TrajectoryPoints to the jerk filtered optimization is empty.");
+    RCLCPP_WARN(logger, "Input TrajectoryPoints to the jerk filtered optimization is empty.");
     return false;
   }
 
@@ -104,7 +105,7 @@ bool JerkFilteredSolver::apply(
     resampling::resampleTrajectory(filtered, v0, 0, base_param_.resample_param);
 
   if (!opt_resampled_trajectory) {
-    RCLCPP_WARN(logger_, "Resample failed!");
+    RCLCPP_WARN(logger, "Resample failed!");
     return false;
   }
   // Ensure terminal velocity is zero
@@ -127,7 +128,7 @@ bool JerkFilteredSolver::apply(
     *opt_resampled_trajectory, 1, opt_resampled_trajectory->size());
 
   if (!zero_vel_id) {
-    RCLCPP_WARN(logger_, "opt_resampled_trajectory must have stop point.");
+    RCLCPP_WARN(logger, "opt_resampled_trajectory must have stop point.");
     return false;
   }
 
@@ -288,7 +289,7 @@ bool JerkFilteredSolver::apply(
   const auto tf1 = std::chrono::system_clock::now();
   const double dt_ms1 =
     std::chrono::duration_cast<std::chrono::nanoseconds>(tf1 - ts).count() * 1.0e-6;
-  RCLCPP_DEBUG(logger_, "optimization time = %f [ms]", dt_ms1);
+  RCLCPP_DEBUG(logger, "optimization time = %f [ms]", dt_ms1);
 
   // get velocity & acceleration
   for (size_t i = 0; i < N; ++i) {
@@ -303,7 +304,7 @@ bool JerkFilteredSolver::apply(
 
   const int status_val = std::get<3>(result);
   if (status_val != 1) {
-    RCLCPP_ERROR(logger_, "optimization failed : %s", qp_solver_.getStatusMessage().c_str());
+    RCLCPP_ERROR(logger, "optimization failed : %s", qp_solver_.getStatusMessage().c_str());
   }
 
   if (TMP_SHOW_DEBUG_INFO) {

--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -26,7 +26,7 @@
 
 namespace motion_velocity_smoother
 {
-JerkFilteredSmoother::JerkFilteredSmoother(rclcpp::Node & node) : SmootherBase(node)
+JerkFilteredSolver::JerkFilteredSolver(rclcpp::Node & node) : SolverBase(node)
 {
   auto & p = smoother_param_;
   p.jerk_weight = node.declare_parameter("jerk_weight", 10.0);
@@ -42,14 +42,14 @@ JerkFilteredSmoother::JerkFilteredSmoother(rclcpp::Node & node) : SmootherBase(n
   qp_solver_.updateVerbose(false);
 }
 
-void JerkFilteredSmoother::setParam(const Param & smoother_param)
+void JerkFilteredSolver::setParam(const Param & smoother_param)
 {
   smoother_param_ = smoother_param;
 }
 
-JerkFilteredSmoother::Param JerkFilteredSmoother::getParam() const { return smoother_param_; }
+JerkFilteredSolver::Param JerkFilteredSolver::getParam() const { return smoother_param_; }
 
-bool JerkFilteredSmoother::apply(
+bool JerkFilteredSolver::apply(
   const double v0, const double a0, const TrajectoryPoints & input, TrajectoryPoints & output,
   std::vector<TrajectoryPoints> & debug_trajectories)
 {
@@ -349,7 +349,7 @@ bool JerkFilteredSmoother::apply(
   return true;
 }
 
-TrajectoryPoints JerkFilteredSmoother::forwardJerkFilter(
+TrajectoryPoints JerkFilteredSolver::forwardJerkFilter(
   const double v0, const double a0, const double a_max, const double a_start, const double j_max,
   const TrajectoryPoints & input) const
 {
@@ -401,7 +401,7 @@ TrajectoryPoints JerkFilteredSmoother::forwardJerkFilter(
   return output;
 }
 
-TrajectoryPoints JerkFilteredSmoother::backwardJerkFilter(
+TrajectoryPoints JerkFilteredSolver::backwardJerkFilter(
   const double v0, const double a0, const double a_min, const double a_stop, const double j_min,
   const TrajectoryPoints & input) const
 {
@@ -416,7 +416,7 @@ TrajectoryPoints JerkFilteredSmoother::backwardJerkFilter(
   return filtered;
 }
 
-TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
+TrajectoryPoints JerkFilteredSolver::mergeFilteredTrajectory(
   const double v0, const double a0, const double a_min, const double j_min,
   const TrajectoryPoints & forward_filtered, const TrajectoryPoints & backward_filtered) const
 {
@@ -467,7 +467,7 @@ TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
   return merged;
 }
 
-boost::optional<TrajectoryPoints> JerkFilteredSmoother::resampleTrajectory(
+boost::optional<TrajectoryPoints> JerkFilteredSolver::resampleTrajectory(
   const TrajectoryPoints & input, const double /*v_current*/, const int closest_id) const
 {
   return resampling::resampleTrajectory(

--- a/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -49,6 +49,7 @@ bool L2PseudoJerkSolver::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
   TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories)
 {
+  auto logger = rclcpp::get_logger("smoother").get_child("l2_pseudo_jerk_smoother");
   debug_trajectories.clear();
 
   const auto ts = std::chrono::system_clock::now();
@@ -56,14 +57,14 @@ bool L2PseudoJerkSolver::apply(
   output = input;
 
   if (std::fabs(input.front().longitudinal_velocity_mps) < 0.1) {
-    RCLCPP_DEBUG(logger_, "closest v_max < 0.1. assume vehicle stopped. return.");
+    RCLCPP_DEBUG(logger, "closest v_max < 0.1. assume vehicle stopped. return.");
     return true;
   }
 
   const unsigned int N = input.size();
 
   if (N < 2) {
-    RCLCPP_WARN(logger_, "trajectory length is not enough.");
+    RCLCPP_WARN(logger, "trajectory length is not enough.");
     return false;
   }
 
@@ -210,13 +211,13 @@ bool L2PseudoJerkSolver::apply(
 
   const int status_val = std::get<3>(result);
   if (status_val != 1) {
-    RCLCPP_WARN(logger_, "optimization failed : %s", qp_solver_.getStatusMessage().c_str());
+    RCLCPP_WARN(logger, "optimization failed : %s", qp_solver_.getStatusMessage().c_str());
   }
 
   const auto tf2 = std::chrono::system_clock::now();
   const double dt_ms2 =
     std::chrono::duration_cast<std::chrono::nanoseconds>(tf2 - ts2).count() * 1.0e-6;
-  RCLCPP_DEBUG(logger_, "init time = %f [ms], optimization time = %f [ms]", dt_ms1, dt_ms2);
+  RCLCPP_DEBUG(logger, "init time = %f [ms], optimization time = %f [ms]", dt_ms1, dt_ms2);
 
   return true;
 }

--- a/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -24,7 +24,7 @@
 
 namespace motion_velocity_smoother
 {
-L2PseudoJerkSmoother::L2PseudoJerkSmoother(rclcpp::Node & node) : SmootherBase(node)
+L2PseudoJerkSolver::L2PseudoJerkSolver(rclcpp::Node & node) : SolverBase(node)
 {
   auto & p = smoother_param_;
   p.pseudo_jerk_weight = node.declare_parameter("pseudo_jerk_weight", 100.0);
@@ -38,14 +38,14 @@ L2PseudoJerkSmoother::L2PseudoJerkSmoother(rclcpp::Node & node) : SmootherBase(n
   qp_solver_.updateVerbose(false);
 }
 
-void L2PseudoJerkSmoother::setParam(const Param & smoother_param)
+void L2PseudoJerkSolver::setParam(const Param & smoother_param)
 {
   smoother_param_ = smoother_param;
 }
 
-L2PseudoJerkSmoother::Param L2PseudoJerkSmoother::getParam() const { return smoother_param_; }
+L2PseudoJerkSolver::Param L2PseudoJerkSolver::getParam() const { return smoother_param_; }
 
-bool L2PseudoJerkSmoother::apply(
+bool L2PseudoJerkSolver::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
   TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories)
 {
@@ -221,7 +221,7 @@ bool L2PseudoJerkSmoother::apply(
   return true;
 }
 
-boost::optional<TrajectoryPoints> L2PseudoJerkSmoother::resampleTrajectory(
+boost::optional<TrajectoryPoints> L2PseudoJerkSolver::resampleTrajectory(
   const TrajectoryPoints & input, const double v_current, const int closest_id) const
 {
   return resampling::resampleTrajectory(input, v_current, closest_id, base_param_.resample_param);

--- a/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -49,6 +49,7 @@ bool LinfPseudoJerkSolver::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
   TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories)
 {
+  auto logger = rclcpp::get_logger("smoother").get_child("linf_pseudo_jerk_smoother");
   debug_trajectories.clear();
 
   const auto ts = std::chrono::system_clock::now();
@@ -57,7 +58,7 @@ bool LinfPseudoJerkSolver::apply(
 
   if (std::fabs(input.front().longitudinal_velocity_mps) < 0.1) {
     RCLCPP_DEBUG(
-      logger_,
+      logger,
       "closest v_max < 0.1, keep stopping. "
       "return.");
     return false;
@@ -223,13 +224,13 @@ bool LinfPseudoJerkSolver::apply(
 
   const int status_val = std::get<3>(result);
   if (status_val != 1) {
-    RCLCPP_WARN(logger_, "optimization failed : %s", qp_solver_.getStatusMessage().c_str());
+    RCLCPP_WARN(logger, "optimization failed : %s", qp_solver_.getStatusMessage().c_str());
   }
 
   const auto tf2 = std::chrono::system_clock::now();
   const double dt_ms2 =
     std::chrono::duration_cast<std::chrono::nanoseconds>(tf2 - ts2).count() * 1.0e-6;
-  RCLCPP_DEBUG(logger_, "init time = %f [ms], optimization time = %f [ms]", dt_ms1, dt_ms2);
+  RCLCPP_DEBUG(logger, "init time = %f [ms], optimization time = %f [ms]", dt_ms1, dt_ms2);
   return true;
 }
 

--- a/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -22,15 +22,29 @@
 #include <limits>
 #include <vector>
 
+static double get_parameter_or(
+  rclcpp::Node & node, const std::string & param_name, const double & default_value)
+{
+  rclcpp::Parameter param;
+  node.get_parameter_or(param_name, param, rclcpp::Parameter(param_name, default_value));
+  return param.as_double();
+}
+
 namespace motion_velocity_smoother
 {
+
+LinfPseudoJerkSolver::LinfPseudoJerkSolver() : SolverBase()
+{
+  qp_solver_.updateMaxIter(20000);
+  qp_solver_.updateRhoInterval(5000);
+  qp_solver_.updateEpsRel(1.0e-4);  // def: 1.0e-4
+  qp_solver_.updateEpsAbs(1.0e-8);  // def: 1.0e-4
+  qp_solver_.updateVerbose(false);
+}
+
 LinfPseudoJerkSolver::LinfPseudoJerkSolver(rclcpp::Node & node) : SolverBase(node)
 {
-  auto & p = smoother_param_;
-  p.pseudo_jerk_weight = node.declare_parameter("pseudo_jerk_weight", 200.0);
-  p.over_v_weight = node.declare_parameter("over_v_weight", 100000.0);
-  p.over_a_weight = node.declare_parameter("over_a_weight", 5000.0);
-
+  smoother_param_ = getParam(node);
   qp_solver_.updateMaxIter(20000);
   qp_solver_.updateRhoInterval(5000);
   qp_solver_.updateEpsRel(1.0e-4);  // def: 1.0e-4
@@ -41,6 +55,16 @@ LinfPseudoJerkSolver::LinfPseudoJerkSolver(rclcpp::Node & node) : SolverBase(nod
 void LinfPseudoJerkSolver::setParam(const Param & smoother_param)
 {
   smoother_param_ = smoother_param;
+}
+
+LinfPseudoJerkSolver::Param LinfPseudoJerkSolver::getParam(rclcpp::Node & node) const
+{
+  LinfPseudoJerkSolver::Param smoother_param;
+  auto & p = smoother_param;
+  p.pseudo_jerk_weight = get_parameter_or(node, "pseudo_jerk_weight", 200.0);
+  p.over_v_weight = get_parameter_or(node, "over_v_weight", 100000.0);
+  p.over_a_weight = get_parameter_or(node, "over_a_weight", 5000.0);
+  return smoother_param;
 }
 
 LinfPseudoJerkSolver::Param LinfPseudoJerkSolver::getParam() const { return smoother_param_; }

--- a/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -24,7 +24,7 @@
 
 namespace motion_velocity_smoother
 {
-LinfPseudoJerkSmoother::LinfPseudoJerkSmoother(rclcpp::Node & node) : SmootherBase(node)
+LinfPseudoJerkSolver::LinfPseudoJerkSolver(rclcpp::Node & node) : SolverBase(node)
 {
   auto & p = smoother_param_;
   p.pseudo_jerk_weight = node.declare_parameter("pseudo_jerk_weight", 200.0);
@@ -38,14 +38,14 @@ LinfPseudoJerkSmoother::LinfPseudoJerkSmoother(rclcpp::Node & node) : SmootherBa
   qp_solver_.updateVerbose(false);
 }
 
-void LinfPseudoJerkSmoother::setParam(const Param & smoother_param)
+void LinfPseudoJerkSolver::setParam(const Param & smoother_param)
 {
   smoother_param_ = smoother_param;
 }
 
-LinfPseudoJerkSmoother::Param LinfPseudoJerkSmoother::getParam() const { return smoother_param_; }
+LinfPseudoJerkSolver::Param LinfPseudoJerkSolver::getParam() const { return smoother_param_; }
 
-bool LinfPseudoJerkSmoother::apply(
+bool LinfPseudoJerkSolver::apply(
   const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
   TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories)
 {
@@ -233,7 +233,7 @@ bool LinfPseudoJerkSmoother::apply(
   return true;
 }
 
-boost::optional<TrajectoryPoints> LinfPseudoJerkSmoother::resampleTrajectory(
+boost::optional<TrajectoryPoints> LinfPseudoJerkSolver::resampleTrajectory(
   const TrajectoryPoints & input, const double v_current, const int closest_id) const
 {
   return resampling::resampleTrajectory(input, v_current, closest_id, base_param_.resample_param);

--- a/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
@@ -21,32 +21,46 @@
 #include <cmath>
 #include <vector>
 
-namespace motion_velocity_smoother
+static double get_parameter_or(
+  rclcpp::Node & node, const std::string & param_name, const double & default_value)
 {
-SolverBase::SolverBase(rclcpp::Node & node)
-{
-  auto & p = base_param_;
-  p.max_accel = node.declare_parameter("normal.max_acc", 2.0);
-  p.min_decel = node.declare_parameter("normal.min_acc", -3.0);
-  p.stop_decel = node.declare_parameter("stop_decel", 0.0);
-  p.max_jerk = node.declare_parameter("normal.max_jerk", 0.3);
-  p.min_jerk = node.declare_parameter("normal.min_jerk", -0.1);
-  p.max_lateral_accel = node.declare_parameter("max_lateral_accel", 0.2);
-  p.decel_distance_before_curve = node.declare_parameter("decel_distance_before_curve", 3.5);
-  p.decel_distance_after_curve = node.declare_parameter("decel_distance_after_curve", 0.0);
-  p.min_curve_velocity = node.declare_parameter("min_curve_velocity", 1.38);
-  p.resample_param.max_trajectory_length = node.declare_parameter("max_trajectory_length", 200.0);
-  p.resample_param.min_trajectory_length = node.declare_parameter("min_trajectory_length", 30.0);
-  p.resample_param.resample_time = node.declare_parameter("resample_time", 10.0);
-  p.resample_param.dense_resample_dt = node.declare_parameter("dense_resample_dt", 0.1);
-  p.resample_param.dense_min_interval_distance =
-    node.declare_parameter("dense_min_interval_distance", 0.1);
-  p.resample_param.sparse_resample_dt = node.declare_parameter("sparse_resample_dt", 0.5);
-  p.resample_param.sparse_min_interval_distance =
-    node.declare_parameter("sparse_min_interval_distance", 4.0);
+  rclcpp::Parameter param;
+  node.get_parameter_or(param_name, param, rclcpp::Parameter(param_name, default_value));
+  return param.as_double();
 }
 
+namespace motion_velocity_smoother
+{
+SolverBase::SolverBase(rclcpp::Node & node) { base_param_ = getBaseParam(node); }
+
 void SolverBase::setParam(const BaseParam & param) { base_param_ = param; }
+
+SolverBase::BaseParam SolverBase::getBaseParam(rclcpp::Node & node) const
+{
+  SolverBase::BaseParam base_param;
+  auto & p = base_param;
+  // if used as a solver and still need to get parameter through rclcpp::Node, calling
+  // "declare_parameter" twice throws exception
+  p.max_accel = get_parameter_or(node, "normal.max_acc", 2.0);
+  p.min_decel = get_parameter_or(node, "normal.min_acc", -3.0);
+  p.stop_decel = get_parameter_or(node, "stop_decel", 0.0);
+  p.max_jerk = get_parameter_or(node, "normal.max_jerk", 0.3);
+  p.min_jerk = get_parameter_or(node, "normal.min_jerk", -0.1);
+  p.max_lateral_accel = get_parameter_or(node, "max_lateral_accel", 0.2);
+  p.decel_distance_before_curve = get_parameter_or(node, "decel_distance_before_curve", 3.5);
+  p.decel_distance_after_curve = get_parameter_or(node, "decel_distance_after_curve", 0.0);
+  p.min_curve_velocity = get_parameter_or(node, "min_curve_velocity", 1.38);
+  p.resample_param.max_trajectory_length = get_parameter_or(node, "max_trajectory_length", 200.0);
+  p.resample_param.min_trajectory_length = get_parameter_or(node, "min_trajectory_length", 30.0);
+  p.resample_param.resample_time = get_parameter_or(node, "resample_time", 10.0);
+  p.resample_param.dense_resample_dt = get_parameter_or(node, "dense_resample_dt", 0.1);
+  p.resample_param.dense_min_interval_distance =
+    get_parameter_or(node, "dense_min_interval_distance", 0.1);
+  p.resample_param.sparse_resample_dt = get_parameter_or(node, "sparse_resample_dt", 0.5);
+  p.resample_param.sparse_min_interval_distance =
+    get_parameter_or(node, "sparse_min_interval_distance", 4.0);
+  return base_param;
+}
 
 SolverBase::BaseParam SolverBase::getBaseParam() const { return base_param_; }
 

--- a/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
@@ -23,7 +23,7 @@
 
 namespace motion_velocity_smoother
 {
-SmootherBase::SmootherBase(rclcpp::Node & node)
+SolverBase::SolverBase(rclcpp::Node & node)
 {
   auto & p = base_param_;
   p.max_accel = node.declare_parameter("normal.max_acc", 2.0);
@@ -46,19 +46,19 @@ SmootherBase::SmootherBase(rclcpp::Node & node)
     node.declare_parameter("sparse_min_interval_distance", 4.0);
 }
 
-void SmootherBase::setParam(const BaseParam & param) { base_param_ = param; }
+void SolverBase::setParam(const BaseParam & param) { base_param_ = param; }
 
-SmootherBase::BaseParam SmootherBase::getBaseParam() const { return base_param_; }
+SolverBase::BaseParam SolverBase::getBaseParam() const { return base_param_; }
 
-double SmootherBase::getMaxAccel() const { return base_param_.max_accel; }
+double SolverBase::getMaxAccel() const { return base_param_.max_accel; }
 
-double SmootherBase::getMinDecel() const { return base_param_.min_decel; }
+double SolverBase::getMinDecel() const { return base_param_.min_decel; }
 
-double SmootherBase::getMaxJerk() const { return base_param_.max_jerk; }
+double SolverBase::getMaxJerk() const { return base_param_.max_jerk; }
 
-double SmootherBase::getMinJerk() const { return base_param_.min_jerk; }
+double SolverBase::getMinJerk() const { return base_param_.min_jerk; }
 
-boost::optional<TrajectoryPoints> SmootherBase::applyLateralAccelerationFilter(
+boost::optional<TrajectoryPoints> SolverBase::applyLateralAccelerationFilter(
   const TrajectoryPoints & input, [[maybe_unused]] const double v0,
   [[maybe_unused]] const double a0, [[maybe_unused]] const bool enable_smooth_limit) const
 {


### PR DESCRIPTION
## Description

The solver classes / solver node were tightly bound because the solver class constructor took rclcpp::Node as the argument , which is only used for fetching parameter / logging. This PR adds an option for creating the instance without passing rclcpp::Node.

Example: 

```cpp
// auto smoother = AnalyticalJerkConstrainedSmoother(node); // current usage. parameter already set.

auto smoother = AnalyticalJerkConstrainedSmoother();
{
  // caveat: also need to init base param
  smoother.setParam(smoother.getBaseParam(node));

  // get ros param from rclcpp::Node.
  auto default_param = smoother.getParam(node);
  // if customize part of the parameters
  default_param.param1 = 1.23;

  smoother.setParam(default_param);
}
{
  // use smoother out of node context
  // in this case, you have to populate all parameters manually
  SmootherBase::BaseParam base_param;
  AnalyticalJerkConstrainedSmoother::Param param;

  base_param.param1 = 0.123;
  param.param1 = 1.23;
  param.param2 = "1.23";
  ....

  smoother.setParam(base_param);
  smoother.setParam(param);
}
smoother.applyXXX(...)
```

**caveat** : The user must call `setParam` both for `BaseParam` and `Param` of that specific smoother if the smoother is not directly initialized using rclcpp::Node, like `auto smoother = AnalyticalJerkConstrainedSmoother(node)`.

## Notes for reviews

logging in each function is still dependent on ROS loggers.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
