### PR TITLE
fix(ad_service_state_monitor): lock shread variables to prevent race …

### DIFF
--- a/system/ad_service_state_monitor/include/ad_service_state_monitor/ad_service_state_monitor_node.hpp
+++ b/system/ad_service_state_monitor/include/ad_service_state_monitor/ad_service_state_monitor_node.hpp
@@ -131,6 +131,10 @@ private:
   StateInput state_input_;
   StateParam state_param_;
 
+  // Lock Variables
+  std::mutex lock_state_machine_;
+  std::mutex lock_state_input_;
+
   // Diagnostic Updater
   diagnostic_updater::Updater updater_;
 

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -228,6 +228,8 @@ bool AutowareStateMonitorNode::onResetRouteService(
   constexpr double timeout = 3.0;
   while (rclcpp::ok()) {
     {
+      // To avoid dead lock, 2-phase lock is required here.
+      std::lock_guard<std::mutex> lock(lock_state_input_);
       std::lock_guard<std::mutex> lock(lock_state_machine_);
       if (state_machine_->getCurrentState() == AutowareState::WaitingForRoute) {
         state_input_.is_route_reset_required = false;
@@ -273,6 +275,7 @@ void AutowareStateMonitorNode::onTimer()
     state_input_.current_time = this->now();
 
     // Update state
+    // To avoid dead lock, 2-phase lock is required here.
     std::lock_guard<std::mutex> lock2(lock_state_machine_);
     prev_autoware_state = state_machine_->getCurrentState();
     autoware_state = state_machine_->updateState(state_input_);

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -85,18 +85,21 @@ geometry_msgs::msg::PoseStamped::SharedPtr getCurrentPose(const tf2_ros::Buffer 
 void AutowareStateMonitorNode::onAutowareEngage(
   const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
+  std::lock_guard<std::mutex> lock(lock_state_input_);
   state_input_.autoware_engage = msg;
 }
 
 void AutowareStateMonitorNode::onVehicleControlMode(
   const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg)
 {
+  std::lock_guard<std::mutex> lock(lock_state_input_);
   state_input_.control_mode_ = msg;
 }
 
 void AutowareStateMonitorNode::onModifiedGoal(
   const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
 {
+  std::lock_guard<std::mutex> lock(lock_state_input_);
   state_input_.modified_goal_pose = msg;
 }
 
@@ -119,10 +122,12 @@ void AutowareStateMonitorNode::onRoute(
   if (!is_route_valid) {
     return;
   }
-  state_input_.route = msg;
 
-  // Get goal pose
   {
+    std::lock_guard<std::mutex> lock(lock_state_input_);
+    state_input_.route = msg;
+
+    // Get goal pose
     geometry_msgs::msg::Pose::SharedPtr p = std::make_shared<geometry_msgs::msg::Pose>();
     *p = msg->goal_pose;
     state_input_.goal_pose = geometry_msgs::msg::Pose::ConstSharedPtr(p);
@@ -136,6 +141,8 @@ void AutowareStateMonitorNode::onRoute(
 
 void AutowareStateMonitorNode::onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg)
 {
+  std::lock_guard<std::mutex> lock(lock_state_input_);
+
   state_input_.odometry = msg;
 
   state_input_.odometry_buffer.push_back(msg);
@@ -164,17 +171,24 @@ bool AutowareStateMonitorNode::onShutdownService(
   const std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
   (void)request_header;
-  state_input_.is_finalizing = true;
+
+  {
+    std::lock_guard<std::mutex> lock(lock_state_input_);
+    state_input_.is_finalizing = true;
+  }
 
   const auto t_start = this->get_clock()->now();
   constexpr double timeout = 3.0;
   while (rclcpp::ok()) {
     // rclcpp::spin_some(this->get_node_base_interface());
 
-    if (state_machine_->getCurrentState() == AutowareState::Finalizing) {
-      response->success = true;
-      response->message = "Shutdown Autoware.";
-      return true;
+    {
+      std::lock_guard<std::mutex> lock(lock_state_machine_);
+      if (state_machine_->getCurrentState() == AutowareState::Finalizing) {
+        response->success = true;
+        response->message = "Shutdown Autoware.";
+        return true;
+      }
     }
 
     if ((this->get_clock()->now() - t_start).seconds() > timeout) {
@@ -196,22 +210,31 @@ bool AutowareStateMonitorNode::onResetRouteService(
   [[maybe_unused]] const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
   const std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
-  if (state_machine_->getCurrentState() != AutowareState::WaitingForEngage) {
-    response->success = false;
-    response->message = "Reset route can be accepted only under WaitingForEngage.";
-    return true;
+  {
+    std::lock_guard<std::mutex> lock(lock_state_machine_);
+    if (state_machine_->getCurrentState() != AutowareState::WaitingForEngage) {
+      response->success = false;
+      response->message = "Reset route can be accepted only under WaitingForEngage.";
+      return true;
+    }
   }
 
-  state_input_.is_route_reset_required = true;
+  {
+    std::lock_guard<std::mutex> lock(lock_state_input_);
+    state_input_.is_route_reset_required = true;
+  }
 
   const auto t_start = this->now();
   constexpr double timeout = 3.0;
   while (rclcpp::ok()) {
-    if (state_machine_->getCurrentState() == AutowareState::WaitingForRoute) {
-      state_input_.is_route_reset_required = false;
-      response->success = true;
-      response->message = "Reset route.";
-      return true;
+    {
+      std::lock_guard<std::mutex> lock(lock_state_machine_);
+      if (state_machine_->getCurrentState() == AutowareState::WaitingForRoute) {
+        state_input_.is_route_reset_required = false;
+        response->success = true;
+        response->message = "Reset route.";
+        return true;
+      }
     }
 
     if ((this->now() - t_start).seconds() > timeout) {
@@ -230,21 +253,30 @@ bool AutowareStateMonitorNode::onResetRouteService(
 
 void AutowareStateMonitorNode::onTimer()
 {
-  // Prepare state input
-  state_input_.current_pose = getCurrentPose(tf_buffer_);
-  if (state_input_.current_pose == nullptr) {
-    RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 5000 /* ms */,
-      "Fail lookupTransform base_link to map");
-  }
+  AutowareState prev_autoware_state;
+  AutowareState autoware_state;
 
-  state_input_.topic_stats = getTopicStats();
-  state_input_.param_stats = getParamStats();
-  state_input_.tf_stats = getTfStats();
-  state_input_.current_time = this->now();
-  // Update state
-  const auto prev_autoware_state = state_machine_->getCurrentState();
-  const auto autoware_state = state_machine_->updateState(state_input_);
+  {
+    std::lock_guard<std::mutex> lock(lock_state_input_);
+
+    // Prepare state input
+    state_input_.current_pose = getCurrentPose(tf_buffer_);
+    if (state_input_.current_pose == nullptr) {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000 /* ms */,
+        "Fail lookupTransform base_link to map");
+    }
+
+    state_input_.topic_stats = getTopicStats();
+    state_input_.param_stats = getParamStats();
+    state_input_.tf_stats = getTfStats();
+    state_input_.current_time = this->now();
+
+    // Update state
+    std::lock_guard<std::mutex> lock2(lock_state_machine_);
+    prev_autoware_state = state_machine_->getCurrentState();
+    autoware_state = state_machine_->updateState(state_input_);
+  }
 
   if (autoware_state != prev_autoware_state) {
     RCLCPP_INFO(
@@ -401,6 +433,7 @@ TfStats AutowareStateMonitorNode::getTfStats() const
 
 bool AutowareStateMonitorNode::isEngaged()
 {
+  std::lock_guard<std::mutex> lock(lock_state_input_);
   if (!state_input_.autoware_engage) {
     return false;
   }

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -273,8 +273,6 @@ void AutowareStateMonitorNode::onTimer()
     // Prepare state input
     state_input_.current_pose = getCurrentPose(tf_buffer_);
     if (state_input_.current_pose == nullptr) {
-      lock_state_input.unlock();
-
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *this->get_clock(), 5000 /* ms */,
         "Fail lookupTransform base_link to map");

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/diagnostics.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/diagnostics.cpp
@@ -48,6 +48,7 @@ void AutowareStateMonitorNode::checkTopicStatus(
 {
   int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
 
+  std::lock_guard<std::mutex> lock(lock_state_input_);
   const auto & topic_stats = state_input_.topic_stats;
 
   // OK
@@ -123,6 +124,7 @@ void AutowareStateMonitorNode::checkTFStatus(
 {
   int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
 
+  std::lock_guard<std::mutex> lock(lock_state_input_);
   const auto & tf_stats = state_input_.tf_stats;
 
   // OK


### PR DESCRIPTION
`state_machine_` and `state_input_` are shared by multiple callback groups (threads).
So, mutex locks have been applied because it may cause race conditions.

Signed-off-by: Yuuki Takano <yuuki.takano@tier4.jp>

## Description

`AutowareStateMonitorNode::state_machine_` and `AutowareStateMonitorNode::state_input_` are accessed by multiple threads without mutex locks. This may cause race conditions.
So, mutex locks have been applied to the shared variables.

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
