### PR TITLE
feat(obstacle_stop_planner): prevent from obstacle hunting

### DIFF
--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -46,6 +46,16 @@ When the deceleration section is inserted, the start point of the section is ins
 
 ## Modules
 
+### Common Parameter
+
+| Parameter               | Type   | Description                                                                              |
+| ----------------------- | ------ | ---------------------------------------------------------------------------------------- |
+| `enable_slow_down`      | bool   | enable slow down planner [-]                                                             |
+| `max_velocity`          | double | max velocity [m/s]                                                                       |
+| `hunting_threshold`     | double | # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s] |
+| `lowpass_gain`          | double | low pass gain for calculating acceleration [-]                                           |
+| `max_yaw_deviation_deg` | double | # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)   |
+
 ### Obstacle Stop Planner
 
 #### Role

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    hunting_threshold: 0.5 # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s]
+
     stop_planner:
       stop_margin: 5.0 # stop margin distance from obstacle on the path [m]
       min_behavior_stop_margin: 2.0 # stop margin distance when any other stop point is inserted in stop margin [m]

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -185,12 +185,14 @@ private:
   std::unique_ptr<motion_planning::AdaptiveCruiseController> acc_controller_;
   std::shared_ptr<ObstacleStopPlannerDebugNode> debug_ptr_;
   std::shared_ptr<LowpassFilter1d> lpf_acc_{nullptr};
-  boost::optional<SlowDownSection> latest_slow_down_section_{};
+  boost::optional<StopPoint> latest_stop_point_{boost::none};
+  boost::optional<SlowDownSection> latest_slow_down_section_{boost::none};
   tf2_ros::Buffer tf_buffer_{get_clock()};
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
   sensor_msgs::msg::PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
   PredictedObjects::ConstSharedPtr object_ptr_{nullptr};
-  rclcpp::Time last_detection_time_;
+  rclcpp::Time last_detect_time_collision_point_;
+  rclcpp::Time last_detect_time_slowdown_point_;
 
   nav_msgs::msg::Odometry::ConstSharedPtr current_velocity_ptr_{nullptr};
   nav_msgs::msg::Odometry::ConstSharedPtr prev_velocity_ptr_{nullptr};

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -773,7 +773,9 @@ void ObstacleStopPlannerNode::searchObstacle(
           planner_data.nearest_collision_point_time, object_ptr, current_velocity_ptr,
           &planner_data.stop_require, &output, trajectory_header);
 
-        last_detect_time_collision_point_ = trajectory_header.stamp;
+        if (planner_data.stop_require) {
+          last_detect_time_collision_point_ = trajectory_header.stamp;
+        }
 
         break;
       }

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -515,7 +515,8 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
   acc_controller_ = std::make_unique<motion_planning::AdaptiveCruiseController>(
     this, i.vehicle_width_m, i.vehicle_length_m, i.max_longitudinal_offset_m);
   debug_ptr_ = std::make_shared<ObstacleStopPlannerDebugNode>(this, i.max_longitudinal_offset_m);
-  last_detection_time_ = this->now();
+  last_detect_time_slowdown_point_ = this->now();
+  last_detect_time_collision_point_ = this->now();
 
   // Publishers
   path_pub_ = this->create_publisher<Trajectory>("~/output/trajectory", 1);
@@ -654,8 +655,9 @@ void ObstacleStopPlannerNode::pathCallback(const Trajectory::ConstSharedPtr inpu
     current_vel, stop_param);
 
   const auto no_slow_down_section = !planner_data.slow_down_require && !latest_slow_down_section_;
-  const auto no_hunting = (rclcpp::Time(input_msg->header.stamp) - last_detection_time_).seconds() >
-                          node_param_.hunting_threshold;
+  const auto no_hunting =
+    (rclcpp::Time(input_msg->header.stamp) - last_detect_time_slowdown_point_).seconds() >
+    node_param_.hunting_threshold;
   if (node_param_.enable_slow_down && no_slow_down_section && set_velocity_limit_ && no_hunting) {
     resetExternalVelocityLimit(current_acc, current_vel);
   }
