### PR TITLE
refactor(run_out): refactor debug markers

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
@@ -98,7 +98,9 @@ public:
   void pushNearestCollisionPoint(const geometry_msgs::msg::Point & point);
   void pushStopPose(const geometry_msgs::msg::Pose & pose);
   void pushDebugLines(const std::vector<geometry_msgs::msg::Point> & debug_line);
-  void pushDebugPolygons(const std::vector<geometry_msgs::msg::Point> & debug_polygon);
+  void pushPredictedVehiclePolygons(const std::vector<geometry_msgs::msg::Point> & polygon);
+  void pushPredictedObstaclePolygons(const std::vector<geometry_msgs::msg::Point> & polygon);
+  void pushCollisionObstaclePolygons(const std::vector<geometry_msgs::msg::Point> & polygon);
   void pushDetectionAreaPolygons(const Polygon2d & debug_polygon);
   void pushDebugTexts(const TextWithPosition & debug_text);
   void pushDebugTexts(
@@ -123,7 +125,9 @@ private:
   std::vector<geometry_msgs::msg::Point> nearest_collision_point_;
   std::vector<geometry_msgs::msg::Pose> stop_pose_;
   std::vector<std::vector<geometry_msgs::msg::Point>> debug_lines_;
-  std::vector<std::vector<geometry_msgs::msg::Point>> debug_polygons_;
+  std::vector<std::vector<geometry_msgs::msg::Point>> predicted_vehicle_polygons_;
+  std::vector<std::vector<geometry_msgs::msg::Point>> predicted_obstacle_polygons_;
+  std::vector<std::vector<geometry_msgs::msg::Point>> collision_obstacle_polygons_;
   std::vector<std::vector<geometry_msgs::msg::Point>> detection_area_polygons_;
   std::vector<TextWithPosition> debug_texts_;
   DebugValues debug_values_;

--- a/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
@@ -124,7 +124,6 @@ private:
   std::vector<geometry_msgs::msg::Point> collision_points_;
   std::vector<geometry_msgs::msg::Point> nearest_collision_point_;
   std::vector<geometry_msgs::msg::Pose> stop_pose_;
-  std::vector<std::vector<geometry_msgs::msg::Point>> debug_lines_;
   std::vector<std::vector<geometry_msgs::msg::Point>> predicted_vehicle_polygons_;
   std::vector<std::vector<geometry_msgs::msg::Point>> predicted_obstacle_polygons_;
   std::vector<std::vector<geometry_msgs::msg::Point>> collision_obstacle_polygons_;

--- a/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
@@ -97,7 +97,6 @@ public:
   void pushCollisionPoints(const std::vector<geometry_msgs::msg::Point> & points);
   void pushNearestCollisionPoint(const geometry_msgs::msg::Point & point);
   void pushStopPose(const geometry_msgs::msg::Pose & pose);
-  void pushDebugLines(const std::vector<geometry_msgs::msg::Point> & debug_line);
   void pushPredictedVehiclePolygons(const std::vector<geometry_msgs::msg::Point> & polygon);
   void pushPredictedObstaclePolygons(const std::vector<geometry_msgs::msg::Point> & polygon);
   void pushCollisionObstaclePolygons(const std::vector<geometry_msgs::msg::Point> & polygon);

--- a/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
@@ -110,6 +110,7 @@ public:
   void publishDebugValue();
   void publishDebugTrajectory(const Trajectory & trajectory);
   visualization_msgs::msg::MarkerArray createVisualizationMarkerArray();
+  void setHeight(const double height);
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray();
 
 private:
@@ -131,6 +132,7 @@ private:
   std::vector<TextWithPosition> debug_texts_;
   DebugValues debug_values_;
   AccelReason accel_reason_;
+  double height_{0};
 };
 
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
@@ -102,10 +102,8 @@ public:
   void pushPredictedObstaclePolygons(const std::vector<geometry_msgs::msg::Point> & polygon);
   void pushCollisionObstaclePolygons(const std::vector<geometry_msgs::msg::Point> & polygon);
   void pushDetectionAreaPolygons(const Polygon2d & debug_polygon);
