### PR TITLE
fix(ekf_localizer): enable enable_yaw_bias

### DIFF
--- a/launch/tier4_localization_launch/launch/pose_twist_fusion_filter/pose_twist_fusion_filter.launch.xml
+++ b/launch/tier4_localization_launch/launch/pose_twist_fusion_filter/pose_twist_fusion_filter.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <group>
     <include file="$(find-pkg-share ekf_localizer)/launch/ekf_localizer.launch.xml">
-      <arg name="enable_yaw_bias_estimation" value="False"/>
+      <arg name="enable_yaw_bias_estimation" value="true"/>
       <arg name="tf_rate" value="50.0"/>
       <arg name="twist_smoothing_steps" value="2"/>
       <arg name="input_initial_pose_name" value="/initialpose3d"/>

--- a/localization/ekf_localizer/launch/ekf_localizer.launch.xml
+++ b/localization/ekf_localizer/launch/ekf_localizer.launch.xml
@@ -60,7 +60,6 @@
     <param name="twist_gate_dist" value="$(var twist_gate_dist)"/>
 
     <param name="proc_stddev_yaw_c" value="$(var proc_stddev_yaw_c)"/>
-    <param name="proc_stddev_yaw_bias_c" value="$(var proc_stddev_yaw_bias_c)"/>
     <param name="proc_stddev_vx_c" value="$(var proc_stddev_vx_c)"/>
     <param name="proc_stddev_wz_c" value="$(var proc_stddev_wz_c)"/>
 

--- a/localization/ekf_localizer/launch/ekf_localizer.launch.xml
+++ b/localization/ekf_localizer/launch/ekf_localizer.launch.xml
@@ -22,7 +22,6 @@
 
   <!-- for process model -->
   <arg name="proc_stddev_yaw_c" default="0.005"/>
