### PR TITLE
feat(motion_utils): add base class of vehicle stop checker

### DIFF
--- a/common/motion_utils/include/motion_utils/vehicle/vehicle_state_checker.hpp
+++ b/common/motion_utils/include/motion_utils/vehicle/vehicle_state_checker.hpp
@@ -31,27 +31,34 @@ using autoware_auto_planning_msgs::msg::Trajectory;
 using geometry_msgs::msg::TwistStamped;
 using nav_msgs::msg::Odometry;
 
-class VehicleStopChecker
+class VehicleStopCheckerBase
+{
+public:
+  VehicleStopCheckerBase(rclcpp::Node * node, double buffer_duration);
+  rclcpp::Logger getLogger() { return logger_; }
+  void addTwist(const TwistStamped & twist);
+  bool isVehicleStopped(const double stop_duration = 0.0) const;
+
+protected:
+  rclcpp::Clock::SharedPtr clock_;
+  rclcpp::Logger logger_;
+
+private:
+  double buffer_duration_;
+  std::deque<TwistStamped> twist_buffer_;
+};
+
+class VehicleStopChecker : public VehicleStopCheckerBase
 {
 public:
   explicit VehicleStopChecker(rclcpp::Node * node);
 
-  bool isVehicleStopped(const double stop_duration = 0.0) const;
-
-  rclcpp::Logger getLogger() { return logger_; }
-
 protected:
   rclcpp::Subscription<Odometry>::SharedPtr sub_odom_;
-  rclcpp::Clock::SharedPtr clock_;
-  rclcpp::Logger logger_;
-
   Odometry::SharedPtr odometry_ptr_;
-
-  std::deque<TwistStamped> twist_buffer_;
 
 private:
   static constexpr double velocity_buffer_time_sec = 10.0;
-
   void onOdom(const Odometry::SharedPtr msg);
 };
 


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Move the common part of `VehicleStopChecker` to the base class `VehicleStopCheckerBase`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
