### PR TITLE
feat(perception_utils): add prediction resampling function

### DIFF
--- a/common/perception_utils/include/perception_utils/predicted_path_utils.hpp
+++ b/common/perception_utils/include/perception_utils/predicted_path_utils.hpp
@@ -44,13 +44,14 @@ inline boost::optional<geometry_msgs::msg::Pose> calcInterpolatedPose(
     return boost::none;
   }
 
+  constexpr double epsilon = 1e-6;
   const auto & time_step = rclcpp::Duration(path.time_step).seconds();
   for (size_t path_idx = 1; path_idx < path.path.size(); ++path_idx) {
     const auto & pt = path.path.at(path_idx);
     const auto & prev_pt = path.path.at(path_idx - 1);
-    if (relative_time <= time_step * static_cast<double>(path_idx)) {
+    if (relative_time + epsilon < time_step * static_cast<double>(path_idx)) {
       const auto offset = relative_time - time_step * static_cast<double>(path_idx - 1);
-      const auto ratio = offset / time_step;
+      const auto ratio = std::clamp(offset / time_step, 0.0, 1.0);
       return tier4_autoware_utils::calcInterpolatedPose(prev_pt, pt, ratio);
     }
   }

--- a/common/perception_utils/include/perception_utils/predicted_path_utils.hpp
+++ b/common/perception_utils/include/perception_utils/predicted_path_utils.hpp
@@ -1,0 +1,120 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PERCEPTION_UTILS__PREDICTED_PATH_UTILS_HPP_
+#define PERCEPTION_UTILS__PREDICTED_PATH_UTILS_HPP_
+
+#include "perception_utils/geometry.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "autoware_auto_perception_msgs/msg/predicted_path.hpp"
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <boost/optional.hpp>
+
+#include <vector>
+
+namespace perception_utils
+{
+/**
+ * @brief Calculate Interpolated Pose from predicted path by time
+ * @param path Input predicted path
+ * @param relative_time time at interpolated point. This should be within [0.0,
+ * time_step*(num_of_path_points)]
+ * @return interpolated pose
+ */
+inline boost::optional<geometry_msgs::msg::Pose> calcInterpolatedPose(
+  const autoware_auto_perception_msgs::msg::PredictedPath & path, const double relative_time)
+{
+  // Check if relative time is in the valid range
+  if (path.path.empty() || relative_time < 0.0) {
+    return boost::none;
+  }
+
+  const auto & time_step = rclcpp::Duration(path.time_step).seconds();
+  for (size_t path_idx = 1; path_idx < path.path.size(); ++path_idx) {
+    const auto & pt = path.path.at(path_idx);
+    const auto & prev_pt = path.path.at(path_idx - 1);
+    if (relative_time <= time_step * static_cast<double>(path_idx)) {
+      const auto offset = relative_time - time_step * static_cast<double>(path_idx - 1);
+      const auto ratio = offset / time_step;
+      return tier4_autoware_utils::calcInterpolatedPose(prev_pt, pt, ratio);
+    }
+  }
+
+  return boost::none;
+}
+
+/**
+ * @brief Resampling predicted path by time step vector
+ * @param path Input predicted path
+ * @param relative_time_vec time at each resampling point. Each time should be within [0.0,
+ * time_step*(num_of_path_points)]
+ * @return resampled path
+ */
+autoware_auto_perception_msgs::msg::PredictedPath resamplePredictedPath(
+  const autoware_auto_perception_msgs::msg::PredictedPath & path,
+  const std::vector<double> & relative_time_vec)
+{
+  autoware_auto_perception_msgs::msg::PredictedPath resampled_path;
+  resampled_path.confidence = path.confidence;
+  resampled_path.time_step = path.time_step;
+
+  for (const auto & rel_time : relative_time_vec) {
+    const auto opt_pose = calcInterpolatedPose(path, rel_time);
+    if (!opt_pose) {
+      continue;
+    }
+
+    resampled_path.path.push_back(*opt_pose);
+  }
+
+  return resampled_path;
+}
+
+/**
+ * @brief Resampling predicted path by sampling time interval. Note that this function samples
+ * terminal point as well as points by sampling time interval
+ * @param path Input predicted path
+ * @param sampling_time_interval sampling time interval for each point
+ * @param enable_sampling_terminal_point flag if to sample terminal point
+ * @return resampled path
+ */
+autoware_auto_perception_msgs::msg::PredictedPath resamplePredictedPath(
+  const autoware_auto_perception_msgs::msg::PredictedPath & path,
+  const double sampling_time_interval, bool enable_sampling_terminal_point = true)
+{
+  std::vector<double> sampling_time_vector;
+  const double predicted_horizon =
+    rclcpp::Duration(path.time_step).seconds() * static_cast<double>(path.path.size() - 1);
+  for (double t = 0.0; t < predicted_horizon; t += sampling_time_interval) {
+    sampling_time_vector.push_back(t);
+  }
+
+  // Insert Predicted Horizon(Terminal Predicted Point)
+  if (enable_sampling_terminal_point) {
+    if (predicted_horizon - sampling_time_vector.back() > 1e-3) {
+      sampling_time_vector.push_back(predicted_horizon);
+    } else {
+      sampling_time_vector.back() = predicted_horizon;
+    }
+  }
+
+  return resamplePredictedPath(path, sampling_time_vector);
+}
+}  // namespace perception_utils
+
+#endif  // PERCEPTION_UTILS__PREDICTED_PATH_UTILS_HPP_

--- a/common/perception_utils/package.xml
+++ b/common/perception_utils/package.xml
@@ -13,6 +13,7 @@
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>interpolation</depend>
   <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>tier4_autoware_utils</depend>

--- a/common/perception_utils/test/src/test_predicted_path_utils.cpp
+++ b/common/perception_utils/test/src/test_predicted_path_utils.cpp
@@ -67,7 +67,7 @@ TEST(predicted_path_utils, testCalcInterpolatedPose)
   using tier4_autoware_utils::createQuaternionFromYaw;
   using tier4_autoware_utils::deg2rad;
 
-  const auto path = createTestPredictedPath(100, 1.0, 1.0);
+  const auto path = createTestPredictedPath(100, 0.1, 1.0);
 
   {
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
@@ -82,6 +82,28 @@ TEST(predicted_path_utils, testCalcInterpolatedPose)
       EXPECT_NEAR(p->orientation.y, ans_quat.y, epsilon);
       EXPECT_NEAR(p->orientation.z, ans_quat.z, epsilon);
       EXPECT_NEAR(p->orientation.w, ans_quat.w, epsilon);
+    }
+  }
+
+  // No Interpolation
+  {
+    // Negative time
+    {
+      const auto p = calcInterpolatedPose(path, -1.0);
+      EXPECT_EQ(p, boost::none);
+    }
+
+    // Over the time horizon
+    {
+      const auto p = calcInterpolatedPose(path, 10.0 + 1e-6);
+      EXPECT_EQ(p, boost::none);
+    }
+
+    // Empty Path
+    {
+      PredictedPath empty_path;
+      const auto p = calcInterpolatedPose(empty_path, -1.0);
+      EXPECT_EQ(p, boost::none);
     }
   }
 }

