### PR TITLE
refactor(radar_tracks_msgs_converter): refactor to use covariance index library in tier4_autoware_util

### DIFF
--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
@@ -184,15 +184,23 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
     tf2::doTransform(radar_pose_stamped, transformed_pose_stamped, *transform_);
     kinematics.pose_with_covariance.pose = transformed_pose_stamped.pose;
 
-    kinematics.pose_with_covariance.covariance[0] = radar_track.position_covariance[0];
-    kinematics.pose_with_covariance.covariance[1] = radar_track.position_covariance[1];
-    kinematics.pose_with_covariance.covariance[2] = radar_track.position_covariance[2];
-    kinematics.pose_with_covariance.covariance[6] = radar_track.position_covariance[1];
-    kinematics.pose_with_covariance.covariance[7] = radar_track.position_covariance[3];
-    kinematics.pose_with_covariance.covariance[8] = radar_track.position_covariance[4];
-    kinematics.pose_with_covariance.covariance[12] = radar_track.position_covariance[2];
-    kinematics.pose_with_covariance.covariance[13] = radar_track.position_covariance[4];
-    kinematics.pose_with_covariance.covariance[14] = radar_track.position_covariance[5];
+    {
+      auto covariance = kinematics.pose_with_covariance.covariance;
+      using P_IDX = tier4_autoware_utils::pose_covariance_index::POSE_COV_IDX;
+      using R_IDX = tier4_autoware_utils::xyz_upper_covariance_index::XYZ_UPPER_COV_IDX;
+
+      covariance[P_IDX::X_X] = radar_track.position_covariance[R_IDX::X_X];
+      covariance[P_IDX::X_Y] = radar_track.position_covariance[R_IDX::X_Y];
+      covariance[P_IDX::X_Z] = radar_track.position_covariance[R_IDX::X_Z];
+      covariance[P_IDX::Y_X] = radar_track.position_covariance[R_IDX::X_Y];
+      covariance[P_IDX::Y_Y] = radar_track.position_covariance[R_IDX::Y_Y];
+      covariance[P_IDX::Y_Z] = radar_track.position_covariance[R_IDX::Y_Z];
+      covariance[P_IDX::Z_X] = radar_track.position_covariance[R_IDX::X_Z];
+      covariance[P_IDX::Z_Y] = radar_track.position_covariance[R_IDX::Y_Z];
+      covariance[P_IDX::Z_Z] = radar_track.position_covariance[R_IDX::Z_Z];
+
+      kinematics.pose_with_covariance.covariance = covariance;
+    }
 
     // convert by tf
     geometry_msgs::msg::Vector3Stamped radar_velocity_stamped{};

--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
@@ -185,10 +185,10 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
     kinematics.pose_with_covariance.pose = transformed_pose_stamped.pose;
 
     {
-      auto & covariance = kinematics.pose_with_covariance.covariance;
       using P_IDX = tier4_autoware_utils::pose_covariance_index::POSE_COV_IDX;
       using R_IDX = tier4_autoware_utils::xyz_upper_covariance_index::XYZ_UPPER_COV_IDX;
 
+      auto & covariance = kinematics.pose_with_covariance.covariance;
       covariance[P_IDX::X_X] = radar_track.position_covariance[R_IDX::X_X];
       covariance[P_IDX::X_Y] = radar_track.position_covariance[R_IDX::X_Y];
       covariance[P_IDX::X_Z] = radar_track.position_covariance[R_IDX::X_Z];

--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
@@ -185,7 +185,7 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
     kinematics.pose_with_covariance.pose = transformed_pose_stamped.pose;
 
     {
-      auto covariance = kinematics.pose_with_covariance.covariance;
+      auto & covariance = kinematics.pose_with_covariance.covariance;
       using P_IDX = tier4_autoware_utils::pose_covariance_index::POSE_COV_IDX;
       using R_IDX = tier4_autoware_utils::xyz_upper_covariance_index::XYZ_UPPER_COV_IDX;
 
@@ -198,8 +198,6 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
       covariance[P_IDX::Z_X] = radar_track.position_covariance[R_IDX::X_Z];
       covariance[P_IDX::Z_Y] = radar_track.position_covariance[R_IDX::Y_Z];
       covariance[P_IDX::Z_Z] = radar_track.position_covariance[R_IDX::Z_Z];
-
-      kinematics.pose_with_covariance.covariance = covariance;
     }
 
     // convert by tf


### PR DESCRIPTION
## Description

Refactor covariance index in radar_tracks_msgs_converter.
Move covariance index to util library merged by https://github.com/autowarefoundation/autoware.universe/pull/1840

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
