### PR TITLE
revert: readability-identifier-naming for datatime plugin

### DIFF
--- a/common/tier4_datetime_rviz_plugin/src/autoware_datetime_panel.cpp
+++ b/common/tier4_datetime_rviz_plugin/src/autoware_datetime_panel.cpp
@@ -22,7 +22,7 @@
 
 #include <ctime>
 
-void set_format_time(QLineEdit * line, double time)
+void setFormatTime(QLineEdit * line, double time)
 {
   char buffer[128];
   auto seconds = static_cast<time_t>(time);
@@ -57,9 +57,9 @@ void AutowareDateTimePanel::onInitialize()
 
 void AutowareDateTimePanel::update()
 {
-  set_format_time(
+  setFormatTime(
     ros_time_label_, rviz_ros_node_.lock()->get_raw_node()->get_clock()->now().seconds());
-  set_format_time(wall_time_label_, rclcpp::Clock().now().seconds());
+  setFormatTime(wall_time_label_, rclcpp::Clock().now().seconds());
 }
 
 #include <pluginlib/class_list_macros.hpp>


### PR DESCRIPTION
Signed-off-by: h-ohta <hiroki.ota@tier4.jp>

## Description

revert readability-identifier-naming in #1605 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
