### PR TITLE
feat(perception_utils): add inline to resampling functions

### DIFF
--- a/common/perception_utils/include/perception_utils/predicted_path_utils.hpp
+++ b/common/perception_utils/include/perception_utils/predicted_path_utils.hpp
@@ -70,7 +70,7 @@ inline boost::optional<geometry_msgs::msg::Pose> calcInterpolatedPose(
  * time_step*(num_of_path_points)]
  * @return resampled path
  */
-autoware_auto_perception_msgs::msg::PredictedPath resamplePredictedPath(
+inline autoware_auto_perception_msgs::msg::PredictedPath resamplePredictedPath(
   const autoware_auto_perception_msgs::msg::PredictedPath & path,
   const std::vector<double> & resampled_time, const bool use_spline_for_xy = true,
   const bool use_spline_for_z = false)
@@ -136,7 +136,7 @@ autoware_auto_perception_msgs::msg::PredictedPath resamplePredictedPath(
  * @param sampling_horizon sampling time horizon
  * @return resampled path
  */
-autoware_auto_perception_msgs::msg::PredictedPath resamplePredictedPath(
+inline autoware_auto_perception_msgs::msg::PredictedPath resamplePredictedPath(
   const autoware_auto_perception_msgs::msg::PredictedPath & path,
   const double sampling_time_interval, const double sampling_horizon,
   const bool use_spline_for_xy = true, const bool use_spline_for_z = false)


### PR DESCRIPTION
## Description

There is no inline declare in predicted path resample function and lead to a build failures. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
