### PR TITLE
feat(behavior_velocity_planner): hold stop margin distance in stop line module

### DIFF
--- a/planning/behavior_velocity_planner/config/stop_line.param.yaml
+++ b/planning/behavior_velocity_planner/config/stop_line.param.yaml
@@ -2,8 +2,8 @@
   ros__parameters:
     stop_line:
       stop_margin: 0.0
-      stop_check_dist: 2.0
       stop_duration_sec: 1.0
+      hold_stop_margin_distance: 2.0
       use_initialization_stop_line_state: true
       debug:
         show_stopline_collision_check: false            # [-] whether to show stopline collision

--- a/planning/behavior_velocity_planner/include/scene_module/stop_line/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/stop_line/scene.hpp
@@ -15,6 +15,7 @@
 #ifndef SCENE_MODULE__STOP_LINE__SCENE_HPP_
 #define SCENE_MODULE__STOP_LINE__SCENE_HPP_
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -70,8 +71,8 @@ public:
   struct PlannerParam
   {
     double stop_margin;
-    double stop_check_dist;
     double stop_duration_sec;
+    double hold_stop_margin_distance;
     bool use_initialization_stop_line_state;
     bool show_stopline_collision_check;
   };
@@ -90,20 +91,9 @@ public:
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;
 
 private:
+  std::shared_ptr<const rclcpp::Time> stopped_time_;
+
   geometry_msgs::msg::Point getCenterOfStopLine(const lanelet::ConstLineString3d & stop_line);
-
-  boost::optional<StopLineModule::SegmentIndexWithOffset> findOffsetSegment(
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-    const StopLineModule::SegmentIndexWithPoint2d & collision);
-
-  boost::optional<StopLineModule::SegmentIndexWithPose> calcStopPose(
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-    const boost::optional<StopLineModule::SegmentIndexWithOffset> & offset_segment);
-
-  autoware_auto_planning_msgs::msg::PathWithLaneId insertStopPose(
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-    const StopLineModule::SegmentIndexWithPose & insert_index_with_pose,
-    tier4_planning_msgs::msg::StopReason * stop_reason);
 
   int64_t lane_id_;
 

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -103,7 +103,7 @@ visualization_msgs::msg::MarkerArray StopLineModule::createVirtualWallMarkerArra
   }
   const auto p_front = tier4_autoware_utils::calcOffsetPose(
     *debug_data_.stop_pose, debug_data_.base_link2front, 0.0, 0.0);
