### PR TITLE
feat(rename_urdf): rename tier4_vehicle_launch/vehicle.xacro to model.xacro

### DIFF
--- a/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
+++ b/launch/tier4_vehicle_launch/launch/vehicle.launch.xml
@@ -11,7 +11,7 @@
 
   <!-- vehicle description -->
   <group>
-    <arg name="model_file" default="$(find-pkg-share tier4_vehicle_launch)/urdf/vehicle.xacro" description="path to the file of model settings (*.xacro)"/>
+    <arg name="model_file" default="$(find-pkg-share tier4_vehicle_launch)/urdf/model.xacro" description="path to the file of model settings (*.xacro)"/>
     <node name="robot_state_publisher" pkg="robot_state_publisher" exec="robot_state_publisher">
       <param name="robot_description" value="$(command 'xacro $(var model_file) vehicle_model:=$(var vehicle_model) sensor_model:=$(var sensor_model) config_dir:=$(var config_dir)')"/>
     </node>

--- a/launch/tier4_vehicle_launch/urdf/model.xacro
+++ b/launch/tier4_vehicle_launch/urdf/model.xacro
@@ -2,12 +2,14 @@
 <robot name="vehicle" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="vehicle_model" default=""/>
   <xacro:arg name="sensor_model" default=""/>
+  <xacro:arg name="config_dir" default="$(find $(arg sensor_model)_description)/config"/>
 
   <!-- vehicle -->
   <xacro:property name="vehicle_model_property" value="$(arg vehicle_model)"/>
   <xacro:include filename="$(find ${vehicle_model_property}_description)/urdf/vehicle.xacro"/>
 
   <!-- sensors -->
+  <!-- NOTE: sensors look up config_dir for calibration data -->
   <xacro:property name="sensor_model_property" value="$(arg sensor_model)"/>
   <xacro:include filename="$(find ${sensor_model_property}_description)/urdf/sensors.xacro"/>
 </robot>


### PR DESCRIPTION
rename tier4_vehicle_launch/vehicle.xacro to model.xacro

Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

`robot_description` parameter is loaded from `tier4_vehicle_launch/urdf/vehicle.xacro` and actually this file includes  `${sensor}_description/urdf/sensors.xacro` and `${vehicle}_description/urdf/vehicle.xacro`, so in this PR I renamed the former one to `model.xacro` to avoid confusion.

## Tests performed

I checked this PR in OSS and internal (Pilo.auto) autoware using sample_vehicle and our product model respectively by viewing the tf_tree was is well created.
 
## Notes for reviewers

The maintainers will need to care `config_dir` when migrating these series of launcher modifications to each product.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
