### PR TITLE
feat(tier4_autoware_utils): add covariance util

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
@@ -22,7 +22,7 @@ namespace xyz_covariance_index
 /// Covariance for x-y-z.
 /// Used at
 /// - sensor_msgs/msg/Imu.msg: msg.linear_acceleration_covariance
-enum class XYZ_COV_IDX {
+enum XYZ_COV_IDX {
   X_X = 0,
   X_Y = 1,
   X_Z = 2,
@@ -41,7 +41,7 @@ namespace rpy_covariance_index
 /// Used at
 /// - sensor_msgs/msg/Imu.msg: msg.angular_velocity_covariance
 /// - sensor_msgs/msg/Imu.msg: msg.orientation_covariance
-enum class RPY_COV_IDX {
+enum RPY_COV_IDX {
   ROLL_ROLL = 0,
   ROLL_PITCH = 1,
   ROLL_YAW = 2,
@@ -61,7 +61,7 @@ namespace pose_covariance_index
 /// - geometry_msgs/msg/AccelWithCovariance.msg: msg.covariance
 /// - geometry_msgs/msg/TwistWithCovariance.msg: msg.covariance
 /// - geometry_msgs/msg/PoseWithCovariance.msg: msg.covariance
-enum class POSE_COV_IDX {
+enum POSE_COV_IDX {
   X_X = 0,
   X_Y = 1,
   X_Z = 2,
@@ -106,7 +106,7 @@ namespace xyz_upper_covariance_index
 /// Upper-triangle covariance about the x, y, z axes
 /// Used at
 /// - radar_msgs/msg/RadarTrack.msg: msg.{position, velocity, acceleration}_covariance
-enum class XYZ_UPPER_COV_IDX {
+enum XYZ_UPPER_COV_IDX {
   X_X = 0,
   X_Y = 1,
   X_Z = 2,

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
@@ -17,7 +17,8 @@
 
 namespace tier4_autoware_utils
 {
-
+namespace xyz_covariance_index
+{
 /// Covariance for x-y-z.
 /// Used at
 /// - sensor_msgs/msg/Imu.msg: msg.linear_acceleration_covariance
@@ -32,7 +33,10 @@ enum class XYZ_COV_IDX {
   Z_Y = 7,
   Z_Z = 8,
 };
+}  // namespace xyz_covariance_index
 
+namespace rpy_covariance_index
+{
 /// Covariance for roll-pitch-yaw.
 /// Used at
 /// - sensor_msgs/msg/Imu.msg: msg.angular_velocity_covariance
@@ -48,7 +52,10 @@ enum class RPY_COV_IDX {
   YAW_PITCH = 7,
   YAW_YAW = 8
 };
+}  // namespace rpy_covariance_index
 
+namespace pose_covariance_index
+{
 /// Covariance for 6-DOF pose.
 /// Used at
 /// - geometry_msgs/msg/AccelWithCovariance.msg: msg.covariance
@@ -92,7 +99,10 @@ enum class POSE_COV_IDX {
   YAW_PITCH = 34,
   YAW_YAW = 35
 };
+}  // namespace pose_covariance_index
 
+namespace xyz_upper_covariance_index
+{
 /// Upper-triangle covariance about the x, y, z axes
 /// Used at
 /// - radar_msgs/msg/RadarTrack.msg: msg.{position, velocity, acceleration}_covariance
@@ -104,6 +114,7 @@ enum class XYZ_UPPER_COV_IDX {
   Y_Z = 4,
   Z_Z = 5,
 };
+}  // namespace xyz_upper_covariance_index
 }  // namespace tier4_autoware_utils
 
 #endif  // TIER4_AUTOWARE_UTILS__ROS__MSG_COVARIANCE_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
@@ -96,7 +96,7 @@ enum POSE_COV_IDX {
 /// Upper-triangle covariance about the x, y, z axes
 /// Used at
 /// - radar_msgs/msg/RadarTrack.msg: msg.{position, velocity, acceleration}_covariance
-enum RPY_COV_IDX {
+enum XYZ_UPPER_COV_IDX {
   X_X = 0,
   X_Y = 1,
   X_Z = 2,

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
@@ -1,0 +1,109 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TIER4_AUTOWARE_UTILS__ROS__MSG_COVARIANCE_HPP_
+#define TIER4_AUTOWARE_UTILS__ROS__MSG_COVARIANCE_HPP_
+
+namespace tier4_autoware_utils
+{
+
+/// Covariance for x-y-z.
+/// Used at
+/// - sensor_msgs/msg/Imu.msg: msg.linear_acceleration_covariance
+enum XYZ_COV_IDX {
+  X_X = 0,
+  X_Y = 1,
+  X_Z = 2,
+  Y_X = 3,
+  Y_Y = 4,
+  Y_Z = 5,
+  Z_X = 6,
+  Z_Y = 7,
+  Z_Z = 8,
+};
+
+/// Covariance for roll-pitch-yaw.
+/// Used at
+/// - sensor_msgs/msg/Imu.msg: msg.angular_velocity_covariance
+/// - sensor_msgs/msg/Imu.msg: msg.orientation_covariance
+enum RPY_COV_IDX {
+  ROLL_ROLL = 0,
+  ROLL_PITCH = 1,
+  ROLL_YAW = 2,
+  PITCH_ROLL = 3,
+  PITCH_PITCH = 4,
+  PITCH_YAW = 5,
+  YAW_ROLL = 6,
+  YAW_PITCH = 7,
+  YAW_YAW = 8
+};
+
+/// Covariance for 6-DOF pose.
+/// Used at
+/// - geometry_msgs/msg/AccelWithCovariance.msg: msg.covariance
+/// - geometry_msgs/msg/TwistWithCovariance.msg: msg.covariance
+/// - geometry_msgs/msg/PoseWithCovariance.msg: msg.covariance
+enum POSE_COV_IDX {
+  X_X = 0,
+  X_Y = 1,
+  X_Z = 2,
+  X_ROLL = 3,
+  X_PITCH = 4,
+  X_YAW = 5,
+  Y_X = 6,
+  Y_Y = 7,
+  Y_Z = 8,
+  Y_ROLL = 9,
+  Y_PITCH = 10,
+  Y_YAW = 11,
+  Z_X = 12,
+  Z_Y = 13,
+  Z_Z = 14,
+  Z_ROLL = 15,
+  Z_PITCH = 16,
+  Z_YAW = 17,
+  ROLL_X = 18,
+  ROLL_Y = 19,
+  ROLL_Z = 20,
+  ROLL_ROLL = 21,
+  ROLL_PITCH = 22,
+  ROLL_YAW = 23,
+  PITCH_X = 24,
+  PITCH_Y = 25,
+  PITCH_Z = 26,
+  PITCH_ROLL = 27,
+  PITCH_PITCH = 28,
+  PITCH_YAW = 29,
+  YAW_X = 30,
+  YAW_Y = 31,
+  YAW_Z = 32,
+  YAW_ROLL = 33,
+  YAW_PITCH = 34,
+  YAW_YAW = 35
+};
+
+/// Upper-triangle covariance about the x, y, z axes
+/// Used at
+/// - radar_msgs/msg/RadarTrack.msg: msg.{position, velocity, acceleration}_covariance
+enum RPY_COV_IDX {
+  X_X = 0,
+  X_Y = 1,
+  X_Z = 2,
+  Y_Y = 3,
+  Y_Z = 4,
+  Z_Z = 5,
+};
+}  // namespace tier4_autoware_utils
+
+#endif  // TIER4_AUTOWARE_UTILS__ROS__MSG_COVARIANCE_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
@@ -21,7 +21,7 @@ namespace tier4_autoware_utils
 /// Covariance for x-y-z.
 /// Used at
 /// - sensor_msgs/msg/Imu.msg: msg.linear_acceleration_covariance
-enum XYZ_COV_IDX {
+enum class XYZ_COV_IDX {
   X_X = 0,
   X_Y = 1,
   X_Z = 2,
@@ -37,7 +37,7 @@ enum XYZ_COV_IDX {
 /// Used at
 /// - sensor_msgs/msg/Imu.msg: msg.angular_velocity_covariance
 /// - sensor_msgs/msg/Imu.msg: msg.orientation_covariance
-enum RPY_COV_IDX {
+enum class RPY_COV_IDX {
   ROLL_ROLL = 0,
   ROLL_PITCH = 1,
   ROLL_YAW = 2,
@@ -54,7 +54,7 @@ enum RPY_COV_IDX {
 /// - geometry_msgs/msg/AccelWithCovariance.msg: msg.covariance
 /// - geometry_msgs/msg/TwistWithCovariance.msg: msg.covariance
 /// - geometry_msgs/msg/PoseWithCovariance.msg: msg.covariance
-enum POSE_COV_IDX {
+enum class POSE_COV_IDX {
   X_X = 0,
   X_Y = 1,
   X_Z = 2,
@@ -96,7 +96,7 @@ enum POSE_COV_IDX {
 /// Upper-triangle covariance about the x, y, z axes
 /// Used at
 /// - radar_msgs/msg/RadarTrack.msg: msg.{position, velocity, acceleration}_covariance
-enum XYZ_UPPER_COV_IDX {
+enum class XYZ_UPPER_COV_IDX {
   X_X = 0,
   X_Y = 1,
   X_Z = 2,

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
@@ -27,12 +27,12 @@
 #include "tier4_autoware_utils/ros/debug_publisher.hpp"
 #include "tier4_autoware_utils/ros/debug_traits.hpp"
 #include "tier4_autoware_utils/ros/marker_helper.hpp"
+#include "tier4_autoware_utils/ros/msg_covariance.hpp"
 #include "tier4_autoware_utils/ros/processing_time_publisher.hpp"
 #include "tier4_autoware_utils/ros/self_pose_listener.hpp"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
 #include "tier4_autoware_utils/ros/update_param.hpp"
 #include "tier4_autoware_utils/ros/wait_for_param.hpp"
-#include "tier4_autoware_utils/ros/msg_covariance.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 
 #endif  // TIER4_AUTOWARE_UTILS__TIER4_AUTOWARE_UTILS_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
@@ -32,6 +32,7 @@
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
 #include "tier4_autoware_utils/ros/update_param.hpp"
 #include "tier4_autoware_utils/ros/wait_for_param.hpp"
+#include "tier4_autoware_utils/ros/msg_covariance.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 
 #endif  // TIER4_AUTOWARE_UTILS__TIER4_AUTOWARE_UTILS_HPP_


### PR DESCRIPTION
## Description

Add msg_covariange for tier4_autoware_util to hundle index of covariance.
After this PR is merged, I would change enum definition in each package like [radar_fusion](https://github.com/autowarefoundation/autoware.universe/blob/4882dafdcba26a84ace7f91d3e8ff03b10538e4e/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object.hpp#L45) and [radar_tracks_msgs_converter](https://github.com/autowarefoundation/autoware.universe/blob/4882dafdcba26a84ace7f91d3e8ff03b10538e4e/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp#L187) to enum of autoware_util.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
