### PR TITLE
feat(obstacle_cruise_planner): deal with self-crossing path and u-turn

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -122,4 +122,14 @@ struct DebugData
   std::vector<geometry_msgs::msg::Point> collision_points;
 };
 
+struct EgoNearestParam
+{
+  EgoNearestParam(const double arg_dist_threshold, const double arg_yaw_threshold)
+  : dist_threshold(arg_dist_threshold), yaw_threshold(arg_yaw_threshold)
+  {
+  }
+  double dist_threshold;
+  double yaw_threshold;
+};
+
 #endif  // OBSTACLE_CRUISE_PLANNER__COMMON_STRUCTS_HPP_

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/optimization_based_planner/optimization_based_planner.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/optimization_based_planner/optimization_based_planner.hpp
@@ -44,7 +44,7 @@ class OptimizationBasedPlanner : public PlannerInterface
 public:
   OptimizationBasedPlanner(
     rclcpp::Node & node, const LongitudinalInfo & longitudinal_info,
-    const vehicle_info_util::VehicleInfo & vehicle_info);
+    const vehicle_info_util::VehicleInfo & vehicle_info, const EgoNearestParam & ego_nearest_param);
 
   Trajectory generateCruiseTrajectory(
     const ObstacleCruisePlannerData & planner_data, boost::optional<VelocityLimit> & vel_limit,

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
@@ -53,7 +53,7 @@ public:
 
   PIDBasedPlanner(
     rclcpp::Node & node, const LongitudinalInfo & longitudinal_info,
-    const vehicle_info_util::VehicleInfo & vehicle_info);
+    const vehicle_info_util::VehicleInfo & vehicle_info, const EgoNearestParam & ego_nearest_param);
 
   Trajectory generateCruiseTrajectory(
     const ObstacleCruisePlannerData & planner_data, boost::optional<VelocityLimit> & vel_limit,
@@ -75,28 +75,6 @@ private:
     visualization_msgs::msg::MarkerArray & debug_walls_marker);
 
   void publishDebugValues(const ObstacleCruisePlannerData & planner_data) const;
-
-  size_t findExtendedNearestIndex(
-    const Trajectory traj, const geometry_msgs::msg::Pose & pose) const
-  {
-    const auto nearest_idx = motion_utils::findNearestIndex(
-      traj.points, pose, nearest_dist_deviation_threshold_, nearest_yaw_deviation_threshold_);
-    if (nearest_idx) {
-      return nearest_idx.get();
-    }
-    return motion_utils::findNearestIndex(traj.points, pose.position);
-  }
-
-  size_t findExtendedNearestSegmentIndex(
-    const Trajectory traj, const geometry_msgs::msg::Pose & pose) const
-  {
-    const auto nearest_segment_idx = motion_utils::findNearestSegmentIndex(
-      traj.points, pose, nearest_dist_deviation_threshold_, nearest_yaw_deviation_threshold_);
-    if (nearest_segment_idx) {
-      return nearest_segment_idx.get();
-    }
-    return motion_utils::findNearestSegmentIndex(traj.points, pose.position);
-  }
 
   // ROS parameters
   double min_accel_during_cruise_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -34,6 +34,7 @@
 
 using autoware_auto_perception_msgs::msg::ObjectClassification;
 using autoware_auto_planning_msgs::msg::Trajectory;
+using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using tier4_planning_msgs::msg::StopSpeedExceeded;
 using tier4_planning_msgs::msg::VelocityLimit;
 
