### PR TITLE
refactor(route_handler): clang tidy and reserving vector

### DIFF
--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -86,7 +86,7 @@ public:
     const Pose & start_checkpoint, const Pose & goal_checkpoint,
     lanelet::ConstLanelets * path_lanelets) const;
   std::vector<HADMapSegment> createMapSegments(const lanelet::ConstLanelets & path_lanelets) const;
-  bool isRouteLooped(const RouteSections & route_sections) const;
+  static bool isRouteLooped(const RouteSections & route_sections);
 
   // for goal
   bool isInGoalRouteSection(const lanelet::ConstLanelet & lanelet) const;
@@ -222,7 +222,7 @@ public:
   bool getClosestLaneletWithinRoute(
     const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;
   lanelet::ConstLanelet getLaneletsFromId(const lanelet::Id id) const;
-  lanelet::ConstLanelets getLaneletsFromIds(const lanelet::Ids ids) const;
+  lanelet::ConstLanelets getLaneletsFromIds(const lanelet::Ids & ids) const;
   lanelet::ConstLanelets getLaneletSequence(
     const lanelet::ConstLanelet & lanelet, const Pose & current_pose,
     const double backward_distance, const double forward_distance) const;
@@ -247,12 +247,12 @@ public:
     bool use_exact = true) const;
   bool getLaneChangeTarget(
     const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const;
-  bool getPullOverTarget(
+  static bool getPullOverTarget(
     const lanelet::ConstLanelets & lanelets, const Pose & goal_pose,
-    lanelet::ConstLanelet * target_lanelet) const;
-  bool getPullOutStartLane(
+    lanelet::ConstLanelet * target_lanelet);
+  static bool getPullOutStartLane(
     const lanelet::ConstLanelets & lanelets, const Pose & pose, const double vehicle_width,
-    lanelet::ConstLanelet * target_lanelet) const;
+    lanelet::ConstLanelet * target_lanelet);
   double getLaneChangeableDistance(
     const Pose & current_pose, const LaneChangeDirection & direction) const;
   lanelet::ConstPolygon3d getIntersectionAreaById(const lanelet::Id id) const;

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1061,7 +1061,7 @@ bool RouteHandler::getLaneChangeTarget(
   const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const
 {
   for (const auto & lanelet : lanelets) {
-    int num = getNumLaneToPreferredLane(lanelet);
+    const int num = getNumLaneToPreferredLane(lanelet);
     if (num == 0) {
       continue;
     }

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1264,7 +1264,7 @@ lanelet::ConstLanelets RouteHandler::getLaneChangeTargetLanes(const Pose & pose)
     return target_lanelets;
   }
 
-  int num = getNumLaneToPreferredLane(lanelet);
+  const int num = getNumLaneToPreferredLane(lanelet);
   if (num < 0) {
     auto right_lanelet = (!!routing_graph_ptr_->right(lanelet))
                            ? routing_graph_ptr_->right(lanelet)

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -76,14 +76,14 @@ lanelet::ConstPoint3d get3DPointFrom2DArcLength(
       if (accumulated_distance2d + distance2d > s) {
         double ratio = (s - accumulated_distance2d) / distance2d;
         auto interpolated_pt = prev_pt.basicPoint() * (1 - ratio) + pt.basicPoint() * ratio;
-        return lanelet::ConstPoint3d(
-          lanelet::InvalId, interpolated_pt.x(), interpolated_pt.y(), interpolated_pt.z());
+        return lanelet::ConstPoint3d{
+          lanelet::InvalId, interpolated_pt.x(), interpolated_pt.y(), interpolated_pt.z()};
       }
       accumulated_distance2d += distance2d;
       prev_pt = pt;
     }
   }
-  return lanelet::ConstPoint3d();
+  return lanelet::ConstPoint3d{};
 }
 
 PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)
@@ -151,16 +151,15 @@ void RouteHandler::setMap(const HADMapBin & map_msg)
   setLaneletsFromRouteMsg();
 }
 
