### PR TITLE
fix(tier4_screen_capture_rviz_plugin): fix release process to handle video writer correctly

### DIFF
--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -137,15 +137,16 @@ void AutowareScreenCapturePanel::onClickVideoCapture()
                              .convertToFormat(QImage::Format_RGB888)
                              .rgbSwapped()
                              .size();
-        current_movie_size = cv::Size(qsize.width(), qsize.height());
-        writer.open(
+        current_movie_size_ = cv::Size(qsize.width(), qsize.height());
+        writer_.open(
           "capture/" + capture_file_name_ + ".mp4", fourcc, capture_hz_->value(),
-          current_movie_size);
+          current_movie_size_);
       }
       capture_timer_->start(clock);
       state_ = State::CAPTURING;
       break;
     case State::CAPTURING:
+      writer_.release();
       capture_timer_->stop();
       capture_to_mp4_button_ptr_->setText("waiting for capture");
       capture_to_mp4_button_ptr_->setStyleSheet("background-color: #00FF00;");
@@ -167,12 +168,12 @@ void AutowareScreenCapturePanel::onTimer()
   cv::Size size = cv::Size(w, h);
   cv::Mat image(
     size, CV_8UC3, const_cast<uchar *>(qimage.bits()), static_cast<size_t>(qimage.bytesPerLine()));
-  if (size != current_movie_size) {
+  if (size != current_movie_size_) {
     cv::Mat new_image;
-    cv::resize(image, new_image, current_movie_size);
-    writer.write(new_image);
+    cv::resize(image, new_image, current_movie_size_);
+    writer_.write(new_image);
   } else {
-    writer.write(image);
+    writer_.write(image);
   }
   cv::waitKey(0);
 }

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
@@ -80,8 +80,8 @@ private:
   State state_;
   std::string capture_file_name_;
   bool is_capture_;
-  cv::VideoWriter writer;
-  cv::Size current_movie_size;
+  cv::VideoWriter writer_;
+  cv::Size current_movie_size_;
   std::vector<cv::Mat> image_vec_;
 
   std::string stateToString(const State & state)


### PR DESCRIPTION
## Description

why previously working ? 
-> because second time open video writer previous writer releases automatically but it was necessary to capture twice.

- this PR include 
- a little bit of refactor 
- fix release process to handle video writer correctly

https://user-images.githubusercontent.com/65527974/185372875-4a2e8159-2d01-41b6-8c67-6bd454120265.mp4


## Pre-review checklist for the PR author


The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
