### PR TITLE
fix(behavior_velocity_planner): do not consider stop_line_margin when a stop line is defined at map in crosswalk module

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -111,7 +111,7 @@ private:
     const PathWithLaneId & ego_path, StopFactor & stop_factor);
 
   boost::optional<std::pair<double, geometry_msgs::msg::Point>> getStopLine(
-    const PathWithLaneId & ego_path) const;
+    const PathWithLaneId & ego_path, bool & exist_stopline_in_map) const;
 
   std::vector<CollisionPoint> getCollisionPoints(
     const PathWithLaneId & ego_path, const PredictedObject & object,


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
In crosswalk module, the parameter `stop_line_distance` should be considered only when the explicit stop_line is not defined in lanelet. 
( 
It is described in the parameter description
https://github.com/autowarefoundation/autoware.universe/blob/30e968eaa3f4e92727543ccabae8befc39d048cd/planning/behavior_velocity_planner/config/crosswalk.param.yaml#L7
)

But, in the current implementation,  `stop_line_distance` is always considered, and the position of stop lines in crosswalk and walkway module are misaligned.
![image](https://user-images.githubusercontent.com/59680180/192734502-ef99ce11-91f8-4abf-88bd-ff288eb5eafd.png)

I fixed it.
![image](https://user-images.githubusercontent.com/59680180/192734934-d19a07a6-18d9-4bff-9136-dc2ac6cc705f.png)


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
