### PR TITLE
refactor(tier4_control_rviz_plugin): apply clang-tidy

### DIFF
--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
@@ -30,7 +30,7 @@ using std::placeholders::_1;
 namespace rviz_plugins
 {
 
-double lowpass_filter(
+double lowpassFilter(
   const double current_value, const double prev_value, double cutoff, const double dt)
 {
   const double tau = 1.0 / (2.0 * M_PI * cutoff);
@@ -144,7 +144,7 @@ void ManualController::update()
   pub_gear_cmd_->publish(gear_cmd);
 }
 
-void ManualController::on_manual_steering()
+void ManualController::onManualSteering()
 {
   const double scale_factor = -0.25;
   steering_angle_ = scale_factor * steering_slider_ptr_->sliderPosition() * M_PI / 180.0;
@@ -153,7 +153,7 @@ void ManualController::on_manual_steering()
   steering_angle_ptr_->setText(steering_string);
 }
 
-void ManualController::on_click_cruise_velocity()
+void ManualController::onClickCruiseVelocity()
 {
   cruise_velocity_ = cruise_velocity_input_->value() / 3.6;
 }
@@ -163,16 +163,16 @@ void ManualController::onInitialize()
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
 
   sub_gate_mode_ = raw_node_->create_subscription<GateMode>(
-    "/control/current_gate_mode", 10, std::bind(&ManualController::on_gate_mode, this, _1));
+    "/control/current_gate_mode", 10, std::bind(&ManualController::onGateMode, this, _1));
 
   sub_velocity_ = raw_node_->create_subscription<VelocityReport>(
-    "/vehicle/status/velocity_status", 1, std::bind(&ManualController::on_velocity, this, _1));
+    "/vehicle/status/velocity_status", 1, std::bind(&ManualController::onVelocity, this, _1));
 
   sub_engage_ = raw_node_->create_subscription<Engage>(
-    "/api/autoware/get/engage", 10, std::bind(&ManualController::on_engage_status, this, _1));
+    "/api/autoware/get/engage", 10, std::bind(&ManualController::onEngageStatus, this, _1));
 
   sub_gear_ = raw_node_->create_subscription<GearReport>(
-    "/vehicle/status/gear_status", 10, std::bind(&ManualController::on_gear, this, _1));
+    "/vehicle/status/gear_status", 10, std::bind(&ManualController::onGear, this, _1));
 
   client_engage_ = raw_node_->create_client<EngageSrv>(
     "/api/autoware/set/engage", rmw_qos_profile_services_default);
@@ -185,7 +185,7 @@ void ManualController::onInitialize()
   pub_gear_cmd_ = raw_node_->create_publisher<GearCommand>("/external/selected/gear_cmd", 1);
 }
 
-void ManualController::on_gate_mode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg)
+void ManualController::onGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg)
 {
   switch (msg->data) {
     case tier4_control_msgs::msg::GateMode::AUTO:
@@ -204,7 +204,7 @@ void ManualController::on_gate_mode(const tier4_control_msgs::msg::GateMode::Con
       break;
   }
 }
-void ManualController::on_engage_status(const Engage::ConstSharedPtr msg)
+void ManualController::onEngageStatus(const Engage::ConstSharedPtr msg)
 {
   current_engage_ = msg->engage;
   if (current_engage_) {
@@ -216,7 +216,7 @@ void ManualController::on_engage_status(const Engage::ConstSharedPtr msg)
   }
 }
 
-void ManualController::on_velocity(const VelocityReport::ConstSharedPtr msg)
+void ManualController::onVelocity(const VelocityReport::ConstSharedPtr msg)
 {
   current_velocity_ = msg->longitudinal_velocity;
   if (previous_velocity_) {
@@ -227,14 +227,14 @@ void ManualController::on_velocity(const VelocityReport::ConstSharedPtr msg)
       current_acceleration_ = std::make_unique<double>(acc);
     } else {
       current_acceleration_ =
-        std::make_unique<double>(lowpass_filter(acc, *current_acceleration_, cutoff, dt));
+        std::make_unique<double>(lowpassFilter(acc, *current_acceleration_, cutoff, dt));
     }
   }
   previous_velocity_ = std::make_unique<double>(msg->longitudinal_velocity);
   prev_stamp_ = rclcpp::Time(msg->header.stamp);
 }
 
