### PR TITLE
fix(behavior_path_planner): fix the calculation of prepare length

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -330,8 +330,9 @@ lanelet::ConstLanelets LaneChangeModule::getLaneChangeLanes(
   lanelet::ConstLanelet current_lane;
   lanelet::utils::query::getClosestLanelet(
     current_lanes, planner_data_->self_pose->pose, &current_lane);
-  const double lane_change_prepare_length =
-    current_twist.linear.x * parameters_.lane_change_prepare_duration;
+  const double lane_change_prepare_length = std::max(
+    current_twist.linear.x * parameters_.lane_change_prepare_duration,
+    planner_data_->parameters.minimum_lane_change_length);
   lanelet::ConstLanelets current_check_lanes =
     route_handler->getLaneletSequence(current_lane, current_pose, 0.0, lane_change_prepare_length);
   lanelet::ConstLanelet lane_change_lane;


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
In the current implementation,  lane_change_prepare_length is proportional to current speed. So, when the vehicle is stopped, lane_change_prepare_length is also 0.
As a result, there are cases that lane-change lanes cannot be searched sufficiently and then a lane change candidate route does not appear.

Fixed this issue by setting a minimum distance to lane_change_prepare_length

Before:
https://user-images.githubusercontent.com/59680180/182078036-47d30538-ec96-4b97-b55e-de3348819231.mp4

After:
https://user-images.githubusercontent.com/59680180/182078023-39006b2b-b9c0-481f-9f3a-d92de7ed7a88.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