-bool RouteHandler::isRouteLooped(const RouteSections & route_sections) const
+bool RouteHandler::isRouteLooped(const RouteSections & route_sections)
 {
   std::set<lanelet::Id> lane_primitives;
   for (const auto & route_section : route_sections) {
     for (const auto & primitive : route_section.primitives) {
-      if (lane_primitives.find(primitive.id) == lane_primitives.end()) {
-        lane_primitives.emplace(primitive.id);
-      } else {
+      if (lane_primitives.find(primitive.id) != lane_primitives.end()) {
         return true;  // find duplicated id
       }
+      lane_primitives.emplace(primitive.id);
     }
   }
   return false;
@@ -185,9 +184,9 @@ bool RouteHandler::isHandlerReady() const { return is_handler_ready_; }
 void RouteHandler::setRouteLanelets(const lanelet::ConstLanelets & path_lanelets)
 {
   if (!path_lanelets.empty()) {
-    auto first_lanelet = path_lanelets.front();
+    const auto & first_lanelet = path_lanelets.front();
     start_lanelets_ = lanelet::utils::query::getAllNeighbors(routing_graph_ptr_, first_lanelet);
-    auto last_lanelet = path_lanelets.back();
+    const auto & last_lanelet = path_lanelets.back();
     goal_lanelets_ = lanelet::utils::query::getAllNeighbors(routing_graph_ptr_, last_lanelet);
   }
 
@@ -275,6 +274,7 @@ void RouteHandler::setRouteLanelets(const lanelet::ConstLanelets & path_lanelets
   }
 
   route_lanelets_.clear();
+  route_lanelets_.reserve(route_lanelets_id.size());
   for (const auto & id : route_lanelets_id) {
     route_lanelets_.push_back(lanelet_map_ptr_->laneletLayer.get(id));
   }
@@ -293,6 +293,7 @@ void RouteHandler::setLaneletsFromRouteMsg()
     return;
   }
   for (const auto & route_section : route_msg_.segments) {
+    route_lanelets_.reserve(route_lanelets_.size() + route_section.primitives.size());
     for (const auto & primitive : route_section.primitives) {
       const auto id = primitive.id;
       const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
@@ -305,11 +306,13 @@ void RouteHandler::setLaneletsFromRouteMsg()
   goal_lanelets_.clear();
   start_lanelets_.clear();
   if (!route_msg_.segments.empty()) {
+    goal_lanelets_.reserve(route_msg_.segments.back().primitives.size());
     for (const auto & primitive : route_msg_.segments.back().primitives) {
       const auto id = primitive.id;
       const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
       goal_lanelets_.push_back(llt);
     }
+    start_lanelets_.reserve(route_msg_.segments.front().primitives.size());
     for (const auto & primitive : route_msg_.segments.front().primitives) {
       const auto id = primitive.id;
       const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
@@ -370,9 +373,9 @@ lanelet::Id RouteHandler::getGoalLaneId() const
 {
   if (route_msg_.segments.empty()) {
     return lanelet::InvalId;
-  } else {
-    return route_msg_.segments.back().preferred_primitive_id;
   }
+
+  return route_msg_.segments.back().preferred_primitive_id;
 }
 
 bool RouteHandler::getGoalLanelet(lanelet::ConstLanelet * goal_lanelet) const
@@ -391,14 +394,14 @@ bool RouteHandler::isInGoalRouteSection(const lanelet::ConstLanelet & lanelet) c
 {
   if (route_msg_.segments.empty()) {
     return false;
-  } else {
-    return exists(route_msg_.segments.back().primitives, lanelet.id());
   }
+  return exists(route_msg_.segments.back().primitives, lanelet.id());
 }
 
-lanelet::ConstLanelets RouteHandler::getLaneletsFromIds(const lanelet::Ids ids) const
+lanelet::ConstLanelets RouteHandler::getLaneletsFromIds(const lanelet::Ids & ids) const
 {
   lanelet::ConstLanelets lanelets;
+  lanelets.reserve(ids.size());
   for (const auto & id : ids) {
     lanelets.push_back(lanelet_map_ptr_->laneletLayer.get(id));
   }
@@ -413,10 +416,7 @@ lanelet::ConstLanelet RouteHandler::getLaneletsFromId(const lanelet::Id id) cons
 bool RouteHandler::isDeadEndLanelet(const lanelet::ConstLanelet & lanelet) const
 {
   lanelet::ConstLanelet next_lanelet;
-  if (getNextLaneletWithinRoute(lanelet, &next_lanelet)) {
-    return false;
-  }
-  return true;
+  return !getNextLaneletWithinRoute(lanelet, &next_lanelet);
 }
 
 lanelet::ConstLanelets RouteHandler::getLaneletSequenceAfter(
@@ -436,7 +436,8 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequenceAfter(
     }
     lanelet_sequence_forward.push_back(next_lanelet);
     current_lanelet = next_lanelet;
-    length += boost::geometry::length(next_lanelet.centerline().basicLineString());
+    length +=
+      static_cast<double>(boost::geometry::length(next_lanelet.centerline().basicLineString()));
   }
 
   return lanelet_sequence_forward;
@@ -481,7 +482,8 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequenceUpTo(
         continue;
       }
       lanelet_sequence_backward.push_back(prev_lanelet);
-      length += boost::geometry::length(prev_lanelet.centerline().basicLineString());
+      length +=
+        static_cast<double>(boost::geometry::length(prev_lanelet.centerline().basicLineString()));
       current_lanelet = prev_lanelet;
       break;
     }
@@ -571,9 +573,6 @@ bool RouteHandler::getFollowingShoulderLanelet(
   back_pose.position.y = lanelet.centerline2d().back().y();
   back_pose.position.z = 0;
 
-  lanelet::ArcCoordinates arc_coordinates;
-  const auto & centerline_2d = to2D(lanelet.centerline());
-
   for (const auto & shoulder_lanelet : shoulder_lanelets_) {
     Pose front_pose;
     front_pose.position.x = shoulder_lanelet.centerline2d().front().x();
@@ -607,7 +606,8 @@ lanelet::ConstLanelets RouteHandler::getShoulderLaneletSequenceAfter(
     }
     lanelet_sequence_forward.push_back(next_lanelet);
     current_lanelet = next_lanelet;
-    length += boost::geometry::length(next_lanelet.centerline().basicLineString());
+    length +=
+      static_cast<double>(boost::geometry::length(next_lanelet.centerline().basicLineString()));
   }
 
   return lanelet_sequence_forward;
@@ -620,9 +620,6 @@ bool RouteHandler::getPreviousShoulderLanelet(
   front_pose.position.x = lanelet.centerline2d().front().x();
   front_pose.position.y = lanelet.centerline2d().front().y();
   front_pose.position.z = 0;
-
-  lanelet::ArcCoordinates arc_coordinates;
-  const auto & centerline_2d = to2D(lanelet.centerline());
 
   for (const auto & shoulder_lanelet : shoulder_lanelets_) {
     Pose back_pose;
@@ -658,7 +655,8 @@ lanelet::ConstLanelets RouteHandler::getShoulderLaneletSequenceUpTo(
 
     lanelet_sequence_backward.insert(lanelet_sequence_backward.begin(), prev_lanelet);
     current_lanelet = prev_lanelet;
-    length += boost::geometry::length(prev_lanelet.centerline().basicLineString());
+    length +=
+      static_cast<double>(boost::geometry::length(prev_lanelet.centerline().basicLineString()));
   }
 
   return lanelet_sequence_backward;
@@ -753,9 +751,8 @@ bool RouteHandler::getRightLaneletWithinRoute(
   if (!!opt_right_lanelet) {
     *right_lanelet = opt_right_lanelet.get();
     return exists(route_lanelets_, *right_lanelet);
-  } else {
-    return false;
   }
+  return false;
 }
 
 bool RouteHandler::getNextLaneletWithinRouteExceptStart(
@@ -843,9 +840,8 @@ bool RouteHandler::getLeftLaneletWithinRoute(
   if (!!opt_left_lanelet) {
     *left_lanelet = opt_left_lanelet.get();
     return exists(route_lanelets_, *left_lanelet);
-  } else {
-    return false;
   }
+  return false;
 }
 
 boost::optional<lanelet::ConstLanelet> RouteHandler::getLeftLanelet(
@@ -989,12 +985,17 @@ lanelet::ConstLineString3d RouteHandler::getRightMostLinestring(
   const auto & opposite = getRightOppositeLanelets(lanelet);
   if (!same && opposite.empty()) {
     return lanelet.rightBound();
-  } else if (same) {
+  }
+
+  if (same) {
     return getRightMostLinestring(same.get());
-  } else if (!opposite.empty()) {
+  }
+
+  if (!opposite.empty()) {
     return getLeftMostLinestring(lanelet::ConstLanelet(opposite.front()));
   }
-  return {};
+
+  return lanelet.rightBound();
 }
 
 lanelet::ConstLineString3d RouteHandler::getLeftMostSameDirectionLinestring(
@@ -1018,12 +1019,17 @@ lanelet::ConstLineString3d RouteHandler::getLeftMostLinestring(
 
   if (!same && opposite.empty()) {
     return lanelet.leftBound();
-  } else if (same) {
+  }
+
+  if (same) {
     return getLeftMostLinestring(same.get());
-  } else if (!opposite.empty()) {
+  }
+
+  if (!opposite.empty()) {
     return getRightMostLinestring(lanelet::ConstLanelet(opposite.front()));
   }
-  return {};
+
+  return lanelet.leftBound();
 }
 
 lanelet::ConstLineStrings3d RouteHandler::getFurthestLinestring(
@@ -1054,9 +1060,7 @@ lanelet::ConstLineStrings3d RouteHandler::getFurthestLinestring(
 bool RouteHandler::getLaneChangeTarget(
   const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const
 {
-  for (auto it = lanelets.begin(); it != lanelets.end(); ++it) {
-    const auto lanelet = *it;
-
+  for (const auto & lanelet : lanelets) {
     int num = getNumLaneToPreferredLane(lanelet);
     if (num == 0) {
       continue;
@@ -1067,9 +1071,8 @@ bool RouteHandler::getLaneChangeTarget(
         auto right_lanelet = routing_graph_ptr_->right(lanelet);
         *target_lanelet = right_lanelet.get();
         return true;
-      } else {
-        continue;
       }
+      continue;
     }
 
     if (num > 0) {
@@ -1077,9 +1080,8 @@ bool RouteHandler::getLaneChangeTarget(
         auto left_lanelet = routing_graph_ptr_->left(lanelet);
         *target_lanelet = left_lanelet.get();
         return true;
-      } else {
-        continue;
       }
+      continue;
     }
   }
 
@@ -1089,7 +1091,7 @@ bool RouteHandler::getLaneChangeTarget(
 
 bool RouteHandler::getPullOverTarget(
   const lanelet::ConstLanelets & lanelets, const Pose & goal_pose,
-  lanelet::ConstLanelet * target_lanelet) const
+  lanelet::ConstLanelet * target_lanelet)
 {
   for (const auto & shoulder_lanelet : lanelets) {
     if (lanelet::utils::isInLanelet(goal_pose, shoulder_lanelet, 0.1)) {
@@ -1102,7 +1104,7 @@ bool RouteHandler::getPullOverTarget(
 
 bool RouteHandler::getPullOutStartLane(
   const lanelet::ConstLanelets & lanelets, const Pose & pose, const double vehicle_width,
-  lanelet::ConstLanelet * target_lanelet) const
+  lanelet::ConstLanelet * target_lanelet)
 {
   for (const auto & shoulder_lanelet : lanelets) {
     if (lanelet::utils::isInLanelet(pose, shoulder_lanelet, vehicle_width / 2.0)) {
@@ -1178,30 +1180,30 @@ PathWithLaneId RouteHandler::getCenterLinePath(
     lanelet::traffic_rules::SpeedLimitInformation limit = traffic_rules_ptr_->speedLimit(llt);
     const lanelet::ConstLineString3d centerline = llt.centerline();
 
-    const auto addPathPoint = [&reference_path, &limit, &llt](const auto & pt) {
+    const auto add_path_point = [&reference_path, &limit, &llt](const auto & pt) {
       PathPointWithLaneId p{};
       p.point.pose.position = lanelet::utils::conversion::toGeomMsgPt(pt);
       p.lane_ids.push_back(llt.id());
-      p.point.longitudinal_velocity_mps = limit.speedLimit.value();
+      p.point.longitudinal_velocity_mps = static_cast<float>(limit.speedLimit.value());
       reference_path.points.push_back(p);
     };
 
     for (size_t i = 0; i < centerline.size(); i++) {
-      const lanelet::ConstPoint3d pt = centerline[i];
+      const auto & pt = centerline[i];
       lanelet::ConstPoint3d next_pt =
         (i + 1 < centerline.size()) ? centerline[i + 1] : centerline[i];
       double distance = lanelet::geometry::distance2d(to2D(pt), to2D(next_pt));
 
       if (s < s_start && s + distance > s_start) {
         const auto p = use_exact ? get3DPointFrom2DArcLength(lanelet_sequence, s_start) : pt;
-        addPathPoint(p);
+        add_path_point(p);
       }
       if (s >= s_start && s <= s_end) {
-        addPathPoint(pt);
+        add_path_point(pt);
       }
       if (s < s_end && s + distance > s_end) {
         const auto p = use_exact ? get3DPointFrom2DArcLength(lanelet_sequence, s_end) : next_pt;
-        addPathPoint(p);
+        add_path_point(p);
       }
       s += distance;
     }
@@ -1211,7 +1213,7 @@ PathWithLaneId RouteHandler::getCenterLinePath(
 
   // append a point only when having one point so that yaw calculation would work
   if (reference_path.points.size() == 1) {
-    const int lane_id = reference_path.points.front().lane_ids.front();
+    const int lane_id = static_cast<int>(reference_path.points.front().lane_ids.front());
     const auto lanelet = lanelet_map_ptr_->laneletLayer.get(lane_id);
     const auto point = reference_path.points.front().point.pose.position;
     const auto lane_yaw = lanelet::utils::getLaneletAngle(lanelet, point);
@@ -1249,7 +1251,7 @@ PathWithLaneId RouteHandler::updatePathTwist(const PathWithLaneId & path) const
     const auto id = point.lane_ids.at(0);
     const auto llt = lanelet_map_ptr_->laneletLayer.get(id);
     lanelet::traffic_rules::SpeedLimitInformation limit = traffic_rules_ptr_->speedLimit(llt);
-    point.point.longitudinal_velocity_mps = limit.speedLimit.value();
+    point.point.longitudinal_velocity_mps = static_cast<float>(limit.speedLimit.value());
   }
   return updated_path;
 }
@@ -1440,7 +1442,7 @@ lanelet::ConstLanelets RouteHandler::getPreviousLaneletSequence(
     return previous_lanelet_sequence;
   }
 
-  auto first_lane = lanelet_sequence.front();
+  const auto & first_lane = lanelet_sequence.front();
   if (exists(start_lanelets_, first_lane)) {
     return previous_lanelet_sequence;
   }
@@ -1577,6 +1579,7 @@ std::vector<lanelet::ConstLanelets> RouteHandler::getLaneSection(
 {
   lanelet::ConstLanelets neighbors = getNeighborsWithinRoute(lanelet);
   std::vector<lanelet::ConstLanelets> lane_section;
+  lane_section.reserve(neighbors.size());
   for (const auto & llt : neighbors) {
     lane_section.push_back(getLaneSequence(llt));
   }
@@ -1590,7 +1593,7 @@ lanelet::ConstLanelets RouteHandler::getNextLaneSequence(
   if (lane_sequence.empty()) {
     return next_lane_sequence;
   }
-  lanelet::ConstLanelet final_lanelet = lane_sequence.back();
+  const auto & final_lanelet = lane_sequence.back();
   lanelet::ConstLanelet next_lanelet;
   if (!getNextLaneletWithinRoute(final_lanelet, &next_lanelet)) {
     return next_lane_sequence;
@@ -1626,6 +1629,7 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   }
 
   const auto shortest_path = optional_route->shortestPath();
+  path_lanelets->reserve(shortest_path.size());
   for (const auto & llt : shortest_path) {
     path_lanelets->push_back(llt);
   }
@@ -1643,10 +1647,12 @@ std::vector<HADMapSegment> RouteHandler::createMapSegments(
     return route_sections;
   }
 
+  route_sections.reserve(main_path.size());
   for (const auto & main_llt : main_path) {
     HADMapSegment route_section_msg;
     lanelet::ConstLanelets route_section_lanelets = getNeighborsWithinRoute(main_llt);
     route_section_msg.preferred_primitive_id = main_llt.id();
+    route_section_msg.primitives.reserve(route_section_lanelets.size());
     for (const auto & section_llt : route_section_lanelets) {
       MapPrimitive p;
       p.id = section_llt.id();

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -292,8 +292,14 @@ void RouteHandler::setLaneletsFromRouteMsg()
   if (!is_route_valid) {
     return;
   }
+
+  size_t primitive_size{0};
   for (const auto & route_section : route_msg_.segments) {
-    route_lanelets_.reserve(route_lanelets_.size() + route_section.primitives.size());
+    primitive_size += route_section.primitives.size();
+  }
+  route_lanelets_.reserve(primitive_size);
+
+  for (const auto & route_section : route_msg_.segments) {
     for (const auto & primitive : route_section.primitives) {
       const auto id = primitive.id;
       const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

The following was done in this PR
1. refactor based on clang-tidy's suggestion
2. add `reserve` wherever possible.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
