### PR TITLE
feat(multi_object_tracker): change ekf_params_.use_measurement_covariance to has_covariance

### DIFF
--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/bicycle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/bicycle_tracker.hpp
@@ -49,8 +49,6 @@ private:
     float q_cov_vx;
     float p0_cov_vx;
     float p0_cov_wz;
-    // if use_measurement_covariance_ is false, use following params
-    bool use_measurement_covariance;
     float r_cov_x;
     float r_cov_y;
     float r_cov_yaw;

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
@@ -49,8 +49,6 @@ private:
     float q_cov_vx;
     float p0_cov_vx;
     float p0_cov_wz;
-    // if use_measurement_covariance_ is false, use following params
-    bool use_measurement_covariance;
     float r_cov_x;
     float r_cov_y;
     float r_cov_yaw;

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
@@ -49,8 +49,6 @@ private:
     float q_cov_vx;
     float p0_cov_vx;
     float p0_cov_wz;
-    // if use_measurement_covariance_ is false, use following params
-    bool use_measurement_covariance;
     float r_cov_x;
     float r_cov_y;
     float r_cov_yaw;

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
@@ -49,8 +49,6 @@ private:
     float q_cov_vx;
     float p0_cov_vx;
     float p0_cov_wz;
-    // if use_measurement_covariance_ is false, use following params
-    bool use_measurement_covariance;
     float r_cov_x;
     float r_cov_y;
     float r_cov_yaw;

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/unknown_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/unknown_tracker.hpp
@@ -47,8 +47,6 @@ private:
     float q_cov_vy;
     float p0_cov_vx;
     float p0_cov_vy;
