### PR TITLE
WIP refactor(ndt_scan_matcher): isolate align function into ndt package

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -41,6 +41,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
 #include <tf2_eigen/tf2_eigen.hpp>
+
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -37,8 +37,10 @@
 #include <tf2/utils.h>
 
 #ifdef ROS_DISTRO_GALACTIC
+#include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
@@ -718,6 +720,32 @@ geometry_msgs::msg::Pose calcInterpolatedPose(
 
   return output_pose;
 }
+
+inline Eigen::Matrix4f poseToMatrix4f(const geometry_msgs::msg::Pose & ros_pose)
+{
+  Eigen::Affine3d eigen_pose_affine;
+  tf2::fromMsg(ros_pose, eigen_pose_affine);
+  Eigen::Matrix4f eigen_pose_matrix = eigen_pose_affine.matrix().cast<float>();
+  return eigen_pose_matrix;
+}
+
+inline Eigen::Vector3d pointToVector3d(const geometry_msgs::msg::Point & ros_pos)
+{
+  Eigen::Vector3d eigen_pos;
+  eigen_pos.x() = ros_pos.x;
+  eigen_pos.y() = ros_pos.y;
+  eigen_pos.z() = ros_pos.z;
+  return eigen_pos;
+}
+
+inline geometry_msgs::msg::Pose matrix4fToPose(const Eigen::Matrix4f & eigen_pose_matrix)
+{
+  Eigen::Affine3d eigen_pose_affine;
+  eigen_pose_affine.matrix() = eigen_pose_matrix.cast<double>();
+  geometry_msgs::msg::Pose ros_pose = tf2::toMsg(eigen_pose_affine);
+  return ros_pose;
+}
+
 }  // namespace tier4_autoware_utils
 
 #endif  // TIER4_AUTOWARE_UTILS__GEOMETRY__GEOMETRY_HPP_

--- a/common/tier4_autoware_utils/package.xml
+++ b/common/tier4_autoware_utils/package.xml
@@ -21,6 +21,7 @@
   <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tier4_debug_msgs</depend>
   <depend>visualization_msgs</depend>

--- a/localization/ndt/CMakeLists.txt
+++ b/localization/ndt/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(ndt
     ${PCL_INCLUDE_DIRS}
 )
 
-ament_target_dependencies(ndt PUBLIC ndt_omp ndt_pcl_modified)
+ament_target_dependencies(ndt PUBLIC ndt_omp ndt_pcl_modified geometry_msgs tier4_autoware_utils)
 # Can't use ament_target_dependencies() here because it doesn't link PCL
 # properly, see ndt_omp for more information.
 target_compile_definitions(ndt PUBLIC ${PCL_DEFINITIONS})

--- a/localization/ndt/include/ndt/base.hpp
+++ b/localization/ndt/include/ndt/base.hpp
@@ -42,7 +42,6 @@ public:
   NormalDistributionsTransformBase();
   virtual ~NormalDistributionsTransformBase() = default;
 
-  // virtual void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) = 0;
   virtual NdtResult align(const geometry_msgs::msg::Pose & initial_pose_msg) = 0;
   virtual void setInputTarget(const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) = 0;
   virtual void setInputSource(const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) = 0;

--- a/localization/ndt/include/ndt/base.hpp
+++ b/localization/ndt/include/ndt/base.hpp
@@ -19,8 +19,18 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl/search/kdtree.h>
-
+#include <geometry_msgs/msg/pose.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <vector>
+
+struct NdtResult
+{
+  geometry_msgs::msg::Pose pose;
+  float transform_probability;
+  float nearest_voxel_transformation_likelihood;
+  int iteration_num;
+  std::vector<geometry_msgs::msg::Pose> transformation_array;
+};
 
 template <class PointSource, class PointTarget>
 class NormalDistributionsTransformBase
@@ -29,7 +39,8 @@ public:
   NormalDistributionsTransformBase();
   virtual ~NormalDistributionsTransformBase() = default;
 
-  virtual void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) = 0;
+  // virtual void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) = 0;
+  virtual NdtResult align(const geometry_msgs::msg::Pose & initial_pose_msg) = 0;
   virtual void setInputTarget(const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) = 0;
   virtual void setInputSource(const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) = 0;
 

