### PR TITLE
refactor(trajectory_follower_nodes): use max_steer_angle in common

### DIFF
--- a/control/trajectory_follower/src/mpc_lateral_controller.cpp
+++ b/control/trajectory_follower/src/mpc_lateral_controller.cpp
@@ -79,13 +79,13 @@ MpcLateralController::MpcLateralController(rclcpp::Node & node) : node_{&node}
   m_new_traj_end_dist = node_->declare_parameter<float64_t>("new_traj_end_dist");            // [m]
 
   /* mpc parameters */
-  const float64_t steer_lim_deg = node_->declare_parameter<float64_t>("steer_lim_deg");
+  const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo();
+  const float64_t wheelbase = vehicle_info.wheel_base_m;
+  const float64_t steer_lim_deg = vehicle_info.max_steer_angle_rad;
   const float64_t steer_rate_lim_dps = node_->declare_parameter<float64_t>("steer_rate_lim_dps");
   constexpr float64_t deg2rad = static_cast<float64_t>(autoware::common::types::PI) / 180.0;
   m_mpc.m_steer_lim = steer_lim_deg * deg2rad;
   m_mpc.m_steer_rate_lim = steer_rate_lim_dps * deg2rad;
-  const float64_t wheelbase =
-    vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo().wheel_base_m;
 
   /* vehicle model setup */
   const std::string vehicle_model_type =

--- a/control/trajectory_follower/src/mpc_lateral_controller.cpp
+++ b/control/trajectory_follower/src/mpc_lateral_controller.cpp
@@ -81,10 +81,9 @@ MpcLateralController::MpcLateralController(rclcpp::Node & node) : node_{&node}
   /* mpc parameters */
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo();
   const float64_t wheelbase = vehicle_info.wheel_base_m;
-  const float64_t steer_lim_deg = vehicle_info.max_steer_angle_rad;
   const float64_t steer_rate_lim_dps = node_->declare_parameter<float64_t>("steer_rate_lim_dps");
   constexpr float64_t deg2rad = static_cast<float64_t>(autoware::common::types::PI) / 180.0;
-  m_mpc.m_steer_lim = steer_lim_deg * deg2rad;
+  m_mpc.m_steer_lim = vehicle_info.max_steer_angle_rad;
   m_mpc.m_steer_rate_lim = steer_rate_lim_dps * deg2rad;
 
   /* vehicle model setup */

--- a/control/trajectory_follower_nodes/design/lateral_controller-design.md
+++ b/control/trajectory_follower_nodes/design/lateral_controller-design.md
@@ -92,22 +92,21 @@ AutonomouStuff Lexus RX 450h for under 40 km/h driving.
 
 #### Vehicle
 
-| Name          | Type   | Description                                                                        | Default value |
-| :------------ | :----- | :--------------------------------------------------------------------------------- | :------------ |
-| cg_to_front_m | double | distance from baselink to the front axle[m]                                        | 1.228         |
-| cg_to_rear_m  | double | distance from baselink to the rear axle [m]                                        | 1.5618        |
-| mass_fl       | double | mass applied to front left tire [kg]                                               | 600           |
-| mass_fr       | double | mass applied to front right tire [kg]                                              | 600           |
-| mass_rl       | double | mass applied to rear left tire [kg]                                                | 600           |
-| mass_rr       | double | mass applied to rear right tire [kg]                                               | 600           |
-| cf            | double | front cornering power [N/rad]                                                      | 155494.663    |
-| cr            | double | rear cornering power [N/rad]                                                       | 155494.663    |
-| steering_tau  | double | steering dynamics time constant (1d approximation) for vehicle model [s]           | 0.3           |
-| steer_lim_deg | double | steering angle limit for vehicle model [deg]. This is also used for QP constraint. | 35.0          |
+| Name          | Type   | Description                                                              | Default value |
+| :------------ | :----- | :----------------------------------------------------------------------- | :------------ |
+| cg_to_front_m | double | distance from baselink to the front axle[m]                              | 1.228         |
+| cg_to_rear_m  | double | distance from baselink to the rear axle [m]                              | 1.5618        |
+| mass_fl       | double | mass applied to front left tire [kg]                                     | 600           |
+| mass_fr       | double | mass applied to front right tire [kg]                                    | 600           |
+| mass_rl       | double | mass applied to rear left tire [kg]                                      | 600           |
+| mass_rr       | double | mass applied to rear right tire [kg]                                     | 600           |
+| cf            | double | front cornering power [N/rad]                                            | 155494.663    |
+| cr            | double | rear cornering power [N/rad]                                             | 155494.663    |
+| steering_tau  | double | steering dynamics time constant (1d approximation) for vehicle model [s] | 0.3           |
 
 ### How to tune MPC parameters
 
-1. Set appropriate vehicle kinematics parameters for distance to front and rear axle, and `steer_lim_deg`.
+1. Set appropriate vehicle kinematics parameters for distance to front and rear axle and max steer angle.
    Also check that the input `VehicleKinematicState` has appropriate values (speed: vehicle rear-wheels-center velocity [km/h], angle: steering (tire) angle [rad]).
    These values give a vehicle information to the controller for path following.
    Errors in these values cause fundamental tracking error.

--- a/control/trajectory_follower_nodes/param/lateral_controller_defaults.param.yaml
+++ b/control/trajectory_follower_nodes/param/lateral_controller_defaults.param.yaml
@@ -44,7 +44,6 @@
     vehicle_model_type: "kinematics" # vehicle model type for mpc prediction. option is kinematics, kinematics_no_delay, and dynamics
     input_delay: 0.24 # steering input delay time for delay compensation
     vehicle_model_steer_tau: 0.3 # steering dynamics time constant (1d approximation) [s]
-    steer_lim_deg: 40.0 # steering angle limit [deg]
     steer_rate_lim_dps: 600.0 # steering angle rate limit [deg/s]
     acceleration_limit: 2.0 # acceleration limit for trajectory velocity modification [m/ss]
     velocity_time_constant: 0.3 # velocity dynamics time constant  for trajectory velocity modification [s]

--- a/launch/tier4_control_launch/config/trajectory_follower/lateral_controller.param.yaml
+++ b/launch/tier4_control_launch/config/trajectory_follower/lateral_controller.param.yaml
@@ -45,7 +45,6 @@
     vehicle_model_type: "kinematics" # vehicle model type for mpc prediction. option is kinematics, kinematics_no_delay, and dynamics
     input_delay: 0.24                # steering input delay time for delay compensation
     vehicle_model_steer_tau: 0.3     # steering dynamics time constant (1d approximation) [s]
-    steer_lim_deg: 40.0              # steering angle limit [deg]
     steer_rate_lim_dps: 600.0        # steering angle rate limit [deg/s]
     acceleration_limit: 2.0          # acceleration limit for trajectory velocity modification [m/ss]
     velocity_time_constant: 0.3      # velocity dynamics time constant  for trajectory velocity modification [s]


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

use max_steer_angle defined in vehicle_info_utils in mpc_follower
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