-    // if use_measurement_covariance_ is false, use following params
-    bool use_measurement_covariance;
     float r_cov_x;
     float r_cov_y;
     float p0_cov_x;

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -50,7 +50,6 @@ BicycleTracker::BicycleTracker(
   object_ = object;
 
   // initialize params
-  ekf_params_.use_measurement_covariance = false;
   float q_stddev_x = 0.6;                                     // [m/s]
   float q_stddev_y = 0.6;                                     // [m/s]
   float q_stddev_yaw = tier4_autoware_utils::deg2rad(10);     // [rad/s]
@@ -95,11 +94,8 @@ BicycleTracker::BicycleTracker(
 
   // initialize P matrix
   Eigen::MatrixXd P = Eigen::MatrixXd::Zero(ekf_params_.dim_x, ekf_params_.dim_x);
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW] == 0.0) {
+
+  if (!object.kinematics.has_position_covariance) {
     const double cos_yaw = std::cos(X(IDX::YAW));
     const double sin_yaw = std::sin(X(IDX::YAW));
     const double sin_2yaw = std::sin(2.0f * X(IDX::YAW));
@@ -252,10 +248,8 @@ bool BicycleTracker::measureWithPose(
 
   /* Set measurement noise covariance */
   Eigen::MatrixXd R = Eigen::MatrixXd::Zero(dim_y, dim_y);
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0) {
+
+  if (!object.kinematics.has_position_covariance) {
     R(0, 0) = ekf_params_.r_cov_x;  // x - x
     R(0, 1) = 0.0;                  // x - y
     R(1, 1) = ekf_params_.r_cov_y;  // y - y

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -48,7 +48,6 @@ BigVehicleTracker::BigVehicleTracker(
   object_ = object;
 
   // initialize params
-  ekf_params_.use_measurement_covariance = true;
   float q_stddev_x = 1.5;                                     // [m/s]
   float q_stddev_y = 1.5;                                     // [m/s]
   float q_stddev_yaw = tier4_autoware_utils::deg2rad(20);     // [rad/s]
@@ -96,11 +95,7 @@ BigVehicleTracker::BigVehicleTracker(
 
   // initialize P matrix
   Eigen::MatrixXd P = Eigen::MatrixXd::Zero(ekf_params_.dim_x, ekf_params_.dim_x);
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW] == 0.0) {
+  if (!object.kinematics.has_position_covariance) {
     const double cos_yaw = std::cos(X(IDX::YAW));
     const double sin_yaw = std::sin(X(IDX::YAW));
     const double sin_2yaw = std::sin(2.0f * X(IDX::YAW));
@@ -283,11 +278,7 @@ bool BigVehicleTracker::measureWithPose(
   C(2, IDX::YAW) = 1.0;  // for yaw
 
   /* Set measurement noise covariance */
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW] == 0.0) {
+  if (!object.kinematics.has_position_covariance) {
     const double cos_yaw = std::cos(measurement_yaw);
     const double sin_yaw = std::sin(measurement_yaw);
     const double sin_2yaw = std::sin(2.0f * measurement_yaw);
@@ -312,9 +303,7 @@ bool BigVehicleTracker::measureWithPose(
     Y(IDX::VX, 0) = object.kinematics.twist_with_covariance.twist.linear.x;
     C(3, IDX::VX) = 1.0;  // for vx
 
-    if (
-      !ekf_params_.use_measurement_covariance ||
-      object.kinematics.twist_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0) {
+    if (!object.kinematics.has_twist_covariance) {
       R(3, 3) = ekf_params_.r_cov_vx;  // vx -vx
     } else {
       R(3, 3) = object.kinematics.twist_with_covariance.covariance[utils::MSG_COV_IDX::X_X];

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -48,7 +48,7 @@ BigVehicleTracker::BigVehicleTracker(
   object_ = object;
 
   // initialize params
-  ekf_params_.use_measurement_covariance = false;
+  ekf_params_.use_measurement_covariance = true;
   float q_stddev_x = 1.5;                                     // [m/s]
   float q_stddev_y = 1.5;                                     // [m/s]
   float q_stddev_yaw = tier4_autoware_utils::deg2rad(20);     // [rad/s]

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -48,7 +48,7 @@ NormalVehicleTracker::NormalVehicleTracker(
   object_ = object;
 
   // initialize params
-  ekf_params_.use_measurement_covariance = false;
+  ekf_params_.use_measurement_covariance = true;
   float q_stddev_x = 1.0;                                     // object coordinate [m/s]
   float q_stddev_y = 1.0;                                     // object coordinate [m/s]
   float q_stddev_yaw = tier4_autoware_utils::deg2rad(20);     // map coordinate[rad/s]

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -48,7 +48,6 @@ NormalVehicleTracker::NormalVehicleTracker(
   object_ = object;
 
   // initialize params
-  ekf_params_.use_measurement_covariance = true;
   float q_stddev_x = 1.0;                                     // object coordinate [m/s]
   float q_stddev_y = 1.0;                                     // object coordinate [m/s]
   float q_stddev_yaw = tier4_autoware_utils::deg2rad(20);     // map coordinate[rad/s]
@@ -96,11 +95,7 @@ NormalVehicleTracker::NormalVehicleTracker(
 
   // initialize P matrix
   Eigen::MatrixXd P = Eigen::MatrixXd::Zero(ekf_params_.dim_x, ekf_params_.dim_x);
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW] == 0.0) {
+  if (!object.kinematics.has_position_covariance) {
     const double cos_yaw = std::cos(X(IDX::YAW));
     const double sin_yaw = std::sin(X(IDX::YAW));
     const double sin_2yaw = std::sin(2.0f * X(IDX::YAW));
@@ -283,11 +278,7 @@ bool NormalVehicleTracker::measureWithPose(
   C(2, IDX::YAW) = 1.0;  // for yaw
 
   /* Set measurement noise covariance */
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW] == 0.0) {
+  if (!object.kinematics.has_position_covariance) {
     const double cos_yaw = std::cos(measurement_yaw);
     const double sin_yaw = std::sin(measurement_yaw);
     const double sin_2yaw = std::sin(2.0f * measurement_yaw);
@@ -313,9 +304,7 @@ bool NormalVehicleTracker::measureWithPose(
     Y(IDX::VX, 0) = object.kinematics.twist_with_covariance.twist.linear.x;
     C(3, IDX::VX) = 1.0;  // for vx
 
-    if (
-      !ekf_params_.use_measurement_covariance ||
-      object.kinematics.twist_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0) {
+    if (!object.kinematics.has_twist_covariance) {
       R(3, 3) = ekf_params_.r_cov_vx;  // vx -vx
     } else {
       R(3, 3) = object.kinematics.twist_with_covariance.covariance[utils::MSG_COV_IDX::X_X];

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -50,7 +50,6 @@ PedestrianTracker::PedestrianTracker(
   object_ = object;
 
   // initialize params
-  ekf_params_.use_measurement_covariance = false;
   float q_stddev_x = 0.4;                                     // [m/s]
   float q_stddev_y = 0.4;                                     // [m/s]
   float q_stddev_yaw = tier4_autoware_utils::deg2rad(20);     // [rad/s]
@@ -95,11 +94,7 @@ PedestrianTracker::PedestrianTracker(
 
   // initialize P matrix
   Eigen::MatrixXd P = Eigen::MatrixXd::Zero(ekf_params_.dim_x, ekf_params_.dim_x);
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW] == 0.0) {
+  if (!object.kinematics.has_position_covariance) {
     const double cos_yaw = std::cos(X(IDX::YAW));
     const double sin_yaw = std::sin(X(IDX::YAW));
     const double sin_2yaw = std::sin(2.0f * X(IDX::YAW));
@@ -255,10 +250,7 @@ bool PedestrianTracker::measureWithPose(
 
   /* Set measurement noise covariance */
   Eigen::MatrixXd R = Eigen::MatrixXd::Zero(dim_y, dim_y);
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0) {
+  if (!object.kinematics.has_position_covariance) {
     R(0, 0) = ekf_params_.r_cov_x;  // x - x
     R(0, 1) = 0.0;                  // x - y
     R(1, 1) = ekf_params_.r_cov_y;  // y - y

--- a/perception/multi_object_tracker/src/tracker/model/unknown_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/unknown_tracker.cpp
@@ -42,7 +42,6 @@ UnknownTracker::UnknownTracker(
   object_ = object;
 
   // initialize params
-  ekf_params_.use_measurement_covariance = false;
   float q_stddev_x = 0.0;                                   // [m/s]
   float q_stddev_y = 0.0;                                   // [m/s]
   float q_stddev_vx = tier4_autoware_utils::kmph2mps(20);   // [m/(s*s)]
@@ -80,10 +79,7 @@ UnknownTracker::UnknownTracker(
 
   // initialize P matrix
   Eigen::MatrixXd P = Eigen::MatrixXd::Zero(ekf_params_.dim_x, ekf_params_.dim_x);
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0) {
+  if (!object.kinematics.has_position_covariance) {
     // Rotate the covariance matrix according to the vehicle yaw
     // because p0_cov_x and y are in the vehicle coordinate system.
     P(IDX::X, IDX::X) = ekf_params_.p0_cov_x;
@@ -193,10 +189,7 @@ bool UnknownTracker::measureWithPose(
 
   /* Set measurement noise covariance */
   Eigen::MatrixXd R = Eigen::MatrixXd::Zero(dim_y, dim_y);
-  if (
-    !ekf_params_.use_measurement_covariance ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X] == 0.0 ||
-    object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y] == 0.0) {
+  if (!object.kinematics.has_position_covariance) {
     R(0, 0) = ekf_params_.r_cov_x;  // x - x
     R(0, 1) = 0.0;                  // x - y
     R(1, 1) = ekf_params_.r_cov_y;  // y - y


### PR DESCRIPTION
Signed-off-by: scepter914 <scepter914@gmail.com>

## Description

Change ekf_params_.use_measurement_covariance to has_covariance.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Test by rosbag,

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