--- a/localization/ndt/include/ndt/base.hpp
+++ b/localization/ndt/include/ndt/base.hpp
@@ -15,12 +15,15 @@
 #ifndef NDT__BASE_HPP_
 #define NDT__BASE_HPP_
 
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+
+#include <geometry_msgs/msg/pose.hpp>
+
 #include <pcl/common/io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl/search/kdtree.h>
-#include <geometry_msgs/msg/pose.hpp>
-#include <tier4_autoware_utils/geometry/geometry.hpp>
+
 #include <vector>
 
 struct NdtResult

--- a/localization/ndt/include/ndt/impl/omp.hpp
+++ b/localization/ndt/include/ndt/impl/omp.hpp
@@ -29,7 +29,8 @@ template <class PointSource, class PointTarget>
 NdtResult NormalDistributionsTransformOMP<PointSource, PointTarget>::align(
   const geometry_msgs::msg::Pose & initial_pose_msg)
 {
-  const Eigen::Matrix4f initial_pose_matrix = tier4_autoware_utils::poseToMatrix4f(initial_pose_msg);
+  const Eigen::Matrix4f initial_pose_matrix =
+    tier4_autoware_utils::poseToMatrix4f(initial_pose_msg);
 
   auto output_cloud = std::make_shared<pcl::PointCloud<PointSource>>();
   ndt_ptr_->align(*output_cloud, initial_pose_matrix);
@@ -46,8 +47,7 @@ NdtResult NormalDistributionsTransformOMP<PointSource, PointTarget>::align(
   ndt_result.pose = tier4_autoware_utils::matrix4fToPose(getFinalTransformation());
   ndt_result.transformation_array = transformation_array_msg;
   ndt_result.transform_probability = getTransformationProbability();
-  ndt_result.nearest_voxel_transformation_likelihood =
-    getNearestVoxelTransformationLikelihood();
+  ndt_result.nearest_voxel_transformation_likelihood = getNearestVoxelTransformationLikelihood();
   ndt_result.iteration_num = getFinalNumIteration();
   return ndt_result;
 }

--- a/localization/ndt/include/ndt/impl/omp.hpp
+++ b/localization/ndt/include/ndt/impl/omp.hpp
@@ -26,10 +26,30 @@ NormalDistributionsTransformOMP<PointSource, PointTarget>::NormalDistributionsTr
 }
 
 template <class PointSource, class PointTarget>
-void NormalDistributionsTransformOMP<PointSource, PointTarget>::align(
-  pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess)
+NdtResult NormalDistributionsTransformOMP<PointSource, PointTarget>::align(
+  const geometry_msgs::msg::Pose & initial_pose_msg)
 {
-  ndt_ptr_->align(output, guess);
+  const Eigen::Matrix4f initial_pose_matrix = tier4_autoware_utils::poseToMatrix4f(initial_pose_msg);
+
+  auto output_cloud = std::make_shared<pcl::PointCloud<PointSource>>();
+  ndt_ptr_->align(*output_cloud, initial_pose_matrix);
+
+  const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
+    transformation_array_matrix = getFinalTransformationArray();
+  std::vector<geometry_msgs::msg::Pose> transformation_array_msg;
+  for (auto pose_matrix : transformation_array_matrix) {
+    geometry_msgs::msg::Pose pose_ros = tier4_autoware_utils::matrix4fToPose(pose_matrix);
+    transformation_array_msg.push_back(pose_ros);
+  }
+
+  NdtResult ndt_result;
+  ndt_result.pose = tier4_autoware_utils::matrix4fToPose(getFinalTransformation());
+  ndt_result.transformation_array = transformation_array_msg;
+  ndt_result.transform_probability = getTransformationProbability();
+  ndt_result.nearest_voxel_transformation_likelihood =
+    getNearestVoxelTransformationLikelihood();
+  ndt_result.iteration_num = getFinalNumIteration();
+  return ndt_result;
 }
 
 template <class PointSource, class PointTarget>