-  void pushDebugTexts(const TextWithPosition & debug_text);
-  void pushDebugTexts(
-    const std::string text, const geometry_msgs::msg::Pose pose, const float lateral_offset);
-  void pushDebugTexts(const std::string text, const geometry_msgs::msg::Point position);
+  void pushTravelTimeTexts(
+    const double travel_time, const geometry_msgs::msg::Pose pose, const float lateral_offset);
   void setAccelReason(const AccelReason & accel_reason);
   void publishDebugValue();
   void publishDebugTrajectory(const Trajectory & trajectory);
@@ -129,7 +127,7 @@ private:
   std::vector<std::vector<geometry_msgs::msg::Point>> predicted_obstacle_polygons_;
   std::vector<std::vector<geometry_msgs::msg::Point>> collision_obstacle_polygons_;
   std::vector<std::vector<geometry_msgs::msg::Point>> detection_area_polygons_;
-  std::vector<TextWithPosition> debug_texts_;
+  std::vector<TextWithPosition> travel_time_texts_;
   DebugValues debug_values_;
   AccelReason accel_reason_;
   double height_{0};

--- a/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/run_out/debug.hpp
@@ -24,12 +24,6 @@ using autoware_auto_planning_msgs::msg::Trajectory;
 using tier4_debug_msgs::msg::Float32MultiArrayStamped;
 using tier4_debug_msgs::msg::Int32Stamped;
 
-enum class PointType : int8_t {
-  Blue = 0,
-  Red,
-  Yellow,
-};
-
 class DebugValues
 {
 public:
@@ -99,12 +93,9 @@ public:
     debug_values_.setValues(type, val);
   }
 
-  bool pushObstaclePoint(const geometry_msgs::msg::Point & obstacle_point, const PointType & type);
-  bool pushObstaclePoint(const pcl::PointXYZ & obstacle_point, const PointType & type);
-  void pushDebugPoints(const pcl::PointXYZ & debug_point);
-  void pushDebugPoints(const geometry_msgs::msg::Point & debug_point);
-  void pushDebugPoints(const std::vector<geometry_msgs::msg::Point> & debug_points);
-  void pushDebugPoints(const geometry_msgs::msg::Point & debug_point, const PointType point_type);
+  void pushCollisionPoints(const geometry_msgs::msg::Point & point);
+  void pushCollisionPoints(const std::vector<geometry_msgs::msg::Point> & points);
+  void pushNearestCollisionPoint(const geometry_msgs::msg::Point & point);
   void pushStopPose(const geometry_msgs::msg::Pose & pose);
   void pushDebugLines(const std::vector<geometry_msgs::msg::Point> & debug_line);
   void pushDebugPolygons(const std::vector<geometry_msgs::msg::Point> & debug_polygon);
@@ -128,9 +119,8 @@ private:
   rclcpp::Publisher<Float32MultiArrayStamped>::SharedPtr pub_debug_values_;
   rclcpp::Publisher<Int32Stamped>::SharedPtr pub_accel_reason_;
   rclcpp::Publisher<Trajectory>::SharedPtr pub_debug_trajectory_;
