### PR TITLE
refactor(intersection): code clean

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -138,8 +138,7 @@ private:
   bool checkCollision(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-    const lanelet::ConstLanelets & detection_area_lanelets,
-    const lanelet::ConstLanelets & adjacent_lanelets,
+    lanelet::ConstLanelets & detection_area_lanelets, lanelet::ConstLanelets & adjacent_lanelets,
     const std::optional<Polygon2d> & intersection_area,
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr,
     const int closest_idx, const Polygon2d & stuck_vehicle_detect_area);
@@ -222,7 +221,7 @@ private:
    * @return true if the given pose belongs to any target lanelet
    */
   bool checkAngleForTargetLanelets(
-    const geometry_msgs::msg::Pose & pose, const std::vector<int> & target_lanelet_ids,
+    const geometry_msgs::msg::Pose & pose, lanelet::ConstLanelets & target_lanelet_ids,
     const double margin = 0);
 
   /**

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -138,7 +138,8 @@ private:
   bool checkCollision(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-    lanelet::ConstLanelets & detection_area_lanelets, lanelet::ConstLanelets & adjacent_lanelets,
+    const lanelet::ConstLanelets & detection_area_lanelets,
+    const lanelet::ConstLanelets & adjacent_lanelets,
     const std::optional<Polygon2d> & intersection_area,
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr,
     const int closest_idx, const Polygon2d & stuck_vehicle_detect_area);
@@ -221,7 +222,7 @@ private:
    * @return true if the given pose belongs to any target lanelet
    */
   bool checkAngleForTargetLanelets(
-    const geometry_msgs::msg::Pose & pose, lanelet::ConstLanelets & target_lanelet_ids,
+    const geometry_msgs::msg::Pose & pose, const lanelet::ConstLanelets & target_lanelet_ids,
     const double margin = 0);
 
   /**

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -138,8 +138,8 @@ private:
   bool checkCollision(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-    const std::vector<int> & detection_area_lanelet_ids,
-    const std::vector<int> & adjacent_lanelet_ids,
+    const lanelet::ConstLanelets & detection_area_lanelets,
+    const lanelet::ConstLanelets & adjacent_lanelets,
     const std::optional<Polygon2d> & intersection_area,
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr,
     const int closest_idx, const Polygon2d & stuck_vehicle_detect_area);

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -110,9 +110,9 @@ int getFirstPointInsidePolygons(
  * @param stop_pose stop point defined on map
  * @return true when the stop point is defined on map.
  */
