### PR TITLE
refactor(behavior_velocity_planner): export scene module libraries for faster build

### DIFF
--- a/planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/CMakeLists.txt
@@ -24,19 +24,42 @@ set(scene_modules
   run_out
 )
 
+# for utilization. this comes first
+ament_auto_add_library(behavior_velocity_planner_utilitzation SHARED
+  src/utilization/path_utilization.cpp
+  src/utilization/util.cpp
+)
+target_include_directories(behavior_velocity_planner_utilitzation
+  SYSTEM PUBLIC
+    ${BOOST_INCLUDE_DIRS}
+    ${PCL_INCLUDE_DIRS}
+    ${tf2_geometry_msgs_INCLUDE_DIRS}
+    ${EIGEN3_INCLUDE_DIR}
+)
+
+# for each scene module export different library
+macro(add_scene_module_library scene_module)
+  file(GLOB_RECURSE ${scene_module}_srcs "src/scene_module/${scene_module}/*")
+  ament_auto_add_library(behavior_velocity_planner_${scene_module} SHARED ${${scene_module}_srcs})
+  target_link_libraries(behavior_velocity_planner_${scene_module} behavior_velocity_planner_utilitzation)
+  target_include_directories(behavior_velocity_planner_${scene_module}
+    SYSTEM PUBLIC
+    ${BOOST_INCLUDE_DIRS}
+    ${PCL_INCLUDE_DIRS}
+    ${tf2_geometry_msgs_INCLUDE_DIRS}
+    ${EIGEN3_INCLUDE_DIR}
+  )
+endmacro()
+
 foreach(scene_module IN LISTS scene_modules)
-  file(GLOB_RECURSE scene_module_src "src/scene_module/${scene_module}/*")
-  list(APPEND scene_modules_src ${scene_module_src})
+  add_scene_module_library(${scene_module})
 endforeach()
 
+# main node
 ament_auto_add_library(behavior_velocity_planner SHARED
   src/node.cpp
   src/planner_manager.cpp
-  src/utilization/path_utilization.cpp
-  src/utilization/util.cpp
-  ${scene_modules_src}
 )
-
 target_include_directories(behavior_velocity_planner
   SYSTEM PUBLIC
     ${BOOST_INCLUDE_DIRS}
@@ -44,6 +67,10 @@ target_include_directories(behavior_velocity_planner
     ${tf2_geometry_msgs_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR}
 )
+# link each scene_module
+foreach(scene_module IN LISTS scene_modules)
+  target_link_libraries(behavior_velocity_planner behavior_velocity_planner_${scene_module})
+endforeach()
 
 ament_target_dependencies(behavior_velocity_planner
   Boost


### PR DESCRIPTION
export each scene module library and then link the main node for faster build

Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

In this PR each scene_module is compiled to `libbehavior_velocity_planner_${scene_module}.so` and then the main planner node is linked against them.

If one of the scene module source file, say `scene_module/intersection/scene_intersection.cpp`, is changed, then only `libbehavior_velocity_planner_intersection.so` is built and linked again.

## Tests performed

(TODO excluding test/ dir)

Measured
```
time colcon build --packages-up-to behavior_velocity_planner
```
.

| build type                  | before PR | this PR  |
| --------------------------- | ------------- | ----------- |
| clean build                | xxx sec     |  192s |
| after one src file edit | xxx sec     |  38s  |
 
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
