### PR TITLE
fix(image_projection_based_fusion): fix input to quaternion

### DIFF
--- a/perception/image_projection_based_fusion/src/utils/geometry.cpp
+++ b/perception/image_projection_based_fusion/src/utils/geometry.cpp
@@ -122,7 +122,7 @@ void boundingBoxToVertices(
 
   const auto position = Eigen::Vector3d(pose.position.x, pose.position.y, pose.position.z);
   const auto orientation = Eigen::Quaterniond(
-    pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
+    pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z);
 
   for (const auto & corner : corners_template) {
     Eigen::Vector3d corner_point(


### PR DESCRIPTION
Signed-off-by: yukke42 <yusuke.muramatsu@tier4.jp>

## Description

The input to `Eigen::Quaterniond` is (w, x, y, z).

https://eigen.tuxfamily.org/dox/classEigen_1_1Quaternion.html#a3eba7a582f77a8f30525614821d7056f


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
