### PR TITLE
fix(tier4_screen_capture_rviz_plugin): fix spell check

### DIFF
--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -131,12 +131,12 @@ void AutowareScreenCapturePanel::onClickVideoCapture()
       {
         int fourcc = cv::VideoWriter::fourcc('h', '2', '6', '4');  // mp4
         QScreen * screen = QGuiApplication::primaryScreen();
-        const auto qsize = screen->grabWindow(main_window_->winId())
+        const auto q_size = screen->grabWindow(main_window_->winId())
                              .toImage()
                              .convertToFormat(QImage::Format_RGB888)
                              .rgbSwapped()
                              .size();
-        current_movie_size_ = cv::Size(qsize.width(), qsize.height());
+        current_movie_size_ = cv::Size(q_size.width(), q_size.height());
         writer_.open(
           "capture/" + capture_file_name_ + ".mp4", fourcc, capture_hz_->value(),
           current_movie_size_);
@@ -160,12 +160,12 @@ void AutowareScreenCapturePanel::onTimer()
   // this is deprecated but only way to capture nicely
   QScreen * screen = QGuiApplication::primaryScreen();
   QPixmap original_pixmap = screen->grabWindow(main_window_->winId());
-  const auto qimage = original_pixmap.toImage().convertToFormat(QImage::Format_RGB888).rgbSwapped();
-  const int h = qimage.height();
-  const int w = qimage.width();
+  const auto q_image = original_pixmap.toImage().convertToFormat(QImage::Format_RGB888).rgbSwapped();
+  const int h = q_image.height();
+  const int w = q_image.width();
   cv::Size size = cv::Size(w, h);
   cv::Mat image(
-    size, CV_8UC3, const_cast<uchar *>(qimage.bits()), static_cast<size_t>(qimage.bytesPerLine()));
+    size, CV_8UC3, const_cast<uchar *>(q_image.bits()), static_cast<size_t>(q_image.bytesPerLine()));
   if (size != current_movie_size_) {
     cv::Mat new_image;
     cv::resize(image, new_image, current_movie_size_);

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -132,10 +132,10 @@ void AutowareScreenCapturePanel::onClickVideoCapture()
         int fourcc = cv::VideoWriter::fourcc('h', '2', '6', '4');  // mp4
         QScreen * screen = QGuiApplication::primaryScreen();
         const auto q_size = screen->grabWindow(main_window_->winId())
-                             .toImage()
-                             .convertToFormat(QImage::Format_RGB888)
-                             .rgbSwapped()
-                             .size();
+                              .toImage()
+                              .convertToFormat(QImage::Format_RGB888)
+                              .rgbSwapped()
+                              .size();
         current_movie_size_ = cv::Size(q_size.width(), q_size.height());
         writer_.open(
           "capture/" + capture_file_name_ + ".mp4", fourcc, capture_hz_->value(),
@@ -160,12 +160,14 @@ void AutowareScreenCapturePanel::onTimer()
   // this is deprecated but only way to capture nicely
   QScreen * screen = QGuiApplication::primaryScreen();
   QPixmap original_pixmap = screen->grabWindow(main_window_->winId());
-  const auto q_image = original_pixmap.toImage().convertToFormat(QImage::Format_RGB888).rgbSwapped();
+  const auto q_image =
+    original_pixmap.toImage().convertToFormat(QImage::Format_RGB888).rgbSwapped();
   const int h = q_image.height();
   const int w = q_image.width();
   cv::Size size = cv::Size(w, h);
   cv::Mat image(
-    size, CV_8UC3, const_cast<uchar *>(q_image.bits()), static_cast<size_t>(q_image.bytesPerLine()));
+    size, CV_8UC3, const_cast<uchar *>(q_image.bits()),
+    static_cast<size_t>(q_image.bytesPerLine()));
   if (size != current_movie_size_) {
     cv::Mat new_image;
     cv::resize(image, new_image, current_movie_size_);


### PR DESCRIPTION
Signed-off-by: h-ohta <hiroki.ota@tier4.jp>

## Description

- fix spellcheck
- qobject and fourcc is fixed in https://github.com/tier4/autoware-spell-check-dict/pull/333

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
