### PR TITLE
fix(lanelet2_extension,had_map_utils): fix node dying bug by lanelet resampling

### DIFF
--- a/common/had_map_utils/src/had_map_utils.cpp
+++ b/common/had_map_utils/src/had_map_utils.cpp
@@ -101,6 +101,7 @@ std::vector<lanelet::BasicPoint3d> resamplePoints(
 
   // Calculate accumulated lengths
   const auto accumulated_lengths = calculateAccumulatedLengths(line_string);
+  if(accumulated_lengths.empty()) return {};
 
   // Create each segment
   std::vector<lanelet::BasicPoint3d> resampled_points;

--- a/common/had_map_utils/src/had_map_utils.cpp
+++ b/common/had_map_utils/src/had_map_utils.cpp
@@ -101,7 +101,7 @@ std::vector<lanelet::BasicPoint3d> resamplePoints(
 
   // Calculate accumulated lengths
   const auto accumulated_lengths = calculateAccumulatedLengths(line_string);
-  if(accumulated_lengths.size() < 2) return {};
+  if (accumulated_lengths.size() < 2) return {};
 
   // Create each segment
   std::vector<lanelet::BasicPoint3d> resampled_points;

--- a/common/had_map_utils/src/had_map_utils.cpp
+++ b/common/had_map_utils/src/had_map_utils.cpp
@@ -101,7 +101,7 @@ std::vector<lanelet::BasicPoint3d> resamplePoints(
 
   // Calculate accumulated lengths
   const auto accumulated_lengths = calculateAccumulatedLengths(line_string);
-  if(accumulated_lengths.empty()) return {};
+  if(accumulated_lengths.size() < 2) return {};
 
   // Create each segment
   std::vector<lanelet::BasicPoint3d> resampled_points;

--- a/map/lanelet2_extension/lib/utilities.cpp
+++ b/map/lanelet2_extension/lib/utilities.cpp
@@ -148,6 +148,7 @@ std::vector<lanelet::BasicPoint3d> resamplePoints(
 
   // Calculate accumulated lengths
   const auto accumulated_lengths = calculateAccumulatedLengths(line_string);
+  if(accumulated_lengths.empty()) return {};
 
   // Create each segment
   std::vector<lanelet::BasicPoint3d> resampled_points;

--- a/map/lanelet2_extension/lib/utilities.cpp
+++ b/map/lanelet2_extension/lib/utilities.cpp
@@ -148,7 +148,7 @@ std::vector<lanelet::BasicPoint3d> resamplePoints(
 
   // Calculate accumulated lengths
   const auto accumulated_lengths = calculateAccumulatedLengths(line_string);
-  if(accumulated_lengths.size() < 2) return {};
+  if (accumulated_lengths.size() < 2) return {};
 
   // Create each segment
   std::vector<lanelet::BasicPoint3d> resampled_points;

--- a/map/lanelet2_extension/lib/utilities.cpp
+++ b/map/lanelet2_extension/lib/utilities.cpp
@@ -148,7 +148,7 @@ std::vector<lanelet::BasicPoint3d> resamplePoints(
 
   // Calculate accumulated lengths
   const auto accumulated_lengths = calculateAccumulatedLengths(line_string);
-  if(accumulated_lengths.empty()) return {};
+  if(accumulated_lengths.size() < 2) return {};
 
   // Create each segment
   std::vector<lanelet::BasicPoint3d> resampled_points;


### PR DESCRIPTION
## Description


https://github.com/autowarefoundation/autoware.universe/blob/3f2560257bc448070a9fb574c7324bcd855ea44e/common/had_map_utils/src/had_map_utils.cpp#L111

Resample points require at least 1 point to resample points with nearest index , however there is no index guard for empty points. This will lead node dies when there is no points for delay.

planninng node dies at the end point of lane change 

![image](https://user-images.githubusercontent.com/65527974/182546864-04ed2e67-9315-4042-80e7-09d7579c2eb6.png)

This PR was verified by experiment.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
