### PR TITLE
refactor(trajectory_follower): simplify namespace format

### DIFF
--- a/control/trajectory_follower/include/trajectory_follower/debug_values.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/debug_values.hpp
@@ -20,13 +20,7 @@
 
 #include <array>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::float64_t;
 /// Debug Values used for debugging or controller tuning
@@ -97,9 +91,6 @@ public:
 private:
   std::array<float64_t, static_cast<size_t>(TYPE::SIZE)> m_values;
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__DEBUG_VALUES_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/input_data.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/input_data.hpp
@@ -19,13 +19,7 @@
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 struct InputData
 {
@@ -33,9 +27,6 @@ struct InputData
   nav_msgs::msg::Odometry::SharedPtr current_odometry_ptr;
   autoware_auto_vehicle_msgs::msg::SteeringReport::SharedPtr current_steering_ptr;
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__INPUT_DATA_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/interpolate.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/interpolate.hpp
@@ -22,13 +22,7 @@
 #include <iostream>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
@@ -52,8 +46,5 @@ TRAJECTORY_FOLLOWER_PUBLIC bool8_t linearInterpolate(
 TRAJECTORY_FOLLOWER_PUBLIC bool8_t linearInterpolate(
   const std::vector<float64_t> & base_index, const std::vector<float64_t> & base_value,
   const float64_t & return_index, float64_t & return_value);
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__INTERPOLATE_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/lateral_controller_base.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/lateral_controller_base.hpp
@@ -23,13 +23,7 @@
 
 #include <boost/optional.hpp>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 struct LateralOutput
 {
@@ -51,9 +45,6 @@ protected:
   LongitudinalSyncData longitudinal_sync_data_;
 };
 
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__LATERAL_CONTROLLER_BASE_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/longitudinal_controller_base.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/longitudinal_controller_base.hpp
@@ -23,13 +23,7 @@
 
 #include <boost/optional.hpp>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 struct LongitudinalOutput
 {
@@ -47,9 +41,6 @@ protected:
   LateralSyncData lateral_sync_data_;
 };
 
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__LONGITUDINAL_CONTROLLER_BASE_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/longitudinal_controller_utils.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/longitudinal_controller_utils.hpp
@@ -33,13 +33,7 @@
 #include <cmath>
 #include <limits>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 namespace longitudinal_utils
 {
@@ -166,9 +160,6 @@ TRAJECTORY_FOLLOWER_PUBLIC float64_t applyDiffLimitFilter(
   const float64_t input_val, const float64_t prev_val, const float64_t dt, const float64_t max_val,
   const float64_t min_val);
 }  // namespace longitudinal_utils
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__LONGITUDINAL_CONTROLLER_UTILS_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/lowpass_filter.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/lowpass_filter.hpp
@@ -23,13 +23,7 @@
 #include <iostream>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
@@ -154,8 +148,5 @@ namespace MoveAverageFilter
  */
 TRAJECTORY_FOLLOWER_PUBLIC bool8_t filt_vector(const int64_t num, std::vector<float64_t> & u);
 }  // namespace MoveAverageFilter
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__LOWPASS_FILTER_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/mpc.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc.hpp
@@ -46,13 +46,7 @@
 #include <string>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
@@ -440,9 +434,6 @@ public:
    */
   inline void setClock(rclcpp::Clock::SharedPtr clock) { m_clock = clock; }
 };  // class MPC
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__MPC_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
@@ -50,13 +50,7 @@
 #include <string>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