-  std::vector<geometry_msgs::msg::Point> debug_points_;
-  std::vector<geometry_msgs::msg::Point> debug_points_red_;
-  std::vector<geometry_msgs::msg::Point> debug_points_yellow_;
+  std::vector<geometry_msgs::msg::Point> collision_points_;
+  std::vector<geometry_msgs::msg::Point> nearest_collision_point_;
   std::vector<geometry_msgs::msg::Pose> stop_pose_;
   std::vector<std::vector<geometry_msgs::msg::Point>> debug_lines_;
   std::vector<std::vector<geometry_msgs::msg::Point>> debug_polygons_;

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
@@ -57,9 +57,9 @@ RunOutDebug::TextWithPosition createDebugText(
 RunOutDebug::RunOutDebug(rclcpp::Node & node) : node_(node)
 {
   pub_debug_values_ =
-    node.create_publisher<Float32MultiArrayStamped>("~/run_out/debug/debug_values", 1);
-  pub_accel_reason_ = node.create_publisher<Int32Stamped>("~/run_out/debug/accel_reason", 1);
-  pub_debug_trajectory_ = node.create_publisher<Trajectory>("~/run_out/debug/trajectory", 1);
+    node.create_publisher<Float32MultiArrayStamped>("~/debug/run_out/debug_values", 1);
+  pub_accel_reason_ = node.create_publisher<Int32Stamped>("~/debug/run_out/accel_reason", 1);
+  pub_debug_trajectory_ = node.create_publisher<Trajectory>("~/debug/run_out/trajectory", 1);
 }
 
 void RunOutDebug::pushDebugPoints(const pcl::PointXYZ & debug_point)

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
@@ -200,7 +200,7 @@ visualization_msgs::msg::MarkerArray RunOutDebug::createVisualizationMarkerArray
   if (!collision_points_.empty()) {
     auto marker = createDefaultMarker(
       "map", current_time, "collision_points", 0, visualization_msgs::msg::Marker::SPHERE_LIST,
-      createMarkerScale(0.5, 0.5, 0.5), createMarkerColor(0, 0.0, 1.0, 0.999));
+      createMarkerScale(0.3, 0.3, 0.3), createMarkerColor(0, 0.0, 1.0, 0.999));
     for (const auto & p : collision_points_) {
       marker.points.push_back(p);
     }
@@ -210,7 +210,7 @@ visualization_msgs::msg::MarkerArray RunOutDebug::createVisualizationMarkerArray
   if (!nearest_collision_point_.empty()) {
     auto marker = createDefaultMarker(
       "map", current_time, "nearest_collision_point", 0,
-      visualization_msgs::msg::Marker::SPHERE_LIST, createMarkerScale(1.0, 1.0, 1.0),
+      visualization_msgs::msg::Marker::SPHERE_LIST, createMarkerScale(0.6, 0.6, 0.6),
       createMarkerColor(1.0, 0, 0, 0.999));
     for (const auto & p : nearest_collision_point_) {
       marker.points.push_back(p);

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
@@ -106,11 +106,6 @@ void RunOutDebug::pushStopPose(const geometry_msgs::msg::Pose & pose)
   stop_pose_.push_back(pose);
 }
 
-void RunOutDebug::pushDebugLines(const std::vector<geometry_msgs::msg::Point> & debug_line)
-{
-  debug_lines_.push_back(debug_line);
-}
-
 void RunOutDebug::pushPredictedVehiclePolygons(
   const std::vector<geometry_msgs::msg::Point> & polygon)
 {
@@ -158,7 +153,6 @@ void RunOutDebug::clearDebugMarker()
 {
   collision_points_.clear();
   nearest_collision_point_.clear();
-  debug_lines_.clear();
   detection_area_polygons_.clear();
   predicted_vehicle_polygons_.clear();
   predicted_obstacle_polygons_.clear();
@@ -219,20 +213,6 @@ visualization_msgs::msg::MarkerArray RunOutDebug::createVisualizationMarkerArray
       marker.points.push_back(p);
     }
     msg.markers.push_back(marker);
-  }
-
-  if (!debug_lines_.empty()) {
-    int32_t marker_id = 0;
-    for (const auto & line : debug_lines_) {
-      auto marker = createDefaultMarker(
-        "map", current_time, "debug_lines", marker_id, visualization_msgs::msg::Marker::LINE_STRIP,
-        createMarkerScale(0.1, 0.0, 0.0), createMarkerColor(0, 0, 1.0, 0.999));
-      for (const auto & p : line) {
-        marker.points.push_back(p);
-      }
-      msg.markers.push_back(marker);
-      marker_id++;
-    }
   }
 
   if (!predicted_vehicle_polygons_.empty()) {

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
@@ -42,16 +42,6 @@ RunOutDebug::TextWithPosition createDebugText(
   return text_with_position;
 }
 
-RunOutDebug::TextWithPosition createDebugText(
-  const std::string text, const geometry_msgs::msg::Point position)
-{
-  RunOutDebug::TextWithPosition text_with_position;
-  text_with_position.text = text;
-  text_with_position.position = position;
-
-  return text_with_position;
-}
-
 visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
   const std::vector<std::vector<geometry_msgs::msg::Point>> & poly, const rclcpp::Time & time,
   const std::string ns, const geometry_msgs::msg::Vector3 & scale,
@@ -136,20 +126,12 @@ void RunOutDebug::pushDetectionAreaPolygons(const Polygon2d & debug_polygon)
   detection_area_polygons_.push_back(ros_points);
 }
 
-void RunOutDebug::pushDebugTexts(const TextWithPosition & debug_text)
+void RunOutDebug::pushTravelTimeTexts(
+  const double travel_time, const geometry_msgs::msg::Pose pose, const float lateral_offset)
 {
-  debug_texts_.push_back(debug_text);
-}
-
-void RunOutDebug::pushDebugTexts(
-  const std::string text, const geometry_msgs::msg::Pose pose, const float lateral_offset)
-{
-  debug_texts_.push_back(createDebugText(text, pose, lateral_offset));
-}
-
-void RunOutDebug::pushDebugTexts(const std::string text, const geometry_msgs::msg::Point position)
-{
-  debug_texts_.push_back(createDebugText(text, position));
+  std::stringstream sstream;
+  sstream << std::setprecision(4) << travel_time << "s";
+  travel_time_texts_.push_back(createDebugText(sstream.str(), pose, lateral_offset));
 }
 
 void RunOutDebug::clearDebugMarker()
@@ -160,7 +142,7 @@ void RunOutDebug::clearDebugMarker()
   predicted_vehicle_polygons_.clear();
   predicted_obstacle_polygons_.clear();
   collision_obstacle_polygons_.clear();
-  debug_texts_.clear();
+  travel_time_texts_.clear();
 }
 
 visualization_msgs::msg::MarkerArray RunOutDebug::createVisualizationMarkerArray()
@@ -259,13 +241,14 @@ visualization_msgs::msg::MarkerArray RunOutDebug::createVisualizationMarkerArray
       &msg);
   }
 
