### PR TITLE
fix(motion_utils): fix terminal point access method

### DIFF
--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -56,7 +56,7 @@ std::vector<geometry_msgs::msg::Pose> resamplePath(
     if (ds < CLOSE_S_THRESHOLD) {
       continue;
     }
-    input_arclength.push_back(ds + input_arclength.at(i - 1));
+    input_arclength.push_back(ds + input_arclength.back());
     x.push_back(curr_pt.position.x);
     y.push_back(curr_pt.position.y);
     z.push_back(curr_pt.position.z);
@@ -153,7 +153,7 @@ autoware_auto_planning_msgs::msg::PathWithLaneId resamplePath(
     if (ds < CLOSE_S_THRESHOLD) {
       continue;
     }
-    input_arclength.push_back(ds + input_arclength.at(i - 1));
+    input_arclength.push_back(ds + input_arclength.back());
     input_pose.push_back(curr_pt.pose);
     v_lon.push_back(curr_pt.longitudinal_velocity_mps);
     v_lat.push_back(curr_pt.lateral_velocity_mps);
@@ -317,7 +317,7 @@ autoware_auto_planning_msgs::msg::Path resamplePath(
     if (ds < CLOSE_S_THRESHOLD) {
       continue;
     }
-    input_arclength.push_back(ds + input_arclength.at(i - 1));
+    input_arclength.push_back(ds + input_arclength.back());
     input_pose.push_back(curr_pt.pose);
     v_lon.push_back(curr_pt.longitudinal_velocity_mps);
     v_lat.push_back(curr_pt.lateral_velocity_mps);
@@ -414,7 +414,7 @@ autoware_auto_planning_msgs::msg::Trajectory resampleTrajectory(
     if (ds < CLOSE_S_THRESHOLD) {
       continue;
     }
-    input_arclength.push_back(ds + input_arclength.at(i - 1));
+    input_arclength.push_back(ds + input_arclength.back());
     input_pose.push_back(curr_pt.pose);
     v_lon.push_back(curr_pt.longitudinal_velocity_mps);
     v_lat.push_back(curr_pt.lateral_velocity_mps);


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description

When the point interval is too small, it ignores the duplicated point. However, since the access of the input_arclength is not correct, the overall code can be collapsed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
