### PR TITLE
fix(behavior_velocity_planner): consider all the lane ids in path

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -450,14 +450,16 @@ boost::optional<BlindSpotPolygons> BlindSpotModule::generateBlindSpotPolygons(
   /* get lane ids until intersection */
   for (const auto & point : path.points) {
     for (const auto lane_id : point.lane_ids) {
-      lane_ids.push_back(lane_id);
+      // make lane_ids unique
+      if (std::find(lane_ids.begin(), lane_ids.end(), lane_id) == lane_ids.end()) {
+        lane_ids.push_back(lane_id);
+      }
+
       if (lane_id == lane_id_) {
         break;
       }
     }
   }
-  /* remove adjacent duplicates */
-  lane_ids.erase(std::unique(lane_ids.begin(), lane_ids.end()), lane_ids.end());
 
   /* reverse lane ids */
   std::reverse(lane_ids.begin(), lane_ids.end());

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -449,9 +449,11 @@ boost::optional<BlindSpotPolygons> BlindSpotModule::generateBlindSpotPolygons(
   lanelet::ConstLanelets blind_spot_lanelets;
   /* get lane ids until intersection */
   for (const auto & point : path.points) {
-    lane_ids.push_back(point.lane_ids.front());
-    if (point.lane_ids.front() == lane_id_) {
-      break;
+    for (const auto lane_id : point.lane_ids) {
+      lane_ids.push_back(lane_id);
+      if (lane_id == lane_id_) {
+        break;
+      }
     }
   }
   /* remove adjacent duplicates */

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -675,13 +675,18 @@ lanelet::ConstLanelets IntersectionModule::getEgoLaneWithNextLane(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path) const
 {
   const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id_);
-  const auto last_itr = std::find_if(
-    path.points.crbegin(), path.points.crend(),
-    [this](const auto & p) { return p.lane_ids.front() == lane_id_; });
+  const auto last_itr =
+    std::find_if(path.points.crbegin(), path.points.crend(), [this](const auto & p) {
+      for (const auto lane_id : p.lane_ids) {
+        if (lane_id == lane_id_) {
+          return true;
+        }
+      }
+      return false;
+    });
   lanelet::ConstLanelets ego_lane_with_next_lane;
   if (last_itr.base() != path.points.end()) {
-    const auto & next_lanelet =
-      lanelet_map_ptr->laneletLayer.get((*last_itr.base()).lane_ids.front());
+    const auto & next_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id_);
     ego_lane_with_next_lane = {assigned_lanelet, next_lanelet};
   } else {
     ego_lane_with_next_lane = {assigned_lanelet};
@@ -694,9 +699,15 @@ double IntersectionModule::calcDistanceUntilIntersectionLanelet(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t closest_idx) const
 {
   const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id_);
-  const auto intersection_first_itr = std::find_if(
-    path.points.cbegin(), path.points.cend(),
-    [this](const auto & p) { return p.lane_ids.front() == lane_id_; });
+  const auto intersection_first_itr =
+    std::find_if(path.points.cbegin(), path.points.cend(), [this](const auto & p) {
+      for (const auto lane_id : p.lane_ids) {
+        if (lane_id == lane_id_) {
+          return true;
+        }
+      }
+      return false;
+    });  // TODO(murooka) use only front lane_id
   if (
     intersection_first_itr == path.points.begin() || intersection_first_itr == path.points.end()) {
     return 0.0;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -707,7 +707,7 @@ double IntersectionModule::calcDistanceUntilIntersectionLanelet(
         }
       }
       return false;
-    });  // TODO(murooka) use only front lane_id
+    });
   if (
     intersection_first_itr == path.points.begin() || intersection_first_itr == path.points.end()) {
     return 0.0;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -677,16 +677,12 @@ lanelet::ConstLanelets IntersectionModule::getEgoLaneWithNextLane(
   const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id_);
   const auto last_itr =
     std::find_if(path.points.crbegin(), path.points.crend(), [this](const auto & p) {
-      for (const auto lane_id : p.lane_ids) {
-        if (lane_id == lane_id_) {
-          return true;
-        }
-      }
-      return false;
+      return std::find(p.lane_ids.begin(), p.lane_ids.end(), lane_id_) != p.lane_ids.end();
     });
   lanelet::ConstLanelets ego_lane_with_next_lane;
   if (last_itr.base() != path.points.end()) {
-    const auto & next_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id_);
+    const auto & next_lanelet =
+      lanelet_map_ptr->laneletLayer.get((*last_itr.base()).lane_ids.front());
     ego_lane_with_next_lane = {assigned_lanelet, next_lanelet};
   } else {
     ego_lane_with_next_lane = {assigned_lanelet};
@@ -701,12 +697,7 @@ double IntersectionModule::calcDistanceUntilIntersectionLanelet(
   const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id_);
   const auto intersection_first_itr =
     std::find_if(path.points.cbegin(), path.points.cend(), [this](const auto & p) {
-      for (const auto lane_id : p.lane_ids) {
-        if (lane_id == lane_id_) {
-          return true;
-        }
-      }
-      return false;
+      return std::find(p.lane_ids.begin(), p.lane_ids.end(), lane_id_) != p.lane_ids.end();
     });
   if (
     intersection_first_itr == path.points.begin() || intersection_first_itr == path.points.end()) {


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

With this PR, the path point sometimes has more than 2 lane_ids which cannot be dealt with in some behavior_velocity_planner's module.
https://github.com/autowarefoundation/autoware.universe/pull/1626

So I fixed behavior_velocity_planner to consider all the lane ids in the path from behavior_path_planner.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
