### PR TITLE
feat(behavior_path_planner): add closest stop point to resampled points

### DIFF
--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -89,9 +89,9 @@ PathWithLaneId resamplePathWithSpline(const PathWithLaneId & path, double interv
     return path;
   }
 
-  std::vector<geometry_msgs::msg::Pose> transformed_path(path.points.size());
+  std::vector<autoware_auto_planning_msgs::msg::PathPoint> transformed_path(path.points.size());
   for (size_t i = 0; i < path.points.size(); ++i) {
-    transformed_path.at(i) = path.points.at(i).point.pose;
+    transformed_path.at(i) = path.points.at(i).point;
   }
 
   constexpr double epsilon = 0.01;
@@ -126,8 +126,16 @@ PathWithLaneId resamplePathWithSpline(const PathWithLaneId & path, double interv
       s_out.push_back(s);
     }
   }
+
+  // Insert Terminal Point
   if (!has_almost_same_value(s_out, path_len)) {
     s_out.push_back(path_len);
+  }
+
+  // Insert Stop Point
+  const auto closest_stop_dist = motion_utils::calcDistanceToForwardStopPoint(transformed_path);
+  if (closest_stop_dist && !has_almost_same_value(s_out, *closest_stop_dist)) {
+    s_out.push_back(*closest_stop_dist);
   }
 
   std::sort(s_out.begin(), s_out.end());


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description

Add closest stop point to the resampled point.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
