### PR TITLE
feat(behavior_path_planner): output debug marker from each module

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -148,8 +148,6 @@ private:
   // debug
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_drivable_area_lanelets_publisher_;
   rclcpp::Publisher<AvoidanceDebugMsgArray>::SharedPtr debug_avoidance_msg_array_publisher_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr debug_marker_publisher_;
-  void publishDebugMarker(const std::vector<MarkerArray> & debug_markers);
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
@@ -49,7 +49,6 @@ public:
 
   BehaviorModuleOutput run(const std::shared_ptr<PlannerData> & data);
   std::vector<std::shared_ptr<SceneModuleStatus>> getModulesStatus();
-  std::vector<MarkerArray> getDebugMarkers();
   AvoidanceDebugMsgArray getAvoidanceDebugMsgArray();
 
 private:

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -227,8 +227,6 @@ public:
 
   std::shared_ptr<const PlannerData> planner_data_;
 
-  MarkerArray getDebugMarker() { return debug_marker_; }
-
   AvoidanceDebugMsgArray::SharedPtr getAvoidanceDebugMsgArray()
   {
     if (debug_avoidance_msg_array_ptr_) {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -30,6 +30,7 @@
 
 #include <behaviortree_cpp_v3/basic_types.h>
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <random>
@@ -97,6 +98,12 @@ public:
     is_waiting_approval_{false},
     current_state_{BT::NodeStatus::IDLE}
   {
+    std::string module_ns;
+    module_ns.resize(name.size());
+    std::transform(name.begin(), name.end(), module_ns.begin(), tolower);
+
+    const auto ns = std::string("~/debug/") + module_ns;
+    pub_debug_marker_ = node.create_publisher<MarkerArray>(ns, 20);
   }
 
   virtual ~SceneModuleInterface() = default;
@@ -212,6 +219,8 @@ public:
    */
   void setData(const std::shared_ptr<const PlannerData> & data) { planner_data_ = data; }
 
+  void publishDebugMarker() { pub_debug_marker_->publish(debug_marker_); }
+
   std::string name() const { return name_; }
 
   rclcpp::Logger getLogger() const { return logger_; }
@@ -234,9 +243,10 @@ private:
   rclcpp::Logger logger_;
 
 protected:
-  MarkerArray debug_marker_;
   rclcpp::Clock::SharedPtr clock_;
+  rclcpp::Publisher<MarkerArray>::SharedPtr pub_debug_marker_;
   mutable AvoidanceDebugMsgArray::SharedPtr debug_avoidance_msg_array_ptr_{};
+  mutable MarkerArray debug_marker_;
 
   std::shared_ptr<RTCInterface> rtc_interface_ptr_;
   UUID uuid_;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -68,9 +68,6 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
   debug_avoidance_msg_array_publisher_ =
     create_publisher<AvoidanceDebugMsgArray>("~/debug/avoidance_debug_message_array", 1);
 
-  // Debug
-  debug_marker_publisher_ = create_publisher<MarkerArray>("~/debug/markers", 1);
-
   if (planner_data_->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
     debug_drivable_area_lanelets_publisher_ =
       create_publisher<MarkerArray>("~/drivable_area_boundary", 1);
@@ -596,7 +593,6 @@ void BehaviorPathPlannerNode::run()
 
   // for debug
   debug_avoidance_msg_array_publisher_->publish(bt_manager_->getAvoidanceDebugMsgArray());
-  publishDebugMarker(bt_manager_->getDebugMarkers());
 
   if (planner_data->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
     const auto drivable_area_lines = marker_utils::createFurthestLineStringMarkerArray(
@@ -650,15 +646,6 @@ bool BehaviorPathPlannerNode::skipSmoothGoalConnection(
     }
   }
   return false;
-}
-
-void BehaviorPathPlannerNode::publishDebugMarker(const std::vector<MarkerArray> & debug_markers)
-{
-  MarkerArray msg{};
-  for (const auto & markers : debug_markers) {
-    tier4_autoware_utils::appendMarkerArray(markers, &msg);
-  }
-  debug_marker_publisher_->publish(msg);
 }
 
 void BehaviorPathPlannerNode::onVelocity(const Odometry::ConstSharedPtr msg)

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -113,15 +113,6 @@ BehaviorTreeManager::getModulesStatus()
   return modules_status_;
 }
 
-std::vector<MarkerArray> BehaviorTreeManager::getDebugMarkers()
-{
-  std::vector<MarkerArray> data;
-  for (const auto & module : scene_modules_) {
-    data.push_back(module->getDebugMarker());
-  }
-  return data;
-}
-
 AvoidanceDebugMsgArray BehaviorTreeManager::getAvoidanceDebugMsgArray()
 {
   const auto avoidance_module = std::find_if(

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -98,6 +98,7 @@ BehaviorModuleOutput BehaviorTreeManager::run(const std::shared_ptr<PlannerData>
   RCLCPP_DEBUG(logger_, "BehaviorPathPlanner::run end status = %s", BT::toStr(res).c_str());
 
   std::for_each(scene_modules_.begin(), scene_modules_.end(), [](const auto & m) {
+    m->publishDebugMarker();
     if (!m->isExecutionRequested()) {
       m->onExit();
     }


### PR DESCRIPTION
## Description

- output debug marker from each module

![image](https://user-images.githubusercontent.com/44889564/187109045-3fd7e5ea-9cf9-4319-b0fe-8e1d123e3d55.png)

```sh
➜  pilot-auto git:(awf-latest) ✗ ros2 topic list | grep behavior_path
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance_left/cooperate_status
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance_right/cooperate_status
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance_debug_message_array
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lanechange
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lanefollowing
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/pullout
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/pullover
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/sideshift
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_boundary
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/input/lateral_offset
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change_left/cooperate_status
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change_right/cooperate_status
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/output/path_candidate
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_out/cooperate_status
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/cooperate_status
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/debug/Cl
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/debug/Cr
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/debug/parking_area
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/debug/path_pose_array
/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/debug/start_pose
```

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
