### PR TITLE
fix(radar_fusion_to_detected_object): make has_twist_covariance enable

### DIFF
--- a/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object.hpp
+++ b/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object.hpp
@@ -105,6 +105,7 @@ private:
   bool isYawCorrect(
     const DetectedObject & object, const TwistWithCovariance & twist_with_covariance,
     const double & yaw_threshold);
+  bool hasTwistCovariance(const TwistWithCovariance & twist_with_covariance);
   Eigen::Vector2d toVector2d(const TwistWithCovariance & twist_with_covariance);
   TwistWithCovariance toTwistWithCovariance(const Eigen::Vector2d & vector2d);
 

--- a/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object.hpp
+++ b/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object.hpp
@@ -42,6 +42,45 @@ using geometry_msgs::msg::TwistWithCovariance;
 using tier4_autoware_utils::LinearRing2d;
 using tier4_autoware_utils::Point2d;
 
+enum MSG_COV_IDX {
+  X_X = 0,
+  X_Y = 1,
+  X_Z = 2,
+  X_ROLL = 3,
+  X_PITCH = 4,
+  X_YAW = 5,
+  Y_X = 6,
+  Y_Y = 7,
+  Y_Z = 8,
+  Y_ROLL = 9,
+  Y_PITCH = 10,
+  Y_YAW = 11,
+  Z_X = 12,
+  Z_Y = 13,
+  Z_Z = 14,
+  Z_ROLL = 15,
+  Z_PITCH = 16,
+  Z_YAW = 17,
+  ROLL_X = 18,
+  ROLL_Y = 19,
+  ROLL_Z = 20,
+  ROLL_ROLL = 21,
+  ROLL_PITCH = 22,
+  ROLL_YAW = 23,
+  PITCH_X = 24,
+  PITCH_Y = 25,
+  PITCH_Z = 26,
+  PITCH_ROLL = 27,
+  PITCH_PITCH = 28,
+  PITCH_YAW = 29,
+  YAW_X = 30,
+  YAW_Y = 31,
+  YAW_Z = 32,
+  YAW_ROLL = 33,
+  YAW_PITCH = 34,
+  YAW_YAW = 35
+};
+
 class RadarFusionToDetectedObject
 {
 public:

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -107,7 +107,9 @@ RadarFusionToDetectedObject::Output RadarFusionToDetectedObject::update(
         if (isYawCorrect(split_object, twist_with_covariance, param_.threshold_yaw_diff)) {
           split_object.kinematics.twist_with_covariance = twist_with_covariance;
           split_object.kinematics.has_twist = true;
-          split_object.kinematics.has_twist_covariance = true;
+          if (hasTwistCovariance(twist_with_covariance)) {
+            split_object.kinematics.has_twist_covariance = true;
+          }
         }
       }
 
@@ -120,6 +122,18 @@ RadarFusionToDetectedObject::Output RadarFusionToDetectedObject::update(
     }
   }
   return output;
+}
+
+// Judge whether twist covariance is available.
+bool RadarFusionToDetectedObject::hasTwistCovariance(
+  const TwistWithCovariance & twist_with_covariance)
+{
+  auto covariance = twist_with_covariance.covariance;
+  if (covariance.at(0) == 0.0 && covariance.at(7) == 0.0 && covariance.at(14) == 0.0) {
+    return false;
+  } else {
+    return true;
+  }
 }
 
 // Judge whether object's yaw is same direction with twist's yaw.

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -129,7 +129,7 @@ bool RadarFusionToDetectedObject::hasTwistCovariance(
   const TwistWithCovariance & twist_with_covariance)
 {
   auto covariance = twist_with_covariance.covariance;
-  if (covariance.at(0) == 0.0 && covariance.at(7) == 0.0 && covariance.at(14) == 0.0) {
+  if (covariance[X_X] == 0.0 && covariance[Y_Y] == 0.0 && covariance[Z_Z] == 0.0) {
     return false;
   } else {
     return true;

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -107,6 +107,7 @@ RadarFusionToDetectedObject::Output RadarFusionToDetectedObject::update(
         if (isYawCorrect(split_object, twist_with_covariance, param_.threshold_yaw_diff)) {
           split_object.kinematics.twist_with_covariance = twist_with_covariance;
           split_object.kinematics.has_twist = true;
+          split_object.kinematics.has_twist_covariance = true;
         }
       }
 


### PR DESCRIPTION
## Description

Add `object.kinematics.has_twist_covariance = true;` in `radar_fusion_to_detected_object` package

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
