### PR TITLE
feat(tier4_system_launch): add Logging ECU support to launch

### DIFF
--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -1,62 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <arg name="run_mode" default="online" description="options: online, planning_simulation"/>
-  <arg name="sensor_model" description="sensor model name"/>
+  <arg name="system_namespace" default="/system" description="system namespace"/>
+  <arg name="system_monitor_only" default="false" description="options: true, false"/>
   <arg name="tier4_system_launch_param_path" default="$(find-pkg-share tier4_system_launch)/config" description="tier4_system_launch parameter path"/>
 
-  <let name="sensor_launch_pkg" value="$(find-pkg-share $(var sensor_model)_launch)"/>
+  <arg name="system_monitor_node_name_suffix" default="" description="system_monitor node name suffix"/>
+  <arg name="cpu_monitor_param_file" default="$(var tier4_system_launch_param_path)/system_monitor/cpu_monitor.param.yaml"/>
+  <arg name="hdd_monitor_param_file" default="$(var tier4_system_launch_param_path)/system_monitor/hdd_monitor.param.yaml"/>
+  <arg name="mem_monitor_param_file" default="$(var tier4_system_launch_param_path)/system_monitor/mem_monitor.param.yaml"/>
+  <arg name="net_monitor_param_file" default="$(var tier4_system_launch_param_path)/system_monitor/net_monitor.param.yaml"/>
+  <arg name="ntp_monitor_param_file" default="$(var tier4_system_launch_param_path)/system_monitor/ntp_monitor.param.yaml"/>
+  <arg name="process_monitor_param_file" default="$(var tier4_system_launch_param_path)/system_monitor/process_monitor.param.yaml"/>
+  <arg name="gpu_monitor_param_file" default="$(var tier4_system_launch_param_path)/system_monitor/gpu_monitor.param.yaml"/>
 
   <group>
-    <push-ros-namespace namespace="/system"/>
+    <push-ros-namespace namespace="$(var system_namespace)"/>
 
     <!-- System Monitor -->
     <group>
       <push-ros-namespace namespace="system_monitor"/>
       <include file="$(find-pkg-share system_monitor)/launch/system_monitor.launch.py">
-        <arg name="cpu_monitor_config_file" value="$(var tier4_system_launch_param_path)/system_monitor/cpu_monitor.param.yaml"/>
-        <arg name="hdd_monitor_config_file" value="$(var tier4_system_launch_param_path)/system_monitor/hdd_monitor.param.yaml"/>
-        <arg name="mem_monitor_config_file" value="$(var tier4_system_launch_param_path)/system_monitor/mem_monitor.param.yaml"/>
-        <arg name="net_monitor_config_file" value="$(var tier4_system_launch_param_path)/system_monitor/net_monitor.param.yaml"/>
-        <arg name="ntp_monitor_config_file" value="$(var tier4_system_launch_param_path)/system_monitor/ntp_monitor.param.yaml"/>
-        <arg name="process_monitor_config_file" value="$(var tier4_system_launch_param_path)/system_monitor/process_monitor.param.yaml"/>
-        <arg name="gpu_monitor_config_file" value="$(var tier4_system_launch_param_path)/system_monitor/gpu_monitor.param.yaml"/>
+        <arg name="node_name_suffix" value="$(var system_monitor_node_name_suffix)"/>
+        <arg name="cpu_monitor_config_file" value="$(var cpu_monitor_param_file)"/>
+        <arg name="hdd_monitor_config_file" value="$(var hdd_monitor_param_file)"/>
+        <arg name="mem_monitor_config_file" value="$(var mem_monitor_param_file)"/>
+        <arg name="net_monitor_config_file" value="$(var net_monitor_param_file)"/>
+        <arg name="ntp_monitor_config_file" value="$(var ntp_monitor_param_file)"/>
+        <arg name="process_monitor_config_file" value="$(var process_monitor_param_file)"/>
+        <arg name="gpu_monitor_config_file" value="$(var gpu_monitor_param_file)"/>
       </include>
     </group>
 
-    <!-- State Monitor -->
-    <group>
-      <let name="config_file" value="$(var tier4_system_launch_param_path)/ad_service_state_monitor/ad_service_state_monitor.param.yaml" if="$(eval &quot;'$(var run_mode)'=='online'&quot;)"/>
-      <let
-        name="config_file"
-        value="$(var tier4_system_launch_param_path)/ad_service_state_monitor/ad_service_state_monitor.planning_simulation.param.yaml"
-        if="$(eval &quot;'$(var run_mode)'=='planning_simulation'&quot;)"
-      />
-      <include file="$(find-pkg-share ad_service_state_monitor)/launch/ad_service_state_monitor.launch.xml">
-        <arg name="config_file" value="$(var config_file)"/>
-      </include>
-    </group>
+    <group unless="$(var system_monitor_only)">
+      <arg name="sensor_model" description="sensor model name"/>
+      <let name="sensor_launch_pkg" value="$(find-pkg-share $(var sensor_model)_launch)"/>
 
