### PR TITLE
fix(behavior_path_planner): fix turn singal

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -71,6 +71,9 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
     const double distance_from_vehicle_front =
       accumulated_distance - vehicle_pose_frenet.length - base_link2front_;
     if (distance_from_vehicle_front > intersection_search_distance_) {
+      if (turn_signal.command == TurnIndicatorsCommand::DISABLE) {
+        distance = std::numeric_limits<double>::max();
+      }
       return std::make_pair(turn_signal, distance);
     }
     // TODO(Horibe): Route Handler should be a library.
@@ -103,7 +106,7 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
       }
     }
   }
-  if (turn_signal.command == TurnIndicatorsCommand::NO_COMMAND) {
+  if (turn_signal.command == TurnIndicatorsCommand::DISABLE) {
     distance = std::numeric_limits<double>::max();
   }
   return std::make_pair(turn_signal, distance);


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Fixed an problem with wrong turn signal timing.
This is because the `getIntersectionTurnSignal` function outputs a structure with NO_COMMAND turn signal and short distance.
So, I changed to substitute `std::numeric_limits<double>::max()` to distance when turn_signal is NO_COMMAND.

Before:
The timing of the left turn signal is slow when returning to the original path from avoidance.
https://user-images.githubusercontent.com/59680180/183375758-54d3113b-d7af-43f9-b8a3-1b0f37c558cc.mp4


After:
https://user-images.githubusercontent.com/59680180/183375830-40615afc-e643-4a1e-8703-a5144bbe6070.mp4


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
