### PR TITLE
feat(intersection): tighten go_out/stop decision for rtc

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -159,7 +159,7 @@ bool IntersectionModule::modifyPathVelocity(
     geometry_msgs::msg::Pose pass_judge_line = path->points.at(pass_judge_line_idx).point.pose;
     is_over_pass_judge_line = planning_utils::isAheadOf(current_pose.pose, pass_judge_line);
   }
-  if (is_go_out_ && is_over_pass_judge_line && !external_stop) {
+  if (is_go_out_ && isActivated() && is_over_pass_judge_line && !external_stop) {
     RCLCPP_DEBUG(logger_, "over the pass judge line. no plan needed.");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     setSafe(true);
@@ -198,7 +198,7 @@ bool IntersectionModule::modifyPathVelocity(
     path->points, planner_data_->current_pose.pose.position,
     path->points.at(stop_line_idx).point.pose.position));
 
-  if (!isActivated()) {
+  if (!isActivated() || is_entry_prohibited) {
     constexpr double v = 0.0;
     is_go_out_ = false;
     if (planner_param_.use_stuck_stopline && is_stuck) {


### PR DESCRIPTION
(1) do not enter the intersection when rtc is not approving even if ego is over pass judge line (2) instantly stop when is_entry_prohibited even if rtc is approving because rtc safe approval is based on prior planning

Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

### Context

- The safety status from `isActivated()` function is obtained from callback from the RTC, so even if intersection module is saying 'STOP' in `modifyPathVeloctiy`, this value can be still `approved` => stop point may not be inserted in this case (Is this expected behavior ?)
- `is_go_out` means "if RTC was approving previously", so this value can be `true` even if `isActivated() == false` in the latest RTC callback
- `setSafe()` is sent to RTC after `modifyPathVelocity()`
 
### Diffs

- insert stop point when `is_entry_prohibited` even if `isActivated() == true`. In this case `StateMachine` is immediately set to `STOP` without margin time 
- ignore other cars and pass the judge line only when `is_go_out == true` and `isActivated == true`

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
