### PR TITLE
docs(joy_controller): joystick keymap fix in readme

### DIFF
--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -42,23 +42,23 @@
 | `max_backward_velocity`   | double | absolute max velocity to go backward                                                                               |
 | `backward_accel_ratio`    | double | ratio to calculate deceleration (commanded acceleration is -ratio \* operation)                                    |
 
-## P65 Joystick Key Map
+## DS4 Joystick Key Map
 
-| Acceleration         | R2                    |
-| -------------------- | --------------------- |
-| Brake                | L2                    |
-| Steering             | Left Stick Left Right |
-| Shift up             | Cursor Up             |
-| Shift down           | Cursor Down           |
-| Shift Drive          | Cursor Left           |
-| Shift Reverse        | Cursor Right          |
-| Turn Signal Left     | L1                    |
-| Turn Signal Right    | R1                    |
-| Clear Turn Signal    | A                     |
-| Gate Mode            | B                     |
-| Emergency Stop       | Select                |
-| Clear Emergency Stop | Start                 |
-| Autoware Engage      | X                     |
-| Autoware Disengage   | Y                     |
-| Vehicle Engage       | PS                    |
-| Vehicle Disengage    | Right Trigger         |
+| Acceleration         | R2                                        |
+| -------------------- | ----------------------------------------- |
+| Brake                | □ or Right Stick Up Down or Left Trigger |
+| Steering             | Left Stick Left Right                     |
+| Shift up             | Cursor Up                                 |
+| Shift down           | Cursor Down                               |
+| Shift Drive          | Cursor Left                               |
+| Shift Reverse        | Cursor Right                              |
+| Turn Signal Left     | L1                                        |
+| Turn Signal Right    | R1                                        |
+| Clear Turn Signal    | SHARE                                     |
+| Gate Mode            | OPTIONS                                   |
+| Emergency Stop       | PS                                        |
+| Clear Emergency Stop | PS                                        |
+| Autoware Engage      | ○                                        |
+| Autoware Disengage   | ○                                        |
+| Vehicle Engage       | △                                        |
+| Vehicle Disengage    | △                                        |

--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -42,6 +42,27 @@
 | `max_backward_velocity`   | double | absolute max velocity to go backward                                                                               |
 | `backward_accel_ratio`    | double | ratio to calculate deceleration (commanded acceleration is -ratio \* operation)                                    |
 
+## P65 Joystick Key Map
+
+| Acceleration         | R2                    |
+| -------------------- | --------------------- |
+| Brake                | L2                    |
+| Steering             | Left Stick Left Right |
+| Shift up             | Cursor Up             |
+| Shift down           | Cursor Down           |
+| Shift Drive          | Cursor Left           |
+| Shift Reverse        | Cursor Right          |
+| Turn Signal Left     | L1                    |
+| Turn Signal Right    | R1                    |
+| Clear Turn Signal    | A                     |
+| Gate Mode            | B                     |
+| Emergency Stop       | Select                |
+| Clear Emergency Stop | Start                 |
+| Autoware Engage      | X                     |
+| Autoware Disengage   | Y                     |
+| Vehicle Engage       | PS                    |
+| Vehicle Disengage    | Right Trigger         |
+
 ## DS4 Joystick Key Map
 
 | Acceleration         | R2                                       |

--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -44,8 +44,9 @@
 
 ## P65 Joystick Key Map
 
-| Acceleration         | R2                    |
+| Action               | Button                |
 | -------------------- | --------------------- |
+| Acceleration         | R2                    |
 | Brake                | L2                    |
 | Steering             | Left Stick Left Right |
 | Shift up             | Cursor Up             |
@@ -65,9 +66,10 @@
 
 ## DS4 Joystick Key Map
 
-| Acceleration         | R2                                       |
+| Action               | Button                                   |
 | -------------------- | ---------------------------------------- |
