### PR TITLE
fix(raw_vehicle_cmd_converter): inconsitent sign of braking command

### DIFF
--- a/vehicle/raw_vehicle_cmd_converter/src/node.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/node.cpp
@@ -102,7 +102,9 @@ void RawVehicleCommandConverterNode::publishActuationCmd()
   }
   if (!current_twist_ptr_ || !control_cmd_ptr_ || !current_steer_ptr_) {
     RCLCPP_WARN_EXPRESSION(
-      get_logger(), is_debugging_, "some of twist/control_cmd/steer pointer is null");
+      get_logger(), is_debugging_, "some pointers are null: %s, %s, %s",
+      !current_twist_ptr_ ? "twist" : "", !control_cmd_ptr_ ? "cmd" : "",
+      !current_steer_ptr_ ? "steer" : "");
     return;
   }
   double desired_accel_cmd = 0.0;
@@ -124,9 +126,9 @@ void RawVehicleCommandConverterNode::publishActuationCmd()
     if (accel_cmd_is_zero) {
       desired_brake_cmd = calculateBrakeMap(vel, acc);
     }
-  } else {
-    // if conversion is disabled use acceleration as brake cmd
-    desired_brake_cmd = (acc < 0) ? acc : 0;
+  } else if (acc < 0) {
+    // if conversion is disabled use negative acceleration as brake cmd
+    desired_brake_cmd = -acc;
   }
   if (convert_steer_cmd_) {
     desired_steer_cmd = calculateSteer(vel, steer, steer_rate);


### PR DESCRIPTION
## Description

Braking Incosistency in raw_vehicle_cmd_converter
This is copied from the [q&a section](https://github.com/orgs/autowarefoundation/discussions/2843)

What confuses me a lot is the line:
```
desired_brake_cmd = (acc < 0) ? acc : 0;
```

which in my opinion is wrong, because it sets negative braking values, moreover it is never positive!
So when `convert_brake_cmd` is true, the `desired_brake_cmd` command contains positive values, and when it's false the `desired_brake_cmd contains` negative values.
Braking command should either be negative, or positive, but nevet both.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [*] I've confirmed the [contribution guidelines].
- [*] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
