### PR TITLE
feat(behavior_path_planner): decrease pull_over hz

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
@@ -52,6 +52,7 @@ struct PullOutStatus
   PathWithLaneId backward_path;
   lanelet::ConstLanelets current_lanes;
   lanelet::ConstLanelets pull_out_lanes;
+  lanelet::ConstLanelets lanes;
   std::vector<uint64_t> lane_follow_lane_ids;
   std::vector<uint64_t> pull_out_lane_ids;
   bool is_safe = false;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_path.hpp
@@ -24,14 +24,14 @@ namespace behavior_path_planner
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 struct ShiftParkingPath
 {
-  PathWithLaneId path;
-  PathWithLaneId straight_path;
-  ShiftedPath shifted_path;
-  ShiftPoint shift_point;
+  PathWithLaneId path{};
+  PathWithLaneId straight_path{};
+  ShiftedPath shifted_path{};
+  ShiftPoint shift_point{};
   double acceleration{0.0};
   double preparation_length{0.0};
   double pull_over_length{0.0};
-  bool is_safe;
+  bool is_safe{false};
 };
 }  // namespace behavior_path_planner
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__PULL_OVER__PULL_OVER_PATH_HPP_

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -624,9 +624,14 @@ BehaviorModuleOutput PullOverModule::plan()
         -calcMinimumShiftPathDistance(), parameters_.deceleration_interval);
     }
   }
+  // generate drivable area
+  {
+    const auto p = planner_data_->parameters;
+    status_.path.drivable_area = util::generateDrivableArea(
+      status_.path, status_.lanes, p.drivable_area_resolution, p.vehicle_length, planner_data_);
+  }
 
   BehaviorModuleOutput output;
-
   // safe: use pull over path
   if (status_.is_safe) {
     output.path = std::make_shared<PathWithLaneId>(status_.path);
@@ -733,10 +738,6 @@ bool PullOverModule::planShiftPath()
   if (!found_safe_path) {
     return found_safe_path;
   }
-
-  shift_parking_path_.path.drivable_area = util::generateDrivableArea(
-    shift_parking_path_.path, status_.lanes, common_parameters.drivable_area_resolution,
-    common_parameters.vehicle_length, planner_data_);
 
   shift_parking_path_.path.header = planner_data_->route_handler->getRouteHeader();
   return found_safe_path;

--- a/planning/behavior_path_planner/src/scene_module/utils/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/src/scene_module/utils/geometric_parallel_parking.cpp
@@ -347,11 +347,6 @@ PathWithLaneId GeometricParallelParking::generateStraightPath(const Pose & start
   auto path = planner_data_->route_handler->getCenterLinePath(
     current_lanes, current_arc_position.length, start_arc_position.length, true);
   path.header = planner_data_->route_handler->getRouteHeader();
-
-  path.drivable_area = util::generateDrivableArea(
-    path, current_lanes, planner_data_->parameters.drivable_area_resolution,
-    planner_data_->parameters.vehicle_length, planner_data_);
-
   path.points.back().point.longitudinal_velocity_mps = 0;
 
   return path;
@@ -429,9 +424,6 @@ std::vector<PathWithLaneId> GeometricParallelParking::planOneTrial(
     p.lane_ids.push_back(closest_shoulder_lanelet.id());
   }
   path_turn_left.header = planner_data_->route_handler->getRouteHeader();
-  path_turn_left.drivable_area = util::generateDrivableArea(
-    path_turn_left, lanes, common_params.drivable_area_resolution, common_params.vehicle_length,
-    planner_data_);
 
   PathWithLaneId path_turn_right = generateArcPath(
     Cr, R_E_r, normalizeRadian(psi + M_PI_2 + theta_l), M_PI_2, !is_forward, is_forward);
@@ -440,9 +432,6 @@ std::vector<PathWithLaneId> GeometricParallelParking::planOneTrial(
     p.lane_ids.push_back(closest_shoulder_lanelet.id());
   }
   path_turn_right.header = planner_data_->route_handler->getRouteHeader();
-  path_turn_right.drivable_area = util::generateDrivableArea(
-    path_turn_right, lanes, common_params.drivable_area_resolution, common_params.vehicle_length,
-    planner_data_);
 
   // Need to add straight path to last right_turning for parking in parallel
   if (std::abs(end_pose_offset) > 0) {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Decrease pull_over hz.
- generate drivable area only for selected path.
- pull_over also be updated

## Related links

<!-- Write the links related to this PR. -->


## Tests performed

<!-- Describe how you have tested this PR. -->

psim 

check that output path is 10 hz in worst case.

![Screenshot from 2022-09-09 01-11-22](https://user-images.githubusercontent.com/39142679/189184053-ce767c87-aed6-4924-a7b7-b72cf712b748.png)

and check that pull_out does not degrade.

## Notes for reviewers



<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
