### PR TITLE
fix(system_monitor): fix parameter threshold of CPU Usage monitoring

### DIFF
--- a/launch/tier4_system_launch/config/system_monitor/cpu_monitor.param.yaml
+++ b/launch/tier4_system_launch/config/system_monitor/cpu_monitor.param.yaml
@@ -1,7 +1,8 @@
 /**:
   ros__parameters:
     usage_warn: 0.96
-    usage_error: 1.00
-    usage_count: 2
+    usage_error: 0.96
+    usage_warn_count: 1
+    usage_error_count: 2
     usage_avg: true
     msr_reader_port: 7634

--- a/system/system_monitor/config/cpu_monitor.param.yaml
+++ b/system/system_monitor/config/cpu_monitor.param.yaml
@@ -1,8 +1,8 @@
 /**:
   ros__parameters:
     usage_warn: 0.96
-    usage_error: 1.00
-    usage_warn_count: 2
+    usage_error: 0.96
+    usage_warn_count: 1
     usage_error_count: 2
     usage_avg: true
     msr_reader_port: 7634

--- a/system/system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -46,8 +46,8 @@ CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::Node
   freqs_(),
   mpstat_exists_(false),
   usage_warn_(declare_parameter<float>("usage_warn", 0.96)),
-  usage_error_(declare_parameter<float>("usage_error", 1.00)),
-  usage_warn_count_(declare_parameter<int>("usage_warn_count", 2)),
+  usage_error_(declare_parameter<float>("usage_error", 0.96)),
+  usage_warn_count_(declare_parameter<int>("usage_warn_count", 1)),
   usage_error_count_(declare_parameter<int>("usage_error_count", 2)),
   usage_avg_(declare_parameter<bool>("usage_avg", true))
 {


### PR DESCRIPTION
Signed-off-by: v-nakayama7440-esol <v-nakayama7440@esol.co.jp>

## Description

Change CPU usage threshold and counter threshold values because there is delay to generate a warning/error after the fix https://github.com/autowarefoundation/autoware.universe/pull/557. There is regression.
- Before the fix:
  - ≧96% x 1 time -> Warning, ≧96% x consecutive 2 times -> Error
  - ≧100% x 1 time -> Error
- After the fix:
  -  ≧96% x consecutive 2 times -> Warning
  - ≧100% x consecutive 2 times -> Error

I believe 100% of CPU usage at a moment shall be allowed. Or rather continuous CPU high load will possibly cause hazardous conditions.
- So the change is made as follows:
  - ≧96% x 1 time -> Warning, ≧96% x consecutive 2 times -> Error

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/557

## Tests performed

1. Simulate CPU high load by using stress-ng command.
   ```console
   stress-ng -k -c 12 -l 96
   ```

1. Verify `cpu_monitor` generates a warning at 1 time of ≧96%. 
1. Verify `cpu_monitor` generates an error  at consecutive 2 times of ≧96%. 
   ```console
   ros2 topic echo /diagnostics | grep -e "cpu_monitor: CPU Usage" -A 7
   ```
   <img width="527" alt="test" src="https://user-images.githubusercontent.com/97144416/189017218-dccec268-3b86-4312-8041-17841cb1151c.png">

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
