### PR TITLE
feat(system_error_monitor): add heartbeat timeout for subscribed data

### DIFF
--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -307,7 +307,6 @@ void AutowareStateMonitorNode::onTimer()
   {
     autoware_auto_system_msgs::msg::AutowareState autoware_state_msg;
     autoware_state_msg.state = toMsg(autoware_state);
-    autoware_state_msg.stamp = this->now();
 
     pub_autoware_state_->publish(autoware_state_msg);
   }

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -307,6 +307,7 @@ void AutowareStateMonitorNode::onTimer()
   {
     autoware_auto_system_msgs::msg::AutowareState autoware_state_msg;
     autoware_state_msg.state = toMsg(autoware_state);
+    autoware_state_msg.stamp = this->now();
 
     pub_autoware_state_->publish(autoware_state_msg);
   }

--- a/system/system_error_monitor/README.md
+++ b/system/system_error_monitor/README.md
@@ -114,6 +114,8 @@ endif
 | `add_leaf_diagnostics`       | bool   | `true`        | Required to use children diagnostics.                                                                                                                   |
 | `diag_timeout_sec`           | double | `1.0` (sec)   | If required diagnostic is not received for a `diag_timeout_sec`, the diagnostic state become STALE state.                                               |
 | `data_ready_timeout`         | double | `30.0`        | If input topics required for system_error_monitor are not available for `data_ready_timeout` seconds, autoware_state will translate to emergency state. |
+| `data_heartbeat_timeout`         | double | `1.0`        | If input topics required for system_error_monitor are not no longer subscribed for `data_heartbeat_timeout` seconds, autoware_state will translate to emergency state. |
+
 
 ### Core Parameters
 

--- a/system/system_error_monitor/README.md
+++ b/system/system_error_monitor/README.md
@@ -108,14 +108,13 @@ endif
 
 ### Node Parameters
 
