### PR TITLE
fix(behavior_path_planner, motion_utils): fix path shifter orientation

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -1058,6 +1058,38 @@ inline boost::optional<size_t> insertStopPoint(
 }
 
 template <class T>
+void insertOrientation(T & points, const bool is_driving_forward)
+{
+  if (is_driving_forward) {
+    for (size_t i = 0; i < points.size() - 1; ++i) {
+      const auto & src_point = tier4_autoware_utils::getPoint(points.at(i));
+      const auto & dst_point = tier4_autoware_utils::getPoint(points.at(i + 1));
+      const double pitch = tier4_autoware_utils::calcElevationAngle(src_point, dst_point);
+      const double yaw = tier4_autoware_utils::calcAzimuthAngle(src_point, dst_point);
+      tier4_autoware_utils::setOrientation(
+        tier4_autoware_utils::createQuaternionFromRPY(0.0, pitch, yaw), points.at(i));
+      if (i == points.size() - 2) {
+        // Terminal orientation is same as the point before it
+        tier4_autoware_utils::setOrientation(
+          tier4_autoware_utils::getPose(points.at(i)).orientation, points.at(i + 1));
+      }
+    }
+  } else {
+    for (size_t i = points.size() - 1; i >= 1; --i) {
+      const auto & src_point = tier4_autoware_utils::getPoint(points.at(i));
+      const auto & dst_point = tier4_autoware_utils::getPoint(points.at(i - 1));
+      const double pitch = tier4_autoware_utils::calcElevationAngle(src_point, dst_point);
+      const double yaw = tier4_autoware_utils::calcAzimuthAngle(src_point, dst_point);
+      tier4_autoware_utils::setOrientation(
+        tier4_autoware_utils::createQuaternionFromRPY(0.0, pitch, yaw), points.at(i));
+    }
+    // Initial orientation is same as the point after it
+    tier4_autoware_utils::setOrientation(
+      tier4_autoware_utils::getPose(points.at(1)).orientation, points.at(0));
+  }
+}
+
+template <class T>
 double calcSignedArcLength(
   const T & points, const geometry_msgs::msg::Point & src_point, const size_t src_seg_idx,
   const geometry_msgs::msg::Point & dst_point, const size_t dst_seg_idx)

--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -80,36 +80,12 @@ std::vector<geometry_msgs::msg::Pose> resamplePath(
 
   const bool is_driving_forward =
     tier4_autoware_utils::isDrivingForward(points.at(0), points.at(1));
-  // Insert Orientation
-  if (is_driving_forward) {
-    for (size_t i = 0; i < resampled_points.size() - 1; ++i) {
-      const auto & src_point = resampled_points.at(i).position;
-      const auto & dst_point = resampled_points.at(i + 1).position;
-      const double pitch = tier4_autoware_utils::calcElevationAngle(src_point, dst_point);
-      const double yaw = tier4_autoware_utils::calcAzimuthAngle(src_point, dst_point);
-      resampled_points.at(i).orientation =
-        tier4_autoware_utils::createQuaternionFromRPY(0.0, pitch, yaw);
-      if (i == resampled_points.size() - 2) {
-        // Terminal Orientation is same as the point before it
-        resampled_points.at(i + 1).orientation = resampled_points.at(i).orientation;
-      }
-    }
-  } else {
-    for (size_t i = resampled_points.size() - 1; i >= 1; --i) {
-      const auto & src_point = resampled_points.at(i).position;
-      const auto & dst_point = resampled_points.at(i - 1).position;
-      const double pitch = tier4_autoware_utils::calcElevationAngle(src_point, dst_point);
-      const double yaw = tier4_autoware_utils::calcAzimuthAngle(src_point, dst_point);
-      resampled_points.at(i).orientation =
-        tier4_autoware_utils::createQuaternionFromRPY(0.0, pitch, yaw);
-    }
+  motion_utils::insertOrientation(resampled_points, is_driving_forward);
 
-    // Initial Orientation is depend on the initial value of the resampled_arclength
-    if (resampled_arclength.front() < 1e-3) {
-      resampled_points.at(0).orientation = points.at(0).orientation;
-    } else {
-      resampled_points.at(0).orientation = resampled_points.at(1).orientation;
-    }
+  // Initial orientation is depend on the initial value of the resampled_arclength
+  // when backward driving
+  if (!is_driving_forward && resampled_arclength.front() < 1e-3) {
+    resampled_points.at(0).orientation = points.at(0).orientation;
   }
 
   return resampled_points;

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -232,6 +232,14 @@ inline void setPose(
 }
 
 template <class T>
+inline void setOrientation(const geometry_msgs::msg::Quaternion & orientation, T & p)
+{
+  auto pose = getPose(p);
+  pose.orientation = orientation;
+  setPose(pose, p);
+}
+
+template <class T>
 void setLongitudinalVelocity([[maybe_unused]] const double velocity, [[maybe_unused]] T & p)
 {
   static_assert(sizeof(T) == 0, "Only specializations of getLongitudinalVelocity can be used.");

--- a/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
@@ -288,6 +288,22 @@ TEST(geometry, setPose)
   }
 }
 
+TEST(geometry, setOrientation)
+{
+  using tier4_autoware_utils::createQuaternionFromRPY;
+  using tier4_autoware_utils::deg2rad;
+  using tier4_autoware_utils::setOrientation;
+
+  geometry_msgs::msg::Pose p;
+  const auto orientation = createQuaternionFromRPY(deg2rad(30), deg2rad(30), deg2rad(30));
+  setOrientation(orientation, p);
+
+  EXPECT_DOUBLE_EQ(p.orientation.x, orientation.x);
+  EXPECT_DOUBLE_EQ(p.orientation.y, orientation.y);
+  EXPECT_DOUBLE_EQ(p.orientation.z, orientation.z);
+  EXPECT_DOUBLE_EQ(p.orientation.w, orientation.w);
+}
+
 TEST(geometry, setLongitudinalVelocity)
 {
   using tier4_autoware_utils::setLongitudinalVelocity;

--- a/planning/behavior_path_planner/src/scene_module/utils/path_shifter.cpp
+++ b/planning/behavior_path_planner/src/scene_module/utils/path_shifter.cpp
@@ -114,6 +114,9 @@ bool PathShifter::generate(
   type == SHIFT_TYPE::SPLINE ? applySplineShifter(shifted_path, offset_back)
                              : applyLinearShifter(shifted_path);
 
+  const bool is_driving_forward = true;
+  motion_utils::insertOrientation(shifted_path->path.points, is_driving_forward);
+
   // DEBUG
   RCLCPP_DEBUG_STREAM(
     logger_, "PathShifter::generate end. shift_points_.size = " << shift_points_.size());


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- make `insertOrientation` function in motion_utils
- Added orientation to shift path.

shift path

- before

![image](https://user-images.githubusercontent.com/39142679/185575968-6c41f553-868d-4c2d-9afb-e37359d5388f.png)

- after

![image](https://user-images.githubusercontent.com/39142679/185576045-6d7349c1-a2ac-4655-85d6-0c239a703bf7.png)


## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
