### PR TITLE
fix(tier4_planning_rviz_plugin): fix initialize planning_rviz_plugin

### DIFF
--- a/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
+++ b/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
@@ -77,6 +77,7 @@ void MaxVelocityDisplay::onInitialize()
   overlay_->updateTextureSize(property_length_->getInt(), property_length_->getInt());
   overlay_->setPosition(property_left_->getInt(), property_top_->getInt());
   overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
+  processMessage(last_msg_ptr_);
 
   // QColor background_color;
   // background_color.setAlpha(0);
@@ -126,9 +127,9 @@ void MaxVelocityDisplay::unsubscribe() { max_vel_sub_.reset(); }
 void MaxVelocityDisplay::processMessage(
   const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg_ptr)
 {
-  if (!isEnabled()) {
-    return;
-  }
+  // if (!isEnabled()) {
+  //   return;
+  // }
   if (!overlay_->isVisible()) {
     return;
   }
@@ -172,8 +173,12 @@ void MaxVelocityDisplay::processMessage(
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream velocity_ss;
+  float velocity = 0.0;
+  if(msg_ptr != nullptr){
+    velocity = msg_ptr->max_velocity;
+  }
   velocity_ss << std::fixed << std::setprecision(0) << "limited" << std::endl
-              << msg_ptr->max_velocity * 3.6 << "km/h";
+              << velocity * 3.6 << "km/h";
   painter.drawText(
     static_cast<int>(line_width * 0.5), std::min(static_cast<int>(line_width * 0.5), h - 1), w,
     std::max(h, 1), Qt::AlignCenter | Qt::AlignVCenter, velocity_ss.str().c_str());

--- a/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
+++ b/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
@@ -127,9 +127,6 @@ void MaxVelocityDisplay::unsubscribe() { max_vel_sub_.reset(); }
 void MaxVelocityDisplay::processMessage(
   const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg_ptr)
 {
-  // if (!isEnabled()) {
-  //   return;
-  // }
   if (!overlay_->isVisible()) {
     return;
   }

--- a/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
+++ b/common/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
@@ -174,7 +174,7 @@ void MaxVelocityDisplay::processMessage(
   painter.setFont(font);
   std::ostringstream velocity_ss;
   float velocity = 0.0;
-  if(msg_ptr != nullptr){
+  if (msg_ptr != nullptr) {
     velocity = msg_ptr->max_velocity;
   }
   velocity_ss << std::fixed << std::setprecision(0) << "limited" << std::endl


### PR DESCRIPTION
Signed-off-by: Takeshi Miura <m.takeshi1995@gmail.com>

## Description
Fixed a problem with initialization at rviz startup not working in environments without nvidia driver.
Before
![image](https://user-images.githubusercontent.com/57553950/180117836-576e877f-2387-4bbe-8332-8c256484343f.png)


After
![image](https://user-images.githubusercontent.com/57553950/180126038-9a76ce3f-80c7-42a1-a9da-70ad44b0e97f.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
