### PR TITLE
fix(tier4_autoware_utils): fix covariance enum name

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
@@ -54,14 +54,14 @@ enum RPY_COV_IDX {
 };
 }  // namespace rpy_covariance_index
 
-namespace pose_covariance_index
+namespace xyzrpy_covariance_index
 {
 /// Covariance for 6-DOF pose.
 /// Used at
 /// - geometry_msgs/msg/AccelWithCovariance.msg: msg.covariance
 /// - geometry_msgs/msg/TwistWithCovariance.msg: msg.covariance
 /// - geometry_msgs/msg/PoseWithCovariance.msg: msg.covariance
-enum POSE_COV_IDX {
+enum XYZRPY_COV_IDX {
   X_X = 0,
   X_Y = 1,
   X_Z = 2,
@@ -99,7 +99,7 @@ enum POSE_COV_IDX {
   YAW_PITCH = 34,
   YAW_YAW = 35
 };
-}  // namespace pose_covariance_index
+}  // namespace xyzrpy_covariance_index
 
 namespace xyz_upper_covariance_index
 {

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/msg_covariance.hpp
@@ -56,7 +56,7 @@ enum RPY_COV_IDX {
 
 namespace xyzrpy_covariance_index
 {
-/// Covariance for 6-DOF pose.
+/// Covariance for 6-DOF.
 /// Used at
 /// - geometry_msgs/msg/AccelWithCovariance.msg: msg.covariance
 /// - geometry_msgs/msg/TwistWithCovariance.msg: msg.covariance

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -133,7 +133,7 @@ RadarFusionToDetectedObject::Output RadarFusionToDetectedObject::update(
 bool RadarFusionToDetectedObject::hasTwistCovariance(
   const TwistWithCovariance & twist_with_covariance)
 {
-  using IDX = tier4_autoware_utils::pose_covariance_index::POSE_COV_IDX;
+  using IDX = tier4_autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   auto covariance = twist_with_covariance.covariance;
   if (covariance[IDX::X_X] == 0.0 && covariance[IDX::Y_Y] == 0.0 && covariance[IDX::Z_Z] == 0.0) {
     return false;

--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
@@ -162,7 +162,7 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
   TrackedObjects tracked_objects;
   tracked_objects.header = radar_data_->header;
   tracked_objects.header.frame_id = node_param_.new_frame_id;
-  using C_INX = tier4_autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  using C_IDX = tier4_autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   using R_IDX = tier4_autoware_utils::xyz_upper_covariance_index::XYZ_UPPER_COV_IDX;
 
   for (auto & radar_track : radar_data_->tracks) {
@@ -188,15 +188,15 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
 
     {
       auto & covariance = kinematics.pose_with_covariance.covariance;
-      covariance[C_INX::X_X] = radar_track.position_covariance[R_IDX::X_X];
-      covariance[C_INX::X_Y] = radar_track.position_covariance[R_IDX::X_Y];
-      covariance[C_INX::X_Z] = radar_track.position_covariance[R_IDX::X_Z];
-      covariance[C_INX::Y_X] = radar_track.position_covariance[R_IDX::X_Y];
-      covariance[C_INX::Y_Y] = radar_track.position_covariance[R_IDX::Y_Y];
-      covariance[C_INX::Y_Z] = radar_track.position_covariance[R_IDX::Y_Z];
-      covariance[C_INX::Z_X] = radar_track.position_covariance[R_IDX::X_Z];
-      covariance[C_INX::Z_Y] = radar_track.position_covariance[R_IDX::Y_Z];
-      covariance[C_INX::Z_Z] = radar_track.position_covariance[R_IDX::Z_Z];
+      covariance[C_IDX::X_X] = radar_track.position_covariance[R_IDX::X_X];
+      covariance[C_IDX::X_Y] = radar_track.position_covariance[R_IDX::X_Y];
+      covariance[C_IDX::X_Z] = radar_track.position_covariance[R_IDX::X_Z];
+      covariance[C_IDX::Y_X] = radar_track.position_covariance[R_IDX::X_Y];
+      covariance[C_IDX::Y_Y] = radar_track.position_covariance[R_IDX::Y_Y];
+      covariance[C_IDX::Y_Z] = radar_track.position_covariance[R_IDX::Y_Z];
+      covariance[C_IDX::Z_X] = radar_track.position_covariance[R_IDX::X_Z];
+      covariance[C_IDX::Z_Y] = radar_track.position_covariance[R_IDX::Y_Z];
+      covariance[C_IDX::Z_Z] = radar_track.position_covariance[R_IDX::Z_Z];
     }
 
     // convert by tf
@@ -219,27 +219,27 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
 
     {
       auto & covariance = kinematics.twist_with_covariance.covariance;
-      covariance[C_INX::X_X] = radar_track.velocity_covariance[R_IDX::X_X];
-      covariance[C_INX::X_Y] = radar_track.velocity_covariance[R_IDX::X_Y];
-      covariance[C_INX::X_Z] = radar_track.velocity_covariance[R_IDX::X_Z];
-      covariance[C_INX::Y_X] = radar_track.velocity_covariance[R_IDX::X_Y];
-      covariance[C_INX::Y_Y] = radar_track.velocity_covariance[R_IDX::Y_Y];
-      covariance[C_INX::Y_Z] = radar_track.velocity_covariance[R_IDX::Y_Z];
-      covariance[C_INX::Z_X] = radar_track.velocity_covariance[R_IDX::X_Z];
-      covariance[C_INX::Z_Y] = radar_track.velocity_covariance[R_IDX::Y_Z];
-      covariance[C_INX::Z_Z] = radar_track.velocity_covariance[R_IDX::Z_Z];
+      covariance[C_IDX::X_X] = radar_track.velocity_covariance[R_IDX::X_X];
+      covariance[C_IDX::X_Y] = radar_track.velocity_covariance[R_IDX::X_Y];
+      covariance[C_IDX::X_Z] = radar_track.velocity_covariance[R_IDX::X_Z];
+      covariance[C_IDX::Y_X] = radar_track.velocity_covariance[R_IDX::X_Y];
+      covariance[C_IDX::Y_Y] = radar_track.velocity_covariance[R_IDX::Y_Y];
+      covariance[C_IDX::Y_Z] = radar_track.velocity_covariance[R_IDX::Y_Z];
+      covariance[C_IDX::Z_X] = radar_track.velocity_covariance[R_IDX::X_Z];
+      covariance[C_IDX::Z_Y] = radar_track.velocity_covariance[R_IDX::Y_Z];
+      covariance[C_IDX::Z_Z] = radar_track.velocity_covariance[R_IDX::Z_Z];
     }
     {
       auto & covariance = kinematics.acceleration_with_covariance.covariance;
-      covariance[C_INX::X_X] = radar_track.acceleration_covariance[R_IDX::X_X];
-      covariance[C_INX::X_Y] = radar_track.acceleration_covariance[R_IDX::X_Y];
-      covariance[C_INX::X_Z] = radar_track.acceleration_covariance[R_IDX::X_Z];
-      covariance[C_INX::Y_X] = radar_track.acceleration_covariance[R_IDX::X_Y];
-      covariance[C_INX::Y_Y] = radar_track.acceleration_covariance[R_IDX::Y_Y];
-      covariance[C_INX::Y_Z] = radar_track.acceleration_covariance[R_IDX::Y_Z];
-      covariance[C_INX::Z_X] = radar_track.acceleration_covariance[R_IDX::X_Z];
-      covariance[C_INX::Z_Y] = radar_track.acceleration_covariance[R_IDX::Y_Z];
-      covariance[C_INX::Z_Z] = radar_track.acceleration_covariance[R_IDX::Z_Z];
+      covariance[C_IDX::X_X] = radar_track.acceleration_covariance[R_IDX::X_X];
+      covariance[C_IDX::X_Y] = radar_track.acceleration_covariance[R_IDX::X_Y];
+      covariance[C_IDX::X_Z] = radar_track.acceleration_covariance[R_IDX::X_Z];
+      covariance[C_IDX::Y_X] = radar_track.acceleration_covariance[R_IDX::X_Y];
+      covariance[C_IDX::Y_Y] = radar_track.acceleration_covariance[R_IDX::Y_Y];
+      covariance[C_IDX::Y_Z] = radar_track.acceleration_covariance[R_IDX::Y_Z];
+      covariance[C_IDX::Z_X] = radar_track.acceleration_covariance[R_IDX::X_Z];
+      covariance[C_IDX::Z_Y] = radar_track.acceleration_covariance[R_IDX::Y_Z];
+      covariance[C_IDX::Z_Z] = radar_track.acceleration_covariance[R_IDX::Z_Z];
     }
 
     tracked_object.kinematics = kinematics;

--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
@@ -162,7 +162,7 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
   TrackedObjects tracked_objects;
   tracked_objects.header = radar_data_->header;
   tracked_objects.header.frame_id = node_param_.new_frame_id;
-  using P_IDX = tier4_autoware_utils::pose_covariance_index::POSE_COV_IDX;
+  using C_INX = tier4_autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   using R_IDX = tier4_autoware_utils::xyz_upper_covariance_index::XYZ_UPPER_COV_IDX;
 
   for (auto & radar_track : radar_data_->tracks) {
@@ -188,15 +188,15 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
 
     {
       auto & covariance = kinematics.pose_with_covariance.covariance;
-      covariance[P_IDX::X_X] = radar_track.position_covariance[R_IDX::X_X];
-      covariance[P_IDX::X_Y] = radar_track.position_covariance[R_IDX::X_Y];
-      covariance[P_IDX::X_Z] = radar_track.position_covariance[R_IDX::X_Z];
-      covariance[P_IDX::Y_X] = radar_track.position_covariance[R_IDX::X_Y];
-      covariance[P_IDX::Y_Y] = radar_track.position_covariance[R_IDX::Y_Y];
-      covariance[P_IDX::Y_Z] = radar_track.position_covariance[R_IDX::Y_Z];
-      covariance[P_IDX::Z_X] = radar_track.position_covariance[R_IDX::X_Z];
-      covariance[P_IDX::Z_Y] = radar_track.position_covariance[R_IDX::Y_Z];
-      covariance[P_IDX::Z_Z] = radar_track.position_covariance[R_IDX::Z_Z];
+      covariance[C_INX::X_X] = radar_track.position_covariance[R_IDX::X_X];
+      covariance[C_INX::X_Y] = radar_track.position_covariance[R_IDX::X_Y];
+      covariance[C_INX::X_Z] = radar_track.position_covariance[R_IDX::X_Z];
+      covariance[C_INX::Y_X] = radar_track.position_covariance[R_IDX::X_Y];
+      covariance[C_INX::Y_Y] = radar_track.position_covariance[R_IDX::Y_Y];
+      covariance[C_INX::Y_Z] = radar_track.position_covariance[R_IDX::Y_Z];
+      covariance[C_INX::Z_X] = radar_track.position_covariance[R_IDX::X_Z];
+      covariance[C_INX::Z_Y] = radar_track.position_covariance[R_IDX::Y_Z];
+      covariance[C_INX::Z_Z] = radar_track.position_covariance[R_IDX::Z_Z];
     }
 
     // convert by tf
@@ -219,27 +219,27 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
 
     {
       auto & covariance = kinematics.twist_with_covariance.covariance;
-      covariance[P_IDX::X_X] = radar_track.velocity_covariance[R_IDX::X_X];
-      covariance[P_IDX::X_Y] = radar_track.velocity_covariance[R_IDX::X_Y];
-      covariance[P_IDX::X_Z] = radar_track.velocity_covariance[R_IDX::X_Z];
-      covariance[P_IDX::Y_X] = radar_track.velocity_covariance[R_IDX::X_Y];
-      covariance[P_IDX::Y_Y] = radar_track.velocity_covariance[R_IDX::Y_Y];
-      covariance[P_IDX::Y_Z] = radar_track.velocity_covariance[R_IDX::Y_Z];
-      covariance[P_IDX::Z_X] = radar_track.velocity_covariance[R_IDX::X_Z];
-      covariance[P_IDX::Z_Y] = radar_track.velocity_covariance[R_IDX::Y_Z];
-      covariance[P_IDX::Z_Z] = radar_track.velocity_covariance[R_IDX::Z_Z];
+      covariance[C_INX::X_X] = radar_track.velocity_covariance[R_IDX::X_X];
+      covariance[C_INX::X_Y] = radar_track.velocity_covariance[R_IDX::X_Y];
+      covariance[C_INX::X_Z] = radar_track.velocity_covariance[R_IDX::X_Z];
+      covariance[C_INX::Y_X] = radar_track.velocity_covariance[R_IDX::X_Y];
+      covariance[C_INX::Y_Y] = radar_track.velocity_covariance[R_IDX::Y_Y];
+      covariance[C_INX::Y_Z] = radar_track.velocity_covariance[R_IDX::Y_Z];
+      covariance[C_INX::Z_X] = radar_track.velocity_covariance[R_IDX::X_Z];
+      covariance[C_INX::Z_Y] = radar_track.velocity_covariance[R_IDX::Y_Z];
+      covariance[C_INX::Z_Z] = radar_track.velocity_covariance[R_IDX::Z_Z];
     }
     {
       auto & covariance = kinematics.acceleration_with_covariance.covariance;
-      covariance[P_IDX::X_X] = radar_track.acceleration_covariance[R_IDX::X_X];
-      covariance[P_IDX::X_Y] = radar_track.acceleration_covariance[R_IDX::X_Y];
-      covariance[P_IDX::X_Z] = radar_track.acceleration_covariance[R_IDX::X_Z];
-      covariance[P_IDX::Y_X] = radar_track.acceleration_covariance[R_IDX::X_Y];
-      covariance[P_IDX::Y_Y] = radar_track.acceleration_covariance[R_IDX::Y_Y];
-      covariance[P_IDX::Y_Z] = radar_track.acceleration_covariance[R_IDX::Y_Z];
-      covariance[P_IDX::Z_X] = radar_track.acceleration_covariance[R_IDX::X_Z];
-      covariance[P_IDX::Z_Y] = radar_track.acceleration_covariance[R_IDX::Y_Z];
-      covariance[P_IDX::Z_Z] = radar_track.acceleration_covariance[R_IDX::Z_Z];
+      covariance[C_INX::X_X] = radar_track.acceleration_covariance[R_IDX::X_X];
+      covariance[C_INX::X_Y] = radar_track.acceleration_covariance[R_IDX::X_Y];
+      covariance[C_INX::X_Z] = radar_track.acceleration_covariance[R_IDX::X_Z];
+      covariance[C_INX::Y_X] = radar_track.acceleration_covariance[R_IDX::X_Y];
+      covariance[C_INX::Y_Y] = radar_track.acceleration_covariance[R_IDX::Y_Y];
+      covariance[C_INX::Y_Z] = radar_track.acceleration_covariance[R_IDX::Y_Z];
+      covariance[C_INX::Z_X] = radar_track.acceleration_covariance[R_IDX::X_Z];
+      covariance[C_INX::Z_Y] = radar_track.acceleration_covariance[R_IDX::Y_Z];
+      covariance[C_INX::Z_Z] = radar_track.acceleration_covariance[R_IDX::Z_Z];
     }
 
     tracked_object.kinematics = kinematics;

--- a/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
+++ b/perception/radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp
@@ -162,8 +162,8 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
   TrackedObjects tracked_objects;
   tracked_objects.header = radar_data_->header;
   tracked_objects.header.frame_id = node_param_.new_frame_id;
-  using C_IDX = tier4_autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
-  using R_IDX = tier4_autoware_utils::xyz_upper_covariance_index::XYZ_UPPER_COV_IDX;
+  using POSE_IDX = tier4_autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  using RADAR_IDX = tier4_autoware_utils::xyz_upper_covariance_index::XYZ_UPPER_COV_IDX;
 
   for (auto & radar_track : radar_data_->tracks) {
     TrackedObject tracked_object;
@@ -187,16 +187,17 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
     kinematics.pose_with_covariance.pose = transformed_pose_stamped.pose;
 
     {
-      auto & covariance = kinematics.pose_with_covariance.covariance;
-      covariance[C_IDX::X_X] = radar_track.position_covariance[R_IDX::X_X];
-      covariance[C_IDX::X_Y] = radar_track.position_covariance[R_IDX::X_Y];
-      covariance[C_IDX::X_Z] = radar_track.position_covariance[R_IDX::X_Z];
-      covariance[C_IDX::Y_X] = radar_track.position_covariance[R_IDX::X_Y];
-      covariance[C_IDX::Y_Y] = radar_track.position_covariance[R_IDX::Y_Y];
-      covariance[C_IDX::Y_Z] = radar_track.position_covariance[R_IDX::Y_Z];
-      covariance[C_IDX::Z_X] = radar_track.position_covariance[R_IDX::X_Z];
-      covariance[C_IDX::Z_Y] = radar_track.position_covariance[R_IDX::Y_Z];
-      covariance[C_IDX::Z_Z] = radar_track.position_covariance[R_IDX::Z_Z];
+      auto & pose_cov = kinematics.pose_with_covariance.covariance;
+      auto & radar_position_cov = radar_track.position_covariance;
+      pose_cov[POSE_IDX::X_X] = radar_position_cov[RADAR_IDX::X_X];
+      pose_cov[POSE_IDX::X_Y] = radar_position_cov[RADAR_IDX::X_Y];
+      pose_cov[POSE_IDX::X_Z] = radar_position_cov[RADAR_IDX::X_Z];
+      pose_cov[POSE_IDX::Y_X] = radar_position_cov[RADAR_IDX::X_Y];
+      pose_cov[POSE_IDX::Y_Y] = radar_position_cov[RADAR_IDX::Y_Y];
+      pose_cov[POSE_IDX::Y_Z] = radar_position_cov[RADAR_IDX::Y_Z];
+      pose_cov[POSE_IDX::Z_X] = radar_position_cov[RADAR_IDX::X_Z];
+      pose_cov[POSE_IDX::Z_Y] = radar_position_cov[RADAR_IDX::Y_Z];
+      pose_cov[POSE_IDX::Z_Z] = radar_position_cov[RADAR_IDX::Z_Z];
     }
 
     // convert by tf
@@ -218,28 +219,30 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects()
     }
 
     {
-      auto & covariance = kinematics.twist_with_covariance.covariance;
-      covariance[C_IDX::X_X] = radar_track.velocity_covariance[R_IDX::X_X];
-      covariance[C_IDX::X_Y] = radar_track.velocity_covariance[R_IDX::X_Y];
-      covariance[C_IDX::X_Z] = radar_track.velocity_covariance[R_IDX::X_Z];
-      covariance[C_IDX::Y_X] = radar_track.velocity_covariance[R_IDX::X_Y];
-      covariance[C_IDX::Y_Y] = radar_track.velocity_covariance[R_IDX::Y_Y];
-      covariance[C_IDX::Y_Z] = radar_track.velocity_covariance[R_IDX::Y_Z];
-      covariance[C_IDX::Z_X] = radar_track.velocity_covariance[R_IDX::X_Z];
-      covariance[C_IDX::Z_Y] = radar_track.velocity_covariance[R_IDX::Y_Z];
-      covariance[C_IDX::Z_Z] = radar_track.velocity_covariance[R_IDX::Z_Z];
+      auto & twist_cov = kinematics.twist_with_covariance.covariance;
+      auto & radar_vel_cov = radar_track.velocity_covariance;
+      twist_cov[POSE_IDX::X_X] = radar_vel_cov[RADAR_IDX::X_X];
+      twist_cov[POSE_IDX::X_Y] = radar_vel_cov[RADAR_IDX::X_Y];
+      twist_cov[POSE_IDX::X_Z] = radar_vel_cov[RADAR_IDX::X_Z];
+      twist_cov[POSE_IDX::Y_X] = radar_vel_cov[RADAR_IDX::X_Y];
+      twist_cov[POSE_IDX::Y_Y] = radar_vel_cov[RADAR_IDX::Y_Y];
+      twist_cov[POSE_IDX::Y_Z] = radar_vel_cov[RADAR_IDX::Y_Z];
+      twist_cov[POSE_IDX::Z_X] = radar_vel_cov[RADAR_IDX::X_Z];
+      twist_cov[POSE_IDX::Z_Y] = radar_vel_cov[RADAR_IDX::Y_Z];
+      twist_cov[POSE_IDX::Z_Z] = radar_vel_cov[RADAR_IDX::Z_Z];
     }
     {
-      auto & covariance = kinematics.acceleration_with_covariance.covariance;
-      covariance[C_IDX::X_X] = radar_track.acceleration_covariance[R_IDX::X_X];
-      covariance[C_IDX::X_Y] = radar_track.acceleration_covariance[R_IDX::X_Y];
-      covariance[C_IDX::X_Z] = radar_track.acceleration_covariance[R_IDX::X_Z];
-      covariance[C_IDX::Y_X] = radar_track.acceleration_covariance[R_IDX::X_Y];
-      covariance[C_IDX::Y_Y] = radar_track.acceleration_covariance[R_IDX::Y_Y];
-      covariance[C_IDX::Y_Z] = radar_track.acceleration_covariance[R_IDX::Y_Z];
-      covariance[C_IDX::Z_X] = radar_track.acceleration_covariance[R_IDX::X_Z];
-      covariance[C_IDX::Z_Y] = radar_track.acceleration_covariance[R_IDX::Y_Z];
-      covariance[C_IDX::Z_Z] = radar_track.acceleration_covariance[R_IDX::Z_Z];
+      auto & accel_cov = kinematics.acceleration_with_covariance.covariance;
+      auto & radar_accel_cov = radar_track.acceleration_covariance;
+      accel_cov[POSE_IDX::X_X] = radar_accel_cov[RADAR_IDX::X_X];
+      accel_cov[POSE_IDX::X_Y] = radar_accel_cov[RADAR_IDX::X_Y];
+      accel_cov[POSE_IDX::X_Z] = radar_accel_cov[RADAR_IDX::X_Z];
+      accel_cov[POSE_IDX::Y_X] = radar_accel_cov[RADAR_IDX::X_Y];
+      accel_cov[POSE_IDX::Y_Y] = radar_accel_cov[RADAR_IDX::Y_Y];
+      accel_cov[POSE_IDX::Y_Z] = radar_accel_cov[RADAR_IDX::Y_Z];
+      accel_cov[POSE_IDX::Z_X] = radar_accel_cov[RADAR_IDX::X_Z];
+      accel_cov[POSE_IDX::Z_Y] = radar_accel_cov[RADAR_IDX::Y_Z];
+      accel_cov[POSE_IDX::Z_Z] = radar_accel_cov[RADAR_IDX::Z_Z];
     }
 
     tracked_object.kinematics = kinematics;


### PR DESCRIPTION
## Description

This PR change from pose_covariance_index::POSE_COV_IDX to xyzrpy_covariance_index::XYZRPY_COV_IDX.
This change of util library may make easy to read.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
