### PR TITLE
refactor(tier4_perception_rviz_plugin): apply clang-tidy

### DIFF
--- a/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.hpp
@@ -59,7 +59,7 @@ private Q_SLOTS:
   void unsubscribe();
   void processMessage(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message);
 
-private:
+private:  // NOLINT for Qt
   void updateHistory();
   void updateLines();
 

--- a/common/tier4_perception_rviz_plugin/src/tools/car_pose.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/car_pose.cpp
@@ -99,7 +99,7 @@ CarInitialPoseTool::CarInitialPoseTool()
 
 void CarInitialPoseTool::onInitialize()
 {
-  PoseTool::onInitialize();
+  rviz_plugins::InteractiveObjectTool::onInitialize();
   setName("2D Dummy Car");
   updateTopic();
 }
@@ -184,7 +184,7 @@ BusInitialPoseTool::BusInitialPoseTool()
 
 void BusInitialPoseTool::onInitialize()
 {
-  PoseTool::onInitialize();
+  rviz_plugins::InteractiveObjectTool::onInitialize();
   setName("2D Dummy Bus");
   updateTopic();
 }

--- a/common/tier4_perception_rviz_plugin/src/tools/car_pose.hpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/car_pose.hpp
@@ -61,16 +61,16 @@ class CarInitialPoseTool : public InteractiveObjectTool
 {
 public:
   CarInitialPoseTool();
-  void onInitialize();
-  Object createObjectMsg() const override;
+  void onInitialize() override;
+  [[nodiscard]] Object createObjectMsg() const override;
 };
 
 class BusInitialPoseTool : public InteractiveObjectTool
 {
 public:
   BusInitialPoseTool();
-  void onInitialize();
-  Object createObjectMsg() const override;
+  void onInitialize() override;
+  [[nodiscard]] Object createObjectMsg() const override;
 };
 
 }  // namespace rviz_plugins

--- a/common/tier4_perception_rviz_plugin/src/tools/delete_all_objects.hpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/delete_all_objects.hpp
@@ -67,16 +67,15 @@ class DeleteAllObjectsTool : public rviz_default_plugins::tools::PoseTool
 
 public:
   DeleteAllObjectsTool();
-  virtual ~DeleteAllObjectsTool() {}
-  virtual void onInitialize();
+  void onInitialize() override;
 
 protected:
-  virtual void onPoseSet(double x, double y, double theta);
+  void onPoseSet(double x, double y, double theta) override;
 
 private Q_SLOTS:
   void updateTopic();
 
-private:
+private:  // NOLINT for Qt
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Publisher<dummy_perception_publisher::msg::Object>::SharedPtr dummy_object_info_pub_;
 

