### PR TITLE
feat(tier4_autoware_api_launch): add rtc_controller to api launch

### DIFF
--- a/launch/tier4_autoware_api_launch/launch/include/external_api_adaptor.launch.py
+++ b/launch/tier4_autoware_api_launch/launch/include/external_api_adaptor.launch.py
@@ -54,6 +54,7 @@ def generate_launch_description():
         _create_api_node("operator", "Operator"),
         _create_api_node("metadata_packages", "MetadataPackages"),
         _create_api_node("route", "Route"),
+        _create_api_node("rtc_controller", "RTCController"),
         _create_api_node("service", "Service"),
         _create_api_node("vehicle_status", "VehicleStatus"),
         _create_api_node("velocity", "Velocity"),


### PR DESCRIPTION
Signed-off-by: khtan <tkh.my.p@gmail.com>

## Description
- add rtc launch to the api launch file

## Pre-review checklist for the PR author
- make sure the follow topic able to echo message
```
/api/external/get/rtc_status
```
- the following service is available
```
/api/external/set/rtc_commands
```

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
