### PR TITLE
chore(dummy_perception_publisher): add use_sim_time argument

### DIFF
--- a/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -4,6 +4,7 @@
   <arg name="visible_range" default="300.0"/>
   <arg name="real" default="true"/>
   <arg name="use_object_recognition" default="true"/>
+  <arg name="use_sim_time" default="false"/>
 
   <group>
     <push-ros-namespace namespace="simulation"/>
@@ -19,6 +20,7 @@
         <param name="enable_ray_tracing" value="false"/>
         <param name="use_object_recognition" value="$(var use_object_recognition)"/>
         <param name="object_centric_pointcloud" value="false"/>
+        <param name="use_sim_time" value="$(var use_sim_time)"/>
       </node>
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
         <arg name="input/objects" value="/perception/object_recognition/detection/labeled_clusters"/>
@@ -36,6 +38,7 @@
         <param name="detection_successful_rate" value="1.0"/>
         <param name="enable_ray_tracing" value="false"/>
         <param name="use_object_recognition" value="$(var use_object_recognition)"/>
+        <param name="use_sim_time" value="$(var use_sim_time)"/>
       </node>
     </group>
 


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

add use_sim_time argument in dummy_perception_publisher in order to designate use_sim_time when executing ros2 launch like `ros2 launch dummy_perception_publisher dummy_perception_publisher.launch.xml use_sim_time:=true`

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
