### PR TITLE
feat(trajectory_follower): use kinematic topic for ego pose

### DIFF
--- a/control/trajectory_follower/include/trajectory_follower/mpc.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc.hpp
@@ -395,8 +395,7 @@ public:
     const autoware_auto_planning_msgs::msg::Trajectory & trajectory_msg,
     const float64_t traj_resample_dist, const bool8_t enable_path_smoothing,
     const int64_t path_filter_moving_ave_num, const int64_t curvature_smoothing_num_traj,
-    const int64_t curvature_smoothing_num_ref_steer,
-    const geometry_msgs::msg::PoseStamped::SharedPtr current_pose_ptr);
+    const int64_t curvature_smoothing_num_ref_steer);
   /**
    * @brief set the vehicle model of this MPC
    */

--- a/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
@@ -114,10 +114,8 @@ private:
   // MPC object
   trajectory_follower::MPC m_mpc;
 
-  //!< @brief measured pose
-  geometry_msgs::msg::PoseStamped::SharedPtr m_current_pose_ptr;
-  //!< @brief measured velocity
-  nav_msgs::msg::Odometry::SharedPtr m_current_odometry_ptr;
+  //!< @brief measured kinematic state
+  nav_msgs::msg::Odometry::SharedPtr m_current_kinematic_state_ptr;
   //!< @brief measured steering
   autoware_auto_vehicle_msgs::msg::SteeringReport::SharedPtr m_current_steering_ptr;
   //!< @brief reference trajectory
@@ -133,10 +131,6 @@ private:
 
   //!< @brief flag whether the first trajectory has been received
   bool m_has_received_first_trajectory = false;
-
-  //!< @brief buffer for transforms
-  tf2::BufferCore m_tf_buffer{tf2::BUFFER_CORE_DEFAULT_CACHE_TIME};
-  tf2_ros::TransformListener m_tf_listener{m_tf_buffer};
 
   // ego nearest index search
   double m_ego_nearest_dist_threshold;
@@ -158,12 +152,6 @@ private:
    * @brief set m_current_trajectory with received message
    */
   void setTrajectory(const autoware_auto_planning_msgs::msg::Trajectory::SharedPtr);
-
-  /**
-   * @brief update current_pose from tf
-   * @return true if the current pose was updated, false otherwise
-   */
-  bool8_t updateCurrentPose();
 
   /**
    * @brief check if the received data is valid.

--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -101,9 +101,9 @@ private:
     const std::vector<rclcpp::Parameter> & parameters);
 
   // pointers for ros topic
-  std::shared_ptr<nav_msgs::msg::Odometry> m_current_velocity_ptr{nullptr};
-  std::shared_ptr<nav_msgs::msg::Odometry> m_prev_velocity_ptr{nullptr};
-  std::shared_ptr<autoware_auto_planning_msgs::msg::Trajectory> m_trajectory_ptr{nullptr};
+  nav_msgs::msg::Odometry::ConstSharedPtr m_current_velocity_ptr{nullptr};
+  nav_msgs::msg::Odometry::ConstSharedPtr m_prev_velocity_ptr{nullptr};
+  autoware_auto_planning_msgs::msg::Trajectory::ConstSharedPtr m_trajectory_ptr{nullptr};
 
   // vehicle info
   float64_t m_wheel_base;

--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -97,7 +97,7 @@ private:
 
   // pointers for ros topic
   nav_msgs::msg::Odometry::ConstSharedPtr m_current_kinematic_state_ptr{nullptr};
-  nav_msgs::msg::Odometry::ConstSharedPtr m_prev_velocity_ptr{nullptr};
+  nav_msgs::msg::Odometry::ConstSharedPtr m_prev_kienmatic_state_ptr{nullptr};
   autoware_auto_planning_msgs::msg::Trajectory::ConstSharedPtr m_trajectory_ptr{nullptr};
 
   // vehicle info

--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -91,17 +91,12 @@ private:
   rclcpp::Publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>::SharedPtr
     m_pub_debug;
 
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr m_tf_sub;
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr m_tf_static_sub;
-  tf2::BufferCore m_tf_buffer{tf2::BUFFER_CORE_DEFAULT_CACHE_TIME};
-  tf2_ros::TransformListener m_tf_listener{m_tf_buffer};
-
   rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr m_set_param_res;
   rcl_interfaces::msg::SetParametersResult paramCallback(
     const std::vector<rclcpp::Parameter> & parameters);
 
   // pointers for ros topic
-  nav_msgs::msg::Odometry::ConstSharedPtr m_current_velocity_ptr{nullptr};
+  nav_msgs::msg::Odometry::ConstSharedPtr m_current_kinematic_state_ptr{nullptr};
   nav_msgs::msg::Odometry::ConstSharedPtr m_prev_velocity_ptr{nullptr};
   autoware_auto_planning_msgs::msg::Trajectory::ConstSharedPtr m_trajectory_ptr{nullptr};
 
@@ -216,7 +211,7 @@ private:
    * @brief set current and previous velocity with received message
    * @param [in] msg current state message
    */
