### PR TITLE
feat(obstacle_cruise_planner): fix collision points

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -93,8 +93,7 @@ private:
   double calcCollisionTimeMargin(
     const geometry_msgs::msg::Pose & current_pose, const double current_vel,
     const std::vector<geometry_msgs::msg::PointStamped> & collision_points,
-    const PredictedObject & predicted_object,
-    const Trajectory & decimated_traj,
+    const PredictedObject & predicted_object, const Trajectory & decimated_traj,
     const bool is_driving_forward);
   void publishVelocityLimit(const boost::optional<VelocityLimit> & vel_limit);
   void publishDebugData(const DebugData & debug_data) const;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -92,10 +92,9 @@ private:
     const Trajectory & traj, std::vector<TargetObstacle> & target_obstacles);
   double calcCollisionTimeMargin(
     const geometry_msgs::msg::Pose & current_pose, const double current_vel,
-    const geometry_msgs::msg::Point & nearest_collision_point,
-    const PredictedObject & predicted_object, const size_t first_within_idx,
+    const std::vector<geometry_msgs::msg::PointStamped> & collision_points,
+    const PredictedObject & predicted_object,
     const Trajectory & decimated_traj,
-    const std::vector<tier4_autoware_utils::Polygon2d> & decimated_traj_polygons,
     const bool is_driving_forward);
   void publishVelocityLimit(const boost::optional<VelocityLimit> & vel_limit);
   void publishDebugData(const DebugData & debug_data) const;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -90,10 +90,6 @@ private:
   void checkConsistency(
     const rclcpp::Time & current_time, const PredictedObjects & predicted_objects,
     const Trajectory & traj, std::vector<TargetObstacle> & target_obstacles);
