### PR TITLE
refactor(behavior_velocity_planner): use motion_utils and tier4_autoware_utils

### DIFF
--- a/planning/behavior_velocity_planner/include/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/util.hpp
@@ -76,6 +76,7 @@ struct PointWithSearchRangeIndex
   SearchRangeIndex index;
 };
 
+using geometry_msgs::msg::Pose;
 using BasicPolygons2d = std::vector<lanelet::BasicPolygon2d>;
 using Polygons2d = std::vector<Polygon2d>;
 using Point2d = boost::geometry::model::d2::point_xy<double>;
@@ -103,20 +104,6 @@ using tier4_planning_msgs::msg::StopReason;
 
 namespace planning_utils
 {
-using geometry_msgs::msg::Pose;
-inline geometry_msgs::msg::Pose getPose(const Path & path, int idx)
-{
-  return path.points.at(idx).pose;
-}
-inline geometry_msgs::msg::Pose getPose(const PathWithLaneId & path, int idx)
-{
-  return path.points.at(idx).point.pose;
-}
-inline geometry_msgs::msg::Pose getPose(const Trajectory & traj, int idx)
-{
-  return traj.points.at(idx).pose;
-}
-
 // create detection area from given range return false if creation failure
 bool createDetectionAreaPolygons(
   Polygons2d & slices, const PathWithLaneId & path, const geometry_msgs::msg::Pose & current_pose,
@@ -132,31 +119,6 @@ void insertVelocity(
   PathWithLaneId & path, const PathPointWithLaneId & path_point, const double v,
   size_t & insert_index, const double min_distance = 0.001);
 inline int64_t bitShift(int64_t original_id) { return original_id << (sizeof(int32_t) * 8 / 2); }
-
-inline double square(const double & a) { return a * a; }
-double normalizeEulerAngle(double euler);
-geometry_msgs::msg::Quaternion getQuaternionFromYaw(double yaw);
-
-template <class T1, class T2>
-double calcSquaredDist2d(const T1 & a, const T2 & b)
-{
-  return square(getPoint(a).x - getPoint(b).x) + square(getPoint(a).y - getPoint(b).y);
-}
-
-template <class T1, class T2>
-double calcDist2d(const T1 & a, const T2 & b)
-{
-  return std::sqrt(calcSquaredDist2d<T1, T2>(a, b));
-}
-
-template <class T>
-bool calcClosestIndex(
-  const T & path, const geometry_msgs::msg::Pose & pose, int & closest, double dist_thr = 3.0,
-  double angle_thr = M_PI_4);
-
-template <class T>
-bool calcClosestIndex(
-  const T & path, const geometry_msgs::msg::Point & point, int & closest, double dist_thr = 3.0);
 
 geometry_msgs::msg::Pose transformRelCoordinate2D(
   const geometry_msgs::msg::Pose & target, const geometry_msgs::msg::Pose & origin);

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -240,7 +240,7 @@ bool BlindSpotModule::generateStopLine(
     geometry_msgs::msg::Pose intersection_enter_pose;
     intersection_enter_pose.position = intersection_enter_point_opt.get();
     const auto stop_idx_ip_opt =
-      motion_utils::findNearestIndex(path_ip.points, intersection_enter_pose, 10.0);
+      motion_utils::findNearestIndex(path_ip.points, intersection_enter_pose, 10.0, M_PI_4);
     if (stop_idx_ip_opt) {
       stop_idx_ip = stop_idx_ip_opt.get();
     }

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -119,8 +119,8 @@ bool BlindSpotModule::modifyPathVelocity(
   debug_data_.judge_point_pose = path->points.at(pass_judge_line_idx).point.pose;
 
   /* if current_state = GO, and current_pose is over judge_line, ignore planning. */
-  is_over_pass_judge_line_ = static_cast<bool>(closest_idx > pass_judge_line_idx);
-  if (closest_idx == pass_judge_line_idx) {
+  is_over_pass_judge_line_ = static_cast<bool>(static_cast<int>(closest_idx) > pass_judge_line_idx);
+  if (static_cast<int>(closest_idx) == pass_judge_line_idx) {
     geometry_msgs::msg::Pose pass_judge_line = path->points.at(pass_judge_line_idx).point.pose;
     is_over_pass_judge_line_ = util::isAheadOf(current_pose.pose, pass_judge_line);
   }
@@ -219,7 +219,7 @@ bool BlindSpotModule::generateStopLine(
   debug_data_.spline_path = path_ip;
 
   /* generate stop point */
-  int stop_idx_ip;  // stop point index for interpolated path.
+  int stop_idx_ip = 0;  // stop point index for interpolated path.
   if (straight_lanelets.size() > 0) {
     boost::optional<int> first_idx_conflicting_lane_opt =
       getFirstPointConflictingLanelets(path_ip, straight_lanelets);

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -17,6 +17,7 @@
 #include <lanelet2_extension/utility/utilities.hpp>
 #include <scene_module/blind_spot/scene.hpp>
 #include <scene_module/intersection/util.hpp>
+#include <tier4_autoware_utils/geometry/path_with_lane_id_geometry.hpp>
 #include <utilization/boost_geometry_helper.hpp>
 #include <utilization/path_utilization.hpp>
 #include <utilization/util.hpp>
@@ -100,13 +101,15 @@ bool BlindSpotModule::modifyPathVelocity(
   }
 
   /* calc closest index */
-  int closest_idx = -1;
-  if (!planning_utils::calcClosestIndex(input_path, current_pose.pose, closest_idx)) {
+  const auto closest_idx_opt =
+    motion_utils::findNearestIndex(input_path.points, current_pose.pose, 3.0, M_PI_4);
+  if (!closest_idx_opt) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
-      logger_, *clock_, 1000 /* ms */, "[Blind Spot] calcClosestIndex fail");
+      logger_, *clock_, 1000 /* ms */, "[Blind Spot] motion_utils::findNearestIndex fail");
     *path = input_path;  // reset path
     return false;
   }
+  const size_t closest_idx = closest_idx_opt.get();
 
   /* get debug info */
   const auto stop_line_pose = util::getAheadPose(
@@ -233,8 +236,15 @@ bool BlindSpotModule::generateStopLine(
       RCLCPP_DEBUG(logger_, "No intersection enter point found.");
       return false;
     }
-    planning_utils::calcClosestIndex(
-      path_ip, intersection_enter_point_opt.get(), stop_idx_ip, 10.0);
+
+    geometry_msgs::msg::Pose intersection_enter_pose;
+    intersection_enter_pose.position = intersection_enter_point_opt.get();
+    const auto stop_idx_ip_opt =
+      motion_utils::findNearestIndex(path_ip.points, intersection_enter_pose, 10.0);
+    if (stop_idx_ip_opt) {
+      stop_idx_ip = stop_idx_ip_opt.get();
+    }
+
     stop_idx_ip = std::max(stop_idx_ip - base2front_idx_dist, 0);
   }
 
@@ -304,7 +314,7 @@ int BlindSpotModule::insertPoint(
 {
   double insert_point_s = 0.0;
   for (int i = 1; i <= insert_idx_ip; i++) {
-    insert_point_s += planning_utils::calcDist2d(
+    insert_point_s += tier4_autoware_utils::calcDistance2d(
       path_ip.points[i].point.pose.position, path_ip.points[i - 1].point.pose.position);
   }
   int insert_idx = -1;
@@ -312,7 +322,7 @@ int BlindSpotModule::insertPoint(
   constexpr double eps = 1e-4;
   double accum_s = eps * 2.0;
   for (size_t i = 1; i < inout_path->points.size(); i++) {
-    accum_s += planning_utils::calcDist2d(
+    accum_s += tier4_autoware_utils::calcDistance2d(
       inout_path->points[i].point.pose.position, inout_path->points[i - 1].point.pose.position);
     if (accum_s > insert_point_s) {
       insert_idx = i;
@@ -328,8 +338,8 @@ int BlindSpotModule::insertPoint(
     constexpr double min_dist = eps;  // to make sure path point is forward insert index
     //! avoid to insert duplicated point
     if (
-      planning_utils::calcDist2d(inserted_point, inout_path->points.at(insert_idx).point) <
-      min_dist) {
+      tier4_autoware_utils::calcDistance2d(
+        inserted_point, inout_path->points.at(insert_idx).point) < min_dist) {
       inout_path->points.at(insert_idx).point.longitudinal_velocity_mps = 0.0;
       is_point_inserted = false;
       return insert_idx;

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
@@ -131,7 +131,8 @@ bool insertTargetVelocityPoint(
 
     if ((point1 - point2).norm() > 1.0E-3) {
       const double yaw = std::atan2(point1.y() - point2.y(), point1.x() - point2.x());
-      target_point_with_lane_id.point.pose.orientation = planning_utils::getQuaternionFromYaw(yaw);
+      target_point_with_lane_id.point.pose.orientation =
+        tier4_autoware_utils::createQuaternionFromYaw(yaw);
     }
     target_point_with_lane_id.point.longitudinal_velocity_mps = velocity;
     if (velocity == 0.0 && target_velocity_point_idx < first_stop_path_point_index) {
@@ -257,7 +258,8 @@ bool insertTargetVelocityPoint(
 
     if ((point1 - point2).norm() > 1.0E-3) {
       const double yaw = std::atan2(point1.y() - point2.y(), point1.x() - point2.x());
-      target_point_with_lane_id.point.pose.orientation = planning_utils::getQuaternionFromYaw(yaw);
+      target_point_with_lane_id.point.pose.orientation =
+        tier4_autoware_utils::createQuaternionFromYaw(yaw);
     }
     target_point_with_lane_id.point.longitudinal_velocity_mps = velocity;
     if (velocity == 0.0 && target_velocity_point_idx < first_stop_path_point_index) {
@@ -364,7 +366,8 @@ bool insertTargetVelocityPoint(
 
     if ((point1 - point2).norm() > 1.0E-3) {
       const double yaw = std::atan2(point1.y() - point2.y(), point1.x() - point2.x());
-      target_point_with_lane_id.point.pose.orientation = planning_utils::getQuaternionFromYaw(yaw);
+      target_point_with_lane_id.point.pose.orientation =
+        tier4_autoware_utils::createQuaternionFromYaw(yaw);
     }
     target_point_with_lane_id.point.longitudinal_velocity_mps = velocity;
     if (velocity == 0.0 && target_velocity_point_idx < first_stop_path_point_index) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -151,8 +151,9 @@ bool IntersectionModule::modifyPathVelocity(
   const size_t closest_idx = closest_idx_opt.get();
 
   /* if current_state = GO, and current_pose is in front of stop_line, ignore planning. */
-  bool is_over_pass_judge_line = static_cast<bool>(closest_idx > pass_judge_line_idx);
-  if (closest_idx == pass_judge_line_idx) {
+  bool is_over_pass_judge_line =
+    static_cast<bool>(static_cast<int>(closest_idx) > pass_judge_line_idx);
+  if (static_cast<int>(closest_idx) == pass_judge_line_idx) {
     geometry_msgs::msg::Pose pass_judge_line = path->points.at(pass_judge_line_idx).point.pose;
     is_over_pass_judge_line = util::isAheadOf(current_pose.pose, pass_judge_line);
   }

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/risk_predictive_braking.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/risk_predictive_braking.cpp
@@ -62,11 +62,13 @@ int insertSafeVelocityToPath(
   const geometry_msgs::msg::Pose & in_pose, const double safe_vel, const PlannerParam & param,
   PathWithLaneId * inout_path)
 {
-  int closest_idx = -1;
-  if (!planning_utils::calcClosestIndex(
-        *inout_path, in_pose, closest_idx, param.dist_thr, param.angle_thr)) {
+  const auto closest_idx_opt =
+    motion_utils::findNearestIndex(inout_path->points, in_pose, param.dist_thr, param.angle_thr);
+  if (!closest_idx_opt) {
     return -1;
   }
+  const size_t closest_idx = closest_idx_opt.get();
+
   PathPointWithLaneId inserted_point;
   inserted_point = inout_path->points.at(closest_idx);
   size_t insert_idx = closest_idx;


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description
use motion_utils and tier4_autoware_utils in behavior velocity planner
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
