### PR TITLE
fix(lidar_centerpoint): include zero in range of yaw_norm_threshold

### DIFF
--- a/perception/lidar_centerpoint/include/lidar_centerpoint/centerpoint_config.hpp
+++ b/perception/lidar_centerpoint/include/lidar_centerpoint/centerpoint_config.hpp
@@ -57,7 +57,7 @@ public:
       circle_nms_dist_threshold_ = circle_nms_dist_threshold;
     }
 
-    if (yaw_norm_threshold > 0 && yaw_norm_threshold < 1) {
+    if (yaw_norm_threshold >= 0 && yaw_norm_threshold < 1) {
       yaw_norm_threshold_ = yaw_norm_threshold;
     }
 


### PR DESCRIPTION
Signed-off-by: Shin-kyoto <58775300+Shin-kyoto@users.noreply.github.com>

## PR Type

- Bug Fix

## Description

- If yaw_norm_threshold is set in 0 by lidar_centerpoint.launch.xml, yaw_norm_threshold is actually set in 0.5.
- So change to include 0 in range of yaw_norm_threshold. After merging this PR, if yaw_norm_threshold is set in 0 by lidar_centerpoint.launch.xml, yaw_norm_threshold is actually set in 0.


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
