### PR TITLE
fix(behavior_velocity_planner): crosswalk module always output stop distance

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -370,6 +370,14 @@ bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
 
   if (isActivated()) {
     if (!nearest_stop_point) {
+      if (!rtc_stop_point) {
+        setDistance(std::numeric_limits<double>::lowest());
+        return true;
+      }
+
+      const auto crosswalk_distance =
+        calcSignedArcLength(ego_path.points, ego_pos, getPoint(rtc_stop_point.get().second));
+      setDistance(crosswalk_distance);
       return true;
     }
 


### PR DESCRIPTION

Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

- crosswalk module always output stop distance

https://user-images.githubusercontent.com/44889564/180353526-d3a3747f-2d59-4dc4-9d6e-765825f076c6.mp4

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
