### PR TITLE
fix(behavior_velocity_planner): fix distance for traffic light module

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -228,6 +228,8 @@ bool TrafficLightModule::modifyPathVelocity(
         planner_param_.stop_margin + planner_data_->vehicle_info_.max_longitudinal_offset_m,
         planner_data_->stop_line_extend_length, stop_line_point, stop_line_point_idx)) {
     RCLCPP_WARN_THROTTLE(logger_, *clock_, 5000, "Failed to calculate stop point and insert index");
+    setSafe(true);
+    setDistance(std::numeric_limits<double>::lowest());
     return false;
   }
 


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
Set invalid distance if traffic light module can not calculate stop point.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
