### PR TITLE
feat(motion_utils): add new search zero velocity

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -144,6 +144,19 @@ boost::optional<size_t> searchZeroVelocityIndex(
 }
 
 template <class T>
+boost::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist, const size_t & src_idx)
+{
+  try {
+    validateNonEmpty(points_with_twist);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
+
+  return searchZeroVelocityIndex(points_with_twist, src_idx, points_with_twist.size());
+}
+
+template <class T>
 boost::optional<size_t> searchZeroVelocityIndex(const T & points_with_twist)
 {
   return searchZeroVelocityIndex(points_with_twist, 0, points_with_twist.size());
@@ -1246,26 +1259,6 @@ size_t findFirstNearestSegmentIndexWithSoftConstraints(
   }
 
   return nearest_idx;
-}
-
-template <class T>
-boost::optional<size_t> searchZeroVelocityIndex(
-  const T & points_with_twist, const geometry_msgs::msg::Pose & src_pose,
-  const double max_dist = std::numeric_limits<double>::max(),
-  const double max_yaw = std::numeric_limits<double>::max())
-{
-  try {
-    validateNonEmpty(points_with_twist);
-  } catch (const std::exception & e) {
-    std::cerr << e.what() << std::endl;
-    return {};
-  }
-
-  const size_t nearest_segment_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
-    points_with_twist, src_pose, max_dist, max_yaw);
-
-  return searchZeroVelocityIndex(
-    points_with_twist, nearest_segment_idx + 1, points_with_twist.size());
 }
 }  // namespace motion_utils
 

--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -1247,6 +1247,26 @@ size_t findFirstNearestSegmentIndexWithSoftConstraints(
 
   return nearest_idx;
 }
+
+template <class T>
+boost::optional<size_t> searchZeroVelocityIndex(
+  const T & points_with_twist, const geometry_msgs::msg::Pose & src_pose,
+  const double max_dist = std::numeric_limits<double>::max(),
+  const double max_yaw = std::numeric_limits<double>::max())
+{
+  try {
+    validateNonEmpty(points_with_twist);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
+
+  const size_t nearest_segment_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+    points_with_twist, src_pose, max_dist, max_yaw);
+
+  return searchZeroVelocityIndex(
+    points_with_twist, nearest_segment_idx + 1, points_with_twist.size());
+}
 }  // namespace motion_utils
 
 #endif  // MOTION_UTILS__TRAJECTORY__TRAJECTORY_HPP_

--- a/common/motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -4334,3 +4334,126 @@ TEST(trajectory, calcSignedArcLengthFromPointAndSegmentIndexToPointIndex)
     EXPECT_NEAR(calcSignedArcLength(traj.points, 4, p2, 1), -1.7, epsilon);
   }
 }
