### PR TITLE
perf(obstacle_stop_planner): prevent unnecessary duplicate points

### DIFF
--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -1392,14 +1392,18 @@ bool ObstacleStopPlannerNode::searchPointcloudNearTrajectory(
                                  ? slow_down_param_.slow_down_search_radius
                                  : stop_param.stop_search_radius;
   const double squared_radius = search_radius * search_radius;
-  for (const auto & trajectory_point : trajectory) {
-    const auto center_pose = getVehicleCenterFromBase(trajectory_point.pose, vehicle_info);
-    for (const auto & point : transformed_points_ptr->points) {
-      const double x = center_pose.position.x - point.x;
-      const double y = center_pose.position.y - point.y;
+  std::vector<geometry_msgs::msg::Point> center_points;
+  center_points.reserve(trajectory.size());
+  for (const auto & trajectory_point : trajectory)
+    center_points.push_back(getVehicleCenterFromBase(trajectory_point.pose, vehicle_info).position);
+  for (const auto & point : transformed_points_ptr->points) {
+    for (const auto & center_point : center_points) {
+      const double x = center_point.x - point.x;
+      const double y = center_point.y - point.y;
       const double squared_distance = x * x + y * y;
       if (squared_distance < squared_radius) {
         output_points_ptr->points.push_back(point);
+        break;
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
This PR improve performance of function `searchPointcloudNearTrajectory()` used to filter a pointcloud and keep only points close enough to a trajectory.

In the current implementation, a point from the pointcloud will be added for all trajectory point that are within range.
This PR ensures that a point can only be added once.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
