### PR TITLE
refactor(tier4_calibration_rviz_plugin): apply clang-tidy

### DIFF
--- a/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.cpp
+++ b/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.cpp
@@ -72,13 +72,13 @@ void AccelBrakeMapCalibratorButtonPanel::onInitialize()
   update_suggest_sub_ = raw_node->create_subscription<std_msgs::msg::Bool>(
     topic_edit_->text().toStdString(), 10,
     std::bind(
-      &AccelBrakeMapCalibratorButtonPanel::callbackUpdateSuggest, this, std::placeholders::_1));
+      &AccelBrakeMapCalibratorButtonPanel::callback_update_suggest, this, std::placeholders::_1));
 
   client_ = raw_node->create_client<tier4_vehicle_msgs::srv::UpdateAccelBrakeMap>(
     "/accel_brake_map_calibrator/update_map_dir");
 }
 
-void AccelBrakeMapCalibratorButtonPanel::callbackUpdateSuggest(
+void AccelBrakeMapCalibratorButtonPanel::callback_update_suggest(
   const std_msgs::msg::Bool::ConstSharedPtr msg)
 {
   if (after_calib_) {
@@ -96,7 +96,7 @@ void AccelBrakeMapCalibratorButtonPanel::callbackUpdateSuggest(
   calibration_button_->setEnabled(true);
 }
 
-void AccelBrakeMapCalibratorButtonPanel::editTopic()
+void AccelBrakeMapCalibratorButtonPanel::edit_topic()
 {
   update_suggest_sub_.reset();
   rclcpp::Node::SharedPtr raw_node =
@@ -104,12 +104,12 @@ void AccelBrakeMapCalibratorButtonPanel::editTopic()
   update_suggest_sub_ = raw_node->create_subscription<std_msgs::msg::Bool>(
     topic_edit_->text().toStdString(), 10,
     std::bind(
-      &AccelBrakeMapCalibratorButtonPanel::callbackUpdateSuggest, this, std::placeholders::_1));
+      &AccelBrakeMapCalibratorButtonPanel::callback_update_suggest, this, std::placeholders::_1));
   calibration_button_->setText("Wait for subscribe topic");
   calibration_button_->setEnabled(false);
 }
 
-void AccelBrakeMapCalibratorButtonPanel::pushCalibrationButton()
+void AccelBrakeMapCalibratorButtonPanel::push_calibration_button()
 {
   // lock button
   calibration_button_->setEnabled(false);

--- a/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.hpp
+++ b/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.hpp
@@ -42,11 +42,11 @@ class AccelBrakeMapCalibratorButtonPanel : public rviz_common::Panel
 public:
   explicit AccelBrakeMapCalibratorButtonPanel(QWidget * parent = nullptr);
   void onInitialize() override;
-  void callbackUpdateSuggest(const std_msgs::msg::Bool::ConstSharedPtr msg);
+  void callback_update_suggest(const std_msgs::msg::Bool::ConstSharedPtr msg);
 
-public Q_SLOTS:
-  void editTopic();
-  void pushCalibrationButton();
+public Q_SLOTS:  // NOLINT for Qt
+  void edit_topic();
+  void push_calibration_button();
 
 protected:
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr update_suggest_sub_;
@@ -56,8 +56,6 @@ protected:
 
   QLabel * topic_label_;
   QLineEdit * topic_edit_;
-  QLabel * dir_label_;
-  QLineEdit * dir_edit_;
   QPushButton * calibration_button_;
   QLabel * status_label_;
 };


### PR DESCRIPTION
## Description

- delete unused variables
- fix `readability-identifier-naming`
- apply NOLINT for `readability-redundant-access-specifiers` due to Qt

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
