### PR TITLE
fix(obstacle_cruise_planner): add max obj length when collision check

### DIFF
--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -172,6 +172,26 @@ double calcAlignedAdaptiveCruise(
 
   return object_vel * std::cos(object_yaw - traj_yaw);
 }
+
+double calcObjectMaxLength(const autoware_auto_perception_msgs::msg::Shape & shape)
+{
+  if (shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    return std::hypot(shape.dimensions.x / 2.0, shape.dimensions.y / 2.0);
+  } else if (shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+    return shape.dimensions.x / 2.0;
+  } else if (shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+    double max_length_to_point = 0.0;
+    for (const auto rel_point : shape.footprint.points) {
+      const double length_to_point = std::hypot(rel_point.x, rel_point.y);
+      if (max_length_to_point < length_to_point) {
+        max_length_to_point = length_to_point;
+      }
+    }
+    return max_length_to_point;
+  }
+
+  throw std::logic_error("The shape type is not supported in obstacle_cruise_planner.");
+}
 }  // namespace
 
 namespace motion_planning
@@ -682,9 +702,11 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
     const double dist_from_obstacle_to_traj = [&]() {
       return motion_utils::calcLateralOffset(decimated_traj.points, object_pose.position);
     }();
+    const double obstacle_max_length = calcObjectMaxLength(predicted_object.shape);
     if (
       std::fabs(dist_from_obstacle_to_traj) >
-      vehicle_info_.vehicle_width_m + obstacle_filtering_param_.rough_detection_area_expand_width) {
+      vehicle_info_.vehicle_width_m + obstacle_max_length +
+        obstacle_filtering_param_.rough_detection_area_expand_width) {
       RCLCPP_INFO_EXPRESSION(
         get_logger(), is_showing_debug_info_,
         "Ignore obstacle (%s) since it is far from the trajectory.", object_id.c_str());
@@ -741,7 +763,7 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
 
       if (
         std::fabs(dist_from_obstacle_to_traj) >
-        vehicle_info_.vehicle_width_m +
+        vehicle_info_.vehicle_width_m + obstacle_max_length +
           obstacle_filtering_param_.outside_rough_detection_area_expand_width) {
         RCLCPP_INFO_EXPRESSION(
           get_logger(), is_showing_debug_info_,


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

**issue**
When the direction of the object is vertical to the ego direction and the object length is large (like a bus), which is shown in the figure of this description, it will be ignored by obstacle_cruise_planner

**fix**
add obstacle max length to detection area of obstacle_cruise_planner

**before**
bus
![image](https://user-images.githubusercontent.com/20228327/182286541-6d797d7d-2797-4e5e-aa4c-2252d46c9d02.png)

**after**
bus
![image](https://user-images.githubusercontent.com/20228327/182286525-cf9af60e-e8d5-40e4-91fe-599a26e2f725.png)
unknown
![image](https://user-images.githubusercontent.com/20228327/182287757-5908e67a-c29e-4b36-9473-74d2fbf02de8.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
