### PR TITLE
fix(behavior_velocity_planner): negative time exception

### DIFF
--- a/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
+++ b/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
@@ -118,7 +118,9 @@ struct PlannerData
     for (const auto & velocity : velocity_buffer) {
       vs.push_back(velocity.twist.linear.x);
 
-      const auto time_diff = now - velocity.header.stamp;
+      const auto & s = velocity.header.stamp;
+      const auto time_diff =
+        now >= s ? now - s : rclcpp::Duration(0, 0);  // Note: negative time throws an exception.
       if (time_diff.seconds() >= stop_duration) {
         break;
       }

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -309,10 +309,12 @@ void BehaviorVelocityPlannerNode::onVehicleVelocity(
 
   // Add velocity to buffer
   planner_data_.velocity_buffer.push_front(*current_velocity);
-  const auto now = this->now();
+  const rclcpp::Time now = this->now();
   while (true) {
     // Check oldest data time
-    const auto time_diff = now - planner_data_.velocity_buffer.back().header.stamp;
+    const auto & s = planner_data_.velocity_buffer.back().header.stamp;
+    const auto time_diff =
+      now >= s ? now - s : rclcpp::Duration(0, 0);  // Note: negative time throws an exception.
 
     // Finish when oldest data is newer than threshold
     if (time_diff.seconds() <= PlannerData::velocity_buffer_time_sec) {


### PR DESCRIPTION
## Description

The current implementation in `behavior_velocity_planner` causes an exception as below. THis PR fixes the bug.

```
[component_container_mt-47] terminate called after throwing an instance of 'std::runtime_error'
[component_container_mt-47]   what():  cannot store a negative time point in rclcpp::Time
```


## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Run planning simulator.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
