### PR TITLE
feat(behavior_path_planner): change shift point to shift line

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
@@ -35,7 +35,7 @@ namespace marker_utils
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_perception_msgs::msg::PredictedPath;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
-using behavior_path_planner::ShiftPointArray;
+using behavior_path_planner::ShiftLineArray;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Polygon;
 using geometry_msgs::msg::Pose;
@@ -89,9 +89,9 @@ MarkerArray createPathMarkerArray(
   const PathWithLaneId & path, std::string && ns, const int64_t & lane_id, const float & r,
   const float & g, const float & b);
 
-MarkerArray createShiftPointMarkerArray(
-  const ShiftPointArray & shift_points, const double & base_shift, std::string && ns,
-  const float & r, const float & g, const float & b, const float & w);
+MarkerArray createShiftLineMarkerArray(
+  const ShiftLineArray & shift_lines, const double & base_shift, std::string && ns, const float & r,
+  const float & g, const float & b, const float & w);
 
 MarkerArray createShiftLengthMarkerArray(
   const std::vector<double> & shift_distance,

--- a/planning/behavior_path_planner/include/behavior_path_planner/path_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/path_utilities.hpp
@@ -56,7 +56,7 @@ void clipPathLength(
 
 std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   const lanelet::ConstLanelets & current_lanes, const ShiftedPath & path,
-  const ShiftPoint & shift_point, const Pose & pose, const double & velocity,
+  const ShiftLine & shift_line, const Pose & pose, const double & velocity,
   const BehaviorPathPlannerParameters & common_parameter);
 
 }  // namespace behavior_path_planner::util

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -68,13 +68,13 @@ public:
   }
 
 private:
-  struct RegisteredShiftPoint
+  struct RegisteredShiftLine
   {
     UUID uuid;
     Pose start_pose;
     Pose finish_pose;
   };
-  using RegisteredShiftPointArray = std::vector<RegisteredShiftPoint>;
+  using RegisteredShiftLineArray = std::vector<RegisteredShiftLine>;
 
   std::shared_ptr<AvoidanceParameters> parameters_;
 
@@ -85,8 +85,8 @@ private:
   RTCInterface rtc_interface_left_;
   RTCInterface rtc_interface_right_;
 
-  RegisteredShiftPointArray left_shift_array_;
-  RegisteredShiftPointArray right_shift_array_;
+  RegisteredShiftLineArray left_shift_array_;
+  RegisteredShiftLineArray right_shift_array_;
   UUID candidate_uuid_;
   UUID uuid_left_;
   UUID uuid_right_;
@@ -181,11 +181,11 @@ private:
   ShiftedPath prev_linear_shift_path_;  // used for shift point check
   PathWithLaneId prev_reference_;
 
-  // for raw_shift_point registration
-  AvoidPointArray registered_raw_shift_points_;
-  AvoidPointArray current_raw_shift_points_;
-  void registerRawShiftPoints(const AvoidPointArray & future_registered);
-  void updateRegisteredRawShiftPoints();
+  // for raw_shift_line registration
+  AvoidLineArray registered_raw_shift_lines_;
+  AvoidLineArray current_raw_shift_lines_;
+  void registerRawShiftLines(const AvoidLineArray & future_registered);
+  void updateRegisteredRawShiftLines();
 
   // -- for state management --
   bool isAvoidancePlanRunning() const;
@@ -202,55 +202,53 @@ private:
   void CompensateDetectionLost(ObjectDataArray & objects) const;
 
   // -- for shift point generation --
-  AvoidPointArray calcShiftPoints(
-    AvoidPointArray & current_raw_shift_points, DebugData & debug) const;
+  AvoidLineArray calcShiftLines(AvoidLineArray & current_raw_shift_lines, DebugData & debug) const;
 
   // shift point generation: generator
   double getShiftLength(
     const ObjectData & object, const bool & is_object_on_right, const double & avoid_margin) const;
