### PR TITLE
ci: add cancel-previous-workflows.yaml

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -79,6 +79,7 @@
                   - \"\"
                   - -cuda
                 include:" {source}
+    - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/check-build-depends.yaml
       pre-commands: |
         sd "container: ros:(\w+)" "container: ghcr.io/autowarefoundation/autoware-universe:\$1-latest" {source}

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -23,9 +23,6 @@ jobs:
             container: ghcr.io/autowarefoundation/autoware-universe:humble-latest
             build-depends-repos: build_depends.humble.repos
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.10.0
-
       - name: Check out repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cancel-previous-workflows.yaml
+++ b/.github/workflows/cancel-previous-workflows.yaml
@@ -1,0 +1,14 @@
+name: cancel-previous-workflows
+
+on:
+  pull_request:
+
+jobs:
+  cancel-previous-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.10.0
+        with:
+          workflow_id: all
+          all_but_latest: true


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

As written in https://github.com/autowarefoundation/autoware.universe/pull/1669, sometimes CI execution will be jammed.

To resolve this, I'd like to introduce this option.
https://github.com/styfle/cancel-workflow-action#advanced-all-but-latest

> Because this action can only cancel workflows if it is actually being run, it only helps if the pipeline isn't saturated and there are still runners available to schedule the workflow.
By default, this action does not cancel any workflows created after itself. The all_but_latest flags allows the action to cancel itself and all later-scheduled workflows, leaving only the latest.

Also, since it's not limited to `build-and-test`, I try splitting the workflow.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
