### PR TITLE
fix(behavior_path_planner): pull over backward parking

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
@@ -185,7 +185,7 @@ private:
   std::unique_ptr<rclcpp::Time> last_approved_time_;
 
   PathWithLaneId getReferencePath() const;
-  PathWithLaneId getStopPath();
+  PathWithLaneId getStopPath() const;
   lanelet::ConstLanelets getPullOverLanes() const;
   std::pair<bool, bool> getSafePath(ShiftParkingPath & safe_path) const;
   Pose getRefinedGoal() const;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fixed a problem with the module finishing when the goal is behind in the current lanes.
This bug is due to https://github.com/autowarefoundation/autoware.universe/pull/1571.


before

https://user-images.githubusercontent.com/39142679/185091978-a5f5b90e-9a11-460d-88d0-e098b2ae79a9.mp4

after

https://user-images.githubusercontent.com/39142679/185092168-8309a3d8-5131-46d1-a3fe-82f61cda9325.mp4

## Related links

<!-- Write the links related to this PR. -->
#1571 

## Tests performed

<!-- Describe how you have tested this PR. -->
psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
for checking backward parking
- enable_arc_backward_parking: true
- enable_arc_forward_parking: fasle
- enable_shift_parking: false
- [plan_from_ego](https://github.com/autowarefoundation/autoware.universe/blob/main/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml#L61): true
- [keep_steer_control_until_converged](https://github.com/autowarefoundation/autoware.universe/blob/main/launch/tier4_control_launch/config/trajectory_follower/lateral_controller.param.yaml#L60) : true
- [enable_keep_stopped_until_steer_convergence](https://github.com/autowarefoundation/autoware.universe/blob/main/launch/tier4_control_launch/config/trajectory_follower/longitudinal_controller.param.yaml#L9) :true

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
