### PR TITLE
fix(rtc_interface): fix name space

### DIFF
--- a/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
+++ b/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
@@ -75,9 +75,8 @@ private:
   CooperateStatusArray registered_status_;
   bool is_auto_mode_;
 
-  // TEMPORARY: Name space will be changed.
-  // std::string cooperate_status_namespace_ = "/planning/cooperate_status";
-  // std::string cooperate_commands_namespace_ = "/planning/cooperate_commands";
+  std::string cooperate_status_namespace_ = "/planning/cooperate_status";
+  std::string cooperate_commands_namespace_ = "/planning/cooperate_commands";
   std::string enable_auto_mode_namespace_ = "/planning/enable_auto_mode/internal";
 };
 

--- a/planning/rtc_interface/src/rtc_interface.cpp
+++ b/planning/rtc_interface/src/rtc_interface.cpp
@@ -76,12 +76,12 @@ RTCInterface::RTCInterface(rclcpp::Node * node, const std::string & name)
 
   // Publisher
   pub_statuses_ =
-    node->create_publisher<CooperateStatusArray>("~/" + name + "/cooperate_status", 1);
+    node->create_publisher<CooperateStatusArray>(cooperate_status_namespace_ + "/" + name, 1);
 
   // Service
   callback_group_ = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   srv_commands_ = node->create_service<CooperateCommands>(
-    "~/" + name + "/cooperate_commands",
+    cooperate_commands_namespace_ + "/" + name,
     std::bind(&RTCInterface::onCooperateCommandService, this, _1, _2),
     rmw_qos_profile_services_default, callback_group_);
   srv_auto_mode_ = node->create_service<AutoMode>(


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description

Before this change, no_stopping_area does not send RTC status because of the limitation of the character of name space.
In this PR, I change the name space of RTC status and commands.

Before:
```
/planning/scenario_planning/lane_driving/behavior_planning/behavior_**_planner/**/cooperate_status
/planning/scenario_planning/lane_driving/behavior_planning/behavior_**_planner/**/cooperate_commands
```

After:
```
/planning/cooperate_status/**
/planning/cooperate_commands/**
```

Change for api is following.
https://github.com/tier4/tier4_ad_api_adaptor/pull/61

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
