### PR TITLE
fix(scenario_selector): timing of handling route

### DIFF
--- a/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
+++ b/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
@@ -52,6 +52,7 @@ public:
   void onOdom(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
   void onParkingState(const std_msgs::msg::Bool::ConstSharedPtr msg);
 
+  bool isDataReady();
   void onTimer();
   void onLaneDrivingTrajectory(
     const autoware_auto_planning_msgs::msg::Trajectory::ConstSharedPtr msg);

--- a/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -219,8 +219,6 @@ void ScenarioSelectorNode::onMap(
 void ScenarioSelectorNode::onRoute(
   const autoware_auto_planning_msgs::msg::HADMapRoute::ConstSharedPtr msg)
 {
-  route_handler_->setRoute(*msg);
-  if (!route_handler_->isHandlerReady()) return;
   route_ = msg;
   current_scenario_ = tier4_planning_msgs::msg::Scenario::EMPTY;
 }
@@ -258,6 +256,14 @@ void ScenarioSelectorNode::onTimer()
 
   // Check all inputs are ready
   if (!current_pose_ || !lanelet_map_ptr_ || !route_ || !twist_) {
+    return;
+  }
+
+  // Check route handler is ready
+  route_handler_->setRoute(*route_);
+  if (!route_handler_->isHandlerReady()) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000, "Waiting for route handler.");
     return;
   }
 


### PR DESCRIPTION
Signed-off-by: Shumpei Wakabayashi <shumpei.wakabayashi@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
Previously if `scenario_selector` loads route earlier than map, there will be no chance to subscribe route again.
This PR resolves this issue and outputs warn throttle on that occasion.
Also, I add `isDataReady` function to check if the required inputs are ready in order to debug easily.

Review procedure is 
- play rosbag immediately after launching logging_simulator.xml with huge map.
- confirm behavior path planner outputs path_with_lane_id.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
