### PR TITLE
fix(behavior_path_planner): lane change set minimum prepare default

### DIFF
--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -3,7 +3,7 @@
     lane_change:
       lane_change_prepare_duration: 4.0         # [s]
       lane_changing_duration: 8.0               # [s]
-      minimum_lane_change_prepare_distance: 0.0 # [m]
+      minimum_lane_change_prepare_distance: 2.0 # [m]
       lane_change_finish_judge_buffer: 3.0      # [m]
       minimum_lane_change_velocity: 5.6         # [m/s]
       prediction_time_resolution: 0.5           # [s]

--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -3,7 +3,7 @@
     lane_change:
       lane_change_prepare_duration: 4.0         # [s]
       lane_changing_duration: 8.0               # [s]
-      minimum_lane_change_prepare_distance: 4.0 # [m]
+      minimum_lane_change_prepare_distance: 0.0 # [m]
       lane_change_finish_judge_buffer: 3.0      # [m]
       minimum_lane_change_velocity: 5.6         # [m/s]
       prediction_time_resolution: 0.5           # [s]

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -129,7 +129,7 @@ std::vector<LaneChangePath> getLaneChangePaths(
       minimum_lane_change_prepare_distance);
     const double lane_changing_distance = getDistanceWhenDecelerate(
       lane_change_prepare_velocity, acceleration, lane_changing_duration,
-      minimum_lane_change_length + buffer);
+      minimum_lane_change_length);
 
     if (prepare_distance < target_distance) {
       continue;


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

Departure from private lane failed due to lane change parameters and slight bug.

## Related links

https://github.com/tier4/autoware_launch/pull/465

## Tests performed

UC-F-10-00002_PSim_1_case1_cmn:1 scenario file is needed.
https://github.com/tier4/autoware_launch/pull/465 is needed.
The run scenario test.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