-  if (!debug_texts_.empty()) {
+  if (!travel_time_texts_.empty()) {
     auto marker = createDefaultMarker(
-      "map", current_time, "debug_texts", 0, visualization_msgs::msg::Marker::TEXT_VIEW_FACING,
-      createMarkerScale(0.0, 0.0, 0.8), createMarkerColor(1.0, 1.0, 1.0, 0.999));
+      "map", current_time, "travel_time_texts", 0,
+      visualization_msgs::msg::Marker::TEXT_VIEW_FACING, createMarkerScale(0.0, 0.0, 0.8),
+      createMarkerColor(1.0, 1.0, 1.0, 0.999));
 
     constexpr float height_offset = 2.0;
-    for (const auto & text : debug_texts_) {
+    for (const auto & text : travel_time_texts_) {
       marker.pose.position = text.position;
       marker.pose.position.z += height_offset;
       marker.text = text.text;

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
@@ -79,19 +79,22 @@ RunOutDebug::RunOutDebug(rclcpp::Node & node) : node_(node)
 
 void RunOutDebug::pushCollisionPoints(const geometry_msgs::msg::Point & point)
 {
-  collision_points_.push_back(point);
+  const auto point_with_height = createPoint(point.x, point.y, height_);
+  collision_points_.push_back(point_with_height);
 }
 
 void RunOutDebug::pushCollisionPoints(const std::vector<geometry_msgs::msg::Point> & points)
 {
   for (const auto & p : points) {
-    collision_points_.push_back(p);
+    const auto point_with_height = createPoint(p.x, p.y, height_);
+    collision_points_.push_back(point_with_height);
   }
 }
 
 void RunOutDebug::pushNearestCollisionPoint(const geometry_msgs::msg::Point & point)
 {
-  nearest_collision_point_.push_back(point);
+  const auto point_with_height = createPoint(point.x, point.y, height_);
+  nearest_collision_point_.push_back(point_with_height);
 }
 
 void RunOutDebug::pushStopPose(const geometry_msgs::msg::Pose & pose)

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/debug.cpp
@@ -55,7 +55,7 @@ RunOutDebug::TextWithPosition createDebugText(
 visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
   const std::vector<std::vector<geometry_msgs::msg::Point>> & poly, const rclcpp::Time & time,
   const std::string ns, const geometry_msgs::msg::Vector3 & scale,
-  const std_msgs::msg::ColorRGBA & color)
+  const std_msgs::msg::ColorRGBA & color, const double height)
 {
   visualization_msgs::msg::MarkerArray marker_array;
   for (size_t i = 0; i < poly.size(); i++) {
@@ -63,10 +63,13 @@ visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
       "map", time, ns, i, visualization_msgs::msg::Marker::LINE_STRIP, scale, color);
 
     for (const auto & p : poly.at(i)) {
-      marker.points.push_back(p);
+      const auto p_with_height = createPoint(p.x, p.y, height);
+      marker.points.push_back(p_with_height);
     }
     // close the polygon
-    marker.points.push_back(poly.at(i).front());
+    const auto & p = poly.at(i).front();
+    const auto p_with_height = createPoint(p.x, p.y, height);
+    marker.points.push_back(p_with_height);
 
     marker_array.markers.push_back(marker);
   }
@@ -236,7 +239,7 @@ visualization_msgs::msg::MarkerArray RunOutDebug::createVisualizationMarkerArray
     appendMarkerArray(
       createPolygonMarkerArray(
         predicted_obstacle_polygons_, current_time, "predicted_obstacle_polygons",
-        createMarkerScale(0.02, 0.0, 0.0), createMarkerColor(1.0, 1.0, 0.0, 0.999)),
+        createMarkerScale(0.02, 0.0, 0.0), createMarkerColor(1.0, 1.0, 0.0, 0.999), height_),
       &msg);
   }
 