-| Name                         | Type   | Default Value | Explanation                                                                                                                                             |
-| ---------------------------- | ------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ignore_missing_diagnostics` | bool   | `false`       | If this parameter is turned off, it will be ignored if required modules have not been received.                                                         |
-| `add_leaf_diagnostics`       | bool   | `true`        | Required to use children diagnostics.                                                                                                                   |
-| `diag_timeout_sec`           | double | `1.0` (sec)   | If required diagnostic is not received for a `diag_timeout_sec`, the diagnostic state become STALE state.                                               |
-| `data_ready_timeout`         | double | `30.0`        | If input topics required for system_error_monitor are not available for `data_ready_timeout` seconds, autoware_state will translate to emergency state. |
-| `data_heartbeat_timeout`         | double | `1.0`        | If input topics required for system_error_monitor are not no longer subscribed for `data_heartbeat_timeout` seconds, autoware_state will translate to emergency state. |
-
+| Name                         | Type   | Default Value | Explanation                                                                                                                                                            |
+| ---------------------------- | ------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ignore_missing_diagnostics` | bool   | `false`       | If this parameter is turned off, it will be ignored if required modules have not been received.                                                                        |
+| `add_leaf_diagnostics`       | bool   | `true`        | Required to use children diagnostics.                                                                                                                                  |
+| `diag_timeout_sec`           | double | `1.0` (sec)   | If required diagnostic is not received for a `diag_timeout_sec`, the diagnostic state become STALE state.                                                              |
+| `data_ready_timeout`         | double | `30.0`        | If input topics required for system_error_monitor are not available for `data_ready_timeout` seconds, autoware_state will translate to emergency state.                |
+| `data_heartbeat_timeout`     | double | `1.0`         | If input topics required for system_error_monitor are not no longer subscribed for `data_heartbeat_timeout` seconds, autoware_state will translate to emergency state. |
 
 ### Core Parameters
 

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -33,6 +33,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <memory>
 
 struct DiagStamped
 {

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -18,7 +18,6 @@
 #include <rclcpp/create_timer.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
-#include <tier4_autoware_utils/system/heartbeat_checker.hpp>
 
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 #include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
@@ -30,7 +29,6 @@
 
 #include <deque>
 #include <map>
-#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -30,10 +30,10 @@
 
 #include <deque>
 #include <map>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <memory>
 
 struct DiagStamped
 {

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/create_timer.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
+#include <tier4_autoware_utils/system/heartbeat_checker.hpp>
 
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 #include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
@@ -71,6 +72,7 @@ private:
     bool ignore_missing_diagnostics;
     bool add_leaf_diagnostics;
     double data_ready_timeout;
+    double data_heartbeat_timeout;
     double diag_timeout_sec;
     double hazard_recovery_timeout;
     int emergency_hazard_level;
@@ -92,6 +94,7 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
 
   bool isDataReady();
+  bool isDataHeartbeatTimeout();
   void onTimer();
 
   // Subscriber
@@ -124,6 +127,16 @@ private:
   bool onClearEmergencyService(
     [[maybe_unused]] std_srvs::srv::Trigger::Request::SharedPtr request,
     std_srvs::srv::Trigger::Response::SharedPtr response);
+
+  // Heartbeat
+  std::shared_ptr<HeaderlessHeartbeatChecker<diagnostic_msgs::msg::DiagnosticArray>>
+    heartbeat_diag_array_;
+  std::shared_ptr<HeaderlessHeartbeatChecker<tier4_control_msgs::msg::GateMode>>
+    heartbeat_current_gate_mode_;
+  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_auto_system_msgs::msg::AutowareState>>
+    heartbeat_autoware_state_;
+  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_auto_vehicle_msgs::msg::ControlModeReport>>
+    heartbeat_control_mode_;
 
   // Algorithm
   boost::optional<DiagStamped> getLatestDiag(const std::string & diag_name) const;

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -115,6 +115,7 @@ private:
   diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr diag_array_;
   autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;
   tier4_control_msgs::msg::GateMode::ConstSharedPtr current_gate_mode_;
+  rclcpp::Time current_gate_mode_stamp_;
   autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
 
   // Publisher
@@ -128,16 +129,6 @@ private:
   bool onClearEmergencyService(
     [[maybe_unused]] std_srvs::srv::Trigger::Request::SharedPtr request,
     std_srvs::srv::Trigger::Response::SharedPtr response);
-
-  // Heartbeat
-  std::shared_ptr<HeaderlessHeartbeatChecker<diagnostic_msgs::msg::DiagnosticArray>>
-    heartbeat_diag_array_;
-  std::shared_ptr<HeaderlessHeartbeatChecker<tier4_control_msgs::msg::GateMode>>
-    heartbeat_current_gate_mode_;
-  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_auto_system_msgs::msg::AutowareState>>
-    heartbeat_autoware_state_;
-  std::shared_ptr<HeaderlessHeartbeatChecker<autoware_auto_vehicle_msgs::msg::ControlModeReport>>
-    heartbeat_control_mode_;
 
   // Algorithm
   boost::optional<DiagStamped> getLatestDiag(const std::string & diag_name) const;

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -113,7 +113,6 @@ private:
   diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr diag_array_;
   autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_;
   tier4_control_msgs::msg::GateMode::ConstSharedPtr current_gate_mode_;
-  rclcpp::Time current_gate_mode_stamp_;
   autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
 
   // Publisher
@@ -127,6 +126,12 @@ private:
   bool onClearEmergencyService(
     [[maybe_unused]] std_srvs::srv::Trigger::Request::SharedPtr request,
     std_srvs::srv::Trigger::Response::SharedPtr response);
+
+  // for Heartbeat
+  rclcpp::Time diag_array_stamp_;
+  rclcpp::Time autoware_state_stamp_;
+  rclcpp::Time current_gate_mode_stamp_;
+  rclcpp::Time control_mode_stamp_;
 
   // Algorithm
   boost::optional<DiagStamped> getLatestDiag(const std::string & diag_name) const;

--- a/system/system_error_monitor/launch/system_error_monitor.launch.xml
+++ b/system/system_error_monitor/launch/system_error_monitor.launch.xml
@@ -3,6 +3,7 @@
   <arg name="ignore_missing_diagnostics" default="false"/>
   <arg name="add_leaf_diagnostics" default="true"/>
   <arg name="data_ready_timeout" default="30.0"/>
+  <arg name="data_heartbeat_timeout" default="1.0"/>
   <arg name="diag_timeout_sec" default="1.0"/>
   <arg name="hazard_recovery_timeout" default="5.0"/>
   <arg name="use_emergency_hold" default="false"/>
@@ -45,6 +46,7 @@
     <arg name="ignore_missing_diagnostics" value="$(var ignore_missing_diagnostics)"/>
     <arg name="add_leaf_diagnostics" value="$(var add_leaf_diagnostics)"/>
     <arg name="data_ready_timeout" value="$(var data_ready_timeout)"/>
+    <arg name="data_heartbeat_timeout" value="$(var data_heartbeat_timeout)"/>
     <arg name="diag_timeout_sec" value="$(var diag_timeout_sec)"/>
     <arg name="hazard_recovery_timeout" value="$(var hazard_recovery_timeout)"/>
     <arg name="use_emergency_hold" value="$(var use_emergency_hold)"/>

--- a/system/system_error_monitor/launch/system_error_monitor_node.launch.xml
+++ b/system/system_error_monitor/launch/system_error_monitor_node.launch.xml
@@ -3,6 +3,7 @@
   <arg name="ignore_missing_diagnostics"/>
   <arg name="add_leaf_diagnostics"/>
   <arg name="data_ready_timeout"/>
+  <arg name="data_heartbeat_timeout"/>
   <arg name="diag_timeout_sec"/>
   <arg name="hazard_recovery_timeout"/>
   <arg name="use_emergency_hold"/>
@@ -23,6 +24,7 @@
     <param name="ignore_missing_diagnostics" value="$(var ignore_missing_diagnostics)"/>
     <param name="add_leaf_diagnostics" value="$(var add_leaf_diagnostics)"/>
     <param name="data_ready_timeout" value="$(var data_ready_timeout)"/>
+    <param name="data_heartbeat_timeout" value="$(var data_heartbeat_timeout)"/>
     <param name="diag_timeout_sec" value="$(var diag_timeout_sec)"/>
     <param name="hazard_recovery_timeout" value="$(var hazard_recovery_timeout)"/>
     <param name="use_emergency_hold" value="$(var use_emergency_hold)"/>

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -364,12 +364,17 @@ void AutowareErrorMonitor::onDiagArray(
       diag_buffer.pop_front();
     }
   }
+
+  // for Heartbeat
+  diag_array_stamp_ = this->now();
 }
 
 void AutowareErrorMonitor::onCurrentGateMode(
   const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg)
 {
   current_gate_mode_ = msg;
+
+  // for Heartbeat
   current_gate_mode_stamp_ = this->now();
 }
 