-void ManualController::on_gear(const GearReport::ConstSharedPtr msg)
+void ManualController::onGear(const GearReport::ConstSharedPtr msg)
 {
   switch (msg->report) {
     case GearReport::PARK:
@@ -252,7 +252,7 @@ void ManualController::on_gear(const GearReport::ConstSharedPtr msg)
   }
 }
 
-void ManualController::on_click_enable_button()
+void ManualController::onClickEnableButton()
 {
   // gate mode
   {

--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
@@ -54,21 +54,21 @@ public:
   explicit ManualController(QWidget * parent = nullptr);
   void onInitialize() override;
 
-public Q_SLOTS:
-  void onClickCruiseVelocity();
-  void onClickEnableButton();
-  void onManualSteering();
+public Q_SLOTS:  // NOLINT for Qt
+  void on_click_cruise_velocity();
+  void on_click_enable_button();
+  void on_manual_steering();
   void update();
 
 protected:
   // Timer
   rclcpp::TimerBase::SharedPtr timer_;
-  void onTimer();
-  void onPublishControlCommand();
-  void onGateMode(const GateMode::ConstSharedPtr msg);
-  void onVelocity(const VelocityReport::ConstSharedPtr msg);
-  void onEngageStatus(const Engage::ConstSharedPtr msg);
-  void onGear(const GearReport::ConstSharedPtr msg);
+  void on_timer();
+  void on_publish_control_command();
+  void on_gate_mode(const GateMode::ConstSharedPtr msg);
+  void on_velocity(const VelocityReport::ConstSharedPtr msg);
+  void on_engage_status(const Engage::ConstSharedPtr msg);
+  void on_gear(const GearReport::ConstSharedPtr msg);
   rclcpp::Node::SharedPtr raw_node_;
   rclcpp::Subscription<GateMode>::SharedPtr sub_gate_mode_;
   rclcpp::Subscription<VelocityReport>::SharedPtr sub_velocity_;
@@ -95,7 +95,7 @@ protected:
   QDial * steering_slider_ptr_;
   QLabel * steering_angle_ptr_;
 
-  bool current_engage_;
+  bool current_engage_{false};
 };
 
 }  // namespace rviz_plugins

--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
@@ -55,20 +55,20 @@ public:
   void onInitialize() override;
 
 public Q_SLOTS:  // NOLINT for Qt
-  void on_click_cruise_velocity();
-  void on_click_enable_button();
-  void on_manual_steering();
+  void onClickCruiseVelocity();
+  void onClickEnableButton();
+  void onManualSteering();
   void update();
 
 protected:
   // Timer
   rclcpp::TimerBase::SharedPtr timer_;
-  void on_timer();
-  void on_publish_control_command();
-  void on_gate_mode(const GateMode::ConstSharedPtr msg);
-  void on_velocity(const VelocityReport::ConstSharedPtr msg);
-  void on_engage_status(const Engage::ConstSharedPtr msg);
-  void on_gear(const GearReport::ConstSharedPtr msg);
+  void onTimer();
+  void onPublishControlCommand();
+  void onGateMode(const GateMode::ConstSharedPtr msg);
+  void onVelocity(const VelocityReport::ConstSharedPtr msg);
+  void onEngageStatus(const Engage::ConstSharedPtr msg);
+  void onGear(const GearReport::ConstSharedPtr msg);
   rclcpp::Node::SharedPtr raw_node_;
   rclcpp::Subscription<GateMode>::SharedPtr sub_gate_mode_;
   rclcpp::Subscription<VelocityReport>::SharedPtr sub_velocity_;


### PR DESCRIPTION
## Description

- apply NOLINT for readability-redundant-access-specifiers due to Qt
- fix below
  - ~~readability-identifier-naming~~
  - `modernize-use-auto`
  - `clang-diagnostic-unused-lambda-capture`
  - `cppcoreguidelines-pro-type-member-init`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
