### PR TITLE
feat(obstacle_cruise_planner): add explanations for holding the closest stop obstacle

### DIFF
--- a/planning/obstacle_cruise_planner/README.md
+++ b/planning/obstacle_cruise_planner/README.md
@@ -274,6 +274,16 @@ In the case of the crosswalk described above, `obstacle_cruise_planner` inserts 
 | --------------------------------- | ------ | ---------------------------------------------------------------------- |
 | `common.min_behavior_stop_margin` | double | minimum stop margin when stopping with the behavior module enabled [m] |
 
+### A function to keep the closest stop obstacle in target obstacles
+
+In order to keep the closest stop obstacle in the target obstacles, we check whether it is disappeared or not from the target obstacles in the `checkConsistency` function.
+If the previous closest stop obstacle is remove from the lists, we keep it in the lists for `stop_obstacle_hold_time_threshold` seconds.
+Note that if a new stop obstacle appears and the previous closest obstacle removes from the lists, we do not add it to the target obstacles again.
+
+| Parameter                                              | Type   | Description                                        |
+| ------------------------------------------------------ | ------ | -------------------------------------------------- |
+| `obstacle_filtering.stop_obstacle_hold_time_threshold` | double | maximum time for holding closest stop obstacle [s] |
+
 ## Visualization for debugging
 
 ### Detection area


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
Update readme to add the explanations about how to keep the closest stop obstacle in the target obstacles.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
