### PR TITLE
refactor(ndt_scan_matcher): modularize get_transform function

### DIFF
--- a/localization/ndt_scan_matcher/CMakeLists.txt
+++ b/localization/ndt_scan_matcher/CMakeLists.txt
@@ -28,6 +28,7 @@ ament_auto_add_executable(ndt_scan_matcher
   src/ndt_scan_matcher_core.cpp
   src/util_func.cpp
   src/pose_array_interpolator.cpp
+  src/tf2_listener_module.cpp
 )
 
 ament_auto_package(

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -18,6 +18,7 @@
 #define FMT_HEADER_ONLY
 
 #include "ndt_scan_matcher/particle.hpp"
+#include "ndt_scan_matcher/tf2_listener_module.hpp"
 
 #include <ndt/omp.hpp>
 #include <ndt/pcl_generic.hpp>
@@ -43,9 +44,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
-#include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_sensor_msgs/tf2_sensor_msgs.h>
@@ -154,10 +153,6 @@ private:
     const geometry_msgs::msg::PoseWithCovarianceStamped & initial_pose_old_msg,
     const geometry_msgs::msg::PoseWithCovarianceStamped & initial_pose_new_msg);
 
-  bool get_transform(
-    const std::string & target_frame, const std::string & source_frame,
-    const geometry_msgs::msg::TransformStamped::SharedPtr & transform_stamped_ptr);
-
   bool validate_num_iteration(const int iter_num, const int max_iter_num);
   bool validate_score(
     const double score, const double score_threshold, const std::string score_name);
@@ -200,8 +195,6 @@ private:
 
   rclcpp::Service<tier4_localization_msgs::srv::PoseWithCovarianceStamped>::SharedPtr service_;
 
-  tf2_ros::Buffer tf2_buffer_;
-  tf2_ros::TransformListener tf2_listener_;
   tf2_ros::TransformBroadcaster tf2_broadcaster_;
 
   NDTImplementType ndt_implement_type_;
@@ -238,6 +231,8 @@ private:
   const float regularization_scale_factor_;
   std::deque<geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr>
     regularization_pose_msg_ptr_array_;
+
+  std::shared_ptr<Tf2ListenerModule> tf2_listener_module_;
 };
 
 #endif  // NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_CORE_HPP_

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
@@ -20,6 +20,7 @@
 #include <tf2/transform_datatypes.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
+
 #include <string>
 
 class Tf2ListenerModule

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
@@ -20,6 +20,7 @@
 #include <tf2/transform_datatypes.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
