### PR TITLE
fix(multi_object_tracker): add missing trailer tracker

### DIFF
--- a/perception/multi_object_tracker/config/default_tracker.param.yaml
+++ b/perception/multi_object_tracker/config/default_tracker.param.yaml
@@ -3,6 +3,7 @@
     car_tracker: "multi_vehicle_tracker"
     truck_tracker: "multi_vehicle_tracker"
     bus_tracker: "multi_vehicle_tracker"
+    trailer_tracker: "multi_vehicle_tracker"
     pedestrian_tracker: "pedestrian_and_bicycle_tracker"
     bicycle_tracker: "pedestrian_and_bicycle_tracker"
     motorcycle_tracker: "pedestrian_and_bicycle_tracker"

--- a/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/utils/utils.hpp
@@ -71,6 +71,13 @@ enum MSG_COV_IDX {
   YAW_PITCH = 34,
   YAW_YAW = 35
 };
+
+inline bool isLargeVehicleLabel(const uint8_t label)
+{
+  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+  return label == Label::BUS || label == Label::TRUCK || label == Label::TRAILER;
+}
+
 }  // namespace utils
 
 #endif  // MULTI_OBJECT_TRACKER__UTILS__UTILS_HPP_

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -106,7 +106,7 @@ bool isSpecificAlivePattern(
     tracker->getTotalMeasurementCount() /
     (tracker->getTotalNoMeasurementCount() + tracker->getTotalMeasurementCount());
 
-  const bool big_vehicle = (label == Label::TRUCK || label == Label::BUS);
+  const bool big_vehicle = utils::isLargeVehicleLabel(label);
 
   const bool slow_velocity = getVelocity(object) < max_velocity;
 
@@ -172,6 +172,8 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
     std::make_pair(Label::TRUCK, this->declare_parameter<std::string>("truck_tracker")));
   tracker_map_.insert(
     std::make_pair(Label::BUS, this->declare_parameter<std::string>("bus_tracker")));
+  tracker_map_.insert(
+    std::make_pair(Label::TRAILER, this->declare_parameter<std::string>("trailer_tracker")));
   tracker_map_.insert(
     std::make_pair(Label::PEDESTRIAN, this->declare_parameter<std::string>("pedestrian_tracker")));
   tracker_map_.insert(

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -228,7 +228,7 @@ bool BigVehicleTracker::measureWithPose(
     constexpr float r_stddev_y = 0.8;  // [m]
     r_cov_x = std::pow(r_stddev_x, 2.0);
     r_cov_y = std::pow(r_stddev_y, 2.0);
-  } else if (label == Label::TRUCK || label == Label::BUS) {
+  } else if (utils::isLargeVehicleLabel(label)) {
     r_cov_x = ekf_params_.r_cov_x;
     r_cov_y = ekf_params_.r_cov_y;
   } else {

--- a/perception/multi_object_tracker/src/tracker/model/multiple_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/multiple_vehicle_tracker.cpp
@@ -55,7 +55,7 @@ bool MultipleVehicleTracker::getTrackedObject(
 
   if (label == Label::CAR) {
     normal_vehicle_tracker_.getTrackedObject(time, object);
-  } else if (label == Label::BUS || label == Label::TRUCK) {
+  } else if (utils::isLargeVehicleLabel(label)) {
     big_vehicle_tracker_.getTrackedObject(time, object);
   }
   object.object_id = getUUID();

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -226,7 +226,7 @@ bool NormalVehicleTracker::measureWithPose(
   if (label == Label::CAR) {
     r_cov_x = ekf_params_.r_cov_x;
     r_cov_y = ekf_params_.r_cov_y;
-  } else if (label == Label::TRUCK || label == Label::BUS) {
+  } else if (utils::isLargeVehicleLabel(label)) {
     constexpr float r_stddev_x = 8.0;  // [m]
     constexpr float r_stddev_y = 0.8;  // [m]
     r_cov_x = std::pow(r_stddev_x, 2.0);


### PR DESCRIPTION
Signed-off-by: yukke42 <yusuke.muramatsu@tier4.jp>

## Description

As title says.

Red Bounding Boxes are TrackedObjects.

before:

https://user-images.githubusercontent.com/24660808/190424317-e8de1725-7540-4c6c-9076-ac85c3f1497b.mp4

after:

https://user-images.githubusercontent.com/24660808/190424341-a65cff74-0530-46bf-b2d3-0b437ce94f8e.mp4



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