-  AvoidPointArray calcRawShiftPointsFromObjects(const ObjectDataArray & objects) const;
+  AvoidLineArray calcRawShiftLinesFromObjects(const ObjectDataArray & objects) const;
   double getRightShiftBound() const;
   double getLeftShiftBound() const;
 
   // shift point generation: combiner
-  AvoidPointArray combineRawShiftPointsWithUniqueCheck(
-    const AvoidPointArray & base_points, const AvoidPointArray & added_points) const;
+  AvoidLineArray combineRawShiftLinesWithUniqueCheck(
+    const AvoidLineArray & base_points, const AvoidLineArray & added_points) const;
 
   // shift point generation: merger
-  AvoidPointArray mergeShiftPoints(
-    const AvoidPointArray & raw_shift_points, DebugData & debug) const;
+  AvoidLineArray mergeShiftLines(const AvoidLineArray & raw_shift_lines, DebugData & debug) const;
   void generateTotalShiftLine(
-    const AvoidPointArray & avoid_points, ShiftLineData & shift_line_data) const;
-  AvoidPointArray extractShiftPointsFromLine(ShiftLineData & shift_line_data) const;
+    const AvoidLineArray & avoid_points, ShiftLineData & shift_line_data) const;
+  AvoidLineArray extractShiftLinesFromLine(ShiftLineData & shift_line_data) const;
   std::vector<size_t> calcParentIds(
-    const AvoidPointArray & parent_candidates, const AvoidPoint & child) const;
+    const AvoidLineArray & parent_candidates, const AvoidLine & child) const;
 
   // shift point generation: trimmers
-  AvoidPointArray trimShiftPoint(const AvoidPointArray & shift_points, DebugData & debug) const;
-  void quantizeShiftPoint(AvoidPointArray & shift_points, const double interval) const;
-  void trimSmallShiftPoint(AvoidPointArray & shift_points, const double shift_diff_thres) const;
-  void trimSimilarGradShiftPoint(AvoidPointArray & shift_points, const double threshold) const;
-  void trimMomentaryReturn(AvoidPointArray & shift_points) const;
-  void trimTooSharpShift(AvoidPointArray & shift_points) const;
-  void trimSharpReturn(AvoidPointArray & shift_points) const;
+  AvoidLineArray trimShiftLine(const AvoidLineArray & shift_lines, DebugData & debug) const;
+  void quantizeShiftLine(AvoidLineArray & shift_lines, const double interval) const;
+  void trimSmallShiftLine(AvoidLineArray & shift_lines, const double shift_diff_thres) const;
+  void trimSimilarGradShiftLine(AvoidLineArray & shift_lines, const double threshold) const;
+  void trimMomentaryReturn(AvoidLineArray & shift_lines) const;
+  void trimTooSharpShift(AvoidLineArray & shift_lines) const;
+  void trimSharpReturn(AvoidLineArray & shift_lines) const;
 
   // shift point generation: return-shift generator
-  void addReturnShiftPointFromEgo(
-    AvoidPointArray & sp_candidates, AvoidPointArray & current_raw_shift_points) const;
+  void addReturnShiftLineFromEgo(
+    AvoidLineArray & sl_candidates, AvoidLineArray & current_raw_shift_lines) const;
 
   // -- for shift point operations --
-  void alignShiftPointsOrder(
-    AvoidPointArray & shift_points, const bool recalculate_start_length = true) const;
-  AvoidPointArray fillAdditionalInfo(const AvoidPointArray & shift_points) const;
-  AvoidPoint fillAdditionalInfo(const AvoidPoint & shift_point) const;
-  void fillAdditionalInfoFromPoint(AvoidPointArray & shift_points) const;
-  void fillAdditionalInfoFromLongitudinal(AvoidPointArray & shift_points) const;
+  void alignShiftLinesOrder(
+    AvoidLineArray & shift_lines, const bool recalculate_start_length = true) const;
+  AvoidLineArray fillAdditionalInfo(const AvoidLineArray & shift_lines) const;
+  AvoidLine fillAdditionalInfo(const AvoidLine & shift_line) const;
+  void fillAdditionalInfoFromPoint(AvoidLineArray & shift_lines) const;
+  void fillAdditionalInfoFromLongitudinal(AvoidLineArray & shift_lines) const;
 
   // -- for new shift point approval --
