### PR TITLE
feat(behavior_path_planner): distance calculation for avoidance module

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2152,6 +2152,8 @@ BehaviorModuleOutput AvoidanceModule::plan()
 
   DEBUG_PRINT("exit plan(): set prev output (back().lat = %f)", prev_output_.shift_length.back());
 
+  updateRegisteredRTCStatus(avoidance_path.path);
+
   return output;
 }
 
@@ -2199,9 +2201,12 @@ BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
   // we can execute the plan() since it handles the approval appropriately.
   BehaviorModuleOutput out = plan();
   const auto candidate = planCandidate();
+  constexpr double threshold_to_update_status = -1.0e-03;
+  if (candidate.distance_to_path_change > threshold_to_update_status) {
+    updateCandidateRTCStatus(candidate);
+    waitApproval();
+  }
   out.path_candidate = std::make_shared<PathWithLaneId>(candidate.path_candidate);
-  updateRTCStatus(candidate);
-  waitApproval();
   return out;
 }
 
@@ -2214,6 +2219,21 @@ void AvoidanceModule::addShiftPointIfApproved(const AvoidPointArray & shift_poin
 
     // register original points for consistency
     registerRawShiftPoints(shift_points);
+
+    int i = shift_points.size() - 1;
+    for (; i > 0; i--) {
+      if (fabs(shift_points.at(i).getRelativeLength()) < 0.01) {
+        continue;
+      } else {
+        break;
+      }
+    }
+
+    if (shift_points.at(i).getRelativeLength() > 0.0) {
+      left_shift_array_.push_back({uuid_left_, shift_points.front().start});
+    } else if (shift_points.at(i).getRelativeLength() < 0.0) {
+      right_shift_array_.push_back({uuid_right_, shift_points.front().start});
+    }
 
     uuid_left_ = generateUUID();
     uuid_right_ = generateUUID();

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2592,6 +2592,8 @@ void AvoidanceModule::initVariables()
   prev_linear_shift_path_ = ShiftedPath();
   prev_reference_ = PathWithLaneId();
   path_shifter_ = PathShifter{};
+  left_shift_array_.clear();
+  right_shift_array_.clear();
 
   debug_avoidance_msg_array_ptr_.reset();
   debug_data_ = DebugData();


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Before this PR, the distance status is not updated after registering the shift point.
I add the feature to calculate distance to registered shift point dynamically.

Furthermore, I fixed the problem that it outputs unnecessary log.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

I tested in planning_simulator.

https://user-images.githubusercontent.com/10190493/182585501-7737b02b-c18b-45d4-b232-6be83eff9552.mp4

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