--- a/common/tier4_perception_rviz_plugin/src/tools/interactive_object.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/interactive_object.cpp
@@ -62,7 +62,6 @@ InteractiveObject::InteractiveObject(const Ogre::Vector3 & point)
 {
   velocity_ = Ogre::Vector3::ZERO;
   point_ = point;
-  theta_ = 0.0;
 
   std::mt19937 gen(std::random_device{}());
   std::independent_bits_engine<std::mt19937, 8, uint8_t> bit_eng(gen);

--- a/common/tier4_perception_rviz_plugin/src/tools/interactive_object.hpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/interactive_object.hpp
@@ -114,8 +114,10 @@ public:
   boost::optional<std::array<uint8_t, 16>> create(const Ogre::Vector3 & point);
   boost::optional<std::array<uint8_t, 16>> remove(const Ogre::Vector3 & point);
   boost::optional<std::array<uint8_t, 16>> update(const Ogre::Vector3 & point);
-  [[nodiscard]] boost::optional<geometry_msgs::msg::Twist> twist(const std::array<uint8_t, 16> & uuid) const;
-  [[nodiscard]] boost::optional<tf2::Transform> transform(const std::array<uint8_t, 16> & uuid) const;
+  [[nodiscard]] boost::optional<geometry_msgs::msg::Twist> twist(
+    const std::array<uint8_t, 16> & uuid) const;
+  [[nodiscard]] boost::optional<tf2::Transform> transform(
+    const std::array<uint8_t, 16> & uuid) const;
 
 private:
   size_t nearest(const Ogre::Vector3 & point);

--- a/common/tier4_perception_rviz_plugin/src/tools/interactive_object.hpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/interactive_object.hpp
@@ -89,9 +89,8 @@ class InteractiveObject
 {
 public:
   explicit InteractiveObject(const Ogre::Vector3 & point);
-  ~InteractiveObject() {}
 
-  std::array<uint8_t, 16> uuid() const;
+  [[nodiscard]] std::array<uint8_t, 16> uuid() const;
   void twist(geometry_msgs::msg::Twist & twist) const;
   void transform(tf2::Transform & tf_map2object) const;
   void update(const Ogre::Vector3 & point);
@@ -99,25 +98,24 @@ public:
   double distance(const Ogre::Vector3 & point);
 
 private:
-  std::array<uint8_t, 16> uuid_;
+  std::array<uint8_t, 16> uuid_{};
   Ogre::Vector3 point_;
   Ogre::Vector3 velocity_;
-  double theta_;
+  double theta_{0.0};
 };
 
 class InteractiveObjectCollection
 {
 public:
   InteractiveObjectCollection();
-  ~InteractiveObjectCollection() {}
 
   void select(const Ogre::Vector3 & point);
   boost::optional<std::array<uint8_t, 16>> reset();
   boost::optional<std::array<uint8_t, 16>> create(const Ogre::Vector3 & point);
   boost::optional<std::array<uint8_t, 16>> remove(const Ogre::Vector3 & point);
   boost::optional<std::array<uint8_t, 16>> update(const Ogre::Vector3 & point);
-  boost::optional<geometry_msgs::msg::Twist> twist(const std::array<uint8_t, 16> & uuid) const;
-  boost::optional<tf2::Transform> transform(const std::array<uint8_t, 16> & uuid) const;
+  [[nodiscard]] boost::optional<geometry_msgs::msg::Twist> twist(const std::array<uint8_t, 16> & uuid) const;
+  [[nodiscard]] boost::optional<tf2::Transform> transform(const std::array<uint8_t, 16> & uuid) const;
 
 private:
   size_t nearest(const Ogre::Vector3 & point);
@@ -130,17 +128,16 @@ class InteractiveObjectTool : public rviz_default_plugins::tools::PoseTool
   Q_OBJECT
 
 public:
-  virtual ~InteractiveObjectTool() = default;
-  virtual void onInitialize();
+  void onInitialize() override;
   int processMouseEvent(rviz_common::ViewportMouseEvent & event) override;
   int processKeyEvent(QKeyEvent * event, rviz_common::RenderPanel * panel) override;
 
-  virtual Object createObjectMsg() const = 0;
+  [[nodiscard]] virtual Object createObjectMsg() const = 0;
 
 protected Q_SLOTS:
   virtual void updateTopic();
 
-protected:
+protected:  // NOLINT for Qt
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Publisher<Object>::SharedPtr dummy_object_info_pub_;
 
@@ -161,7 +158,7 @@ protected:
 
 private:
   void publishObjectMsg(const std::array<uint8_t, 16> & uuid, const uint32_t action);
-  void onPoseSet(double x, double y, double theta);
+  void onPoseSet(double x, double y, double theta) override;
 
   InteractiveObjectCollection objects_;
 };

--- a/common/tier4_perception_rviz_plugin/src/tools/pedestrian_pose.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/pedestrian_pose.cpp
@@ -93,7 +93,7 @@ PedestrianInitialPoseTool::PedestrianInitialPoseTool()
 
 void PedestrianInitialPoseTool::onInitialize()
 {
-  PoseTool::onInitialize();
+  rviz_plugins::InteractiveObjectTool::onInitialize();
   setName("2D Dummy Pedestrian");
   updateTopic();
 }

--- a/common/tier4_perception_rviz_plugin/src/tools/pedestrian_pose.hpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/pedestrian_pose.hpp
@@ -61,8 +61,8 @@ class PedestrianInitialPoseTool : public InteractiveObjectTool
 {
 public:
   PedestrianInitialPoseTool();
-  void onInitialize();
-  Object createObjectMsg() const override;
+  void onInitialize() override;
+  [[nodiscard]] Object createObjectMsg() const override;
 };
 
 }  // namespace rviz_plugins

--- a/common/tier4_perception_rviz_plugin/src/tools/unknown_pose.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/unknown_pose.cpp
@@ -88,7 +88,7 @@ UnknownInitialPoseTool::UnknownInitialPoseTool()
 
 void UnknownInitialPoseTool::onInitialize()
 {
-  PoseTool::onInitialize();
+  rviz_plugins::InteractiveObjectTool::onInitialize();
   setName("2D Dummy Unknown");
   updateTopic();
 }

--- a/common/tier4_perception_rviz_plugin/src/tools/unknown_pose.hpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/unknown_pose.hpp
@@ -56,8 +56,8 @@ class UnknownInitialPoseTool : public InteractiveObjectTool
 {
 public:
   UnknownInitialPoseTool();
-  void onInitialize();
-  Object createObjectMsg() const override;
+  void onInitialize() override;
+  [[nodiscard]] Object createObjectMsg() const override;
 };
 
 }  // namespace rviz_plugins


### PR DESCRIPTION
## Description

- apply NOLINT for readability-redundant-access-specifiers due to Qt
- fix below
  - clang-diagnostic-inconsistent-missing-override
  - modernize-use-override
  - modernize-use-nodiscard
  - bugprone-parent-virtual-call
  - cppcoreguidelines-pro-type-member-init
- delete destructor which has no definition 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