-  <arg name="proc_stddev_yaw_bias_c" default="0.001"/>
   <arg name="proc_stddev_vx_c" default="5.0"/>
   <arg name="proc_stddev_wz_c" default="1.0"/>
 

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -320,7 +320,7 @@ void EKFLocalizer::callbackInitialPose(
   P(IDX::X, IDX::X) = initialpose->pose.covariance[0];
   P(IDX::Y, IDX::Y) = initialpose->pose.covariance[6 + 1];
   P(IDX::YAW, IDX::YAW) = initialpose->pose.covariance[6 * 5 + 5];
-  P(IDX::YAWB, IDX::YAWB) = 0.0001;
+  P(IDX::YAWB, IDX::YAWB) = proc_stddev_yaw_bias_c_;
   P(IDX::VX, IDX::VX) = 0.01;
   P(IDX::WZ, IDX::WZ) = 0.01;
 

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -68,7 +68,6 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
   proc_cov_vx_d_ = std::pow(proc_stddev_vx_c_ * ekf_dt_, 2.0);
   proc_cov_wz_d_ = std::pow(proc_stddev_wz_c_ * ekf_dt_, 2.0);
   proc_cov_yaw_d_ = std::pow(proc_stddev_yaw_c_ * ekf_dt_, 2.0);
-  proc_cov_yaw_bias_d_ = std::pow(proc_stddev_yaw_bias_c_ * ekf_dt_, 2.0);
 
   /* initialize ros system */
   auto period_control_ns =
@@ -317,10 +316,12 @@ void EKFLocalizer::callbackInitialPose(
   X(IDX::VX) = 0.0;
   X(IDX::WZ) = 0.0;
 
-  P(IDX::X, IDX::X) = initialpose->pose.covariance[0];
-  P(IDX::Y, IDX::Y) = initialpose->pose.covariance[6 + 1];
+  P(IDX::X, IDX::X) = initialpose->pose.covariance[6 * 0 + 0];
+  P(IDX::Y, IDX::Y) = initialpose->pose.covariance[6 * 1 + 1];
   P(IDX::YAW, IDX::YAW) = initialpose->pose.covariance[6 * 5 + 5];
-  P(IDX::YAWB, IDX::YAWB) = proc_stddev_yaw_bias_c_;
+  if (enable_yaw_bias_estimation_) {
+    P(IDX::YAWB, IDX::YAWB) = 0.0001;
+  }
   P(IDX::VX, IDX::VX) = 0.01;
   P(IDX::WZ, IDX::WZ) = 0.01;
 
@@ -361,7 +362,9 @@ void EKFLocalizer::initEKF()
   Eigen::MatrixXd X = Eigen::MatrixXd::Zero(dim_x_, 1);
   Eigen::MatrixXd P = Eigen::MatrixXd::Identity(dim_x_, dim_x_) * 1.0E15;  // for x & y
   P(IDX::YAW, IDX::YAW) = 50.0;                                            // for yaw
-  P(IDX::YAWB, IDX::YAWB) = proc_cov_yaw_bias_d_;                          // for yaw bias
+  if (enable_yaw_bias_estimation_) {
+    P(IDX::YAWB, IDX::YAWB) = 0.0001;                                      // for yaw bias
+  }
   P(IDX::VX, IDX::VX) = 1000.0;                                            // for vx
   P(IDX::WZ, IDX::WZ) = 50.0;                                              // for wz
 
@@ -434,7 +437,7 @@ void EKFLocalizer::predictKinematicsModel()
   Q(IDX::X, IDX::X) = 0.0;
   Q(IDX::Y, IDX::Y) = 0.0;
   Q(IDX::YAW, IDX::YAW) = proc_cov_yaw_d_;         // for yaw
-  Q(IDX::YAWB, IDX::YAWB) = proc_cov_yaw_bias_d_;  // for yaw bias
+  Q(IDX::YAWB, IDX::YAWB) = 0.0;
   Q(IDX::VX, IDX::VX) = proc_cov_vx_d_;            // for vx
   Q(IDX::WZ, IDX::WZ) = proc_cov_wz_d_;            // for wz
 

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -363,7 +363,7 @@ void EKFLocalizer::initEKF()
   Eigen::MatrixXd P = Eigen::MatrixXd::Identity(dim_x_, dim_x_) * 1.0E15;  // for x & y
   P(IDX::YAW, IDX::YAW) = 50.0;                                            // for yaw
   if (enable_yaw_bias_estimation_) {
-    P(IDX::YAWB, IDX::YAWB) = 50.0;                                        // for yaw bias
+    P(IDX::YAWB, IDX::YAWB) = 50.0;  // for yaw bias
   }
   P(IDX::VX, IDX::VX) = 1000.0;  // for vx
   P(IDX::WZ, IDX::WZ) = 50.0;    // for wz

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -57,12 +57,8 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
 
   /* process noise */
   proc_stddev_yaw_c_ = declare_parameter("proc_stddev_yaw_c", 0.005);
-  proc_stddev_yaw_bias_c_ = declare_parameter("proc_stddev_yaw_bias_c", 0.001);
   proc_stddev_vx_c_ = declare_parameter("proc_stddev_vx_c", 5.0);
   proc_stddev_wz_c_ = declare_parameter("proc_stddev_wz_c", 1.0);
-  if (!enable_yaw_bias_estimation_) {
-    proc_stddev_yaw_bias_c_ = 0.0;
-  }
 
   /* convert to continuous to discrete */
   proc_cov_vx_d_ = std::pow(proc_stddev_vx_c_ * ekf_dt_, 2.0);
@@ -131,7 +127,6 @@ void EKFLocalizer::updatePredictFrequency()
       proc_cov_vx_d_ = std::pow(proc_stddev_vx_c_ * ekf_dt_, 2.0);
       proc_cov_wz_d_ = std::pow(proc_stddev_wz_c_ * ekf_dt_, 2.0);
       proc_cov_yaw_d_ = std::pow(proc_stddev_yaw_c_ * ekf_dt_, 2.0);
-      proc_cov_yaw_bias_d_ = std::pow(proc_stddev_yaw_bias_c_ * ekf_dt_, 2.0);
     }
   }
   last_predict_time_ = std::make_shared<const rclcpp::Time>(get_clock()->now());

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -363,7 +363,7 @@ void EKFLocalizer::initEKF()
   Eigen::MatrixXd P = Eigen::MatrixXd::Identity(dim_x_, dim_x_) * 1.0E15;  // for x & y
   P(IDX::YAW, IDX::YAW) = 50.0;                                            // for yaw
   if (enable_yaw_bias_estimation_) {
-    P(IDX::YAWB, IDX::YAWB) = 0.0001;                                      // for yaw bias
+    P(IDX::YAWB, IDX::YAWB) = 50.0;                                        // for yaw bias
   }
   P(IDX::VX, IDX::VX) = 1000.0;                                            // for vx
   P(IDX::WZ, IDX::WZ) = 50.0;                                              // for wz


### PR DESCRIPTION
Signed-off-by: kminoda <koji.m.minoda@gmail.com>

## Description
Enabling `enable_yaw_bias_estimation`.
We were aware of the issue that the EKF keeps estimating "yaw bias" even when `enable_yaw_bias_estimation` is false, which is odd. It turned out that the yaw bias covariance was wrongly initialized in `callbackInitialPose()`. By modifying this, I confirmed that the yaw bias estimation successfully stopped when `enable_yaw_bias_estimation = false`. 
<!-- Write a brief description of this PR. -->

I propose to...
- set yaw bias covariance Q in motion update to 0.0
- thus, remove `proc_stddev_yaw_bias_*` parameters from the node
- set initial yaw bias covariance to 0.0001 when `enable_yaw_bias_estimation=True`, else 0.0.
- to set `enable_yaw_bias_estimation=True` in `autoware_launch.*/localization_launch/pose_twist_fusion_filter.launch.xml` so that the EKF performance won't change before and after this PR (https://github.com/tier4/autoware_launch/pull/443 and for other `autoware_launch.product`)


FYI
![Screenshot from 2022-08-17 14-50-16](https://user-images.githubusercontent.com/44218668/185044375-946a7d52-b298-43d7-a22e-9ce105edca37.png)

## Related links
- https://github.com/tier4/autoware_launch/pull/443 (This PR is necessary to ensure that the performance of localization does not change)
<!-- Write the links related to this PR. -->

## Tests performed
- build ekf_localizer
- launch logging_simulator
- confirmed that the estimation of yaw bias does not change largely with this PR
<!-- Describe how you have tested this PR. -->
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
