### PR TITLE
refactor(imu_corrector): refactor covariance index

### DIFF
--- a/sensing/imu_corrector/package.xml
+++ b/sensing/imu_corrector/package.xml
@@ -15,6 +15,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>tier4_autoware_utils</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/sensing/imu_corrector/src/imu_corrector_core.cpp
+++ b/sensing/imu_corrector/src/imu_corrector_core.cpp
@@ -14,6 +14,8 @@
 
 #include "imu_corrector/imu_corrector_core.hpp"
 
+#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+
 namespace imu_corrector
 {
 ImuCorrector::ImuCorrector(const rclcpp::NodeOptions & node_options)
@@ -42,11 +44,12 @@ void ImuCorrector::callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_m
   imu_msg.angular_velocity.y -= angular_velocity_offset_y_;
   imu_msg.angular_velocity.z -= angular_velocity_offset_z_;
 
-  imu_msg.angular_velocity_covariance[0 * 3 + 0] =
+  using IDX = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+  imu_msg.angular_velocity_covariance[IDX::X_X] =
     angular_velocity_stddev_xx_ * angular_velocity_stddev_xx_;
-  imu_msg.angular_velocity_covariance[1 * 3 + 1] =
+  imu_msg.angular_velocity_covariance[IDX::Y_Y] =
     angular_velocity_stddev_yy_ * angular_velocity_stddev_yy_;
-  imu_msg.angular_velocity_covariance[2 * 3 + 2] =
+  imu_msg.angular_velocity_covariance[IDX::Z_Z] =
     angular_velocity_stddev_zz_ * angular_velocity_stddev_zz_;
 
   imu_pub_->publish(imu_msg);


### PR DESCRIPTION
Signed-off-by: scepter914 <scepter914@gmail.com>

## Description

Refactor covariance magic number index.
Change magic number to tier4_autoware_util library merged in https://github.com/autowarefoundation/autoware.universe/pull/1840.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