+#include <string>
 
 class Tf2ListenerModule
 {

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
@@ -1,0 +1,40 @@
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NDT_SCAN_MATCHER__TF2_LISTENER_MODULE_HPP_
+#define NDT_SCAN_MATCHER__TF2_LISTENER_MODULE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2/transform_datatypes.h>
+
+class Tf2ListenerModule
+{
+  using TransformStamped = geometry_msgs::msg::TransformStamped;
+public:
+  Tf2ListenerModule(rclcpp::Node * node);
+bool get_transform(
+  const builtin_interfaces::msg::Time & timestamp,
+  const std::string & target_frame, const std::string & source_frame,
+  const geometry_msgs::msg::TransformStamped::SharedPtr & transform_stamped_ptr) const;
+
+private:
+  rclcpp::Logger logger_;
+  tf2_ros::Buffer tf2_buffer_;
+  tf2_ros::TransformListener tf2_listener_;
+};
+
+#endif  // NDT_SCAN_MATCHER__TF2_LISTEN_MODULE_HPP_

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
@@ -17,19 +17,20 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <tf2_ros/transform_listener.h>
-#include <tf2_ros/buffer.h>
 #include <tf2/transform_datatypes.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 class Tf2ListenerModule
 {
   using TransformStamped = geometry_msgs::msg::TransformStamped;
+
 public:
   Tf2ListenerModule(rclcpp::Node * node);
-bool get_transform(
-  const builtin_interfaces::msg::Time & timestamp,
-  const std::string & target_frame, const std::string & source_frame,
-  const geometry_msgs::msg::TransformStamped::SharedPtr & transform_stamped_ptr) const;
+  bool get_transform(
+    const builtin_interfaces::msg::Time & timestamp, const std::string & target_frame,
+    const std::string & source_frame,
+    const geometry_msgs::msg::TransformStamped::SharedPtr & transform_stamped_ptr) const;
 
 private:
   rclcpp::Logger logger_;
@@ -37,4 +38,4 @@ private:
   tf2_ros::TransformListener tf2_listener_;
 };
 
-#endif  // NDT_SCAN_MATCHER__TF2_LISTEN_MODULE_HPP_
+#endif  // NDT_SCAN_MATCHER__TF2_LISTENER_MODULE_HPP_

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/tf2_listener_module.hpp
@@ -26,7 +26,7 @@ class Tf2ListenerModule
   using TransformStamped = geometry_msgs::msg::TransformStamped;
 
 public:
-  Tf2ListenerModule(rclcpp::Node * node);
+  explicit Tf2ListenerModule(rclcpp::Node * node);
   bool get_transform(
     const builtin_interfaces::msg::Time & timestamp, const std::string & target_frame,
     const std::string & source_frame,

--- a/localization/ndt_scan_matcher/src/tf2_listener_module.cpp
+++ b/localization/ndt_scan_matcher/src/tf2_listener_module.cpp
@@ -1,0 +1,63 @@
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ndt_scan_matcher/tf2_listener_module.hpp"
+
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+
+geometry_msgs::msg::TransformStamped identity_transform_stamped(
+  const builtin_interfaces::msg::Time & timestamp, const std::string & header_frame_id,
+  const std::string & child_frame_id)
+{
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.stamp = timestamp;
+  transform.header.frame_id = header_frame_id;
+  transform.child_frame_id = child_frame_id;
+  transform.transform.rotation = tier4_autoware_utils::createQuaternion(0.0, 0.0, 0.0, 1.0);
+  transform.transform.translation = tier4_autoware_utils::createTranslation(0.0, 0.0, 0.0);
+  return transform;
+}
+
+Tf2ListenerModule::Tf2ListenerModule(rclcpp::Node * node)
+: logger_(node->get_logger()),
+  tf2_buffer_(node->get_clock()),
+  tf2_listener_(tf2_buffer_)
+{}
+
+bool Tf2ListenerModule::get_transform(
+  const builtin_interfaces::msg::Time & timestamp,
+  const std::string & target_frame, const std::string & source_frame,
+  const TransformStamped::SharedPtr & transform_stamped_ptr) const
+{
+  const TransformStamped identity =
+    identity_transform_stamped(timestamp, target_frame, source_frame);
+
+  if (target_frame == source_frame) {
+    *transform_stamped_ptr = identity;
+    return true;
+  }
+
+  try {
+    *transform_stamped_ptr =
+      tf2_buffer_.lookupTransform(target_frame, source_frame, tf2::TimePointZero);
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_WARN(logger_, "%s", ex.what());
+    RCLCPP_ERROR(
+      logger_, "Please publish TF %s to %s", target_frame.c_str(), source_frame.c_str());
+
+    *transform_stamped_ptr = identity;
+    return false;
+  }
+  return true;
+}

--- a/localization/ndt_scan_matcher/src/tf2_listener_module.cpp
+++ b/localization/ndt_scan_matcher/src/tf2_listener_module.cpp
@@ -30,15 +30,13 @@ geometry_msgs::msg::TransformStamped identity_transform_stamped(
 }
 
 Tf2ListenerModule::Tf2ListenerModule(rclcpp::Node * node)
-: logger_(node->get_logger()),
-  tf2_buffer_(node->get_clock()),
-  tf2_listener_(tf2_buffer_)
-{}
+: logger_(node->get_logger()), tf2_buffer_(node->get_clock()), tf2_listener_(tf2_buffer_)
+{
+}
 
 bool Tf2ListenerModule::get_transform(
-  const builtin_interfaces::msg::Time & timestamp,
-  const std::string & target_frame, const std::string & source_frame,
-  const TransformStamped::SharedPtr & transform_stamped_ptr) const
+  const builtin_interfaces::msg::Time & timestamp, const std::string & target_frame,
+  const std::string & source_frame, const TransformStamped::SharedPtr & transform_stamped_ptr) const
 {
   const TransformStamped identity =
     identity_transform_stamped(timestamp, target_frame, source_frame);
@@ -53,8 +51,7 @@ bool Tf2ListenerModule::get_transform(
       tf2_buffer_.lookupTransform(target_frame, source_frame, tf2::TimePointZero);
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(logger_, "%s", ex.what());
-    RCLCPP_ERROR(
-      logger_, "Please publish TF %s to %s", target_frame.c_str(), source_frame.c_str());
+    RCLCPP_ERROR(logger_, "Please publish TF %s to %s", target_frame.c_str(), source_frame.c_str());
 
     *transform_stamped_ptr = identity;
     return false;


### PR DESCRIPTION
Signed-off-by: kminoda <koji.m.minoda@gmail.com>

## Description
Modularize get_transform function as a single class module.
`ndt_scan_matcher` will hold the class in a shared_ptr.

After this PR, I would like to divide the current ndt_scan_matcher into several components, and in that case several components will use this `Tf2ListenerModule`.


NOTE: the performance should not change before and after this PR
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
