### PR TITLE
revert: readability-identifier-naming for pose history

### DIFF
--- a/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp
@@ -95,7 +95,7 @@ void PoseHistory::processMessage(const geometry_msgs::msg::PoseStamped::ConstSha
   update_history();
 }
 
-void PoseHistory::update_history()
+void PoseHistory::updateHistory()
 {
   const auto buffer_size = static_cast<size_t>(property_buffer_size_->getInt());
   while (buffer_size < history_.size()) {
@@ -103,7 +103,7 @@ void PoseHistory::update_history()
   }
 }
 
-void PoseHistory::update_lines()
+void PoseHistory::updateLines()
 {
   Ogre::ColourValue color = rviz_common::properties::qtToOgre(property_line_color_->getColor());
   color.a = property_line_alpha_->getFloat();

--- a/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.cpp
@@ -62,7 +62,7 @@ void PoseHistory::update(float wall_dt, float ros_dt)
   if (!history_.empty()) {
     lines_->clear();
     if (property_line_view_->getBool()) {
-      update_lines();
+      updateLines();
     }
   }
 }
@@ -92,7 +92,7 @@ void PoseHistory::processMessage(const geometry_msgs::msg::PoseStamped::ConstSha
   history_.emplace_back(message);
   last_stamp_ = message->header.stamp;
 
-  update_history();
+  updateHistory();
 }
 
 void PoseHistory::updateHistory()

--- a/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.hpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history/pose_history_display.hpp
@@ -59,8 +59,8 @@ private:
   void subscribe() override;
   void unsubscribe() override;
   void processMessage(const geometry_msgs::msg::PoseStamped::ConstSharedPtr message) override;
-  void update_history();
-  void update_lines();
+  void updateHistory();
+  void updateLines();
 
   std::string target_frame_;
   std::deque<geometry_msgs::msg::PoseStamped::ConstSharedPtr> history_;


### PR DESCRIPTION
This reverts commit 9278e714bdbd29ca344976e9a2b26fdb93b41370 in #1608 . 

Signed-off-by: h-ohta <hiroki.ota@tier4.jp>

## Description

- revert readability-identifier-naming

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