-    <!-- Error Monitor -->
-    <group>
-      <let name="config_file" value="$(var tier4_system_launch_param_path)/system_error_monitor/system_error_monitor.param.yaml" if="$(eval &quot;'$(var run_mode)'=='online'&quot;)"/>
-      <let
-        name="config_file"
-        value="$(var tier4_system_launch_param_path)/system_error_monitor/system_error_monitor.planning_simulation.param.yaml"
-        if="$(eval &quot;'$(var run_mode)'=='planning_simulation'&quot;)"
-      />
-      <include file="$(find-pkg-share system_error_monitor)/launch/system_error_monitor.launch.xml">
-        <arg name="config_file" value="$(var config_file)"/>
-        <arg name="extra_agg_config_file_sensing" value="$(var sensor_launch_pkg)/config/diagnostic_aggregator/sensor_kit.param.yaml"/>
-        <arg name="extra_agg_config_file_vehicle" value="$(var tier4_system_launch_param_path)/diagnostic_aggregator/vehicle.param.yaml"/>
-        <arg name="use_emergency_hold" value="false"/>
-      </include>
-    </group>
+      <!-- State Monitor -->
+      <group>
+        <let name="config_file" value="$(var tier4_system_launch_param_path)/ad_service_state_monitor/ad_service_state_monitor.param.yaml" if="$(eval &quot;'$(var run_mode)'=='online'&quot;)"/>
+        <let
+          name="config_file"
+          value="$(var tier4_system_launch_param_path)/ad_service_state_monitor/ad_service_state_monitor.planning_simulation.param.yaml"
+          if="$(eval &quot;'$(var run_mode)'=='planning_simulation'&quot;)"
+        />
+        <include file="$(find-pkg-share ad_service_state_monitor)/launch/ad_service_state_monitor.launch.xml">
+          <arg name="config_file" value="$(var config_file)"/>
+        </include>
+      </group>
 
-    <!-- Emergency Handler -->
-    <group>
-      <include file="$(find-pkg-share emergency_handler)/launch/emergency_handler.launch.xml">
-        <arg name="config_file" value="$(var tier4_system_launch_param_path)/emergency_handler/emergency_handler.param.yaml"/>
-      </include>
+      <!-- Error Monitor -->
+      <group>
+        <let name="config_file" value="$(var tier4_system_launch_param_path)/system_error_monitor/system_error_monitor.param.yaml" if="$(eval &quot;'$(var run_mode)'=='online'&quot;)"/>
+        <let
+          name="config_file"
+          value="$(var tier4_system_launch_param_path)/system_error_monitor/system_error_monitor.planning_simulation.param.yaml"
+          if="$(eval &quot;'$(var run_mode)'=='planning_simulation'&quot;)"
+        />
+        <include file="$(find-pkg-share system_error_monitor)/launch/system_error_monitor.launch.xml">
+          <arg name="config_file" value="$(var config_file)"/>
+          <arg name="extra_agg_config_file_sensing" value="$(var sensor_launch_pkg)/config/diagnostic_aggregator/sensor_kit.param.yaml"/>
+          <arg name="extra_agg_config_file_vehicle" value="$(var tier4_system_launch_param_path)/diagnostic_aggregator/vehicle.param.yaml"/>
+          <arg name="use_emergency_hold" value="false"/>
+        </include>
+      </group>
+
+      <!-- Emergency Handler -->
+      <group>
+        <include file="$(find-pkg-share emergency_handler)/launch/emergency_handler.launch.xml">
+          <arg name="config_file" value="$(var tier4_system_launch_param_path)/emergency_handler/emergency_handler.param.yaml"/>
+        </include>
+      </group>
     </group>
   </group>
 </launch>

--- a/system/system_monitor/launch/system_monitor.launch.py
+++ b/system/system_monitor/launch/system_monitor.launch.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import os
+import re
 
 from ament_index_python.packages import get_package_share_directory
 import launch
 from launch.actions import DeclareLaunchArgument
 from launch.actions import OpaqueFunction
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import SubstitutionFailure
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 import yaml
@@ -26,12 +28,20 @@ import yaml
 
 def launch_setup(context, *args, **kwargs):
 