+
+TEST(trajectory, searchZeroVelocityIndex_from_pose)
+{
+  using motion_utils::searchZeroVelocityIndex;
+
+  // No zero velocity point
+  {
+    const auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    EXPECT_FALSE(searchZeroVelocityIndex(traj.points, pose));
+  }
+
+  // Only start point is zero(boundary condition)
+  {
+    const size_t idx_ans = 0;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_FALSE(searchZeroVelocityIndex(traj.points, pose));
+  }
+
+  // Only index 1 is zero
+  {
+    const size_t idx_ans = 1;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
+  }
+
+  // Only end point is zero
+  {
+    const size_t idx_ans = 9;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
+  }
+
+  // Only middle point is zero
+  {
+    const size_t idx_ans = 5;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
+  }
+
+  // Two points are zero
+  {
+    const size_t idx_ans = 3;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    updateTrajectoryVelocityAt(traj.points, 6, 0.0);
+    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
+  }
+
+  // Negative velocity point is before zero velocity point
+  {
+    const size_t idx_ans = 3;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, 2, -1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
+  }
+
+  // Stop point is behind the current pose
+  {
+    const size_t idx_ans = 3;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    const auto pose = createPose(5.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_FALSE(searchZeroVelocityIndex(traj.points, pose));
+  }
+
+  // Current pose is outside of the trajectory (In front of the trajectory)
+  {
+    const size_t idx_ans = 3;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    const auto pose = createPose(-5.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
+  }
+
+  // Current pose is outside of the trajectory
+  {
+    const size_t idx_ans = 8;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    const auto pose = createPose(15.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_FALSE(searchZeroVelocityIndex(traj.points, pose));
+  }
+
+  {
+    const size_t idx_ans = 9;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    const auto pose = createPose(15.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
+  }
+}

--- a/common/motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -242,6 +242,69 @@ TEST(trajectory, searchZeroVelocityIndex)
   }
 }
 
+TEST(trajectory, searchZeroVelocityIndex_from_pose)
+{
+  using motion_utils::searchZeroVelocityIndex;
+
+  // No zero velocity point
+  {
+    const auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    EXPECT_FALSE(searchZeroVelocityIndex(traj.points, 0));
+  }
+
+  // Only start point is zero
+  {
+    const size_t idx_ans = 0;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, 0), idx_ans);
+  }
+
+  // Only end point is zero
+  {
+    const size_t idx_ans = 9;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, 0), idx_ans);
+  }
+
+  // Only middle point is zero
+  {
+    const size_t idx_ans = 5;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, 0), idx_ans);
+  }
+
+  // Two points are zero
+  {
+    const size_t idx_ans = 3;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+    updateTrajectoryVelocityAt(traj.points, 6, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, 0), idx_ans);
+  }
+
+  // Negative velocity point is before zero velocity point
+  {
+    const size_t idx_ans = 3;
+
+    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
+    updateTrajectoryVelocityAt(traj.points, 2, -1.0);
+    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
+
+    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, 0), idx_ans);
+  }
+}
+
 TEST(trajectory, findNearestIndex_Pos_StraightTrajectory)
 {
   using motion_utils::findNearestIndex;
@@ -4332,128 +4395,5 @@ TEST(trajectory, calcSignedArcLengthFromPointAndSegmentIndexToPointIndex)
     EXPECT_NEAR(calcSignedArcLength(traj.points, p1, 4, 2), -2.3, epsilon);
     EXPECT_NEAR(calcSignedArcLength(traj.points, 4, p2, 2), -1.7, epsilon);
     EXPECT_NEAR(calcSignedArcLength(traj.points, 4, p2, 1), -1.7, epsilon);
-  }
-}
-
-TEST(trajectory, searchZeroVelocityIndex_from_pose)
-{
-  using motion_utils::searchZeroVelocityIndex;
-
-  // No zero velocity point
-  {
-    const auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-    EXPECT_FALSE(searchZeroVelocityIndex(traj.points, pose));
-  }
-
-  // Only start point is zero(boundary condition)
-  {
-    const size_t idx_ans = 0;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_FALSE(searchZeroVelocityIndex(traj.points, pose));
-  }
-
-  // Only index 1 is zero
-  {
-    const size_t idx_ans = 1;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
-  }
-
-  // Only end point is zero
-  {
-    const size_t idx_ans = 9;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
-  }
-
-  // Only middle point is zero
-  {
-    const size_t idx_ans = 5;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
-  }
-
-  // Two points are zero
-  {
-    const size_t idx_ans = 3;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    updateTrajectoryVelocityAt(traj.points, 6, 0.0);
-    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
-  }
-
-  // Negative velocity point is before zero velocity point
-  {
-    const size_t idx_ans = 3;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, 2, -1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    const auto pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
-  }
-
-  // Stop point is behind the current pose
-  {
-    const size_t idx_ans = 3;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    const auto pose = createPose(5.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_FALSE(searchZeroVelocityIndex(traj.points, pose));
-  }
-
-  // Current pose is outside of the trajectory (In front of the trajectory)
-  {
-    const size_t idx_ans = 3;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    const auto pose = createPose(-5.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
-  }
-
-  // Current pose is outside of the trajectory
-  {
-    const size_t idx_ans = 8;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    const auto pose = createPose(15.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_FALSE(searchZeroVelocityIndex(traj.points, pose));
-  }
-
-  {
-    const size_t idx_ans = 9;
-
-    auto traj = generateTestTrajectory<Trajectory>(10, 1.0, 1.0);
-    updateTrajectoryVelocityAt(traj.points, idx_ans, 0.0);
-    const auto pose = createPose(15.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-
-    EXPECT_EQ(*searchZeroVelocityIndex(traj.points, pose), idx_ans);
   }
 }


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description

Add new search zero velocity function that can search stop point in front of the given point.
## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Unit Tests

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
