### PR TITLE
chore(motion_velocity_smoother): disable debug publish in smoother by default

### DIFF
--- a/planning/motion_velocity_smoother/launch/motion_velocity_smoother.launch.xml
+++ b/planning/motion_velocity_smoother/launch/motion_velocity_smoother.launch.xml
@@ -7,7 +7,7 @@
   <arg name="output_trajectory" default="/planning/scenario_planning/trajectory"/>
 
   <!-- debug flags -->
-  <arg name="publish_debug_trajs" default="true"/>
+  <arg name="publish_debug_trajs" default="false"/>
   <arg name="smoother_type" default="JerkFiltered"/>
   <!-- Analytical, JerkFiltered, L2, or Linf -->
 


### PR DESCRIPTION


## Description

Disable to publish debug topics in the smoother since they are too heavy.

When I tested in Kashiwanoha, the size of `ros2 bag record -a` decreased from 3.1G to 2.0G.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
