### PR TITLE
feat(motion_velocity_smoother): change max_lateral_accel from 0.8 to 1.0

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/common/motion_velocity_smoother/motion_velocity_smoother.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/common/motion_velocity_smoother/motion_velocity_smoother.param.yaml
@@ -8,7 +8,7 @@
     margin_to_insert_external_velocity_limit: 0.3   #  margin distance to insert external velocity limit [m]
 
     # curve parameters
-    max_lateral_accel: 0.8             # max lateral acceleration limit [m/ss]
+    max_lateral_accel: 1.0             # max lateral acceleration limit [m/ss]
     min_curve_velocity: 0.5            # min velocity at lateral acceleration limit and steering angle rate limit [m/s]
     decel_distance_before_curve: 3.5   # slow speed distance before a curve for lateral acceleration limit
     decel_distance_after_curve: 2.0    # slow speed distance after a curve for lateral acceleration limit


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
This PR increases the value of the `max_lateral_accel` parameter in the `motion_velocity_smoother` node. allowing to drive at higher velocities in curves.

The current value of `0.8` m/s² is very conservative to avoid situations where the ego vehicle would drive too fast when close to some obstacles (e.g., guard rail) in curves. This PR changes the value to `1.0` m/s².

A new node (https://github.com/autowarefoundation/autoware.universe/pull/1579) can be used to limit the velocity when driving near obstacles.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
