### PR TITLE
fix(behavior_path_planner): remove waitForData() in constructor

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -93,7 +93,7 @@ private:
   std::mutex mutex_bt_;  // mutex for bt_manager_
 
   // setup
-  void waitForData();
+  bool isDataReady();
 
   // parameters
   BehaviorPathPlannerParameters getCommonParam();

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -148,9 +148,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       planner_data_->parameters.base_link2front, intersection_search_distance);
   }
 
-  waitForData();
-
-  // Start timer. This must be done after all data (e.g. vehicle pose, velocity) are ready.
+  // Start timer
   {
     const auto planning_hz = declare_parameter("planning_hz", 10.0);
     const auto period_ns = rclcpp::Rate(planning_hz).period();
@@ -495,46 +493,36 @@ BehaviorTreeManagerParam BehaviorPathPlannerNode::getBehaviorTreeManagerParam()
   return p;
 }
 
-void BehaviorPathPlannerNode::waitForData()
+// wait until mandatory data is ready
+bool BehaviorPathPlannerNode::isDataReady()
 {
-  // wait until mandatory data is ready
-  while (!current_scenario_ && rclcpp::ok()) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000, "waiting for scenario topic");
-    rclcpp::spin_some(this->get_node_base_interface());
-    rclcpp::Rate(100).sleep();
-  }
+  if (!current_scenario_) return false;
 
   mutex_pd_.lock();  // for planner_data_
-  while (!planner_data_->route_handler->isHandlerReady() && rclcpp::ok()) {
+  if (
+    !planner_data_->route_handler->isHandlerReady() || !planner_data_->dynamic_object ||
+    !planner_data_->self_odometry) {
     mutex_pd_.unlock();
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
-      get_logger(), *get_clock(), 5000, "waiting for route to be ready");
-    rclcpp::spin_some(this->get_node_base_interface());
-    rclcpp::Rate(100).sleep();
-    mutex_pd_.lock();
+    return false;
   }
 
-  while (rclcpp::ok()) {
-    if (planner_data_->dynamic_object && planner_data_->self_odometry) {
-      break;
-    }
-
-    mutex_pd_.unlock();
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
-      get_logger(), *get_clock(), 5000,
-      "waiting for vehicle pose, vehicle_velocity, and obstacles");
-    rclcpp::spin_some(this->get_node_base_interface());
-    rclcpp::Rate(100).sleep();
-    mutex_pd_.lock();
-  }
-
-  self_pose_listener_.waitForFirstPose();
   planner_data_->self_pose = self_pose_listener_.getCurrentPose();
+  if (!planner_data_->self_pose) {
+    mutex_pd_.unlock();
+    return false;
+  }
+
   mutex_pd_.unlock();
+  return true;
 }
 
 void BehaviorPathPlannerNode::run()
 {
+  if (!isDataReady()) {
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000, "waiting data...");
+    return;
+  }
+
   RCLCPP_DEBUG(get_logger(), "----- BehaviorPathPlannerNode start -----");
   mutex_bt_.lock();  // for bt_manager_
   mutex_pd_.lock();  // for planner_data_


### PR DESCRIPTION
## Description

Remove `waitForData()` in the constructor since it disturbs other nodes in the same component to launch.
Add `isDataReady()` instead at the beginning of the timer callback process.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

- run psim and check if there is no degradation.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
