### PR TITLE
fix(behavior_velocity_planner): fix getNearestLaneId()

### DIFF
--- a/planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -181,7 +181,7 @@ void getAllPartitionLanelets(const lanelet::LaneletMapConstPtr ll, BasicPolygons
     for (const auto & p : partition) {
       line.emplace_back(lanelet::BasicPoint2d{p.x(), p.y()});
     }
-    // corect line to calculate distance accuratry
+    // correct line to calculate distance in accurate
     boost::geometry::correct(line);
     polys.emplace_back(lanelet::BasicPolygon2d(line));
   }


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description

Before this change, if the ego vehicle runs out from the lane, the behavior planning module is re-launched.
To fix this behavior, I fixed the logic to get nearest lane id as following:
- Find nearest lane id from lane ids included in the original path

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Tested in planning_simulator

https://user-images.githubusercontent.com/10190493/183883367-b35c42b0-5b4c-4d25-b024-bf84c955fa5f.mp4

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