-bool getStopPoseIndexFromMap(
+bool getStopLineIndexFromMap(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int lane_id,
-  const std::shared_ptr<const PlannerData> & planner_data, int & stop_idx_ip, int dist_thr,
+  const std::shared_ptr<const PlannerData> & planner_data, int * stop_idx_ip, int dist_thr,
   const rclcpp::Logger logger);
 
 std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLaneletsVec(
@@ -122,10 +122,6 @@ std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLanelets(
   const lanelet::ConstLanelets & ll_vec, double clip_length);
 
 std::vector<int> getLaneletIdsFromLaneletsVec(const std::vector<lanelet::ConstLanelets> & ll_vec);
-
-lanelet::ConstLanelet generateOffsetLanelet(
-  const lanelet::ConstLanelet lanelet, double right_margin, double left_margin);
-geometry_msgs::msg::Pose toPose(const geometry_msgs::msg::Point & p);
 
 /**
  * @brief check if ego is over the target_idx. If the index is same, compare the exact pose
@@ -142,7 +138,7 @@ bool isBeforeTargetIndex(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
   const geometry_msgs::msg::Pose & current_pose, const int target_idx);
 
-std::vector<int> extendedAdjacentDirectionLanes(
+lanelet::ConstLanelets extendedAdjacentDirectionLanes(
   const lanelet::LaneletMapPtr map, const lanelet::routing::RoutingGraphPtr routing_graph,
   lanelet::ConstLanelet lane);
 

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace behavior_velocity_planner
@@ -48,10 +49,9 @@ bool getDuplicatedPointIdx(
 /**
  * @brief get objective polygons for detection area
  */
-bool getDetectionLanelets(
+std::tuple<lanelet::ConstLanelets, lanelet::ConstLanelets> getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
-  const int lane_id, const double detection_area_length,
-  lanelet::ConstLanelets * detection_lanelets_result, const bool tl_arrow_solid_on = false);
+  const int lane_id, const double detection_area_length, const bool tl_arrow_solid_on = false);
 
 struct StopLineIdx
 {

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -121,7 +121,14 @@ std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLaneletsVec(
 std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLanelets(
   const lanelet::ConstLanelets & ll_vec, double clip_length);
 
+std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLanelets(
+  const lanelet::ConstLanelets & ll_vec);
+
 std::vector<int> getLaneletIdsFromLaneletsVec(const std::vector<lanelet::ConstLanelets> & ll_vec);
+
+lanelet::ConstLanelet generateOffsetLanelet(
+  const lanelet::ConstLanelet lanelet, double right_margin, double left_margin);
+geometry_msgs::msg::Pose toPose(const geometry_msgs::msg::Point & p);
 
 /**
  * @brief check if ego is over the target_idx. If the index is same, compare the exact pose

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -70,7 +70,7 @@ struct StopLineIdx
  * lane)
  * @param stop_line_idx   generated stop line index
  * @param pass_judge_line_idx  generated stop line index
- * @return false when generation failed
+ * @return false when path is not intersecting with detection area, or stop_line is behind path[0]
  */
 bool generateStopLine(
   const int lane_id, const std::vector<lanelet::CompoundPolygon3d> detection_areas,

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -85,7 +85,7 @@ bool IntersectionModule::modifyPathVelocity(
     logger_, "lane_id = %ld, state = %s", lane_id_, StateMachine::toString(current_state).c_str());
 
   /* get current pose */
-  geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
+  const geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
 
   /* get lanelet map */
   const auto lanelet_map_ptr = planner_data_->route_handler_->getLaneletMapPtr();
@@ -95,23 +95,22 @@ bool IntersectionModule::modifyPathVelocity(
     planner_data_->route_handler_->getLaneletMapPtr()->laneletLayer.get(lane_id_);
 
   /* get detection area*/
-  lanelet::ConstLanelets detection_area_lanelets;
+  /* dynamically change detection area based on tl_arrow_solid_on */
   const bool tl_arrow_solid_on =
     util::isTrafficLightArrowActivated(assigned_lanelet, planner_data_->traffic_light_id_map);
+  lanelet::ConstLanelets detection_area_lanelets;
   util::getDetectionLanelets(
     lanelet_map_ptr, routing_graph_ptr, lane_id_, planner_param_.detection_area_length,
     &detection_area_lanelets, tl_arrow_solid_on);
-  std::vector<lanelet::CompoundPolygon3d> detection_areas =
-    util::getPolygon3dFromLanelets(detection_area_lanelets, planner_param_.detection_area_length);
-  std::vector<int> detection_area_lanelet_ids =
-    util::getLaneletIdsFromLaneletsVec({detection_area_lanelets});
-
-  if (detection_areas.empty()) {
+  if (detection_areas_lanelets.empty()) {
     RCLCPP_DEBUG(logger_, "no detection area. skip computation.");
     setSafe(true);
     setDistance(std::numeric_limits<double>::lowest());
     return true;
   }
+  const std::vector<lanelet::CompoundPolygon3d> detection_areas =
+    util::getPolygon3dFromLanelets(detection_area_lanelets, planner_param_.detection_area_length);
+
   debug_data_.detection_area = detection_areas;
 
   /* get intersection area */
@@ -122,12 +121,8 @@ bool IntersectionModule::modifyPathVelocity(
   }
 
   /* get adjacent lanelets */
-  const auto adjacent_lanelet_ids =
+  const auto adjacent_lanelets =
     util::extendedAdjacentDirectionLanes(lanelet_map_ptr, routing_graph_ptr, assigned_lanelet);
-  std::vector<lanelet::CompoundPolygon3d> adjacent_lanes;
-  for (auto && adjacent_lanelet_id : adjacent_lanelet_ids) {
-    adjacent_lanes.push_back(lanelet_map_ptr->laneletLayer.get(adjacent_lanelet_id).polygon3d());
-  }
   debug_data_.adjacent_area = adjacent_lanes;
 
   /* set stop-line and stop-judgement-line for base_link */
@@ -146,13 +141,6 @@ bool IntersectionModule::modifyPathVelocity(
   const int stop_line_idx = stop_line_idxs.stop_line_idx;
   const int pass_judge_line_idx = stop_line_idxs.pass_judge_line_idx;
   const int keep_detection_line_idx = stop_line_idxs.keep_detection_line_idx;
-  if (stop_line_idx <= 0) {
-    RCLCPP_DEBUG(logger_, "stop line line is at path[0], ignore planning.");
-    RCLCPP_DEBUG(logger_, "===== plan end =====");
-    setSafe(true);
-    setDistance(std::numeric_limits<double>::lowest());
-    return true;
-  }
 
   /* calc closest index */
   const auto closest_idx_opt =
@@ -185,6 +173,7 @@ bool IntersectionModule::modifyPathVelocity(
         "continue planning");
       // no return here, keep planning
     } else if (is_go_out_ && !external_stop) {
+      // TODO(Mamoru Sobue): refactor this block
       RCLCPP_DEBUG(logger_, "over the keep_detection line and not low speed. no plan needed.");
       RCLCPP_DEBUG(logger_, "===== plan end =====");
       setSafe(true);
@@ -206,7 +195,7 @@ bool IntersectionModule::modifyPathVelocity(
     planner_param_.stuck_vehicle_detect_dist);
   bool is_stuck = checkStuckVehicleInIntersection(objects_ptr, stuck_vehicle_detect_area);
   bool has_collision = checkCollision(
-    lanelet_map_ptr, *path, detection_area_lanelet_ids, adjacent_lanelet_ids, intersection_area,
+    lanelet_map_ptr, *path, detection_area_lanelets, adjacent_lanelets, intersection_area,
     objects_ptr, closest_idx, stuck_vehicle_detect_area);
   bool is_entry_prohibited = (has_collision || is_stuck);
   if (external_go) {
@@ -226,10 +215,12 @@ bool IntersectionModule::modifyPathVelocity(
     path->points.at(stop_line_idx).point.pose.position));
 
   if (!isActivated()) {
+    // if RTC says intersection entry is 'dangerous', insert stop_line(v == 0.0) in this block
     constexpr double v = 0.0;
     is_go_out_ = false;
     int stop_line_idx_stop = stop_line_idx;
     int pass_judge_line_idx_stop = pass_judge_line_idx;
+    // TODO(Mamoru Sobue): refactor this block
     if (planner_param_.use_stuck_stopline && is_stuck) {
       int stuck_stop_line_idx = -1;
       int stuck_pass_judge_line_idx = -1;
@@ -291,8 +282,9 @@ void IntersectionModule::cutPredictPathWithDuration(
 bool IntersectionModule::checkCollision(
   lanelet::LaneletMapConstPtr lanelet_map_ptr,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const std::vector<int> & detection_area_lanelet_ids,
-  const std::vector<int> & adjacent_lanelet_ids, const std::optional<Polygon2d> & intersection_area,
+  const lanelet::ConstLanelets & detection_area_lanelets,
+  const lanelet::ConstLanelets & adjacent_lanelets,
+  const std::optional<Polygon2d> & intersection_area,
   const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr,
   const int closest_idx, const Polygon2d & stuck_vehicle_detect_area)
 {
@@ -340,18 +332,17 @@ bool IntersectionModule::checkCollision(
       const auto intersection_area_2d = intersection_area.value();
       const auto is_in_intersection_area = bg::within(obj_poly, intersection_area_2d);
       const auto is_in_adjacent_lanelets = checkAngleForTargetLanelets(
-        object_direction, adjacent_lanelet_ids, planner_param_.detection_area_margin);
+        object_direction, adjacent_lanelets, planner_param_.detection_area_margin);
       if (is_in_adjacent_lanelets) continue;
       if (is_in_intersection_area) {
         target_objects.objects.push_back(object);
       } else if (checkAngleForTargetLanelets(
-                   object_direction, detection_area_lanelet_ids,
+                   object_direction, detection_area_lanelets,
                    planner_param_.detection_area_margin)) {
         target_objects.objects.push_back(object);
       }
     } else if (checkAngleForTargetLanelets(
-                 object_direction, detection_area_lanelet_ids,
-                 planner_param_.detection_area_margin)) {
+                 object_direction, detection_area_lanelets, planner_param_.detection_area_margin)) {
       // intersection_area is not available, use detection_area_with_margin as before
       target_objects.objects.push_back(object);
     }
@@ -636,11 +627,10 @@ bool IntersectionModule::isTargetExternalInputStatus(const int target_status)
 }
 
 bool IntersectionModule::checkAngleForTargetLanelets(
-  const geometry_msgs::msg::Pose & pose, const std::vector<int> & target_lanelet_ids,
+  const geometry_msgs::msg::Pose & pose, const lanelet::ConstLanelets & target_lanelets,
   const double margin)
 {
-  for (const int lanelet_id : target_lanelet_ids) {
-    const auto ll = planner_data_->route_handler_->getLaneletMapPtr()->laneletLayer.get(lanelet_id);
+  for (const auto & ll : target_lanelets) {
     if (!lanelet::utils::isInLanelet(pose, ll, margin)) {
       continue;
     }

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -102,7 +102,7 @@ bool IntersectionModule::modifyPathVelocity(
   util::getDetectionLanelets(
     lanelet_map_ptr, routing_graph_ptr, lane_id_, planner_param_.detection_area_length,
     &detection_area_lanelets, tl_arrow_solid_on);
-  if (detection_areas_lanelets.empty()) {
+  if (detection_area_lanelets.empty()) {
     RCLCPP_DEBUG(logger_, "no detection area. skip computation.");
     setSafe(true);
     setDistance(std::numeric_limits<double>::lowest());
@@ -121,9 +121,9 @@ bool IntersectionModule::modifyPathVelocity(
   }
 
   /* get adjacent lanelets */
-  const auto adjacent_lanelets =
+  auto adjacent_lanelets =
     util::extendedAdjacentDirectionLanes(lanelet_map_ptr, routing_graph_ptr, assigned_lanelet);
-  debug_data_.adjacent_area = adjacent_lanes;
+  debug_data_.adjacent_area = util::getPolygon3dFromLanelets(adjacent_lanelets);
 
   /* set stop-line and stop-judgement-line for base_link */
   util::StopLineIdx stop_line_idxs;
@@ -282,8 +282,7 @@ void IntersectionModule::cutPredictPathWithDuration(
 bool IntersectionModule::checkCollision(
   lanelet::LaneletMapConstPtr lanelet_map_ptr,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const lanelet::ConstLanelets & detection_area_lanelets,
-  const lanelet::ConstLanelets & adjacent_lanelets,
+  lanelet::ConstLanelets & detection_area_lanelets, lanelet::ConstLanelets & adjacent_lanelets,
   const std::optional<Polygon2d> & intersection_area,
   const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr,
   const int closest_idx, const Polygon2d & stuck_vehicle_detect_area)
@@ -627,7 +626,7 @@ bool IntersectionModule::isTargetExternalInputStatus(const int target_status)
 }
 
 bool IntersectionModule::checkAngleForTargetLanelets(
-  const geometry_msgs::msg::Pose & pose, const lanelet::ConstLanelets & target_lanelets,
+  const geometry_msgs::msg::Pose & pose, lanelet::ConstLanelets & target_lanelets,
   const double margin)
 {
   for (const auto & ll : target_lanelets) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -86,6 +86,7 @@ bool IntersectionModule::modifyPathVelocity(
 
   /* get current pose */
   const geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
+  const double current_vel = planner_data_->current_velocity->twist.linear.x;
 
   /* get lanelet map */
   const auto lanelet_map_ptr = planner_data_->route_handler_->getLaneletMapPtr();
@@ -163,9 +164,9 @@ bool IntersectionModule::modifyPathVelocity(
      */
     const bool is_before_keep_detection_line =
       util::isBeforeTargetIndex(*path, closest_idx, current_pose.pose, keep_detection_line_idx);
-    if (
-      is_before_keep_detection_line && std::fabs(planner_data_->current_velocity->twist.linear.x) <
-                                         planner_param_.keep_detection_vel_thr) {
+    const bool keep_detection = is_before_keep_detection_line &&
+                                std::fabs(current_vel) < planner_param_.keep_detection_vel_thr;
+    if (keep_detection) {
       RCLCPP_DEBUG(
         logger_,
         "over the pass judge line, but before keep detection line and low speed, "

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -131,8 +131,13 @@ bool generateStopLine(
   const double pass_judge_line_dist = planning_utils::calcJudgeLineDistWithJerkLimit(
     current_vel, current_acc, max_acc, max_jerk, delay_response_time);
 
-  /* set parameters */
+  /* spline interpolation */
   constexpr double interval = 0.2;
+  autoware_auto_planning_msgs::msg::PathWithLaneId path_ip;
+  // TODO(Mamoru Sobue): crop only intersection part of path for computation cost
+  if (!splineInterpolate(target_path, interval, path_ip, logger)) {
+    return false;
+  }
 
   const int stop_line_margin_idx_dist = std::ceil(stop_line_margin / interval);
   const int keep_detection_line_margin_idx_dist = std::ceil(keep_detection_line_margin / interval);
@@ -140,69 +145,45 @@ bool generateStopLine(
     std::ceil(planner_data->vehicle_info_.max_longitudinal_offset_m / interval);
   const int pass_judge_idx_dist = std::ceil(pass_judge_line_dist / interval);
 
-  /* spline interpolation */
-  autoware_auto_planning_msgs::msg::PathWithLaneId path_ip;
-  if (!splineInterpolate(target_path, interval, path_ip, logger)) {
-    return false;
-  }
-
-  int first_idx_inside_lane = -1;
-  int pass_judge_line_idx = -1;
-  int stop_line_idx = -1;
-  int keep_detection_line_idx = -1;
   /* generate stop point */
-  // If a stop_line is defined in lanelet_map, use it.
-  // else, generates a local stop_line with considering the lane conflicts.
-  int first_idx_ip_inside_lane;  // first stop point index for interpolated path.
-  int stop_idx_ip;               // stop point index for interpolated path.
-  if (getStopPoseIndexFromMap(path_ip, lane_id, planner_data, stop_idx_ip, 10.0, logger)) {
+  // If a stop_line tag is defined on lanelet_map, use it.
+  // else generate a stop_line behind the intersection of path and detection area (by margin
+  // stop_line_margin).
+  // stop point index for interpolated(ip) path.
+  int stop_idx_ip;
+  if (getStopLineIndexFromMap(path_ip, lane_id, planner_data, &stop_idx_ip, 10.0, logger)) {
     stop_idx_ip = std::max(stop_idx_ip - base2front_idx_dist, 0);
   } else {
-    // get idx of first_inside_lane point
-    first_idx_ip_inside_lane = getFirstPointInsidePolygons(path_ip, detection_areas);
-    if (first_idx_ip_inside_lane == -1) {
-      RCLCPP_DEBUG(logger, "generate stopline, but no intersect line found.");
+    // find the index of the first point that intersects with detection_areas
+    const int first_ip_idx_in_detection_area =
+      getFirstPointInsidePolygons(path_ip, detection_areas);
+    // if path is not intersecting with detection_area, skip
+    if (first_ip_idx_in_detection_area == -1) {
+      RCLCPP_DEBUG(
+        logger, "Path is not intersecting with detection_area, not generating stop_line");
       return false;
     }
-    // only for visualization
-    const auto first_inside_point = path_ip.points.at(first_idx_ip_inside_lane).point.pose;
+    stop_idx_ip = std::max(
+      first_ip_idx_in_detection_area - 1 - stop_line_margin_idx_dist - base2front_idx_dist, 0);
+  }
 
-    const auto first_idx_inside_lane_opt =
-      motion_utils::findNearestIndex(original_path->points, first_inside_point, 10.0, M_PI_4);
-    if (first_idx_inside_lane_opt) {
-      first_idx_inside_lane = first_idx_inside_lane_opt.get();
-    }
-
-    if (first_idx_inside_lane == 0) {
-      RCLCPP_DEBUG(
-        logger,
-        "path[0] is already in the detection area. This happens if you have "
-        "already crossed the stop line or are very far from the intersection. Ignore computation.");
-      stop_line_idxs->first_idx_inside_lane = 0;
-      stop_line_idxs->pass_judge_line_idx = 0;
-      stop_line_idxs->stop_line_idx = 0;
-      stop_line_idxs->keep_detection_line_idx = 0;
-      return true;
-    }
-    stop_idx_ip =
-      std::max(first_idx_ip_inside_lane - 1 - stop_line_margin_idx_dist - base2front_idx_dist, 0);
+  if (stop_idx_ip == 0) {
+    RCLCPP_DEBUG(logger_, "stop line is at path[0], ignore planning.");
   }
 
   /* insert keep_detection_line */
   const int keep_detection_idx_ip = std::min(
     stop_idx_ip + keep_detection_line_margin_idx_dist, static_cast<int>(path_ip.points.size()) - 1);
-  const auto inserted_keep_detection_point = path_ip.points.at(keep_detection_idx_ip).point.pose;
-  if (!util::getDuplicatedPointIdx(
-        *original_path, inserted_keep_detection_point.position, &keep_detection_line_idx)) {
-    keep_detection_line_idx = util::insertPoint(inserted_keep_detection_point, original_path);
+  if (const auto inserted_point = path_ip.points.at(keep_detection_idx_ip).point.pose;
+      !util::getDuplicatedPointIdx(
+        *original_path, inserted_point.position, &keep_detection_line_idx)) {
+    keep_detection_line_idx = util::insertPoint(inserted_point, original_path);
   }
 
   /* insert stop_point */
-  const auto inserted_stop_point = path_ip.points.at(stop_idx_ip).point.pose;
-  // if path has too close (= duplicated) point to the stop point, do not insert it
-  // and consider the index of the duplicated point as stop_line_idx
-  if (!util::getDuplicatedPointIdx(*original_path, inserted_stop_point.position, &stop_line_idx)) {
-    stop_line_idx = util::insertPoint(inserted_stop_point, original_path);
+  if (const auto inserted_point = path_ip.points.at(stop_idx_ip).point.pose;
+      !util::getDuplicatedPointIdx(*original_path, inserted_point.position, &stop_line_idx)) {
+    stop_line_idx = util::insertPoint(inserted_point, original_path);
     ++keep_detection_line_idx;  // the index is incremented by judge stop line insertion
   }
 
@@ -218,15 +199,13 @@ bool generateStopLine(
   /* insert judge point */
   const int pass_judge_idx_ip = std::min(
     static_cast<int>(path_ip.points.size()) - 1, std::max(stop_idx_ip - pass_judge_idx_dist, 0));
-  if (has_prior_stopline || stop_idx_ip == pass_judge_idx_ip) {
+  if (has_prior_stopline || pass_judge_idx_ip == stop_idx_ip) {
     pass_judge_line_idx = stop_line_idx;
   } else {
-    const auto inserted_pass_judge_point = path_ip.points.at(pass_judge_idx_ip).point.pose;
-    // if path has too close (= duplicated) point to the pass judge point, do not insert it
-    // and consider the index of the duplicated point as pass_judge_line_idx
-    if (!util::getDuplicatedPointIdx(
-          *original_path, inserted_pass_judge_point.position, &pass_judge_line_idx)) {
-      pass_judge_line_idx = util::insertPoint(inserted_pass_judge_point, original_path);
+    if (const auto inserted_point = path_ip.points.at(pass_judge_idx_ip).point.pose;
+        !util::getDuplicatedPointIdx(
+          *original_path, inserted_point.position, &pass_judge_line_idx)) {
+      pass_judge_line_idx = util::insertPoint(inserted_point, original_path);
       ++stop_line_idx;            // stop index is incremented by judge line insertion
       ++keep_detection_line_idx;  // same.
     }
@@ -246,9 +225,9 @@ bool generateStopLine(
   return true;
 }
 
-bool getStopPoseIndexFromMap(
+bool getStopLineIndexFromMap(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int lane_id,
-  const std::shared_ptr<const PlannerData> & planner_data, int & stop_idx_ip, int dist_thr,
+  const std::shared_ptr<const PlannerData> & planner_data, int * stop_idx_ip, int dist_thr,
   const rclcpp::Logger logger)
 {
   lanelet::ConstLanelet lanelet =
@@ -316,12 +295,13 @@ bool getDetectionLanelets(
 {
   const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id);
 
-  const auto tl_regelems = assigned_lanelet.regulatoryElementsAs<lanelet::TrafficLight>();
-  bool has_tl = false;
-  if (tl_regelems.size() != 0) {
+  // retrieve a stopline associated with a traffic light
+  bool has_traffic_light = false;
+  if (const auto tl_regelems = assigned_lanelet.regulatoryElementsAs<lanelet::TrafficLight>();
+      tl_regelems.size() != 0) {
     const auto tl_regelem = tl_regelems.front();
     const auto stop_line_opt = tl_regelem->stopLine();
-    if (!!stop_line_opt) has_tl = true;
+    if (!!stop_line_opt) has_traffic_light = true;
   }
 
   const auto turn_direction = assigned_lanelet.attributeOr("turn_direction", "else");
@@ -360,18 +340,18 @@ bool getDetectionLanelets(
   const auto & conflicting_lanelets =
     lanelet::utils::getConflictingLanelets(routing_graph_ptr, assigned_lanelet);
 
-  lanelet::ConstLanelets detection_lanelets;  // final objective lanelets
+  // final objective lanelets
+  lanelet::ConstLanelets detection_lanelets;
 
   // exclude yield lanelets and ego lanelets from detection_lanelets
-  // if assigned lanelet is "straight" with traffic light, detection area is not necessary
-  if (turn_direction == std::string("straight") && has_tl) {
+  if (turn_direction == std::string("straight") && has_traffic_light) {
+    // if assigned lanelet is "straight" with traffic light, detection area is not necessary
   } else {
     // otherwise we need to know the priority from RightOfWay
     for (const auto & conflicting_lanelet : conflicting_lanelets) {
-      if (lanelet::utils::contains(yield_lanelets, conflicting_lanelet)) {
-        continue;
-      }
-      if (lanelet::utils::contains(ego_lanelets, conflicting_lanelet)) {
+      if (
+        lanelet::utils::contains(yield_lanelets, conflicting_lanelet) ||
+        lanelet::utils::contains(yield_lanelets, conflicting_lanelet)) {
         continue;
       }
       detection_lanelets.push_back(conflicting_lanelet);
@@ -406,19 +386,6 @@ bool getDetectionLanelets(
   return true;
 }
 
-std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLaneletsVec(
-  const std::vector<lanelet::ConstLanelets> & ll_vec, double clip_length)
-{
-  std::vector<lanelet::CompoundPolygon3d> p_vec;
-  for (const auto & ll : ll_vec) {
-    const double path_length = lanelet::utils::getLaneletLength3d(ll);
-    const auto polygon3d =
-      lanelet::utils::getPolygonFromArcLength(ll, path_length - clip_length, path_length);
-    p_vec.push_back(polygon3d);
-  }
-  return p_vec;
-}
-
 std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLanelets(
   const lanelet::ConstLanelets & ll_vec, double clip_length)
 {
@@ -432,42 +399,11 @@ std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLanelets(
   return p_vec;
 }
 
-std::vector<int> getLaneletIdsFromLaneletsVec(const std::vector<lanelet::ConstLanelets> & ll_vec)
+std::vector<int> getLaneletIdsFromLanelets(lanelet::ConstLanelets ll)
 {
   std::vector<int> id_list;
-  for (const auto & lls : ll_vec) {
-    for (const auto & ll : lls) {
-      id_list.emplace_back(ll.id());
-    }
-  }
+  for (const auto & l : ll) id_list.push_bac(l.id());
   return id_list;
-}
-
-lanelet::ConstLanelet generateOffsetLanelet(
-  const lanelet::ConstLanelet lanelet, double right_margin, double left_margin)
-{
-  lanelet::Points3d lefts, rights;
-
-  const double right_offset = right_margin;
-  const double left_offset = left_margin;
-  const auto offset_rightBound = lanelet::utils::getRightBoundWithOffset(lanelet, right_offset);
-  const auto offset_leftBound = lanelet::utils::getLeftBoundWithOffset(lanelet, left_offset);
-
-  const auto original_left_bound = offset_leftBound;
-  const auto original_right_bound = offset_rightBound;
-
-  for (const auto & pt : original_left_bound) {
-    lefts.push_back(lanelet::Point3d(pt));
-  }
-  for (const auto & pt : original_right_bound) {
-    rights.push_back(lanelet::Point3d(pt));
-  }
-  const auto left_bound = lanelet::LineString3d(lanelet::InvalId, lefts);
-  const auto right_bound = lanelet::LineString3d(lanelet::InvalId, rights);
-  auto lanelet_with_margin = lanelet::Lanelet(lanelet::InvalId, left_bound, right_bound);
-  const auto centerline = lanelet::utils::generateFineCenterline(lanelet_with_margin, 5.0);
-  lanelet_with_margin.setCenterline(centerline);
-  return std::move(lanelet_with_margin);
 }
 
 bool generateStopLineBeforeIntersection(
@@ -612,7 +548,7 @@ static std::vector<int> getAllAdjacentLanelets(
   return std::vector<int>(results.begin(), results.end());
 }
 
-std::vector<int> extendedAdjacentDirectionLanes(
+lanelet::ConstLanelets extendedAdjacentDirectionLanes(
   const lanelet::LaneletMapPtr map, const lanelet::routing::RoutingGraphPtr routing_graph,
   lanelet::ConstLanelet lane)
 {
@@ -620,7 +556,7 @@ std::vector<int> extendedAdjacentDirectionLanes(
   // lanelets are not sharing the LineStrings
   const std::string turn_direction = getTurnDirection(lane);
   if (turn_direction != "left" && turn_direction != "right" && turn_direction != "straight")
-    return std::vector<int>();
+    return {};
 
   std::set<int> previous_lanelet_ids;
   for (auto && previous_lanelet : routing_graph->previous(lane)) {
@@ -646,7 +582,11 @@ std::vector<int> extendedAdjacentDirectionLanes(
         following_turning_lanelets.insert(following_lanelet.id());
     }
   }
-  return std::vector<int>(following_turning_lanelets.begin(), following_turning_lanelets.end());
+  lanelet::ConstLanelets ret{};
+  for (auto && id : following_turning_lanelets) {
+    ret.push_back(map->laneletLayer.get(id));
+  }
+  return ret;
 }
 
 std::optional<Polygon2d> getIntersectionArea(
@@ -667,7 +607,7 @@ bool isTrafficLightArrowActivated(
   const std::map<int, autoware_auto_perception_msgs::msg::TrafficSignalStamped> & tl_infos)
 {
   const auto & turn_direction = lane.attributeOr("turn_direction", "else");
-  boost::optional<int> tl_id = boost::none;
+  std::optional<int> tl_id = std::nullopt;
   for (auto && tl_regelem : lane.regulatoryElementsAs<lanelet::TrafficLight>()) {
     tl_id = tl_regelem->id();
     break;
@@ -676,7 +616,7 @@ bool isTrafficLightArrowActivated(
     // this lane has no traffic light
     return false;
   }
-  const auto tl_info_it = tl_infos.find(tl_id.get());
+  const auto tl_info_it = tl_infos.find(tl_id.value());
   if (tl_info_it == tl_infos.end()) {
     // the info of this traffic light is not available
     return false;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -179,6 +179,7 @@ bool generateStopLine(
 
   if (stop_idx_ip == 0) {
     RCLCPP_DEBUG(logger, "stop line is at path[0], ignore planning.");
+    return false;
   }
 
   /* insert keep_detection_line */


### PR DESCRIPTION
## Description

Since the functionality is getting stable, this module can be refactored.

cc: @veqcc 

list of refactored points (improvement of computation time will be done in next PR)
- [X] renamed variable for simplicity
- [X] add `const`
- [X] deleted `vector<lanelet id>`, and use `vector<lanelet>`
- [ ] use planning_utils (TODO)
- [ ] cache lanelet stuff to lower computation cost (TODO)

## Tests performed

Checked in psim

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
