### PR TITLE
fix(crosswalk_traffic_light_estimator): fix invalid access

### DIFF
--- a/perception/crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/crosswalk_traffic_light_estimator/src/node.cpp
@@ -203,13 +203,15 @@ void CrosswalkTrafficLightEstimatorNode::updateLastDetectedSignal(
     last_detect_color_.at(id) = input_traffic_signal.second;
   }
 
+  std::vector<int32_t> erase_id_list;
   for (auto & last_traffic_signal : last_detect_color_) {
     const auto & id = last_traffic_signal.second.map_primitive_id;
 
     if (traffic_light_id_map.count(id) == 0) {
-      last_detect_color_.erase(id);
+      erase_id_list.emplace_back(id);
     }
   }
+  for (const auto id : erase_id_list) last_detect_color_.erase(id);
 }
 
 void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description

(crosswalk_traffic_light_estimator)
Currently, in the for-loop of `last_detect_color_`, `last_detect_color_.erase()` is called.
It causes invalid access and the crosswalk_traffic_light_estimator node dies frequently now.
I fixed it.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed
I confirmed the improvement with the rosbag.
(I'm sorry but I can't provide the rosbag here because it contains camera images including personal data.)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
