### PR TITLE
feat(occlusion_spot): reduce noise for on coming car

### DIFF
--- a/planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.hpp
@@ -101,6 +101,19 @@ inline Polygon2d lines2polygon(const LineString2d & left_line, const LineString2
   return polygon;
 }
 
+inline Polygon2d upScalePolygon(
+  const geometry_msgs::msg::Point & position, const Polygon2d & polygon, const double scale)
+{
+  Polygon2d transformed_polygon;
+  // upscale
+  for (size_t i = 0; i < polygon.outer().size(); i++) {
+    const double upscale_x = (polygon.outer().at(i).x() - position.x) * scale + position.x;
+    const double upscale_y = (polygon.outer().at(i).y() - position.y) * scale + position.y;
+    transformed_polygon.outer().emplace_back(Point2d(upscale_x, upscale_y));
+  }
+  return transformed_polygon;
+}
+
 inline geometry_msgs::msg::Polygon toGeomPoly(const Polygon2d & polygon)
 {
   geometry_msgs::msg::Polygon polygon_msg;

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/grid_utils.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/grid_utils.cpp
@@ -128,14 +128,10 @@ boost::optional<Polygon2d> generateOcclusionPolygon(
   using tier4_autoware_utils::normalizeRadian;
   const double origin_x = origin.x();
   const double origin_y = origin.y();
-  // TODO(tanaka): consider this later
-  const double delay_angle = M_PI / 6.0;
   const double min_theta =
-    normalizeRadian(std::atan2(min_theta_pos.y() - origin_y, min_theta_pos.x() - origin_x), 0.0) -
-    delay_angle;
+    normalizeRadian(std::atan2(min_theta_pos.y() - origin_y, min_theta_pos.x() - origin_x), 0.0);
   const double max_theta =
-    normalizeRadian(std::atan2(max_theta_pos.y() - origin_y, max_theta_pos.x() - origin_x), 0.0) +
-    delay_angle;
+    normalizeRadian(std::atan2(max_theta_pos.y() - origin_y, max_theta_pos.x() - origin_x), 0.0);
   LineString2d theta_min_ray = {
     origin,
     {origin_x + ray_max_length * std::cos(min_theta),

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/occlusion_spot_utils.cpp
@@ -37,7 +37,7 @@ namespace occlusion_spot_utils
 {
 Polygon2d toFootprintPolygon(const PredictedObject & object, const double scale = 1.0)
 {
-   const Pose & obj_pose = object.kinematics.initial_pose_with_covariance.pose;
+  const Pose & obj_pose = object.kinematics.initial_pose_with_covariance.pose;
   Polygon2d obj_footprint = tier4_autoware_utils::toPolygon2d(object);
   // upscale foot print for noise
   obj_footprint = upScalePolygon(obj_pose.position, obj_footprint, scale);

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/occlusion_spot_utils.cpp
@@ -35,6 +35,15 @@ namespace behavior_velocity_planner
 namespace bg = boost::geometry;
 namespace occlusion_spot_utils
 {
+Polygon2d toFootprintPolygon(const PredictedObject & object, const double scale = 1.0)
+{
+   const Pose & obj_pose = object.kinematics.initial_pose_with_covariance.pose;
+  Polygon2d obj_footprint = tier4_autoware_utils::toPolygon2d(object);
+  // upscale foot print for noise
+  obj_footprint = upScalePolygon(obj_pose.position, obj_footprint, scale);
+  return obj_footprint;
+}
+
 lanelet::ConstLanelet toPathLanelet(const PathWithLaneId & path)
 {
   lanelet::Points3d path_points;
@@ -207,11 +216,18 @@ void categorizeVehicles(
 {
   moving_vehicle_foot_prints.clear();
   stuck_vehicle_foot_prints.clear();
+  /**
+   * Note: these parameters are use to reduce noise in occupancy grid
+   * up_scale: case predicted poly is larger than actual
+   * down_scale: case predicted poly is smaller than actual
+   */
+  const double up_scale = 1.5;
+  const double down_scale = 0.8;
   for (const auto & vehicle : vehicles) {
     if (isMovingVehicle(vehicle, stuck_vehicle_vel)) {
-      moving_vehicle_foot_prints.emplace_back(tier4_autoware_utils::toPolygon2d(vehicle));
+      moving_vehicle_foot_prints.emplace_back(toFootprintPolygon(vehicle, up_scale));
     } else if (isStuckVehicle(vehicle, stuck_vehicle_vel)) {
-      stuck_vehicle_foot_prints.emplace_back(tier4_autoware_utils::toPolygon2d(vehicle));
+      stuck_vehicle_foot_prints.emplace_back(toFootprintPolygon(vehicle, down_scale));
     }
   }
   return;


### PR DESCRIPTION
## Description

 - remove unused segment 
 - reduce noise for occupancy grid using predicted object better
 
 TODO: reduce hunting and consider prediction delay for vehicle velocity in relatively better way

https://user-images.githubusercontent.com/65527974/186827782-de1a04d2-dadf-4b72-bf4d-b643b28288ea.mp4


this probelm is due to occupancy grid's latency
![image](https://user-images.githubusercontent.com/65527974/188557658-f4b399d5-180b-42eb-8369-ca657784ccac.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
