### PR TITLE
feat(tier4_vehicle launch): switch config_dir value for default/individual_param

### DIFF
--- a/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
+++ b/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
@@ -5,7 +5,7 @@
   <arg name="sensor_model" description="sensor model name"/>
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" description="vehicle specific ID"/>
   <arg name="initial_engage_state" default="false" description="/vehicle/engage state after starting Autoware"/>
-  <arg name="config_dir" default="($(var sensor_model)_description)/config/sensors_calibration.yaml" description="path to sensors_calibration.yaml, etc."/>
+  <arg name="config_dir" default="$(find-pkg-share $(var sensor_model)_description)/config" description="path to dir where sensors_calibration.yaml, etc. are located"/>
 
   <let name="vehicle_launch_pkg" value="$(find-pkg-share $(var vehicle_model)_launch)"/>
 
@@ -13,7 +13,7 @@
   <group>
     <arg name="model_file" default="$(find-pkg-share tier4_vehicle_launch)/urdf/vehicle.xacro" description="path to the file of model settings (*.xacro)"/>
     <node name="robot_state_publisher" pkg="robot_state_publisher" exec="robot_state_publisher">
-      <param name="robot_description" value="$(command 'xacro $(var model_file) vehicle_model:=$(var vehicle_model) sensor_model:=$(var sensor_model)')"/>
+      <param name="robot_description" value="$(command 'xacro $(var model_file) vehicle_model:=$(var vehicle_model) sensor_model:=$(var sensor_model) config_dir:=$(var config_dir)')"/>
     </node>
   </group>
 

--- a/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
+++ b/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
@@ -5,6 +5,7 @@
   <arg name="sensor_model" description="sensor model name"/>
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" description="vehicle specific ID"/>
   <arg name="initial_engage_state" default="false" description="/vehicle/engage state after starting Autoware"/>
+  <arg name="config_dir" default="($(var sensor_model)_description)/config/sensors_calibration.yaml" description="path to sensors_calibration.yaml, etc."/>
 
   <let name="vehicle_launch_pkg" value="$(find-pkg-share $(var vehicle_model)_launch)"/>
 


### PR DESCRIPTION
## Description

To directly launch `tier4_vehicle_launch` from autoware_launch/planning_simulator_launch instead of `vehicle_launch` package (which will be removed after these series of PRs (#1337 , #1411 )), tier4_vehicle_launch.xml will need to take `config_dir` as the argument.

This variable should point to the directory where `sensors_calibration.yaml` is located. Currently the default value of `config_dir` is set to `$(sensor_model)_description/config` in `sensors.xacro`, and the value is also used in this PR as the default value of the launch file. If the launch file would be used for a product, this variable should be set to `individual_param/config/<vehicle_id>/<sensor_model>` externally.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
