### PR TITLE
feat(obstacle_cruise_planner): add velocity_threshold to outside obstacle

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -50,6 +50,7 @@
       collision_time_margin : 8.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 
       outside_rough_detection_area_expand_width : 0.5 # rough lateral margin for rough detection area expansion for obstacles outside the trajectory [m]
+      outside_obstacle_min_velocity_threshold : 3.0 # minimum velocity threshold of obstacles outside the trajectory to cruise or stop [m/s]
       ego_obstacle_overlap_time_threshold : 1.0 #  time threshold to decide cut-in obstacle for cruise or stop [s]
       max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
 

--- a/planning/obstacle_cruise_planner/README.md
+++ b/planning/obstacle_cruise_planner/README.md
@@ -141,10 +141,11 @@ Near Cut-in vehicles are defined as vehicle objects
 
 In the `obstacle_filtering` namespace,
 
-| Parameter                                 | Type   | Description                                                     |
-| ----------------------------------------- | ------ | --------------------------------------------------------------- |
-| `ego_obstacle_overlap_time_threshold`     | double | time threshold to decide cut-in obstacle for cruise or stop [s] |
-| `max_prediction_time_for_collision_check` | double | prediction time to check collision between obstacle and ego [s] |
+| Parameter                                 | Type   | Description                                                              |
+| ----------------------------------------- | ------ | ------------------------------------------------------------------------ |
+| `ego_obstacle_overlap_time_threshold`     | double | time threshold to decide cut-in obstacle for cruise or stop [s]          |
+| `max_prediction_time_for_collision_check` | double | prediction time to check collision between obstacle and ego [s]          |
+| `outside_obstacle_min_velocity_threshold` | double | minimum velocity threshold of target obstacle for cut-in detection [m/s] |
 
 ### Stop planning
 

--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -50,6 +50,7 @@
       collision_time_margin : 8.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 
       outside_rough_detection_area_expand_width : 0.5 # rough lateral margin for rough detection area expansion for obstacles outside the trajectory [m]
+      outside_obstacle_min_velocity_threshold : 3.0 # minimum velocity threshold of obstacles outside the trajectory to cruise or stop [m/s]
       ego_obstacle_overlap_time_threshold : 1.0 #  time threshold to decide cut-in obstacle for cruise or stop [s]
       max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
 

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -177,6 +177,7 @@ private:
     double collision_time_margin;
     // outside
     double outside_rough_detection_area_expand_width;
+    double outside_obstacle_min_velocity_threshold;
     double ego_obstacle_overlap_time_threshold;
     double max_prediction_time_for_collision_check;
     double crossing_obstacle_traj_angle_threshold;

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -242,6 +242,8 @@ ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions &
       declare_parameter<double>("obstacle_filtering.collision_time_margin");
     obstacle_filtering_param_.outside_rough_detection_area_expand_width =
       declare_parameter<double>("obstacle_filtering.outside_rough_detection_area_expand_width");
+    obstacle_filtering_param_.outside_obstacle_min_velocity_threshold =
+      declare_parameter<double>("obstacle_filtering.outside_obstacle_min_velocity_threshold");
     obstacle_filtering_param_.ego_obstacle_overlap_time_threshold =
       declare_parameter<double>("obstacle_filtering.ego_obstacle_overlap_time_threshold");
     obstacle_filtering_param_.max_prediction_time_for_collision_check =
@@ -741,6 +743,16 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
         RCLCPP_INFO_EXPRESSION(
           get_logger(), is_showing_debug_info_,
           "Ignore outside obstacle (%s) since it is far from the trajectory.", object_id.c_str());
+        continue;
+      }
+
+      const double object_vel =
+        predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x;
+      if (
+        std::fabs(object_vel) < obstacle_filtering_param_.outside_obstacle_min_velocity_threshold) {
+        RCLCPP_INFO_EXPRESSION(
+          get_logger(), is_showing_debug_info_,
+          "Ignore outside obstacle (%s) since the obstacle velocity is low.", object_id.c_str());
         continue;
       }
 


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Related Links
https://github.com/tier4/autoware_launch/pull/447

## Description

Add min velocity threshold parameter for ignoring slow obstacles outside the trajectory.

This parameter is useful, for example, for filtering slow vehicles on non-priority opossite lanes.
https://user-images.githubusercontent.com/59680180/185863373-be2ec6c9-0146-4b1e-a3d0-fd9e79af74a0.mp4

Note that this parameter also slows down the cut-in response for low-speed vehicles.


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
