### PR TITLE
fix(avoidance): guard invalid shift point

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2229,6 +2229,11 @@ boost::optional<AvoidPointArray> AvoidanceModule::findNewShiftPoint(
       throw std::logic_error("prev_reference_ and prev_linear_shift_path_ must have same size.");
     }
 
+    // new shift points must exist in front of Ego
+    if (candidate.start_longitudinal < 0.0) {
+      continue;
+    }
+
     // TODO(Horibe): this code prohibits the changes on ego pose. Think later.
     // if (candidate.start_idx < avoidance_data_.ego_closest_path_index) {
     //   DEBUG_PRINT("%s, start_idx is behind ego. skip.", pfx);


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

- guard shift points whose start point exists behind the ego position

- before (chattering the avoidance path)

https://user-images.githubusercontent.com/44889564/191468531-3d1294df-1db7-4ed5-aee8-b4f119e6039b.mp4

- after (the avoidance path is stable)

https://user-images.githubusercontent.com/44889564/191468811-5246a73e-57c2-4c05-a764-d9c8b2eaf054.mp4

### Link (For TIER4 INTERNAL)

- https://tier4.atlassian.net/browse/T4PB-20855

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
