### PR TITLE
fix(motion_velocity_smoother): add missing definition for clock

### DIFF
--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -134,7 +134,7 @@ private:
 
   double over_stop_velocity_warn_thr_;  // threshold to publish over velocity warn
 
-  mutable rclcpp::Clock::SharedPtr clock_;
+  rclcpp::Clock::SharedPtr clock_;
 
   // parameter update
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -117,6 +117,8 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
   max_vel_msg.stamp = this->now();
   max_vel_msg.max_velocity = node_param_.max_velocity;
   pub_velocity_limit_->publish(max_vel_msg);
+
+  clock_ = get_clock();
 }
 
 rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter(


### PR DESCRIPTION
## Description

Add a missing definition for clock_ member.
The `mutable` is not needed and then removed.

This undefinition of the clock caused the process to die.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Check psim and make sure the process will never die. 

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
