### PR TITLE
fix(behavior_path_planner): lane change intersection stop

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -277,8 +277,8 @@ PathWithLaneId setDecelerationVelocity(
 
 bool checkLaneIsInIntersection(
   const RouteHandler & route_handler, const PathWithLaneId & ref,
-  const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add,
-  const BehaviorPathPlannerParameters & parameters);
+  const lanelet::ConstLanelets & lanelet_sequence, const BehaviorPathPlannerParameters & parameters,
+  double & additional_length_to_add);
 
 PathWithLaneId setDecelerationVelocity(
   const PathWithLaneId & input, const double target_velocity, const Pose target_pose,

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -277,7 +277,9 @@ PathWithLaneId setDecelerationVelocity(
 
 bool checkLaneIsInIntersection(
   const RouteHandler & route_handler, const PathWithLaneId & ref,
-  const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add);
+  const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add,
+  const BehaviorPathPlannerParameters & parameters);
+
 PathWithLaneId setDecelerationVelocity(
   const PathWithLaneId & input, const double target_velocity, const Pose target_pose,
   const double buffer, const double deceleration_interval);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -271,7 +271,7 @@ PathWithLaneId LaneChangeModule::getReferencePath() const
 
   double optional_lengths{0.0};
   const auto isInIntersection = util::checkLaneIsInIntersection(
-    *route_handler, reference_path, current_lanes, optional_lengths, common_parameters);
+    *route_handler, reference_path, current_lanes, common_parameters, optional_lengths);
   if (isInIntersection) {
     reference_path = util::getCenterLinePath(
       *route_handler, current_lanes, current_pose, common_parameters.backward_path_length,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -271,7 +271,7 @@ PathWithLaneId LaneChangeModule::getReferencePath() const
 
   double optional_lengths{0.0};
   const auto isInIntersection = util::checkLaneIsInIntersection(
-    *route_handler, reference_path, current_lanes, optional_lengths);
+    *route_handler, reference_path, current_lanes, optional_lengths, common_parameters);
   if (isInIntersection) {
     reference_path = util::getCenterLinePath(
       *route_handler, current_lanes, current_pose, common_parameters.backward_path_length,

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -103,7 +103,7 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
   {
     double optional_lengths{0.0};
     const auto isInIntersection = util::checkLaneIsInIntersection(
-      *route_handler, reference_path, current_lanes, optional_lengths);
+      *route_handler, reference_path, current_lanes, optional_lengths, p);
 
     if (isInIntersection) {
       reference_path = util::getCenterLinePath(

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -103,7 +103,7 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
   {
     double optional_lengths{0.0};
     const auto isInIntersection = util::checkLaneIsInIntersection(
-      *route_handler, reference_path, current_lanes, optional_lengths, p);
+      *route_handler, reference_path, current_lanes, p, optional_lengths);
 
     if (isInIntersection) {
       reference_path = util::getCenterLinePath(

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1684,8 +1684,8 @@ PathWithLaneId getCenterLinePath(
 
 bool checkLaneIsInIntersection(
   const RouteHandler & route_handler, const PathWithLaneId & reference_path,
-  const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add,
-  const BehaviorPathPlannerParameters & parameter)
+  const lanelet::ConstLanelets & lanelet_sequence, const BehaviorPathPlannerParameters & parameter,
+  double & additional_length_to_add)
 {
   if (lanelet_sequence.size() < 2 || reference_path.points.empty()) {
     return false;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1684,7 +1684,8 @@ PathWithLaneId getCenterLinePath(
 
 bool checkLaneIsInIntersection(
   const RouteHandler & route_handler, const PathWithLaneId & reference_path,
-  const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add)
+  const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add,
+  const BehaviorPathPlannerParameters & parameter)
 {
   if (lanelet_sequence.size() < 2 || reference_path.points.empty()) {
     return false;
@@ -1752,10 +1753,9 @@ bool checkLaneIsInIntersection(
   const auto prohibited_arc_coordinate =
     lanelet::utils::getArcCoordinates(lane_change_prohibited_lanes, end_of_route_pose);
 
-  constexpr double small_earlier_stopping_buffer = 0.2;
-  additional_length_to_add =
-    prohibited_arc_coordinate.length +
-    small_earlier_stopping_buffer;  // additional a slight "buffer so that vehicle stop earlier"
+  additional_length_to_add = prohibited_arc_coordinate.length +
+                             parameter.minimum_lane_change_length +
+                             parameter.backward_length_buffer_for_end_of_lane;
 
   return true;
 }


### PR DESCRIPTION
fixing lane change stopping before lane change prohibited area.
currently the stop function is not working so properly.

Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description
In current lane change module, if the goal pose is slightly after intersection, and the minimum distance to perform lane change is insufficient, ego vehicle should stop before the intersection.

However, at the present module, ego stop before intersection, but the distance is not enough to perform lane change. example is as follows
![Before](https://user-images.githubusercontent.com/93502286/182097101-2556c72f-fb82-450c-a235-de235b2415f6.png)

This pr aims to solve this issue by fixing the bug. In addition to the intersection length, we should also consider the stopping distance. the result is as follows.
![After](https://user-images.githubusercontent.com/93502286/182097092-d64b678e-77b6-41e4-a3b2-ecfde035e2a7.png)
## Related links

## Tests performed

Using psim and test lane change scenario.

1. disable rtc auto approval for lane change.
```
ros2 service call /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change_left/enable_auto_mode tier4_rtc_msgs/srv/AutoMode enable:\ false && ros2 service call /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change_right/enable_auto_mode tier4_rtc_msgs/srv/AutoMode enable:\ false
```
2. place ego 20 - 30 meters away from intersection.
3. place the goal slightly after intersection.
4. engage vehicle.
5. Ego vehicle should stop before intersection, and lane change is possible.


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
