### PR TITLE
fix: better index guard

### DIFF
--- a/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
@@ -111,11 +111,13 @@ boost::optional<TrajectoryPoints> SmootherBase::applyLateralAccelerationFilter(
     const size_t start = i > after_decel_index ? i - after_decel_index : 0;
     const size_t end = std::min(output->size(), i + before_decel_index + 1);
     for (size_t j = start; j < end; ++j) {
+      if (j >= curvature_v.size()) return output;
       curvature = std::max(curvature, std::fabs(curvature_v.at(j)));
     }
     double v_curvature_max = std::sqrt(max_lateral_accel_abs / std::max(curvature, 1.0E-5));
     v_curvature_max = std::max(v_curvature_max, base_param_.min_curve_velocity);
     if (enable_smooth_limit) {
+      if (i >= latacc_min_vel_arr.size()) return output;
       v_curvature_max = std::max(v_curvature_max, latacc_min_vel_arr.at(i));
     }
     if (output->at(i).longitudinal_velocity_mps > v_curvature_max) {


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

MotionVelcoitySmoother dies where simulation time delays much

![image (3)](https://user-images.githubusercontent.com/65527974/181740502-1602b5be-d3b2-4e28-a3aa-b65e18432d50.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
