### PR TITLE
fix(osqp_interface): fix memory leak

### DIFF
--- a/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
+++ b/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
@@ -78,6 +78,7 @@ public:
   OSQPInterface(
     const CSC_Matrix & P, const CSC_Matrix & A, const std::vector<float64_t> & q,
     const std::vector<float64_t> & l, const std::vector<float64_t> & u, const c_float eps_abs);
+  ~OSQPInterface();
 
   /****************
    * OPTIMIZATION

--- a/common/osqp_interface/src/osqp_interface.cpp
+++ b/common/osqp_interface/src/osqp_interface.cpp
@@ -68,6 +68,12 @@ OSQPInterface::OSQPInterface(
   initializeProblem(P, A, q, l, u);
 }
 
+OSQPInterface::~OSQPInterface()
+{
+  if (m_data->P) free(m_data->P);
+  if (m_data->A) free(m_data->A);
+}
+
 void OSQPInterface::OSQPWorkspaceDeleter(OSQPWorkspace * ptr) noexcept
 {
   if (ptr != nullptr) {
@@ -261,10 +267,12 @@ int64_t OSQPInterface::initializeProblem(
    * POPULATE DATA
    *****************/
   m_data->n = m_param_n;
+  if (m_data->P) free(m_data->P);
   m_data->P = csc_matrix(
     m_data->n, m_data->n, static_cast<c_int>(P_csc.m_vals.size()), P_csc.m_vals.data(),
     P_csc.m_row_idxs.data(), P_csc.m_col_idxs.data());
   m_data->q = q_dyn;
+  if (m_data->A) free(m_data->A);
   m_data->A = csc_matrix(
     m_data->m, m_data->n, static_cast<c_int>(A_csc.m_vals.size()), A_csc.m_vals.data(),
     A_csc.m_row_idxs.data(), A_csc.m_col_idxs.data());


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
Fix a memory leak detected in the `trajectory_follower` (https://github.com/autowarefoundation/autoware.universe/issues/2047).

This PR implements the solution proposed by @VRichardJP https://github.com/autowarefoundation/autoware.universe/issues/2047#issuecomment-1276954312.
- Delete each `csc_matrix` before assigning a new one.
- Delete each `csc_matrix` when the `OSQPInterface` is deleted.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
