### PR TITLE
fix(obstacle_avoidance_planner): fix build error

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -1145,12 +1145,12 @@ Trajectories ObstacleAvoidancePlanner::optimizeTrajectory(
   constexpr double max_path_change_diff = 1.0e4;
   for (size_t i = 0; i < eb_traj->size(); ++i) {
     const auto & eb_pos = eb_traj->at(i).pose.position;
-    const auto & path_pos = path.points.at(std::min(i, path.points.size() - 1)).pose.position;
+    const auto & path_pos = p.path.points.at(std::min(i, p.path.points.size() - 1)).pose.position;
 
     const double diff_x = eb_pos.x - path_pos.x;
     const double diff_y = eb_pos.y - path_pos.y;
     if (max_path_change_diff < std::abs(diff_x) || max_path_change_diff < std::abs(diff_y)) {
-      return getPrevTrajs(path.points);
+      return getPrevTrajs(p.path.points);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

fix build error of obstacle_avoidance_planner caused by https://github.com/autowarefoundation/autoware.universe/pull/1881
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
