### PR TITLE
fix(elevation_map_loader): remove and create map bagfile if it cannot be loaded

### DIFF
--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -21,6 +21,7 @@
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>rosbag2_storage_default_plugins</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -44,6 +44,7 @@
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp>
 
 ElevationMapLoaderNode::ElevationMapLoaderNode(const rclcpp::NodeOptions & options)
 : Node("elevation_map_loader", options)
@@ -102,8 +103,25 @@ void ElevationMapLoaderNode::publish()
     RCLCPP_INFO(
       this->get_logger(), "Load elevation map from: %s",
       data_manager_.elevation_map_path_->c_str());
-    grid_map::GridMapRosConverter::loadFromBag(
-      *data_manager_.elevation_map_path_, "elevation_map", elevation_map_);
+
+    // Check if bag can be loaded
+    bool isBagLoaded = false;
+    try {
+      isBagLoaded = grid_map::GridMapRosConverter::loadFromBag(
+        *data_manager_.elevation_map_path_, "elevation_map", elevation_map_);
+    } catch (rosbag2_storage_plugins::SqliteException & e) {
+      isBagLoaded = false;
+    }
+    if (!isBagLoaded) {
+      // Delete directory including elevation map if bag is broken
+      RCLCPP_ERROR(
+        this->get_logger(), "Try to loading bag, but bag is broken. Remove %s",
+        data_manager_.elevation_map_path_->c_str());
+      std::filesystem::remove_all(data_manager_.elevation_map_path_->c_str());
+      // Create elevation map from pointcloud map if bag is broken
+      RCLCPP_INFO(this->get_logger(), "Create elevation map from pointcloud map ");
+      createElevationMap();
+    }
   }
 
   elevation_map_.setFrameId(map_frame_);

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -105,14 +105,14 @@ void ElevationMapLoaderNode::publish()
       data_manager_.elevation_map_path_->c_str());
 
     // Check if bag can be loaded
-    bool isBagLoaded = false;
+    bool is_bag_loaded = false;
     try {
-      isBagLoaded = grid_map::GridMapRosConverter::loadFromBag(
+      is_bag_loaded = grid_map::GridMapRosConverter::loadFromBag(
         *data_manager_.elevation_map_path_, "elevation_map", elevation_map_);
     } catch (rosbag2_storage_plugins::SqliteException & e) {
-      isBagLoaded = false;
+      is_bag_loaded = false;
     }
-    if (!isBagLoaded) {
+    if (!is_bag_loaded) {
       // Delete directory including elevation map if bag is broken
       RCLCPP_ERROR(
         this->get_logger(), "Try to loading bag, but bag is broken. Remove %s",


### PR DESCRIPTION
Signed-off-by: Shin-kyoto <58775300+Shin-kyoto@users.noreply.github.com>

## PR Type

- Bug Fix

## Description

<!-- Write a brief description of this PR. -->
- When bag file of elevation map is broken, elevation_map_loader node cannot load it and dies.
- So if elevation_map_loader node cannot load broken bag file, removing broken bag file and create elevation map.

## Review Procedure

Follow the steps below to ensure that the elevation map is generated even if there is broken bag file in `/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps`.

1. Create elevation map.
2. Check if there is `.db3` file in `/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/<MAP_HASH>/`. <MAP_HASH> depends on pointcloud map you used to create elevation_map. For example, `/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2b0fe3948d486f048177b826fbba046d468956e51b25e9916feef02b0aeffeee/2b0fe3948d486f048177b826fbba046d468956e51b25e9916feef02b0aeffeee_0.db3` is that bag file.
3. Remove this file and create empty file with the same name as the removed bag file. For example, 

```bash
rm -rf /install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2b0fe3948d486f048177b826fbba046d468956e51b25e9916feef02b0aeffeee/2b0fe3948d486f048177b826fbba046d468956e51b25e9916feef02b0aeffeee_0.db3
touch /install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2b0fe3948d486f048177b826fbba046d468956e51b25e9916feef02b0aeffeee/2b0fe3948d486f048177b826fbba046d468956e51b25e9916feef02b0aeffeee_0.db3
```

4. Check if the broken bag file is removed and  the elevation map is generated again.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