--- a/localization/ndt/include/ndt/impl/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_generic.hpp
@@ -30,7 +30,8 @@ template <class PointSource, class PointTarget>
 NdtResult NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::align(
   const geometry_msgs::msg::Pose & initial_pose_msg)
 {
-  const Eigen::Matrix4f initial_pose_matrix = tier4_autoware_utils::poseToMatrix4f(initial_pose_msg);
+  const Eigen::Matrix4f initial_pose_matrix =
+    tier4_autoware_utils::poseToMatrix4f(initial_pose_msg);
 
   auto output_cloud = std::make_shared<pcl::PointCloud<PointSource>>();
   ndt_ptr_->align(*output_cloud, initial_pose_matrix);
@@ -47,8 +48,7 @@ NdtResult NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::alig
   ndt_result.pose = tier4_autoware_utils::matrix4fToPose(getFinalTransformation());
   ndt_result.transformation_array = transformation_array_msg;
   ndt_result.transform_probability = getTransformationProbability();
-  ndt_result.nearest_voxel_transformation_likelihood =
-    getNearestVoxelTransformationLikelihood();
+  ndt_result.nearest_voxel_transformation_likelihood = getNearestVoxelTransformationLikelihood();
   ndt_result.iteration_num = getFinalNumIteration();
   return ndt_result;
 }

--- a/localization/ndt/include/ndt/impl/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_generic.hpp
@@ -27,10 +27,30 @@ NormalDistributionsTransformPCLGeneric<
 }
 
 template <class PointSource, class PointTarget>
-void NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::align(
-  pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess)
+NdtResult NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::align(
+  const geometry_msgs::msg::Pose & initial_pose_msg)
 {
-  ndt_ptr_->align(output, guess);
+  const Eigen::Matrix4f initial_pose_matrix = tier4_autoware_utils::poseToMatrix4f(initial_pose_msg);
+
+  auto output_cloud = std::make_shared<pcl::PointCloud<PointSource>>();
+  ndt_ptr_->align(*output_cloud, initial_pose_matrix);
+
+  const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
+    transformation_array_matrix = getFinalTransformationArray();
+  std::vector<geometry_msgs::msg::Pose> transformation_array_msg;
+  for (auto pose_matrix : transformation_array_matrix) {
+    geometry_msgs::msg::Pose pose_ros = tier4_autoware_utils::matrix4fToPose(pose_matrix);
+    transformation_array_msg.push_back(pose_ros);
+  }
+
+  NdtResult ndt_result;
+  ndt_result.pose = tier4_autoware_utils::matrix4fToPose(getFinalTransformation());
+  ndt_result.transformation_array = transformation_array_msg;
+  ndt_result.transform_probability = getTransformationProbability();
+  ndt_result.nearest_voxel_transformation_likelihood =
+    getNearestVoxelTransformationLikelihood();
+  ndt_result.iteration_num = getFinalNumIteration();
+  return ndt_result;
 }
 
 template <class PointSource, class PointTarget>

--- a/localization/ndt/include/ndt/impl/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_modified.hpp
@@ -30,7 +30,8 @@ template <class PointSource, class PointTarget>
 NdtResult NormalDistributionsTransformPCLModified<PointSource, PointTarget>::align(
   const geometry_msgs::msg::Pose & initial_pose_msg)
 {
-  const Eigen::Matrix4f initial_pose_matrix = tier4_autoware_utils::poseToMatrix4f(initial_pose_msg);
+  const Eigen::Matrix4f initial_pose_matrix =
+    tier4_autoware_utils::poseToMatrix4f(initial_pose_msg);
 
   auto output_cloud = std::make_shared<pcl::PointCloud<PointSource>>();
   ndt_ptr_->align(*output_cloud, initial_pose_matrix);
@@ -47,8 +48,7 @@ NdtResult NormalDistributionsTransformPCLModified<PointSource, PointTarget>::ali
   ndt_result.pose = tier4_autoware_utils::matrix4fToPose(getFinalTransformation());
   ndt_result.transformation_array = transformation_array_msg;
   ndt_result.transform_probability = getTransformationProbability();
-  ndt_result.nearest_voxel_transformation_likelihood =
-    getNearestVoxelTransformationLikelihood();
+  ndt_result.nearest_voxel_transformation_likelihood = getNearestVoxelTransformationLikelihood();
   ndt_result.iteration_num = getFinalNumIteration();
   return ndt_result;
 }

--- a/localization/ndt/include/ndt/omp.hpp
+++ b/localization/ndt/include/ndt/omp.hpp
@@ -32,7 +32,7 @@ public:
   NormalDistributionsTransformOMP();
   ~NormalDistributionsTransformOMP() = default;
 
-  void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) override;
+  NdtResult align(const geometry_msgs::msg::Pose & initial_pose_msg) override;
   void setInputTarget(const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) override;
   void setInputSource(const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) override;
 