-  std::vector<geometry_msgs::msg::PointStamped> calcNearestCollisionPoint(
-    const size_t & first_within_idx,
-    const std::vector<geometry_msgs::msg::PointStamped> & collision_points,
-    const Trajectory & decimated_traj, const bool is_driving_forward);
   double calcCollisionTimeMargin(
     const geometry_msgs::msg::Pose & current_pose, const double current_vel,
     const geometry_msgs::msg::Point & nearest_collision_point,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -34,15 +34,22 @@ namespace bg = boost::geometry;
 using tier4_autoware_utils::Point2d;
 using tier4_autoware_utils::Polygon2d;
 
-boost::optional<size_t> getFirstCollisionIndex(
-  const std::vector<Polygon2d> & traj_polygons, const Polygon2d & obj_polygon,
-  const std_msgs::msg::Header & obj_header,
+boost::optional<size_t> getCollisionIndex(
+  const std::vector<Polygon2d> & traj_polygons, const geometry_msgs::msg::PoseStamped & obj_pose,
+  const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::PointStamped> & collision_points);
 
 boost::optional<size_t> getFirstNonCollisionIndex(
   const std::vector<Polygon2d> & base_polygons,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const autoware_auto_perception_msgs::msg::Shape & shape, const size_t start_idx);
+
+std::vector<geometry_msgs::msg::PointStamped> getCollisionPoints(
+  const autoware_auto_planning_msgs::msg::Trajectory & traj,
+  const std::vector<Polygon2d> & traj_polygons, const std_msgs::msg::Header & obj_header,
+  const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
+  const autoware_auto_perception_msgs::msg::Shape & shape, const rclcpp::Time & current_time,
+  const double vehicle_max_longitudinal_offset, const bool is_driving_forward);
 
 boost::optional<size_t> willCollideWithSurroundObstacle(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,
@@ -56,6 +63,12 @@ boost::optional<size_t> willCollideWithSurroundObstacle(
 std::vector<Polygon2d> createOneStepPolygons(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,
   const vehicle_info_util::VehicleInfo & vehicle_info, const double expand_width);
+
+geometry_msgs::msg::PointStamped calcNearestCollisionPoint(
+  const size_t & first_within_idx,
+  const std::vector<geometry_msgs::msg::PointStamped> & collision_points,
+  const autoware_auto_planning_msgs::msg::Trajectory & decimated_traj,
+  const double vehicle_max_longitudinal_offset, const bool is_driving_forward);
 }  // namespace polygon_utils
 
 #endif  // OBSTACLE_CRUISE_PLANNER__POLYGON_UTILS_HPP_

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -26,6 +26,7 @@
 #include <boost/geometry.hpp>
 #include <boost/optional.hpp>
 
+#include <limits>
 #include <vector>
 
 namespace polygon_utils

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -35,30 +35,30 @@ using tier4_autoware_utils::Point2d;
 using tier4_autoware_utils::Polygon2d;
 
 boost::optional<size_t> getCollisionIndex(
+  const autoware_auto_planning_msgs::msg::Trajectory & traj,
   const std::vector<Polygon2d> & traj_polygons, const geometry_msgs::msg::PoseStamped & obj_pose,
   const autoware_auto_perception_msgs::msg::Shape & shape,
-  std::vector<geometry_msgs::msg::PointStamped> & collision_points);
-
-boost::optional<size_t> getFirstNonCollisionIndex(
-  const std::vector<Polygon2d> & base_polygons,
-  const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
-  const autoware_auto_perception_msgs::msg::Shape & shape, const size_t start_idx);
+  std::vector<geometry_msgs::msg::PointStamped> & collision_points,
+  const double max_dist = std::numeric_limits<double>::max());
 
 std::vector<geometry_msgs::msg::PointStamped> getCollisionPoints(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,
   const std::vector<Polygon2d> & traj_polygons, const std_msgs::msg::Header & obj_header,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const autoware_auto_perception_msgs::msg::Shape & shape, const rclcpp::Time & current_time,
-  const double vehicle_max_longitudinal_offset, const bool is_driving_forward);
+  const double vehicle_max_longitudinal_offset, const bool is_driving_forward,
+  const double max_dist = std::numeric_limits<double>::max(),
+  const double max_prediction_time_for_collision_check = std::numeric_limits<double>::max());
 
-boost::optional<size_t> willCollideWithSurroundObstacle(
+std::vector<geometry_msgs::msg::PointStamped> willCollideWithSurroundObstacle(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,
   const std::vector<Polygon2d> & traj_polygons, const std_msgs::msg::Header & obj_header,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
-  const autoware_auto_perception_msgs::msg::Shape & shape, const double max_dist,
+  const autoware_auto_perception_msgs::msg::Shape & shape, const rclcpp::Time & current_time,
+  const double max_dist,
   const double ego_obstacle_overlap_time_threshold,
   const double max_prediction_time_for_collision_check,
-  std::vector<geometry_msgs::msg::PointStamped> & collision_geom_points);
+  const double vehicle_max_longitudinal_offset, const bool is_driving_forward);
 
 std::vector<Polygon2d> createOneStepPolygons(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/polygon_utils.hpp
@@ -55,8 +55,7 @@ std::vector<geometry_msgs::msg::PointStamped> willCollideWithSurroundObstacle(
   const std::vector<Polygon2d> & traj_polygons, const std_msgs::msg::Header & obj_header,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const autoware_auto_perception_msgs::msg::Shape & shape, const rclcpp::Time & current_time,
-  const double max_dist,
-  const double ego_obstacle_overlap_time_threshold,
+  const double max_dist, const double ego_obstacle_overlap_time_threshold,
   const double max_prediction_time_for_collision_check,
   const double vehicle_max_longitudinal_offset, const bool is_driving_forward);
 

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -782,7 +782,7 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
     }
 
     // For debug
-    for (const auto cp : collision_points) {
+    for (const auto & cp : collision_points) {
       debug_data.collision_points.push_back(cp.point);
     }
 

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -779,10 +779,11 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
         debug_data.intentionally_ignored_obstacles.push_back(predicted_object);
         continue;
       }
+    }
 