@@ -377,12 +382,18 @@ void AutowareErrorMonitor::onAutowareState(
   const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr msg)
 {
   autoware_state_ = msg;
+
+  // for Heartbeat
+  autoware_state_stamp_ = this->now();
 }
 
 void AutowareErrorMonitor::onControlMode(
   const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg)
 {
   control_mode_ = msg;
+
+  // for Heartbeat
+  control_mode_stamp_ = this->now();
 }
 
 bool AutowareErrorMonitor::isDataReady()
@@ -417,7 +428,7 @@ bool AutowareErrorMonitor::isDataHeartbeatTimeout()
     return time_diff.seconds() > threshold;
   };
 
-  if (isTimeout(diag_array_->header.stamp, params_.data_heartbeat_timeout)) {
+  if (isTimeout(diag_array_stamp_, params_.data_heartbeat_timeout)) {
     RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "diag_array msg is timeout...");
     return true;
   }
@@ -427,12 +438,12 @@ bool AutowareErrorMonitor::isDataHeartbeatTimeout()
     return true;
   }
 
-  if (isTimeout(autoware_state_->stamp, params_.data_heartbeat_timeout)) {
+  if (isTimeout(autoware_state_stamp_, params_.data_heartbeat_timeout)) {
     RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "autoware_state msg is timeout...");
     return true;
   }
 
-  if (isTimeout(control_mode_->stamp, params_.data_heartbeat_timeout)) {
+  if (isTimeout(control_mode_stamp_, params_.data_heartbeat_timeout)) {
     RCLCPP_ERROR_THROTTLE(
       get_logger(), *get_clock(), 5000, "vehicle_state_report msg is timeout...");
     return true;


### PR DESCRIPTION
## Description

The system_error_monitor can't decide emergency when any of required topics are not be able to subscribed due to process death.
For example...
1. autoware_state is `WAITING_FOR_ROUTE` and current_gate_mode is `AUTO`
2. isInNoFaultCondition() is true, so some error diags are ignored
3. Now, kill ad_service_state_monitor and autoware_state msg is no longer updated
4. item 2 is stil true...

To avoid such a situation, I'll add heartbeat timeout to required topics.
Timeout parameter is set to 1 second as default and we can change from launch.xml.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

- Launch planning simulator and set start and goal
- kill required topics publisher with the command `ps -aux | grep ad_service_state_monitor | awk '{print $2}' | xargs kill`
- publish `/system/emergency/hazard_status` as timeout like below

```
---
stamp:
  sec: 1659433471
  nanosec: 185921844
status:
  level: 3
  emergency: true
  emergency_holding: false
  diag_no_fault: []
  diag_safe_fault: []
  diag_latent_fault: []
  diag_single_point_fault:
  - level: "\x02"
    name: system_error_monitor/input_data_timeout
    message: ''
    hardware_id: system_error_monitor
    values: []
```

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