--- a/localization/ndt/include/ndt/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/pcl_generic.hpp
@@ -32,7 +32,7 @@ public:
   NormalDistributionsTransformPCLGeneric();
   ~NormalDistributionsTransformPCLGeneric() = default;
 
-  void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) override;
+  NdtResult align(const geometry_msgs::msg::Pose & initial_pose_msg) override;
   void setInputTarget(const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) override;
   void setInputSource(const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) override;
 

--- a/localization/ndt/include/ndt/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/pcl_modified.hpp
@@ -33,7 +33,7 @@ public:
   NormalDistributionsTransformPCLModified();
   ~NormalDistributionsTransformPCLModified() = default;
 
-  void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) override;
+  NdtResult align(const geometry_msgs::msg::Pose & initial_pose_msg) override;
   void setInputTarget(const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) override;
   void setInputSource(const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) override;
 

--- a/localization/ndt/package.xml
+++ b/localization/ndt/package.xml
@@ -15,6 +15,8 @@
   <depend>libpcl-all-dev</depend>
   <depend>ndt_omp</depend>
   <depend>ndt_pcl_modified</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tier4_autoware_utils</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/localization/ndt/package.xml
+++ b/localization/ndt/package.xml
@@ -12,10 +12,10 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>libpcl-all-dev</depend>
   <depend>ndt_omp</depend>
   <depend>ndt_pcl_modified</depend>
-  <depend>geometry_msgs</depend>
   <depend>tier4_autoware_utils</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -68,15 +68,6 @@ enum class ConvergedParamType {
   NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD = 1
 };
 
-struct NdtResult
-{
-  geometry_msgs::msg::Pose pose;
-  float transform_probability;
-  float nearest_voxel_transformation_likelihood;
-  int iteration_num;
-  std::vector<geometry_msgs::msg::Pose> transformation_array;
-};
-
 template <typename PointSource, typename PointTarget>
 std::shared_ptr<NormalDistributionsTransformBase<PointSource, PointTarget>> get_ndt(
   const NDTImplementType & ndt_mode)
@@ -127,7 +118,6 @@ private:
   void callback_regularization_pose(
     geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr pose_conv_msg_ptr);
 
-  NdtResult align(const geometry_msgs::msg::Pose & initial_pose_msg);
   geometry_msgs::msg::PoseWithCovarianceStamped align_using_monte_carlo(
     const std::shared_ptr<NormalDistributionsTransformBase<PointSource, PointTarget>> & ndt_ptr,
     const geometry_msgs::msg::PoseWithCovarianceStamped & initial_pose_with_cov);

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
@@ -25,6 +25,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
 #include <tf2_eigen/tf2_eigen.hpp>
+
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
@@ -67,11 +67,6 @@ void pop_old_pose(
     pose_cov_msg_ptr_array,
   const rclcpp::Time & time_stamp);
 
-// Eigen::Affine3d pose_to_affine3d(const geometry_msgs::msg::Pose & ros_pose);
-// Eigen::Matrix4f pose_to_matrix4f(const geometry_msgs::msg::Pose & ros_pose);
-// geometry_msgs::msg::Pose matrix4f_to_pose(const Eigen::Matrix4f & eigen_pose_matrix);
-// Eigen::Vector3d point_to_vector3d(const geometry_msgs::msg::Point & ros_pos);
-
 std::vector<geometry_msgs::msg::Pose> create_random_pose_array(
   const geometry_msgs::msg::PoseWithCovarianceStamped & base_pose_with_cov, const int particle_num);
 

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
@@ -25,7 +25,6 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
 #include <tf2_eigen/tf2_eigen.hpp>
-
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
@@ -68,10 +67,10 @@ void pop_old_pose(
     pose_cov_msg_ptr_array,
   const rclcpp::Time & time_stamp);
 
