### PR TITLE
fix(avoidance): fix avoidance path chattering

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -42,6 +42,7 @@ namespace behavior_path_planner
 {
 using motion_utils::calcSignedArcLength;
 using motion_utils::findNearestIndex;
+using motion_utils::findNearestSegmentIndex;
 using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcLateralDeviation;
 using tier4_planning_msgs::msg::AvoidanceDebugFactor;
@@ -140,8 +141,11 @@ AvoidancePlanningData AvoidanceModule::calcAvoidancePlanningData(DebugData & deb
     // if the resampled path has only 1 point, use original path.
     data.reference_path = center_path;
   }
+
+  const size_t nearest_segment_index =
+    findNearestSegmentIndex(data.reference_path.points, data.reference_pose.position);
   data.ego_closest_path_index =
-    findNearestIndex(data.reference_path.points, data.reference_pose.position);
+    std::min(nearest_segment_index + 1, data.reference_path.points.size() - 1);
 
   // arclength from ego pose (used in many functions)
   data.arclength_from_ego = util::calcPathArcLengthArray(


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

Fix avoidance path chattering. In this module, the shift point's `start_longitudinal` is calculated by using ego closest path index. So, `start_longitudinal` can be a negative value.

- nominal case
```
                                                 start_longitudinal (positive value)
                                                     <------> 
-------x-------------------------x------------------o--------x-----------
                                                   ego       ^
                                                   nearest_ego_path_index (shift point start_idx)
```

- bad case
```
                             start_longitudinal (nagative value)
                                  <------> 
-------x-------------------------x--------o------------------x-----------
                                 ^       ego
                     nearest_ego_path_index (shift point start_idx)
```

In this PR, I fixed `nearest_ego_path_index` caluculation. The index is always in front of the ego position.

```
                                            start_longitudinal (always positive value)
                                           <----------------> 
-------x-------------------------x--------o------------------x-----------
                                         ego                 ^
                                              nearest_ego_path_index (shift point start_idx)
```

### Before

https://user-images.githubusercontent.com/44889564/193758677-79ee89cc-2ca2-4ca6-b277-1a776c3b2420.mp4

### After (this PR)

https://user-images.githubusercontent.com/44889564/193758686-2297f60a-0959-4ffa-a21e-b23006e1458c.mp4

### Link

[TIER IV internal] https://tier4.atlassian.net/browse/T4PB-20855

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