@@ -244,7 +247,7 @@ visualization_msgs::msg::MarkerArray RunOutDebug::createVisualizationMarkerArray
     appendMarkerArray(
       createPolygonMarkerArray(
         collision_obstacle_polygons_, current_time, "collision_obstacle_polygons",
-        createMarkerScale(0.04, 0.0, 0.0), createMarkerColor(1.0, 0.0, 0.0, 0.999)),
+        createMarkerScale(0.04, 0.0, 0.0), createMarkerColor(1.0, 0.0, 0.0, 0.999), height_),
       &msg);
   }
 
@@ -252,7 +255,7 @@ visualization_msgs::msg::MarkerArray RunOutDebug::createVisualizationMarkerArray
     appendMarkerArray(
       createPolygonMarkerArray(
         detection_area_polygons_, current_time, "detection_area_polygons",
-        createMarkerScale(0.04, 0.0, 0.0), createMarkerColor(0.0, 0.0, 1.0, 0.999)),
+        createMarkerScale(0.04, 0.0, 0.0), createMarkerColor(0.0, 0.0, 1.0, 0.999), height_),
       &msg);
   }
 
@@ -296,6 +299,8 @@ void RunOutDebug::publishDebugTrajectory(const Trajectory & trajectory)
 {
   pub_debug_trajectory_->publish(trajectory);
 }
+
+void RunOutDebug::setHeight(const double height) { height_ = height; }
 
 // scene module
 visualization_msgs::msg::MarkerArray RunOutModule::createDebugMarkerArray()

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -217,14 +217,8 @@ boost::optional<DynamicObstacle> RunOutModule::detectCollision(
       continue;
     }
 
