### PR TITLE
fix(obstacle_stop_planner): use common ego nearest search

### DIFF
--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -48,13 +48,12 @@ When the deceleration section is inserted, the start point of the section is ins
 
 ### Common Parameter
 
-| Parameter               | Type   | Description                                                                              |
-| ----------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| `enable_slow_down`      | bool   | enable slow down planner [-]                                                             |
-| `max_velocity`          | double | max velocity [m/s]                                                                       |
-| `hunting_threshold`     | double | # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s] |
-| `lowpass_gain`          | double | low pass gain for calculating acceleration [-]                                           |
-| `max_yaw_deviation_deg` | double | # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)   |
+| Parameter           | Type   | Description                                                                              |
+| ------------------- | ------ | ---------------------------------------------------------------------------------------- |
+| `enable_slow_down`  | bool   | enable slow down planner [-]                                                             |
+| `max_velocity`      | double | max velocity [m/s]                                                                       |
+| `hunting_threshold` | double | # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s] |
+| `lowpass_gain`      | double | low pass gain for calculating acceleration [-]                                           |
 
 ### Obstacle Stop Planner
 

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -8,7 +8,6 @@
       step_length: 1.0 # step length for pointcloud search range [m]
       extend_distance: 0.0 # extend trajectory to consider after goal obstacle in the extend_distance
       expand_stop_range: 0.0 # margin of vehicle footprint [m]
-      max_yaw_deviation_deg: 90.0 # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)
       hold_stop_margin_distance: 0.0 # the ego keeps stopping if the ego is in this margin [m]
 
     slow_down_planner:

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -98,12 +98,12 @@ public:
 
   struct NodeParam
   {
-    bool enable_slow_down;         // set True, slow down for obstacle beside the path
-    double max_velocity;           // max velocity [m/s]
-    double lowpass_gain;           // smoothing calculated current acceleration [-]
-    double hunting_threshold;      // keep slow down or stop state if obstacle vanished [s]
-    double max_yaw_deviation_rad;  // maximum ego yaw deviation from trajectory [rad] (measures
-                                   // against overlapping lanes)
+    bool enable_slow_down;              // set True, slow down for obstacle beside the path
+    double max_velocity;                // max velocity [m/s]
+    double lowpass_gain;                // smoothing calculated current acceleration [-]
+    double hunting_threshold;           // keep slow down or stop state if obstacle vanished [s]
+    double ego_nearest_dist_threshold;  // dist threshold for ego's nearest index
+    double ego_nearest_yaw_threshold;   // yaw threshold for ego's nearest index
   };
 
   struct StopParam

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -834,7 +834,7 @@ void ObstacleStopPlannerNode::insertVelocity(
         if (lon_offset < 0) {
           stop_seg_idx = std::max(static_cast<size_t>(0), stop_point.index - 1);
         } else {
-          stop_seg_idx = std::min(output.size() - 2, stop_point.index + 1);
+          stop_seg_idx = std::min(output.size() - 2, stop_point.index);
         }
 
         return calcSignedArcLength(


### PR DESCRIPTION
## Description

use the new nearest index search algorithm in obstacle stop planner to deal with edge cases shown in the issue.

## Related links
issue
https://github.com/autowarefoundation/autoware.universe/issues/1581

depends on
https://github.com/autowarefoundation/autoware.universe/pull/1582
https://github.com/tier4/autoware_launch/pull/437

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
