### PR TITLE
fix(heatmap_visualizer): add unknown class

### DIFF
--- a/perception/heatmap_visualizer/include/heatmap_visualizer/heatmap_visualizer_node.hpp
+++ b/perception/heatmap_visualizer/include/heatmap_visualizer/heatmap_visualizer_node.hpp
@@ -66,8 +66,8 @@ private:
   float map_length_;
   float map_resolution_;
   bool use_confidence_;
-  std::vector<std::string> class_names_{"CAR",     "TRUCK",     "BUS",       "TRAILER",
-                                        "BICYCLE", "MOTORBIKE", "PEDESTRIAN"};
+  std::vector<std::string> class_names_{"UNKNWON", "CAR",     "TRUCK",     "BUS",
+                                        "TRAILER", "BICYCLE", "MOTORBIKE", "PEDESTRIAN"};
   bool rename_car_to_truck_and_bus_;
 
   // Number of width and height cells


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description

When the input object topic includes unknown objects,  heatmap_visualizer dies with a following message.
![image](https://user-images.githubusercontent.com/59680180/188392178-93b29c52-3ba3-412a-9835-4c073e174e6a.png)

This is due to invalid access to `heatmaps_` [here](https://github.com/autowarefoundation/autoware.universe/blob/d049063058eb3beeed70940e5ca4900ef3ff3ea6/perception/heatmap_visualizer/src/heatmap_visualizer_node.cpp#L87)
I fixed it by adding unknown to `class_names_`


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
