### PR TITLE
feat: add no detection area filter

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -390,7 +390,7 @@ def launch_setup(context, *args, **kwargs):
             [
                 FindPackageShare("tier4_planning_launch"),
                 "/launch/scenario_planning/lane_driving/behavior_planning/compare_map.launch.py",
-            ]
+            ],
         ),
         launch_arguments={
             "use_pointcloud_container": LaunchConfiguration("use_pointcloud_container"),
@@ -413,10 +413,39 @@ def launch_setup(context, *args, **kwargs):
         ),
     )
 
+    load_no_detection_area_filter = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                FindPackageShare("tier4_planning_launch"),
+                "/launch/scenario_planning/lane_driving/behavior_planning/no_detection_area_filter.launch.py",
+            ]
+        ),
+        launch_arguments={
+            "use_pointcloud_container": LaunchConfiguration("use_pointcloud_container"),
+            "container_name": LaunchConfiguration("container_name"),
+            "use_multithread": "true",
+        }.items(),
+        # launch no detection area filter only when run_out module is enabled and detection method is Points
+        condition=IfCondition(
+            PythonExpression(
+                [
+                    LaunchConfiguration(
+                        "launch_run_out", default=behavior_velocity_planner_param["launch_run_out"]
+                    ),
+                    " and ",
+                    "'",
+                    run_out_param["run_out"]["detection_method"],
+                    "' == 'Points'",
+                ]
+            )
+        ),
+    )
+
     group = GroupAction(
         [
             container,
             load_compare_map,
+            load_no_detection_area_filter,
         ]
     )
 

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/no_detection_area_filter.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/no_detection_area_filter.launch.py
@@ -40,28 +40,22 @@ def generate_launch_description():
     )
 
     composable_nodes = [
-        ComposableNode(
-            package="compare_map_segmentation",
-            plugin="compare_map_segmentation::VoxelDistanceBasedCompareMapFilterComponent",
-            name="voxel_distance_based_compare_map_filter_node",
-            remappings=[
-                ("input", "no_detection_area_filtered/pointcloud"),
-                ("map", "/map/pointcloud_map"),
-                ("output", "compare_map_filtered/pointcloud"),
-            ],
-            parameters=[
-                {
-                    "distance_threshold": 0.7,
-                }
-            ],
-            extra_arguments=[
-                {"use_intra_process_comms": False}  # this node has QoS of transient local
-            ],
-        ),
+            ComposableNode(
+                package="pointcloud_preprocessor",
+                plugin="pointcloud_preprocessor::NoDetectionAreaFilterComponent",
+                name="no_detection_area_filter",
+                remappings=[
+                    ("input", "/perception/obstacle_segmentation/pointcloud"),
+                    ("input/vector_map", "/map/vector_map"),
+                    ("output", "no_detection_area_filtered/pointcloud"),
+                ],
+                # this node has QoS of transient local
+                extra_arguments=[{"use_intra_process_comms": False}],
+            )
     ]
 
