### PR TITLE
fix(behavior_velocity_planner): fix intersection safety status

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -145,6 +145,7 @@ private:
   int64_t lane_id_;
   std::string turn_direction_;
   bool has_traffic_light_;
+  bool is_go_out_;
 
   // Parameter
   PlannerParam planner_param_;


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description

Before change, margin time for state transition in intersection module does not work.
In this PR, I fixed it.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Before

https://user-images.githubusercontent.com/10190493/180145355-72906624-0f30-4ddd-a826-b70f273313b9.mp4

After

https://user-images.githubusercontent.com/10190493/180145398-5f952ec7-f60d-4f24-afd1-c35ce1f82c49.mp4

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