--- a/common/perception_utils/test/src/test_predicted_path_utils.cpp
+++ b/common/perception_utils/test/src/test_predicted_path_utils.cpp
@@ -125,3 +125,31 @@ TEST(predicted_path_utils, testCalcInterpolatedPose)
     }
   }
 }
+
+TEST(predicted_path_utils, resamplePredictedPath_by_Vector)
+{
+  using perception_utils::resamplePredictedPath;
+  using tier4_autoware_utils::createQuaternionFromRPY;
+  using tier4_autoware_utils::createQuaternionFromYaw;
+  using tier4_autoware_utils::deg2rad;
+
+  // Resample Same Points
+  {
+    const auto path = createTestPredictedPath(10, 1.0, 1.0);
+    const std::vector<double> resampling_vec = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+    const auto resampled_path = resamplePredictedPath(path, resampling_vec);
+
+    EXPECT_EQ(resampled_path.path.size(), path.path.size());
+    EXPECT_NEAR(path.confidence, resampled_path.confidence, epsilon);
+
+    for (size_t i = 0; i < path.path.size(); ++i) {
+      EXPECT_NEAR(path.path.at(i).position.x, resampled_path.path.at(i).position.x, epsilon);
+      EXPECT_NEAR(path.path.at(i).position.y, resampled_path.path.at(i).position.y, epsilon);
+      EXPECT_NEAR(path.path.at(i).position.z, resampled_path.path.at(i).position.z, epsilon);
+      EXPECT_NEAR(path.path.at(i).orientation.x, resampled_path.path.at(i).orientation.x, epsilon);
+      EXPECT_NEAR(path.path.at(i).orientation.y, resampled_path.path.at(i).orientation.y, epsilon);
+      EXPECT_NEAR(path.path.at(i).orientation.z, resampled_path.path.at(i).orientation.z, epsilon);
+      EXPECT_NEAR(path.path.at(i).orientation.w, resampled_path.path.at(i).orientation.w, epsilon);
+    }
+  }
+}

