### PR TITLE
feat(rtc_interface): lock command update

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -67,6 +67,18 @@ public:
     return false;
   }
 
+  void lockRTCCommand() override
+  {
+    rtc_interface_left_.lockCommandUpdate();
+    rtc_interface_right_.lockCommandUpdate();
+  }
+
+  void unlockRTCCommand() override
+  {
+    rtc_interface_left_.unlockCommandUpdate();
+    rtc_interface_right_.unlockCommandUpdate();
+  }
+
 private:
   struct RegisteredShiftLine
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -73,6 +73,18 @@ public:
     return false;
   }
 
+  void lockRTCCommand() override
+  {
+    rtc_interface_left_.lockCommandUpdate();
+    rtc_interface_right_.lockCommandUpdate();
+  }
+
+  void unlockRTCCommand() override
+  {
+    rtc_interface_left_.unlockCommandUpdate();
+    rtc_interface_right_.unlockCommandUpdate();
+  }
+
 private:
   std::shared_ptr<LaneChangeParameters> parameters_;
   LaneChangeStatus status_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -234,6 +234,22 @@ public:
   }
   bool isWaitingApproval() const { return is_waiting_approval_; }
 
+  virtual void lockRTCCommand()
+  {
+    if (!rtc_interface_ptr_) {
+      return;
+    }
+    rtc_interface_ptr_->lockCommandUpdate();
+  }
+
+  virtual void unlockRTCCommand()
+  {
+    if (!rtc_interface_ptr_) {
+      return;
+    }
+    rtc_interface_ptr_->unlockCommandUpdate();
+  }
+
 private:
   std::string name_;
   rclcpp::Logger logger_;

--- a/planning/behavior_path_planner/src/scene_module/scene_module_bt_node_interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/scene_module_bt_node_interface.cpp
@@ -51,6 +51,7 @@ BT::NodeStatus SceneModuleBTNodeInterface::tick()
 
   const bool is_waiting_approval = !scene_module_->isActivated();
   if (is_waiting_approval && !is_lane_following) {
+    scene_module_->lockRTCCommand();
     try {
       // NOTE: Since BehaviorTreeCpp has an issue to shadow the exception reason thrown
       // in the TreeNode, catch and display it here until the issue is fixed.
@@ -66,12 +67,14 @@ BT::NodeStatus SceneModuleBTNodeInterface::tick()
         scene_module_->getLogger(), "behavior module has failed with exception: " << e.what());
       // std::exit(EXIT_FAILURE);  // TODO(Horibe) do appropriate handing
     }
+    scene_module_->unlockRTCCommand();
     return BT::NodeStatus::SUCCESS;
   }
 
   while (rclcpp::ok()) {
     // NOTE: Since BehaviorTreeCpp has an issue to shadow the exception reason thrown
     // in the TreeNode, catch and display it here until the issue is fixed.
+    scene_module_->lockRTCCommand();
     try {
       auto res = setOutput<BehaviorModuleOutput>("output", scene_module_->run());
       if (!res) {
@@ -97,6 +100,7 @@ BT::NodeStatus SceneModuleBTNodeInterface::tick()
       break;
     }
 
+    scene_module_->unlockRTCCommand();
     setStatusRunningAndYield();
   }
 

--- a/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
+++ b/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
@@ -55,6 +55,8 @@ public:
   void clearCooperateStatus();
   bool isActivated(const UUID & uuid);
   bool isRegistered(const UUID & uuid);
+  void lockCommandUpdate();
+  void unlockCommandUpdate();
 
 private:
   void onCooperateCommandService(
@@ -62,7 +64,11 @@ private:
     const CooperateCommands::Response::SharedPtr responses);
   void onAutoModeService(
     const AutoMode::Request::SharedPtr request, const AutoMode::Response::SharedPtr response);
+  std::vector<CooperateResponse> validateCooperateCommands(
+    const std::vector<CooperateCommand> & commands);
+  void updateCooperateCommandStatus(const std::vector<CooperateCommand> & commands);
   rclcpp::Logger getLogger() const;
+  bool isLocked() const;
 
   rclcpp::Publisher<CooperateStatusArray>::SharedPtr pub_statuses_;
   rclcpp::Service<CooperateCommands>::SharedPtr srv_commands_;
@@ -73,7 +79,9 @@ private:
   rclcpp::Logger logger_;
   Module module_;
   CooperateStatusArray registered_status_;
+  std::vector<CooperateCommand> stored_commands_;
   bool is_auto_mode_;
+  bool is_locked_;
 
   std::string cooperate_status_namespace_ = "/planning/cooperate_status";
   std::string cooperate_commands_namespace_ = "/planning/cooperate_commands";


### PR DESCRIPTION
Signed-off-by: Fumiya Watanabe <rej55.g@gmail.com>

## Description

Before this change, the state in rtc_interface may change during processing of behavior_path_planner modules.
To avoid this, I add the function to lock updating the state.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Real vehicle test was performed.
TIER IV internal test was performed.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
