### PR TITLE
fix: Fix missing dependent repos and missing packages in cmake

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -41,3 +41,19 @@ repositories:
     type: git
     url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
     version: main
+  universe/external/tier4_ad_api_adaptor:
+    type: git
+    url: https://github.com/tier4/tier4_ad_api_adaptor.git
+    version: tier4/universe
+  universe/external/cudnn_cmake_module:
+    type: git
+    url: https://github.com/tier4/cudnn_cmake_module.git
+    version: 0.0.1
+  universe/external/point_cloud_msg_wrapper:
+    type: git
+    url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper.git
+    version: galactic
+  universe/external/tensorrt_cmake_module:
+    type: git
+    url: https://github.com/tier4/tensorrt_cmake_module.git
+    version: 0.0.3

--- a/control/obstacle_collision_checker/CMakeLists.txt
+++ b/control/obstacle_collision_checker/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(obstacle_collision_checker)
 
 find_package(autoware_cmake REQUIRED)
+find_package(PCL REQUIRED)
 autoware_package()
 
 include_directories(
@@ -10,6 +11,8 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
 )
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
 
 ament_auto_add_library(obstacle_collision_checker SHARED
   src/obstacle_collision_checker_node/obstacle_collision_checker.cpp

--- a/map/util/lanelet2_map_preprocessor/CMakeLists.txt
+++ b/map/util/lanelet2_map_preprocessor/CMakeLists.txt
@@ -2,13 +2,16 @@ cmake_minimum_required(VERSION 3.14)
 project(lanelet2_map_preprocessor)
 
 find_package(autoware_cmake REQUIRED)
+find_package(PCL REQUIRED)
 autoware_package()
 
 include_directories(
   include
   SYSTEM
-    ${PCL_INCLUDE_DIRS}
+  ${PCL_INCLUDE_DIRS}
 )
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
 
 ament_auto_add_executable(fix_z_value_by_pcd src/fix_z_value_by_pcd.cpp)
 ament_auto_add_executable(transform_maps src/transform_maps.cpp)

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 find_package(OpenCV REQUIRED)
+find_package(behaviortree_cpp_v3)
 
 ament_auto_add_library(behavior_path_planner_node SHARED
   src/behavior_path_planner_node.cpp


### PR DESCRIPTION
I ran a clean build on [nvidia/cuda:11.7.1-cudnn8-devel-ubuntu20.04](https://hub.docker.com/layers/nvidia/cuda/11.7.1-cudnn8-devel-ubuntu20.04/images/sha256-69c8bb0d2ef7b4f2a246f49846de2c6cb54c2f605db4907433e800d787edbce7?context=explore) docker image and it failed with several missing dependencies. This PR adds several missing deps to fix this build.

Besides, the container used in the container installation doc ([link](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/docker-installation/)) does not have TensorRT installed. It causes some of the binary builds to be skipped. I think the doc could mention that TensorRT must be manually installed.