-  boost::optional<AvoidPointArray> findNewShiftPoint(
-    const AvoidPointArray & shift_points, const PathShifter & shifter) const;
-  void addShiftPointIfApproved(const AvoidPointArray & point);
-  void addNewShiftPoints(PathShifter & path_shifter, const AvoidPointArray & shift_points) const;
+  boost::optional<AvoidLineArray> findNewShiftLine(
+    const AvoidLineArray & shift_lines, const PathShifter & shifter) const;
+  void addShiftLineIfApproved(const AvoidLineArray & point);
+  void addNewShiftLines(PathShifter & path_shifter, const AvoidLineArray & shift_lines) const;
 
   // -- path generation --
   ShiftedPath generateAvoidancePath(PathShifter & shifter) const;
@@ -267,7 +265,7 @@ private:
   TurnSignalInfo calcTurnSignalInfo(const ShiftedPath & path) const;
 
   // intersection (old)
-  boost::optional<AvoidPoint> calcIntersectionShiftPoint(const AvoidancePlanningData & data) const;
+  boost::optional<AvoidLine> calcIntersectionShiftLine(const AvoidancePlanningData & data) const;
 
   bool isTargetObjectType(const PredictedObject & object) const;
 
@@ -275,8 +273,8 @@ private:
   mutable DebugData debug_data_;
   void setDebugData(const PathShifter & shifter, const DebugData & debug);
   void updateAvoidanceDebugData(std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const;
-  mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_point_;
-  mutable rclcpp::Time debug_avoidance_initializer_for_shift_point_time_;
+  mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_line_;
+  mutable rclcpp::Time debug_avoidance_initializer_for_shift_line_time_;
   // =====================================
   // ========= helper functions ==========
   // =====================================
@@ -287,7 +285,7 @@ private:
   // TODO(Horibe): think later.
   // for unique ID
   mutable uint64_t original_unique_id = 0;  // TODO(Horibe) remove mutable
-  uint64_t getOriginalShiftPointUniqueId() const { return original_unique_id++; }
+  uint64_t getOriginalShiftLineUniqueId() const { return original_unique_id++; }
 
   double getNominalAvoidanceDistance(const double shift_length) const;
   double getNominalPrepareDistance() const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -201,7 +201,7 @@ using ObjectDataArray = std::vector<ObjectData>;
 /*
  * Shift point with additional info for avoidance planning
  */
-struct AvoidPoint : public ShiftPoint
+struct AvoidLine : public ShiftLine
 {
   // relative shift length from start to end point
   double start_length = 0.0;
@@ -221,13 +221,13 @@ struct AvoidPoint : public ShiftPoint
   // corresponding object
   ObjectData object{};
 
-  double getRelativeLength() const { return length - start_length; }
+  double getRelativeLength() const { return end_shift_length - start_length; }
 
   double getRelativeLongitudinal() const { return end_longitudinal - start_longitudinal; }
 
   double getGradient() const { return getRelativeLength() / getRelativeLongitudinal(); }
 };
-using AvoidPointArray = std::vector<AvoidPoint>;
+using AvoidLineArray = std::vector<AvoidLine>;
 
 /*
  * Common data for avoidance planning
@@ -287,20 +287,20 @@ struct DebugData
   std::shared_ptr<lanelet::ConstLanelets> current_lanelets;
   std::shared_ptr<lanelet::ConstLineStrings3d> farthest_linestring_from_overhang;
 
-  AvoidPointArray current_shift_points;  // in path shifter
-  AvoidPointArray new_shift_points;      // in path shifter
+  AvoidLineArray current_shift_lines;  // in path shifter
+  AvoidLineArray new_shift_lines;      // in path shifter
 
-  AvoidPointArray registered_raw_shift;
-  AvoidPointArray current_raw_shift;
-  AvoidPointArray extra_return_shift;
+  AvoidLineArray registered_raw_shift;
+  AvoidLineArray current_raw_shift;
+  AvoidLineArray extra_return_shift;
 
-  AvoidPointArray merged;
-  AvoidPointArray trim_similar_grad_shift;
-  AvoidPointArray quantized;
-  AvoidPointArray trim_small_shift;
-  AvoidPointArray trim_similar_grad_shift_second;
-  AvoidPointArray trim_momentary_return;
-  AvoidPointArray trim_too_sharp_shift;
+  AvoidLineArray merged;
+  AvoidLineArray trim_similar_grad_shift;
+  AvoidLineArray quantized;
+  AvoidLineArray trim_small_shift;
+  AvoidLineArray trim_similar_grad_shift_second;
+  AvoidLineArray trim_momentary_return;
+  AvoidLineArray trim_too_sharp_shift;
   std::vector<double> pos_shift;
   std::vector<double> neg_shift;
   std::vector<double> total_shift;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -37,14 +37,14 @@ size_t findPathIndexFromArclength(
 
 ShiftedPath toShiftedPath(const PathWithLaneId & path);
 
-ShiftPointArray toShiftPointArray(const AvoidPointArray & avoid_points);
+ShiftLineArray toShiftLineArray(const AvoidLineArray & avoid_points);
 
 std::vector<size_t> concatParentIds(
   const std::vector<size_t> & ids1, const std::vector<size_t> & ids2);
 
-double lerpShiftLengthOnArc(double arc, const AvoidPoint & ap);
+double lerpShiftLengthOnArc(double arc, const AvoidLine & al);
 
-void clipByMinStartIdx(const AvoidPointArray & shift_points, PathWithLaneId & path);
+void clipByMinStartIdx(const AvoidLineArray & shift_lines, PathWithLaneId & path);
 
 void fillLongitudinalAndLengthByClosestFootprint(
   const PathWithLaneId & path, const PredictedObject & object, const Point & ego_pos,
@@ -54,11 +54,11 @@ double calcOverhangDistance(
   const ObjectData & object_data, const Pose & base_pose, Point & overhang_pose);
 
 void setEndData(
-  AvoidPoint & ap, const double length, const geometry_msgs::msg::Pose & end, const size_t end_idx,
+  AvoidLine & al, const double length, const geometry_msgs::msg::Pose & end, const size_t end_idx,
   const double end_dist);
 
 void setStartData(
-  AvoidPoint & ap, const double start_length, const geometry_msgs::msg::Pose & start,
+  AvoidLine & al, const double start_length, const geometry_msgs::msg::Pose & start,
   const size_t start_idx, const double start_dist);
 
 std::string getUuidStr(const ObjectData & obj);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -36,15 +36,15 @@ namespace marker_utils::avoidance_marker
 {
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
-using behavior_path_planner::AvoidPointArray;
-using behavior_path_planner::ShiftPointArray;
+using behavior_path_planner::AvoidLineArray;
+using behavior_path_planner::ShiftLineArray;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Polygon;
 using geometry_msgs::msg::Pose;
 using visualization_msgs::msg::MarkerArray;
 
-MarkerArray createAvoidPointMarkerArray(
-  const AvoidPointArray & shift_points, std::string && ns, const float & r, const float & g,
+MarkerArray createAvoidLineMarkerArray(
+  const AvoidLineArray & shift_points, std::string && ns, const float & r, const float & g,
   const float & b, const double & w);
 
 MarkerArray createAvoidanceObjectsMarkerArray(
@@ -59,12 +59,12 @@ MarkerArray createOverhangFurthestLineStringMarkerArray(
 
 }  // namespace marker_utils::avoidance_marker
 
-std::string toStrInfo(const behavior_path_planner::ShiftPointArray & sp_arr);
+std::string toStrInfo(const behavior_path_planner::ShiftLineArray & sp_arr);
 
-std::string toStrInfo(const behavior_path_planner::AvoidPointArray & ap_arr);
+std::string toStrInfo(const behavior_path_planner::AvoidLineArray & ap_arr);
 
-std::string toStrInfo(const behavior_path_planner::ShiftPoint & sp);
+std::string toStrInfo(const behavior_path_planner::ShiftLine & sp);
 
-std::string toStrInfo(const behavior_path_planner::AvoidPoint & ap);
+std::string toStrInfo(const behavior_path_planner::AvoidLine & ap);
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__DEBUG_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_path.hpp
@@ -30,7 +30,7 @@ struct LaneChangePath
 {
   PathWithLaneId path;
   ShiftedPath shifted_path;
-  ShiftPoint shift_point;
+  ShiftLine shift_line;
   double acceleration{0.0};
   double preparation_length{0.0};
   double lane_change_length{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -59,7 +59,7 @@ double getDistanceWhenDecelerate(
 
 std::optional<LaneChangePath> constructCandidatePath(
   const PathWithLaneId & prepare_segment, const PathWithLaneId & lane_changing_segment,
-  const PathWithLaneId & target_lane_reference_path, const ShiftPoint & shift_point,
+  const PathWithLaneId & target_lane_reference_path, const ShiftLine & shift_line,
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
   const double & acceleration, const double & prepare_distance, const double & prepare_duration,
   const double & prepare_speed, const double & minimum_prepare_distance,
@@ -103,7 +103,7 @@ bool hasEnoughDistance(
   const bool isInGoalRouteSection, const Pose & goal_pose,
   const lanelet::routing::RoutingGraphContainer & overall_graphs);
 
-ShiftPoint getLaneChangeShiftPoint(
+ShiftLine getLaneChangeShiftLine(
   const PathWithLaneId & path1, const PathWithLaneId & path2,
   const lanelet::ConstLanelets & target_lanes, const PathWithLaneId & reference_path);
 
@@ -130,7 +130,7 @@ PathWithLaneId getLaneChangePathLaneChangingSegment(
 
 TurnSignalInfo calc_turn_signal_info(
   const PathWithLaneId & prepare_path, const double prepare_velocity,
-  const double min_prepare_distance, const double prepare_duration, const ShiftPoint & shift_points,
+  const double min_prepare_distance, const double prepare_duration, const ShiftLine & shift_line,
   const ShiftedPath & lane_changing_path);
 
 void get_turn_signal_info(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_path.hpp
@@ -32,7 +32,7 @@ struct PullOverPath
   Pose start_pose{};
   Pose end_pose{};
   ShiftedPath shifted_path{};
-  ShiftPoint shift_point{};
+  ShiftLine shift_line{};
   double acceleration{0.0};
   double preparation_length{0.0};
   double pull_over_length{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -77,9 +77,9 @@ private:
   // non-const methods
   void adjustDrivableArea(ShiftedPath * path) const;
 
-  ShiftPoint calcShiftPoint() const;
+  ShiftLine calcShiftLine() const;
 
-  bool addShiftPoint();
+  bool addShiftLine();
 
   // const methods
   void publishPath(const PathWithLaneId & path) const;
@@ -104,7 +104,7 @@ private:
   PathShifter path_shifter_;
 
   ShiftedPath prev_output_;
-  ShiftPoint prev_shift_point_;
+  ShiftLine prev_shift_line_;
 
   // NOTE: this function is ported from avoidance.
   PoseStamped getUnshiftedEgoPose(const ShiftedPath & prev_path) const;

--- a/planning/behavior_path_planner/src/debug_utilities.cpp
+++ b/planning/behavior_path_planner/src/debug_utilities.cpp
@@ -21,7 +21,7 @@
 
 namespace marker_utils
 {
-using behavior_path_planner::ShiftPoint;
+using behavior_path_planner::ShiftLine;
 using behavior_path_planner::util::calcPathArcLengthArray;
 using behavior_path_planner::util::shiftPose;
 using std_msgs::msg::ColorRGBA;
@@ -85,23 +85,23 @@ MarkerArray createPathMarkerArray(
 
   return msg;
 }
-MarkerArray createShiftPointMarkerArray(
-  const ShiftPointArray & shift_points, const double & base_shift, std::string && ns,
-  const float & r, const float & g, const float & b, const float & w)
+MarkerArray createShiftLineMarkerArray(
+  const ShiftLineArray & shift_lines, const double & base_shift, std::string && ns, const float & r,
+  const float & g, const float & b, const float & w)
 {
-  ShiftPointArray shift_points_local = shift_points;
-  if (shift_points_local.empty()) {
-    shift_points_local.push_back(ShiftPoint());
+  ShiftLineArray shift_lines_local = shift_lines;
+  if (shift_lines.empty()) {
+    shift_lines_local.push_back(ShiftLine());
   }
 
   MarkerArray msg;
-  msg.markers.reserve(shift_points_local.size() * 3);
+  msg.markers.reserve(shift_lines_local.size() * 3);
   const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
   int id{0};
 
   // TODO(Horibe) now assuming the shift point is aligned in longitudinal distance order
   double current_shift = base_shift;
-  for (const auto & sp : shift_points_local) {
+  for (const auto & sp : shift_lines_local) {
     // ROS_ERROR("sp: s = (%f, %f), g = (%f, %f)", sp.start.x, sp.start.y, sp.end.x, sp.end.y);
     Marker basic_marker = createDefaultMarker(
       "map", current_time, ns, 0L, Marker::CUBE, createMarkerScale(0.5, 0.5, 0.5),
@@ -119,7 +119,7 @@ MarkerArray createShiftPointMarkerArray(
       auto marker_e = basic_marker;
       marker_e.id = ++id;
       marker_e.pose = sp.end;
-      shiftPose(&marker_e.pose, sp.length);
+      shiftPose(&marker_e.pose, sp.end_shift_length);
       msg.markers.push_back(marker_e);
 
       // start-to-end line
@@ -132,7 +132,7 @@ MarkerArray createShiftPointMarkerArray(
       marker_l.points.push_back(marker_e.pose.position);
       msg.markers.push_back(marker_l);
     }
-    current_shift = sp.length;
+    current_shift = sp.end_shift_length;
   }
 
   return msg;

--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -185,7 +185,7 @@ void clipPathLength(
 
 std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   const lanelet::ConstLanelets & current_lanes, const ShiftedPath & path,
-  const ShiftPoint & shift_point, const Pose & pose, const double & velocity,
+  const ShiftLine & shift_line, const Pose & pose, const double & velocity,
   const BehaviorPathPlannerParameters & common_parameter)
 {
   TurnIndicatorsCommand turn_signal;
@@ -213,9 +213,9 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   //                      smaller than tl_on_threshold_lat for right signal
   //  2. side point at shift start/end point cross the line
   const double distance_to_shift_start =
-    std::invoke([&current_lanes, &shift_point, &arc_position_current_pose]() {
+    std::invoke([&current_lanes, &shift_line, &arc_position_current_pose]() {
       const auto arc_position_shift_start =
-        lanelet::utils::getArcCoordinates(current_lanes, shift_point.start);
+        lanelet::utils::getArcCoordinates(current_lanes, shift_line.start);
       return arc_position_shift_start.length - arc_position_current_pose.length;
     });
 
@@ -223,17 +223,17 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
     (std::abs(velocity) < epsilon) ? max_time : distance_to_shift_start / velocity;
 
   const double diff =
-    path.shift_length.at(shift_point.end_idx) - path.shift_length.at(shift_point.start_idx);
+    path.shift_length.at(shift_line.end_idx) - path.shift_length.at(shift_line.start_idx);
 
-  Pose shift_start_point = path.path.points.at(shift_point.start_idx).point.pose;
-  Pose shift_end_point = path.path.points.at(shift_point.end_idx).point.pose;
+  Pose shift_start_point = path.path.points.at(shift_line.start_idx).point.pose;
+  Pose shift_end_point = path.path.points.at(shift_line.end_idx).point.pose;
   Pose left_start_point = shift_start_point;
   Pose right_start_point = shift_start_point;
   Pose left_end_point = shift_end_point;
   Pose right_end_point = shift_end_point;
   {
-    const double start_yaw = tf2::getYaw(shift_point.start.orientation);
-    const double end_yaw = tf2::getYaw(shift_point.end.orientation);
+    const double start_yaw = tf2::getYaw(shift_line.start.orientation);
+    const double end_yaw = tf2::getYaw(shift_line.end.orientation);
     left_start_point.position.x -= std::sin(start_yaw) * (shift_to_outside);
     left_start_point.position.y += std::cos(start_yaw) * (shift_to_outside);
     right_start_point.position.x -= std::sin(start_yaw) * (-shift_to_outside);
@@ -287,9 +287,9 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
 
   // calc distance from ego vehicle front to shift end point.
   const double distance_from_vehicle_front =
-    std::invoke([&current_lanes, &shift_point, &arc_position_current_pose, &base_link2front]() {
+    std::invoke([&current_lanes, &shift_line, &arc_position_current_pose, &base_link2front]() {
       const auto arc_position_shift_end =
-        lanelet::utils::getArcCoordinates(current_lanes, shift_point.end);
+        lanelet::utils::getArcCoordinates(current_lanes, shift_line.end);
       return arc_position_shift_end.length - arc_position_current_pose.length - base_link2front;
     });
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -52,13 +52,13 @@ ShiftedPath toShiftedPath(const PathWithLaneId & path)
   return out;
 }
 
-ShiftPointArray toShiftPointArray(const AvoidPointArray & avoid_points)
+ShiftLineArray toShiftLineArray(const AvoidLineArray & avoid_points)
 {
-  ShiftPointArray shift_points;
+  ShiftLineArray shift_lines;
   for (const auto & ap : avoid_points) {
-    shift_points.push_back(ap);
+    shift_lines.push_back(ap);
   }
-  return shift_points;
+  return shift_lines;
 }
 
 size_t findPathIndexFromArclength(
@@ -87,27 +87,27 @@ std::vector<size_t> concatParentIds(
   return v;
 }
 
-double lerpShiftLengthOnArc(double arc, const AvoidPoint & ap)
+double lerpShiftLengthOnArc(double arc, const AvoidLine & ap)
 {
   if (ap.start_longitudinal <= arc && arc < ap.end_longitudinal) {
     if (std::abs(ap.getRelativeLongitudinal()) < 1.0e-5) {
-      return ap.length;
+      return ap.end_shift_length;
     }
     const auto start_weight = (ap.end_longitudinal - arc) / ap.getRelativeLongitudinal();
-    return start_weight * ap.start_length + (1.0 - start_weight) * ap.length;
+    return start_weight * ap.start_length + (1.0 - start_weight) * ap.end_shift_length;
   }
   return 0.0;
 }
 
-void clipByMinStartIdx(const AvoidPointArray & shift_points, PathWithLaneId & path)
+void clipByMinStartIdx(const AvoidLineArray & shift_lines, PathWithLaneId & path)
 {
   if (path.points.empty()) {
     return;
   }
 
   size_t min_start_idx = std::numeric_limits<size_t>::max();
-  for (const auto & sp : shift_points) {
-    min_start_idx = std::min(min_start_idx, sp.start_idx);
+  for (const auto & sl : shift_lines) {
+    min_start_idx = std::min(min_start_idx, sl.start_idx);
   }
   min_start_idx = std::min(min_start_idx, path.points.size() - 1);
   path.points =
@@ -168,17 +168,17 @@ double calcOverhangDistance(
 }
 
 void setEndData(
-  AvoidPoint & ap, const double length, const geometry_msgs::msg::Pose & end, const size_t end_idx,
+  AvoidLine & ap, const double length, const geometry_msgs::msg::Pose & end, const size_t end_idx,
   const double end_dist)
 {
-  ap.length = length;
+  ap.end_shift_length = length;
   ap.end = end;
   ap.end_idx = end_idx;
   ap.end_longitudinal = end_dist;
 }
 
 void setStartData(
-  AvoidPoint & ap, const double start_length, const geometry_msgs::msg::Pose & start,
+  AvoidLine & ap, const double start_length, const geometry_msgs::msg::Pose & start,
   const size_t start_idx, const double start_dist)
 {
   ap.start_length = start_length;

--- a/planning/behavior_path_planner/src/scene_module/pull_over/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/shift_pull_over.cpp
@@ -208,10 +208,10 @@ std::vector<PullOverPath> ShiftPullOver::generatePullOverPaths(
     path_shifter.setPath(
       util::resamplePathWithSpline(target_lane_reference_path, resample_interval));
 
-    ShiftPoint shift_point;
+    ShiftLine shift_line;
     {
-      shift_point.start = road_lane_reference_path.points.back().point.pose;
-      shift_point.end = shift_end_point.point.pose;
+      shift_line.start = road_lane_reference_path.points.back().point.pose;
+      shift_line.end = shift_end_point.point.pose;
 
       // distance between shoulder lane's left boundary and current lane center
       const double distance_road_to_left_boundary = util::getDistanceToShoulderBoundary(
@@ -220,8 +220,8 @@ std::vector<PullOverPath> ShiftPullOver::generatePullOverPaths(
       const double distance_road_to_target =
         distance_road_to_left_boundary + common_parameters.vehicle_width / 2 + margin;
 
-      shift_point.length = distance_road_to_target;
-      path_shifter.addShiftPoint(shift_point);
+      shift_line.end_shift_length = distance_road_to_target;
+      path_shifter.addShiftLine(shift_line);
     }
 
     // offset front side from reference path
@@ -278,12 +278,12 @@ std::vector<PullOverPath> ShiftPullOver::generatePullOverPaths(
       candidate_path.partial_paths.push_back(
         pull_over_utils::combineReferencePath(road_lane_reference_path, shifted_path.path));
       candidate_path.shifted_path = shifted_path;
-      shift_point.start_idx = path_shifter.getShiftPoints().front().start_idx;
-      shift_point.end_idx = path_shifter.getShiftPoints().front().end_idx;
-      candidate_path.start_pose = path_shifter.getShiftPoints().front().start;
-      candidate_path.end_pose = path_shifter.getShiftPoints().front().end;
+      shift_line.start_idx = path_shifter.getShiftLines().front().start_idx;
+      shift_line.end_idx = path_shifter.getShiftLines().front().end_idx;
+      candidate_path.start_pose = path_shifter.getShiftLines().front().start;
+      candidate_path.end_pose = path_shifter.getShiftLines().front().end;
       candidate_path.shifted_path.shift_length = shifted_path.shift_length;
-      candidate_path.shift_point = shift_point;
+      candidate_path.shift_line = shift_line;
       candidate_path.preparation_length = straight_distance;
       candidate_path.pull_over_length = pull_over_distance;
     } else {


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description

Currently, ShiftPoint has several points in it, which makes it difficult to understand the meaning of this variable. In this PR, I renamed it to ShiftLine to make the meaning of this variable clearer.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
