### PR TITLE
fix(surround_obstacle_checker): fix logical error in isStopRequired

### DIFF
--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -336,7 +336,7 @@ bool SurroundObstacleCheckerNode::isObstacleFound(const double min_dist_to_obj)
 bool SurroundObstacleCheckerNode::isStopRequired(
   const bool is_obstacle_found, const bool is_stopped)
 {
-  if (!is_stopped) {
+  if (is_stopped) {
     return false;
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
   isStopRequired  return false if vehicle was stopped.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
