### PR TITLE
feat(autoware_auto_perception_rviz_plugin): rviz predicted objects multi-threading

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -127,6 +127,11 @@ public:
     m_marker_common.addMessage(marker_ptr);
   }
 
+  void add_marker(visualization_msgs::msg::MarkerArray::ConstSharedPtr markers_ptr)
+  {
+    m_marker_common.addMessage(markers_ptr);
+  }
+
 protected:
   /// \brief Convert given shape msg into a Marker
   /// \tparam ClassificationContainerT List type with ObjectClassificationMsg

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
@@ -18,12 +18,14 @@
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 
+#include <boost/functional/hash.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
+#include <condition_variable>
 #include <list>
-#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware
@@ -93,10 +95,23 @@ private:
     return id_map.at(uuid);
   }
 
-  std::map<boost::uuids::uuid, int32_t> id_map;
+  std::vector<visualization_msgs::msg::Marker::SharedPtr> createMarkers(
+    PredictedObjects::ConstSharedPtr msg);
+  void workerThread();
+
+  void update(float wall_dt, float ros_dt) override;
+
+  std::unordered_map<boost::uuids::uuid, int32_t, boost::hash<boost::uuids::uuid>> id_map;
+  // std::unordered_map<boost::uuids::uuid, int32_t> id_map;
   std::list<int32_t> unused_marker_ids;
   int32_t marker_id = 0;
   const int32_t PATH_ID_CONSTANT = 1e3;
+
+  PredictedObjects::ConstSharedPtr msg;
+  bool consumed{false};
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::vector<visualization_msgs::msg::Marker::SharedPtr> markers;
 };
 
 }  // namespace object_detection

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -30,7 +30,7 @@ PredictedObjectsDisplay::PredictedObjectsDisplay() : ObjectPolygonDisplayBase("t
 
 void PredictedObjectsDisplay::workerThread()
 {
-  for (;;) {
+  while (true) {
     std::unique_lock<std::mutex> lock(mutex);
     condition.wait(lock, [this] { return this->msg; });
 
@@ -179,7 +179,7 @@ void PredictedObjectsDisplay::update(float wall_dt, float ros_dt)
 {
   std::unique_lock<std::mutex> lock(mutex);
 
-  if (markers.size() > 0) {
+  if (!markers.empty()) {
     clear_markers();
 
     for (const auto & marker : markers) {

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -22,12 +22,37 @@ namespace rviz_plugins
 {
 namespace object_detection
 {
-PredictedObjectsDisplay::PredictedObjectsDisplay() : ObjectPolygonDisplayBase("tracks") {}
-
-void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr msg)
+PredictedObjectsDisplay::PredictedObjectsDisplay() : ObjectPolygonDisplayBase("tracks")
 {
-  clear_markers();
+  std::thread worker(&PredictedObjectsDisplay::workerThread, this);
+  worker.detach();
+}
+
+void PredictedObjectsDisplay::workerThread()
+{
+  for (;;) {
+    std::unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock, [this] { return this->msg; });
+
+    auto tmp_msg = this->msg;
+    this->msg.reset();
+
+    lock.unlock();
+
+    auto tmp_markers = createMarkers(tmp_msg);
+    lock.lock();
+    markers = tmp_markers;
+
+    consumed = true;
+  }
+}
+
+std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay::createMarkers(
+  PredictedObjects::ConstSharedPtr msg)
+{
   update_id_map(msg);
+
+  std::vector<visualization_msgs::msg::Marker::SharedPtr> markers;
 
   for (const auto & object : msg->objects) {
     // Get marker for shape
@@ -39,7 +64,7 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
       auto shape_marker_ptr = shape_marker.value();
       shape_marker_ptr->header = msg->header;
       shape_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      add_marker(shape_marker_ptr);
+      markers.push_back(shape_marker_ptr);
     }
 
     // Get marker for label
@@ -50,7 +75,7 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
       auto label_marker_ptr = label_marker.value();
       label_marker_ptr->header = msg->header;
       label_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      add_marker(label_marker_ptr);
+      markers.push_back(label_marker_ptr);
     }
 
     // Get marker for id
@@ -65,7 +90,7 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
       auto id_marker_ptr = id_marker.value();
       id_marker_ptr->header = msg->header;
       id_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      add_marker(id_marker_ptr);
+      markers.push_back(id_marker_ptr);
     }
 
     // Get marker for pose with covariance
@@ -75,7 +100,7 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
       auto pose_with_covariance_marker_ptr = pose_with_covariance_marker.value();
       pose_with_covariance_marker_ptr->header = msg->header;
       pose_with_covariance_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      add_marker(pose_with_covariance_marker_ptr);
+      markers.push_back(pose_with_covariance_marker_ptr);
     }
 
     // Get marker for velocity text
@@ -90,7 +115,7 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
       auto velocity_text_marker_ptr = velocity_text_marker.value();
       velocity_text_marker_ptr->header = msg->header;
       velocity_text_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      add_marker(velocity_text_marker_ptr);
+      markers.push_back(velocity_text_marker_ptr);
     }
 
     // Get marker for twist
@@ -101,7 +126,7 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
       auto twist_marker_ptr = twist_marker.value();
       twist_marker_ptr->header = msg->header;
       twist_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      add_marker(twist_marker_ptr);
+      markers.push_back(twist_marker_ptr);
     }
 
     // Add marker for each candidate path
@@ -115,8 +140,8 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
         predicted_path_marker_ptr->header = msg->header;
         predicted_path_marker_ptr->id =
           uuid_to_marker_id(object.object_id) + path_count * PATH_ID_CONSTANT;
-        add_marker(predicted_path_marker_ptr);
         path_count++;
+        markers.push_back(predicted_path_marker_ptr);
       }
     }
 
@@ -133,11 +158,41 @@ void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr ms
         path_confidence_marker_ptr->header = msg->header;
         path_confidence_marker_ptr->id =
           uuid_to_marker_id(object.object_id) + path_count * PATH_ID_CONSTANT;
-        add_marker(path_confidence_marker_ptr);
         path_count++;
+        markers.push_back(path_confidence_marker_ptr);
       }
     }
   }
+
+  return markers;
+}
+
+void PredictedObjectsDisplay::processMessage(PredictedObjects::ConstSharedPtr msg)
+{
+  std::unique_lock<std::mutex> lock(mutex);
+
+  this->msg = msg;
+  condition.notify_one();
+}
+
+void PredictedObjectsDisplay::update(float wall_dt, float ros_dt)
+{
+  std::unique_lock<std::mutex> lock(mutex);
+
+  if (markers.size() > 0) {
+    clear_markers();
+
+    for (const auto & marker : markers) {
+      add_marker(marker);
+    }
+
+    markers.clear();
+  }
+
+  lock.unlock();
+
+  ObjectPolygonDisplayBase<autoware_auto_perception_msgs::msg::PredictedObjects>::update(
+    wall_dt, ros_dt);
 }
 
 }  // namespace object_detection


### PR DESCRIPTION
## Description
When the number of predicted objects is large, Rviz's Hz drops significantly and drawing stops, so I multithreaded the visualization of predicted objects.

![image](https://user-images.githubusercontent.com/59680180/195564803-817dc190-c5ab-420c-be33-484d48bdfc22.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
