### PR TITLE
fix(behavior_path_planner): resamplePathWithSpline z interpolation

### DIFF
--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -106,7 +106,7 @@ PathWithLaneId resamplePathWithSpline(const PathWithLaneId & path, double interv
 
   const auto resampled_x = interpolation::slerp(base_points, base_x, sampling_points);
   const auto resampled_y = interpolation::slerp(base_points, base_y, sampling_points);
-  const auto resampled_z = interpolation::slerp(base_points, base_z, sampling_points);
+  const auto resampled_z = interpolation::lerp(base_points, base_z, sampling_points);
 
   PathWithLaneId resampled_path{};
   resampled_path.header = path.header;


### PR DESCRIPTION
## Description

In the behavior path planner, the z-axis is currently interpolated using `spline`.
So it might be more feasible to use linear instead.

## Related links

[Jira link: レーンチェンジ承認後経路のZ位置が波打つ](https://tier4.atlassian.net/browse/T4PB-19114)

## Tests performed

Use PSIM and confirm that there is not issues with normal and lane change operation.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
