### PR TITLE
fix(behavior_path_planner): fix shift pull out

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_out/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/geometric_pull_out.cpp
@@ -50,7 +50,7 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
     return {};
   }
 
-  // collsion check with objects in shoulder lanes
+  // collision check with objects in shoulder lanes
   const auto arc_path = planner_.getArcPath();
   const auto shoulder_lane_objects =
     util::filterObjectsByLanelets(*(planner_data_->dynamic_object), shoulder_lanes);

--- a/planning/behavior_path_planner/src/scene_module/pull_out/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/geometric_pull_out.cpp
@@ -36,7 +36,7 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
 {
   PullOutPath output;
 
-  // conbine road lane and shoulder lane
+  // combine road lane and shoulder lane
   const auto road_lanes = util::getCurrentLanes(planner_data_);
   const auto shoulder_lanes = getPullOutLanes(road_lanes, planner_data_);
   auto lanes = road_lanes;

--- a/planning/behavior_path_planner/src/scene_module/pull_out/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/shift_pull_out.cpp
@@ -167,6 +167,7 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
       double s_end = arc_position_goal.length;
       road_lane_reference_path = route_handler.getCenterLinePath(road_lanes, s_start, s_end);
     }
+    path_shifter.setPath(road_lane_reference_path);
 
     // get shift point start/end
     const auto shift_point_start = shoulder_reference_path.points.back();
@@ -186,7 +187,6 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
       shift_point.length = distance_to_road_center;
     }
     path_shifter.addShiftPoint(shift_point);
-    path_shifter.setPath(road_lane_reference_path);
 
     // offset front side
     ShiftedPath shifted_path;

--- a/planning/behavior_path_planner/src/scene_module/pull_out/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/shift_pull_out.cpp
@@ -69,7 +69,7 @@ boost::optional<PullOutPath> ShiftPullOut::plan(Pose start_pose, Pose goal_pose)
     auto & shift_path =
       pull_out_path.partial_paths.front();  // shift path is not separate but only one.
 
-    // check lane_depature and collsion with path between current to pull_out_end
+    // check lane_departure and collision with path between current to pull_out_end
     PathWithLaneId path_current_to_shift_end;
     {
       const auto current_idx = findNearestIndex(shift_path.points, current_pose);

--- a/planning/behavior_path_planner/src/scene_module/utils/path_shifter.cpp
+++ b/planning/behavior_path_planner/src/scene_module/utils/path_shifter.cpp
@@ -259,6 +259,12 @@ std::vector<double> PathShifter::calcLateralJerk() const
 
 void PathShifter::updateShiftPointIndices(ShiftPointArray & shift_points) const
 {
+  if (reference_path_.points.empty()) {
+    RCLCPP_ERROR(
+      logger_,
+      "reference path is empty, setPath is needed before addShiftPoint/setShiftPoints.");
+  }
+
   for (auto & p : shift_points) {
     // TODO(murooka) remove findNearestIndex for except
     // lane_following to support u-turn & crossing path

--- a/planning/behavior_path_planner/src/scene_module/utils/path_shifter.cpp
+++ b/planning/behavior_path_planner/src/scene_module/utils/path_shifter.cpp
@@ -261,8 +261,7 @@ void PathShifter::updateShiftPointIndices(ShiftPointArray & shift_points) const
 {
   if (reference_path_.points.empty()) {
     RCLCPP_ERROR(
-      logger_,
-      "reference path is empty, setPath is needed before addShiftPoint/setShiftPoints.");
+      logger_, "reference path is empty, setPath is needed before addShiftPoint/setShiftPoints.");
   }
 
   for (auto & p : shift_points) {


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
In https://github.com/autowarefoundation/autoware.universe/pull/1875, `setPath` is needed before `addShiftPoint` or `setShiftPoints`.
(and fix some typos)

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

In https://github.com/autowarefoundation/autoware.universe/pull/1875,

## Tests performed
psim

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
