### PR TITLE
fix(behavior_path_planner): fix pull_over dies when occupancy_grid_map is not ready

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -83,7 +83,7 @@ void PullOverModule::resetStatus()
 // This function is needed for waiting for planner_data_
 void PullOverModule::updateOccupancyGrid()
 {
-  if (planner_data_->occupancy_grid == nullptr) {
+  if (!planner_data_->occupancy_grid) {
     RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 5000, "occupancy_grid is not ready");
     return;
   }

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -83,6 +83,10 @@ void PullOverModule::resetStatus()
 // This function is needed for waiting for planner_data_
 void PullOverModule::updateOccupancyGrid()
 {
+  if (planner_data_->occupancy_grid == nullptr) {
+    RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 5000, "occupancy_grid is not ready");
+    return;
+  }
   occupancy_grid_map_.setMap(*(planner_data_->occupancy_grid));
 }
 

--- a/planning/behavior_path_planner/src/scene_module/utils/occupancy_grid_based_collision_detector.cpp
+++ b/planning/behavior_path_planner/src/scene_module/utils/occupancy_grid_based_collision_detector.cpp
@@ -155,6 +155,11 @@ void OccupancyGridBasedCollisionDetector::computeCollisionIndexes(
 bool OccupancyGridBasedCollisionDetector::detectCollision(
   const IndexXYT & base_index, const bool check_out_of_range) const
 {
+  if (coll_indexes_table_.empty()) {
+    std::cerr << "[occupancy_grid_based_collision_detector] setMap has not yet been done."
+              << std::endl;
+    return false;
+  }
   const auto & coll_indexes_2d = coll_indexes_table_[base_index.theta];
   for (const auto & coll_index_2d : coll_indexes_2d) {
     int idx_theta = 0;  // whatever. Yaw is nothing to do with collision detection between grids.

--- a/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -160,6 +160,10 @@ void AbstractPlanningAlgorithm::computeCollisionIndexes(
 
 bool AbstractPlanningAlgorithm::detectCollision(const IndexXYT & base_index)
 {
+  if (coll_indexes_table_.empty()) {
+    std::cerr << "[abstrac_algorithm] setMap has not yet been done." << std::endl;
+    return false;
+  }
   const auto & coll_indexes_2d = coll_indexes_table_[base_index.theta];
   for (const auto & coll_index_2d : coll_indexes_2d) {
     int idx_theta = 0;  // whatever. Yaw is nothing to do with collision detection between grids.

--- a/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -161,7 +161,7 @@ void AbstractPlanningAlgorithm::computeCollisionIndexes(
 bool AbstractPlanningAlgorithm::detectCollision(const IndexXYT & base_index)
 {
   if (coll_indexes_table_.empty()) {
-    std::cerr << "[abstrac_algorithm] setMap has not yet been done." << std::endl;
+    std::cerr << "[abstract_algorithm] setMap has not yet been done." << std::endl;
     return false;
   }
   const auto & coll_indexes_2d = coll_indexes_table_[base_index.theta];


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fix pull_over dies when there is no occupancy_grid map. 
This problem happed using lsim and play rosbag which has no occupancy_grid map. 

And I also fixed same one in free space planenr.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
