### PR TITLE
refactor(ekf_localizer): add functions to check if a matrix has nan or inf

### DIFF
--- a/localization/ekf_localizer/CMakeLists.txt
+++ b/localization/ekf_localizer/CMakeLists.txt
@@ -42,6 +42,7 @@ if(BUILD_TESTING)
 
   set(TEST_FILES
     test/test_measurement.cpp
+    test/test_numeric.cpp
     test/test_state_transition.cpp)
 
   foreach(filepath ${TEST_FILES})

--- a/localization/ekf_localizer/include/ekf_localizer/numeric.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/numeric.hpp
@@ -1,0 +1,34 @@
+// Copyright 2022 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EKF_LOCALIZER__NUMERIC_HPP_
+#define EKF_LOCALIZER__NUMERIC_HPP_
+
+#include <Eigen/Core>
+
+#include <cmath>
+
+
+inline bool hasInf(const Eigen::MatrixXd & v)
+{
+  return v.array().isInf().any();
+}
+
+inline bool hasNan(const Eigen::MatrixXd & v)
+{
+  return v.array().isNaN().any();
+}
+
+
+#endif  // EKF_LOCALIZER__NUMERIC_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/numeric.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/numeric.hpp
@@ -19,16 +19,8 @@
 
 #include <cmath>
 
+inline bool hasInf(const Eigen::MatrixXd & v) { return v.array().isInf().any(); }
 
-inline bool hasInf(const Eigen::MatrixXd & v)
-{
-  return v.array().isInf().any();
-}
-
-inline bool hasNan(const Eigen::MatrixXd & v)
-{
-  return v.array().isNaN().any();
-}
-
+inline bool hasNan(const Eigen::MatrixXd & v) { return v.array().isNaN().any(); }
 
 #endif  // EKF_LOCALIZER__NUMERIC_HPP_

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -16,6 +16,7 @@
 
 #include "ekf_localizer/matrix_types.hpp"
 #include "ekf_localizer/measurement.hpp"
+#include "ekf_localizer/numeric.hpp"
 #include "ekf_localizer/state_index.hpp"
 #include "ekf_localizer/state_transition.hpp"
 #include "ekf_localizer/warning.hpp"
@@ -484,7 +485,7 @@ void EKFLocalizer::measurementUpdatePose(const geometry_msgs::msg::PoseWithCovar
   Eigen::MatrixXd y(dim_y, 1);
   y << pose.pose.pose.position.x, pose.pose.pose.position.y, yaw;
 
-  if (isnan(y.array()).any() || isinf(y.array()).any()) {
+  if (hasNan(y) || hasInf(y)) {
     warning_.warn(
       "[EKF] pose measurement matrix includes NaN of Inf. ignore update. check pose message.");
     return;
@@ -565,7 +566,7 @@ void EKFLocalizer::measurementUpdateTwist(
   Eigen::MatrixXd y(dim_y, 1);
   y << twist.twist.twist.linear.x, twist.twist.twist.angular.z;
 
-  if (isnan(y.array()).any() || isinf(y.array()).any()) {
+  if (hasNan(y) || hasInf(y)) {
     warning_.warn(
       "[EKF] twist measurement matrix includes NaN of Inf. ignore update. check twist message.");
     return;

--- a/localization/ekf_localizer/test/test_numeric.cpp
+++ b/localization/ekf_localizer/test/test_numeric.cpp
@@ -14,10 +14,9 @@
 
 #include "ekf_localizer/numeric.hpp"
 
-#include <gtest/gtest.h>
-
 #include <Eigen/Core>
 
+#include <gtest/gtest.h>
 
 TEST(Numeric, HasNan)
 {

--- a/localization/ekf_localizer/test/test_numeric.cpp
+++ b/localization/ekf_localizer/test/test_numeric.cpp
@@ -1,0 +1,48 @@
+// Copyright 2022 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ekf_localizer/numeric.hpp"
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Core>
+
+
+TEST(Numeric, HasNan)
+{
+  const Eigen::VectorXd empty(0);
+  const double inf = std::numeric_limits<double>::infinity();
+  const double nan = std::nan("");
+
+  EXPECT_FALSE(hasNan(empty));
+  EXPECT_FALSE(hasNan(Eigen::Vector3d(0., 0., 1.)));
+  EXPECT_FALSE(hasNan(Eigen::Vector3d(1e16, 0., 1.)));
+  EXPECT_FALSE(hasNan(Eigen::Vector3d(0., 1., inf)));
+
+  EXPECT_TRUE(hasNan(Eigen::Vector3d(nan, 1., 0.)));
+}
+
+TEST(Numeric, HasInf)
+{
+  const Eigen::VectorXd empty(0);
+  const double inf = std::numeric_limits<double>::infinity();
+  const double nan = std::nan("");
+
+  EXPECT_FALSE(hasInf(empty));
+  EXPECT_FALSE(hasInf(Eigen::Vector3d(0., 0., 1.)));
+  EXPECT_FALSE(hasInf(Eigen::Vector3d(1e16, 0., 1.)));
+  EXPECT_FALSE(hasInf(Eigen::Vector3d(nan, 1., 0.)));
+
+  EXPECT_TRUE(hasInf(Eigen::Vector3d(0., 1., inf)));
+}


### PR DESCRIPTION
## Description

I added functions to check if a matrix has nan or inf.
This aims to improve testability and readability.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

The test checks if the functions can detect nan or inf

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