--- a/common/perception_utils/test/src/test_predicted_path_utils.cpp
+++ b/common/perception_utils/test/src/test_predicted_path_utils.cpp
@@ -1,0 +1,87 @@
+// Copyright 2020 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "perception_utils/predicted_path_utils.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/math/unit_conversion.hpp"
+
+#include <gtest/gtest.h>
+
+using tier4_autoware_utils::Point2d;
+using tier4_autoware_utils::Point3d;
+
+constexpr double epsilon = 1e-06;
+
+namespace
+{
+using autoware_auto_perception_msgs::msg::PredictedPath;
+using tier4_autoware_utils::createPoint;
+using tier4_autoware_utils::createQuaternionFromRPY;
+using tier4_autoware_utils::transformPoint;
+
+geometry_msgs::msg::Pose createPose(
+  double x, double y, double z, double roll, double pitch, double yaw)
+{
+  geometry_msgs::msg::Pose p;
+  p.position = createPoint(x, y, z);
+  p.orientation = createQuaternionFromRPY(roll, pitch, yaw);
+  return p;
+}
+
+PredictedPath createTestPredictedPath(
+  const size_t num_points, const double point_time_interval, const double vel,
+  const double init_theta = 0.0, const double delta_theta = 0.0)
+{
+  PredictedPath path;
+  path.confidence = 1.0;
+  path.time_step = rclcpp::Duration::from_seconds(point_time_interval);
+
+  const double point_interval = vel * point_time_interval;
+  for (size_t i = 0; i < num_points; ++i) {
+    const double theta = init_theta + i * delta_theta;
+    const double x = i * point_interval * std::cos(theta);
+    const double y = i * point_interval * std::sin(theta);
+
+    const auto p = createPose(x, y, 0.0, 0.0, 0.0, theta);
+    path.path.push_back(p);
+  }
+  return path;
+}
+}  // namespace
+
+TEST(predicted_path_utils, testCalcInterpolatedPose)
+{
+  using perception_utils::calcInterpolatedPose;
+  using tier4_autoware_utils::createQuaternionFromRPY;
+  using tier4_autoware_utils::createQuaternionFromYaw;
+  using tier4_autoware_utils::deg2rad;
+
+  const auto path = createTestPredictedPath(100, 1.0, 1.0);
+
+  {
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+    for (double t = 0.0; t < 10.0; t += 1.0) {
+      const auto p = calcInterpolatedPose(path, t);
+
+      EXPECT_NE(p, boost::none);
+      EXPECT_NEAR(p->position.x, t * 1.0, epsilon);
+      EXPECT_NEAR(p->position.y, 0.0, epsilon);
+      EXPECT_NEAR(p->position.z, 0.0, epsilon);
+      EXPECT_NEAR(p->orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p->orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p->orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p->orientation.w, ans_quat.w, epsilon);
+    }
+  }
+}

--- a/common/perception_utils/test/src/test_predicted_path_utils.cpp
+++ b/common/perception_utils/test/src/test_predicted_path_utils.cpp
@@ -69,9 +69,27 @@ TEST(predicted_path_utils, testCalcInterpolatedPose)
 
   const auto path = createTestPredictedPath(100, 0.1, 1.0);
 
+  // Normal Case (same point as the original point)
   {
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
-    for (double t = 0.0; t < 10.0; t += 1.0) {
+    for (double t = 0.0; t < 9.0 + 1e-6; t += 1.0) {
+      const auto p = calcInterpolatedPose(path, t);
+
+      EXPECT_NE(p, boost::none);
+      EXPECT_NEAR(p->position.x, t * 1.0, epsilon);
+      EXPECT_NEAR(p->position.y, 0.0, epsilon);
+      EXPECT_NEAR(p->position.z, 0.0, epsilon);
+      EXPECT_NEAR(p->orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p->orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p->orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p->orientation.w, ans_quat.w, epsilon);
+    }
+  }
+
+  // Normal Case (random case)
+  {
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+    for (double t = 0.0; t < 9.0; t += 0.3) {
       const auto p = calcInterpolatedPose(path, t);
 
       EXPECT_NE(p, boost::none);
@@ -95,14 +113,14 @@ TEST(predicted_path_utils, testCalcInterpolatedPose)
 
     // Over the time horizon
     {
-      const auto p = calcInterpolatedPose(path, 10.0 + 1e-6);
+      const auto p = calcInterpolatedPose(path, 11.0);
       EXPECT_EQ(p, boost::none);
     }
 
     // Empty Path
     {
       PredictedPath empty_path;
-      const auto p = calcInterpolatedPose(empty_path, -1.0);
+      const auto p = calcInterpolatedPose(empty_path, 5.0);
       EXPECT_EQ(p, boost::none);
     }
   }


### PR DESCRIPTION
## Description
In autoware, there are a few duplicated functions for resampling predicted path, so I make several resampling functions in perception utils. 

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
