### PR TITLE
refactor(tier4_state_rviz_plugin): apply clang-tidy

### DIFF
--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -287,7 +287,7 @@ void AutowareStatePanel::onClickVelocityLimit()
 
 void AutowareStatePanel::onClickAutowareEngage()
 {
-  using Engage = tier4_external_api_msgs::srv::Engage;
+  using tier4_external_api_msgs::srv::Engage;
 
   auto req = std::make_shared<Engage::Request>();
   req->engage = !current_engage_;

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -300,7 +300,7 @@ void AutowareStatePanel::onClickAutowareEngage()
   }
 
   client_engage_->async_send_request(
-    req, [this](rclcpp::Client<Engage>::SharedFuture result) {  // NOLINT
+    req, [this](rclcpp::Client<Engage>::SharedFuture result) {
       RCLCPP_INFO(
         raw_node_->get_logger(), "Status: %d, %s", result.get()->status.code,
         result.get()->status.message.c_str());
@@ -318,7 +318,7 @@ void AutowareStatePanel::onClickEmergencyButton()
   RCLCPP_INFO(raw_node_->get_logger(), request->emergency ? "Set Emergency" : "Clear Emergency");
 
   client_emergency_stop_->async_send_request(
-    request, [this](rclcpp::Client<SetEmergency>::SharedFuture result) {  // NOLINT
+    request, [this](rclcpp::Client<SetEmergency>::SharedFuture result) {
       const auto & response = result.get();
       if (response->status.code == ResponseStatus::SUCCESS) {
         RCLCPP_INFO(raw_node_->get_logger(), "service succeeded");

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -300,7 +300,7 @@ void AutowareStatePanel::onClickAutowareEngage()
   }
 
   client_engage_->async_send_request(
-    req, [this](rclcpp::Client<Engage>::SharedFuture result) { // NOLINT
+    req, [this](rclcpp::Client<Engage>::SharedFuture result) {  // NOLINT
       RCLCPP_INFO(
         raw_node_->get_logger(), "Status: %d, %s", result.get()->status.code,
         result.get()->status.message.c_str());
@@ -318,7 +318,7 @@ void AutowareStatePanel::onClickEmergencyButton()
   RCLCPP_INFO(raw_node_->get_logger(), request->emergency ? "Set Emergency" : "Clear Emergency");
 
   client_emergency_stop_->async_send_request(
-    request, [this](rclcpp::Client<SetEmergency>::SharedFuture result) { // NOLINT
+    request, [this](rclcpp::Client<SetEmergency>::SharedFuture result) {  // NOLINT
       const auto & response = result.get();
       if (response->status.code == ResponseStatus::SUCCESS) {
         RCLCPP_INFO(raw_node_->get_logger(), "service succeeded");

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -299,12 +299,11 @@ void AutowareStatePanel::onClickAutowareEngage()
     return;
   }
 
-  client_engage_->async_send_request(
-    req, [this](rclcpp::Client<Engage>::SharedFuture result) {
-      RCLCPP_INFO(
-        raw_node_->get_logger(), "Status: %d, %s", result.get()->status.code,
-        result.get()->status.message.c_str());
-    });
+  client_engage_->async_send_request(req, [this](rclcpp::Client<Engage>::SharedFuture result) {
+    RCLCPP_INFO(
+      raw_node_->get_logger(), "Status: %d, %s", result.get()->status.code,
+      result.get()->status.message.c_str());
+  });
 }
 
 void AutowareStatePanel::onClickEmergencyButton()

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -309,8 +309,8 @@ void AutowareStatePanel::onClickAutowareEngage()
 
 void AutowareStatePanel::onClickEmergencyButton()
 {
-  using SetEmergency = tier4_external_api_msgs::srv::SetEmergency;
-  using ResponseStatus = tier4_external_api_msgs::msg::ResponseStatus;
+  using tier4_external_api_msgs::srv::SetEmergency;
+  using tier4_external_api_msgs::msg::ResponseStatus;
 
   auto request = std::make_shared<SetEmergency::Request>();
   request->emergency = !current_emergency_;

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -309,8 +309,8 @@ void AutowareStatePanel::onClickAutowareEngage()
 
 void AutowareStatePanel::onClickEmergencyButton()
 {
-  using tier4_external_api_msgs::srv::SetEmergency;
   using tier4_external_api_msgs::msg::ResponseStatus;
+  using tier4_external_api_msgs::srv::SetEmergency;
 
   auto request = std::make_shared<SetEmergency::Request>();
   request->emergency = !current_emergency_;

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -44,7 +44,7 @@ public:
   explicit AutowareStatePanel(QWidget * parent = nullptr);
   void onInitialize() override;
 
-public Q_SLOTS:
+public Q_SLOTS: // NOLINT
   void onClickAutowareEngage();
   void onClickVelocityLimit();
   void onClickGateMode();
@@ -89,8 +89,8 @@ protected:
   QSpinBox * pub_velocity_limit_input_;
   QPushButton * emergency_button_ptr_;
 
-  bool current_engage_;
-  bool current_emergency_;
+  bool current_engage_{false};
+  bool current_emergency_{false};
 };
 
 }  // namespace rviz_plugins

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -44,7 +44,7 @@ public:
   explicit AutowareStatePanel(QWidget * parent = nullptr);
   void onInitialize() override;
 
-public Q_SLOTS: // NOLINT
+public Q_SLOTS:  // NOLINT
   void onClickAutowareEngage();
   void onClickVelocityLimit();
   void onClickGateMode();

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -44,7 +44,7 @@ public:
   explicit AutowareStatePanel(QWidget * parent = nullptr);
   void onInitialize() override;
 
-public Q_SLOTS:  // NOLINT
+public Q_SLOTS:  // NOLINT for Qt
   void onClickAutowareEngage();
   void onClickVelocityLimit();
   void onClickGateMode();


### PR DESCRIPTION
## Description

- fix clang-tidy
  - add `const &`
  - add initial value
  - fix boolean condition 
- add NOLINT to avoid
  - readability-redundant-access-specifiers
- use `using` to shrink type definition

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