-    compare_map_container = ComposableNodeContainer(
-        name=LaunchConfiguration("container_name"),
+    no_detection_area_filter_container = ComposableNodeContainer(
+        name="no_detection_area_filter_container",
         namespace="",
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
@@ -80,10 +74,10 @@ def generate_launch_description():
         [
             add_launch_arg("use_multithread", "true"),
             add_launch_arg("use_pointcloud_container", "true"),
-            add_launch_arg("container_name", "compare_map_container"),
+            add_launch_arg("container_name", "no_detection_area_filter_container"),
             set_container_executable,
             set_container_mt_executable,
-            compare_map_container,
+            no_detection_area_filter_container,
             load_composable_nodes,
         ]
     )

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
@@ -114,10 +114,13 @@ void Lanelet2MapVisualizationNode::onMapBin(
   lanelet::ConstPolygons3d parking_lots = lanelet::utils::query::getAllParkingLots(viz_lanelet_map);
   lanelet::ConstPolygons3d obstacle_polygons =
     lanelet::utils::query::getAllObstaclePolygons(viz_lanelet_map);
+  lanelet::ConstPolygons3d no_detection_area =
+    lanelet::utils::query::getAllNoDetectionArea(viz_lanelet_map);
 
   std_msgs::msg::ColorRGBA cl_road, cl_shoulder, cl_cross, cl_partitions, cl_pedestrian_markings,
     cl_ll_borders, cl_shoulder_borders, cl_stoplines, cl_trafficlights, cl_detection_areas,
-    cl_parking_lots, cl_parking_spaces, cl_lanelet_id, cl_obstacle_polygons, cl_no_stopping_areas;
+    cl_parking_lots, cl_parking_spaces, cl_lanelet_id, cl_obstacle_polygons, cl_no_stopping_areas,
+    cl_no_detection_area;
   setColor(&cl_road, 0.27, 0.27, 0.27, 0.999);
   setColor(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   setColor(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -133,6 +136,7 @@ void Lanelet2MapVisualizationNode::onMapBin(
   setColor(&cl_parking_lots, 0.5, 0.5, 0.0, 0.3);
   setColor(&cl_parking_spaces, 1.0, 0.647, 0.0, 0.6);
   setColor(&cl_lanelet_id, 0.5, 0.5, 0.5, 0.999);
+  setColor(&cl_no_detection_area, 0.37, 0.37, 0.27, 0.5);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -196,6 +200,9 @@ void Lanelet2MapVisualizationNode::onMapBin(
   insertMarkerArray(
     &map_marker_array,
     lanelet::visualization::laneletsAsTriangleMarkerArray("road_lanelets", road_lanelets, cl_road));
+  insertMarkerArray(
+    &map_marker_array,
+    lanelet::visualization::noDetectionAreaAsMarkerArray(no_detection_area, cl_no_detection_area));
 
   pub_marker_->publish(map_marker_array);
 }

--- a/sensing/pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/pointcloud_preprocessor/CMakeLists.txt
@@ -40,6 +40,7 @@ ament_auto_add_library(pointcloud_preprocessor_filter SHARED
   src/distortion_corrector/distortion_corrector.cpp
   src/blockage_diag/blockage_diag_nodelet.cpp
   src/polygon_remover/polygon_remover.cpp
+  src/no_detection_area_filter/no_detection_area_filter.cpp
 )
 
 target_link_libraries(pointcloud_preprocessor_filter
@@ -60,12 +61,10 @@ rclcpp_components_register_node(pointcloud_preprocessor_filter
   PLUGIN "pointcloud_preprocessor::PointCloudConcatenateDataSynchronizerComponent"
   EXECUTABLE concatenate_data_node)
 
-
 # ========== CropBox ==========
 rclcpp_components_register_node(pointcloud_preprocessor_filter
   PLUGIN "pointcloud_preprocessor::CropBoxFilterComponent"
   EXECUTABLE crop_box_filter_node)
-
 
 # ========== Down Sampler Filter ==========
 # -- Voxel Grid Downsample Filter --
@@ -114,18 +113,15 @@ rclcpp_components_register_node(pointcloud_preprocessor_filter
   PLUGIN "pointcloud_preprocessor::PassThroughFilterUInt16Component"
   EXECUTABLE passthrough_filter_uint16_node)
 
-
 # ========== Pointcloud Accumulator Filter ==========
 rclcpp_components_register_node(pointcloud_preprocessor_filter
   PLUGIN "pointcloud_preprocessor::PointcloudAccumulatorComponent"
   EXECUTABLE pointcloud_accumulator_node)
 
-
 # ========== Vector Map Filter ==========
 rclcpp_components_register_node(pointcloud_preprocessor_filter
   PLUGIN "pointcloud_preprocessor::Lanelet2MapFilterComponent"
   EXECUTABLE vector_map_filter_node)
-
 
 # ========== Distortion Corrector ==========
 rclcpp_components_register_node(pointcloud_preprocessor_filter
@@ -144,6 +140,11 @@ rclcpp_components_register_node(pointcloud_preprocessor_filter
 
 set(CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE TRUE)
 target_link_libraries(polygon_remover_node gmp CGAL CGAL::CGAL CGAL::CGAL_Core)
+
+# ========== No Detection Area Filter ===========
+rclcpp_components_register_node(pointcloud_preprocessor_filter
+  PLUGIN "pointcloud_preprocessor::NoDetectionAreaFilterComponent"
+  EXECUTABLE no_detection_area_filter_node)
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/no_detection_area_filter/no_detection_area_filter.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/no_detection_area_filter/no_detection_area_filter.hpp
@@ -1,0 +1,70 @@
+// Copyright 2022 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POINTCLOUD_PREPROCESSOR__NO_DETECTION_AREA_FILTER__LANELET2_NO_DETECTION_AREA_FILTER_HPP_
+#define POINTCLOUD_PREPROCESSOR__NO_DETECTION_AREA_FILTER__LANELET2_NO_DETECTION_AREA_FILTER_HPP_
+
+#include "pointcloud_preprocessor/filter.hpp"
+
+#include <lanelet2_extension/utility/message_conversion.hpp>
+#include <lanelet2_extension/utility/query.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/geometry/boost_geometry.hpp>
+
+#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tier4_debug_msgs/msg/float32_stamped.hpp>
+
+#include <pcl/filters/voxel_grid.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
+
+#include <tf2_ros/transform_listener.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+using tier4_autoware_utils::LinearRing2d;
+using tier4_autoware_utils::MultiPoint2d;
+using tier4_autoware_utils::Point2d;
+
+namespace pointcloud_preprocessor
+{
+class NoDetectionAreaFilterComponent : public pointcloud_preprocessor::Filter
+{
+private:
+  void filter(
+    const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
+    PointCloud2 & output) override;
+
+  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr map_sub_;
+  lanelet::ConstPolygons3d no_detection_area_lanelets_;
+
+  void mapCallback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
+
+public:
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
+  explicit NoDetectionAreaFilterComponent(const rclcpp::NodeOptions & options);
+};
+
+}  // namespace pointcloud_preprocessor
+
+#endif  // POINTCLOUD_PREPROCESSOR__NO_DETECTION_AREA_FILTER__LANELET2_NO_DETECTION_AREA_FILTER_HPP_

--- a/sensing/pointcloud_preprocessor/src/no_detection_area_filter/no_detection_area_filter.cpp
+++ b/sensing/pointcloud_preprocessor/src/no_detection_area_filter/no_detection_area_filter.cpp
@@ -1,0 +1,141 @@
+// Copyright 2022 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pointcloud_preprocessor/no_detection_area_filter/no_detection_area_filter.hpp"
+
+#include "pointcloud_preprocessor/filter.hpp"
+
+#include <pcl_ros/transforms.hpp>
+
+#include <lanelet2_core/geometry/Polygon.h>
+#include <tf2_ros/create_timer_ros.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace
+{
+bool pointWithinLanelets(const Point2d & point, const lanelet::ConstPolygons3d & lanelets)
+{
+  for (const auto & lanelet : lanelets) {
+    if (boost::geometry::within(point, lanelet::utils::to2D(lanelet).basicPolygon())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+tier4_autoware_utils::Box2d calcBoundingBox(
+  const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & input_cloud)
+{
+  MultiPoint2d candidate_points;
+  for (const auto & p : input_cloud->points) {
+    candidate_points.emplace_back(p.x, p.y);
+  }
+
+  // return envelope_box;
+  return boost::geometry::return_envelope<tier4_autoware_utils::Box2d>(candidate_points);
+}
+
+lanelet::ConstPolygons3d calcIntersectedPolygons(
+  const tier4_autoware_utils::Box2d & bounding_box, const lanelet::ConstPolygons3d & polygons)
+{
+  lanelet::ConstPolygons3d intersected_polygons;
+  for (const auto & polygon : polygons) {
+    if (boost::geometry::intersects(bounding_box, lanelet::utils::to2D(polygon).basicPolygon())) {
+      intersected_polygons.push_back(polygon);
+    }
+  }
+  return intersected_polygons;
+}
+
+pcl::PointCloud<pcl::PointXYZ> removePointsWithinPolygons(
+  const lanelet::ConstPolygons3d & polygons, const pcl::PointCloud<pcl::PointXYZ>::Ptr & cloud)
+{
+  pcl::PointCloud<pcl::PointXYZ> filtered_cloud;
+  filtered_cloud.header = cloud->header;
+
+  for (const auto & p : cloud->points) {
+    if (pointWithinLanelets(Point2d(p.x, p.y), polygons)) {
+      continue;
+    }
+
+    filtered_cloud.points.push_back(p);
+  }
+
+  return filtered_cloud;
+}
+
+}  // anonymous namespace
+
+namespace pointcloud_preprocessor
+{
+NoDetectionAreaFilterComponent::NoDetectionAreaFilterComponent(
+  const rclcpp::NodeOptions & node_options)
+: Filter("NoDetectionAreaFilter", node_options)
+{
+  using std::placeholders::_1;
+
+  // Set subscriber
+  map_sub_ = this->create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
+    "input/vector_map", rclcpp::QoS{1}.transient_local(),
+    std::bind(&NoDetectionAreaFilterComponent::mapCallback, this, _1));
+}
+
+void NoDetectionAreaFilterComponent::filter(
+  const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
+  PointCloud2 & output)
+{
+  if (no_detection_area_lanelets_.empty()) {
+    output = *input;
+    return;
+  }
+
+  // convert to PCL message
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pc_input = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+  pcl::fromROSMsg(*input, *pc_input);
+
+  // calculate bounding box of points
+  const auto bounding_box = calcBoundingBox(pc_input);
+
+  // use only intersected lanelets to reduce calculation cost
+  const auto intersected_lanelets =
+    calcIntersectedPolygons(bounding_box, no_detection_area_lanelets_);
+
+  // filter pointcloud by lanelet
+  const auto filtered_pc = removePointsWithinPolygons(intersected_lanelets, pc_input);
+
+  // convert to ROS message
+  pcl::toROSMsg(filtered_pc, output);
+  output.header = input->header;
+}
+
+void NoDetectionAreaFilterComponent::mapCallback(
+  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr map_msg)
+{
+  tf_input_frame_ = map_msg->header.frame_id;
+
+  const auto lanelet_map_ptr = std::make_shared<lanelet::LaneletMap>();
+  lanelet::utils::conversion::fromBinMsg(*map_msg, lanelet_map_ptr);
+  no_detection_area_lanelets_ = lanelet::utils::query::getAllNoDetectionArea(lanelet_map_ptr);
+}
+
+}  // namespace pointcloud_preprocessor
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(pointcloud_preprocessor::NoDetectionAreaFilterComponent)


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description

Added points filter that removes the points in `no_detection_area`.
`no_detection_area` is polygon area given by the lanelet maps.

## Related links


## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
