### PR TITLE
fix: blindspot insert zero index

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -318,8 +318,8 @@ int BlindSpotModule::insertPoint(
   }
   int insert_idx = -1;
   // initialize with epsilon so that comparison with insert_point_s = 0.0 would work
-  constexpr double eps = 1e-4;
-  double accum_s = eps * 2.0;
+  constexpr double eps = 1e-2;
+  double accum_s = eps + std::numeric_limits<double>::epsilon();
   for (size_t i = 1; i < inout_path->points.size(); i++) {
     accum_s += tier4_autoware_utils::calcDistance2d(
       inout_path->points[i].point.pose.position, inout_path->points[i - 1].point.pose.position);
@@ -342,6 +342,14 @@ int BlindSpotModule::insertPoint(
       inout_path->points.at(insert_idx).point.longitudinal_velocity_mps = 0.0;
       is_point_inserted = false;
       return insert_idx;
+    } else if (
+      insert_idx != 0 &&
+      tier4_autoware_utils::calcDistance2d(
+        inserted_point, inout_path->points.at(static_cast<size_t>(insert_idx - 1)).point) <
+        min_dist) {
+      inout_path->points.at(insert_idx - 1).point.longitudinal_velocity_mps = 0.0;
+      insert_idx--;
+      is_point_inserted = false;
     }
     inout_path->points.insert(it, inserted_point);
     is_point_inserted = true;

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -350,6 +350,7 @@ int BlindSpotModule::insertPoint(
       inout_path->points.at(insert_idx - 1).point.longitudinal_velocity_mps = 0.0;
       insert_idx--;
       is_point_inserted = false;
+      return insert_idx;
     }
     inout_path->points.insert(it, inserted_point);
     is_point_inserted = true;


### PR DESCRIPTION
## Description

fix blindspot insert duplicate stop point at index zero
note : this is only for hotfix

review procedure
to check this case works fine without dying
![image](https://user-images.githubusercontent.com/65527974/186346288-5d6cc8ea-b55a-420f-b1ee-d15c72f93fd1.png)
![image](https://user-images.githubusercontent.com/65527974/186346722-9849f547-16e5-4048-870e-bb5860f35de3.png)

TODO
- remove this insert point original functions after merging this change
-  replace blindspot util to motion utils

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
