### PR TITLE
fix(behavior_velocity_planner): do not consider stop_line_margin when a stop line is defined at map in walkway module

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
@@ -59,7 +59,7 @@ private:
   int64_t module_id_;
 
   [[nodiscard]] boost::optional<std::pair<double, geometry_msgs::msg::Point>> getStopLine(
-    const PathWithLaneId & ego_path) const;
+    const PathWithLaneId & ego_path, bool & exist_stopline_in_map) const;
 
   enum class State { APPROACH, STOP, SURPASSED };
 


### PR DESCRIPTION


Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
In walkway module, the parameter stop_line_distance should be considered only when the explicit stop_line is not defined in lanelet. But, in the current implementation, stop_line_distance is always considered. I fixed it.

<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/1978

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
