### PR TITLE
fix(obstacle_stop_planner): fix virtual wall posiiton

### DIFF
--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/debug_marker.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/debug_marker.hpp
@@ -42,7 +42,7 @@ enum class PolygonType : int8_t { Vehicle = 0, Collision, SlowDownRange, SlowDow
 
 enum class PointType : int8_t { Stop = 0, SlowDown };
 
-enum class PoseType : int8_t { Stop = 0, SlowDownStart, SlowDownEnd };
+enum class PoseType : int8_t { Stop = 0, TargetStop, SlowDownStart, SlowDownEnd };
 
 class DebugValues
 {
@@ -119,6 +119,7 @@ private:
   double base_link2front_;
 
   std::shared_ptr<geometry_msgs::msg::Pose> stop_pose_ptr_;
+  std::shared_ptr<geometry_msgs::msg::Pose> target_stop_pose_ptr_;
   std::shared_ptr<geometry_msgs::msg::Pose> slow_down_start_pose_ptr_;
   std::shared_ptr<geometry_msgs::msg::Pose> slow_down_end_pose_ptr_;
   std::shared_ptr<geometry_msgs::msg::Point> stop_obstacle_point_ptr_;

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -833,19 +833,22 @@ void ObstacleStopPlannerNode::insertVelocity(
           insertStopPoint(current_stop_pos, output, planner_data.stop_reason_diag);
           latest_stop_point_ = current_stop_pos;
 
-          debug_ptr_->pushPose(getPose(stop_point.point), PoseType::Stop);
+          debug_ptr_->pushPose(getPose(stop_point.point), PoseType::TargetStop);
+          debug_ptr_->pushPose(getPose(current_stop_pos.point), PoseType::Stop);
         }
 
       } else {
         insertStopPoint(stop_point, output, planner_data.stop_reason_diag);
         latest_stop_point_ = stop_point;
 
+        debug_ptr_->pushPose(getPose(stop_point.point), PoseType::TargetStop);
         debug_ptr_->pushPose(getPose(stop_point.point), PoseType::Stop);
       }
     }
   } else if (!no_hunting_collision_point) {
     if (latest_stop_point_) {
       insertStopPoint(latest_stop_point_.get(), output, planner_data.stop_reason_diag);
+      debug_ptr_->pushPose(getPose(latest_stop_point_.get().point), PoseType::TargetStop);
       debug_ptr_->pushPose(getPose(latest_stop_point_.get().point), PoseType::Stop);
     }
   }


### PR DESCRIPTION
## Description

- visualize actual stop posiion by virtual wall

## Related link

- https://github.com/autowarefoundation/autoware.universe/pull/1434

### obstacle_stop_planner

- `hold_stop_margin_distance`: 2.0 [m]

https://user-images.githubusercontent.com/44889564/184602983-987d3775-3379-4f59-8458-9682fda777a0.mp4
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