-  if (state_ == State::APPROACH) {
+  if (state_ == State::APPROACH || state_ == State::STOPPED) {
     appendMarkerArray(
       motion_utils::createStopVirtualWallMarker(p_front, "stopline", now, module_id_), &wall_marker,
       now);

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
@@ -29,7 +29,7 @@ StopLineModuleManager::StopLineModuleManager(rclcpp::Node & node)
   const std::string ns(getModuleName());
   auto & p = planner_param_;
   p.stop_margin = node.declare_parameter(ns + ".stop_margin", 0.0);
-  p.stop_check_dist = node.declare_parameter(ns + ".stop_check_dist", 2.0);
+  p.hold_stop_margin_distance = node.declare_parameter(ns + ".hold_stop_margin_distance", 2.0);
   p.stop_duration_sec = node.declare_parameter(ns + ".stop_duration_sec", 1.0);
   p.use_initialization_stop_line_state =
     node.declare_parameter(ns + ".use_initialization_stop_line_state", false);

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -74,13 +74,10 @@ bool StopLineModule::modifyPathVelocity(
    */
   const size_t stop_line_seg_idx = planning_utils::calcSegmentIndexFromPointIndex(
     path->points, stop_pose.position, stop_point_idx);
-  const double stop_line_margin = base_link2front + planner_param_.stop_margin;
   const size_t current_seg_idx = findEgoSegmentIndex(path->points);
-  const double signed_arc_dist_to_stop_point =
-    motion_utils::calcSignedArcLength(
-      path->points, planner_data_->current_pose.pose.position, current_seg_idx, stop_pose.position,
-      stop_line_seg_idx) -
-    stop_line_margin;
+  const double signed_arc_dist_to_stop_point = motion_utils::calcSignedArcLength(
+    path->points, planner_data_->current_pose.pose.position, current_seg_idx, stop_pose.position,
+    stop_line_seg_idx);
   switch (state_) {
     case State::APPROACH: {
       // Insert stop pose
@@ -127,8 +124,7 @@ bool StopLineModule::modifyPathVelocity(
 
       SegmentIndexWithPose ego_pos_on_path;
       ego_pos_on_path.pose = stopped_pose.get();
-      ego_pos_on_path.index = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
-        path->points, stopped_pose.get());
+      ego_pos_on_path.index = findEgoSegmentIndex(path->points);
 
       // Insert stop pose
       planning_utils::insertStopPoint(ego_pos_on_path.pose.position, ego_pos_on_path.index, *path);

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -81,46 +81,88 @@ bool StopLineModule::modifyPathVelocity(
       path->points, planner_data_->current_pose.pose.position, current_seg_idx, stop_pose.position,
       stop_line_seg_idx) -
     stop_line_margin;
-  if (state_ == State::APPROACH) {
-    // Insert stop pose
-    planning_utils::insertStopPoint(stop_pose.position, stop_line_seg_idx, *path);
+  switch (state_) {
+    case State::APPROACH: {
+      // Insert stop pose
+      planning_utils::insertStopPoint(stop_pose.position, stop_line_seg_idx, *path);
 
-    // Update first stop index
-    first_stop_path_point_index_ = static_cast<int>(stop_point_idx);
-    debug_data_.stop_pose = stop_pose;
+      // Update first stop index
+      first_stop_path_point_index_ = static_cast<int>(stop_point_idx);
+      debug_data_.stop_pose = stop_pose;
 
-    // Get stop point and stop factor
-    {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = stop_pose;
-      stop_factor.stop_factor_points.push_back(getCenterOfStopLine(stop_line_));
-      planning_utils::appendStopReason(stop_factor, stop_reason);
-    }
-
-    // Move to stopped state if stopped
-    if (
-      signed_arc_dist_to_stop_point < planner_param_.stop_check_dist &&
-      planner_data_->isVehicleStopped(planner_param_.stop_duration_sec)) {
-      RCLCPP_INFO(logger_, "APPROACH -> STOPPED");
-      state_ = State::STOPPED;
-      if (signed_arc_dist_to_stop_point < -planner_param_.stop_check_dist) {
-        RCLCPP_ERROR(
-          logger_, "Failed to stop near stop line but ego stopped. Change state to STOPPED");
+      // Get stop point and stop factor
+      {
+        tier4_planning_msgs::msg::StopFactor stop_factor;
+        stop_factor.stop_pose = stop_pose;
+        stop_factor.stop_factor_points.push_back(getCenterOfStopLine(stop_line_));
+        planning_utils::appendStopReason(stop_factor, stop_reason);
       }
-    }
-  } else if (state_ == State::STOPPED) {
-    // Change state after vehicle departure
-    if (!planner_data_->isVehicleStopped()) {
-      RCLCPP_INFO(logger_, "STOPPED -> START");
-      state_ = State::START;
-    }
-  } else if (state_ == State::START) {
-    // Initialize if vehicle is far from stop_line
-    if (planner_param_.use_initialization_stop_line_state) {
-      if (signed_arc_dist_to_stop_point > planner_param_.stop_check_dist) {
-        RCLCPP_INFO(logger_, "START -> APPROACH");
-        state_ = State::APPROACH;
+
+      // Move to stopped state if stopped
+      if (
+        signed_arc_dist_to_stop_point < planner_param_.hold_stop_margin_distance &&
+        planner_data_->isVehicleStopped()) {
+        RCLCPP_INFO(logger_, "APPROACH -> STOPPED");
+
+        state_ = State::STOPPED;
+        stopped_time_ = std::make_shared<const rclcpp::Time>(clock_->now());
+
+        if (signed_arc_dist_to_stop_point < -planner_param_.hold_stop_margin_distance) {
+          RCLCPP_ERROR(
+            logger_, "Failed to stop near stop line but ego stopped. Change state to STOPPED");
+        }
       }
+
+      break;
+    }
+
+    case State::STOPPED: {
+      // Change state after vehicle departure
+      const auto stopped_pose = motion_utils::calcLongitudinalOffsetPose(
+        path->points, planner_data_->current_pose.pose.position, 0.0);
+
+      if (!stopped_pose) {
+        break;
+      }
+
+      SegmentIndexWithPose ego_pos_on_path;
+      ego_pos_on_path.pose = stopped_pose.get();
+      ego_pos_on_path.index = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+        path->points, stopped_pose.get());
+
+      // Insert stop pose
+      planning_utils::insertStopPoint(ego_pos_on_path.pose.position, ego_pos_on_path.index, *path);
+
+      debug_data_.stop_pose = stop_pose;
+
+      // Get stop point and stop factor
+      {
+        tier4_planning_msgs::msg::StopFactor stop_factor;
+        stop_factor.stop_pose = ego_pos_on_path.pose;
+        stop_factor.stop_factor_points.push_back(getCenterOfStopLine(stop_line_));
+        planning_utils::appendStopReason(stop_factor, stop_reason);
+      }
+
+      const auto elapsed_time = (clock_->now() - *stopped_time_).seconds();
+
+      if (planner_param_.stop_duration_sec < elapsed_time) {
+        RCLCPP_INFO(logger_, "STOPPED -> START");
+        state_ = State::START;
+      }
+
+      break;
+    }
+
+    case State::START: {
+      // Initialize if vehicle is far from stop_line
+      if (planner_param_.use_initialization_stop_line_state) {
+        if (signed_arc_dist_to_stop_point > planner_param_.hold_stop_margin_distance) {
+          RCLCPP_INFO(logger_, "START -> APPROACH");
+          state_ = State::APPROACH;
+        }
+      }
+
+      break;
     }
   }
 


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

This PR is resubmission of #1433. (#1433 has been reverted in #1645)

Please see https://github.com/autowarefoundation/autoware.universe/pull/1433 description.

test perform (`stop_duration_sec`= 5.0[s], `hold_stop_margin_distance`= 2.0[m])

https://user-images.githubusercontent.com/44889564/185872691-8702b22c-2674-467f-9ba7-253809cf2ec3.mp4

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
