### PR TITLE
refactor(radar_fusion_to_detected_object): move covariance index to util

### DIFF
--- a/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object.hpp
+++ b/perception/radar_fusion_to_detected_object/include/radar_fusion_to_detected_object.hpp
@@ -42,45 +42,6 @@ using geometry_msgs::msg::TwistWithCovariance;
 using tier4_autoware_utils::LinearRing2d;
 using tier4_autoware_utils::Point2d;
 
-enum MSG_COV_IDX {
-  X_X = 0,
-  X_Y = 1,
-  X_Z = 2,
-  X_ROLL = 3,
-  X_PITCH = 4,
-  X_YAW = 5,
-  Y_X = 6,
-  Y_Y = 7,
-  Y_Z = 8,
-  Y_ROLL = 9,
-  Y_PITCH = 10,
-  Y_YAW = 11,
-  Z_X = 12,
-  Z_Y = 13,
-  Z_Z = 14,
-  Z_ROLL = 15,
-  Z_PITCH = 16,
-  Z_YAW = 17,
-  ROLL_X = 18,
-  ROLL_Y = 19,
-  ROLL_Z = 20,
-  ROLL_ROLL = 21,
-  ROLL_PITCH = 22,
-  ROLL_YAW = 23,
-  PITCH_X = 24,
-  PITCH_Y = 25,
-  PITCH_Z = 26,
-  PITCH_ROLL = 27,
-  PITCH_PITCH = 28,
-  PITCH_YAW = 29,
-  YAW_X = 30,
-  YAW_Y = 31,
-  YAW_Z = 32,
-  YAW_ROLL = 33,
-  YAW_PITCH = 34,
-  YAW_YAW = 35
-};
-
 class RadarFusionToDetectedObject
 {
 public:

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -133,9 +133,9 @@ RadarFusionToDetectedObject::Output RadarFusionToDetectedObject::update(
 bool RadarFusionToDetectedObject::hasTwistCovariance(
   const TwistWithCovariance & twist_with_covariance)
 {
-  using namespace tier4_autoware_utils::pose_covariance_index;
+  using IDX = tier4_autoware_utils::pose_covariance_index::POSE_COV_IDX;
   auto covariance = twist_with_covariance.covariance;
-  if (covariance[X_X] == 0.0 && covariance[Y_Y] == 0.0 && covariance[Z_Z] == 0.0) {
+  if (covariance[IDX::X_X] == 0.0 && covariance[IDX::Y_Y] == 0.0 && covariance[IDX::Z_Z] == 0.0) {
     return false;
   } else {
     return true;

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -133,6 +133,7 @@ RadarFusionToDetectedObject::Output RadarFusionToDetectedObject::update(
 bool RadarFusionToDetectedObject::hasTwistCovariance(
   const TwistWithCovariance & twist_with_covariance)
 {
+  using namespace tier4_autoware_utils::pose_covariance_index;
   auto covariance = twist_with_covariance.covariance;
   if (covariance[X_X] == 0.0 && covariance[Y_Y] == 0.0 && covariance[Z_Z] == 0.0) {
     return false;


### PR DESCRIPTION
## Description

Refactor covariance index in radar fusion.
Move covariance index to util library merged by https://github.com/autowarefoundation/autoware.universe/pull/1840

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