-      for (const auto cp : collision_points) {
-        debug_data.collision_points.push_back(cp.point);
-      }
+    // For debug
+    for (const auto cp : collision_points) {
+      debug_data.collision_points.push_back(cp.point);
     }
 
     // convert to obstacle type

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -717,8 +717,8 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
       // ignore running vehicle crossing the ego trajectory with high speed with some condition
       if (!is_angle_aligned && has_high_speed && !collision_points.empty()) {
         const double collision_time_margin = calcCollisionTimeMargin(
-          current_pose, current_vel, collision_points, predicted_object,
-          decimated_traj, is_driving_forward);
+          current_pose, current_vel, collision_points, predicted_object, decimated_traj,
+          is_driving_forward);
         if (collision_time_margin > obstacle_filtering_param_.collision_time_margin) {
           // Ignore vehicle obstacles inside the trajectory, which is crossing the trajectory with
           // high speed and does not collide with ego in a certain time.
@@ -766,7 +766,8 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
         predicted_object.shape, current_time,
         vehicle_info_.vehicle_width_m + obstacle_filtering_param_.rough_detection_area_expand_width,
         obstacle_filtering_param_.ego_obstacle_overlap_time_threshold,
-        obstacle_filtering_param_.max_prediction_time_for_collision_check, vehicle_info_.max_longitudinal_offset_m, is_driving_forward);
+        obstacle_filtering_param_.max_prediction_time_for_collision_check,
+        vehicle_info_.max_longitudinal_offset_m, is_driving_forward);
 
       if (collision_points.empty()) {
         // Ignore vehicle obstacles outside the trajectory, whose predicted path
@@ -779,7 +780,7 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
         continue;
       }
 
-      for(const auto cp : collision_points) {
+      for (const auto cp : collision_points) {
         debug_data.collision_points.push_back(cp.point);
       }
     }
@@ -910,8 +911,7 @@ void ObstacleCruisePlannerNode::checkConsistency(
 double ObstacleCruisePlannerNode::calcCollisionTimeMargin(
   const geometry_msgs::msg::Pose & current_pose, const double current_vel,
   const std::vector<geometry_msgs::msg::PointStamped> & collision_points,
-  const PredictedObject & predicted_object,
-  const Trajectory & decimated_traj,
+  const PredictedObject & predicted_object, const Trajectory & decimated_traj,
   const bool is_driving_forward)
 {
   const auto predicted_path = getHighestConfidencePredictedPath(predicted_object);
@@ -930,7 +930,9 @@ double ObstacleCruisePlannerNode::calcCollisionTimeMargin(
     return dist_from_ego_to_obstacle / std::max(1e-6, std::abs(current_vel));
   }();
 
-  const double time_to_obstacle_getting_out = (rclcpp::Time(collision_points.back().header.stamp) - rclcpp::Time(collision_points.front().header.stamp)).seconds();
+  const double time_to_obstacle_getting_out = (rclcpp::Time(collision_points.back().header.stamp) -
+                                               rclcpp::Time(collision_points.front().header.stamp))
+                                                .seconds();
 
   return time_to_collision - time_to_obstacle_getting_out;
 }

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -657,12 +657,13 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
       continue;
     }
 
-    const auto object_pose = obstacle_cruise_utils::getCurrentObjectPose(
-      predicted_object, predicted_objects.header, current_time, false);
+    const auto current_object_pose = obstacle_cruise_utils::getCurrentObjectPose(
+      predicted_object, predicted_objects.header, current_time, true);
     const auto & object_velocity =
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x;
 