-Eigen::Affine3d pose_to_affine3d(const geometry_msgs::msg::Pose & ros_pose);
-Eigen::Matrix4f pose_to_matrix4f(const geometry_msgs::msg::Pose & ros_pose);
-geometry_msgs::msg::Pose matrix4f_to_pose(const Eigen::Matrix4f & eigen_pose_matrix);
-Eigen::Vector3d point_to_vector3d(const geometry_msgs::msg::Point & ros_pos);
+// Eigen::Affine3d pose_to_affine3d(const geometry_msgs::msg::Pose & ros_pose);
+// Eigen::Matrix4f pose_to_matrix4f(const geometry_msgs::msg::Pose & ros_pose);
+// geometry_msgs::msg::Pose matrix4f_to_pose(const Eigen::Matrix4f & eigen_pose_matrix);
+// Eigen::Vector3d point_to_vector3d(const geometry_msgs::msg::Point & ros_pos);
 
 std::vector<geometry_msgs::msg::Pose> create_random_pose_array(
   const geometry_msgs::msg::PoseWithCovarianceStamped & base_pose_with_cov, const int particle_num);

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -72,8 +72,10 @@ bool validate_local_optimal_solution_oscillation(
   int oscillation_cnt = 0;
 
   for (size_t i = 2; i < result_pose_msg_array.size(); ++i) {
-    const Eigen::Vector3d current_pose = tier4_autoware_utils::pointToVector3d(result_pose_msg_array.at(i).position);
-    const Eigen::Vector3d prev_pose = tier4_autoware_utils::pointToVector3d(result_pose_msg_array.at(i - 1).position);
+    const Eigen::Vector3d current_pose =
+      tier4_autoware_utils::pointToVector3d(result_pose_msg_array.at(i).position);
+    const Eigen::Vector3d prev_pose =
+      tier4_autoware_utils::pointToVector3d(result_pose_msg_array.at(i - 1).position);
     const Eigen::Vector3d prev_prev_pose =
       tier4_autoware_utils::pointToVector3d(result_pose_msg_array.at(i - 2).position);
     const auto current_vec = current_pose - prev_pose;
@@ -537,7 +539,8 @@ void NDTScanMatcher::callback_sensor_points(
 
   auto sensor_points_mapTF_ptr = std::make_shared<pcl::PointCloud<PointSource>>();
   pcl::transformPointCloud(
-    *sensor_points_baselinkTF_ptr, *sensor_points_mapTF_ptr, tier4_autoware_utils::poseToMatrix4f(ndt_result.pose));
+    *sensor_points_baselinkTF_ptr, *sensor_points_mapTF_ptr,
+    tier4_autoware_utils::poseToMatrix4f(ndt_result.pose));
   publish_point_cloud(sensor_ros_time, map_frame_, sensor_points_mapTF_ptr);
 
   key_value_stdmap_["transform_probability"] = std::to_string(ndt_result.transform_probability);
@@ -596,7 +599,8 @@ geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::align_using_monte_
 
     auto sensor_points_mapTF_ptr = std::make_shared<pcl::PointCloud<PointSource>>();
     pcl::transformPointCloud(
-      *ndt_ptr->getInputSource(), *sensor_points_mapTF_ptr, tier4_autoware_utils::poseToMatrix4f(ndt_result.pose));
+      *ndt_ptr->getInputSource(), *sensor_points_mapTF_ptr,
+      tier4_autoware_utils::poseToMatrix4f(ndt_result.pose));
     publish_point_cloud(initial_pose_with_cov.header.stamp, map_frame_, sensor_points_mapTF_ptr);
   }
 

--- a/localization/ndt_scan_matcher/src/util_func.cpp
+++ b/localization/ndt_scan_matcher/src/util_func.cpp
@@ -205,36 +205,36 @@ void pop_old_pose(
   }
 }
 
-Eigen::Affine3d pose_to_affine3d(const geometry_msgs::msg::Pose & ros_pose)
-{
-  Eigen::Affine3d eigen_pose;
-  tf2::fromMsg(ros_pose, eigen_pose);
-  return eigen_pose;
-}
+// Eigen::Affine3d pose_to_affine3d(const geometry_msgs::msg::Pose & ros_pose)
+// {
+//   Eigen::Affine3d eigen_pose;
+//   tf2::fromMsg(ros_pose, eigen_pose);
+//   return eigen_pose;
+// }
 
-Eigen::Matrix4f pose_to_matrix4f(const geometry_msgs::msg::Pose & ros_pose)
-{
-  Eigen::Affine3d eigen_pose_affine = pose_to_affine3d(ros_pose);
-  Eigen::Matrix4f eigen_pose_matrix = eigen_pose_affine.matrix().cast<float>();
-  return eigen_pose_matrix;
-}
+// Eigen::Matrix4f pose_to_matrix4f(const geometry_msgs::msg::Pose & ros_pose)
+// {
+//   Eigen::Affine3d eigen_pose_affine = pose_to_affine3d(ros_pose);
+//   Eigen::Matrix4f eigen_pose_matrix = eigen_pose_affine.matrix().cast<float>();
+//   return eigen_pose_matrix;
+// }
 
