### PR TITLE
fix(default_ad_api): temporary disable api route to resolve type conflict

### DIFF
--- a/system/default_ad_api/src/routing.cpp
+++ b/system/default_ad_api/src/routing.cpp
@@ -22,7 +22,7 @@ RoutingNode::RoutingNode(const rclcpp::NodeOptions & options) : Node("routing", 
   const auto adaptor = component_interface_utils::NodeAdaptor(this);
   group_srv_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.relay_message(pub_route_state_, sub_route_state_);
-  adaptor.relay_message(pub_route_, sub_route_);
+  // adaptor.relay_message(pub_route_, sub_route_);  // TODO(Takagi, Isamu): temporary disabled
   adaptor.relay_service(cli_set_route_points_, srv_set_route_points_, group_srv_);
   adaptor.relay_service(cli_set_route_, srv_set_route_, group_srv_);
   adaptor.relay_service(cli_clear_route_, srv_clear_route_, group_srv_);


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

This is temporary fix for https://github.com/autowarefoundation/autoware.universe/issues/1927. Related to https://github.com/autowarefoundation/autoware.universe/pull/1495.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
