### PR TITLE
feat(obstacle_avoidance_planner): check footprint with boost::geometry::intersection

### DIFF
--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -18,7 +18,7 @@
       enable_pre_smoothing: true # enable EB
       skip_optimization: false # skip MPT and EB
       reset_prev_optimization: false
-      is_considering_footprint_edges: false # consider the edges of the ego's footprint
+      is_considering_footprint_edges: false # consider ego footprint edges to decide whether footprint is outside drivable area
 
     common:
       # sampling

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -18,6 +18,7 @@
       enable_pre_smoothing: true # enable EB
       skip_optimization: false # skip MPT and EB
       reset_prev_optimization: false
+      is_considering_footprint_edges: false # consider the edges of the ego's footprint
 
     common:
       # sampling

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
@@ -178,6 +178,7 @@ private:
   bool enable_pre_smoothing_;
   bool skip_optimization_;
   bool reset_prev_optimization_;
+  bool is_considering_footprint_edges_;
 
   // vehicle circles info for for mpt constraints
   std::string vehicle_circle_method_;

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/utils.hpp
@@ -359,7 +359,8 @@ namespace drivable_area_utils
 bool isOutsideDrivableAreaFromRectangleFootprint(
   const autoware_auto_planning_msgs::msg::TrajectoryPoint & traj_point,
   const std::vector<geometry_msgs::msg::Point> & left_bound,
-  const std::vector<geometry_msgs::msg::Point> & right_bound, const VehicleParam & vehicle_param, const bool is_considering_footprint_edges);
+  const std::vector<geometry_msgs::msg::Point> & right_bound, const VehicleParam & vehicle_param,
+  const bool is_considering_footprint_edges);
 }
 
 #endif  // OBSTACLE_AVOIDANCE_PLANNER__UTILS__UTILS_HPP_

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/utils.hpp
@@ -359,7 +359,7 @@ namespace drivable_area_utils
 bool isOutsideDrivableAreaFromRectangleFootprint(
   const autoware_auto_planning_msgs::msg::TrajectoryPoint & traj_point,
   const std::vector<geometry_msgs::msg::Point> & left_bound,
-  const std::vector<geometry_msgs::msg::Point> & right_bound, const VehicleParam & vehicle_param);
+  const std::vector<geometry_msgs::msg::Point> & right_bound, const VehicleParam & vehicle_param, const bool is_considering_footprint_edges);
 }
 
 #endif  // OBSTACLE_AVOIDANCE_PLANNER__UTILS__UTILS_HPP_

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -305,7 +305,8 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
     enable_pre_smoothing_ = declare_parameter<bool>("option.enable_pre_smoothing");
     skip_optimization_ = declare_parameter<bool>("option.skip_optimization");
     reset_prev_optimization_ = declare_parameter<bool>("option.reset_prev_optimization");
