### PR TITLE
chore(radar_fusion_to_detected_object): fix TODO comments

### DIFF
--- a/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object.hpp
+++ b/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object.hpp
@@ -93,7 +93,7 @@ private:
   Param param_{};
   std::shared_ptr<std::vector<RadarInput>> filterRadarWithinObject(
     const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars);
-  // [TODO] (Satoshi Tanaka) Implement
+  // TODO(Satoshi Tanaka): Implement
   // std::vector<DetectedObject> splitObject(
   //   const DetectedObject & object, const std::shared_ptr<std::vector<RadarInput>> & radars);
   TwistWithCovariance estimateTwist(

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -82,7 +82,7 @@ RadarFusionToDetectedObject::Output RadarFusionToDetectedObject::update(
     std::shared_ptr<std::vector<RadarInput>> radars_within_object =
       filterRadarWithinObject(object, input.radars);
 
-    // [TODO] (Satoshi Tanaka) Implement
+    // TODO(Satoshi Tanaka): Implement
     // Split the object going in a different direction
     // std::vector<DetectedObject> split_objects = splitObject(object, radars_within_object);
     std::vector<DetectedObject> split_objects;
@@ -165,7 +165,7 @@ RadarFusionToDetectedObject::filterRadarWithinObject(
   return std::make_shared<std::vector<RadarFusionToDetectedObject::RadarInput>>(outputs);
 }
 
-// [TODO] (Satoshi Tanaka) Implementation
+// TODO(Satoshi Tanaka): Implementation
 // std::vector<DetectedObject> RadarFusionToDetectedObject::splitObject(
 //   const DetectedObject & object, const std::vector<RadarInput> & radars)
 // {

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -257,7 +257,7 @@ TwistWithCovariance RadarFusionToDetectedObject::estimateTwist(
                             vec_target_value_average * param_.velocity_weight_target_value_average;
   TwistWithCovariance estimated_twist_with_covariance = toTwistWithCovariance(sum_vec);
 
-  // [TODO] (Satoshi Tanaka) Implement
+  // TODO(Satoshi Tanaka): Implement
   // Convert doppler velocity to twist
   // if (param_.convert_doppler_to_twist) {
   //   twist_with_covariance = convertDopplerToTwist(object, twist_with_covariance);
@@ -280,7 +280,7 @@ bool RadarFusionToDetectedObject::isQualified(
   }
 }
 
-// [TODO] (Satoshi Tanaka) Implement for radar pointcloud fusion
+// TODO(Satoshi Tanaka): Implement for radar pointcloud fusion
 // TwistWithCovariance RadarFusionToDetectedObject::convertDopplerToTwist(
 //   const DetectedObject & object, const TwistWithCovariance & twist_with_covariance)
 // {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Fixed TODO comments to follow https://google.github.io/styleguide/cppguide.html#TODO_Comments.

I've noticed this in https://github.com/autowarefoundation/autoware.universe/pull/1429.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
