### PR TITLE
fix(behavior_path_planner): fix turn signal logic in intersection

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -98,13 +98,13 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
           turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
         } else if (lane_attribute == std::string("right")) {
           turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
-        } else {
-          // when lane_attribute is straight, return the turn signal with max distance
-          return std::make_pair(turn_signal, std::numeric_limits<double>::max());
         }
         distance = distance_from_vehicle_front;
       }
     }
+  }
+  if (turn_signal.command == TurnIndicatorsCommand::NO_COMMAND) {
+    distance = std::numeric_limits<double>::max();
   }
   return std::make_pair(turn_signal, distance);
 }


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description
Fix turn signal logic.
Before this change, if the turn_direction is straight, it finishes search turn direction due to the early return.
To fix it, I add the distance update in final step in the turn signal decider.
<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/1511
<!-- Write the links related to this PR. -->

## Tests performed
Tested in planning simulator.
![Screenshot from 2022-08-04 18-31-01](https://user-images.githubusercontent.com/10190493/182814290-630fa247-4f79-43dd-9243-d8c6126ac2b7.png)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
