### PR TITLE
fix(motion_velocity_smoother): removed unnecessary info for external velocity limit calculation

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -328,7 +328,7 @@ void MotionVelocitySmootherNode::onExternalVelocityLimit(const VelocityLimit::Co
 
       if (msg->max_velocity < max_velocity_with_deceleration_) {
         // TODO(mkuri) If v0 < msg->max_velocity < max_velocity_with_deceleration_ meets, stronger
-        // jerk than expexted may be applied to external velocity limit.
+        // jerk than expected may be applied to external velocity limit.
         double stop_dist = 0.0;
         std::map<double, double> jerk_profile;
         if (!trajectory_utils::calcStopDistWithJerkConstraints(

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -327,6 +327,8 @@ void MotionVelocitySmootherNode::onExternalVelocityLimit(const VelocityLimit::Co
       }
 
       if (msg->max_velocity < max_velocity_with_deceleration_) {
+        // TODO(mkuri) If v0 < msg->max_velocity < max_velocity_with_deceleration_ meets, stronger
+        // jerk than expexted may be applied to external velocity limit.
         double stop_dist = 0.0;
         std::map<double, double> jerk_profile;
         if (!trajectory_utils::calcStopDistWithJerkConstraints(

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -316,13 +316,7 @@ void MotionVelocitySmootherNode::onExternalVelocityLimit(const VelocityLimit::Co
       const auto a_min = msg->use_constraints ? cstr.min_acceleration : smoother_->getMinDecel();
       const auto j_max = msg->use_constraints ? cstr.max_jerk : smoother_->getMaxJerk();
       const auto j_min = msg->use_constraints ? cstr.min_jerk : smoother_->getMinJerk();
-      double stop_dist = 0.0;
-      std::map<double, double> jerk_profile;
-      if (!trajectory_utils::calcStopDistWithJerkConstraints(
-            v0, a0, j_max, j_min, a_min, msg->max_velocity, jerk_profile, stop_dist)) {
-        RCLCPP_WARN(get_logger(), "Stop distance calculation is failed!");
-      }
-      external_velocity_limit_dist_ = stop_dist + margin;
+
       // If the closest acceleration is positive, velocity will increase
       // until the acceleration becomes zero
       // So we set the maximum increased velocity as the velocity limit
@@ -332,7 +326,15 @@ void MotionVelocitySmootherNode::onExternalVelocityLimit(const VelocityLimit::Co
         max_velocity_with_deceleration_ = v0;
       }
 
-      if (max_velocity_with_deceleration_ < msg->max_velocity) {
+      if (msg->max_velocity < max_velocity_with_deceleration_) {
+        double stop_dist = 0.0;
+        std::map<double, double> jerk_profile;
+        if (!trajectory_utils::calcStopDistWithJerkConstraints(
+              v0, a0, j_max, j_min, a_min, msg->max_velocity, jerk_profile, stop_dist)) {
+          RCLCPP_WARN(get_logger(), "Stop distance calculation failed!");
+        }
+        external_velocity_limit_dist_ = stop_dist + margin;
+      } else {
         max_velocity_with_deceleration_ = msg->max_velocity;
         external_velocity_limit_dist_ = 0.0;
       }


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

Without this PR, when the velocity in external_velocity_limit is higher than v0, somtimes the message `"t1 < 0. unexpected condition."` is output which is not expected.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
