### PR TITLE
fix(ekf_localizer): update the state and publish the estimated pose only after initialization

### DIFF
--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -196,6 +196,8 @@ private:
   double proc_cov_vx_d_;        //!< @brief  discrete process noise in d_vx=0
   double proc_cov_wz_d_;        //!< @brief  discrete process noise in d_wz=0
 
+  bool is_initialized_;
+
   enum IDX {
     X = 0,
     Y = 1,

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -70,6 +70,8 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
   proc_cov_yaw_d_ = std::pow(proc_stddev_yaw_c_ * ekf_dt_, 2.0);
   proc_cov_yaw_bias_d_ = std::pow(proc_stddev_yaw_bias_c_ * ekf_dt_, 2.0);
 
+  is_initialized_ = false;
+
   /* initialize ros system */
   auto period_control_ns =
     std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(ekf_dt_));
@@ -143,6 +145,10 @@ void EKFLocalizer::updatePredictFrequency()
  */
 void EKFLocalizer::timerCallback()
 {
+  if (!is_initialized_) {
+    return;
+  }
+
   DEBUG_INFO(get_logger(), "========================= timer called =========================");
 
   /* update predict frequency with measured timer rate */
@@ -240,6 +246,10 @@ void EKFLocalizer::setCurrentResult()
  */
 void EKFLocalizer::timerTFCallback()
 {
+  if (!is_initialized_) {
+    return;
+  }
+
   if (current_ekf_pose_.header.frame_id == "") {
     return;
   }
@@ -329,6 +339,8 @@ void EKFLocalizer::callbackInitialPose(
   updateSimple1DFilters(*initialpose);
 
   while (!current_pose_info_queue_.empty()) current_pose_info_queue_.pop();
+
+  is_initialized_ = true;
 }
 
 /*


### PR DESCRIPTION
## Description

ekf_localizer has a bug that it publishes the default pose (identity) and accepts poses and twists for state update even before state initialization.
To resolve this error, I added a flag that manages the initialization state and made them update the state and publish messages only after the state initialization.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/1421

## Tests performed

The test really needs to be added. But a lot of refactoring work is necessary before writing tests.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

* This behavior change can affect other Autoware modules. Please carefully read the code and validate the behavior
* I added the branch to the original repository so that other people can commit to this
 
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
