### PR TITLE
fix(vehicle_cmd_gate): fix double-published topic

### DIFF
--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -370,7 +370,6 @@ void VehicleCmdGate::onTimer()
   }
 
   // Publish topics
-  gate_mode_pub_->publish(current_gate_mode_);
   turn_indicator_cmd_pub_->publish(turn_indicator);
   hazard_light_cmd_pub_->publish(hazard_light);
   gear_cmd_pub_->publish(gear);


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/1077


## Description
In the vehicle_cmd_gate, the current_gate_mode topic was published by `publishStatus()`  and `onTimer` functions, both of which are callback functions at 10 Hz.
As a result, the freqency of current_gate_mode became 20Hz. I fixed the problem by not publishing the current_gate_mode in the `onTimer` function


## Review Procedure
$ros2 topic hz /control/current_gate_mode 
(Check that current_gate_mode is published at 10Hz)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
