### PR TITLE
feat(behavior_velocity_planner): generate stop line if private path conflicts with urban lane

### DIFF
--- a/planning/behavior_velocity_planner/merge-from-private-design.md
+++ b/planning/behavior_velocity_planner/merge-from-private-design.md
@@ -4,7 +4,7 @@
 
 When an ego vehicle enters a public road from a private road (e.g. a parking lot), it needs to face and stop before entering the public road to make sure it is safe.
 
-This module is activated when there is an intersection at the location where the vehicle enters the public road from the private road. The basic behavior is the same as the intersection module, but the ego vehicle must stop once at the stop line.
+This module is activated when there is an intersection at the private area from which the vehicle enters the public road. The stop line is generated both when the goal is in the intersection lane and when the path goes beyond the intersection lane. The basic behavior is the same as the intersection module, but the ego vehicle must stop once at the stop line.
 
 ![merge-from-private](docs/intersection/merge_from_private.png)
 


### PR DESCRIPTION
activate merge_from_private if the goal is in private path and the lane is conflicting with urban lane

Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

Previously `merge_from_private` module worked if (1) the lane is intersection lane (2) if the lane is private lane (3) if the next lane on the path is urban lane. This PR relax condition (3) and generate stop line even if the goal is in private path, if the lane conflicts with urban lane.

## Tests performed

In the left image merge_from_private stop line is not generated, and in the right one it is generated
![Screenshot from 2022-08-24 16-06-00](https://user-images.githubusercontent.com/28677420/186353222-93808c05-24d0-4ede-9e51-f222139824a5.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
