### PR TITLE
feat(motion_utils): add option to use slerp for orientation

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -703,13 +703,14 @@ inline boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
  * @param points points of trajectory, path, ...
  * @param src_idx index of source point
  * @param offset length of offset from source point
- * @param use_slerp_for_orientation set orientation by spherical interpolation if true
+ * @param set_orientation_from_position_direction set orientation by spherical interpolation if
+ * false
  * @return offset pose
  */
 template <class T>
 inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const T & points, const size_t src_idx, const double offset,
-  const bool use_slerp_for_orientation = false, const bool throw_exception = false)
+  const bool set_orientation_from_position_direction = true, const bool throw_exception = false)
 {
   try {
     validateNonEmpty(points);
@@ -751,7 +752,8 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
       const auto dist_res = -offset - dist_sum;
       if (dist_res <= 0.0) {
         return tier4_autoware_utils::calcInterpolatedPose(
-          p_back, p_front, std::abs(dist_res / dist_segment), !use_slerp_for_orientation);
+          p_back, p_front, std::abs(dist_res / dist_segment),
+          set_orientation_from_position_direction);
       }
     }
   } else {
@@ -767,7 +769,8 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
       const auto dist_res = offset - dist_sum;
       if (dist_res <= 0.0) {
         return tier4_autoware_utils::calcInterpolatedPose(
-          p_front, p_back, 1.0 - std::abs(dist_res / dist_segment), !use_slerp_for_orientation);
+          p_front, p_back, 1.0 - std::abs(dist_res / dist_segment),
+          set_orientation_from_position_direction);
       }
     }
   }
@@ -781,13 +784,14 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
  * @param points points of trajectory, path, ...
  * @param src_point source point
  * @param offset length of offset from source point
- * @param use_slerp_for_orientation set orientation by spherical interpolation if true
+ * @param set_orientation_from_position_direction set orientation by spherical interpolation if
+ * false
  * @return offset pase
  */
 template <class T>
 inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const T & points, const geometry_msgs::msg::Point & src_point, const double offset,
-  const bool use_slerp_for_orientation = false)
+  const bool set_orientation_from_position_direction = true)
 {
   try {
     validateNonEmpty(points);
@@ -801,7 +805,8 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
     calcLongitudinalOffsetToSegment(points, src_seg_idx, src_point);
 
   return calcLongitudinalOffsetPose(
-    points, src_seg_idx, offset + signed_length_src_offset, use_slerp_for_orientation);
+    points, src_seg_idx, offset + signed_length_src_offset,
+    set_orientation_from_position_direction);
 }
 
 /**

--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -703,11 +703,13 @@ inline boost::optional<geometry_msgs::msg::Point> calcLongitudinalOffsetPoint(
  * @param points points of trajectory, path, ...
  * @param src_idx index of source point
  * @param offset length of offset from source point
+ * @param use_slerp_for_orientation set orientation by spherical interpolation if true
  * @return offset pose
  */
 template <class T>
 inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
-  const T & points, const size_t src_idx, const double offset, const bool throw_exception = false)
+  const T & points, const size_t src_idx, const double offset,
+  const bool use_slerp_for_orientation = false, const bool throw_exception = false)
 {
   try {
     validateNonEmpty(points);
@@ -749,7 +751,7 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
       const auto dist_res = -offset - dist_sum;
       if (dist_res <= 0.0) {
         return tier4_autoware_utils::calcInterpolatedPose(
-          p_back, p_front, std::abs(dist_res / dist_segment));
+          p_back, p_front, std::abs(dist_res / dist_segment), !use_slerp_for_orientation);
       }
     }
   } else {
@@ -765,7 +767,7 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
       const auto dist_res = offset - dist_sum;
       if (dist_res <= 0.0) {
         return tier4_autoware_utils::calcInterpolatedPose(
-          p_front, p_back, 1.0 - std::abs(dist_res / dist_segment));
+          p_front, p_back, 1.0 - std::abs(dist_res / dist_segment), !use_slerp_for_orientation);
       }
     }
   }
@@ -779,11 +781,13 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
  * @param points points of trajectory, path, ...
  * @param src_point source point
  * @param offset length of offset from source point
+ * @param use_slerp_for_orientation set orientation by spherical interpolation if true
  * @return offset pase
  */
 template <class T>
 inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
