### PR TITLE
fix(tensorrt_yolo): change the CMakeLists.txt folders for compiling error on Jetson AGX-Orin

### DIFF
--- a/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
+++ b/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
@@ -6,7 +6,7 @@ autoware_package()
 
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}")
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)
@@ -25,8 +25,6 @@ else()
   message("CUDA NOT FOUND")
   set(CUDA_AVAIL OFF)
 endif()
-
-
 
 # set flags for TensorRT availability
 option(TRT_AVAIL "TensorRT available" OFF)

--- a/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
+++ b/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
@@ -5,7 +5,8 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
-
+set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)
@@ -24,6 +25,8 @@ else()
   message("CUDA NOT FOUND")
   set(CUDA_AVAIL OFF)
 endif()
+
+
 
 # set flags for TensorRT availability
 option(TRT_AVAIL "TensorRT available" OFF)

--- a/perception/lidar_centerpoint/CMakeLists.txt
+++ b/perception/lidar_centerpoint/CMakeLists.txt
@@ -6,7 +6,7 @@ autoware_package()
 
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}")
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)

--- a/perception/lidar_centerpoint/CMakeLists.txt
+++ b/perception/lidar_centerpoint/CMakeLists.txt
@@ -5,7 +5,8 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
-
+set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)

--- a/perception/tensorrt_yolo/CMakeLists.txt
+++ b/perception/tensorrt_yolo/CMakeLists.txt
@@ -7,7 +7,8 @@ autoware_package()
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
 find_package(OpenCV REQUIRED)
-
+set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)

--- a/perception/tensorrt_yolo/CMakeLists.txt
+++ b/perception/tensorrt_yolo/CMakeLists.txt
@@ -8,7 +8,7 @@ option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
 find_package(OpenCV REQUIRED)
 set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}")
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)

--- a/perception/traffic_light_classifier/CMakeLists.txt
+++ b/perception/traffic_light_classifier/CMakeLists.txt
@@ -5,6 +5,9 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
+
+set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)

--- a/perception/traffic_light_classifier/CMakeLists.txt
+++ b/perception/traffic_light_classifier/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
 set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}")
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)

--- a/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
@@ -7,7 +7,8 @@ autoware_package()
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
 find_package(OpenCV REQUIRED)
-
+set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)

--- a/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
@@ -8,7 +8,7 @@ option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
 find_package(OpenCV REQUIRED)
 set(DEPRECATION_FLAG "-Wno-error=deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}"
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAG}")
 # set flags for CUDA availability
 option(CUDA_AVAIL "CUDA available" OFF)
 find_package(CUDA)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Jetson AGX-Orin uses Jetpack 5.1.0 which includes:
- CUDA 11.4.14
- TensorRT 8.4.0 Early Access
- cuDNN 8.3.2

These library versions were giving deprecation errors while compiling some packages:
- tensorrt_yolo
- lidar_apollo_instance_segmentation
- lidar_centerpoint
- traffic_light_ssd_fine_detector
- traffic_light_classifier

To fix this issue, compiler flag added to CMakeLists.txt. Should we add this situation to documantation? I opened an[ issue](https://github.com/autowarefoundation/autoware-documentation/issues/166) in autoware-documentation for this case.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