-    is_considering_footprint_edges_ = declare_parameter<bool>("option.is_considering_footprint_edges");
+    is_considering_footprint_edges_ =
+      declare_parameter<bool>("option.is_considering_footprint_edges");
   }
 
   {  // trajectory parameter
@@ -601,7 +602,8 @@ rcl_interfaces::msg::SetParametersResult ObstacleAvoidancePlanner::onParam(
     updateParam<bool>(parameters, "option.enable_pre_smoothing", enable_pre_smoothing_);
     updateParam<bool>(parameters, "option.skip_optimization", skip_optimization_);
     updateParam<bool>(parameters, "option.reset_prev_optimization", reset_prev_optimization_);
-    updateParam<bool>(parameters, "option.is_considering_footprint_edges", is_considering_footprint_edges_);
+    updateParam<bool>(
+      parameters, "option.is_considering_footprint_edges", is_considering_footprint_edges_);
   }
 
   {  // trajectory parameter

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -305,6 +305,7 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
     enable_pre_smoothing_ = declare_parameter<bool>("option.enable_pre_smoothing");
     skip_optimization_ = declare_parameter<bool>("option.skip_optimization");
     reset_prev_optimization_ = declare_parameter<bool>("option.reset_prev_optimization");
+    is_considering_footprint_edges_ = declare_parameter<bool>("option.is_considering_footprint_edges");
   }
 
   {  // trajectory parameter
@@ -600,6 +601,7 @@ rcl_interfaces::msg::SetParametersResult ObstacleAvoidancePlanner::onParam(
     updateParam<bool>(parameters, "option.enable_pre_smoothing", enable_pre_smoothing_);
     updateParam<bool>(parameters, "option.skip_optimization", skip_optimization_);
     updateParam<bool>(parameters, "option.reset_prev_optimization", reset_prev_optimization_);
+    updateParam<bool>(parameters, "option.is_considering_footprint_edges", is_considering_footprint_edges_);
   }
 
   {  // trajectory parameter
@@ -1293,7 +1295,7 @@ void ObstacleAvoidancePlanner::insertZeroVelocityOutsideDrivableArea(
 
     // calculate the first point being outside drivable area
     const bool is_outside = drivable_area_utils::isOutsideDrivableAreaFromRectangleFootprint(
-      traj_point, left_bound, right_bound, vehicle_param_);
+      traj_point, left_bound, right_bound, vehicle_param_, is_considering_footprint_edges_);
 
     // only insert zero velocity to the first point outside drivable area
     if (is_outside) {

--- a/planning/obstacle_avoidance_planner/src/utils/utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/utils.cpp
@@ -686,7 +686,7 @@ namespace drivable_area_utils
 bool isOutsideDrivableAreaFromRectangleFootprint(
   const autoware_auto_planning_msgs::msg::TrajectoryPoint & traj_point,
   const std::vector<geometry_msgs::msg::Point> & left_bound,
-  const std::vector<geometry_msgs::msg::Point> & right_bound, const VehicleParam & vehicle_param)
+  const std::vector<geometry_msgs::msg::Point> & right_bound, const VehicleParam & vehicle_param, const bool is_considering_footprint_edges)
 {
   if (left_bound.empty() || right_bound.empty()) {
     return false;
@@ -711,35 +711,38 @@ bool isOutsideDrivableAreaFromRectangleFootprint(
     tier4_autoware_utils::calcOffsetPose(traj_point.pose, -base_to_rear, -base_to_left, 0.0)
       .position;
 
-  LinearRing2d footprint_polygon;
-  LineString2d left_bound_line;
-  LineString2d right_bound_line;
-  LineString2d back_bound_line;
+  if(is_considering_footprint_edges){
 
-  footprint_polygon.push_back({top_left_pos.x, top_left_pos.y});
-  footprint_polygon.push_back({top_right_pos.x, top_right_pos.y});
-  footprint_polygon.push_back({bottom_right_pos.x, bottom_right_pos.y});
-  footprint_polygon.push_back({bottom_left_pos.x, bottom_left_pos.y});
+    LinearRing2d footprint_polygon;
+    LineString2d left_bound_line;
+    LineString2d right_bound_line;
+    LineString2d back_bound_line;
 
-  bg::correct(footprint_polygon);
+    footprint_polygon.push_back({top_left_pos.x, top_left_pos.y});
+    footprint_polygon.push_back({top_right_pos.x, top_right_pos.y});
+    footprint_polygon.push_back({bottom_right_pos.x, bottom_right_pos.y});
+    footprint_polygon.push_back({bottom_left_pos.x, bottom_left_pos.y});
 
-  for (const auto & p : left_bound) {
-    left_bound_line.push_back({p.x, p.y});
+    bg::correct(footprint_polygon);
+
+    for (const auto & p : left_bound) {
+      left_bound_line.push_back({p.x, p.y});
+    }
+
+    for (const auto & p : right_bound) {
+      right_bound_line.push_back({p.x, p.y});
+    }
+
+    back_bound_line = {left_bound_line.back(), right_bound_line.back()};
+
+    if (
+      bg::intersects(footprint_polygon, left_bound_line) ||
+      bg::intersects(footprint_polygon, right_bound_line) ||
+      bg::intersects(footprint_polygon, back_bound_line)) {
+      return true;
+    }
   }
-
-  for (const auto & p : right_bound) {
-    right_bound_line.push_back({p.x, p.y});
-  }
-
-  back_bound_line = {left_bound_line.back(), right_bound_line.back()};
-
-  if (
-    bg::intersects(footprint_polygon, left_bound_line) ||
-    bg::intersects(footprint_polygon, right_bound_line) ||
-    bg::intersects(footprint_polygon, back_bound_line)) {
-    return true;
-  }
-
+  
   const bool front_top_left = isFrontDrivableArea(top_left_pos, left_bound, right_bound);
   const bool front_top_right = isFrontDrivableArea(top_right_pos, left_bound, right_bound);
   const bool front_bottom_left = isFrontDrivableArea(bottom_left_pos, left_bound, right_bound);

--- a/planning/obstacle_avoidance_planner/src/utils/utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/utils.cpp
@@ -686,7 +686,8 @@ namespace drivable_area_utils
 bool isOutsideDrivableAreaFromRectangleFootprint(
   const autoware_auto_planning_msgs::msg::TrajectoryPoint & traj_point,
   const std::vector<geometry_msgs::msg::Point> & left_bound,
-  const std::vector<geometry_msgs::msg::Point> & right_bound, const VehicleParam & vehicle_param, const bool is_considering_footprint_edges)
+  const std::vector<geometry_msgs::msg::Point> & right_bound, const VehicleParam & vehicle_param,
+  const bool is_considering_footprint_edges)
 {
   if (left_bound.empty() || right_bound.empty()) {
     return false;
@@ -711,8 +712,7 @@ bool isOutsideDrivableAreaFromRectangleFootprint(
     tier4_autoware_utils::calcOffsetPose(traj_point.pose, -base_to_rear, -base_to_left, 0.0)
       .position;
 
-  if(is_considering_footprint_edges){
-
+  if (is_considering_footprint_edges) {
     LinearRing2d footprint_polygon;
     LineString2d left_bound_line;
     LineString2d right_bound_line;
@@ -742,7 +742,7 @@ bool isOutsideDrivableAreaFromRectangleFootprint(
       return true;
     }
   }
-  
+
   const bool front_top_left = isFrontDrivableArea(top_left_pos, left_bound, right_bound);
   const bool front_top_right = isFrontDrivableArea(top_right_pos, left_bound, right_bound);
   const bool front_bottom_left = isFrontDrivableArea(bottom_left_pos, left_bound, right_bound);

--- a/planning/obstacle_avoidance_planner/src/utils/utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/utils.cpp
@@ -741,6 +741,7 @@ bool isOutsideDrivableAreaFromRectangleFootprint(
       bg::intersects(footprint_polygon, back_bound_line)) {
       return true;
     }
+    return false;
   }
 
   const bool front_top_left = isFrontDrivableArea(top_left_pos, left_bound, right_bound);

--- a/planning/obstacle_avoidance_planner/src/utils/utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/utils.cpp
@@ -38,6 +38,9 @@ typedef bg::model::polygon<bg_point> bg_polygon;
 
 namespace
 {
+namespace bg = boost::geometry;
+using tier4_autoware_utils::LinearRing2d;
+using tier4_autoware_utils::LineString2d;
 std::vector<double> convertEulerAngleToMonotonic(const std::vector<double> & angle)
 {
   if (angle.empty()) {
@@ -707,6 +710,35 @@ bool isOutsideDrivableAreaFromRectangleFootprint(
   const auto bottom_left_pos =
     tier4_autoware_utils::calcOffsetPose(traj_point.pose, -base_to_rear, -base_to_left, 0.0)
       .position;
+
+  LinearRing2d footprint_polygon;
+  LineString2d left_bound_line;
+  LineString2d right_bound_line;
+  LineString2d back_bound_line;
+
+  footprint_polygon.push_back({top_left_pos.x, top_left_pos.y});
+  footprint_polygon.push_back({top_right_pos.x, top_right_pos.y});
+  footprint_polygon.push_back({bottom_right_pos.x, bottom_right_pos.y});
+  footprint_polygon.push_back({bottom_left_pos.x, bottom_left_pos.y});
+
+  bg::correct(footprint_polygon);
+
+  for (const auto & p : left_bound) {
+    left_bound_line.push_back({p.x, p.y});
+  }
+
+  for (const auto & p : right_bound) {
+    right_bound_line.push_back({p.x, p.y});
+  }
+
+  back_bound_line = {left_bound_line.back(), right_bound_line.back()};
+
+  if (
+    bg::intersects(footprint_polygon, left_bound_line) ||
+    bg::intersects(footprint_polygon, right_bound_line) ||
+    bg::intersects(footprint_polygon, back_bound_line)) {
+    return true;
+  }
 
   const bool front_top_left = isFrontDrivableArea(top_left_pos, left_bound, right_bound);
   const bool front_top_right = isFrontDrivableArea(top_right_pos, left_bound, right_bound);


### PR DESCRIPTION
## Description

This PR was created to add a different approach to checking that the footprint of the vehicle is within the drivable area.

Fixes: https://github.com/autowarefoundation/autoware.universe/issues/1716

before this PR, [175](https://github.com/autowarefoundation/autoware_launch/pull/175) needs to merge

## Tests performed

I was using boost::geometry::intersection as a separate approach at the first place. But the current version already uses the boost library so it doesn't make sense to add my approach as an option. It makes more sense to combine the current approach and my approach. Because both approaches have limitations;

#### Current version's limitation:

In current version the corners of the footprint are checked. But like in following diagram if the vehicle is long enough, corners can be in the drivable area but body of vehicle is outside the drivable area. So it need a second check.

![intersection drawio](https://user-images.githubusercontent.com/32412808/212840177-7f3e7d3e-185a-411b-8da5-9a677ec0f234.svg)

If you set `is_considering_footprint_edges` param false:

https://user-images.githubusercontent.com/32412808/214093242-ac71fb0b-e0ed-49bc-8a11-5504ac2ddfd8.mp4

#### New version's limitation:

In the new version, it is checked whether there is an intersection between the vehicle and the drivable area. if there is an intersection, it is concluded that the vehicle is outside the driveable area as it is on the driveable area boundaries. But, when the vehicle is completely outside the drivable area boundaries, there will be no intersection and in this approach the vehicle will be considered in the drivable area. however, the vehicle is outside the drivable area as shown in the following diagram.

![outside drawio](https://user-images.githubusercontent.com/32412808/212846344-30173029-75a7-46ae-a237-a7b12f61feee.svg)

If you set `is_considering_footprint_edges` param true:

https://user-images.githubusercontent.com/32412808/214093872-9dc95bd0-5b98-40f5-8984-f16f3041d895.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
