### PR TITLE
fix(behavior_path_planner): reset candidate uuid when activated

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2255,6 +2255,7 @@ void AvoidanceModule::addShiftPointIfApproved(const AvoidPointArray & shift_poin
 
     uuid_left_ = generateUUID();
     uuid_right_ = generateUUID();
+    candidate_uuid_ = generateUUID();
 
     DEBUG_PRINT("shift_point size: %lu -> %lu", prev_size, path_shifter_.getShiftPointsSize());
   } else {


### PR DESCRIPTION
## Description

Sometimes, the rtc status which is already activated is removed by removeCandidateRTCStatus()
I fixed it.
https://user-images.githubusercontent.com/59680180/186399892-d9af6e3b-9d77-4e5f-8423-40f68b19b68d.mp4



<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