-  const T & points, const geometry_msgs::msg::Point & src_point, const double offset)
+  const T & points, const geometry_msgs::msg::Point & src_point, const double offset,
+  const bool use_slerp_for_orientation = false)
 {
   try {
     validateNonEmpty(points);
@@ -796,7 +800,8 @@ inline boost::optional<geometry_msgs::msg::Pose> calcLongitudinalOffsetPose(
   const double signed_length_src_offset =
     calcLongitudinalOffsetToSegment(points, src_seg_idx, src_point);
 
-  return calcLongitudinalOffsetPose(points, src_seg_idx, offset + signed_length_src_offset);
+  return calcLongitudinalOffsetPose(
+    points, src_seg_idx, offset + signed_length_src_offset, use_slerp_for_orientation);
 }
 
 /**

--- a/common/motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -1339,7 +1339,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
 
   // Found pose(forward)
   for (double len = 0.0; len < total_length; len += 0.1) {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, len, true);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, len, false);
     // ratio between two points
     const auto ratio = len / total_length;
     const auto ans_quat =
@@ -1357,7 +1357,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
 
   // Found pose(backward)
   for (double len = total_length; 0.0 < len; len -= 0.1) {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, -len, true);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, -len, false);
     // ratio between two points
     const auto ratio = len / total_length;
     const auto ans_quat =
@@ -1375,7 +1375,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
 
   // Boundary condition
   {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, total_length, true);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, total_length, false);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
     EXPECT_NE(p_out, boost::none);
@@ -1390,7 +1390,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
 
   // Boundary condition
   {
-    const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, 0.0, true);
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, 0.0, false);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
     EXPECT_NE(p_out, boost::none);
@@ -1601,7 +1601,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatSphericalInterpolation)
     const auto src_offset = calcLongitudinalOffsetToSegment(traj.points, 0, p_src);
 
     for (double len = -src_offset; len < total_length - src_offset; len += 0.1) {
-      const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, len, true);
+      const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, len, false);
       // ratio between two points
       const auto ratio = (src_offset + len) / total_length;
       const auto ans_quat =
@@ -1628,7 +1628,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatSphericalInterpolation)
     const auto src_offset = calcLongitudinalOffsetToSegment(traj.points, 0, p_src);
 
     const auto p_out =
-      calcLongitudinalOffsetPose(traj.points, p_src, total_length - src_offset, true);
+      calcLongitudinalOffsetPose(traj.points, p_src, total_length - src_offset, false);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
     EXPECT_NE(p_out, boost::none);

--- a/common/motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -1312,6 +1312,96 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatInterpolation)
   }
 }
 
+TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
+{
+  using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+  using motion_utils::calcArcLength;
+  using motion_utils::calcLongitudinalOffsetPose;
+  using tier4_autoware_utils::deg2rad;
+
+  Trajectory traj{};
+
+  {
+    TrajectoryPoint p;
+    p.pose = createPose(0.0, 0.0, 0.0, deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
+    p.longitudinal_velocity_mps = 0.0;
+    traj.points.push_back(p);
+  }
+
+  {
+    TrajectoryPoint p;
+    p.pose = createPose(1.0, 1.0, 0.0, deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+    p.longitudinal_velocity_mps = 0.0;
+    traj.points.push_back(p);
+  }
+
+  const auto total_length = calcArcLength(traj.points);
+
+  // Found pose(forward)
+  for (double len = 0.0; len < total_length; len += 0.1) {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, len, true);
+    const auto ratio = 1 - (len / total_length);
+    const auto ans_quat =
+      createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 * ratio));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, len * std::cos(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.get().position.y, len * std::sin(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+
+  // Found pose(backward)
+  for (double len = total_length; 0.0 < len; len -= 0.1) {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, -len, true);
+    const auto ratio = len / total_length;
+    const auto ans_quat =
+      createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 * ratio));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 1.0 - len * std::cos(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.0 - len * std::sin(deg2rad(45.0)), epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+
+  // Boundary condition
+  {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, total_length, true);
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+
+  // Boundary condition
+  {
+    const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, 0.0, true);
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+}
+
 TEST(trajectory, calcLongitudinalOffsetPoseFromPoint)
 {
   using motion_utils::calcArcLength;
@@ -1459,6 +1549,83 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatInterpolation)
     const auto src_offset = calcLongitudinalOffsetToSegment(traj.points, 0, p_src);
 
     const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, total_length - src_offset);
+    const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+
+    EXPECT_NE(p_out, boost::none);
+    EXPECT_NEAR(p_out.get().position.x, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.y, 1.0, epsilon);
+    EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+    EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+  }
+}
+
+TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatSphericalInterpolation)
+{
+  using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+  using motion_utils::calcArcLength;
+  using motion_utils::calcLongitudinalOffsetPose;
+  using motion_utils::calcLongitudinalOffsetToSegment;
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::deg2rad;
+
+  Trajectory traj{};
+
+  {
+    TrajectoryPoint p;
+    p.pose = createPose(0.0, 0.0, 0.0, deg2rad(0.0), deg2rad(0.0), deg2rad(45.0));
+    p.longitudinal_velocity_mps = 0.0;
+    traj.points.push_back(p);
+  }
+
+  {
+    TrajectoryPoint p;
+    p.pose = createPose(1.0, 1.0, 0.0, deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
+    p.longitudinal_velocity_mps = 0.0;
+    traj.points.push_back(p);
+  }
+
+  const auto total_length = calcArcLength(traj.points);
+
+  // Found pose
+  for (double len_start = 0.0; len_start < total_length; len_start += 0.1) {
+    constexpr double deviation = 0.1;
+
+    const auto p_src = createPoint(
+      len_start * std::cos(deg2rad(45.0)) + deviation,
+      len_start * std::sin(deg2rad(45.0)) - deviation, 0.0);
+    const auto src_offset = calcLongitudinalOffsetToSegment(traj.points, 0, p_src);
+
+    for (double len = -src_offset; len < total_length - src_offset; len += 0.1) {
+      const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, len, true);
+      const auto ratio = 1 - ((src_offset + len) / total_length);
+      const auto ans_quat =
+        createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 * ratio));
+
+      EXPECT_NE(p_out, boost::none);
+      EXPECT_NEAR(
+        p_out.get().position.x, p_src.x + len * std::cos(deg2rad(45.0)) - deviation, epsilon);
+      EXPECT_NEAR(
+        p_out.get().position.y, p_src.y + len * std::sin(deg2rad(45.0)) + deviation, epsilon);
+      EXPECT_NEAR(p_out.get().position.z, 0.0, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.x, ans_quat.x, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.y, ans_quat.y, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.z, ans_quat.z, epsilon);
+      EXPECT_NEAR(p_out.get().orientation.w, ans_quat.w, epsilon);
+    }
+  }
+
+  // Boundary condition
+  {
+    constexpr double deviation = 0.1;
+
+    const auto p_src = createPoint(1.0 + deviation, 1.0 - deviation, 0.0);
+    const auto src_offset = calcLongitudinalOffsetToSegment(traj.points, 0, p_src);
+
+    const auto p_out =
+      calcLongitudinalOffsetPose(traj.points, p_src, total_length - src_offset, true);
     const auto ans_quat = createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(0.0));
 
     EXPECT_NE(p_out, boost::none);

--- a/common/motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -1340,9 +1340,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
   // Found pose(forward)
   for (double len = 0.0; len < total_length; len += 0.1) {
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 0, len, true);
-    const auto ratio = 1 - (len / total_length);
+    // ratio between two points
+    const auto ratio = len / total_length;
     const auto ans_quat =
-      createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 * ratio));
+      createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 - 45.0 * ratio));
 
     EXPECT_NE(p_out, boost::none);
     EXPECT_NEAR(p_out.get().position.x, len * std::cos(deg2rad(45.0)), epsilon);
@@ -1357,6 +1358,7 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromIndex_quatSphericalInterpolation)
   // Found pose(backward)
   for (double len = total_length; 0.0 < len; len -= 0.1) {
     const auto p_out = calcLongitudinalOffsetPose(traj.points, 1, -len, true);
+    // ratio between two points
     const auto ratio = len / total_length;
     const auto ans_quat =
       createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 * ratio));
@@ -1600,9 +1602,10 @@ TEST(trajectory, calcLongitudinalOffsetPoseFromPoint_quatSphericalInterpolation)
 
     for (double len = -src_offset; len < total_length - src_offset; len += 0.1) {
       const auto p_out = calcLongitudinalOffsetPose(traj.points, p_src, len, true);
-      const auto ratio = 1 - ((src_offset + len) / total_length);
+      // ratio between two points
+      const auto ratio = (src_offset + len) / total_length;
       const auto ans_quat =
-        createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 * ratio));
+        createQuaternionFromRPY(deg2rad(0.0), deg2rad(0.0), deg2rad(45.0 - 45.0 * ratio));
 
       EXPECT_NE(p_out, boost::none);
       EXPECT_NEAR(


### PR DESCRIPTION
## Description

Added option to use spherical interpolation to calculate the orientation.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
