### PR TITLE
fix(behavior_velocity_planner): fix invalid access in velocity callback function

### DIFF
--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -309,7 +309,7 @@ void BehaviorVelocityPlannerNode::onVehicleVelocity(
   // Add velocity to buffer
   planner_data_.velocity_buffer.push_front(*current_velocity);
   const rclcpp::Time now = this->now();
-  while (true) {
+  while (!planner_data_.velocity_buffer.empty()) {
     // Check oldest data time
     const auto & s = planner_data_.velocity_buffer.back().header.stamp;
     const auto time_diff =
@@ -320,9 +320,6 @@ void BehaviorVelocityPlannerNode::onVehicleVelocity(
       break;
     }
 
-    if (planner_data_.velocity_buffer.empty()) {
-      break;
-    }
     // Remove old data
     planner_data_.velocity_buffer.pop_back();
   }


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
In the current implementation, even if `planner_data_.velocity_buffer` is empty, `planner_data_.velocity_buffer.back()` may be accessed. 
As a result,  sometimes a negative value is assigned to rclcpp::Time, and the module dies with the following error. I fixed this.
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  cannot store a negative time point in rclcpp::Time
```


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
