### PR TITLE
feat(tier4_planning_rviz_plugin): add velocity_text to path_with_lane_id

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/path_with_lane_id/display.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path_with_lane_id/display.hpp
@@ -24,6 +24,7 @@
 #include <rviz_common/properties/float_property.hpp>
 #include <rviz_common/properties/parse_color.hpp>
 #include <rviz_common/validate_floats.hpp>
+#include <rviz_rendering/objects/movable_text.hpp>
 
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 
@@ -62,6 +63,8 @@ protected:
     const QColor & color_min, const QColor & color_max, const double ratio);
   Ogre::ManualObject * path_manual_object_;
   Ogre::ManualObject * velocity_manual_object_;
+  std::vector<rviz_rendering::MovableText *> velocity_texts_;
+  std::vector<Ogre::SceneNode *> velocity_text_nodes_;
   rviz_common::properties::BoolProperty * property_path_view_;
   rviz_common::properties::BoolProperty * property_velocity_view_;
   rviz_common::properties::FloatProperty * property_path_width_;
@@ -70,6 +73,8 @@ protected:
   rviz_common::properties::FloatProperty * property_path_alpha_;
   rviz_common::properties::FloatProperty * property_velocity_alpha_;
   rviz_common::properties::FloatProperty * property_velocity_scale_;
+  rviz_common::properties::BoolProperty * property_velocity_text_view_;
+  rviz_common::properties::FloatProperty * property_velocity_text_scale_;
   rviz_common::properties::BoolProperty * property_path_color_view_;
   rviz_common::properties::BoolProperty * property_velocity_color_view_;
   rviz_common::properties::FloatProperty * property_vel_max_;

--- a/common/tier4_planning_rviz_plugin/include/path_with_lane_id/display.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path_with_lane_id/display.hpp
@@ -36,6 +36,7 @@
 
 #include <deque>
 #include <memory>
+#include <vector>
 
 namespace rviz_plugins
 {

--- a/common/tier4_planning_rviz_plugin/src/path_with_lane_id/display.cpp
+++ b/common/tier4_planning_rviz_plugin/src/path_with_lane_id/display.cpp
@@ -85,7 +85,10 @@ AutowarePathWithLaneIdDisplay::AutowarePathWithLaneIdDisplay()
     "Constant Color", false, "", property_velocity_view_, SLOT(updateVisualization()), this);
   property_velocity_color_ = new rviz_common::properties::ColorProperty(
     "Color", Qt::black, "", property_velocity_view_, SLOT(updateVisualization()), this);
-
+  property_velocity_text_view_ = new rviz_common::properties::BoolProperty(
+    "View Text Velocity", false, "", this, SLOT(updateVisualization()), this);
+  property_velocity_text_scale_ = new rviz_common::properties::FloatProperty(
+    "Scale", 0.3, "", property_velocity_text_view_, SLOT(updateVisualization()), this);
   property_vel_max_ = new rviz_common::properties::FloatProperty(
     "Color Border Vel Max", 3.0, "[m/s]", this, SLOT(updateVisualization()), this);
   property_vel_max_->setMin(0.0);
@@ -96,6 +99,12 @@ AutowarePathWithLaneIdDisplay::~AutowarePathWithLaneIdDisplay()
   if (initialized()) {
     scene_manager_->destroyManualObject(path_manual_object_);
     scene_manager_->destroyManualObject(velocity_manual_object_);
+    for (size_t i = 0; i < velocity_text_nodes_.size(); i++) {
+      Ogre::SceneNode * node = velocity_text_nodes_.at(i);
+      node->removeAndDestroyAllChildren();
+      node->detachAllObjects();
+      scene_manager_->destroySceneNode(node);
+    }
   }
 }
 
@@ -168,6 +177,29 @@ void AutowarePathWithLaneIdDisplay::processMessage(
     // path_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_STRIP);
     velocity_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP);
 
+    if (msg_ptr->points.size() > velocity_texts_.size()) {
+      for (size_t i = velocity_texts_.size(); i < msg_ptr->points.size(); i++) {
+        Ogre::SceneNode * node = scene_node_->createChildSceneNode();
+        rviz_rendering::MovableText * text =
+          new rviz_rendering::MovableText("not initialized", "Liberation Sans", 0.1);
+        text->setVisible(false);
+        text->setTextAlignment(
+          rviz_rendering::MovableText::H_CENTER, rviz_rendering::MovableText::V_ABOVE);
+        node->attachObject(text);
+        velocity_texts_.push_back(text);
+        velocity_text_nodes_.push_back(node);
+      }
+    } else if (msg_ptr->points.size() < velocity_texts_.size()) {
+      for (size_t i = velocity_texts_.size() - 1; i >= msg_ptr->points.size(); i--) {
+        Ogre::SceneNode * node = velocity_text_nodes_.at(i);
+        node->detachAllObjects();
+        node->removeAndDestroyAllChildren();
+        scene_manager_->destroySceneNode(node);
+      }
+      velocity_texts_.resize(msg_ptr->points.size());
+      velocity_text_nodes_.resize(msg_ptr->points.size());
+    }
+
     for (size_t point_idx = 0; point_idx < msg_ptr->points.size(); point_idx++) {
       const auto & e = msg_ptr->points.at(point_idx);
       /*
@@ -235,6 +267,29 @@ void AutowarePathWithLaneIdDisplay::processMessage(
           e.point.pose.position.z +
             e.point.longitudinal_velocity_mps * property_velocity_scale_->getFloat());
         velocity_manual_object_->colour(color);
+      }
+
+      /*
+       * Velocity Text
+       */
+      if (property_velocity_text_view_->getBool()) {
+        Ogre::Vector3 position;
+        position.x = e.point.pose.position.x;
+        position.y = e.point.pose.position.y;
+        position.z = e.point.pose.position.z;
+        Ogre::SceneNode * node = velocity_text_nodes_.at(point_idx);
+        node->setPosition(position);
+
+        rviz_rendering::MovableText * text = velocity_texts_.at(point_idx);
+        double vel = e.point.longitudinal_velocity_mps;
+        text->setCaption(
+          std::to_string(static_cast<int>(std::floor(vel))) + "." +
+          std::to_string(static_cast<int>(std::floor(vel * 100))));
+        text->setCharacterHeight(property_velocity_text_scale_->getFloat());
+        text->setVisible(true);
+      } else {
+        rviz_rendering::MovableText * text = velocity_texts_.at(point_idx);
+        text->setVisible(false);
       }
     }
 


### PR DESCRIPTION
## Description
Added velocity text visualizer to path_with_lane_id of tier4_planning_rviz_plugin.

![Screenshot from 2022-08-31 12-24-52](https://user-images.githubusercontent.com/39142679/187587051-5d13a495-8243-4331-a516-41382b2c6f1a.png)


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
