### PR TITLE
feat(obstacle_avoidance_planne): enable plan_from_ego by default

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -58,7 +58,7 @@
       option:
         steer_limit_constraint: true
         fix_points_around_ego: true
-        plan_from_ego: false
+        plan_from_ego: true
         max_plan_from_ego_length: 10.0
         visualize_sampling_num: 1
         enable_manual_warm_start: true

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -58,7 +58,7 @@
       option:
         steer_limit_constraint: true
         fix_points_around_ego: true
-        plan_from_ego: false
+        plan_from_ego: true
         max_plan_from_ego_length: 10.0
         visualize_sampling_num: 1
         enable_manual_warm_start: true

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -127,7 +127,7 @@ struct ReferencePoint
   //       one is fixing points around ego for stability
   //       second is fixing current ego pose when no velocity for planning from ego pose
   boost::optional<Eigen::Vector2d> fix_kinematic_state = boost::none;
-  bool plan_from_ego = false;
+  bool plan_from_ego = true;
   Eigen::Vector2d optimized_kinematic_state;
   double optimized_input;
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

enable keeping steer control until converged by default for checking pull_over geometric parking in scenario tests.



If the path length is within 10m(max_plan_from_ego_length) after stopping (5m before the basic ego is guaranteed, so 5m from ego to the goal), the path is planned from ego.
If plan_from_ego is set to true, there was a problem that the optimization could not be solved if the path was long when the vehicle stopped, but this time, it is limited to short paths (it is assumed that there are almost no cases that satisfy the condition except for pull_over, pull_out, free_space_planner). So far, we have not encountered any cases where the optimization is not solvable under these conditions.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
