### PR TITLE
fix(automatic_pose_initializer): fix starvation

### DIFF
--- a/system/default_ad_api_helpers/automatic_pose_initializer/src/automatic_pose_initializer.cpp
+++ b/system/default_ad_api_helpers/automatic_pose_initializer/src/automatic_pose_initializer.cpp
@@ -35,6 +35,7 @@ AutomaticPoseInitializer::AutomaticPoseInitializer() : Node("automatic_pose_init
 
 void AutomaticPoseInitializer::on_timer()
 {
+  timer_->cancel();
   if (state_.state == State::Message::UNINITIALIZED) {
     try {
       const auto req = std::make_shared<Initialize::Service::Request>();
@@ -42,6 +43,7 @@ void AutomaticPoseInitializer::on_timer()
     } catch (const component_interface_utils::ServiceException & error) {
     }
   }
+  timer_->reset();
 }
 
 }  // namespace automatic_pose_initializer


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Fix for https://github.com/autowarefoundation/autoware.universe/issues/1750.

If the timer rate is too fast, the next timer callback will be executed before the service was completed. This causes starvation of the state topic callback. Fixed to stop the timer before starting the service and restart it after completion.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