@@ -723,6 +725,8 @@ void ObstacleStopPlannerNode::searchObstacle(
         debug_ptr_->pushObstaclePoint(planner_data.nearest_slow_down_point, PointType::SlowDown);
         debug_ptr_->pushPolygon(
           one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
+
+        last_detect_time_slowdown_point_ = trajectory_header.stamp;
       }
 
     } else {
@@ -769,6 +773,8 @@ void ObstacleStopPlannerNode::searchObstacle(
           planner_data.nearest_collision_point_time, object_ptr, current_velocity_ptr,
           &planner_data.stop_require, &output, trajectory_header);
 
+        last_detect_time_collision_point_ = trajectory_header.stamp;
+
         break;
       }
     }
@@ -781,6 +787,9 @@ void ObstacleStopPlannerNode::insertVelocity(
   const double current_acc, const double current_vel, const StopParam & stop_param)
 {
   const auto & base_link2front = vehicle_info.max_longitudinal_offset_m;
+  const auto no_hunting_collision_point =
+    (rclcpp::Time(trajectory_header.stamp) - last_detect_time_collision_point_).seconds() >
+    node_param_.hunting_threshold;
 
   if (planner_data.stop_require) {
     // insert stop point
@@ -820,17 +829,28 @@ void ObstacleStopPlannerNode::insertVelocity(
           current_stop_pos.point.pose = ego_pos_on_path.get();
 
           insertStopPoint(current_stop_pos, output, planner_data.stop_reason_diag);
+          latest_stop_point_ = current_stop_pos;
 
           debug_ptr_->pushPose(getPose(stop_point.point), PoseType::Stop);
         }
 
       } else {
         insertStopPoint(stop_point, output, planner_data.stop_reason_diag);
+        latest_stop_point_ = stop_point;
 
         debug_ptr_->pushPose(getPose(stop_point.point), PoseType::Stop);
       }
     }
+  } else if (!no_hunting_collision_point) {
+    if (latest_stop_point_) {
+      insertStopPoint(latest_stop_point_.get(), output, planner_data.stop_reason_diag);
+      debug_ptr_->pushPose(getPose(latest_stop_point_.get().point), PoseType::Stop);
+    }
   }
+
+  const auto no_hunting_slowdown_point =
+    (rclcpp::Time(trajectory_header.stamp) - last_detect_time_slowdown_point_).seconds() >
+    node_param_.hunting_threshold;
 
   if (planner_data.slow_down_require) {
     // insert slow down point
@@ -856,16 +876,19 @@ void ObstacleStopPlannerNode::insertVelocity(
         current_vel);
 
       if (
-        !latest_slow_down_section_ &&
-        dist_baselink_to_obstacle + index_with_dist_remain.get().second <
-          vehicle_info.max_longitudinal_offset_m) {
+        (!latest_slow_down_section_ &&
+         dist_baselink_to_obstacle + index_with_dist_remain.get().second <
+           vehicle_info.max_longitudinal_offset_m) ||
+        !no_hunting_slowdown_point) {
         latest_slow_down_section_ = slow_down_section;
       }
 
       insertSlowDownSection(slow_down_section, output);
     }
-
-    last_detection_time_ = trajectory_header.stamp;
+  } else if (!no_hunting_slowdown_point) {
+    if (latest_slow_down_section_) {
+      insertSlowDownSection(latest_slow_down_section_.get(), output);
+    }
   }
 
   if (node_param_.enable_slow_down && latest_slow_down_section_) {
@@ -891,7 +914,7 @@ void ObstacleStopPlannerNode::insertVelocity(
         set_velocity_limit_ ? std::numeric_limits<double>::max() : slow_down_param_.slow_down_vel;
 
       insertSlowDownSection(slow_down_section, output);
-    } else {
+    } else if (no_hunting_slowdown_point) {
       latest_slow_down_section_ = {};
     }
   }


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

In this PR, I fixed stop (slowdown) judge logic in order to prevent from judgement hunting.

- Add `hunting_threshold` (default: 0.5[s])
- Even if the obstacle disappears, the stop judgment continues for `hunting_threshold` seconds.

test perform (`hunting_threshold` = 2.0 [s])

https://user-images.githubusercontent.com/44889564/181649100-88fee723-c30a-4d87-a54f-fd7b4248bfa5.mp4

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
