### PR TITLE
ci(check-build-depends): use ROS container

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -82,7 +82,6 @@
     - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/check-build-depends.yaml
       pre-commands: |
-        sd "container: ros:(\w+)" "container: ghcr.io/autowarefoundation/autoware-universe:\$1-latest" {source}
         sd -f ms '(rosdistro: humble.*?build-depends-repos): build_depends.repos' '$1: build_depends.humble.repos' {source}
     - source: .github/workflows/update-codeowners-from-packages.yaml
     - source: codecov.yaml

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -17,10 +17,10 @@ jobs:
           - humble
         include:
           - rosdistro: galactic
-            container: ghcr.io/autowarefoundation/autoware-universe:galactic-latest
+            container: ros:galactic
             build-depends-repos: build_depends.repos
           - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware-universe:humble-latest
+            container: ros:humble
             build-depends-repos: build_depends.humble.repos
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I guess now it can be tested with ROS containers.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
