### PR TITLE
fix(tier4_perception_launch): add input/pointcloud to ground-segmentation

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -465,7 +465,7 @@ def launch_setup(context, *args, **kwargs):
     components = []
     components.extend(
         pipeline.create_single_frame_obstacle_segmentation_components(
-            input_topic="/sensing/lidar/concatenated/pointcloud",
+            input_topic=LaunchConfiguration("input/pointcloud"),
             output_topic=pipeline.single_frame_obstacle_seg_output,
         )
     )
@@ -521,6 +521,7 @@ def generate_launch_description():
     add_launch_arg("use_pointcloud_container", "False")
     add_launch_arg("container_name", "perception_pipeline_container")
     add_launch_arg("tier4_perception_launch_param_path", "tier4_perception_launch parameter path")
+    add_launch_arg("input/pointcloud", "/sensing/lidar/concatenated/pointcloud")
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",


### PR DESCRIPTION
Signed-off-by: yukke42 <yusuke.muramatsu@tier4.jp>

## Description

Add the arg of input/pointcloud to ground_segmentation so that the chane of input/pointcloud in perception.launch.xml is applied to ground_segmentation.py as well.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
