### PR TITLE
refactor(mission_planner): apply clang-tidy

### DIFF
--- a/planning/mission_planner/src/goal_pose_visualizer/goal_pose_visualizer.cpp
+++ b/planning/mission_planner/src/goal_pose_visualizer/goal_pose_visualizer.cpp
@@ -21,12 +21,12 @@ GoalPoseVisualizer::GoalPoseVisualizer(const rclcpp::NodeOptions & node_options)
 {
   sub_route_ = create_subscription<autoware_auto_planning_msgs::msg::HADMapRoute>(
     "input/route", rclcpp::QoS{1}.transient_local(),
-    std::bind(&GoalPoseVisualizer::echoBackRouteCallback, this, std::placeholders::_1));
+    std::bind(&GoalPoseVisualizer::echo_back_route_callback, this, std::placeholders::_1));
   pub_goal_pose_ = create_publisher<geometry_msgs::msg::PoseStamped>(
     "output/goal_pose", rclcpp::QoS{1}.transient_local());
 }
 
-void GoalPoseVisualizer::echoBackRouteCallback(
+void GoalPoseVisualizer::echo_back_route_callback(
   const autoware_auto_planning_msgs::msg::HADMapRoute::ConstSharedPtr msg)
 {
   geometry_msgs::msg::PoseStamped goal_pose;

--- a/planning/mission_planner/src/goal_pose_visualizer/goal_pose_visualizer.hpp
+++ b/planning/mission_planner/src/goal_pose_visualizer/goal_pose_visualizer.hpp
@@ -31,7 +31,7 @@ private:
   rclcpp::Subscription<autoware_auto_planning_msgs::msg::HADMapRoute>::SharedPtr sub_route_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_goal_pose_;
 
-  void echoBackRouteCallback(
+  void echo_back_route_callback(
     const autoware_auto_planning_msgs::msg::HADMapRoute::ConstSharedPtr msg);
 };
 

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -40,9 +40,9 @@ MissionPlanner::MissionPlanner(
   using std::placeholders::_1;
 
   goal_subscriber_ = create_subscription<geometry_msgs::msg::PoseStamped>(
-    "input/goal_pose", 10, std::bind(&MissionPlanner::goalPoseCallback, this, _1));
+    "input/goal_pose", 10, std::bind(&MissionPlanner::goal_pose_callback, this, _1));
   checkpoint_subscriber_ = create_subscription<geometry_msgs::msg::PoseStamped>(
-    "input/checkpoint", 10, std::bind(&MissionPlanner::checkpointCallback, this, _1));
+    "input/checkpoint", 10, std::bind(&MissionPlanner::checkpoint_callback, this, _1));
 
   rclcpp::QoS durable_qos{1};
   durable_qos.transient_local();
@@ -52,7 +52,7 @@ MissionPlanner::MissionPlanner(
     create_publisher<visualization_msgs::msg::MarkerArray>("debug/route_marker", durable_qos);
 }
 
-bool MissionPlanner::getEgoVehiclePose(geometry_msgs::msg::PoseStamped * ego_vehicle_pose)
+bool MissionPlanner::get_ego_vehicle_pose(geometry_msgs::msg::PoseStamped * ego_vehicle_pose)
 {
   geometry_msgs::msg::PoseStamped base_link_origin;
   base_link_origin.header.frame_id = base_link_frame_;
@@ -65,10 +65,10 @@ bool MissionPlanner::getEgoVehiclePose(geometry_msgs::msg::PoseStamped * ego_veh
   base_link_origin.pose.orientation.w = 1;
 
   //  transform base_link frame origin to map_frame to get vehicle positions
-  return transformPose(base_link_origin, ego_vehicle_pose, map_frame_);
+  return transform_pose(base_link_origin, ego_vehicle_pose, map_frame_);
 }
 
-bool MissionPlanner::transformPose(
+bool MissionPlanner::transform_pose(
   const geometry_msgs::msg::PoseStamped & input_pose, geometry_msgs::msg::PoseStamped * output_pose,
   const std::string & target_frame)
 {
@@ -84,17 +84,17 @@ bool MissionPlanner::transformPose(
   }
 }
 
-void MissionPlanner::goalPoseCallback(
+void MissionPlanner::goal_pose_callback(
   const geometry_msgs::msg::PoseStamped::ConstSharedPtr goal_msg_ptr)
 {
   // set start pose
-  if (!getEgoVehiclePose(&start_pose_)) {
+  if (!get_ego_vehicle_pose(&start_pose_)) {
     RCLCPP_ERROR(
       get_logger(), "Failed to get ego vehicle pose in map frame. Aborting mission planning");
     return;
   }
   // set goal pose
-  if (!transformPose(*goal_msg_ptr, &goal_pose_, map_frame_)) {
+  if (!transform_pose(*goal_msg_ptr, &goal_pose_, map_frame_)) {
     RCLCPP_ERROR(get_logger(), "Failed to get goal pose in map frame. Aborting mission planning");
     return;
   }
@@ -104,16 +104,16 @@ void MissionPlanner::goalPoseCallback(
   checkpoints_.push_back(start_pose_);
   checkpoints_.push_back(goal_pose_);
 
-  if (!isRoutingGraphReady()) {
+  if (!is_routing_graph_ready()) {
     RCLCPP_ERROR(get_logger(), "RoutingGraph is not ready. Aborting mission planning");
     return;
   }
 
-  autoware_auto_planning_msgs::msg::HADMapRoute route = planRoute();
-  publishRoute(route);
+  autoware_auto_planning_msgs::msg::HADMapRoute route = plan_route();
+  publish_route(route);
 }  // namespace mission_planner
 
-void MissionPlanner::checkpointCallback(
+void MissionPlanner::checkpoint_callback(
   const geometry_msgs::msg::PoseStamped::ConstSharedPtr checkpoint_msg_ptr)
 {
   if (checkpoints_.size() < 2) {
@@ -124,7 +124,7 @@ void MissionPlanner::checkpointCallback(
   }
 
   geometry_msgs::msg::PoseStamped transformed_checkpoint;
-  if (!transformPose(*checkpoint_msg_ptr, &transformed_checkpoint, map_frame_)) {
+  if (!transform_pose(*checkpoint_msg_ptr, &transformed_checkpoint, map_frame_)) {
     RCLCPP_ERROR(
       get_logger(), "Failed to get checkpoint pose in map frame. Aborting mission planning");
     return;
@@ -133,16 +133,17 @@ void MissionPlanner::checkpointCallback(
   // insert checkpoint before goal
   checkpoints_.insert(checkpoints_.end() - 1, transformed_checkpoint);
 
-  autoware_auto_planning_msgs::msg::HADMapRoute route = planRoute();
-  publishRoute(route);
+  autoware_auto_planning_msgs::msg::HADMapRoute route = plan_route();
+  publish_route(route);
 }
 
-void MissionPlanner::publishRoute(const autoware_auto_planning_msgs::msg::HADMapRoute & route) const
+void MissionPlanner::publish_route(
+  const autoware_auto_planning_msgs::msg::HADMapRoute & route) const
 {
   if (!route.segments.empty()) {
     RCLCPP_INFO(get_logger(), "Route successfully planned. Publishing...");
     route_publisher_->publish(route);
-    visualizeRoute(route);
+    visualize_route(route);
   } else {
     RCLCPP_ERROR(get_logger(), "Calculated route is empty!");
   }

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -70,7 +70,7 @@ bool MissionPlanner::getEgoVehiclePose(geometry_msgs::msg::PoseStamped * ego_veh
 
 bool MissionPlanner::transformPose(
   const geometry_msgs::msg::PoseStamped & input_pose, geometry_msgs::msg::PoseStamped * output_pose,
-  const std::string target_frame)
+  const std::string & target_frame)
 {
   geometry_msgs::msg::TransformStamped transform;
   try {

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -47,11 +47,11 @@ protected:
 
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_publisher_;
 
-  virtual bool isRoutingGraphReady() const = 0;
-  virtual autoware_auto_planning_msgs::msg::HADMapRoute planRoute() = 0;
-  virtual void visualizeRoute(
+  virtual bool is_routing_graph_ready() const = 0;
+  virtual autoware_auto_planning_msgs::msg::HADMapRoute plan_route() = 0;
+  virtual void visualize_route(
     const autoware_auto_planning_msgs::msg::HADMapRoute & route) const = 0;
-  virtual void publishRoute(const autoware_auto_planning_msgs::msg::HADMapRoute & route) const;
+  virtual void publish_route(const autoware_auto_planning_msgs::msg::HADMapRoute & route) const;
 
 private:
   rclcpp::Publisher<autoware_auto_planning_msgs::msg::HADMapRoute>::SharedPtr route_publisher_;
@@ -61,12 +61,13 @@ private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
-  bool getEgoVehiclePose(geometry_msgs::msg::PoseStamped * ego_vehicle_pose);
-  void goalPoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr goal_msg_ptr);
-  void checkpointCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr checkpoint_msg_ptr);
-  bool transformPose(
+  bool get_ego_vehicle_pose(geometry_msgs::msg::PoseStamped * ego_vehicle_pose);
+  void goal_pose_callback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr goal_msg_ptr);
+  void checkpoint_callback(
+    const geometry_msgs::msg::PoseStamped::ConstSharedPtr checkpoint_msg_ptr);
+  bool transform_pose(
     const geometry_msgs::msg::PoseStamped & input_pose,
-    geometry_msgs::msg::PoseStamped * output_pose, const std::string target_frame);
+    geometry_msgs::msg::PoseStamped * output_pose, const std::string & target_frame);
 };
 
 }  // namespace mission_planner

--- a/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
+++ b/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.cpp
@@ -140,10 +140,10 @@ MissionPlannerLanelet2::MissionPlannerLanelet2(const rclcpp::NodeOptions & node_
   using std::placeholders::_1;
   map_subscriber_ = create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
     "input/vector_map", rclcpp::QoS{10}.transient_local(),
-    std::bind(&MissionPlannerLanelet2::mapCallback, this, _1));
+    std::bind(&MissionPlannerLanelet2::map_callback, this, _1));
 }
 
-void MissionPlannerLanelet2::mapCallback(
+void MissionPlannerLanelet2::map_callback(
   const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg)
 {
   route_handler_.setMap(*msg);
@@ -156,9 +156,9 @@ void MissionPlannerLanelet2::mapCallback(
   is_graph_ready_ = true;
 }
 
-bool MissionPlannerLanelet2::isRoutingGraphReady() const { return is_graph_ready_; }
+bool MissionPlannerLanelet2::is_routing_graph_ready() const { return is_graph_ready_; }
 
-void MissionPlannerLanelet2::visualizeRoute(
+void MissionPlannerLanelet2::visualize_route(
   const autoware_auto_planning_msgs::msg::HADMapRoute & route) const
 {
   lanelet::ConstLanelets route_lanelets;
@@ -183,32 +183,32 @@ void MissionPlannerLanelet2::visualizeRoute(
   std_msgs::msg::ColorRGBA cl_end;
   std_msgs::msg::ColorRGBA cl_normal;
   std_msgs::msg::ColorRGBA cl_goal;
-  setColor(&cl_route, 0.2, 0.4, 0.2, 0.05);
-  setColor(&cl_goal, 0.2, 0.4, 0.4, 0.05);
-  setColor(&cl_end, 0.2, 0.2, 0.4, 0.05);
-  setColor(&cl_normal, 0.2, 0.4, 0.2, 0.05);
-  setColor(&cl_ll_borders, 1.0, 1.0, 1.0, 0.999);
+  set_color(&cl_route, 0.2, 0.4, 0.2, 0.05);
+  set_color(&cl_goal, 0.2, 0.4, 0.4, 0.05);
+  set_color(&cl_end, 0.2, 0.2, 0.4, 0.05);
+  set_color(&cl_normal, 0.2, 0.4, 0.2, 0.05);
+  set_color(&cl_ll_borders, 1.0, 1.0, 1.0, 0.999);
 
   visualization_msgs::msg::MarkerArray route_marker_array;
-  insertMarkerArray(
+  insert_marker_array(
     &route_marker_array,
     lanelet::visualization::laneletsBoundaryAsMarkerArray(route_lanelets, cl_ll_borders, false));
-  insertMarkerArray(
+  insert_marker_array(
     &route_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
                            "route_lanelets", route_lanelets, cl_route));
-  insertMarkerArray(
+  insert_marker_array(
     &route_marker_array,
     lanelet::visualization::laneletsAsTriangleMarkerArray("end_lanelets", end_lanelets, cl_end));
-  insertMarkerArray(
+  insert_marker_array(
     &route_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
                            "normal_lanelets", normal_lanelets, cl_normal));
-  insertMarkerArray(
+  insert_marker_array(
     &route_marker_array,
     lanelet::visualization::laneletsAsTriangleMarkerArray("goal_lanelets", goal_lanelets, cl_goal));
   marker_publisher_->publish(route_marker_array);
 }
 
-bool MissionPlannerLanelet2::isGoalValid() const
+bool MissionPlannerLanelet2::is_goal_valid() const
 {
   lanelet::Lanelet closest_lanelet;
   if (!lanelet::utils::query::getClosestLanelet(
@@ -264,7 +264,7 @@ bool MissionPlannerLanelet2::isGoalValid() const
   return false;
 }
 
-autoware_auto_planning_msgs::msg::HADMapRoute MissionPlannerLanelet2::planRoute()
+autoware_auto_planning_msgs::msg::HADMapRoute MissionPlannerLanelet2::plan_route()
 {
   std::stringstream log_ss;
   for (const auto & checkpoint : checkpoints_) {
@@ -278,7 +278,7 @@ autoware_auto_planning_msgs::msg::HADMapRoute MissionPlannerLanelet2::planRoute(
   autoware_auto_planning_msgs::msg::HADMapRoute route_msg;
   RouteSections route_sections;
 
-  if (!isGoalValid()) {
+  if (!is_goal_valid()) {
     RCLCPP_WARN(get_logger(), "Goal is not valid! Please check position and angle of goal_pose");
     return route_msg;
   }
@@ -302,7 +302,7 @@ autoware_auto_planning_msgs::msg::HADMapRoute MissionPlannerLanelet2::planRoute(
       get_logger(), "Loop detected within route! Be aware that looped route is not debugged!");
   }
 
-  refineGoalHeight(route_sections);
+  refine_goal_height(route_sections);
 
   route_msg.header.stamp = this->now();
   route_msg.header.frame_id = map_frame_;
@@ -313,7 +313,7 @@ autoware_auto_planning_msgs::msg::HADMapRoute MissionPlannerLanelet2::planRoute(
   return route_msg;
 }
 
-void MissionPlannerLanelet2::refineGoalHeight(const RouteSections & route_sections)
+void MissionPlannerLanelet2::refine_goal_height(const RouteSections & route_sections)
 {
   const auto goal_lane_id = route_sections.back().preferred_primitive_id;
   lanelet::Lanelet goal_lanelet = lanelet_map_ptr_->laneletLayer.get(goal_lane_id);

--- a/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.hpp
+++ b/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.hpp
@@ -56,14 +56,14 @@ private:
 
   rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr map_subscriber_;
 
-  void mapCallback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
-  bool isGoalValid() const;
-  void refineGoalHeight(const RouteSections & route_sections);
+  void map_callback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
+  bool is_goal_valid() const;
+  void refine_goal_height(const RouteSections & route_sections);
 
   // virtual functions
-  bool isRoutingGraphReady() const;
-  autoware_auto_planning_msgs::msg::HADMapRoute planRoute();
-  void visualizeRoute(const autoware_auto_planning_msgs::msg::HADMapRoute & route) const;
+  bool isRoutingGraphReady() const override;
+  autoware_auto_planning_msgs::msg::HADMapRoute planRoute() override;
+  void visualizeRoute(const autoware_auto_planning_msgs::msg::HADMapRoute & route) const override;
 };
 }  // namespace mission_planner
 

--- a/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.hpp
+++ b/planning/mission_planner/src/mission_planner_lanelet2/mission_planner_lanelet2.hpp
@@ -61,9 +61,9 @@ private:
   void refine_goal_height(const RouteSections & route_sections);
 
   // virtual functions
-  bool isRoutingGraphReady() const override;
-  autoware_auto_planning_msgs::msg::HADMapRoute planRoute() override;
-  void visualizeRoute(const autoware_auto_planning_msgs::msg::HADMapRoute & route) const override;
+  bool is_routing_graph_ready() const override;
+  autoware_auto_planning_msgs::msg::HADMapRoute plan_route() override;
+  void visualize_route(const autoware_auto_planning_msgs::msg::HADMapRoute & route) const override;
 };
 }  // namespace mission_planner
 

--- a/planning/mission_planner/src/mission_planner_lanelet2/utility_functions.cpp
+++ b/planning/mission_planner/src/mission_planner_lanelet2/utility_functions.cpp
@@ -49,7 +49,7 @@ void insertMarkerArray(
   a1->markers.insert(a1->markers.end(), a2.markers.begin(), a2.markers.end());
 }
 
-std::vector<std::pair<double, lanelet::Lanelet>> excludeSubtypeLaneletsWithDistance(
+std::vector<std::pair<double, lanelet::Lanelet>> exclude_subtype_lanelets_with_distance(
   const std::vector<std::pair<double, lanelet::Lanelet>> & lls, const char subtype[])
 {
   std::vector<std::pair<double, lanelet::Lanelet>> exclude_subtype_lanelets;

--- a/planning/mission_planner/src/mission_planner_lanelet2/utility_functions.hpp
+++ b/planning/mission_planner/src/mission_planner_lanelet2/utility_functions.hpp
@@ -39,8 +39,8 @@ bool exists(const std::vector<T> & vectors, const T & item)
   return false;
 }
 
-void setColor(std_msgs::msg::ColorRGBA * cl, double r, double g, double b, double a);
-void insertMarkerArray(
+void set_color(std_msgs::msg::ColorRGBA * cl, double r, double g, double b, double a);
+void insert_marker_array(
   visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2);
-std::string toString(const geometry_msgs::msg::Pose & pose);
+std::string to_string(const geometry_msgs::msg::Pose & pose);
 #endif  // MISSION_PLANNER_LANELET2__UTILITY_FUNCTIONS_HPP_


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Apply clang-tidy for readability.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
