### PR TITLE
fix(behavior_path_planner): fix unnecessary output of behavior_path_planner

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -96,9 +96,12 @@ private:
         uuid_right_, isExecutionReady(), candidate.distance_to_path_change, clock_->now());
       return;
     }
-
-    RCLCPP_WARN_STREAM(
-      getLogger(), "Direction is UNKNOWN, distance = " << candidate.distance_to_path_change);
+    
+    if(candidate.distance_to_path_change>0.0)
+    {
+      RCLCPP_WARN_STREAM(
+        getLogger(), "Direction is UNKNOWN, distance = " << candidate.distance_to_path_change);
+    }
   }
 
   void removeRTCStatus() override

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -96,7 +96,6 @@ private:
         uuid_right_, isExecutionReady(), candidate.distance_to_path_change, clock_->now());
       return;
     }
-    
     if(candidate.distance_to_path_change>0.0)
     {
       RCLCPP_WARN_STREAM(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -96,8 +96,7 @@ private:
         uuid_right_, isExecutionReady(), candidate.distance_to_path_change, clock_->now());
       return;
     }
-    if(candidate.distance_to_path_change>0.0)
-    {
+    if (candidate.distance_to_path_change > 0.0) {
       RCLCPP_WARN_STREAM(
         getLogger(), "Direction is UNKNOWN, distance = " << candidate.distance_to_path_change);
     }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2159,8 +2159,8 @@ CandidateOutput AvoidanceModule::planCandidate() const
 {
   DEBUG_PRINT("AVOIDANCE planCandidate start");
   CandidateOutput output;
-  output.distance_to_path_change=0.0;
-  
+  output.distance_to_path_change = 0.0;
+
   auto path_shifter = path_shifter_;
   auto debug_data = debug_data_;
   auto current_raw_shift_points = current_raw_shift_points_;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2159,7 +2159,8 @@ CandidateOutput AvoidanceModule::planCandidate() const
 {
   DEBUG_PRINT("AVOIDANCE planCandidate start");
   CandidateOutput output;
-
+  output.distance_to_path_change=0.0;
+  
   auto path_shifter = path_shifter_;
   auto debug_data = debug_data_;
   auto current_raw_shift_points = current_raw_shift_points_;


### PR DESCRIPTION
## Description
Add conditions to limit unnecessary output without new obstacle avoidance information
<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/issues/1476
<!-- Write the links related to this PR. -->

## Tests performed
simulation after adding conditions:
![Screenshot from 2022-08-01 15-52-33](https://user-images.githubusercontent.com/102840938/182100291-2de1fab8-e1e8-42a1-8d0b-8a978cb1d584.png)
![no_output](https://user-images.githubusercontent.com/102840938/182099922-85fc533f-b515-4f22-8637-0a1cb0cceed4.png)


<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
