### PR TITLE
fix(behavior_path_planner): keep previously inserted shift points

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -109,6 +109,7 @@ private:
   PathShifter path_shifter_;
 
   ShiftedPath prev_output_;
+  ShiftPoint prev_shiftpoint_;
 
   // NOTE: this function is ported from avoidance.
   PoseStamped getUnshiftedEgoPose(const ShiftedPath & prev_path) const;

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -73,6 +73,7 @@ void SideShiftModule::initVariables()
   start_pose_reset_request_ = false;
   lateral_offset_ = 0.0;
   prev_output_ = ShiftedPath{};
+  prev_shiftpoint_ = ShiftPoint{};
   path_shifter_ = PathShifter{};
 }
 
@@ -232,6 +233,11 @@ bool SideShiftModule::addShiftPoint()
 
   // check if the new_shift_points overlap with existing shift points.
   const auto new_sp = calcShiftPoint();
+  // check if the new_shift_points is same with lately inserted shift_points.
+  if(new_sp.length == prev_shiftpoint_.length){
+    return false;
+  }
+
   const auto new_sp_longitudinal_to_shift_start = calcLongitudinal_to_shift_start(new_sp);
   const auto new_sp_longitudinal_to_shift_end = calcLongitudinal_to_shift_end(new_sp);
 
@@ -239,6 +245,7 @@ bool SideShiftModule::addShiftPoint()
     shift_points.begin(), shift_points.end(),
     [this, calcLongitudinal_to_shift_start, calcLongitudinal_to_shift_end,
      new_sp_longitudinal_to_shift_start, new_sp_longitudinal_to_shift_end](const ShiftPoint & sp) {
+      const bool check_with_prev_sp = (sp.length == prev_shiftpoint_.length);
       const auto old_sp_longitudinal_to_shift_start = calcLongitudinal_to_shift_start(sp);
       const auto old_sp_longitudinal_to_shift_end = calcLongitudinal_to_shift_end(sp);
       const bool sp_overlap_front =
@@ -253,7 +260,10 @@ bool SideShiftModule::addShiftPoint()
       const bool sp_old_contain_new =
         ((old_sp_longitudinal_to_shift_start <= new_sp_longitudinal_to_shift_start) &&
          (new_sp_longitudinal_to_shift_end <= old_sp_longitudinal_to_shift_end));
-      return (sp_overlap_front || sp_overlap_back || sp_new_contain_old || sp_old_contain_new);
+      const bool overlap_with_new_sp = (sp_overlap_front || sp_overlap_back ||
+      sp_new_contain_old || sp_old_contain_new);
+
+      return (overlap_with_new_sp && !check_with_prev_sp);
     });
 
   shift_points.erase(remove_overlap_iter, shift_points.end());
@@ -271,6 +281,12 @@ bool SideShiftModule::addShiftPoint()
 
   // if no conflict, then add the new point.
   shift_points.push_back(new_sp);
+  const bool new_sp_is_same_with_previous = new_sp.length == prev_shiftpoint_.length;
+
+  if (!new_sp_is_same_with_previous)
+  {
+    prev_shiftpoint_ = new_sp;
+  }
 
   // set to path_shifter
   path_shifter_.setShiftPoints(shift_points);


### PR DESCRIPTION
## Description
In the sideshift module, there was no function to erase existing shift points when a new offset value is given.
As a result, unstable routes were generated as different sets of shift points intersected within a certain section.
With this change, if a newly added shift point overlaps a straight line created from existing shift points, the existing shift points are erased.

##Pre-review checklist for the PR author
The PR author **must** check the checkboxes below when creating the PR.

 

- [x]  I've confirmed the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
- [x]  The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).

## In-review checklist for the PR reviewers
The PR reviewers **must** check the checkboxes below before approval.
- [ ] The PR follows the [pull request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).

## Post-review checklist for the PR author
The PR author must check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.