### PR TITLE
refactor(behavior_path_planner): refactoring some utils function

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/path_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/path_utilities.hpp
@@ -38,8 +38,8 @@ using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 
 std::vector<double> calcPathArcLengthArray(
-  const PathWithLaneId & path, size_t start = 0, size_t end = std::numeric_limits<size_t>::max(),
-  double offset = 0.0);
+  const PathWithLaneId & path, const size_t start = 0,
+  const size_t end = std::numeric_limits<size_t>::max(), const double offset = 0.0);
 
 PathWithLaneId resamplePathWithSpline(const PathWithLaneId & path, double interval);
 

--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -195,12 +195,12 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   if (path.shift_length.empty()) {
     return std::make_pair(turn_signal, max_distance);
   }
-  const auto & base_link2front = common_parameter.base_link2front;
-  const auto & vehicle_width = common_parameter.vehicle_width;
+  const auto base_link2front = common_parameter.base_link2front;
+  const auto vehicle_width = common_parameter.vehicle_width;
   const auto shift_to_outside = vehicle_width / 2;
-  const auto & tl_on_threshold_lat = common_parameter.turn_light_on_threshold_dis_lat;
-  const auto & tl_on_threshold_long = common_parameter.turn_light_on_threshold_dis_long;
-  const auto & prev_sec = common_parameter.turn_light_on_threshold_time;
+  const auto tl_on_threshold_lat = common_parameter.turn_light_on_threshold_dis_lat;
+  const auto tl_on_threshold_long = common_parameter.turn_light_on_threshold_dis_long;
+  const auto prev_sec = common_parameter.turn_light_on_threshold_time;
   constexpr double epsilon = 1e-6;
   const auto arc_position_current_pose = lanelet::utils::getArcCoordinates(current_lanes, pose);
 

--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -212,7 +212,7 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   //  1. lateral offset is larger than tl_on_threshold_lat for left signal
   //                      smaller than tl_on_threshold_lat for right signal
   //  2. side point at shift start/end point cross the line
