### PR TITLE
ci(build-and-test-differential): disable no-cuda test

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -51,7 +51,6 @@
         sd -- \
         "       include:" \
         "       container-suffix:
-                  - \"\"
                   - -cuda
                 include:" {source}
 
@@ -66,7 +65,6 @@
         sd -- \
         "       include:" \
         "       container-suffix:
-                  - \"\"
                   - -cuda
                 include:" {source}
     - source: .github/workflows/build-and-test-self-hosted.yaml

--- a/.github/workflows/build-and-test-differential-self-hosted.yaml
+++ b/.github/workflows/build-and-test-differential-self-hosted.yaml
@@ -26,7 +26,6 @@ jobs:
           - galactic
           - humble
         container-suffix:
-          - ""
           - -cuda
         include:
           - rosdistro: galactic

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -14,7 +14,6 @@ jobs:
           - galactic
           - humble
         container-suffix:
-          - ""
           - -cuda
         include:
           - rosdistro: galactic


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Due to the number of CI jobs introduced by https://github.com/autowarefoundation/autoware.universe/pull/1307, many jobs are jammed now. :cry: 
![image](https://user-images.githubusercontent.com/31987104/186084305-73adf116-5449-49d1-8830-5a726d22f6da.png)

To resolve the jam, I'd like to disable no-cuda test for the differential build.

Even though it disables checks for open PRs, it's still tested daily, and tested after a PR is merged.
Also, if necessary, you can trigger a full-build test whenever you like using `workflow_dispatch`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
