### PR TITLE
feat(tier4_autoware_utils): add time argument in appendMarkerArray

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/marker_helper.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/marker_helper.hpp
@@ -19,6 +19,8 @@
 
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <boost/optional.hpp>
+
 #include <string>
 
 namespace tier4_autoware_utils
@@ -88,10 +90,15 @@ inline visualization_msgs::msg::Marker createDefaultMarker(
 
 inline void appendMarkerArray(
   const visualization_msgs::msg::MarkerArray & additional_marker_array,
-  visualization_msgs::msg::MarkerArray * marker_array)
+  visualization_msgs::msg::MarkerArray * marker_array,
+  const boost::optional<rclcpp::Time> & current_time)
 {
   for (const auto & marker : additional_marker_array.markers) {
     marker_array->markers.push_back(marker);
+
+    if (current_time) {
+      marker_array->markers.back().header.stamp = current_time.get();
+    }
   }
 }
 }  // namespace tier4_autoware_utils

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/marker_helper.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/marker_helper.hpp
@@ -91,7 +91,7 @@ inline visualization_msgs::msg::Marker createDefaultMarker(
 inline void appendMarkerArray(
   const visualization_msgs::msg::MarkerArray & additional_marker_array,
   visualization_msgs::msg::MarkerArray * marker_array,
-  const boost::optional<rclcpp::Time> & current_time)
+  const boost::optional<rclcpp::Time> & current_time = {})
 {
   for (const auto & marker : additional_marker_array.markers) {
     marker_array->markers.push_back(marker);


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

**No behavior changes of autoware**
add time argument in appendMarkerArray

In order to make following appendMarkerArray in behavior velocity planner common
https://github.com/autowarefoundation/autoware.universe/blob/16228926f9baa33df9ee5398474d6577528c4757/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp#L160-L162
https://github.com/autowarefoundation/autoware.universe/blob/16228926f9baa33df9ee5398474d6577528c4757/planning/behavior_velocity_planner/include/utilization/marker_helper.hpp#L92-L101
<!-- Write a brief description of this PR. -->


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