-Eigen::Vector3d point_to_vector3d(const geometry_msgs::msg::Point & ros_pos)
-{
-  Eigen::Vector3d eigen_pos;
-  eigen_pos.x() = ros_pos.x;
-  eigen_pos.y() = ros_pos.y;
-  eigen_pos.z() = ros_pos.z;
-  return eigen_pos;
-}
+// Eigen::Vector3d point_to_vector3d(const geometry_msgs::msg::Point & ros_pos)
+// {
+//   Eigen::Vector3d eigen_pos;
+//   eigen_pos.x() = ros_pos.x;
+//   eigen_pos.y() = ros_pos.y;
+//   eigen_pos.z() = ros_pos.z;
+//   return eigen_pos;
+// }
 
-geometry_msgs::msg::Pose matrix4f_to_pose(const Eigen::Matrix4f & eigen_pose_matrix)
-{
-  Eigen::Affine3d eigen_pose_affine;
-  eigen_pose_affine.matrix() = eigen_pose_matrix.cast<double>();
-  geometry_msgs::msg::Pose ros_pose = tf2::toMsg(eigen_pose_affine);
-  return ros_pose;
-}
+// geometry_msgs::msg::Pose matrix4f_to_pose(const Eigen::Matrix4f & eigen_pose_matrix)
+// {
+//   Eigen::Affine3d eigen_pose_affine;
+//   eigen_pose_affine.matrix() = eigen_pose_matrix.cast<double>();
+//   geometry_msgs::msg::Pose ros_pose = tf2::toMsg(eigen_pose_affine);
+//   return ros_pose;
+// }
 
 std::vector<geometry_msgs::msg::Pose> create_random_pose_array(
   const geometry_msgs::msg::PoseWithCovarianceStamped & base_pose_with_cov, const int particle_num)

--- a/localization/ndt_scan_matcher/src/util_func.cpp
+++ b/localization/ndt_scan_matcher/src/util_func.cpp
@@ -205,37 +205,6 @@ void pop_old_pose(
   }
 }
 
-// Eigen::Affine3d pose_to_affine3d(const geometry_msgs::msg::Pose & ros_pose)
-// {
-//   Eigen::Affine3d eigen_pose;
-//   tf2::fromMsg(ros_pose, eigen_pose);
-//   return eigen_pose;
-// }
-
-// Eigen::Matrix4f pose_to_matrix4f(const geometry_msgs::msg::Pose & ros_pose)
-// {
-//   Eigen::Affine3d eigen_pose_affine = pose_to_affine3d(ros_pose);
-//   Eigen::Matrix4f eigen_pose_matrix = eigen_pose_affine.matrix().cast<float>();
-//   return eigen_pose_matrix;
-// }
-
-// Eigen::Vector3d point_to_vector3d(const geometry_msgs::msg::Point & ros_pos)
-// {
-//   Eigen::Vector3d eigen_pos;
-//   eigen_pos.x() = ros_pos.x;
-//   eigen_pos.y() = ros_pos.y;
-//   eigen_pos.z() = ros_pos.z;
-//   return eigen_pos;
-// }
-
-// geometry_msgs::msg::Pose matrix4f_to_pose(const Eigen::Matrix4f & eigen_pose_matrix)
-// {
-//   Eigen::Affine3d eigen_pose_affine;
-//   eigen_pose_affine.matrix() = eigen_pose_matrix.cast<double>();
-//   geometry_msgs::msg::Pose ros_pose = tf2::toMsg(eigen_pose_affine);
-//   return ros_pose;
-// }
-
 std::vector<geometry_msgs::msg::Pose> create_random_pose_array(
   const geometry_msgs::msg::PoseWithCovarianceStamped & base_pose_with_cov, const int particle_num)
 {


### PR DESCRIPTION
Signed-off-by: kminoda <koji.m.minoda@gmail.com>

## Description
I propose to isloate align function in `ndt` package.

Current interface of `ndt_ptr_` (defined in `ndt`) is a bit redundant. It would be easier to handle the object by making a new function as 
```
const NdtResult ndt_result = ndt_ptr_->align(initial_guess_pose)
```
I will make this pull request open after https://github.com/autowarefoundation/autoware.universe/pull/2024.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
