### PR TITLE
fix: remove rtc staus when no avoidance candidate is output

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -129,7 +129,7 @@ private:
     rtc_interface_right_.clearCooperateStatus();
   }
 
-  void removeCandaiteRTCStatus()
+  void removeCandidateRTCStatus()
   {
     if (rtc_interface_left_.isRegistered(candidate_uuid_)) {
       rtc_interface_left_.removeCooperateStatus(candidate_uuid_);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -83,6 +83,7 @@ private:
 
   RegisteredShiftPointArray left_shift_array_;
   RegisteredShiftPointArray right_shift_array_;
+  UUID candidate_uuid_;
   UUID uuid_left_;
   UUID uuid_right_;
 
@@ -91,11 +92,13 @@ private:
     if (candidate.lateral_shift > 0.0) {
       rtc_interface_left_.updateCooperateStatus(
         uuid_left_, isExecutionReady(), candidate.distance_to_path_change, clock_->now());
+      candidate_uuid_ = uuid_left_;
       return;
     }
     if (candidate.lateral_shift < 0.0) {
       rtc_interface_right_.updateCooperateStatus(
         uuid_right_, isExecutionReady(), candidate.distance_to_path_change, clock_->now());
+      candidate_uuid_ = uuid_right_;
       return;
     }
 
@@ -124,6 +127,15 @@ private:
   {
     rtc_interface_left_.clearCooperateStatus();
     rtc_interface_right_.clearCooperateStatus();
+  }
+
+  void removeCandaiteRTCStatus()
+  {
+    if (rtc_interface_left_.isRegistered(candidate_uuid_)) {
+      rtc_interface_left_.removeCooperateStatus(candidate_uuid_);
+    } else if (rtc_interface_right_.isRegistered(candidate_uuid_)) {
+      rtc_interface_right_.removeCooperateStatus(candidate_uuid_);
+    }
   }
 
   void removePreviousRTCStatusLeft()

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2222,7 +2222,7 @@ BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
     waitApproval();
   } else {
     clearWaitingApproval();
-    removeCandaiteRTCStatus();
+    removeCandidateRTCStatus();
   }
   out.path_candidate = std::make_shared<PathWithLaneId>(candidate.path_candidate);
   return out;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2129,7 +2129,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
     addShiftPointIfApproved(*new_shift_points);
   } else if (isWaitingApproval()) {
     clearWaitingApproval();
-    removeRTCStatus();
+    removeCandaiteRTCStatus();
   }
 
   // generate path with shift points that have been inserted.
@@ -2222,7 +2222,7 @@ BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
     waitApproval();
   } else {
     clearWaitingApproval();
-    removeRTCStatus();
+    removeCandaiteRTCStatus();
   }
   out.path_candidate = std::make_shared<PathWithLaneId>(candidate.path_candidate);
   return out;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2129,6 +2129,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
     addShiftPointIfApproved(*new_shift_points);
   } else if (isWaitingApproval()) {
     clearWaitingApproval();
+    removeRTCStatus();
   }
 
   // generate path with shift points that have been inserted.
@@ -2219,6 +2220,9 @@ BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
   if (candidate.distance_to_path_change > threshold_to_update_status) {
     updateCandidateRTCStatus(candidate);
     waitApproval();
+  } else {
+    clearWaitingApproval();
+    removeRTCStatus();
   }
   out.path_candidate = std::make_shared<PathWithLaneId>(candidate.path_candidate);
   return out;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2129,7 +2129,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
     addShiftPointIfApproved(*new_shift_points);
   } else if (isWaitingApproval()) {
     clearWaitingApproval();
-    removeCandaiteRTCStatus();
+    removeCandidateRTCStatus();
   }
 
   // generate path with shift points that have been inserted.


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Fixed a bug that avoidance's rtc_status is continuously output even if avoidance is canceled and no candidate route is output.
<!-- Write a brief description of this PR. -->

## Check
Please confirm that rtc-status output stops properly when avoidance is cancelled.
$ros2 topic echo /api/external/get/rtc_status

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
