### PR TITLE
fix(tier4_control_launch): pass vehicle_info_param to trajectory_follower

### DIFF
--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -96,6 +96,7 @@ def launch_setup(context, *args, **kwargs):
             },
             lon_controller_param,
             lat_controller_param,
+            vehicle_info_param,
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )


### PR DESCRIPTION
## Description
In https://github.com/autowarefoundation/autoware.universe/pull/1422, trajectory_follower was modified to use VehicleInfoUtil which listens to vehicle_info_parameters.
Therefore, we should modify control.launch.py to pass vehicle_info_param to the node so that control.launch.py can be launched without an error.

## Review Procedure
Run the following command:
```
ros2 launch tier4_control_launch control.launch.py lateral_controller_mode:=mpc_follower vehicle_info_param_file:=$(ros2 pkg prefix sample_vehicle_description)/share/sample_vehicle_description/config/vehicle_info.param.yaml
```

Comfirm that the following error disappears with this PR. 
```
[component_container-1] [ERROR] [1658963426.295600556] [control.control_container]: Component constructor threw an exception: Statically typed parameter 'wheel_radius' must be initialized.
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
