### PR TITLE
feat(behavior_path_planner): fix goal velocity

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -914,7 +914,6 @@ bool setGoal(
 
       const double closest_vel = input.points.at(closest_seg_idx).point.longitudinal_velocity_mps;
       const double next_vel = input.points.at(closest_seg_idx + 1).point.longitudinal_velocity_mps;
-      const double internal_div_ratio = std::clamp(closest_to_pre_goal_dist / seg_dist, 0.0, 1.0);
       pre_refined_goal.point.longitudinal_velocity_mps =
         std::abs(seg_dist) < 1e-06 ? next_vel : closest_vel;
 

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -916,8 +916,7 @@ bool setGoal(
       const double next_vel = input.points.at(closest_seg_idx + 1).point.longitudinal_velocity_mps;
       const double internal_div_ratio = std::clamp(closest_to_pre_goal_dist / seg_dist, 0.0, 1.0);
       pre_refined_goal.point.longitudinal_velocity_mps =
-        std::abs(seg_dist) < 1e-06 ? next_vel
-                                   : closest_vel + (next_vel - closest_vel) * internal_div_ratio;
+        std::abs(seg_dist) < 1e-06 ? next_vel : closest_vel;
 
       pre_refined_goal.lane_ids = input.points.back().lane_ids;
     }


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description

Change terminal velocity by using zero-order hold instead of using linear interpolation

![image](https://user-images.githubusercontent.com/43805014/182328202-6be6cc2d-d8c7-4702-9322-bda95783a750.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
