### PR TITLE
fix(obstacle_cruise_planner): publish empty stop reason

### DIFF
--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -51,6 +51,25 @@ tier4_planning_msgs::msg::StopReasonArray makeStopReasonArray(
   return stop_reason_array;
 }
 
+tier4_planning_msgs::msg::StopReasonArray makeEmptyStopReasonArray(
+  const rclcpp::Time & current_time)
+{
+  // create header
+  std_msgs::msg::Header header;
+  header.frame_id = "map";
+  header.stamp = current_time;
+
+  // create stop reason stamped
+  tier4_planning_msgs::msg::StopReason stop_reason_msg;
+  stop_reason_msg.reason = tier4_planning_msgs::msg::StopReason::OBSTACLE_STOP;
+
+  // create stop reason array
+  tier4_planning_msgs::msg::StopReasonArray stop_reason_array;
+  stop_reason_array.header = header;
+  stop_reason_array.stop_reasons.emplace_back(stop_reason_msg);
+  return stop_reason_array;
+}
+
 double calcMinimumDistanceToStop(
   const double initial_vel, const double max_acc, const double min_acc)
 {
@@ -70,6 +89,7 @@ Trajectory PlannerInterface::generateStopTrajectory(
                                   : std::abs(vehicle_info_.min_longitudinal_offset_m);
 
   if (planner_data.target_obstacles.empty()) {
+    stop_reasons_pub_->publish(makeEmptyStopReasonArray(planner_data.current_time));
     return planner_data.traj;
   }
 


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
In other module such as obstacle_stop_planner or behavior_velocity_planner, the stop_reason is also published when a stop point is not inserted for notifing the cancellation of the stop line.

https://github.com/autowarefoundation/autoware.universe/blob/main/planning/obstacle_stop_planner/src/debug_marker.cpp#L352-L376

However, in the obstacle_cruise_planner module, the stop_reason was published only when a stop point was inserted. I fixed it.

## Review Procedure
With obstacle_cruise_planner launched, confirm that the following topics are updated properly by placing a obstacle on the trajectory and then removing it.

$ ros2 topic echo /awapi/autoware/get/status --field stop_reason.stop_reasons
$ros2 topic echo /planning/scenario_planning/status/stop_reasons

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
