### PR TITLE
fix(rviz_plugin): fix screen capture plugin

### DIFF
--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
@@ -58,7 +58,6 @@ public:
   void onInitialize() override;
   void createWallTimer();
   void onTimer();
-  void convertPNGImagesToMP4();
   void save(rviz_common::Config config) const override;
   void load(const rviz_common::Config & config) override;
   void onCaptureTrigger(
@@ -67,7 +66,6 @@ public:
 
 public Q_SLOTS:
   void onClickScreenCapture();
-  void onClickCaptureToVideo();
   void onClickVideoCapture();
   void onRateChanged();
 
@@ -80,8 +78,7 @@ private:
   QMainWindow * main_window_;
   enum class State { WAITING_FOR_CAPTURE, CAPTURING };
   State state_;
-  std::string root_folder_;
-  size_t counter_;
+  std::string capture_file_name_;
   bool is_capture_;
   cv::VideoWriter writer;
   cv::Size current_movie_size;


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

resolve #1491 
fix setting empty filename before updating

check to capture screen and see files
note: capture/1970-01-01-09-00-41.mp4 is created with simulation time
![image](https://user-images.githubusercontent.com/65527974/182288877-d4093044-56dc-456c-ae26-b8011055d94d.png)

![image](https://user-images.githubusercontent.com/65527974/182288767-0408ac03-4b12-4951-9991-36ebae00f87c.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