@@ -215,9 +209,6 @@ private:
   rcl_interfaces::msg::SetParametersResult paramCallback(
     const std::vector<rclcpp::Parameter> & parameters);
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__MPC_LATERAL_CONTROLLER_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/mpc_trajectory.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_trajectory.hpp
@@ -24,13 +24,7 @@
 #include <iostream>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::float64_t;
 /**
@@ -98,8 +92,5 @@ public:
     return points;
   }
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__MPC_TRAJECTORY_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/mpc_utils.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_utils.hpp
@@ -44,13 +44,7 @@
 #include <string>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 namespace MPCUtils
 {
@@ -184,8 +178,5 @@ TRAJECTORY_FOLLOWER_PUBLIC bool8_t calcNearestPoseInterp(
 TRAJECTORY_FOLLOWER_PUBLIC float64_t calcStopDistance(
   const autoware_auto_planning_msgs::msg::Trajectory & current_trajectory, const int64_t origin);
 }  // namespace MPCUtils
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__MPC_UTILS_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/pid.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid.hpp
@@ -20,13 +20,7 @@
 
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
@@ -100,9 +94,6 @@ private:
   bool8_t m_is_gains_set;
   bool8_t m_is_limits_set;
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__PID_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -45,13 +45,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
@@ -369,9 +363,6 @@ private:
     const Motion & ctrl_cmd, const geometry_msgs::msg::Pose & current_pose,
     const ControlData & control_data);
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__PID_LONGITUDINAL_CONTROLLER_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_interface.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_interface.hpp
@@ -21,13 +21,7 @@
 #include "eigen3/Eigen/LU"
 #include "trajectory_follower/visibility_control.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 /// Interface for solvers of Quadratic Programming (QP) problems
@@ -56,8 +50,5 @@ public:
     const Eigen::VectorXd & lb, const Eigen::VectorXd & ub, const Eigen::VectorXd & lb_a,
     const Eigen::VectorXd & ub_a, Eigen::VectorXd & u) = 0;
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__QP_SOLVER__QP_SOLVER_INTERFACE_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_osqp.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_osqp.hpp
@@ -22,13 +22,7 @@
 #include "trajectory_follower/qp_solver/qp_solver_interface.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
@@ -67,8 +61,5 @@ private:
   autoware::common::osqp::OSQPInterface osqpsolver_;
   rclcpp::Logger logger_;
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__QP_SOLVER__QP_SOLVER_OSQP_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_unconstr_fast.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_unconstr_fast.hpp
@@ -24,13 +24,7 @@
 
 #include <cmath>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 /**
@@ -67,8 +61,5 @@ public:
     const Eigen::VectorXd & lb, const Eigen::VectorXd & ub, const Eigen::VectorXd & lb_a,
     const Eigen::VectorXd & ub_a, Eigen::VectorXd & u) override;
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__QP_SOLVER__QP_SOLVER_UNCONSTR_FAST_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/smooth_stop.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/smooth_stop.hpp
@@ -27,13 +27,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
@@ -120,9 +114,6 @@ private:
   rclcpp::Time m_weak_acc_time;
   bool8_t m_is_set_params = false;
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__SMOOTH_STOP_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/sync_data.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/sync_data.hpp
@@ -15,13 +15,7 @@
 #ifndef TRAJECTORY_FOLLOWER__SYNC_DATA_HPP_
 #define TRAJECTORY_FOLLOWER__SYNC_DATA_HPP_
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 struct LateralSyncData
 {
@@ -33,9 +27,6 @@ struct LongitudinalSyncData
   bool is_velocity_converged{false};
 };
 
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 
 #endif  // TRAJECTORY_FOLLOWER__SYNC_DATA_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_dynamics.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_dynamics.hpp
@@ -53,13 +53,7 @@
 #include "trajectory_follower/vehicle_model/vehicle_model_interface.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::float64_t;
 /**
@@ -114,8 +108,5 @@ private:
   float64_t m_cf;    //!< @brief front cornering power [N/rad]
   float64_t m_cr;    //!< @brief rear cornering power [N/rad]
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_DYNAMICS_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_kinematics.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_kinematics.hpp
@@ -47,13 +47,7 @@
 #include "trajectory_follower/vehicle_model/vehicle_model_interface.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::float64_t;
 /**
@@ -99,8 +93,5 @@ private:
   float64_t m_steer_lim;  //!< @brief steering angle limit [rad]
   float64_t m_steer_tau;  //!< @brief steering time constant for 1d-model [s]
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp
@@ -44,13 +44,7 @@
 #include "trajectory_follower/vehicle_model/vehicle_model_interface.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::float64_t;
 /**
@@ -93,8 +87,5 @@ public:
 private:
   float64_t m_steer_lim;  //!< @brief steering angle limit [rad]
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_NO_DELAY_HPP_

--- a/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_interface.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_interface.hpp
@@ -19,13 +19,7 @@
 #include "eigen3/Eigen/Core"
 #include "trajectory_follower/visibility_control.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using autoware::common::types::float64_t;
 /**
@@ -111,8 +105,5 @@ public:
    */
   virtual void calculateReferenceInput(Eigen::MatrixXd & u_ref) = 0;
 };
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower
 #endif  // TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_INTERFACE_HPP_

