### PR TITLE
fix(lidar_centerpoint): fixed the lidar_centerpoint related packages for their use without installing symlinks

### DIFF
--- a/perception/image_projection_based_fusion/CMakeLists.txt
+++ b/perception/image_projection_based_fusion/CMakeLists.txt
@@ -177,7 +177,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     EXECUTABLE pointpainting_fusion_node
   )
 
-  INSTALL(
+  install(
     TARGETS pointpainting_cuda_lib
     DESTINATION lib
   )

--- a/perception/image_projection_based_fusion/CMakeLists.txt
+++ b/perception/image_projection_based_fusion/CMakeLists.txt
@@ -177,6 +177,11 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     EXECUTABLE pointpainting_fusion_node
   )
 
+  INSTALL(
+    TARGETS pointpainting_cuda_lib
+    DESTINATION lib
+  )
+
 else()
   message("Skipping build of some nodes due to missing dependencies")
 endif()

--- a/perception/lidar_centerpoint/CMakeLists.txt
+++ b/perception/lidar_centerpoint/CMakeLists.txt
@@ -183,6 +183,11 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
       data
       config
   )
+
+  INSTALL(
+    TARGETS centerpoint_cuda_lib
+    DESTINATION lib
+  )
 else()
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_build_dependencies()

--- a/perception/lidar_centerpoint/CMakeLists.txt
+++ b/perception/lidar_centerpoint/CMakeLists.txt
@@ -185,7 +185,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
       config
   )
 
-  INSTALL(
+  install(
     TARGETS centerpoint_cuda_lib
     DESTINATION lib
   )


### PR DESCRIPTION
## Description
When compiling this package without the symlink option, the cuda library is not installed.

Before this PR:
```
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to lidar_centerpoint


find . -name 'libcenterpoint_cuda_lib.so'
>>> ./build/lidar_centerpoint/libcenterpoint_cuda_lib.so


ldd ./install/lidar_centerpoint/lib/libcenterpoint_lib.so | grep 'libcenterpoint_cuda_lib.so'
	libcenterpoint_cuda_lib.so => not found
```

After this PR:
```
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to lidar_centerpoint

 find . -name 'libcenterpoint_cuda_lib.so'
./build/lidar_centerpoint/libcenterpoint_cuda_lib.so
./install/lidar_centerpoint/lib/libcenterpoint_cuda_lib.so

ldd ./install/lidar_centerpoint/lib/libcenterpoint_lib.so | grep 'libcenterpoint_cuda_lib.so'
	libcenterpoint_cuda_lib.so => /***/install/lidar_centerpoint/lib/libcenterpoint_cuda_lib.so (0x00007fe81d9d0000)
```
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