@@ -42,8 +43,10 @@ class PlannerInterface
 public:
   PlannerInterface(
     rclcpp::Node & node, const LongitudinalInfo & longitudinal_info,
-    const vehicle_info_util::VehicleInfo & vehicle_info)
-  : longitudinal_info_(longitudinal_info), vehicle_info_(vehicle_info)
+    const vehicle_info_util::VehicleInfo & vehicle_info, const EgoNearestParam & ego_nearest_param)
+  : longitudinal_info_(longitudinal_info),
+    vehicle_info_(vehicle_info),
+    ego_nearest_param_(ego_nearest_param)
   {
     stop_reasons_pub_ =
       node.create_publisher<tier4_planning_msgs::msg::StopReasonArray>("~/output/stop_reasons", 1);
@@ -112,6 +115,8 @@ protected:
   // Vehicle Parameters
   vehicle_info_util::VehicleInfo vehicle_info_;
 
+  EgoNearestParam ego_nearest_param_;
+
   // TODO(shimizu) remove these parameters
   Trajectory::ConstSharedPtr smoothed_trajectory_ptr_;
 
@@ -127,6 +132,25 @@ protected:
       ego_vel * i.idling_time + std::pow(ego_vel, 2) * 0.5 / std::abs(i.min_ego_accel_for_rss) -
       std::pow(obj_vel, 2) * 0.5 / std::abs(i.min_object_accel_for_rss) + margin;
     return rss_dist_with_margin;
+  }
+
+  size_t findEgoIndex(const Trajectory & traj, const geometry_msgs::msg::Pose & ego_pose) const
+  {
+    const auto traj_points = motion_utils::convertToTrajectoryPointArray(traj);
+
+    const auto & p = ego_nearest_param_;
+    return motion_utils::findFirstNearestIndexWithSoftConstraints(
+      traj_points, ego_pose, p.dist_threshold, p.yaw_threshold);
+  }
+
+  size_t findEgoSegmentIndex(
+    const Trajectory & traj, const geometry_msgs::msg::Pose & ego_pose) const
+  {
+    const auto traj_points = motion_utils::convertToTrajectoryPointArray(traj);
+
+    const auto & p = ego_nearest_param_;
+    return motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+      traj_points, ego_pose, p.dist_threshold, p.yaw_threshold);
   }
 };
 

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -261,6 +261,14 @@ ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions &
       safe_distance_margin};
   }();
 
+  const auto ego_nearest_param = [&]() {
+    const double ego_nearest_dist_threshold =
+      declare_parameter<double>("ego_nearest_dist_threshold");
+    const double ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
+
+    return EgoNearestParam(ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
+  }();
+
   is_showing_debug_info_ = declare_parameter<bool>("common.is_showing_debug_info");
 
   {  // Obstacle filtering parameters
@@ -337,10 +345,11 @@ ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions &
     planning_algorithm_ = getPlanningAlgorithmType(planning_algorithm_param);
 
     if (planning_algorithm_ == PlanningAlgorithm::OPTIMIZATION_BASE) {
-      planner_ptr_ =
-        std::make_unique<OptimizationBasedPlanner>(*this, longitudinal_info, vehicle_info_);
+      planner_ptr_ = std::make_unique<OptimizationBasedPlanner>(
+        *this, longitudinal_info, vehicle_info_, ego_nearest_param);
     } else if (planning_algorithm_ == PlanningAlgorithm::PID_BASE) {
-      planner_ptr_ = std::make_unique<PIDBasedPlanner>(*this, longitudinal_info, vehicle_info_);
+      planner_ptr_ = std::make_unique<PIDBasedPlanner>(
+        *this, longitudinal_info, vehicle_info_, ego_nearest_param);
     } else {
       std::logic_error("Designated algorithm is not supported.");
     }

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -54,8 +54,8 @@ Float32MultiArrayStamped convertDebugValuesToMsg(
 
 PIDBasedPlanner::PIDBasedPlanner(
   rclcpp::Node & node, const LongitudinalInfo & longitudinal_info,
-  const vehicle_info_util::VehicleInfo & vehicle_info)
-: PlannerInterface(node, longitudinal_info, vehicle_info)
+  const vehicle_info_util::VehicleInfo & vehicle_info, const EgoNearestParam & ego_nearest_param)
+: PlannerInterface(node, longitudinal_info, vehicle_info, ego_nearest_param)
 {
   min_accel_during_cruise_ =
     node.declare_parameter<double>("pid_based_planner.min_accel_during_cruise");
@@ -199,7 +199,7 @@ VelocityLimit PIDBasedPlanner::doCruise(
   }();
   const double dist_to_obstacle = cruise_obstacle_info.dist_to_obstacle;
 
-  const size_t ego_idx = findExtendedNearestIndex(planner_data.traj, planner_data.current_pose);
+  const size_t ego_idx = findEgoIndex(planner_data.traj, planner_data.current_pose);
 
   // calculate target velocity with acceleration limit by PID controller
   const double pid_output_vel = pid_controller_->calc(filtered_normalized_dist_to_cruise);


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

Deal with u-turn and self-crossing path in PID-based planner
Related to https://github.com/autowarefoundation/autoware.universe/issues/1581
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