--- a/control/trajectory_follower/src/interpolate.cpp
+++ b/control/trajectory_follower/src/interpolate.cpp
@@ -22,13 +22,7 @@
  * linear interpolation
  */
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 namespace
 {
@@ -137,7 +131,4 @@ bool8_t linearInterpolate(
   return_value = return_value_v.at(0);
   return true;
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/longitudinal_controller_utils.cpp
+++ b/control/trajectory_follower/src/longitudinal_controller_utils.cpp
@@ -29,13 +29,7 @@
 #include <algorithm>
 #include <limits>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 namespace longitudinal_utils
 {
@@ -187,7 +181,4 @@ float64_t applyDiffLimitFilter(
   return applyDiffLimitFilter(input_val, prev_val, dt, max_val, min_val);
 }
 }  // namespace longitudinal_utils
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/lowpass_filter.cpp
+++ b/control/trajectory_follower/src/lowpass_filter.cpp
@@ -16,13 +16,7 @@
 
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 Butterworth2dFilter::Butterworth2dFilter(float64_t dt, float64_t f_cutoff_hz)
 {
@@ -143,7 +137,4 @@ bool8_t filt_vector(const int64_t num, std::vector<float64_t> & u)
   return true;
 }
 }  // namespace MoveAverageFilter
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/mpc.cpp
+++ b/control/trajectory_follower/src/mpc.cpp
@@ -25,13 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 using namespace std::literals::chrono_literals;
 using ::motion::motion_common::to_angle;
@@ -832,7 +826,4 @@ bool8_t MPC::isValid(const MPCMatrix & m) const
 
   return true;
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/mpc_lateral_controller.cpp
+++ b/control/trajectory_follower/src/mpc_lateral_controller.cpp
@@ -25,13 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 namespace
 {
@@ -546,7 +540,4 @@ bool8_t MpcLateralController::isValidTrajectory(
   return true;
 }
 
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/mpc_lateral_controller.cpp
+++ b/control/trajectory_follower/src/mpc_lateral_controller.cpp
@@ -251,31 +251,29 @@ bool MpcLateralController::isSteerConverged(
 bool8_t MpcLateralController::checkData() const
 {
   if (!m_mpc.hasVehicleModel()) {
-    RCLCPP_DEBUG(node_->get_logger(), "MPC does not have a vehicle model");
+    RCLCPP_ERROR(node_->get_logger(), "MPC does not have a vehicle model");
     return false;
   }
   if (!m_mpc.hasQPSolver()) {
-    RCLCPP_DEBUG(node_->get_logger(), "MPC does not have a QP solver");
+    RCLCPP_ERROR(node_->get_logger(), "MPC does not have a QP solver");
     return false;
   }
 
-  if (!m_current_kinematic_state_ptr) {
-    RCLCPP_DEBUG(
-      node_->get_logger(), "waiting data. kinematic_state = %d",
-      m_current_kinematic_state_ptr != nullptr);
+  const auto invalid = [this](const auto & msg) {
+    RCLCPP_DEBUG(node_->get_logger(), "%s", msg);
     return false;
+  };
+
+  if (!m_current_kinematic_state_ptr) {
+    return invalid("waiting kinematic_state");
   }
 
   if (!m_current_steering_ptr) {
-    RCLCPP_DEBUG(
-      node_->get_logger(), "waiting data. current_steering = %d",
-      m_current_steering_ptr != nullptr);
-    return false;
+    return invalid("waiting steering");
   }
 
-  if (m_mpc.m_ref_traj.size() == 0) {
-    RCLCPP_DEBUG(node_->get_logger(), "trajectory size is zero.");
-    return false;
+  if (m_mpc.m_ref_traj.empty()) {
+    return invalid("trajectory is empty");
   }
 
   return true;

--- a/control/trajectory_follower/src/mpc_trajectory.cpp
+++ b/control/trajectory_follower/src/mpc_trajectory.cpp
@@ -14,13 +14,7 @@
 
 #include "trajectory_follower/mpc_trajectory.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 void MPCTrajectory::push_back(
   const float64_t & xp, const float64_t & yp, const float64_t & zp, const float64_t & yawp,
@@ -60,7 +54,4 @@ size_t MPCTrajectory::size() const
     return 0;
   }
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/mpc_utils.cpp
+++ b/control/trajectory_follower/src/mpc_utils.cpp
@@ -21,13 +21,7 @@
 #include <string>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 namespace MPCUtils
 {
@@ -409,7 +403,4 @@ float64_t calcStopDistance(
 }
 
 }  // namespace MPCUtils
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/pid.cpp
+++ b/control/trajectory_follower/src/pid.cpp
@@ -20,13 +20,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 PIDController::PIDController()
 : m_error_integral(0.0),
@@ -109,7 +103,4 @@ void PIDController::reset()
   m_prev_error = 0.0;
   m_is_first_time = true;
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/pid_longitudinal_controller.cpp
+++ b/control/trajectory_follower/src/pid_longitudinal_controller.cpp
@@ -26,13 +26,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 PidLongitudinalController::PidLongitudinalController(rclcpp::Node & node) : node_{&node}
 {
@@ -945,7 +939,4 @@ void PidLongitudinalController::updateDebugVelAcc(
   m_debug_values.setValues(DebugValues::TYPE::ERROR_VEL, target_motion.vel - current_vel);
 }
 
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/qp_solver/qp_solver_osqp.cpp
+++ b/control/trajectory_follower/src/qp_solver/qp_solver_osqp.cpp
@@ -17,13 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 QPSolverOSQP::QPSolverOSQP(const rclcpp::Logger & logger) : logger_{logger} {}
 bool8_t QPSolverOSQP::solve(
@@ -80,7 +74,4 @@ bool8_t QPSolverOSQP::solve(
   }
   return true;
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/qp_solver/qp_solver_unconstr_fast.cpp
+++ b/control/trajectory_follower/src/qp_solver/qp_solver_unconstr_fast.cpp
@@ -14,13 +14,7 @@
 
 #include "trajectory_follower/qp_solver/qp_solver_unconstr_fast.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 QPSolverEigenLeastSquareLLT::QPSolverEigenLeastSquareLLT() {}
 bool8_t QPSolverEigenLeastSquareLLT::solve(
@@ -36,7 +30,4 @@ bool8_t QPSolverEigenLeastSquareLLT::solve(
 
   return true;
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/smooth_stop.cpp
+++ b/control/trajectory_follower/src/smooth_stop.cpp
@@ -22,13 +22,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 void SmoothStop::init(const float64_t pred_vel_in_target, const float64_t pred_stop_dist)
 {
@@ -167,7 +161,4 @@ float64_t SmoothStop::calculate(
   // when the car is not running
   return m_params.strong_stop_acc;
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_dynamics.cpp
+++ b/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_dynamics.cpp
@@ -16,13 +16,7 @@
 
 #include <algorithm>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 DynamicsBicycleModel::DynamicsBicycleModel(
   const float64_t wheelbase, const float64_t mass_fl, const float64_t mass_fr,
@@ -92,7 +86,4 @@ void DynamicsBicycleModel::calculateReferenceInput(Eigen::MatrixXd & u_ref)
     m_lr * m_mass / (2 * m_cf * m_wheelbase) - m_lf * m_mass / (2 * m_cr * m_wheelbase);
   u_ref(0, 0) = m_wheelbase * m_curvature + Kv * vel * vel * m_curvature;
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
+++ b/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
@@ -16,13 +16,7 @@
 
 #include <cmath>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 KinematicsBicycleModel::KinematicsBicycleModel(
   const float64_t wheelbase, const float64_t steer_lim, const float64_t steer_tau)
@@ -70,7 +64,4 @@ void KinematicsBicycleModel::calculateReferenceInput(Eigen::MatrixXd & u_ref)
 {
   u_ref(0, 0) = std::atan(m_wheelbase * m_curvature);
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.cpp
+++ b/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.cpp
@@ -16,13 +16,7 @@
 
 #include <cmath>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 KinematicsBicycleModelNoDelay::KinematicsBicycleModelNoDelay(
   const float64_t wheelbase, const float64_t steer_lim)
@@ -61,7 +55,4 @@ void KinematicsBicycleModelNoDelay::calculateReferenceInput(Eigen::MatrixXd & u_
 {
   u_ref(0, 0) = std::atan(m_wheelbase * m_curvature);
 }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower/src/vehicle_model/vehicle_model_interface.cpp
+++ b/control/trajectory_follower/src/vehicle_model/vehicle_model_interface.cpp
@@ -14,13 +14,7 @@
 
 #include "trajectory_follower/vehicle_model/vehicle_model_interface.hpp"
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower
+namespace autoware::motion::control::trajectory_follower
 {
 VehicleModelInterface::VehicleModelInterface(
   int64_t dim_x, int64_t dim_u, int64_t dim_y, float64_t wheelbase)
@@ -33,7 +27,4 @@ int64_t VehicleModelInterface::getDimY() { return m_dim_y; }
 float64_t VehicleModelInterface::getWheelbase() { return m_wheelbase; }
 void VehicleModelInterface::setVelocity(const float64_t velocity) { m_velocity = velocity; }
 void VehicleModelInterface::setCurvature(const float64_t curvature) { m_curvature = curvature; }
-}  // namespace trajectory_follower
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower

--- a/control/trajectory_follower_nodes/src/controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/controller_node.cpp
@@ -28,13 +28,7 @@
 #include <utility>
 #include <vector>
 
-namespace autoware
-{
-namespace motion
-{
-namespace control
-{
-namespace trajectory_follower_nodes
+namespace autoware::motion::control::trajectory_follower_nodes
 {
 Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("controller", node_options)
 {
@@ -166,10 +160,7 @@ void Controller::callbackTimerControl()
   control_cmd_pub_->publish(out);
 }
 
-}  // namespace trajectory_follower_nodes
-}  // namespace control
-}  // namespace motion
-}  // namespace autoware
+}  // namespace autoware::motion::control::trajectory_follower_nodes
 
 #include "rclcpp_components/register_node_macro.hpp"
 RCLCPP_COMPONENTS_REGISTER_NODE(autoware::motion::control::trajectory_follower_nodes::Controller)


### PR DESCRIPTION
## Description

- simplify namespace format
- use autoware_utils for unit conversion rad2deg, etc.

Note: merge after https://github.com/autowarefoundation/autoware.universe/pull/1791

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
