### PR TITLE
refactor(vehicle_cmd_gate): move private headers

### DIFF
--- a/control/vehicle_cmd_gate/src/vehicle_cmd_filter.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_filter.cpp
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "vehicle_cmd_gate/vehicle_cmd_filter.hpp"
+
+#include "vehicle_cmd_filter.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VEHICLE_CMD_GATE__VEHICLE_CMD_FILTER_HPP_
-#define VEHICLE_CMD_GATE__VEHICLE_CMD_FILTER_HPP_
+#ifndef VEHICLE_CMD_FILTER_HPP_
+#define VEHICLE_CMD_FILTER_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -74,4 +74,4 @@ private:
   double limitDiff(const double curr, const double prev, const double diff_lim) const;
 };
 
-#endif  // VEHICLE_CMD_GATE__VEHICLE_CMD_FILTER_HPP_
+#endif  // VEHICLE_CMD_FILTER_HPP_

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "vehicle_cmd_gate/vehicle_cmd_gate.hpp"
+#include "vehicle_cmd_gate.hpp"
 
 #include <rclcpp/logging.hpp>
 #include <tier4_api_utils/tier4_api_utils.hpp>

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VEHICLE_CMD_GATE__VEHICLE_CMD_GATE_HPP_
-#define VEHICLE_CMD_GATE__VEHICLE_CMD_GATE_HPP_
+#ifndef VEHICLE_CMD_GATE_HPP_
+#define VEHICLE_CMD_GATE_HPP_
 
-#include "vehicle_cmd_gate/vehicle_cmd_filter.hpp"
+#include "vehicle_cmd_filter.hpp"
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -252,4 +252,4 @@ private:
 };
 
 }  // namespace vehicle_cmd_gate
-#endif  // VEHICLE_CMD_GATE__VEHICLE_CMD_GATE_HPP_
+#endif  // VEHICLE_CMD_GATE_HPP_

--- a/control/vehicle_cmd_gate/test/src/test_vehicle_cmd_filter.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_vehicle_cmd_filter.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "vehicle_cmd_gate/vehicle_cmd_filter.hpp"
+#include "../../src/vehicle_cmd_filter.hpp"
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Move private headers from include to src.
https://github.com/autowarefoundation/autoware/discussions/2824#discussioncomment-3508008

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
