### PR TITLE
fix(tier4_perception_launch): remove duplicated namespace of clustering in camera-lidar-fusion mode

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -132,9 +132,9 @@
 
       <group>
         <include file="$(find-pkg-share object_range_splitter)/launch/object_range_splitter.launch.xml">
-          <arg name="input/object" value="camera_lidar_fusion/objects"/>
-          <arg name="output/long_range_object" value="camera_lidar_fusion/long_range_objects"/>
-          <arg name="output/short_range_object" value="camera_lidar_fusion/short_range_objects"/>
+          <arg name="input/object" value="objects"/>
+          <arg name="output/long_range_object" value="long_range_objects"/>
+          <arg name="output/short_range_object" value="short_range_objects"/>
           <arg name="split_range" value="30.0"/>
         </include>
       </group>


### PR DESCRIPTION
Signed-off-by: yukke42 <yusuke.muramatsu@tier4.jp>

## Description

Remove the duplicated name space of `camera_lidar_fusion` in object_range_splitter.

## Related links

https://github.com/tier4/autoware_launch/pull/449
<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
