### PR TITLE
fix(simple_planning_simulator): fix timer type

### DIFF
--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -135,8 +135,8 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
     std::bind(&SimplePlanningSimulator::on_parameter, this, _1));
 
   timer_sampling_time_ms_ = static_cast<uint32_t>(declare_parameter("timer_sampling_time_ms", 25));
-  on_timer_ = create_wall_timer(
-    std::chrono::milliseconds(timer_sampling_time_ms_),
+  on_timer_ = rclcpp::create_timer(
+    this, get_clock(), std::chrono::milliseconds(timer_sampling_time_ms_),
     std::bind(&SimplePlanningSimulator::on_timer, this));
 
   tier4_api_utils::ServiceProxyNodeInterface proxy(this);


### PR DESCRIPTION
## Description

Fix timer in `simple_planning_simulator` to use ros-time correctly.

### issue to be solved

In the current implementation, due to the timer type in `simple_planning_simulator`, the vehicle motion doesn't move correctly.

With `use_sim_time:=true`, the vehicle exceeds the stop line and gets too close to the obstacle in the obstacle-stop scenario.
![image](https://user-images.githubusercontent.com/21360593/183374068-4ef2e81b-c71e-4ac3-a6b1-dce0da208099.png)


After merging this PR, the vehicle will not exceed the stop line.
![image](https://user-images.githubusercontent.com/21360593/183374657-22d96bbf-ae64-475c-9119-78993f90c0ea.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
