### PR TITLE
ci: add update-codeownders-from-packages.yaml

### DIFF
--- a/.github/CODEOWNERS-manual
+++ b/.github/CODEOWNERS-manual
@@ -1,0 +1,1 @@
+.github/* @autowarefoundation/autoware-maintainers

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -83,6 +83,7 @@
       pre-commands: |
         sd "container: ros:(\w+)" "container: ghcr.io/autowarefoundation/autoware-universe:\$1-latest" {source}
         sd -f ms '(rosdistro: humble.*?build-depends-repos): build_depends.repos' '$1: build_depends.humble.repos' {source}
+    - source: .github/workflows/update-codeowners-from-packages.yaml
     - source: codecov.yaml
 
 - repository: autowarefoundation/autoware-documentation

--- a/.github/workflows/update-codeowners-from-packages.yaml
+++ b/.github/workflows/update-codeowners-from-packages.yaml
@@ -1,0 +1,33 @@
+name: update-codeowners-from-packages
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  check-secret:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1
+    secrets:
+      secret: ${{ secrets.APP_ID }}
+
+  update-codeowners-from-packages:
+    needs: check-secret
+    if: ${{ needs.check-secret.outputs.set == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run update-codeowners-from-packages
+        uses: autowarefoundation/autoware-github-actions/update-codeowners-from-packages@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pr-labels: |
+            bot
+            update-codeowners-from-packages
+          auto-merge-method: squash


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

To automatically set reviewers and to ensure reviews by code owners, I'd like to introduce `CODEOWNERS`.
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

As it's troublesome to manually maintain `CODEOWNERS` for each package, I propose a way to generate it from maintainers in `package.xml`.

We have to update maintainers before merging this.
Related: https://github.com/autowarefoundation/autoware.universe/pull/1610

Also, I'm planning to implement this in `autoware-github-actions` and use it in common for all repositories.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
