### PR TITLE
feat(pure_pursuit): add maximum steering angle limit

### DIFF
--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -60,6 +60,7 @@ struct Param
 {
   // Global Parameters
   double wheel_base;
+  double max_steering_angle;  // [rad]
 
   // Algorithm Parameters
   double lookahead_distance_ratio;

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -61,6 +61,7 @@ PurePursuitLateralController::PurePursuitLateralController(rclcpp::Node & node)
   // Vehicle Parameters
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo();
   param_.wheel_base = vehicle_info.wheel_base_m;
+  param_.max_steering_angle = vehicle_info.max_steer_angle_rad;
 
   // Algorithm Parameters
   param_.lookahead_distance_ratio =
@@ -137,10 +138,16 @@ boost::optional<LateralOutput> PurePursuitLateralController::run()
 AckermannLateralCommand PurePursuitLateralController::generateCtrlCmdMsg(
   const double target_curvature)
 {
+  const double tmp_steering = planning_utils::convertCurvatureToSteeringAngle(
+    param_.wheel_base,
+    target_curvature);
   AckermannLateralCommand cmd;
   cmd.stamp = node_->get_clock()->now();
   cmd.steering_tire_angle =
-    planning_utils::convertCurvatureToSteeringAngle(param_.wheel_base, target_curvature);
+    static_cast<float>(std::min(
+      std::max(tmp_steering, -param_.max_steering_angle),
+      param_.max_steering_angle));
+
   // pub_ctrl_cmd_->publish(cmd);
   return cmd;
 }

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -138,15 +138,12 @@ boost::optional<LateralOutput> PurePursuitLateralController::run()
 AckermannLateralCommand PurePursuitLateralController::generateCtrlCmdMsg(
   const double target_curvature)
 {
-  const double tmp_steering = planning_utils::convertCurvatureToSteeringAngle(
-    param_.wheel_base,
-    target_curvature);
+  const double tmp_steering =
+    planning_utils::convertCurvatureToSteeringAngle(param_.wheel_base, target_curvature);
   AckermannLateralCommand cmd;
   cmd.stamp = node_->get_clock()->now();
-  cmd.steering_tire_angle =
-    static_cast<float>(std::min(
-      std::max(tmp_steering, -param_.max_steering_angle),
-      param_.max_steering_angle));
+  cmd.steering_tire_angle = static_cast<float>(
+    std::min(std::max(tmp_steering, -param_.max_steering_angle), param_.max_steering_angle));
 
   // pub_ctrl_cmd_->publish(cmd);
   return cmd;


### PR DESCRIPTION
Signed-off-by: Berkay Karaman <berkay@leodrive.ai>

## Description

<!-- Write a brief description of this PR. -->

In current implementation of `pure_pursuit` controller does not check the maximum steering while calculating control command. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