-| Brake                | □ or Right Stick Up Down or Left Trigger |
+| Acceleration         | R2, ×, or Right Stick Up                |
+| Brake                | L2, □, or Right Stick Down              |
 | Steering             | Left Stick Left Right                    |
 | Shift up             | Cursor Up                                |
 | Shift down           | Cursor Down                              |

--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -66,22 +66,22 @@
 
 ## DS4 Joystick Key Map
 
-| Action               | Button                                   |
-| -------------------- | ---------------------------------------- |
-| Acceleration         | R2, ×, or Right Stick Up                |
-| Brake                | L2, □, or Right Stick Down              |
-| Steering             | Left Stick Left Right                    |
-| Shift up             | Cursor Up                                |
-| Shift down           | Cursor Down                              |
-| Shift Drive          | Cursor Left                              |
-| Shift Reverse        | Cursor Right                             |
-| Turn Signal Left     | L1                                       |
-| Turn Signal Right    | R1                                       |
-| Clear Turn Signal    | SHARE                                    |
-| Gate Mode            | OPTIONS                                  |
-| Emergency Stop       | PS                                       |
-| Clear Emergency Stop | PS                                       |
-| Autoware Engage      | ○                                        |
-| Autoware Disengage   | ○                                        |
-| Vehicle Engage       | △                                        |
-| Vehicle Disengage    | △                                        |
+| Action               | Button                     |
+| -------------------- | -------------------------- |
+| Acceleration         | R2, ×, or Right Stick Up   |
+| Brake                | L2, □, or Right Stick Down |
+| Steering             | Left Stick Left Right      |
+| Shift up             | Cursor Up                  |
+| Shift down           | Cursor Down                |
+| Shift Drive          | Cursor Left                |
+| Shift Reverse        | Cursor Right               |
+| Turn Signal Left     | L1                         |
+| Turn Signal Right    | R1                         |
+| Clear Turn Signal    | SHARE                      |
+| Gate Mode            | OPTIONS                    |
+| Emergency Stop       | PS                         |
+| Clear Emergency Stop | PS                         |
+| Autoware Engage      | ○                          |
+| Autoware Disengage   | ○                          |
+| Vehicle Engage       | △                          |
+| Vehicle Disengage    | △                          |

--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -44,20 +44,20 @@
 
 ## DS4 Joystick Key Map
 
-| Acceleration         | R2                                        |
-| -------------------- | ----------------------------------------- |
+| Acceleration         | R2                                       |
+| -------------------- | ---------------------------------------- |
 | Brake                | □ or Right Stick Up Down or Left Trigger |
-| Steering             | Left Stick Left Right                     |
-| Shift up             | Cursor Up                                 |
-| Shift down           | Cursor Down                               |
-| Shift Drive          | Cursor Left                               |
-| Shift Reverse        | Cursor Right                              |
-| Turn Signal Left     | L1                                        |
-| Turn Signal Right    | R1                                        |
-| Clear Turn Signal    | SHARE                                     |
-| Gate Mode            | OPTIONS                                   |
-| Emergency Stop       | PS                                        |
-| Clear Emergency Stop | PS                                        |
+| Steering             | Left Stick Left Right                    |
+| Shift up             | Cursor Up                                |
+| Shift down           | Cursor Down                              |
+| Shift Drive          | Cursor Left                              |
+| Shift Reverse        | Cursor Right                             |
+| Turn Signal Left     | L1                                       |
+| Turn Signal Right    | R1                                       |
+| Clear Turn Signal    | SHARE                                    |
+| Gate Mode            | OPTIONS                                  |
+| Emergency Stop       | PS                                       |
+| Clear Emergency Stop | PS                                       |
 | Autoware Engage      | ○                                        |
 | Autoware Disengage   | ○                                        |
 | Vehicle Engage       | △                                        |


### PR DESCRIPTION
## Description

Convert the joystick key map in the readme from P65 to DS4.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
