### PR TITLE
feat(autoware_auto_perception_rviz_plugin): add accel text visualization

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -22,6 +22,7 @@
 #include <autoware_auto_perception_msgs/msg/object_classification.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_path.hpp>
 #include <autoware_auto_perception_msgs/msg/shape.hpp>
+#include <geometry_msgs/msg/accel.hpp>
 #include <geometry_msgs/msg/pose_with_covariance.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/twist_with_covariance.hpp>
@@ -103,6 +104,11 @@ get_pose_with_covariance_marker_ptr(
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_velocity_text_marker_ptr(
   const geometry_msgs::msg::Twist & twist, const geometry_msgs::msg::Point & vis_pos,
+  const std_msgs::msg::ColorRGBA & color_rgba);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
+get_acceleration_text_marker_ptr(
+  const geometry_msgs::msg::Accel & accel, const geometry_msgs::msg::Point & vis_pos,
   const std_msgs::msg::ColorRGBA & color_rgba);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -68,6 +68,8 @@ public:
       this},
     m_display_velocity_text_property{
       "Display Velocity", true, "Enable/disable velocity text visualization", this},
+    m_display_acceleration_text_property{
+      "Display Acceleration", true, "Enable/disable acceleration text visualization", this},
     m_display_twist_property{"Display Twist", true, "Enable/disable twist visualization", this},
     m_display_predicted_paths_property{
       "Display Predicted Paths", true, "Enable/disable predicted paths visualization", this},
@@ -202,6 +204,19 @@ protected:
     if (m_display_velocity_text_property.getBool()) {
       const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
       return detail::get_velocity_text_marker_ptr(twist, vis_pos, color_rgba);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  template <typename ClassificationContainerT>
+  std::optional<Marker::SharedPtr> get_acceleration_text_marker_ptr(
+    const geometry_msgs::msg::Accel & accel, const geometry_msgs::msg::Point & vis_pos,
+    const ClassificationContainerT & labels) const
+  {
+    if (m_display_acceleration_text_property.getBool()) {
+      const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
+      return detail::get_acceleration_text_marker_ptr(accel, vis_pos, color_rgba);
     } else {
       return std::nullopt;
     }
@@ -356,6 +371,8 @@ private:
   rviz_common::properties::BoolProperty m_display_pose_with_covariance_property;
   // Property to enable/disable velocity text visualization
   rviz_common::properties::BoolProperty m_display_velocity_text_property;
+  // Property to enable/disable acceleration text visualization
+  rviz_common::properties::BoolProperty m_display_acceleration_text_property;
   // Property to enable/disable twist visualization
   rviz_common::properties::BoolProperty m_display_twist_property;
   // Property to enable/disable predicted paths visualization

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -20,9 +20,23 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
+
+namespace
+{
+// get string of double value rounded after first decimal place
+// e.g. roundAfterFirstDecimalPlace(12.345) -> "1.2"
+std::string getRoundedDoubleString(const double val)
+{
+  std::stringstream ss;
+  ss << std::fixed << std::setprecision(1) << val;
+  return ss.str();
+}
+}  // namespace
 
 namespace autoware
 {
@@ -123,6 +137,27 @@ visualization_msgs::msg::Marker::SharedPtr get_velocity_text_marker_ptr(
     twist.linear.x * twist.linear.x + twist.linear.y * twist.linear.y +
     twist.linear.z * twist.linear.z);
   marker_ptr->text = std::to_string(static_cast<int>(vel * 3.6)) + std::string("[km/h]");
+  marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
+  marker_ptr->pose.position = vis_pos;
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->color = color_rgba;
+  return marker_ptr;
+}
+
+visualization_msgs::msg::Marker::SharedPtr get_acceleration_text_marker_ptr(
+  const geometry_msgs::msg::Accel & accel, const geometry_msgs::msg::Point & vis_pos,
+  const std_msgs::msg::ColorRGBA & color_rgba)
+{
+  auto marker_ptr = std::make_shared<Marker>();
+  marker_ptr->type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+  marker_ptr->ns = std::string("acceleration");
+  marker_ptr->scale.x = 0.5;
+  marker_ptr->scale.z = 0.5;
+
+  double acc = std::sqrt(
+    accel.linear.x * accel.linear.x + accel.linear.y * accel.linear.y +
+    accel.linear.z * accel.linear.z);
+  marker_ptr->text = getRoundedDoubleString(acc) + std::string("[m/s^2]");
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose.position = vis_pos;
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -93,6 +93,21 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
       add_marker(velocity_text_marker_ptr);
     }
 
+    // Get marker for acceleration text
+    geometry_msgs::msg::Point acc_vis_position;
+    acc_vis_position.x = uuid_vis_position.x - 1.0;
+    acc_vis_position.y = uuid_vis_position.y;
+    acc_vis_position.z = uuid_vis_position.z - 1.0;
+    auto acceleration_text_marker = get_acceleration_text_marker_ptr(
+      object.kinematics.initial_acceleration_with_covariance.accel, acc_vis_position,
+      object.classification);
+    if (acceleration_text_marker) {
+      auto acceleration_text_marker_ptr = acceleration_text_marker.value();
+      acceleration_text_marker_ptr->header = msg->header;
+      acceleration_text_marker_ptr->id = uuid_to_marker_id(object.object_id);
+      add_marker(acceleration_text_marker_ptr);
+    }
+
     // Get marker for twist
     auto twist_marker = get_twist_marker_ptr(
       object.kinematics.initial_pose_with_covariance,

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/tracked_objects_display.cpp
@@ -94,6 +94,21 @@ void TrackedObjectsDisplay::processMessage(TrackedObjects::ConstSharedPtr msg)
       add_marker(velocity_text_marker_ptr);
     }
 
+    // Get marker for acceleration text
+    geometry_msgs::msg::Point acc_vis_position;
+    acc_vis_position.x = uuid_vis_position.x - 1.0;
+    acc_vis_position.y = uuid_vis_position.y;
+    acc_vis_position.z = uuid_vis_position.z - 1.0;
+    auto acceleration_text_marker = get_acceleration_text_marker_ptr(
+      object.kinematics.acceleration_with_covariance.accel, acc_vis_position,
+      object.classification);
+    if (acceleration_text_marker) {
+      auto acceleration_text_marker_ptr = acceleration_text_marker.value();
+      acceleration_text_marker_ptr->header = msg->header;
+      acceleration_text_marker_ptr->id = uuid_to_marker_id(object.object_id);
+      add_marker(acceleration_text_marker_ptr);
+    }
+
     // Get marker for twist
     auto twist_marker = get_twist_marker_ptr(
       object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance);


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

add accel visualization for predicted/tracked objects on rviz
<!-- Write a brief description of this PR. -->

![image](https://user-images.githubusercontent.com/20228327/195039321-dfb77ea5-5e96-4ed3-91b5-0dedf109f9da.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
