### PR TITLE
feat(behavior_path_planner): larger backward path length

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -180,9 +180,13 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.base_link2front = vehicle_info.max_longitudinal_offset_m;
   p.base_link2rear = p.rear_overhang;
 
-  // NOTE: backward_path_length is used not only calculating path length but also calculating the size of a drivable area.
-  //       The drivable area has to cover not the base link but the vehicle itself. Therefore rear_overhang must be added to backward_path_length.
-  //       In addition, because of the calculation of the drivable area in the obstacle_avoidance_planner package, the drivable area has to be a little longer than the backward_path_length parameter by adding min_backward_offset.
+  // NOTE: backward_path_length is used not only calculating path length but also calculating the
+  // size of a drivable area.
+  //       The drivable area has to cover not the base link but the vehicle itself. Therefore
+  //       rear_overhang must be added to backward_path_length. In addition, because of the
+  //       calculation of the drivable area in the obstacle_avoidance_planner package, the drivable
+  //       area has to be a little longer than the backward_path_length parameter by adding
+  //       min_backward_offset.
   constexpr double min_backward_offset = 1.0;
   const double backward_offset = vehicle_info.rear_overhang_m + min_backward_offset;
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -164,9 +164,30 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
 BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
 {
-  // ROS parameters
   BehaviorPathPlannerParameters p{};
-  p.backward_path_length = declare_parameter("backward_path_length", 5.0);
+
+  // vehicle info
+  const auto vehicle_info = VehicleInfoUtil(*this).getVehicleInfo();
+  p.vehicle_info = vehicle_info;
+  p.vehicle_width = vehicle_info.vehicle_width_m;
+  p.vehicle_length = vehicle_info.vehicle_length_m;
+  p.wheel_tread = vehicle_info.wheel_tread_m;
+  p.wheel_base = vehicle_info.wheel_base_m;
+  p.front_overhang = vehicle_info.front_overhang_m;
+  p.rear_overhang = vehicle_info.rear_overhang_m;
+  p.left_over_hang = vehicle_info.left_overhang_m;
+  p.right_over_hang = vehicle_info.right_overhang_m;
+  p.base_link2front = vehicle_info.max_longitudinal_offset_m;
+  p.base_link2rear = p.rear_overhang;
+
+  // NOTE: backward_path_length is used not only calculating path length but also calculating the size of a drivable area.
+  //       The drivable area has to cover not the base link but the vehicle itself. Therefore rear_overhang must be added to backward_path_length.
+  //       In addition, because of the calculation of the drivable area in the obstacle_avoidance_planner package, the drivable area has to be a little longer than the backward_path_length parameter by adding min_backward_offset.
+  constexpr double min_backward_offset = 1.0;
+  const double backward_offset = vehicle_info.rear_overhang_m + min_backward_offset;
+
+  // ROS parameters
+  p.backward_path_length = declare_parameter("backward_path_length", 5.0) + backward_offset;
   p.forward_path_length = declare_parameter("forward_path_length", 100.0);
   p.backward_length_buffer_for_end_of_lane =
     declare_parameter("backward_length_buffer_for_end_of_lane", 5.0);
@@ -187,20 +208,6 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.turn_light_on_threshold_time = declare_parameter("turn_light_on_threshold_time", 3.0);
   p.visualize_drivable_area_for_shared_linestrings_lanelet =
     declare_parameter("visualize_drivable_area_for_shared_linestrings_lanelet", true);
-
-  // vehicle info
-  const auto vehicle_info = VehicleInfoUtil(*this).getVehicleInfo();
-  p.vehicle_info = vehicle_info;
-  p.vehicle_width = vehicle_info.vehicle_width_m;
-  p.vehicle_length = vehicle_info.vehicle_length_m;
-  p.wheel_tread = vehicle_info.wheel_tread_m;
-  p.wheel_base = vehicle_info.wheel_base_m;
-  p.front_overhang = vehicle_info.front_overhang_m;
-  p.rear_overhang = vehicle_info.rear_overhang_m;
-  p.left_over_hang = vehicle_info.left_overhang_m;
-  p.right_over_hang = vehicle_info.right_overhang_m;
-  p.base_link2front = vehicle_info.max_longitudinal_offset_m;
-  p.base_link2rear = p.rear_overhang;
 
   return p;
 }


### PR DESCRIPTION
## Description

**issue**
https://github.com/autowarefoundation/autoware.universe/blob/463767bb8ee39b360d2bd9ce31fe406d73ba8adf/planning/behavior_path_planner/src/behavior_path_planner_node.cpp#L183-L189

For example, shown in the figure of "before", the drivable area is a bit short for the obstacle avoidance planner to calculate the road boundary

**how to fix**
add the offset length (rear_overhang + 1.0m) to the path start point.

<!-- Write a brief description of this PR. -->


**before**
1
![image](https://user-images.githubusercontent.com/20228327/182054567-fabd41ad-17aa-4d6e-825e-d7bda7a9e922.png)

2
![image](https://user-images.githubusercontent.com/20228327/182054559-2af766a8-7482-4d4f-a3f3-77bf23f152b4.png)


**after**
1
![image](https://user-images.githubusercontent.com/20228327/182054524-48940aa7-189e-40ec-93ee-5679a68dfe0c.png)

2
![image](https://user-images.githubusercontent.com/20228327/182054540-f1844fdb-0048-4d2f-ae31-6c91643a26e8.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