-    const bool is_front_obstacle = isFrontObstacle(traj, ego_idx, object_pose.pose.position);
+    const bool is_front_obstacle =
+      isFrontObstacle(traj, ego_idx, current_object_pose.pose.position);
     if (!is_front_obstacle) {
       RCLCPP_INFO_EXPRESSION(
         get_logger(), is_showing_debug_info_,
@@ -672,7 +673,8 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
 
     // rough detection area filtering without polygons
     const double dist_from_obstacle_to_traj = [&]() {
-      return motion_utils::calcLateralOffset(decimated_traj.points, object_pose.pose.position);
+      return motion_utils::calcLateralOffset(
+        decimated_traj.points, current_object_pose.pose.position);
     }();
     const double obstacle_max_length = calcObjectMaxLength(predicted_object.shape);
     if (
@@ -685,26 +687,29 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
       continue;
     }
 
-    // calculate collision points
-    const auto obstacle_polygon =
-      tier4_autoware_utils::toPolygon2d(object_pose.pose, predicted_object.shape);
+    // Get highest confidence predicted path
+    const auto predicted_path = getHighestConfidencePredictedPath(predicted_object);
+    const auto resampled_predicted_path = perception_utils::resamplePredictedPath(
+      predicted_path, obstacle_filtering_param_.prediction_resampling_time_interval,
+      obstacle_filtering_param_.prediction_resampling_time_horizon);
+
+    // calculate current collision points
     std::vector<geometry_msgs::msg::PointStamped> closest_collision_points;
-    const auto first_within_idx = polygon_utils::getFirstCollisionIndex(
-      decimated_traj_polygons, obstacle_polygon, predicted_objects.header,
+    const auto first_within_idx = polygon_utils::getCollisionIndex(
+      decimated_traj_polygons, current_object_pose, predicted_object.shape,
       closest_collision_points);
 
     // precise detection area filtering with polygons
     std::vector<geometry_msgs::msg::PointStamped> collision_points;
     if (first_within_idx) {  // obstacles inside the trajectory
       // calculate nearest collision point
-      collision_points = calcNearestCollisionPoint(
-        first_within_idx.get(), closest_collision_points, decimated_traj, is_driving_forward);
-      if (!collision_points.empty()) {
-        debug_data.collision_points.push_back(collision_points.front().point);
-      }
+      collision_points = polygon_utils::getCollisionPoints(
+        decimated_traj, decimated_traj_polygons, predicted_objects.header, resampled_predicted_path,
+        predicted_object.shape, current_time, vehicle_info_.max_longitudinal_offset_m,
+        is_driving_forward);
 
       const bool is_angle_aligned = isAngleAlignedWithTrajectory(
-        decimated_traj, object_pose.pose,
+        decimated_traj, current_object_pose.pose,
         obstacle_filtering_param_.crossing_obstacle_traj_angle_threshold);
       const double has_high_speed =
         std::abs(object_velocity) > obstacle_filtering_param_.crossing_obstacle_velocity_threshold;
@@ -756,11 +761,6 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
         continue;
       }
 
-      const auto predicted_path = getHighestConfidencePredictedPath(predicted_object);
-      const auto resampled_predicted_path = perception_utils::resamplePredictedPath(
-        predicted_path, obstacle_filtering_param_.prediction_resampling_time_interval,
-        obstacle_filtering_param_.prediction_resampling_time_horizon);
-
       std::vector<geometry_msgs::msg::PointStamped> future_collision_points;
       const auto collision_traj_poly_idx = polygon_utils::willCollideWithSurroundObstacle(
         decimated_traj, decimated_traj_polygons, predicted_objects.header, resampled_predicted_path,
@@ -780,11 +780,11 @@ std::vector<TargetObstacle> ObstacleCruisePlannerNode::filterObstacles(
         continue;
       }
 
-      collision_points = calcNearestCollisionPoint(
-        collision_traj_poly_idx.get(), future_collision_points, decimated_traj, is_driving_forward);
-      if (!collision_points.empty()) {
-        debug_data.collision_points.push_back(collision_points.front().point);
-      }
+      const auto collision_point = polygon_utils::calcNearestCollisionPoint(
+        collision_traj_poly_idx.get(), future_collision_points, decimated_traj,
+        vehicle_info_.max_longitudinal_offset_m, is_driving_forward);
+      debug_data.collision_points.push_back(collision_point.point);
+      collision_points.push_back(collision_point);
     }
 
     // convert to obstacle type
@@ -908,45 +908,6 @@ void ObstacleCruisePlannerNode::checkConsistency(
       prev_closest_obstacle_ptr_ = nullptr;
     }
   }
-}
-
-std::vector<geometry_msgs::msg::PointStamped> ObstacleCruisePlannerNode::calcNearestCollisionPoint(
-  const size_t & first_within_idx,
-  const std::vector<geometry_msgs::msg::PointStamped> & collision_points,
-  const Trajectory & decimated_traj, const bool is_driving_forward)
-{
-  std::array<geometry_msgs::msg::Point, 2> segment_points;
-  if (first_within_idx == 0) {
-    const auto & traj_front_pose = decimated_traj.points.at(0).pose;
-    const auto front_pos = tier4_autoware_utils::calcOffsetPose(
-                             traj_front_pose, vehicle_info_.max_longitudinal_offset_m, 0.0, 0.0)
-                             .position;
-    if (is_driving_forward) {
-      segment_points.at(0) = traj_front_pose.position;
-      segment_points.at(1) = front_pos;
-    } else {
-      segment_points.at(0) = front_pos;
-      segment_points.at(1) = traj_front_pose.position;
-    }
-  } else {
-    const size_t seg_idx = first_within_idx - 1;
-    segment_points.at(0) = decimated_traj.points.at(seg_idx).pose.position;
-    segment_points.at(1) = decimated_traj.points.at(seg_idx + 1).pose.position;
-  }
-
-  size_t min_idx = 0;
-  double min_dist = std::numeric_limits<double>::max();
-  for (size_t cp_idx = 0; cp_idx < collision_points.size(); ++cp_idx) {
-    const auto & collision_point = collision_points.at(cp_idx);
-    const double dist =
-      motion_utils::calcLongitudinalOffsetToSegment(segment_points, 0, collision_point.point);
-    if (dist < min_dist) {
-      min_dist = dist;
-      min_idx = cp_idx;
-    }
-  }
-
-  return {collision_points.at(min_idx)};
 }
 
 double ObstacleCruisePlannerNode::calcCollisionTimeMargin(

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -88,13 +88,21 @@ Polygon2d createOneStepPolygon(
 namespace polygon_utils
 {
 boost::optional<size_t> getCollisionIndex(
+  const autoware_auto_planning_msgs::msg::Trajectory & traj,
   const std::vector<Polygon2d> & traj_polygons, const geometry_msgs::msg::PoseStamped & obj_pose,
   const autoware_auto_perception_msgs::msg::Shape & shape,
-  std::vector<geometry_msgs::msg::PointStamped> & collision_geom_points)
+  std::vector<geometry_msgs::msg::PointStamped> & collision_geom_points,
+  const double max_dist)
 {
   const auto obj_polygon = tier4_autoware_utils::toPolygon2d(obj_pose.pose, shape);
   for (size_t i = 0; i < traj_polygons.size(); ++i) {
-    std::deque<Polygon2d> collision_polygons;
+    const double approximated_dist =
+        tier4_autoware_utils::calcDistance2d(traj.points.at(i).pose, obj_pose.pose);
+    if (approximated_dist > max_dist) {
+      continue;
+    }
+
+    std::vector<Polygon2d> collision_polygons;
     boost::geometry::intersection(traj_polygons.at(i), obj_polygon, collision_polygons);
 
     bool has_collision = false;
@@ -120,39 +128,23 @@ boost::optional<size_t> getCollisionIndex(
   return {};
 }
 
-boost::optional<size_t> getFirstNonCollisionIndex(
-  const std::vector<Polygon2d> & traj_polygons,
-  const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
-  const autoware_auto_perception_msgs::msg::Shape & shape, const size_t start_idx)
-{
-  constexpr double epsilon = 1e-3;
-
-  size_t latest_collision_idx = start_idx;
-  for (const auto & path_point : predicted_path.path) {
-    const auto obj_polygon = tier4_autoware_utils::toPolygon2d(path_point, shape);
-    for (size_t i = start_idx; i < traj_polygons.size(); ++i) {
-      const double dist = bg::distance(traj_polygons.at(i), obj_polygon);
-      if (dist <= epsilon) {
-        latest_collision_idx = i;
-        break;
-      }
-      if (i == traj_polygons.size() - 1) {
-        return latest_collision_idx;
-      }
-    }
-  }
-  return {};
-}
-
 std::vector<geometry_msgs::msg::PointStamped> getCollisionPoints(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,
   const std::vector<Polygon2d> & traj_polygons, const std_msgs::msg::Header & obj_header,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const autoware_auto_perception_msgs::msg::Shape & shape, const rclcpp::Time & current_time,
-  const double vehicle_max_longitudinal_offset, const bool is_driving_forward)
+  const double vehicle_max_longitudinal_offset, const bool is_driving_forward,
+  const double max_dist,
+  const double max_prediction_time_for_collision_check)
 {
   std::vector<geometry_msgs::msg::PointStamped> collision_points;
   for (size_t i = 0; i < predicted_path.path.size(); ++i) {
+    if (
+      max_prediction_time_for_collision_check <
+      rclcpp::Duration(predicted_path.time_step).seconds() * static_cast<double>(i)) {
+      break;
+    }
+
     const auto object_time =
       rclcpp::Time(obj_header.stamp) + rclcpp::Duration(predicted_path.time_step) * i;
     // Ignore past position
@@ -167,7 +159,7 @@ std::vector<geometry_msgs::msg::PointStamped> getCollisionPoints(
 
     std::vector<geometry_msgs::msg::PointStamped> current_collision_points;
     const auto collision_idx =
-      getCollisionIndex(traj_polygons, obj_pose, shape, current_collision_points);
+      getCollisionIndex(traj, traj_polygons, obj_pose, shape, current_collision_points, max_dist);
     if (collision_idx) {
       const auto nearest_collision_point = calcNearestCollisionPoint(
         *collision_idx, current_collision_points, traj, vehicle_max_longitudinal_offset,
@@ -179,82 +171,25 @@ std::vector<geometry_msgs::msg::PointStamped> getCollisionPoints(
   return collision_points;
 }
 
-boost::optional<size_t> willCollideWithSurroundObstacle(
+std::vector<geometry_msgs::msg::PointStamped> willCollideWithSurroundObstacle(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,
   const std::vector<Polygon2d> & traj_polygons, const std_msgs::msg::Header & obj_header,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
-  const autoware_auto_perception_msgs::msg::Shape & shape, const double max_dist,
+  const autoware_auto_perception_msgs::msg::Shape & shape, const rclcpp::Time & current_time,
+  const double max_dist,
   const double ego_obstacle_overlap_time_threshold,
   const double max_prediction_time_for_collision_check,
-  std::vector<geometry_msgs::msg::PointStamped> & collision_geom_points)
+  const double vehicle_max_longitudinal_offset, const bool is_driving_forward)
 {
-  constexpr double epsilon = 1e-3;
+  const auto collision_points = getCollisionPoints(traj, traj_polygons, obj_header, predicted_path, shape, current_time,
+                                                   vehicle_max_longitudinal_offset, is_driving_forward, max_dist, max_prediction_time_for_collision_check);
 
-  bool is_found = false;
-  size_t start_predicted_path_idx = 0;
-  for (size_t i = 0; i < predicted_path.path.size(); ++i) {
-    const auto & path_point = predicted_path.path.at(i);
-    if (
-      max_prediction_time_for_collision_check <
-      rclcpp::Duration(predicted_path.time_step).seconds() * static_cast<double>(i)) {
-      return {};
-    }
-
-    for (size_t j = 0; j < traj.points.size(); ++j) {
-      const auto & traj_point = traj.points.at(j);
-      const double approximated_dist =
-        tier4_autoware_utils::calcDistance2d(path_point.position, traj_point.pose.position);
-      if (approximated_dist > max_dist) {
-        continue;
-      }
-
-      const auto & traj_polygon = traj_polygons.at(j);
-      const auto obj_polygon = tier4_autoware_utils::toPolygon2d(path_point, shape);
-      const double dist = bg::distance(traj_polygon, obj_polygon);
-
-      if (dist < epsilon) {
-        if (!is_found) {
-          // calculate collision point by polygon collision
-          std::deque<Polygon2d> collision_polygons;
-          boost::geometry::intersection(traj_polygon, obj_polygon, collision_polygons);
-
-          bool has_collision = false;
-          for (const auto & collision_polygon : collision_polygons) {
-            if (boost::geometry::area(collision_polygon) > 0.0) {
-              has_collision = true;
-
-              for (const auto & collision_point : collision_polygon.outer()) {
-                geometry_msgs::msg::PointStamped collision_geom_point;
-                const auto collision_time =
-                  rclcpp::Time(obj_header.stamp) + rclcpp::Duration(predicted_path.time_step) * i;
-                collision_geom_point.header.frame_id = obj_header.frame_id;
-                collision_geom_point.header.stamp = collision_time;
-                collision_geom_point.point.x = collision_point.x();
-                collision_geom_point.point.y = collision_point.y();
-                collision_geom_points.push_back(collision_geom_point);
-              }
-            }
-          }
-
-          if (has_collision) {
-            start_predicted_path_idx = i;
-            is_found = true;
-          }
-        } else {
-          const double overlap_time = (static_cast<double>(i) - start_predicted_path_idx) *
-                                      rclcpp::Duration(predicted_path.time_step).seconds();
-          if (ego_obstacle_overlap_time_threshold < overlap_time) {
-            return j;
-          }
-        }
-      } else {
-        is_found = false;
-      }
-    }
+  const double overlap_time = (rclcpp::Time(collision_points.back().header.stamp) - rclcpp::Time(collision_points.front().header.stamp)).seconds();
+  if(overlap_time < ego_obstacle_overlap_time_threshold) {
+    return {};
   }
 
-  collision_geom_points.clear();
-  return {};
+  return collision_points;
 }
 
 std::vector<Polygon2d> createOneStepPolygons(

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -91,13 +91,12 @@ boost::optional<size_t> getCollisionIndex(
   const autoware_auto_planning_msgs::msg::Trajectory & traj,
   const std::vector<Polygon2d> & traj_polygons, const geometry_msgs::msg::PoseStamped & obj_pose,
   const autoware_auto_perception_msgs::msg::Shape & shape,
-  std::vector<geometry_msgs::msg::PointStamped> & collision_geom_points,
-  const double max_dist)
+  std::vector<geometry_msgs::msg::PointStamped> & collision_geom_points, const double max_dist)
 {
   const auto obj_polygon = tier4_autoware_utils::toPolygon2d(obj_pose.pose, shape);
   for (size_t i = 0; i < traj_polygons.size(); ++i) {
     const double approximated_dist =
-        tier4_autoware_utils::calcDistance2d(traj.points.at(i).pose, obj_pose.pose);
+      tier4_autoware_utils::calcDistance2d(traj.points.at(i).pose, obj_pose.pose);
     if (approximated_dist > max_dist) {
       continue;
     }
@@ -134,8 +133,7 @@ std::vector<geometry_msgs::msg::PointStamped> getCollisionPoints(
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const autoware_auto_perception_msgs::msg::Shape & shape, const rclcpp::Time & current_time,
   const double vehicle_max_longitudinal_offset, const bool is_driving_forward,
-  const double max_dist,
-  const double max_prediction_time_for_collision_check)
+  const double max_dist, const double max_prediction_time_for_collision_check)
 {
   std::vector<geometry_msgs::msg::PointStamped> collision_points;
   for (size_t i = 0; i < predicted_path.path.size(); ++i) {
@@ -176,16 +174,19 @@ std::vector<geometry_msgs::msg::PointStamped> willCollideWithSurroundObstacle(
   const std::vector<Polygon2d> & traj_polygons, const std_msgs::msg::Header & obj_header,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const autoware_auto_perception_msgs::msg::Shape & shape, const rclcpp::Time & current_time,
-  const double max_dist,
-  const double ego_obstacle_overlap_time_threshold,
+  const double max_dist, const double ego_obstacle_overlap_time_threshold,
   const double max_prediction_time_for_collision_check,
   const double vehicle_max_longitudinal_offset, const bool is_driving_forward)
 {
-  const auto collision_points = getCollisionPoints(traj, traj_polygons, obj_header, predicted_path, shape, current_time,
-                                                   vehicle_max_longitudinal_offset, is_driving_forward, max_dist, max_prediction_time_for_collision_check);
+  const auto collision_points = getCollisionPoints(
+    traj, traj_polygons, obj_header, predicted_path, shape, current_time,
+    vehicle_max_longitudinal_offset, is_driving_forward, max_dist,
+    max_prediction_time_for_collision_check);
 
-  const double overlap_time = (rclcpp::Time(collision_points.back().header.stamp) - rclcpp::Time(collision_points.front().header.stamp)).seconds();
-  if(overlap_time < ego_obstacle_overlap_time_threshold) {
+  const double overlap_time = (rclcpp::Time(collision_points.back().header.stamp) -
+                               rclcpp::Time(collision_points.front().header.stamp))
+                                .seconds();
+  if (overlap_time < ego_obstacle_overlap_time_threshold) {
     return {};
   }
 

--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -183,6 +183,10 @@ std::vector<geometry_msgs::msg::PointStamped> willCollideWithSurroundObstacle(
     vehicle_max_longitudinal_offset, is_driving_forward, max_dist,
     max_prediction_time_for_collision_check);
 
+  if (collision_points.empty()) {
+    return {};
+  }
+
   const double overlap_time = (rclcpp::Time(collision_points.back().header.stamp) -
                                rclcpp::Time(collision_points.front().header.stamp))
                                 .seconds();


### PR DESCRIPTION
## Description
Currently, obstacle cruise planner can only have one collision point and it does not compute multiple collision points. In this PR, I changed it to enable the collision check function to calculate multiple collision points. Moreover, there are some bags in the current collision check function. This PR also fixed that bug.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

I texted the code with Planning Simulator.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
