### PR TITLE
refactor(lidar_centerpoint): refactor isCarLikeVehicle function

### DIFF
--- a/perception/lidar_centerpoint/lib/ros_utils.cpp
+++ b/perception/lidar_centerpoint/lib/ros_utils.cpp
@@ -14,8 +14,9 @@
 
 #include "lidar_centerpoint/ros_utils.hpp"
 
-#include <tier4_autoware_utils/geometry/geometry.hpp>
-#include <tier4_autoware_utils/math/constants.hpp>
+#include "perception_utils/perception_utils.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/math/constants.hpp"
 
 namespace centerpoint
 {
@@ -40,7 +41,7 @@ void box3DToDetectedObject(
       rclcpp::get_logger("lidar_centerpoint"), "Unexpected label: UNKNOWN is set.");
   }
 
-  if (isCarLikeVehicleLabel(classification.label)) {
+  if (perception_utils::isCarLikeVehicle(classification.label)) {
     obj.kinematics.orientation_availability =
       autoware_auto_perception_msgs::msg::DetectedObjectKinematics::SIGN_UNKNOWN;
   }
@@ -89,12 +90,6 @@ uint8_t getSemanticType(const std::string & class_name)
   } else {
     return Label::UNKNOWN;
   }
-}
-
-bool isCarLikeVehicleLabel(const uint8_t label)
-{
-  return label == Label::CAR || label == Label::TRUCK || label == Label::BUS ||
-         label == Label::TRAILER;
 }
 
 }  // namespace centerpoint


### PR DESCRIPTION
Signed-off-by: scepter914 <scepter914@gmail.com>

## Description

Replace isCarLikeVehicle() function to perception_util.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
