### PR TITLE
fix(system_monitor): multithreading support for boost::process

### DIFF
--- a/system/system_monitor/include/system_monitor/ntp_monitor/ntp_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/ntp_monitor/ntp_monitor.hpp
@@ -57,10 +57,12 @@ protected:
    * @brief function to execute chronyc
    * @param [out] outOffset offset value of NTP time
    * @param [out] out_tracking_map "chronyc tracking" output for diagnostic
-   * @return if error occurred, return error string
+   * @param [out] pipe2_err_str if pipe2 error occurred, return error string
+   * @return if chronyc error occurred, return error string
    */
   std::string executeChronyc(
-    float & outOffset, std::map<std::string, std::string> & out_tracking_map);
+    float & outOffset, std::map<std::string, std::string> & out_tracking_map,
+    std::string & pipe2_err_str);
 
   diagnostic_updater::Updater updater_;  //!< @brief Updater class which advertises to /diagnostics
 

--- a/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
+++ b/system/system_monitor/include/system_monitor/process_monitor/process_monitor.hpp
@@ -122,7 +122,8 @@ protected:
     memory_tasks_;                      //!< @brief list of diagnostics tasks for high memory procs
   rclcpp::TimerBase::SharedPtr timer_;  //!< @brief timer to execute top command
   std::string top_output_;              //!< @brief output from top command
-  bool is_top_error_;                   //!< @brief flag if an error occurs
+  bool is_top_error_;                   //!< @brief flag if an top error occurs
+  bool is_pipe2_error_;                 //!< @brief flag if an pipe2 error occurs
   double elapsed_ms_;                   //!< @brief Execution time of top command
   std::mutex mutex_;                    //!< @brief mutex for output from top command
   rclcpp::CallbackGroup::SharedPtr timer_callback_group_;  //!< @brief Callback Group

--- a/system/system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -134,8 +134,31 @@ void CPUMonitorBase::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & st
   }
 
   // Get CPU Usage
-  bp::ipstream is_out;
-  bp::ipstream is_err;
+
+  // boost::process create file descriptor without O_CLOEXEC required for multithreading.
+  // So create file descriptor with O_CLOEXEC and pass it to boost::process.
+  int out_fd[2];
+  if (pipe2(out_fd, O_CLOEXEC) != 0) {
+    stat.summary(DiagStatus::ERROR, "pipe2 error");
+    stat.add("pipe2", strerror(errno));
+    cpu_usage.all.status = CpuStatus::STALE;
+    publishCpuUsage(cpu_usage);
+    return;
+  }
+  bp::pipe out_pipe{out_fd[0], out_fd[1]};
+  bp::ipstream is_out{std::move(out_pipe)};
+
+  int err_fd[2];
+  if (pipe2(err_fd, O_CLOEXEC) != 0) {
+    stat.summary(DiagStatus::ERROR, "pipe2 error");
+    stat.add("pipe2", strerror(errno));
+    cpu_usage.all.status = CpuStatus::STALE;
+    publishCpuUsage(cpu_usage);
+    return;
+  }
+  bp::pipe err_pipe{err_fd[0], err_fd[1]};
+  bp::ipstream is_err{std::move(err_pipe)};
+
   bp::child c("mpstat -P ALL 1 1 -o JSON", bp::std_out > is_out, bp::std_err > is_err);
   c.wait();
 


### PR DESCRIPTION
Signed-off-by: v-nakayama7440-esol <v-nakayama7440@esol.co.jp>

## Description

boost::process::pipe internally creates file descriptor. However, this file descriptor does not support multithreading because O_CLOEXEC is not set. Because of this, when each thread of SystemMontor uses boost::process to create a child process, the file descriptors of boost::process::pipe conflict between child processes. As a result, the child process waits for the file descriptor to be released.

In this PR, the SystemMonitor application creates file descriptor with O_CLOEXEC set and passes it to boost::process::pipe to eliminate the wait for child process to release file descriptor.

## Related links

- The issue https://github.com/autowarefoundation/autoware.universe/issues/939 was still observed after the fix https://github.com/autowarefoundation/autoware.universe/pull/948.
- This is related to the boost::process issue and to apply the workaround described in https://github.com/boostorg/process/issues/169#issuecomment-679170651.

## Tests performed

Process Monitor's /diagnostics topic message timestamp interval is essentially about 1 second (diagnostic_updater event execution cycle is 1hz). However, before the fix, the interval would occasionally be about 2 seconds.

Graph before fix (vertical axis unit is msec, horizontal axis unit is message order):
![image](https://user-images.githubusercontent.com/97144416/187135812-acd9ef0f-676f-4845-9577-c1103a8075e4.png)

After the fix, Process Monitor confirmed that the timestamp interval for messages on the /diagnostics topic was not always reaching 2 seconds. Monitors other than Process Monitor were also checked in the same way.

Graph after fix (vertical axis unit is msec, horizontal axis unit is message order):
![image](https://user-images.githubusercontent.com/97144416/187135945-f43a9023-d77b-4cb4-b38c-a31edef75c74.png)
![image](https://user-images.githubusercontent.com/97144416/187137405-7eac3cba-21ec-43ef-a768-82f643f19188.png)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
