### PR TITLE
fix(behavior_path_planner): fix turn signal distance

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -37,8 +37,8 @@ TurnIndicatorsCommand TurnSignalDecider::getTurnSignal(
   const auto intersection_distance = intersection_result.second;
 
   if (
-    intersection_distance < plan_distance turn_signal_plan.command ==
-      TurnIndicatorsCommand::NO_COMMAND ||
+    intersection_distance < plan_distance ||
+    turn_signal_plan.command == TurnIndicatorsCommand::NO_COMMAND ||
     turn_signal_plan.command == TurnIndicatorsCommand::DISABLE) {
     turn_signal.command = intersection_turn_signal.command;
   }
@@ -85,6 +85,7 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
       bool lighting_turn_signal = false;
       if (lane.attributeOr("turn_direction", std::string("none")) != lane_attribute) {
         if (
+          distance_from_vehicle_front >= 0.0 &&
           distance_from_vehicle_front <
             lane.attributeOr("turn_signal_distance", intersection_search_distance_) &&
           path_point_distance > 0.0) {

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -99,10 +99,11 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
       if (lighting_turn_signal) {
         if (lane_attribute == std::string("left")) {
           turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+          distance = distance_from_vehicle_front;
         } else if (lane_attribute == std::string("right")) {
           turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
+          distance = distance_from_vehicle_front;
         }
-        distance = distance_from_vehicle_front;
       }
     }
   }

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -36,7 +36,10 @@ TurnIndicatorsCommand TurnSignalDecider::getTurnSignal(
   const auto intersection_turn_signal = intersection_result.first;
   const auto intersection_distance = intersection_result.second;
 
-  if (intersection_distance < plan_distance) {
+  if (
+    intersection_distance < plan_distance turn_signal_plan.command ==
+      TurnIndicatorsCommand::NO_COMMAND ||
+    turn_signal_plan.command == TurnIndicatorsCommand::DISABLE) {
     turn_signal.command = intersection_turn_signal.command;
   }
 


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Fix turn signal distance.

1. distance-rewritten bug

Before the change, the distance of intersection turn signal could be accidentally rewritten by lanes with `none` attribute.
After the change, distance will be only updated by lane with `left` or `right` attribute.

2. minus-distance turn signal from intersection
When avoiding near the intersection, the intersection turn_signal with big minus distance is output as shown below, and the avoidance turn signal does not turn on correctly.
After the change, the intersection turn_signal with minus distance will not be output from `getIntersectionTurnSignal`

```
[component_container_mt-47] [ERROR 1660720681.073442459] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660720681.073497523] [tmp]: avoid_turn_signal2
[component_container_mt-47] [ERROR 1660720681.073514104] [tmp]: avoid_distance29.2685
[component_container_mt-47] [ERROR 1660720681.073522763] [tmp]: intersection_turn_signal1
[component_container_mt-47] [ERROR 1660720681.073534476] [tmp]: intersection_distance1.79769e+308
[component_container_mt-47] [ERROR 1660720681.173590824] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660720681.173633209] [tmp]: lane8231
[component_container_mt-47] [ERROR 1660720681.173649558] [tmp]: avoid_turn_signal2
[component_container_mt-47] [ERROR 1660720681.173658836] [tmp]: avoid_distance28.7431
[component_container_mt-47] [ERROR 1660720681.173664062] [tmp]: intersection_turn_signal3
[component_container_mt-47] [ERROR 1660720681.173669557] [tmp]: intersection_distance-7.94307 <- this!
[component_container_mt-47] [ERROR 1660720681.273433434] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660720681.273475030] [tmp]: lane8231
[component_container_mt-47] [ERROR 1660720681.273492750] [tmp]: avoid_turn_signal2
[component_container_mt-47] [ERROR 1660720681.273502568] [tmp]: avoid_distance28.2165
[component_container_mt-47] [ERROR 1660720681.273507652] [tmp]: intersection_turn_signal3
[component_container_mt-47] [ERROR 1660720681.273514532] [tmp]: intersection_distance-8.37621 <- this!
[component_container_mt-47] [ERROR 1660720681.373796097] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660720681.373841634] [tmp]: avoid_turn_signal2
[component_container_mt-47] [ERROR 1660720681.373853138] [tmp]: avoid_distance27.689
[component_container_mt-47] [ERROR 1660720681.373858560] [tmp]: intersection_turn_signal1
[component_container_mt-47] [ERROR 1660720681.373866317] [tmp]: intersection_distance1.79769e+308
[component_container_mt-47] [ERROR 1660720681.473503680] [tmp]: =========================================
```

3. no-command-turn-signal from avoidance

Sometimes, the turn signal with NO_COMMAND is output from avoidance module, and it rewrites the intersection turn signal.
After the change, turn_signal with NO_COMMAND  will be ignored.

```
[component_container_mt-47] [ERROR 1660721220.857009443] [tmp]: avoid_turn_signal0  <- this!
[component_container_mt-47] [ERROR 1660721220.857017539] [tmp]: avoid_distance0.653192
[component_container_mt-47] [ERROR 1660721220.857021850] [tmp]: intersection_turn_signal3
[component_container_mt-47] [ERROR 1660721220.857026484] [tmp]: intersection_distance0.808469
[component_container_mt-47] [ERROR 1660721220.957536496] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660721220.957582795] [tmp]: avoid_turn_signal0  <- this!
[component_container_mt-47] [ERROR 1660721220.957590812] [tmp]: avoid_distance0.298453
[component_container_mt-47] [ERROR 1660721220.957596287] [tmp]: intersection_turn_signal3
[component_container_mt-47] [ERROR 1660721220.957603096] [tmp]: intersection_distance1.09024
[component_container_mt-47] [ERROR 1660721221.057352833] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660721221.057410941] [tmp]: avoid_turn_signal0  <- this!
[component_container_mt-47] [ERROR 1660721221.057421654] [tmp]: avoid_distance1.79769e+308
[component_container_mt-47] [ERROR 1660721221.057427318] [tmp]: intersection_turn_signal3
[component_container_mt-47] [ERROR 1660721221.057433378] [tmp]: intersection_distance1.36582
[component_container_mt-47] [ERROR 1660721221.157416610] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660721221.157467834] [tmp]: avoid_turn_signal0  <- this!
[component_container_mt-47] [ERROR 1660721221.157479068] [tmp]: avoid_distance1.79769e+308
[component_container_mt-47] [ERROR 1660721221.157484237] [tmp]: intersection_turn_signal3
[component_container_mt-47] [ERROR 1660721221.157489837] [tmp]: intersection_distance1.62823
[component_container_mt-47] [ERROR 1660721221.258417137] [tmp]: =========================================
```


*** 
I checked turn_signal value by inserting following code in turn_signal_decider.cpp
```
  RCLCPP_ERROR_STREAM(
    rclcpp::get_logger("tmp"), "avoid_turn_signal" << static_cast<int>(turn_signal_plan.command));
  RCLCPP_ERROR_STREAM(rclcpp::get_logger("tmp"), "avoid_distance" << plan_distance);

  RCLCPP_ERROR_STREAM(
    rclcpp::get_logger("tmp"),
    "intersection_turn_signal" << static_cast<int>(intersection_turn_signal.command));
  RCLCPP_ERROR_STREAM(rclcpp::get_logger("tmp"), "intersection_distance" << intersection_distance);

```


** Note ** 
https://user-images.githubusercontent.com/59680180/185071535-37d0131f-ce97-420e-8692-b7fcd31c0007.mp4

TODO: 
Even after merging this PR, sometimes turn signal chattering still occurs.
This may be because the calculation method of distance to intersection is crude, and the distance to the lane changes depending on how lane_ids are embedded in PathWithLaneId. 

```
[component_container_mt-47] [ERROR 1660723693.904823015] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660723693.904848874] [tmp]: avoid_turn_signal2
[component_container_mt-47] [ERROR 1660723693.904854754] [tmp]: avoid_distance37.2723
[component_container_mt-47] [ERROR 1660723693.904857682] [tmp]: intersection_turn_signal1
[component_container_mt-47] [ERROR 1660723693.904861938] [tmp]: intersection_distance1.79769e+308
[component_container_mt-47] [ERROR 1660723694.004621365] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660723694.004652211] [tmp]: avoid_turn_signal2
[component_container_mt-47] [ERROR 1660723694.004658282] [tmp]: avoid_distance36.8584
[component_container_mt-47] [ERROR 1660723694.004661173] [tmp]: intersection_turn_signal1
[component_container_mt-47] [ERROR 1660723694.004665300] [tmp]: intersection_distance1.79769e+308
[component_container_mt-47] [ERROR 1660723694.104611395] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660723694.104649982] [tmp]: avoid_turn_signal2
[component_container_mt-47] [ERROR 1660723694.104657756] [tmp]: avoid_distance36.4352
[component_container_mt-47] [ERROR 1660723694.104662272] [tmp]: intersection_turn_signal3
[component_container_mt-47] [ERROR 1660723694.104667225] [tmp]: intersection_distance0.145327 <- here.
[component_container_mt-47] [ERROR 1660723694.204462664] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660723694.204486688] [tmp]: lane8231
[component_container_mt-47] [ERROR 1660723694.204494304] [tmp]: avoid_turn_signal2
[component_container_mt-47] [ERROR 1660723694.204500710] [tmp]: avoid_distance36.0029
[component_container_mt-47] [ERROR 1660723694.204503602] [tmp]: intersection_turn_signal3
[component_container_mt-47] [ERROR 1660723694.204506635] [tmp]: intersection_distance0.567311 <- here.
[component_container_mt-47] [ERROR 1660723694.304347545] [tmp]: =========================================
[component_container_mt-47] [ERROR 1660723694.304372956] [tmp]: avoid_turn_signal2
[component_container_mt-47] [ERROR 1660723694.304378871] [tmp]: avoid_distance35.4655
[component_container_mt-47] [ERROR 1660723694.304381925] [tmp]: intersection_turn_signal1
[component_container_mt-47] [ERROR 1660723694.304386079] [tmp]: intersection_distance1.79769e+308

```


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
