### PR TITLE
fix(component_interface_specs): add missing dep

### DIFF
--- a/common/component_interface_specs/package.xml
+++ b/common/component_interface_specs/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <build_depend>autoware_cmake</build_depend>
-  
+
   <depend>autoware_adapi_v1_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/common/component_interface_specs/package.xml
+++ b/common/component_interface_specs/package.xml
@@ -10,6 +10,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <build_depend>autoware_cmake</build_depend>
+  
+  <depend>autoware_adapi_v1_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Package `component_interface_specs` uses messages from package `autoware_adapi_v1_msgs` which is missing from the dependency of `package.xml`. This can cause errors when building Autoware from scratch.
This PR adds the missing dependency.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
