### PR TITLE
ci(cancel-previous-workflows): use pull_request_target

### DIFF
--- a/.github/workflows/cancel-previous-workflows.yaml
+++ b/.github/workflows/cancel-previous-workflows.yaml
@@ -1,7 +1,7 @@
 name: cancel-previous-workflows
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   cancel-previous-workflows:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

According to the documentation, it won't work with PRs from forks.
https://github.com/styfle/cancel-workflow-action#advanced-pull-requests-from-forks

I guess `pull_request_target` can be used instead of `workflow_call`.

Related?: https://github.com/styfle/cancel-workflow-action/issues/139

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
