### PR TITLE
fix(behavior_velocity_planenr): add header on debug path msgs

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
@@ -209,6 +209,7 @@ protected:
     pub_debug_->publish(debug_marker_array);
     if (is_publish_debug_path_) {
       autoware_auto_planning_msgs::msg::PathWithLaneId debug_path;
+      debug_path.header = path->header;
       debug_path.points = path->points;
       pub_debug_path_->publish(debug_path);
     }


### PR DESCRIPTION
## Description

Without header, we can't visualize the debug paths on Rviz.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
