### PR TITLE
fix(behavior_velocity): fixed missing initialization in merge_from_private module

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -64,6 +64,10 @@ MergeFromPrivateModuleManager::MergeFromPrivateModuleManager(rclcpp::Node & node
   mp.stop_duration_sec =
     node.declare_parameter(ns + ".merge_from_private_area.stop_duration_sec", 1.0);
   mp.detection_area_length = node.get_parameter("intersection.detection_area_length").as_double();
+  mp.detection_area_right_margin =
+    node.get_parameter("intersection.detection_area_right_margin").as_double();
+  mp.detection_area_left_margin =
+    node.get_parameter("intersection.detection_area_left_margin").as_double();
   mp.stop_line_margin = node.get_parameter("intersection.stop_line_margin").as_double();
 }
 


### PR DESCRIPTION
Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

Some of the parameters were not initialized in merge_from_private module.

## Tests performed

Checked if the specified parameters are used.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