-  double distance_to_shift_start =
+  const double distance_to_shift_start =
     std::invoke([&current_lanes, &shift_point, &arc_position_current_pose]() {
       const auto arc_position_shift_start =
         lanelet::utils::getArcCoordinates(current_lanes, shift_point.start);

--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -36,13 +36,13 @@ namespace behavior_path_planner::util
 std::vector<double> calcPathArcLengthArray(
   const PathWithLaneId & path, size_t start, size_t end, double offset)
 {
+  start = std::max(start + 1, size_t{1});
+  end = std::min(end, path.points.size());
   std::vector<double> out;
+  out.reserve(end - start + 1);
 
   double sum = offset;
   out.push_back(sum);
-
-  start = std::max(start + 1, size_t{1});
-  end = std::min(end, path.points.size());
 
   for (size_t i = start; i < end; ++i) {
     sum +=
@@ -110,11 +110,11 @@ PathWithLaneId resamplePathWithSpline(const PathWithLaneId & path, double interv
     s_out.push_back(*closest_stop_dist);
   }
 
-  std::sort(s_out.begin(), s_out.end());
-
   if (s_out.empty()) {
     return path;
   }
+
+  std::sort(s_out.begin(), s_out.end());
 
   return motion_utils::resamplePath(path, s_out);
 }
@@ -195,13 +195,13 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   if (path.shift_length.empty()) {
     return std::make_pair(turn_signal, max_distance);
   }
-  const auto base_link2front = common_parameter.base_link2front;
-  const auto vehicle_width = common_parameter.vehicle_width;
+  const auto & base_link2front = common_parameter.base_link2front;
+  const auto & vehicle_width = common_parameter.vehicle_width;
   const auto shift_to_outside = vehicle_width / 2;
-  const auto tl_on_threshold_lat = common_parameter.turn_light_on_threshold_dis_lat;
-  const auto tl_on_threshold_long = common_parameter.turn_light_on_threshold_dis_long;
-  const auto prev_sec = common_parameter.turn_light_on_threshold_time;
-  const double epsilon = 1e-6;
+  const auto & tl_on_threshold_lat = common_parameter.turn_light_on_threshold_dis_lat;
+  const auto & tl_on_threshold_long = common_parameter.turn_light_on_threshold_dis_long;
+  const auto & prev_sec = common_parameter.turn_light_on_threshold_time;
+  constexpr double epsilon = 1e-6;
   const auto arc_position_current_pose = lanelet::utils::getArcCoordinates(current_lanes, pose);
 
   // Start turn signal when 1 or 2 is satisfied
@@ -212,12 +212,12 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   //  1. lateral offset is larger than tl_on_threshold_lat for left signal
   //                      smaller than tl_on_threshold_lat for right signal
   //  2. side point at shift start/end point cross the line
-  double distance_to_shift_start;
-  {
-    const auto arc_position_shift_start =
-      lanelet::utils::getArcCoordinates(current_lanes, shift_point.start);
-    distance_to_shift_start = arc_position_shift_start.length - arc_position_current_pose.length;
-  }
+  double distance_to_shift_start =
+    std::invoke([&current_lanes, &shift_point, &arc_position_current_pose]() {
+      const auto arc_position_shift_start =
+        lanelet::utils::getArcCoordinates(current_lanes, shift_point.start);
+      return arc_position_shift_start.length - arc_position_current_pose.length;
+    });
 
   const auto time_to_shift_start =
     (std::abs(velocity) < epsilon) ? max_time : distance_to_shift_start / velocity;
@@ -265,17 +265,17 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
     }
   }
 
-  bool cross_line = false;
-  bool TEMPORARY_SET_CROSS_LINE_TRUE =
-    true;  // due to a bug. See link:
-           // https://github.com/autowarefoundation/autoware.universe/pull/748
-  if (TEMPORARY_SET_CROSS_LINE_TRUE) {
-    cross_line = true;
-  } else {
-    cross_line =
-      (left_start_point_is_in_lane != left_end_point_is_in_lane ||
-       right_start_point_is_in_lane != right_end_point_is_in_lane);
-  }
+  const bool cross_line = std::invoke([&]() {
+    constexpr bool temporary_set_cross_line_true =
+      true;  // due to a bug. See link:
+             // https://github.com/autowarefoundation/autoware.universe/pull/748
+    if (temporary_set_cross_line_true) {
+      return true;
+    }
+    return (
+      left_start_point_is_in_lane != left_end_point_is_in_lane ||
+      right_start_point_is_in_lane != right_end_point_is_in_lane);
+  });
 
   if (time_to_shift_start < prev_sec || distance_to_shift_start < tl_on_threshold_long) {
     if (diff > tl_on_threshold_lat && cross_line) {
@@ -286,13 +286,12 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   }
 
   // calc distance from ego vehicle front to shift end point.
-  double distance_from_vehicle_front;
-  {
-    const auto arc_position_shift_end =
-      lanelet::utils::getArcCoordinates(current_lanes, shift_point.end);
-    distance_from_vehicle_front =
-      arc_position_shift_end.length - arc_position_current_pose.length - base_link2front;
-  }
+  const double distance_from_vehicle_front =
+    std::invoke([&current_lanes, &shift_point, &arc_position_current_pose, &base_link2front]() {
+      const auto arc_position_shift_end =
+        lanelet::utils::getArcCoordinates(current_lanes, shift_point.end);
+      return arc_position_shift_end.length - arc_position_current_pose.length - base_link2front;
+    });
 
   if (distance_from_vehicle_front >= 0.0) {
     return std::make_pair(turn_signal, distance_from_vehicle_front);

--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -34,17 +34,17 @@ namespace behavior_path_planner::util
  * @brief calc path arclength on each points from start point to end point.
  */
 std::vector<double> calcPathArcLengthArray(
-  const PathWithLaneId & path, size_t start, size_t end, double offset)
+  const PathWithLaneId & path, const size_t start, const size_t end, const double offset)
 {
-  start = std::max(start + 1, size_t{1});
-  end = std::min(end, path.points.size());
+  const auto bounded_start = std::max(start, size_t{0});
+  const auto bounded_end = std::min(end, path.points.size());
   std::vector<double> out;
-  out.reserve(end - start + 1);
+  out.reserve(bounded_end - bounded_start);
 
   double sum = offset;
   out.push_back(sum);
 
-  for (size_t i = start; i < end; ++i) {
+  for (size_t i = bounded_start + 1; i < bounded_end; ++i) {
     sum +=
       tier4_autoware_utils::calcDistance2d(path.points.at(i).point, path.points.at(i - 1).point);
     out.push_back(sum);

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -61,9 +61,13 @@ double calcInterpolatedVelocity(
 
 namespace drivable_area_utils
 {
+using autoware_auto_planning_msgs::msg::PathWithLaneId;
+using geometry_msgs::msg::Pose;
+using route_handler::RouteHandler;
+
 template <class T>
 size_t findNearestSegmentIndex(
-  const std::vector<T> & points, const geometry_msgs::msg::Pose & pose, const double dist_threshold,
+  const std::vector<T> & points, const Pose & pose, const double dist_threshold,
   const double yaw_threshold)
 {
   const auto nearest_idx =
@@ -112,7 +116,7 @@ bool sumLengthFromTwoPoints(
   return is_end;
 }
 
-void fillYawFromXY(std::vector<geometry_msgs::msg::Pose> & points)
+void fillYawFromXY(std::vector<Pose> & points)
 {
   if (points.size() < 2) {
     return;
@@ -128,51 +132,166 @@ void fillYawFromXY(std::vector<geometry_msgs::msg::Pose> & points)
   }
 }
 
-std::array<double, 4> getPathScope(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const std::shared_ptr<route_handler::RouteHandler> route_handler,
-  const geometry_msgs::msg::Pose & current_pose, const double forward_lane_length,
-  const double backward_lane_length, const double lane_margin, const double max_dist,
-  const double max_yaw)
+lanelet::ConstLanelets extractLanesFromPathWithLaneId(
+  const std::shared_ptr<RouteHandler> & route_handler, const PathWithLaneId & path)
 {
-  // extract lanes from path_with_lane_id
-  lanelet::ConstLanelets path_lanes = [&]() {
-    // extract "unique" lane ids from path_with_lane_id
-    std::vector<size_t> path_lane_ids;
-    for (const auto & path_point : path.points) {
-      for (const size_t lane_id : path_point.lane_ids) {
-        if (std::find(path_lane_ids.begin(), path_lane_ids.end(), lane_id) == path_lane_ids.end()) {
-          path_lane_ids.push_back(lane_id);
-        }
+  // extract "unique" lane ids from path_with_lane_id
+  std::vector<size_t> path_lane_ids;
+  for (const auto & path_point : path.points) {
+    for (const size_t lane_id : path_point.lane_ids) {
+      if (std::find(path_lane_ids.begin(), path_lane_ids.end(), lane_id) == path_lane_ids.end()) {
+        path_lane_ids.push_back(lane_id);
       }
     }
+  }
 
-    // get lanes according to lane ids
-    lanelet::ConstLanelets path_lanes;
-    for (const auto path_lane_id : path_lane_ids) {
-      const auto & lane = route_handler->getLaneletsFromId(path_lane_id);
-      path_lanes.push_back(lane);
-    }
+  // get lanes according to lane ids
+  lanelet::ConstLanelets path_lanes;
+  path_lanes.reserve(path_lane_ids.size());
+  for (const auto path_lane_id : path_lane_ids) {
+    const auto & lane = route_handler->getLaneletsFromId(static_cast<lanelet::Id>(path_lane_id));
+    path_lanes.push_back(lane);
+  }
 
-    return path_lanes;
-  }();
+  return path_lanes;
+}
 
-  // calculate nearest lane idx
-  const int nearest_lane_idx = [&]() -> int {
-    lanelet::ConstLanelet closest_lanelet;
-    if (lanelet::utils::query::getClosestLanelet(path_lanes, current_pose, &closest_lanelet)) {
-      for (size_t i = 0; i < path_lanes.size(); ++i) {
-        if (path_lanes.at(i).id() == closest_lanelet.id()) {
-          return i;
-        }
+size_t getNearestLaneId(const lanelet::ConstLanelets & path_lanes, const Pose & current_pose)
+{
+  lanelet::ConstLanelet closest_lanelet;
+  if (lanelet::utils::query::getClosestLanelet(path_lanes, current_pose, &closest_lanelet)) {
+    for (size_t i = 0; i < path_lanes.size(); ++i) {
+      if (path_lanes.at(i).id() == closest_lanelet.id()) {
+        return i;
       }
     }
-    return 0;
-  }();
+  }
+  return 0;
+}
+
+void updateMinMaxPositionFromForwardLanelet(
+  const lanelet::ConstLanelets & path_lanes, const std::vector<Pose> & points,
+  const Pose & current_pose, const double & forward_lane_length, const double & lane_margin,
+  const size_t & nearest_lane_idx, const size_t & nearest_segment_idx,
+  const std::function<lanelet::ConstLineString2d(const lanelet::ConstLanelet & lane)> &
+    get_bound_func,
+  boost::optional<double> & min_x, boost::optional<double> & min_y, boost::optional<double> & max_x,
+  boost::optional<double> & max_y)
+{
+  const auto forward_offset_length = motion_utils::calcSignedArcLength(
+    points, current_pose.position, nearest_segment_idx, nearest_segment_idx);
+  double sum_length = std::min(forward_offset_length, 0.0);
+  size_t current_lane_idx = nearest_lane_idx;
+  auto current_lane = path_lanes.at(current_lane_idx);
+  size_t current_point_idx = nearest_segment_idx;
+  while (true) {
+    const auto & bound = get_bound_func(current_lane);
+    if (current_point_idx != bound.size() - 1) {
+      const Eigen::Vector2d & current_point = bound[current_point_idx].basicPoint();
+      const Eigen::Vector2d & next_point = bound[current_point_idx + 1].basicPoint();
+      const bool is_end_lane = drivable_area_utils::sumLengthFromTwoPoints(
+        current_point, next_point, forward_lane_length + lane_margin, sum_length, min_x, min_y,
+        max_x, max_y);
+      if (is_end_lane) {
+        break;
+      }
+
+      ++current_point_idx;
+    } else {
+      const auto previous_lane = current_lane;
+      const size_t previous_point_idx = get_bound_func(previous_lane).size() - 1;
+      const auto & previous_bound = get_bound_func(previous_lane);
+      drivable_area_utils::updateMinMaxPosition(
+        previous_bound[previous_point_idx].basicPoint(), min_x, min_y, max_x, max_y);
+
+      if (current_lane_idx == path_lanes.size() - 1) {
+        break;
+      }
+
+      current_lane_idx += 1;
+      current_lane = path_lanes.at(current_lane_idx);
+      current_point_idx = 0;
+      const auto & current_bound = get_bound_func(current_lane);
+
+      const Eigen::Vector2d & prev_point = previous_bound[previous_point_idx].basicPoint();
+      const Eigen::Vector2d & current_point = current_bound[current_point_idx].basicPoint();
+      const bool is_end_lane = drivable_area_utils::sumLengthFromTwoPoints(
+        prev_point, current_point, forward_lane_length + lane_margin, sum_length, min_x, min_y,
+        max_x, max_y);
+      if (is_end_lane) {
+        break;
+      }
+    }
+  }
+}
+
+void updateMinMaxPositionFromBackwardLanelet(
+  const lanelet::ConstLanelets & path_lanes, const std::vector<Pose> & points,
+  const Pose & current_pose, const double & backward_lane_length, const double & lane_margin,
+  const size_t & nearest_lane_idx, const size_t & nearest_segment_idx,
+  const std::function<lanelet::ConstLineString2d(const lanelet::ConstLanelet & lane)> &
+    get_bound_func,
+  boost::optional<double> & min_x, boost::optional<double> & min_y, boost::optional<double> & max_x,
+  boost::optional<double> & max_y)
+{
+  size_t current_point_idx = nearest_segment_idx + 1;
+  const auto backward_offset_length = motion_utils::calcSignedArcLength(
+    points, nearest_segment_idx + 1, current_pose.position, nearest_segment_idx);
+  double sum_length = std::min(backward_offset_length, 0.0);
+  size_t current_lane_idx = nearest_lane_idx;
+  lanelet::ConstLanelet current_lane = path_lanes.at(current_lane_idx);
+  while (true) {
+    const auto & bound = get_bound_func(current_lane);
+    if (current_point_idx != 0) {
+      const Eigen::Vector2d & current_point = bound[current_point_idx].basicPoint();
+      const Eigen::Vector2d & prev_point = bound[current_point_idx - 1].basicPoint();
+      const bool is_end_lane = drivable_area_utils::sumLengthFromTwoPoints(
+        current_point, prev_point, backward_lane_length + lane_margin, sum_length, min_x, min_y,
+        max_x, max_y);
+      if (is_end_lane) {
+        break;
+      }
+
+      --current_point_idx;
+    } else {
+      const auto next_lane = current_lane;
+      const size_t next_point_idx = 0;
+      const auto & next_bound = get_bound_func(next_lane);
+      drivable_area_utils::updateMinMaxPosition(
+        next_bound[next_point_idx].basicPoint(), min_x, min_y, max_x, max_y);
+
+      if (current_lane_idx == 0) {
+        break;
+      }
+
+      current_lane_idx -= 1;
+      current_lane = path_lanes.at(current_lane_idx);
+      const auto & current_bound = get_bound_func(current_lane);
+      current_point_idx = current_bound.size() - 1;
+
+      const Eigen::Vector2d & next_point = next_bound[next_point_idx].basicPoint();
+      const Eigen::Vector2d & current_point = current_bound[current_point_idx].basicPoint();
+      const bool is_end_lane = drivable_area_utils::sumLengthFromTwoPoints(
+        next_point, current_point, backward_lane_length + lane_margin, sum_length, min_x, min_y,
+        max_x, max_y);
+      if (is_end_lane) {
+        break;
+      }
+    }
+  }
+}
+std::array<double, 4> getPathScope(
+  const PathWithLaneId & path, const std::shared_ptr<RouteHandler> & route_handler,
+  const Pose & current_pose, const double forward_lane_length, const double backward_lane_length,
+  const double lane_margin, const double max_dist, const double max_yaw)
+{
+  const lanelet::ConstLanelets path_lanes = extractLanesFromPathWithLaneId(route_handler, path);
+
+  const size_t nearest_lane_idx = getNearestLaneId(path_lanes, current_pose);
 
   // define functions to get right/left bounds as a vector
-  const auto get_bound_funcs =
-    std::vector<std::function<lanelet::ConstLineString2d(const lanelet::ConstLanelet & lane)>>{
+  const std::vector<std::function<lanelet::ConstLineString2d(const lanelet::ConstLanelet & lane)>>
+    get_bound_funcs{
       [](const lanelet::ConstLanelet & lane) -> lanelet::ConstLineString2d {
         return lane.rightBound2d();
       },
@@ -193,111 +312,33 @@ std::array<double, 4> getPathScope(
       continue;
     }
 
-    std::vector<geometry_msgs::msg::Pose> points;
-    for (const auto & point : nearest_bound) {  // calculate x and y
-      geometry_msgs::msg::Pose p;
-      p.position.x = point.x();
-      p.position.y = point.y();
-      points.push_back(p);
-    }
-    fillYawFromXY(points);  // calculate yaw
+    const std::vector<Pose> points = std::invoke([&nearest_bound]() {
+      std::vector<Pose> points;
+      points.reserve(nearest_bound.size());
+      for (const auto & point : nearest_bound) {  // calculate x and y
+        Pose p;
+        p.position.x = point.x();
+        p.position.y = point.y();
+        points.push_back(p);
+      }
+
+      fillYawFromXY(points);  // calculate yaw
+      return points;
+    });
+
     const size_t nearest_segment_idx =
       motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
         points, current_pose, max_dist, max_yaw);
 
     // forward lanelet
-    const auto forward_offset_length = motion_utils::calcSignedArcLength(
-      points, current_pose.position, nearest_segment_idx, nearest_segment_idx);
-    double sum_length = std::min(forward_offset_length, 0.0);
-    size_t current_lane_idx = nearest_lane_idx;
-    auto current_lane = path_lanes.at(current_lane_idx);
-    size_t current_point_idx = nearest_segment_idx;
-    while (true) {
-      const auto & bound = get_bound_func(current_lane);
-      if (current_point_idx != bound.size() - 1) {
-        const Eigen::Vector2d & current_point = bound[current_point_idx].basicPoint();
-        const Eigen::Vector2d & next_point = bound[current_point_idx + 1].basicPoint();
-        const bool is_end_lane = drivable_area_utils::sumLengthFromTwoPoints(
-          current_point, next_point, forward_lane_length + lane_margin, sum_length, min_x, min_y,
-          max_x, max_y);
-        if (is_end_lane) {
-          break;
-        }
-
-        ++current_point_idx;
-      } else {
-        const auto previous_lane = current_lane;
-        const size_t previous_point_idx = get_bound_func(previous_lane).size() - 1;
-        const auto & previous_bound = get_bound_func(previous_lane);
-        drivable_area_utils::updateMinMaxPosition(
-          previous_bound[previous_point_idx].basicPoint(), min_x, min_y, max_x, max_y);
-
-        if (current_lane_idx == path_lanes.size() - 1) {
-          break;
-        }
-
-        current_lane_idx += 1;
-        current_lane = path_lanes.at(current_lane_idx);
-        current_point_idx = 0;
-        const auto & current_bound = get_bound_func(current_lane);
-
-        const Eigen::Vector2d & prev_point = previous_bound[previous_point_idx].basicPoint();
-        const Eigen::Vector2d & current_point = current_bound[current_point_idx].basicPoint();
-        const bool is_end_lane = drivable_area_utils::sumLengthFromTwoPoints(
-          prev_point, current_point, forward_lane_length + lane_margin, sum_length, min_x, min_y,
-          max_x, max_y);
-        if (is_end_lane) {
-          break;
-        }
-      }
-    }
+    updateMinMaxPositionFromForwardLanelet(
+      path_lanes, points, current_pose, forward_lane_length, lane_margin, nearest_lane_idx,
+      nearest_segment_idx, get_bound_func, min_x, min_y, max_x, max_y);
 
     // backward lanelet
-    current_point_idx = nearest_segment_idx + 1;
-    const auto backward_offset_length = motion_utils::calcSignedArcLength(
-      points, nearest_segment_idx + 1, current_pose.position, nearest_segment_idx);
-    sum_length = std::min(backward_offset_length, 0.0);
-    current_lane_idx = nearest_lane_idx;
-    current_lane = path_lanes.at(current_lane_idx);
-    while (true) {
-      const auto & bound = get_bound_func(current_lane);
-      if (current_point_idx != 0) {
-        const Eigen::Vector2d & current_point = bound[current_point_idx].basicPoint();
-        const Eigen::Vector2d & prev_point = bound[current_point_idx - 1].basicPoint();
-        const bool is_end_lane = drivable_area_utils::sumLengthFromTwoPoints(
-          current_point, prev_point, backward_lane_length + lane_margin, sum_length, min_x, min_y,
-          max_x, max_y);
-        if (is_end_lane) {
-          break;
-        }
-
-        --current_point_idx;
-      } else {
-        const auto next_lane = current_lane;
-        const size_t next_point_idx = 0;
-        const auto & next_bound = get_bound_func(next_lane);
-        drivable_area_utils::updateMinMaxPosition(
-          next_bound[next_point_idx].basicPoint(), min_x, min_y, max_x, max_y);
-
-        if (current_lane_idx == 0) {
-          break;
-        }
-
-        current_lane_idx -= 1;
-        current_lane = path_lanes.at(current_lane_idx);
-        const auto & current_bound = get_bound_func(current_lane);
-        current_point_idx = current_bound.size() - 1;
-
-        const Eigen::Vector2d & next_point = next_bound[next_point_idx].basicPoint();
-        const Eigen::Vector2d & current_point = current_bound[current_point_idx].basicPoint();
-        const bool is_end_lane = drivable_area_utils::sumLengthFromTwoPoints(
-          next_point, current_point, backward_lane_length + lane_margin, sum_length, min_x, min_y,
-          max_x, max_y);
-        if (is_end_lane) {
-          break;
-        }
-      }
-    }
+    updateMinMaxPositionFromBackwardLanelet(
+      path_lanes, points, current_pose, backward_lane_length, lane_margin, nearest_lane_idx,
+      nearest_segment_idx, get_bound_func, min_x, min_y, max_x, max_y);
   }
 
   if (!min_x || !min_y || !max_x || !max_y) {
@@ -321,6 +362,7 @@ using tier4_autoware_utils::Point2d;
 std::vector<Pose> convertToPoseArray(const PathWithLaneId & path)
 {
   std::vector<Pose> pose_array;
+  pose_array.reserve(path.points.size());
   for (const auto & pt : path.points) {
     pose_array.push_back(pt.point.pose);
   }
@@ -700,6 +742,7 @@ std::vector<size_t> filterObjectIndicesByLanelets(
         continue;
       }
       Polygon2d lanelet_polygon;
+      lanelet_polygon.outer().reserve(polygon2d.size() + 1);
       for (const auto & lanelet_point : polygon2d) {
         lanelet_polygon.outer().emplace_back(lanelet_point.x(), lanelet_point.y());
       }
@@ -721,6 +764,7 @@ PredictedObjects filterObjectsByLanelets(
 {
   PredictedObjects filtered_objects;
   const auto indices = filterObjectIndicesByLanelets(objects, target_lanelets);
+  filtered_objects.objects.reserve(indices.size());
   for (const size_t i : indices) {
     filtered_objects.objects.push_back(objects.objects.at(i));
   }
@@ -762,9 +806,8 @@ std::vector<double> calcObjectsDistanceToPath(
       continue;
     }
     LineString2d ego_path_line;
-    for (size_t j = 0; j < ego_path_point_array.size(); ++j) {
-      boost::geometry::append(
-        ego_path_line, Point2d(ego_path_point_array.at(j).x, ego_path_point_array.at(j).y));
+    for (const auto & ego_path_point : ego_path_point_array) {
+      boost::geometry::append(ego_path_line, Point2d(ego_path_point.x, ego_path_point.y));
     }
     const double distance = boost::geometry::distance(obj_polygon, ego_path_line);
     distance_array.push_back(distance);
@@ -784,9 +827,8 @@ std::vector<size_t> filterObjectsIndicesByPath(
       continue;
     }
     LineString2d ego_path_line;
-    for (size_t j = 0; j < ego_path_point_array.size(); ++j) {
-      boost::geometry::append(
-        ego_path_line, Point2d(ego_path_point_array.at(j).x, ego_path_point_array.at(j).y));
+    for (const auto & ego_path_point : ego_path_point_array) {
+      boost::geometry::append(ego_path_line, Point2d(ego_path_point.x, ego_path_point.y));
     }
     const double distance = boost::geometry::distance(obj_polygon, ego_path_line);
     if (distance < vehicle_width) {
@@ -829,7 +871,7 @@ bool exists(std::vector<T> vec, T element)
 
 boost::optional<size_t> findIndexOutOfGoalSearchRange(
   const std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId> & points,
-  const geometry_msgs::msg::Pose & goal, const int64_t goal_lane_id,
+  const Pose & goal, const int64_t goal_lane_id,
   const double max_dist = std::numeric_limits<double>::max())
 {
   if (points.empty()) {
@@ -1536,9 +1578,9 @@ void imageToOccupancyGrid(const cv::Mat & cv_image, OccupancyGrid * occupancy_gr
 cv::Point toCVPoint(
   const Point & geom_point, const double width_m, const double height_m, const double resolution)
 {
-  return cv::Point(
+  return {
     static_cast<int>((height_m - geom_point.y) / resolution),
-    static_cast<int>((width_m - geom_point.x) / resolution));
+    static_cast<int>((width_m - geom_point.x) / resolution)};
 }
 
 // TODO(Horibe) There is a similar function in route_handler.
@@ -1931,8 +1973,8 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
 }
 
 lanelet::ConstLanelets calcLaneAroundPose(
-  const std::shared_ptr<RouteHandler> route_handler, const geometry_msgs::msg::Pose & pose,
-  const double forward_length, const double backward_length)
+  const std::shared_ptr<RouteHandler> route_handler, const Pose & pose, const double forward_length,
+  const double backward_length)
 {
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(pose, &current_lane)) {


### PR DESCRIPTION
## Description

This PR includes refactoring such as
1. Add `reserve` before any `push_back` in `behavior_path_planner::utils`
2. Refactor function to reduce cognitive complexity to 20 or below.
3. Other small clang tidy changes. 

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

Degradation test are conducted using autoware evaluator.
So far no apparent issue.

## Notes for reviewers

The PR doesn't yet address all clang-tidy issues.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
