### PR TITLE
feat(motion_utils): substitute input path initila point informaiton

### DIFF
--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -152,6 +152,8 @@ autoware_auto_planning_msgs::msg::PathWithLaneId resamplePath(
   v_lon.front() = input_path.points.front().point.longitudinal_velocity_mps;
   v_lat.front() = input_path.points.front().point.lateral_velocity_mps;
   heading_rate.front() = input_path.points.front().point.heading_rate_rps;
+  is_final.front() = input_path.points.front().point.is_final;
+  lane_ids.front() = input_path.points.front().lane_ids;
   for (size_t i = 1; i < input_path.points.size(); ++i) {
     const auto & prev_pt = input_path.points.at(i - 1).point;
     const auto & curr_pt = input_path.points.at(i).point;


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
Since current resamplePath function in motion utils miss some information in motion utils, I fix this bag in this PR. Currently, this function is not used by other modules, so there is no big influence in autoware.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
