### PR TITLE
feat(behavior_path_planner): add start shift length

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -203,9 +203,6 @@ using ObjectDataArray = std::vector<ObjectData>;
  */
 struct AvoidLine : public ShiftLine
 {
-  // relative shift length from start to end point
-  double start_length = 0.0;
-
   // Distance from ego to start point in Frenet
   double start_longitudinal = 0.0;
 
@@ -221,7 +218,7 @@ struct AvoidLine : public ShiftLine
   // corresponding object
   ObjectData object{};
 
-  double getRelativeLength() const { return end_shift_length - start_length; }
+  double getRelativeLength() const { return end_shift_length - start_shift_length; }
 
   double getRelativeLongitudinal() const { return end_longitudinal - start_longitudinal; }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -58,7 +58,7 @@ void setEndData(
   const double end_dist);
 
 void setStartData(
-  AvoidLine & al, const double start_length, const geometry_msgs::msg::Pose & start,
+  AvoidLine & al, const double start_shift_length, const geometry_msgs::msg::Pose & start,
   const size_t start_idx, const double start_dist);
 
 std::string getUuidStr(const ObjectData & obj);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/utils/path_shifter.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/utils/path_shifter.hpp
@@ -39,8 +39,12 @@ struct ShiftLine
 {
   Pose start{};  // shift start point in absolute coordinate
   Pose end{};    // shift start point in absolute coordinate
-  double
-    end_shift_length{};  // absolute shift length at the end point related to the reference path
+
+  // relative shift length at the start point related to the reference path
+  double start_shift_length{};
+
+  // relative shift length at the end point related to the reference path
+  double end_shift_length{};
 
   size_t start_idx{};  // associated start-point index for the reference path
   size_t end_idx{};    // associated end-point index for the reference path

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -94,7 +94,7 @@ double lerpShiftLengthOnArc(double arc, const AvoidLine & ap)
       return ap.end_shift_length;
     }
     const auto start_weight = (ap.end_longitudinal - arc) / ap.getRelativeLongitudinal();
-    return start_weight * ap.start_length + (1.0 - start_weight) * ap.end_shift_length;
+    return start_weight * ap.start_shift_length + (1.0 - start_weight) * ap.end_shift_length;
   }
   return 0.0;
 }
@@ -178,10 +178,10 @@ void setEndData(
 }
 
 void setStartData(
-  AvoidLine & ap, const double start_length, const geometry_msgs::msg::Pose & start,
+  AvoidLine & ap, const double start_shift_length, const geometry_msgs::msg::Pose & start,
   const size_t start_idx, const double start_dist)
 {
-  ap.start_length = start_length;
+  ap.start_shift_length = start_shift_length;
   ap.start = start;
   ap.start_idx = start_idx;
   ap.start_longitudinal = start_dist;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -57,7 +57,7 @@ MarkerArray createAvoidLineMarkerArray(
       marker_s.id = id++;
       marker_s.pose = sl.start;
       // shiftPose(&marker_s.pose, current_shift);  // old
-      shiftPose(&marker_s.pose, sl.start_length);
+      shiftPose(&marker_s.pose, sl.start_shift_length);
       msg.markers.push_back(marker_s);
 
       // end point
@@ -208,8 +208,8 @@ std::string toStrInfo(const behavior_path_planner::AvoidLine & ap)
   ss << "id = " << ap.id << ", shift length: " << ap.end_shift_length
      << ", start_idx: " << ap.start_idx << ", end_idx: " << ap.end_idx
      << ", start_dist = " << ap.start_longitudinal << ", end_dist = " << ap.end_longitudinal
-     << ", start_length: " << ap.start_length << ", start: (" << ps.x << ", " << ps.y << "), end: ("
-     << pe.x << ", " << pe.y << "), relative_length: " << ap.getRelativeLength()
+     << ", start_shift_length: " << ap.start_shift_length << ", start: (" << ps.x << ", " << ps.y
+     << "), end: (" << pe.x << ", " << pe.y << "), relative_length: " << ap.getRelativeLength()
      << ", grad = " << ap.getGradient() << ", parent_ids = [" << pids.str() << "]";
   return ss.str();
 }


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
Add start shift length to enable it to have shift length at the start point of the segment of the shifted segment.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