+    node_name_suffix = ""
+    try:
+        node_name_suffix = re.sub(
+            "_$", "", "_" + LaunchConfiguration("node_name_suffix").perform(context)
+        )
+    except SubstitutionFailure as e:
+        print(e)
+
     with open(LaunchConfiguration("cpu_monitor_config_file").perform(context), "r") as f:
         cpu_monitor_config = yaml.safe_load(f)["/**"]["ros__parameters"]
     cpu_monitor = ComposableNode(
         package="system_monitor",
         plugin="CPUMonitor",
-        name="cpu_monitor",
+        name="cpu_monitor" + node_name_suffix,
         parameters=[
             cpu_monitor_config,
         ],
@@ -41,7 +51,7 @@ def launch_setup(context, *args, **kwargs):
     hdd_monitor = ComposableNode(
         package="system_monitor",
         plugin="HDDMonitor",
-        name="hdd_monitor",
+        name="hdd_monitor" + node_name_suffix,
         parameters=[
             hdd_monitor_config,
         ],
@@ -51,7 +61,7 @@ def launch_setup(context, *args, **kwargs):
     mem_monitor = ComposableNode(
         package="system_monitor",
         plugin="MemMonitor",
-        name="mem_monitor",
+        name="mem_monitor" + node_name_suffix,
         parameters=[
             mem_monitor_config,
         ],
@@ -61,7 +71,7 @@ def launch_setup(context, *args, **kwargs):
     net_monitor = ComposableNode(
         package="system_monitor",
         plugin="NetMonitor",
-        name="net_monitor",
+        name="net_monitor" + node_name_suffix,
         parameters=[
             net_monitor_config,
         ],
@@ -71,7 +81,7 @@ def launch_setup(context, *args, **kwargs):
     ntp_monitor = ComposableNode(
         package="system_monitor",
         plugin="NTPMonitor",
-        name="ntp_monitor",
+        name="ntp_monitor" + node_name_suffix,
         parameters=[
             ntp_monitor_config,
         ],
@@ -81,7 +91,7 @@ def launch_setup(context, *args, **kwargs):
     process_monitor = ComposableNode(
         package="system_monitor",
         plugin="ProcessMonitor",
-        name="process_monitor",
+        name="process_monitor" + node_name_suffix,
         parameters=[
             process_monitor_config,
         ],
@@ -91,7 +101,7 @@ def launch_setup(context, *args, **kwargs):
     gpu_monitor = ComposableNode(
         package="system_monitor",
         plugin="GPUMonitor",
-        name="gpu_monitor",
+        name="gpu_monitor" + node_name_suffix,
         parameters=[
             gpu_monitor_config,
         ],


### PR DESCRIPTION
Signed-off-by: v-nakayama7440-esol <v-nakayama7440@esol.co.jp>

## Description

Depending on the ECU configuration, there is a requirement to launch Autoware's SystemMonitor only. Add some launch parameters to `system.launch.xml` to accommodate this request.

The parameters to add are as follows.

- `system_monitor_only` : `true` is System Monitor only mode. `false` is Normal mode. Defualt value is `false`.
- `system_namespace` : Set the namespace of the node to start. Default value is `/system`.
- `system_monitor_node_name_suffix` : Set the suffix of the SystemMonitor node name. Default value is not set.
- `cpu_monitor_param_file` : Set the CPU Monitor parameter file path. The default value is the parameter file path of the `tier4_system_launch` package.
- `hdd_monitor_param_file` : Set the HDD Monitor parameter file path. The default value is the parameter file path of the `tier4_system_launch` package.
- `mem_monitor_param_file` : Set the Memory Monitor parameter file path. The default value is the parameter file path of the `tier4_system_launch` package.
- `net_monitor_param_file` : Set the Net Monitor parameter file path. The default value is the parameter file path of the `tier4_system_launch` package.
- `ntp_monitor_param_file` : Set the NTP Monitor parameter file path. The default value is the parameter file path of the `tier4_system_launch` package.
- `process_monitor_param_file` : Set the Process Monitor parameter file path. The default value is the parameter file path of the `tier4_system_launch` package.
- `gpu_monitor_param_file` : Set the GPU Monitor parameter file path. The default value is the parameter file path of the `tier4_system_launch` package.

## Related links

## Tests performed

**Normal mode (Same behavior as before this PR.)**

Executed `$ ros2 launch tier4_system_launch system.launch.xml sensor_model:=sample_sensor_kit` command.

<img width="411" alt="img1" src="https://user-images.githubusercontent.com/97144416/191687657-b376822c-9d11-493e-9884-f6ffe9b48fe1.png">

**System Monitor only mode**

Executed `$ ros2 launch tier4_system_launch system.launch.xml system_monitor_only:="true" system_namespace:="/logger" system_monitor_node_name_suffix:="logger"` command.

<img width="420" alt="img2" src="https://user-images.githubusercontent.com/97144416/191687701-d5c61a44-cdff-4307-87d3-22798660c80a.png">

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
