### PR TITLE
fix(behavior_path_planner): drivable area not properly extended

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1706,18 +1706,14 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
   lanelet::ConstLanelets extended_lanelets = current_lanes;
 
   for (const auto & current_lane : current_lanes) {
-    if (!parameters_->enable_avoidance_over_opposite_direction) {
+    if (!parameters_->enable_avoidance_over_same_direction) {
       break;
     }
 
     const auto extend_from_current_lane = std::invoke(
       [this, &route_handler](const lanelet::ConstLanelet & lane) {
-        const auto ignore_opposite = !parameters_->enable_avoidance_over_opposite_direction;
-        if (ignore_opposite) {
-          return route_handler->getAllSharedLineStringLanelets(lane, true, true, ignore_opposite);
-        }
-
-        return route_handler->getAllSharedLineStringLanelets(lane);
+        const auto enable_opposite = parameters_->enable_avoidance_over_opposite_direction;
+        return route_handler->getAllSharedLineStringLanelets(lane, true, true, enable_opposite);
       },
       current_lane);
     extended_lanelets.reserve(extended_lanelets.size() + extend_from_current_lane.size());


### PR DESCRIPTION
fix drivable area not properly extended when
enable_avoidance_over_opposite_direction is true

Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

When `enable_avoidance_over_opposite_direction` is false, the drivable area is not extended to lane with same direction.

This PR aims to fix this bug.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/1812

## Tests performed

1. Set `enable_avoidance_over_opposite_direction` to `false`
2. Start planning simulator
3. Set start and goal pose.
4. Place obstacle on the middle of the generated path.


### Result
```
enable_avoidance_over_same_direction: true
enable_avoidance_over_opposite_direction: false
```

Map with opposite direction

![Screenshot from 2022-09-08 22-52-47](https://user-images.githubusercontent.com/93502286/189142332-e1a0f246-a85f-45b4-923a-9e493d730970.png)

Map with same direction
![Screenshot from 2022-09-08 22-53-50](https://user-images.githubusercontent.com/93502286/189142359-2550279d-c3ba-40ad-a69e-7703bfe9a3a2.png)

```
enable_avoidance_over_same_direction: false
enable_avoidance_over_opposite_direction: false
```

Map with opposite direction

![Screenshot from 2022-09-08 22-55-27](https://user-images.githubusercontent.com/93502286/189142491-805a8709-8562-474d-beb9-26f60f5de4d7.png)

Map with same direction

![Screenshot from 2022-09-08 22-54-48](https://user-images.githubusercontent.com/93502286/189142450-ece95a27-0614-48de-bf8a-7c1c46e9df42.png)

```
enable_avoidance_over_same_direction: true
enable_avoidance_over_opposite_direction: true
```

Map with opposite direction

![Screenshot from 2022-09-08 22-56-22](https://user-images.githubusercontent.com/93502286/189142620-4ae5598c-95ea-49af-84ec-9377e39a73fd.png)

Map with same direction

![Screenshot from 2022-09-08 22-57-08](https://user-images.githubusercontent.com/93502286/189142635-ea2d15b0-534c-4b8d-93ff-065e42f90f7e.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
