### PR TITLE
fix(behavior_velocity): fix insertVelocity

### DIFF
--- a/planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -212,7 +212,7 @@ void insertVelocity(
     std::min(static_cast<int>(insert_index + 1), static_cast<int>(path.points.size() - 1));
   for (int i = min_idx; i <= max_idx; i++) {
     if (calcDistance2d(path.points.at(static_cast<size_t>(i)), path_point) < min_distance) {
-      path.points.at(i).point.longitudinal_velocity_mps = 0;
+      path.points.at(i).point.longitudinal_velocity_mps = v;
       already_has_path_point = true;
       insert_index = static_cast<size_t>(i);
       // set velocity from is going to insert min velocity later


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

bug fix for insertVelcity util function in behavior velocity
- this happen only insert path point is close to original 

before
![image](https://user-images.githubusercontent.com/65527974/188075450-dddbed75-10fa-4b2b-badb-a355b10e6dac.png)

after 
![image](https://user-images.githubusercontent.com/65527974/188075406-43949e39-2ced-41f9-bad6-8627e4d3ab1d.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
