### PR TITLE
feat: optimize screen capture panel

### DIFF
--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -106,25 +106,6 @@ void AutowareScreenCapturePanel::onClickScreenCapture()
 
 void AutowareScreenCapturePanel::convertPNGImagesToMP4()
 {
-  cv::VideoCapture capture(root_folder_ + "/%06d.png", cv::CAP_IMAGES);
-  if (!capture.isOpened()) {
-    return;
-  }
-  int fourcc = cv::VideoWriter::fourcc('h', '2', '6', '4');  // mp4
-  cv::VideoWriter writer;
-  cv::Size size = cv::Size(width_, height_);
-  writer.open("capture/" + root_folder_ + ".mp4", fourcc, capture_hz_->value(), size);
-  cv::Mat image;
-  while (true) {
-    capture >> image;
-    if (image.empty()) {
-      break;
-    }
-    // need to resize for fixed frame video
-    writer << image;
-    cv::waitKey(0);
-  }
-  capture.release();
   writer.release();
   // remove temporary created folder
   std::filesystem::remove_all(root_folder_);
@@ -155,6 +136,18 @@ void AutowareScreenCapturePanel::onClickVideoCapture()
       }
       capture_to_mp4_button_ptr_->setText("capturing rviz screen");
       capture_to_mp4_button_ptr_->setStyleSheet("background-color: #FF0000;");
+      {
+        int fourcc = cv::VideoWriter::fourcc('h', '2', '6', '4');  // mp4
+        QScreen * screen = QGuiApplication::primaryScreen();
+        const auto qsize = screen->grabWindow(main_window_->winId())
+                             .toImage()
+                             .convertToFormat(QImage::Format_RGB888)
+                             .rgbSwapped()
+                             .size();
+        current_movie_size = cv::Size(qsize.width(), qsize.height());
+        writer.open(
+          "capture/" + root_folder_ + ".mp4", fourcc, capture_hz_->value(), current_movie_size);
+      }
       capture_timer_->start(clock);
       state_ = State::CAPTURING;
       break;
@@ -174,22 +167,25 @@ void AutowareScreenCapturePanel::onClickVideoCapture()
 
 void AutowareScreenCapturePanel::onTimer()
 {
-  std::stringstream count_text;
-  count_text << std::setw(6) << std::setfill('0') << counter_;
-  const std::string file = root_folder_ + "/" + count_text.str() + ".png";
   if (!main_window_) return;
-  try {
-    // this is deprecated but only way to capture nicely
-    QScreen * screen = QGuiApplication::primaryScreen();
-    QPixmap original_pixmap = screen->grabWindow(main_window_->winId());
-    QString format = "png";
-    QString file_name = QString::fromStdString(file);
-    if (!file_name.isEmpty())
-      original_pixmap.scaled(width_, height_).save(file_name, format.toLatin1().constData());
-  } catch (std::exception & e) {
-    std::cout << e.what() << std::endl;
+  // this is deprecated but only way to capture nicely
+  QScreen * screen = QGuiApplication::primaryScreen();
+  QPixmap original_pixmap = screen->grabWindow(main_window_->winId());
+  const auto qimage = original_pixmap.toImage().convertToFormat(QImage::Format_RGB888).rgbSwapped();
+  const int h = qimage.height();
+  const int w = qimage.width();
+  cv::Size size = cv::Size(w, h);
+  cv::Mat image(
+    size, CV_8UC3, const_cast<uchar *>(qimage.bits()), static_cast<size_t>(qimage.bytesPerLine()));
+  if (size != current_movie_size) {
+    cv::Mat new_image;
+    cv::resize(image, new_image, current_movie_size);
+    writer.write(new_image);
+
+  } else {
+    writer.write(image);
   }
-  counter_++;
+  cv::waitKey(0);
 }
 
 void AutowareScreenCapturePanel::update()
@@ -197,19 +193,9 @@ void AutowareScreenCapturePanel::update()
   setFormatDate(ros_time_label_, raw_node_->get_clock()->now().seconds());
 }
 
-void AutowareScreenCapturePanel::save(rviz_common::Config config) const
-{
-  Panel::save(config);
-  config.mapSetValue("width", width_);
-  config.mapSetValue("height", height_);
-}
+void AutowareScreenCapturePanel::save(rviz_common::Config config) const { Panel::save(config); }
 
-void AutowareScreenCapturePanel::load(const rviz_common::Config & config)
-{
-  Panel::load(config);
-  if (!config.mapGetFloat("width", &width_)) width_ = 1280;
-  if (!config.mapGetFloat("height", &height_)) height_ = 720;
-}
+void AutowareScreenCapturePanel::load(const rviz_common::Config & config) { Panel::load(config); }
 
 AutowareScreenCapturePanel::~AutowareScreenCapturePanel()
 {

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
@@ -82,8 +82,9 @@ private:
   std::string root_folder_;
   size_t counter_;
   bool is_capture_;
-  float width_ = {1280};
-  float height_ = {720};
+  cv::VideoWriter writer;
+  cv::Size current_movie_size;
+  std::vector<cv::Mat> image_vec_;
 
   std::string stateToString(const State & state)
   {

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
@@ -43,6 +43,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 class QLineEdit;
 


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
- optimize screen capture panel.

When taking a video with screen_capture_panel, changed to write the video directly instead of saving the images once.
It is now possible to record with almost no processing loss regardless of the size of Rviz.

In addition, the maximum memory occupied by Rviz is about 3GB regardless of the video recording time.


https://user-images.githubusercontent.com/59680180/181747617-669d5603-8816-471e-8e26-1ea027852ccb.mp4



<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