-    // debug
-    {
-      std::stringstream sstream;
-      sstream << std::setprecision(4) << "ttc: " << std::to_string(travel_time) << "s";
-      debug_ptr_->pushDebugTexts(sstream.str(), obstacle_selected->nearest_collision_point);
-      debug_ptr_->pushCollisionPoints(obstacle_selected->collision_points);
-      debug_ptr_->pushNearestCollisionPoint(obstacle_selected->nearest_collision_point);
-    }
+    debug_ptr_->pushCollisionPoints(obstacle_selected->collision_points);
+    debug_ptr_->pushNearestCollisionPoint(obstacle_selected->nearest_collision_point);
 
     return obstacle_selected;
   }

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -55,6 +55,9 @@ bool RunOutModule::modifyPathVelocity(
   const auto current_acc = planner_data_->current_accel.get();
   const auto & current_pose = planner_data_->current_pose.pose;
 
+  // set height of debug data
+  debug_ptr_->setHeight(current_pose.position.z);
+
   // smooth velocity of the path to calculate time to collision accurately
   PathWithLaneId smoothed_path;
   if (!smoothPath(*path, smoothed_path, planner_data_)) {

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -222,8 +222,8 @@ boost::optional<DynamicObstacle> RunOutModule::detectCollision(
       std::stringstream sstream;
       sstream << std::setprecision(4) << "ttc: " << std::to_string(travel_time) << "s";
       debug_ptr_->pushDebugTexts(sstream.str(), obstacle_selected->nearest_collision_point);
-      debug_ptr_->pushDebugPoints(obstacle_selected->collision_points);
-      debug_ptr_->pushDebugPoints(obstacle_selected->nearest_collision_point, PointType::Red);
+      debug_ptr_->pushCollisionPoints(obstacle_selected->collision_points);
+      debug_ptr_->pushNearestCollisionPoint(obstacle_selected->nearest_collision_point);
     }
 
     return obstacle_selected;
@@ -737,10 +737,6 @@ void RunOutModule::insertApproachingVelocity(
     motion_utils::findNearestSegmentIndex(output_path.points, current_pose.position);
   run_out_utils::insertPathVelocityFromIndexLimited(
     nearest_seg_idx, approaching_vel, output_path.points);
-
-  // debug
-  debug_ptr_->pushDebugPoints(
-    output_path.points.at(nearest_seg_idx).point.pose.position, PointType::Yellow);
 
   // calculate stop point to insert 0 velocity
   const float base_to_collision_point =

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -201,13 +201,8 @@ boost::optional<DynamicObstacle> RunOutModule::detectCollision(
 
     const auto vehicle_poly = createVehiclePolygon(p2.pose);
 
-    // debug
-    {
-      debug_ptr_->pushPredictedVehiclePolygons(vehicle_poly);
-      std::stringstream sstream;
-      sstream << std::setprecision(4) << travel_time << "s";
-      debug_ptr_->pushDebugTexts(sstream.str(), p2.pose, /* lateral_offset */ 3.0);
-    }
+    debug_ptr_->pushPredictedVehiclePolygons(vehicle_poly);
+    debug_ptr_->pushTravelTimeTexts(travel_time, p2.pose, /* lateral_offset */ 3.0);
 
     auto obstacles_collision =
       checkCollisionWithObstacles(dynamic_obstacles, vehicle_poly, travel_time);

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -200,7 +200,7 @@ boost::optional<DynamicObstacle> RunOutModule::detectCollision(
 
     // debug
     {
-      debug_ptr_->pushDebugPolygons(vehicle_poly);
+      debug_ptr_->pushPredictedVehiclePolygons(vehicle_poly);
       std::stringstream sstream;
       sstream << std::setprecision(4) << travel_time << "s";
       debug_ptr_->pushDebugTexts(sstream.str(), p2.pose, /* lateral_offset */ 3.0);
@@ -447,18 +447,18 @@ bool RunOutModule::checkCollisionWithCylinder(
   const auto bg_bounding_box_for_points =
     run_out_utils::createBoostPolyFromMsg(bounding_box_for_points);
 
-  // debug
-  debug_ptr_->pushDebugPolygons(bounding_box_for_points);
-
   // check collision with 2d polygon
   std::vector<tier4_autoware_utils::Point2d> collision_points_bg;
   bg::intersection(vehicle_polygon, bg_bounding_box_for_points, collision_points_bg);
 
   // no collision detected
   if (collision_points_bg.empty()) {
+    debug_ptr_->pushPredictedObstaclePolygons(bounding_box_for_points);
     return false;
   }
 
+  // detected collision
+  debug_ptr_->pushCollisionObstaclePolygons(bounding_box_for_points);
   for (const auto & p : collision_points_bg) {
     const auto p_msg =
       tier4_autoware_utils::createPoint(p.x(), p.y(), pose_with_range.pose_min.position.z);
@@ -512,18 +512,18 @@ bool RunOutModule::checkCollisionWithBoundingBox(
     createBoundingBoxForRangedPoints(pose_with_range, dimension.x / 2.0, dimension.y / 2.0);
   const auto bg_bounding_box = run_out_utils::createBoostPolyFromMsg(bounding_box);
 
-  // debug
-  debug_ptr_->pushDebugPolygons(bounding_box);
-
   // check collision with 2d polygon
   std::vector<tier4_autoware_utils::Point2d> collision_points_bg;
   bg::intersection(vehicle_polygon, bg_bounding_box, collision_points_bg);
 
   // no collision detected
   if (collision_points_bg.empty()) {
+    debug_ptr_->pushPredictedObstaclePolygons(bounding_box);
     return false;
   }
 
+  // detected collision
+  debug_ptr_->pushCollisionObstaclePolygons(bounding_box);
   for (const auto & p : collision_points_bg) {
     const auto p_msg =
       tier4_autoware_utils::createPoint(p.x(), p.y(), pose_with_range.pose_min.position.z);


### PR DESCRIPTION
## Description

Refactor for debug marker of run out module.
There are no effects to the actual behavior.
- modified the topic name
- organized the namespace
- removed unnecessary marker
- fix the height of the marker to see in 3D

https://user-images.githubusercontent.com/11865769/189089453-cb8b217c-6302-4c20-bb76-de55b47dff93.mp4


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
