### PR TITLE
feat(behavior_path_planner): params to expand drivable area in each module

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
@@ -1,20 +1,20 @@
 /**:
   ros__parameters:
     avoidance:
-      drivable_area_right_bound_offset: 0.5
-      drivable_area_left_bound_offset: 0.5
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0
     lane_change:
-      drivable_area_right_bound_offset: 1.0
-      drivable_area_left_bound_offset: 1.0
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0
     lane_following:
-      drivable_area_right_bound_offset: 1.5
-      drivable_area_left_bound_offset: 1.5
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0
     pull_out:
-      drivable_area_right_bound_offset: 2.0
-      drivable_area_left_bound_offset: 2.0
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0
     pull_over:
-      drivable_area_right_bound_offset: 2.5
-      drivable_area_left_bound_offset: 2.5
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0
     side_shift:
-      drivable_area_right_bound_offset: 3.0
-      drivable_area_left_bound_offset: 3.0
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
@@ -1,0 +1,20 @@
+/**:
+  ros__parameters:
+    avoidance:
+      drivable_area_right_bound_offset: 0.5
+      drivable_area_left_bound_offset: 0.5
+    lane_change:
+      drivable_area_right_bound_offset: 1.0
+      drivable_area_left_bound_offset: 1.0
+    lane_following:
+      drivable_area_right_bound_offset: 1.5
+      drivable_area_left_bound_offset: 1.5
+    pull_out:
+      drivable_area_right_bound_offset: 2.0
+      drivable_area_left_bound_offset: 2.0
+    pull_over:
+      drivable_area_right_bound_offset: 2.5
+      drivable_area_left_bound_offset: 2.5
+    side_shift:
+      drivable_area_right_bound_offset: 3.0
+      drivable_area_left_bound_offset: 3.0

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_following/lane_following.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_following/lane_following.param.yaml
@@ -1,7 +1,4 @@
 /**:
   ros__parameters:
     lane_following:
-      expand_drivable_area: false
-      right_bound_offset: 0.5
-      left_bound_offset: 0.5
       lane_change_prepare_duration: 2.0

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -121,6 +121,17 @@ def launch_setup(context, *args, **kwargs):
     with open(pull_out_param_path, "r") as f:
         pull_out_param = yaml.safe_load(f)["/**"]["ros__parameters"]
 
+    drivable_area_expansion_param_path = os.path.join(
+        LaunchConfiguration("tier4_planning_launch_param_path").perform(context),
+        "scenario_planning",
+        "lane_driving",
+        "behavior_planning",
+        "behavior_path_planner",
+        "drivable_area_expansion.param.yaml",
+    )
+    with open(drivable_area_expansion_param_path, "r") as f:
+        drivable_area_expansion_param = yaml.safe_load(f)["/**"]["ros__parameters"]
+
     behavior_path_planner_param_path = os.path.join(
         LaunchConfiguration("tier4_planning_launch_param_path").perform(context),
         "scenario_planning",
@@ -156,6 +167,7 @@ def launch_setup(context, *args, **kwargs):
             lane_following_param,
             pull_over_param,
             pull_out_param,
+            drivable_area_expansion_param,
             behavior_path_planner_param,
             vehicle_info_param,
             {

--- a/planning/behavior_path_planner/config/drivable_area_expansion.yaml
+++ b/planning/behavior_path_planner/config/drivable_area_expansion.yaml
@@ -1,0 +1,20 @@
+/**:
+  ros__parameters:
+    avoidance:
+      drivable_area_right_bound_offset: 0.5
+      drivable_area_left_bound_offset: 0.5
+    lane_change:
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0
+    lane_following:
+      drivable_area_right_bound_offset: 0.5
+      drivable_area_left_bound_offset: 0.5
+    pull_out:
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0
+    pull_over:
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0
+    side_shift:
+      drivable_area_right_bound_offset: 0.0
+      drivable_area_left_bound_offset: 0.0

--- a/planning/behavior_path_planner/config/lane_following/lane_following.param.yaml
+++ b/planning/behavior_path_planner/config/lane_following/lane_following.param.yaml
@@ -1,7 +1,4 @@
 /**:
   ros__parameters:
     lane_following:
-      expand_drivable_area: false
-      right_bound_offset: 0.5
-      left_bound_offset: 0.5
       lane_change_prepare_duration: 2.0

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -156,6 +156,10 @@ struct AvoidanceParameters
   bool avoid_motorcycle{false};  // avoidance is performed for type object motorbike
   bool avoid_pedestrian{false};  // avoidance is performed for type object pedestrian
 
+  // drivable area expansion
+  double drivable_area_right_bound_offset;
+  double drivable_area_left_bound_offset;
+
   // debug
   bool publish_debug_marker = false;
   bool print_debug_info = false;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
@@ -41,6 +41,9 @@ struct LaneChangeParameters
   bool use_predicted_path_outside_lanelet;
   bool use_all_predicted_path;
   bool publish_debug_marker;
+  // drivable area expansion
+  double drivable_area_right_bound_offset;
+  double drivable_area_left_bound_offset;
 };
 
 struct LaneChangeStatus

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
@@ -29,10 +29,10 @@ using autoware_auto_planning_msgs::msg::PathWithLaneId;
 
 struct LaneFollowingParameters
 {
-  bool expand_drivable_area;
-  double right_bound_offset;
-  double left_bound_offset;
   double lane_change_prepare_duration;
+  // drivable area expansion
+  double drivable_area_right_bound_offset;
+  double drivable_area_left_bound_offset;
 };
 
 class LaneFollowingModule : public SceneModuleInterface

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_parameters.hpp
@@ -49,6 +49,9 @@ struct PullOutParameters
   double max_back_distance;
   double backward_search_resolution;
   double backward_path_update_duration;
+  // drivable area expansion
+  double drivable_area_right_bound_offset;
+  double drivable_area_left_bound_offset;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_parameters.hpp
@@ -78,6 +78,9 @@ struct PullOverParameters
   bool enable_collision_check_at_prepare_phase;
   bool use_predicted_path_outside_lanelet;
   bool use_all_predicted_path;
+  // drivable area expansion
+  double drivable_area_right_bound_offset;
+  double drivable_area_left_bound_offset;
   // debug
   bool print_debug_info;
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -45,6 +45,9 @@ struct SideShiftParameters
   double drivable_area_width;
   double drivable_area_height;
   double shift_request_time_limit;
+  // drivable area expansion
+  double drivable_area_right_bound_offset;
+  double drivable_area_left_bound_offset;
 };
 
 class SideShiftModule : public SceneModuleInterface

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -284,9 +284,18 @@ OccupancyGrid generateDrivableArea(
 lanelet::ConstLineStrings3d getDrivableAreaForAllSharedLinestringLanelets(
   const std::shared_ptr<const PlannerData> & planner_data);
 
+/**
+ * @brief Expand the borders of the given lanelets
+ * @param [in] lanelets lanelets to expand
+ * @param [in] left_bound_offset [m] expansion distance of the left bound
+ * @param [in] right_bound_offset [m] expansion distance of the right bound
+ * @param [in] types_to_skip linestring types that will not be expanded
+ * @return expanded lanelets
+ */
 lanelet::ConstLanelets expandLanelets(
-  const lanelet::ConstLanelets & lanelets, const double right_bound_offset,
-  const double left_bound_offset);
+  const lanelet::ConstLanelets & lanelets, const double left_bound_offset,
+  const double right_bound_offset, const std::vector<std::string> & types_to_skip = {});
+
 // goal management
 
 /**

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -283,6 +283,10 @@ OccupancyGrid generateDrivableArea(
 
 lanelet::ConstLineStrings3d getDrivableAreaForAllSharedLinestringLanelets(
   const std::shared_ptr<const PlannerData> & planner_data);
+
+lanelet::ConstLanelets expandLanelets(
+  const lanelet::ConstLanelets & lanelets, const double right_bound_offset,
+  const double left_bound_offset);
 // goal management
 
 /**

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -238,6 +238,8 @@ SideShiftParameters BehaviorPathPlannerNode::getSideShiftParam()
   p.min_shifting_distance = dp("min_shifting_distance", 5.0);
   p.min_shifting_speed = dp("min_shifting_speed", 5.56);
   p.shift_request_time_limit = dp("shift_request_time_limit", 1.0);
+  p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
+  p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);
 
   return p;
 }
@@ -300,6 +302,9 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.avoid_motorcycle = dp("target_object.motorcycle", false);
   p.avoid_pedestrian = dp("target_object.pedestrian", false);
 
+  p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
+  p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);
+
   p.avoidance_execution_lateral_threshold = dp("avoidance_execution_lateral_threshold", 0.499);
 
   return p;
@@ -308,9 +313,10 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
 LaneFollowingParameters BehaviorPathPlannerNode::getLaneFollowingParam()
 {
   LaneFollowingParameters p{};
-  p.expand_drivable_area = declare_parameter("lane_following.expand_drivable_area", false);
-  p.right_bound_offset = declare_parameter("lane_following.right_bound_offset", 0.5);
-  p.left_bound_offset = declare_parameter("lane_following.left_bound_offset", 0.5);
+  p.drivable_area_right_bound_offset =
+    declare_parameter("lane_following.drivable_area_right_bound_offset", 0.0);
+  p.drivable_area_left_bound_offset =
+    declare_parameter("lane_following.drivable_area_left_bound_offset", 0.0);
   p.lane_change_prepare_duration =
     declare_parameter("lane_following.lane_change_prepare_duration", 2.0);
   return p;
@@ -341,6 +347,8 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.use_predicted_path_outside_lanelet = dp("use_predicted_path_outside_lanelet", true);
   p.use_all_predicted_path = dp("use_all_predicted_path", true);
   p.publish_debug_marker = dp("publish_debug_marker", false);
+  p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
+  p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);
 
   // validation of parameters
   if (p.lane_change_sampling_num < 1) {
@@ -426,6 +434,9 @@ PullOverParameters BehaviorPathPlannerNode::getPullOverParam()
   p.enable_collision_check_at_prepare_phase = dp("enable_collision_check_at_prepare_phase", true);
   p.use_predicted_path_outside_lanelet = dp("use_predicted_path_outside_lanelet", true);
   p.use_all_predicted_path = dp("use_all_predicted_path", false);
+  // drivable area
+  p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
+  p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);
   // debug
   p.print_debug_info = dp("print_debug_info", false);
 
@@ -485,6 +496,9 @@ PullOutParameters BehaviorPathPlannerNode::getPullOutParam()
   p.max_back_distance = dp("max_back_distance", 15.0);
   p.backward_search_resolution = dp("backward_search_resolution", 2.0);
   p.backward_path_update_duration = dp("backward_path_update_duration", 3.0);
+  // drivable area
+  p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
+  p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);
 
   // validation of parameters
   if (p.pull_out_sampling_num < 1) {

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1770,8 +1770,8 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
   }
 
   extended_lanelets = util::expandLanelets(
-    extended_lanelets, parameters_->drivable_area_right_bound_offset,
-    parameters_->drivable_area_left_bound_offset);
+    extended_lanelets, parameters_->drivable_area_left_bound_offset,
+    parameters_->drivable_area_right_bound_offset, {"road_border"});
 
   {
     const auto & p = planner_data_->parameters;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1769,6 +1769,10 @@ void AvoidanceModule::generateExtendedDrivableArea(ShiftedPath * shifted_path) c
       });
   }
 
+  extended_lanelets = util::expandLanelets(
+    extended_lanelets, parameters_->drivable_area_right_bound_offset,
+    parameters_->drivable_area_left_bound_offset);
+
   {
     const auto & p = planner_data_->parameters;
     shifted_path->path.drivable_area = util::generateDrivableArea(

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -173,8 +173,8 @@ BehaviorModuleOutput LaneChangeModule::plan()
     lanes.insert(lanes.end(), status_.current_lanes.begin(), status_.current_lanes.end());
     lanes.insert(lanes.end(), status_.lane_change_lanes.begin(), status_.lane_change_lanes.end());
     lanes = util::expandLanelets(
-      lanes, parameters_->drivable_area_right_bound_offset,
-      parameters_->drivable_area_left_bound_offset);
+      lanes, parameters_->drivable_area_left_bound_offset,
+      parameters_->drivable_area_right_bound_offset);
 
     const double & resolution = common_parameters.drivable_area_resolution;
     path.drivable_area = util::generateDrivableArea(
@@ -328,8 +328,8 @@ PathWithLaneId LaneChangeModule::getReferencePath() const
     lane_change_buffer);
 
   const auto current_extended_lanes = util::expandLanelets(
-    current_lanes, parameters_->drivable_area_right_bound_offset,
-    parameters_->drivable_area_left_bound_offset);
+    current_lanes, parameters_->drivable_area_left_bound_offset,
+    parameters_->drivable_area_right_bound_offset);
 
   reference_path.drivable_area = util::generateDrivableArea(
     reference_path, current_extended_lanes, common_parameters.drivable_area_resolution,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -172,6 +172,9 @@ BehaviorModuleOutput LaneChangeModule::plan()
     lanes.reserve(status_.current_lanes.size() + status_.lane_change_lanes.size());
     lanes.insert(lanes.end(), status_.current_lanes.begin(), status_.current_lanes.end());
     lanes.insert(lanes.end(), status_.lane_change_lanes.begin(), status_.lane_change_lanes.end());
+    lanes = util::expandLanelets(
+      lanes, parameters_->drivable_area_right_bound_offset,
+      parameters_->drivable_area_left_bound_offset);
 
     const double & resolution = common_parameters.drivable_area_resolution;
     path.drivable_area = util::generateDrivableArea(
@@ -324,8 +327,12 @@ PathWithLaneId LaneChangeModule::getReferencePath() const
     *route_handler, reference_path, current_lanes, parameters_->lane_change_prepare_duration,
     lane_change_buffer);
 
+  const auto current_extended_lanes = util::expandLanelets(
+    current_lanes, parameters_->drivable_area_right_bound_offset,
+    parameters_->drivable_area_left_bound_offset);
+
   reference_path.drivable_area = util::generateDrivableArea(
-    reference_path, current_lanes, common_parameters.drivable_area_resolution,
+    reference_path, current_extended_lanes, common_parameters.drivable_area_resolution,
     common_parameters.vehicle_length, planner_data_);
 
   return reference_path;

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -137,8 +137,8 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
   }
 
   current_lanes = util::expandLanelets(
-    current_lanes, parameters_.drivable_area_right_bound_offset,
-    parameters_.drivable_area_left_bound_offset);
+    current_lanes, parameters_.drivable_area_left_bound_offset,
+    parameters_.drivable_area_right_bound_offset);
 
   reference_path.drivable_area = util::generateDrivableArea(
     reference_path, current_lanes, p.drivable_area_resolution, p.vehicle_length, planner_data_);

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -136,24 +136,9 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
       lane_change_buffer);
   }
 
-  if (parameters_.expand_drivable_area) {
-    lanelet::ConstLanelets expand_lanes{};
-    for (const auto & current_lane : current_lanes) {
-      const std::string r_type =
-        current_lane.rightBound().attributeOr(lanelet::AttributeName::Type, "none");
-      const std::string l_type =
-        current_lane.leftBound().attributeOr(lanelet::AttributeName::Type, "none");
-
-      const double r_offset =
-        r_type.compare("road_border") != 0 ? -parameters_.right_bound_offset : 0.0;
-      const double l_offset =
-        l_type.compare("road_border") != 0 ? parameters_.left_bound_offset : 0.0;
-
-      expand_lanes.push_back(lanelet::utils::getExpandedLanelet(current_lane, l_offset, r_offset));
-    }
-
-    current_lanes = expand_lanes;
-  }
+  current_lanes = util::expandLanelets(
+    current_lanes, parameters_.drivable_area_right_bound_offset,
+    parameters_.drivable_area_left_bound_offset);
 
   reference_path.drivable_area = util::generateDrivableArea(
     reference_path, current_lanes, p.drivable_area_resolution, p.vehicle_length, planner_data_);

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -184,8 +184,11 @@ BehaviorModuleOutput PullOutModule::plan()
   } else {
     path = status_.backward_path;
   }
+  const auto expanded_lanes = util::expandLanelets(
+    status_.lanes, parameters_.drivable_area_right_bound_offset,
+    parameters_.drivable_area_left_bound_offset);
   path.drivable_area = util::generateDrivableArea(
-    path, status_.lanes, planner_data_->parameters.drivable_area_resolution,
+    path, expanded_lanes, planner_data_->parameters.drivable_area_resolution,
     planner_data_->parameters.vehicle_length, planner_data_);
 
   output.path = std::make_shared<PathWithLaneId>(path);
@@ -276,6 +279,10 @@ BehaviorModuleOutput PullOutModule::planWaitingApproval()
   const auto pull_out_lanes = pull_out_utils::getPullOutLanes(current_lanes, planner_data_);
   auto lanes = current_lanes;
   lanes.insert(lanes.end(), pull_out_lanes.begin(), pull_out_lanes.end());
+
+  lanes = util::expandLanelets(
+    lanes, parameters_.drivable_area_right_bound_offset,
+    parameters_.drivable_area_left_bound_offset);
 
   auto candidate_path = status_.back_finished ? getCurrentPath() : status_.backward_path;
   candidate_path.drivable_area = util::generateDrivableArea(

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -185,8 +185,8 @@ BehaviorModuleOutput PullOutModule::plan()
     path = status_.backward_path;
   }
   const auto expanded_lanes = util::expandLanelets(
-    status_.lanes, parameters_.drivable_area_right_bound_offset,
-    parameters_.drivable_area_left_bound_offset);
+    status_.lanes, parameters_.drivable_area_left_bound_offset,
+    parameters_.drivable_area_right_bound_offset);
   path.drivable_area = util::generateDrivableArea(
     path, expanded_lanes, planner_data_->parameters.drivable_area_resolution,
     planner_data_->parameters.vehicle_length, planner_data_);
@@ -281,8 +281,8 @@ BehaviorModuleOutput PullOutModule::planWaitingApproval()
   lanes.insert(lanes.end(), pull_out_lanes.begin(), pull_out_lanes.end());
 
   lanes = util::expandLanelets(
-    lanes, parameters_.drivable_area_right_bound_offset,
-    parameters_.drivable_area_left_bound_offset);
+    lanes, parameters_.drivable_area_left_bound_offset,
+    parameters_.drivable_area_right_bound_offset);
 
   auto candidate_path = status_.back_finished ? getCurrentPath() : status_.backward_path;
   candidate_path.drivable_area = util::generateDrivableArea(

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -521,6 +521,9 @@ BehaviorModuleOutput PullOverModule::plan()
   for (size_t i = status_.current_path_idx; i < status_.pull_over_path.partial_paths.size(); ++i) {
     auto & path = status_.pull_over_path.partial_paths.at(i);
     const auto p = planner_data_->parameters;
+    const auto lane = util::expandLanelets(
+      status_.lanes, parameters_.drivable_area_right_bound_offset,
+      parameters_.drivable_area_left_bound_offset);
     path.drivable_area = util::generateDrivableArea(
       path, status_.lanes, p.drivable_area_resolution, p.vehicle_length, planner_data_);
   }
@@ -684,8 +687,12 @@ PathWithLaneId PullOverModule::getReferencePath() const
       -calcMinimumShiftPathDistance(), parameters_.deceleration_interval);
   }
 
+  const auto lanes = util::expandLanelets(
+    status_.current_lanes, parameters_.drivable_area_right_bound_offset,
+    parameters_.drivable_area_left_bound_offset);
+
   reference_path.drivable_area = util::generateDrivableArea(
-    reference_path, status_.current_lanes, common_parameters.drivable_area_resolution,
+    reference_path, lanes, common_parameters.drivable_area_resolution,
     common_parameters.vehicle_length, planner_data_);
 
   return reference_path;
@@ -723,9 +730,13 @@ PathWithLaneId PullOverModule::generateStopPath() const
     }
   }
 
+  const auto lanes = util::expandLanelets(
+    status_.current_lanes, parameters_.drivable_area_right_bound_offset,
+    parameters_.drivable_area_left_bound_offset);
+
   stop_path.drivable_area = util::generateDrivableArea(
-    stop_path, status_.current_lanes, common_parameters.drivable_area_resolution,
-    common_parameters.vehicle_length, planner_data_);
+    stop_path, lanes, common_parameters.drivable_area_resolution, common_parameters.vehicle_length,
+    planner_data_);
 
   return stop_path;
 }

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -522,8 +522,8 @@ BehaviorModuleOutput PullOverModule::plan()
     auto & path = status_.pull_over_path.partial_paths.at(i);
     const auto p = planner_data_->parameters;
     const auto lane = util::expandLanelets(
-      status_.lanes, parameters_.drivable_area_right_bound_offset,
-      parameters_.drivable_area_left_bound_offset);
+      status_.lanes, parameters_.drivable_area_left_bound_offset,
+      parameters_.drivable_area_right_bound_offset);
     path.drivable_area = util::generateDrivableArea(
       path, status_.lanes, p.drivable_area_resolution, p.vehicle_length, planner_data_);
   }
@@ -688,8 +688,8 @@ PathWithLaneId PullOverModule::getReferencePath() const
   }
 
   const auto lanes = util::expandLanelets(
-    status_.current_lanes, parameters_.drivable_area_right_bound_offset,
-    parameters_.drivable_area_left_bound_offset);
+    status_.current_lanes, parameters_.drivable_area_left_bound_offset,
+    parameters_.drivable_area_right_bound_offset);
 
   reference_path.drivable_area = util::generateDrivableArea(
     reference_path, lanes, common_parameters.drivable_area_resolution,
@@ -731,8 +731,8 @@ PathWithLaneId PullOverModule::generateStopPath() const
   }
 
   const auto lanes = util::expandLanelets(
-    status_.current_lanes, parameters_.drivable_area_right_bound_offset,
-    parameters_.drivable_area_left_bound_offset);
+    status_.current_lanes, parameters_.drivable_area_left_bound_offset,
+    parameters_.drivable_area_right_bound_offset);
 
   stop_path.drivable_area = util::generateDrivableArea(
     stop_path, lanes, common_parameters.drivable_area_resolution, common_parameters.vehicle_length,

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -407,11 +407,14 @@ void SideShiftModule::adjustDrivableArea(ShiftedPath * path) const
 
   constexpr double threshold = 0.1;
   constexpr double margin = 0.5;
-  const double right_offset = std::min(*itr.first - (*itr.first < -threshold ? margin : 0.0), 0.0);
-  const double left_offset = std::max(*itr.second + (*itr.first > threshold ? margin : 0.0), 0.0);
+  const double right_offset = std::min(
+    *itr.first - (*itr.first < -threshold ? margin : 0.0),
+    parameters_.drivable_area_right_bound_offset);
+  const double left_offset = std::max(
+    *itr.second + (*itr.first > threshold ? margin : 0.0),
+    parameters_.drivable_area_left_bound_offset);
 
-  const auto extended_lanelets =
-    lanelet::utils::getExpandedLanelets(current_lanelets_, left_offset, right_offset);
+  const auto extended_lanelets = util::expandLanelets(current_lanelets_, right_offset, left_offset);
 
   {
     const auto & p = planner_data_->parameters;

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -407,14 +407,14 @@ void SideShiftModule::adjustDrivableArea(ShiftedPath * path) const
 
   constexpr double threshold = 0.1;
   constexpr double margin = 0.5;
-  const double right_offset = std::min(
-    *itr.first - (*itr.first < -threshold ? margin : 0.0),
-    parameters_.drivable_area_right_bound_offset);
   const double left_offset = std::max(
     *itr.second + (*itr.first > threshold ? margin : 0.0),
     parameters_.drivable_area_left_bound_offset);
+  const double right_offset = std::min(
+    *itr.first - (*itr.first < -threshold ? margin : 0.0),
+    parameters_.drivable_area_right_bound_offset);
 
-  const auto extended_lanelets = util::expandLanelets(current_lanelets_, right_offset, left_offset);
+  const auto extended_lanelets = util::expandLanelets(current_lanelets_, left_offset, right_offset);
 
   {
     const auto & p = planner_data_->parameters;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1658,21 +1658,25 @@ lanelet::ConstLineStrings3d getDrivableAreaForAllSharedLinestringLanelets(
 }
 
 lanelet::ConstLanelets expandLanelets(
-  const lanelet::ConstLanelets & lanelets, const double right_bound_offset,
-  const double left_bound_offset)
+  const lanelet::ConstLanelets & lanelets, const double left_bound_offset,
+  const double right_bound_offset, const std::vector<std::string> & types_to_skip)
 {
-  if (right_bound_offset == 0.0 && left_bound_offset == 0.0) return lanelets;
+  if (left_bound_offset == 0.0 && right_bound_offset == 0.0) return lanelets;
 
   lanelet::ConstLanelets expanded_lanelets{};
   expanded_lanelets.reserve(lanelets.size());
   for (const auto & lanelet : lanelets) {
-    const std::string r_type =
-      lanelet.rightBound().attributeOr(lanelet::AttributeName::Type, "none");
     const std::string l_type =
       lanelet.leftBound().attributeOr(lanelet::AttributeName::Type, "none");
+    const std::string r_type =
+      lanelet.rightBound().attributeOr(lanelet::AttributeName::Type, "none");
 
-    const double r_offset = r_type != "road_border" ? -right_bound_offset : 0.0;
-    const double l_offset = l_type != "road_border" ? left_bound_offset : 0.0;
+    const bool l_skip =
+      std::find(types_to_skip.begin(), types_to_skip.end(), l_type) != types_to_skip.end();
+    const bool r_skip =
+      std::find(types_to_skip.begin(), types_to_skip.end(), r_type) != types_to_skip.end();
+    const double l_offset = l_skip ? 0.0 : left_bound_offset;
+    const double r_offset = r_skip ? 0.0 : -right_bound_offset;
 
     expanded_lanelets.push_back(lanelet::utils::getExpandedLanelet(lanelet, l_offset, r_offset));
   }

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1657,6 +1657,28 @@ lanelet::ConstLineStrings3d getDrivableAreaForAllSharedLinestringLanelets(
   return linestring_shared;
 }
 
+lanelet::ConstLanelets expandLanelets(
+  const lanelet::ConstLanelets & lanelets, const double right_bound_offset,
+  const double left_bound_offset)
+{
+  if (right_bound_offset == 0.0 && left_bound_offset == 0.0) return lanelets;
+
+  lanelet::ConstLanelets expanded_lanelets{};
+  expanded_lanelets.reserve(lanelets.size());
+  for (const auto & lanelet : lanelets) {
+    const std::string r_type =
+      lanelet.rightBound().attributeOr(lanelet::AttributeName::Type, "none");
+    const std::string l_type =
+      lanelet.leftBound().attributeOr(lanelet::AttributeName::Type, "none");
+
+    const double r_offset = r_type != "road_border" ? -right_bound_offset : 0.0;
+    const double l_offset = l_type != "road_border" ? left_bound_offset : 0.0;
+
+    expanded_lanelets.push_back(lanelet::utils::getExpandedLanelet(lanelet, l_offset, r_offset));
+  }
+  return expanded_lanelets;
+}
+
 PredictedObjects filterObjectsByVelocity(const PredictedObjects & objects, double lim_v)
 {
   return filterObjectsByVelocity(objects, -lim_v, lim_v);


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@tier4.jp>

## Description

Close https://github.com/autowarefoundation/autoware.universe/issues/1854

Add options to expand the drivable area in all modules of the `behavior_path_planner`.

Changes are:
- new parameter file for drivable area expansion containing the left & right expansion offsets for each module.
- new utility function to expand the lanelets (such that the corresponding drivable area is expanded).
- call the new utility function before building the drivable area in each module.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/