### PR TITLE
refactor(tier4_planning_rviz_plugin): apply clang-tidy for drivable_area

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/drivable_area/display.hpp
+++ b/common/tier4_planning_rviz_plugin/include/drivable_area/display.hpp
@@ -71,11 +71,9 @@
 namespace Ogre
 {
 class ManualObject;
-}
+}  // namespace Ogre
 
-namespace rviz_common
-{
-namespace properties
+namespace rviz_common::properties
 {
 class EnumProperty;
 class FloatProperty;
@@ -84,8 +82,7 @@ class Property;
 class QuaternionProperty;
 class VectorProperty;
 
-}  // namespace properties
-}  // namespace rviz_common
+}  // namespace rviz_common::properties
 
 namespace rviz_plugins
 {
@@ -112,14 +109,14 @@ public:
   void fixedFrameChanged() override;
   void reset() override;
 
-  float getResolution() { return resolution_; }
-  size_t getWidth() { return width_; }
-  size_t getHeight() { return height_; }
+  [[nodiscard]] float getResolution() const { return resolution_; }
+  [[nodiscard]] size_t getWidth() const { return width_; }
+  [[nodiscard]] size_t getHeight() const { return height_; }
 
   /** @brief Copy msg into current_map_ and call showMap(). */
   void processMessage(autoware_auto_planning_msgs::msg::Path::ConstSharedPtr msg) override;
 
-public Q_SLOTS:
+public Q_SLOTS: // NOLINT
   void showMap();
 
 Q_SIGNALS:
@@ -134,7 +131,7 @@ protected Q_SLOTS:
   void transformMap();
   void updateMapUpdateTopic();
 
-protected:
+protected: // NOLINT for Qt
   void updateTopic() override;
   void update(float wall_dt, float ros_dt) override;
 
@@ -146,7 +143,7 @@ protected:
   /** @brief Copy update's data into current_map_ and call showMap(). */
   void incomingUpdate(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
 
-  bool updateDataOutOfBounds(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update) const;
+  [[nodiscard]] bool updateDataOutOfBounds(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update) const;
   void updateMapDataInMemory(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
 
   void clear();
@@ -157,12 +154,12 @@ protected:
   void showValidMap();
   void resetSwatchesIfNecessary(size_t width, size_t height, float resolution);
   void createSwatches();
-  void doubleSwatchNumber(
-    size_t & swatch_width, size_t & swatch_height, int & number_swatches) const;
+  static void doubleSwatchNumber(
+    size_t & swatch_width, size_t & swatch_height, int & number_swatches);
   void tryCreateSwatches(
     size_t width, size_t height, float resolution, size_t swatch_width, size_t swatch_height,
     int number_swatches);
-  size_t getEffectiveDimension(size_t map_dimension, size_t swatch_dimension, size_t position);
+  static size_t getEffectiveDimension(size_t map_dimension, size_t swatch_dimension, size_t position);
   void updateSwatches() const;
 
   std::vector<std::shared_ptr<Swatch>> swatches_;

--- a/common/tier4_planning_rviz_plugin/include/drivable_area/display.hpp
+++ b/common/tier4_planning_rviz_plugin/include/drivable_area/display.hpp
@@ -116,7 +116,7 @@ public:
   /** @brief Copy msg into current_map_ and call showMap(). */
   void processMessage(autoware_auto_planning_msgs::msg::Path::ConstSharedPtr msg) override;
 
-public Q_SLOTS: // NOLINT
+public Q_SLOTS:  // NOLINT
   void showMap();
 
 Q_SIGNALS:
@@ -131,7 +131,7 @@ protected Q_SLOTS:
   void transformMap();
   void updateMapUpdateTopic();
 
-protected: // NOLINT for Qt
+protected:  // NOLINT for Qt
   void updateTopic() override;
   void update(float wall_dt, float ros_dt) override;
 
@@ -143,7 +143,8 @@ protected: // NOLINT for Qt
   /** @brief Copy update's data into current_map_ and call showMap(). */
   void incomingUpdate(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
 
-  [[nodiscard]] bool updateDataOutOfBounds(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update) const;
+  [[nodiscard]] bool updateDataOutOfBounds(
+    map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update) const;
   void updateMapDataInMemory(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
 
   void clear();
@@ -159,7 +160,8 @@ protected: // NOLINT for Qt
   void tryCreateSwatches(
     size_t width, size_t height, float resolution, size_t swatch_width, size_t swatch_height,
     int number_swatches);
-  static size_t getEffectiveDimension(size_t map_dimension, size_t swatch_dimension, size_t position);
+  static size_t getEffectiveDimension(
+    size_t map_dimension, size_t swatch_dimension, size_t position);
   void updateSwatches() const;
 
   std::vector<std::shared_ptr<Swatch>> swatches_;

--- a/common/tier4_planning_rviz_plugin/src/drivable_area/display.cpp
+++ b/common/tier4_planning_rviz_plugin/src/drivable_area/display.cpp
@@ -257,8 +257,8 @@ void AutowareDrivableAreaDisplay::unsubscribeToUpdateTopic() { update_subscripti
 void AutowareDrivableAreaDisplay::updateAlpha()
 {
   float alpha = alpha_property_->getFloat();
-  Ogre::SceneBlendType scene_blending;
-  bool depth_write;
+  Ogre::SceneBlendType scene_blending = Ogre::SceneBlendType::SBT_TRANSPARENT_ALPHA;
+  bool depth_write = false;
 
   rviz_rendering::MaterialManager::enableAlphaBlending(scene_blending, depth_write, alpha);
 
@@ -398,7 +398,7 @@ void AutowareDrivableAreaDisplay::createSwatches()
 }
 
 void AutowareDrivableAreaDisplay::doubleSwatchNumber(
-  size_t & swatch_width, size_t & swatch_height, int & number_swatches) const
+  size_t & swatch_width, size_t & swatch_height, int & number_swatches)
 {
   RVIZ_COMMON_LOG_ERROR_STREAM(
     "Failed to create map using " << number_swatches


### PR DESCRIPTION
## Description

- apply NOLINT for readability-redundant-access-specifiers due to Qt
- fix below
  - modernize-use-nodiscard
  - llvm-namespace-comment
  - modernize-concat-nested-namespaces
  - readability-make-member-function-const
  - cppcoreguidelines-init-variables
  - readability-convert-member-functions-to-static

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
