### PR TITLE
fix(behavior_velocity_planner): fix clang-tidy warning in crosswalk module

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.hpp
@@ -38,7 +38,7 @@ public:
   const char * getModuleName() override { return "crosswalk"; }
 
 private:
-  CrosswalkModule::PlannerParam crosswalk_planner_param_;
+  CrosswalkModule::PlannerParam crosswalk_planner_param_{};
 
   void launchNewModules(const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 
@@ -54,7 +54,7 @@ public:
   const char * getModuleName() override { return "walkway"; }
 
 private:
-  WalkwayModule::PlannerParam walkway_planner_param_;
+  WalkwayModule::PlannerParam walkway_planner_param_{};
 
   void launchNewModules(const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -95,7 +95,7 @@ public:
 
   CrosswalkModule(
     const int64_t module_id, const lanelet::ConstLanelet & crosswalk,
-    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
@@ -142,17 +142,17 @@ private:
 
   bool isRedSignalForPedestrians() const;
 
-  bool isVehicle(const PredictedObject & object) const;
+  static bool isVehicle(const PredictedObject & object);
 
   bool isTargetType(const PredictedObject & object) const;
 
   bool isTargetExternalInputStatus(const int target_status) const;
 
-  geometry_msgs::msg::Polygon createObjectPolygon(
-    const double width_m, const double length_m) const;
+  static geometry_msgs::msg::Polygon createObjectPolygon(
+    const double width_m, const double length_m);
 
-  geometry_msgs::msg::Polygon createVehiclePolygon(
-    const vehicle_info_util::VehicleInfo & vehicle_info) const;
+  static geometry_msgs::msg::Polygon createVehiclePolygon(
+    const vehicle_info_util::VehicleInfo & vehicle_info);
 
   lanelet::ConstLanelet crosswalk_;
 

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -94,9 +94,8 @@ public:
   };
 
   CrosswalkModule(
-    const int64_t module_id, const lanelet::ConstLanelet & crosswalk,
-    const PlannerParam & planner_param, const rclcpp::Logger & logger,
-    const rclcpp::Clock::SharedPtr clock);
+    const int64_t module_id, lanelet::ConstLanelet crosswalk, const PlannerParam & planner_param,
+    const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
@@ -47,9 +47,8 @@ public:
     double external_input_timeout;
   };
   WalkwayModule(
-    const int64_t module_id, const lanelet::ConstLanelet & walkway,
-    const PlannerParam & planner_param, const rclcpp::Logger & logger,
-    const rclcpp::Clock::SharedPtr clock);
+    const int64_t module_id, lanelet::ConstLanelet walkway, const PlannerParam & planner_param,
+    const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
@@ -40,7 +40,6 @@ using tier4_planning_msgs::msg::StopReason;
 class WalkwayModule : public SceneModuleInterface
 {
 public:
-public:
   struct PlannerParam
   {
     double stop_line_distance;
@@ -49,7 +48,7 @@ public:
   };
   WalkwayModule(
     const int64_t module_id, const lanelet::ConstLanelet & walkway,
-    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
@@ -60,7 +59,7 @@ public:
 private:
   int64_t module_id_;
 
-  boost::optional<std::pair<double, geometry_msgs::msg::Point>> getStopLine(
+  [[nodiscard]] boost::optional<std::pair<double, geometry_msgs::msg::Point>> getStopLine(
     const PathWithLaneId & ego_path) const;
 
   void insertStopPoint(const geometry_msgs::msg::Point & stop_point, PathWithLaneId & output);

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/util.hpp
@@ -46,8 +46,8 @@ enum class CollisionPointState { YIELD, EGO_PASS_FIRST, EGO_PASS_LATER, IGNORE }
 struct CollisionPoint
 {
   geometry_msgs::msg::Point collision_point{};
-  double time_to_collision;
-  double time_to_vehicle;
+  double time_to_collision{};
+  double time_to_vehicle{};
   CollisionPointState state{CollisionPointState::EGO_PASS_FIRST};
 };
 

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -130,12 +130,13 @@ void sortCrosswalksByDistance(
 }  // namespace
 
 CrosswalkModule::CrosswalkModule(
-  const int64_t module_id, const lanelet::ConstLanelet & crosswalk,
-  const PlannerParam & planner_param, const rclcpp::Logger & logger,
-  const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock), module_id_(module_id), crosswalk_(crosswalk)
+  const int64_t module_id, lanelet::ConstLanelet crosswalk, const PlannerParam & planner_param,
+  const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock),
+  module_id_(module_id),
+  crosswalk_(std::move(crosswalk)),
+  planner_param_(planner_param)
 {
-  planner_param_ = planner_param;
 }
 
 bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -32,12 +32,9 @@ using motion_utils::calcArcLength;
 using motion_utils::calcLateralOffset;
 using motion_utils::calcLongitudinalOffsetPoint;
 using motion_utils::calcLongitudinalOffsetPose;
-using motion_utils::calcLongitudinalOffsetToSegment;
 using motion_utils::calcSignedArcLength;
-using motion_utils::findNearestIndex;
 using motion_utils::findNearestSegmentIndex;
 using motion_utils::insertTargetPoint;
-using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::createPoint;
 using tier4_autoware_utils::getPoint;
 using tier4_autoware_utils::getPose;
@@ -134,7 +131,7 @@ void sortCrosswalksByDistance(
 
 CrosswalkModule::CrosswalkModule(
   const int64_t module_id, const lanelet::ConstLanelet & crosswalk,
-  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const PlannerParam & planner_param, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr clock)
 : SceneModuleInterface(module_id, logger, clock), module_id_(module_id), crosswalk_(crosswalk)
 {
@@ -726,13 +723,13 @@ CollisionPointState CrosswalkModule::getCollisionPointState(
 {
   if (ttc + planner_param_.ego_pass_first_margin < ttv) {
     return CollisionPointState::EGO_PASS_FIRST;
-  } else if (ttv + planner_param_.ego_pass_later_margin < ttc) {
-    return CollisionPointState::EGO_PASS_LATER;
-  } else {
-    return CollisionPointState::YIELD;
   }
 
-  return CollisionPointState::IGNORE;
+  if (ttv + planner_param_.ego_pass_later_margin < ttc) {
+    return CollisionPointState::EGO_PASS_LATER;
+  }
+
+  return CollisionPointState::YIELD;
 }
 
 bool CrosswalkModule::isStuckVehicle(
@@ -801,7 +798,7 @@ bool CrosswalkModule::isRedSignalForPedestrians() const
   return false;
 }
 
-bool CrosswalkModule::isVehicle(const PredictedObject & object) const
+bool CrosswalkModule::isVehicle(const PredictedObject & object)
 {
   if (object.classification.empty()) {
     return false;
@@ -875,7 +872,7 @@ bool CrosswalkModule::isTargetExternalInputStatus(const int target_status) const
 }
 
 geometry_msgs::msg::Polygon CrosswalkModule::createObjectPolygon(
-  const double width_m, const double length_m) const
+  const double width_m, const double length_m)
 {
   geometry_msgs::msg::Polygon polygon{};
 
@@ -888,7 +885,7 @@ geometry_msgs::msg::Polygon CrosswalkModule::createObjectPolygon(
 }
 
 geometry_msgs::msg::Polygon CrosswalkModule::createVehiclePolygon(
-  const vehicle_info_util::VehicleInfo & vehicle_info) const
+  const vehicle_info_util::VehicleInfo & vehicle_info)
 {
   const auto & i = vehicle_info;
   const auto & front_m = i.max_longitudinal_offset_m;

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -32,15 +32,14 @@ using tier4_autoware_utils::createPoint;
 using tier4_autoware_utils::getPose;
 
 WalkwayModule::WalkwayModule(
-  const int64_t module_id, const lanelet::ConstLanelet & walkway,
-  const PlannerParam & planner_param, const rclcpp::Logger & logger,
-  const rclcpp::Clock::SharedPtr clock)
+  const int64_t module_id, lanelet::ConstLanelet walkway, const PlannerParam & planner_param,
+  const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock)
 : SceneModuleInterface(module_id, logger, clock),
   module_id_(module_id),
-  walkway_(walkway),
-  state_(State::APPROACH)
+  walkway_(std::move(walkway)),
+  state_(State::APPROACH),
+  planner_param_(planner_param)
 {
-  planner_param_ = planner_param;
 }
 
 boost::optional<std::pair<double, geometry_msgs::msg::Point>> WalkwayModule::getStopLine(

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -33,7 +33,7 @@ using tier4_autoware_utils::getPose;
 
 WalkwayModule::WalkwayModule(
   const int64_t module_id, const lanelet::ConstLanelet & walkway,
-  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const PlannerParam & planner_param, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr clock)
 : SceneModuleInterface(module_id, logger, clock),
   module_id_(module_id),
@@ -139,8 +139,9 @@ bool WalkwayModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_
     }
 
     return true;
+  }
 
-  } else if (state_ == State::STOP) {
+  if (state_ == State::STOP) {
     if (planner_data_->isVehicleStopped()) {
       state_ = State::SURPASSED;
     }

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
@@ -47,7 +47,6 @@ using Point = bg::model::d2::point_xy<double>;
 using Polygon = bg::model::polygon<Point>;
 using Line = bg::model::linestring<Point>;
 using motion_utils::calcSignedArcLength;
-using motion_utils::findNearestSegmentIndex;
 using tier4_autoware_utils::createPoint;
 
 std::vector<Point> getPolygonIntersects(


### PR DESCRIPTION

Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

fix clang-tidy warning in crosswalk module

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
