### PR TITLE
fix(behavior_velocity_planner, tier4_planning_launch): modify delay_resopnse_time

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -15,4 +15,4 @@
     max_accel: -2.8
     max_jerk: -5.0
     system_delay: 0.5
-    delay_response_time: 1.3
+    delay_response_time: 0.5

--- a/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -15,4 +15,4 @@
     max_accel: -2.8
     max_jerk: -5.0
     system_delay: 0.5
-    delay_response_time: 1.3
+    delay_response_time: 0.5


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

delay_response_time in behavior velocity planner, which is the delay time for sensing and actuation, is too large for the usual vehicle model.

FYI
delay time of acceleration for sample_vehicle
https://github.com/autowarefoundation/sample_vehicle_launch/blob/95f0165c2636fe9b925a2b9e1becb55ae75a4177/sample_vehicle_description/config/simulator_model.param.yaml#L13

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
