### PR TITLE
refactor(obstacle_avoidance_planner): use max_steer_angle in common

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -68,9 +68,7 @@
         num_curvature_sampling_points: 5 # number of sampling points when calculating curvature
         delta_arc_length_for_mpt_points: 0.5 # delta arc length when generating mpt [m]
 
-      kinematics:
-        max_steer_deg: 40.0 # max steering angle [deg]
-
+      # kinematics:
         # If this parameter is commented out, the parameter is set as below by default.
         # The logic could be `optimization_center_offset = vehicle_info.wheel_base * 0.8`
         # The 0.8 scale is adopted as it performed the best.

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -69,8 +69,6 @@
         delta_arc_length_for_mpt_points: 0.5 # delta arc length when generating mpt [m]
 
       kinematics:
-        max_steer_deg: 40.0 # max steering angle [deg]
-
         # If this parameter is commented out, the parameter is set as below by default.
         # The logic could be `optimization_center_offset = vehicle_info.wheel_base * 0.8`
         # The 0.8 scale is adopted as it performed the best.

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -68,7 +68,7 @@
         num_curvature_sampling_points: 5 # number of sampling points when calculating curvature
         delta_arc_length_for_mpt_points: 0.5 # delta arc length when generating mpt [m]
 
-      kinematics:
+      # kinematics:
         # If this parameter is commented out, the parameter is set as below by default.
         # The logic could be `optimization_center_offset = vehicle_info.wheel_base * 0.8`
         # The 0.8 scale is adopted as it performed the best.

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -400,7 +400,7 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
       declare_parameter<double>("mpt.common.delta_arc_length_for_mpt_points");
 
     // kinematics
-    mpt_param_.max_steer_rad = vehicle_info.max_steer_angle_rad * 180.0 / M_PI;
+    mpt_param_.max_steer_rad = vehicle_info.max_steer_angle_rad;
 
     // By default, optimization_center_offset will be vehicle_info.wheel_base * 0.8
     // The 0.8 scale is adopted as it performed the best.

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -268,9 +268,9 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
     "/planning/scenario_planning/lane_driving/obstacle_avoidance_approval", rclcpp::QoS{10},
     std::bind(&ObstacleAvoidancePlanner::enableAvoidanceCallback, this, std::placeholders::_1));
 
+  const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();
   {  // vehicle param
     vehicle_param_ = VehicleParam{};
-    const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();
     vehicle_param_.width = vehicle_info.vehicle_width_m;
     vehicle_param_.length = vehicle_info.vehicle_length_m;
     vehicle_param_.wheelbase = vehicle_info.wheel_base_m;
@@ -400,8 +400,7 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
       declare_parameter<double>("mpt.common.delta_arc_length_for_mpt_points");
 
     // kinematics
-    mpt_param_.max_steer_rad =
-      declare_parameter<double>("mpt.kinematics.max_steer_deg") * M_PI / 180.0;
+    mpt_param_.max_steer_rad = vehicle_info.max_steer_angle_rad * 180.0 / M_PI;
 
     // By default, optimization_center_offset will be vehicle_info.wheel_base * 0.8
     // The 0.8 scale is adopted as it performed the best.
@@ -662,9 +661,6 @@ rcl_interfaces::msg::SetParametersResult ObstacleAvoidancePlanner::paramCallback
       mpt_param_.delta_arc_length_for_mpt_points);
 
     // kinematics
-    double max_steer_deg = mpt_param_.max_steer_rad * 180.0 / M_PI;
-    updateParam<double>(parameters, "mpt.kinematics.max_steer_deg", max_steer_deg);
-    mpt_param_.max_steer_rad = max_steer_deg * M_PI / 180.0;
     updateParam<double>(
       parameters, "mpt.kinematics.optimization_center_offset",
       mpt_param_.optimization_center_offset);


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

use max_steer_angle defined in vehicle_info_utils in obstacle_avoidance_planner
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
