### PR TITLE
fix(behavior_velocity_planner): fix safety slow down crosswalk intersection check

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -133,7 +133,7 @@ private:
 
   CollisionPointState getCollisionPointState(const double ttc, const double ttv) const;
 
-  void applySafetySlowDownSpeed(PathWithLaneId & output);
+  bool applySafetySlowDownSpeed(PathWithLaneId & output);
 
   float calcTargetVelocity(
     const geometry_msgs::msg::Point & stop_point, const PathWithLaneId & ego_path) const;

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -172,8 +172,9 @@ bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
 
   if (crosswalk_.hasAttribute("safety_slow_down_speed")) {
     // Safety slow down is on
-    applySafetySlowDownSpeed(*path);
-    ego_path = *path;
+    if (applySafetySlowDownSpeed(*path)) {
+      ego_path = *path;
+    }
   }
 
   RCLCPP_INFO_EXPRESSION(
@@ -731,8 +732,12 @@ CollisionPointState CrosswalkModule::getCollisionPointState(
   return CollisionPointState::YIELD;
 }
 
-void CrosswalkModule::applySafetySlowDownSpeed(PathWithLaneId & output)
+bool CrosswalkModule::applySafetySlowDownSpeed(PathWithLaneId & output)
 {
+  if (path_intersects_.empty()) {
+    return false;
+  }
+
   const auto & ego_pos = planner_data_->current_pose.pose.position;
   const auto ego_path = output;
 
@@ -772,6 +777,7 @@ void CrosswalkModule::applySafetySlowDownSpeed(PathWithLaneId & output)
       }
     }
   }
+  return true;
 }
 
 bool CrosswalkModule::isStuckVehicle(


### PR DESCRIPTION
Signed-off-by: Mehmet Dogru <42mehmetdogru42@gmail.com>

Related PR: https://github.com/autowarefoundation/autoware.universe/pull/1528

## Description

Small bug / when there is no intersection between safety slow down crosswalk and the path bvp crashes.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