-  void setCurrentVelocity(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
+  void setKinematicState(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
 
   /**
    * @brief set reference trajectory with received message

--- a/control/trajectory_follower/src/mpc.cpp
+++ b/control/trajectory_follower/src/mpc.cpp
@@ -181,8 +181,7 @@ void MPC::setReferenceTrajectory(
   const autoware_auto_planning_msgs::msg::Trajectory & trajectory_msg,
   const float64_t traj_resample_dist, const bool8_t enable_path_smoothing,
   const int64_t path_filter_moving_ave_num, const int64_t curvature_smoothing_num_traj,
-  const int64_t curvature_smoothing_num_ref_steer,
-  const geometry_msgs::msg::PoseStamped::SharedPtr current_pose_ptr)
+  const int64_t curvature_smoothing_num_ref_steer)
 {
   trajectory_follower::MPCTrajectory mpc_traj_raw;        // received raw trajectory
   trajectory_follower::MPCTrajectory mpc_traj_resampled;  // resampled trajectory
@@ -220,10 +219,8 @@ void MPC::setReferenceTrajectory(
   }
 
   /* calculate yaw angle */
-  if (current_pose_ptr) {
-    trajectory_follower::MPCUtils::calcTrajectoryYawFromXY(&mpc_traj_smoothed, m_is_forward_shift);
-    trajectory_follower::MPCUtils::convertEulerAngleToMonotonic(&mpc_traj_smoothed.yaw);
-  }
+  trajectory_follower::MPCUtils::calcTrajectoryYawFromXY(&mpc_traj_smoothed, m_is_forward_shift);
+  trajectory_follower::MPCUtils::convertEulerAngleToMonotonic(&mpc_traj_smoothed.yaw);
 
   /* calculate curvature */
   trajectory_follower::MPCUtils::calcTrajectoryCurvature(

--- a/control/trajectory_follower/src/pid_longitudinal_controller.cpp
+++ b/control/trajectory_follower/src/pid_longitudinal_controller.cpp
@@ -217,7 +217,7 @@ void PidLongitudinalController::setCurrentVelocity(
   if (m_current_velocity_ptr) {
     m_prev_velocity_ptr = m_current_velocity_ptr;
   }
-  m_current_velocity_ptr = std::make_shared<nav_msgs::msg::Odometry>(*msg);
+  m_current_velocity_ptr = msg;
 }
 
 void PidLongitudinalController::setTrajectory(
@@ -237,7 +237,7 @@ void PidLongitudinalController::setTrajectory(
     return;
   }
 
-  m_trajectory_ptr = std::make_shared<autoware_auto_planning_msgs::msg::Trajectory>(*msg);
+  m_trajectory_ptr = msg;
 }
 
 rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallback(

--- a/control/trajectory_follower/src/pid_longitudinal_controller.cpp
+++ b/control/trajectory_follower/src/pid_longitudinal_controller.cpp
@@ -206,18 +206,17 @@ PidLongitudinalController::PidLongitudinalController(rclcpp::Node & node) : node
 void PidLongitudinalController::setInputData(InputData const & input_data)
 {
   setTrajectory(input_data.current_trajectory_ptr);
-  setCurrentVelocity(input_data.current_odometry_ptr);
+  setKinematicState(input_data.current_odometry_ptr);
 }
 
-void PidLongitudinalController::setCurrentVelocity(
-  const nav_msgs::msg::Odometry::ConstSharedPtr msg)
+void PidLongitudinalController::setKinematicState(const nav_msgs::msg::Odometry::ConstSharedPtr msg)
 {
   if (!msg) return;
 
-  if (m_current_velocity_ptr) {
-    m_prev_velocity_ptr = m_current_velocity_ptr;
+  if (m_current_kinematic_state_ptr) {
+    m_prev_velocity_ptr = m_current_kinematic_state_ptr;
   }
-  m_current_velocity_ptr = msg;
+  m_current_kinematic_state_ptr = msg;
 }
 
 void PidLongitudinalController::setTrajectory(
@@ -366,22 +365,12 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
 boost::optional<LongitudinalOutput> PidLongitudinalController::run()
 {
   // wait for initial pointers
-  if (
-    !m_current_velocity_ptr || !m_prev_velocity_ptr || !m_trajectory_ptr ||
-    !m_tf_buffer.canTransform(m_trajectory_ptr->header.frame_id, "base_link", tf2::TimePointZero)) {
+  if (!m_current_kinematic_state_ptr || !m_prev_velocity_ptr || !m_trajectory_ptr) {
     return boost::none;
   }
 
-  // get current ego pose
-  geometry_msgs::msg::TransformStamped tf =
-    m_tf_buffer.lookupTransform(m_trajectory_ptr->header.frame_id, "base_link", tf2::TimePointZero);
-
   // calculate current pose and control data
-  geometry_msgs::msg::Pose current_pose;
-  current_pose.position.x = tf.transform.translation.x;
-  current_pose.position.y = tf.transform.translation.y;
-  current_pose.position.z = tf.transform.translation.z;
-  current_pose.orientation = tf.transform.rotation;
+  geometry_msgs::msg::Pose current_pose = m_current_kinematic_state_ptr->pose.pose;
 
   const auto control_data = getControlData(current_pose);
 
@@ -713,15 +702,15 @@ float64_t PidLongitudinalController::getDt()
 PidLongitudinalController::Motion PidLongitudinalController::getCurrentMotion() const
 {
   const float64_t dv =
-    m_current_velocity_ptr->twist.twist.linear.x - m_prev_velocity_ptr->twist.twist.linear.x;
+    m_current_kinematic_state_ptr->twist.twist.linear.x - m_prev_velocity_ptr->twist.twist.linear.x;
   const float64_t dt = std::max(
-    (rclcpp::Time(m_current_velocity_ptr->header.stamp) -
+    (rclcpp::Time(m_current_kinematic_state_ptr->header.stamp) -
      rclcpp::Time(m_prev_velocity_ptr->header.stamp))
       .seconds(),
     1e-03);
   const float64_t accel = dv / dt;
 
-  const float64_t current_vel = m_current_velocity_ptr->twist.twist.linear.x;
+  const float64_t current_vel = m_current_kinematic_state_ptr->twist.twist.linear.x;
   const float64_t current_acc = m_lpf_acc->filter(accel);
 
   return Motion{current_vel, current_acc};

--- a/control/trajectory_follower/src/pid_longitudinal_controller.cpp
+++ b/control/trajectory_follower/src/pid_longitudinal_controller.cpp
@@ -214,7 +214,7 @@ void PidLongitudinalController::setKinematicState(const nav_msgs::msg::Odometry:
   if (!msg) return;
 
   if (m_current_kinematic_state_ptr) {
-    m_prev_velocity_ptr = m_current_kinematic_state_ptr;
+    m_prev_kienmatic_state_ptr = m_current_kinematic_state_ptr;
   }
   m_current_kinematic_state_ptr = msg;
 }
@@ -365,7 +365,7 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
 boost::optional<LongitudinalOutput> PidLongitudinalController::run()
 {
   // wait for initial pointers
-  if (!m_current_kinematic_state_ptr || !m_prev_velocity_ptr || !m_trajectory_ptr) {
+  if (!m_current_kinematic_state_ptr || !m_prev_kienmatic_state_ptr || !m_trajectory_ptr) {
     return boost::none;
   }
 
@@ -701,11 +701,11 @@ float64_t PidLongitudinalController::getDt()
 
 PidLongitudinalController::Motion PidLongitudinalController::getCurrentMotion() const
 {
-  const float64_t dv =
-    m_current_kinematic_state_ptr->twist.twist.linear.x - m_prev_velocity_ptr->twist.twist.linear.x;
+  const float64_t dv = m_current_kinematic_state_ptr->twist.twist.linear.x -
+                       m_prev_kienmatic_state_ptr->twist.twist.linear.x;
   const float64_t dt = std::max(
     (rclcpp::Time(m_current_kinematic_state_ptr->header.stamp) -
-     rclcpp::Time(m_prev_velocity_ptr->header.stamp))
+     rclcpp::Time(m_prev_kienmatic_state_ptr->header.stamp))
       .seconds(),
     1e-03);
   const float64_t accel = dv / dt;

--- a/control/trajectory_follower/test/test_mpc.cpp
+++ b/control/trajectory_follower/test/test_mpc.cpp
@@ -177,8 +177,7 @@ protected:
     // Init trajectory
     mpc.setReferenceTrajectory(
       dummy_straight_trajectory, traj_resample_dist, enable_path_smoothing,
-      path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer,
-      pose_zero_ptr);
+      path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer);
   }
 };  // class MPCTest
 
@@ -236,8 +235,7 @@ TEST_F(MPCTest, InitializeAndCalculateRightTurn)
   initializeMPC(mpc);
   mpc.setReferenceTrajectory(
     dummy_right_turn_trajectory, traj_resample_dist, enable_path_smoothing,
-    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer,
-    pose_zero_ptr);
+    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer);
 
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
@@ -255,8 +253,7 @@ TEST_F(MPCTest, OsqpCalculate)
   initializeMPC(mpc);
   mpc.setReferenceTrajectory(
     dummy_straight_trajectory, traj_resample_dist, enable_path_smoothing,
-    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer,
-    pose_zero_ptr);
+    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer);
 
   const std::string vehicle_model_type = "kinematics";
   std::shared_ptr<trajectory_follower::VehicleModelInterface> vehicle_model_ptr =
@@ -287,8 +284,7 @@ TEST_F(MPCTest, OsqpCalculateRightTurn)
   initializeMPC(mpc);
   mpc.setReferenceTrajectory(
     dummy_right_turn_trajectory, traj_resample_dist, enable_path_smoothing,
-    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer,
-    pose_zero_ptr);
+    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer);
 
   const std::string vehicle_model_type = "kinematics";
   std::shared_ptr<trajectory_follower::VehicleModelInterface> vehicle_model_ptr =
@@ -333,8 +329,7 @@ TEST_F(MPCTest, KinematicsNoDelayCalculate)
   // Init trajectory
   mpc.setReferenceTrajectory(
     dummy_straight_trajectory, traj_resample_dist, enable_path_smoothing,
-    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer,
-    pose_zero_ptr);
+    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer);
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
@@ -351,8 +346,7 @@ TEST_F(MPCTest, KinematicsNoDelayCalculateRightTurn)
   initializeMPC(mpc);
   mpc.setReferenceTrajectory(
     dummy_right_turn_trajectory, traj_resample_dist, enable_path_smoothing,
-    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer,
-    pose_zero_ptr);
+    path_filter_moving_ave_num, curvature_smoothing_num_traj, curvature_smoothing_num_ref_steer);
 
   const std::string vehicle_model_type = "kinematics_no_delay";
   std::shared_ptr<trajectory_follower::VehicleModelInterface> vehicle_model_ptr =


### PR DESCRIPTION
## Description


For ego pose, replace TF with kinematic_state topic. As background, [discussions on the localization interface](https://github.com/orgs/autowarefoundation/discussions/2594) resulted in the decision to use a topic instead of TF for ego pose information.

## Related links

https://github.com/orgs/autowarefoundation/discussions/2594

## Tests performed

Run in a planning simulator and checked if the controller tracked the trajectory.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
