### PR TITLE
fix(traffic_light): fix stop reason

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
@@ -16,6 +16,7 @@
 #define SCENE_MODULE__TRAFFIC_LIGHT__SCENE_HPP_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -52,7 +53,8 @@ public:
     geometry_msgs::msg::Pose first_stop_pose;
     std::vector<geometry_msgs::msg::Pose> dead_line_poses;
     std::vector<geometry_msgs::msg::Point> traffic_light_points;
-    geometry_msgs::msg::Point highest_confidence_traffic_light_point;
+    std::optional<geometry_msgs::msg::Point> highest_confidence_traffic_light_point = {
+      std::nullopt};
   };
 
   struct PlannerParam


### PR DESCRIPTION
## Description

resolve https://github.com/autowarefoundation/autoware.universe/issues/1862

before this PR 
RTC
- stop factor for traffic light is used for uninitialized value
![image](https://user-images.githubusercontent.com/65527974/190102769-fa6557a2-e91a-4b85-936e-3faefdc90ac5.png)
AW without RTC
- stop factor of traffic light
![image](https://user-images.githubusercontent.com/65527974/190103217-8f1b5665-79e6-4d88-b9bc-295d17e4dae4.png)


after this PR
fix traffic light stop reason when no points are given(especially when using RTC ).
RTC
- no stop factor is given so no stop reason is appended
![image](https://user-images.githubusercontent.com/65527974/190101290-b3d830b1-27b9-4ebb-971d-3e2641674d79.png)
AW without RTC
- stop factor of traffic light
![image](https://user-images.githubusercontent.com/65527974/190101547-5ed03282-c0e1-439e-acbc-56059c757488.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
