### PR TITLE
fix(obstacle_avoidance_planner): fix drivable area virtual wall z

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -1261,6 +1261,14 @@ void ObstacleAvoidancePlanner::insertZeroVelocityOutsideDrivableArea(
     if (is_outside) {
       traj_points[i].longitudinal_velocity_mps = 0.0;
       debug_data_.stop_pose_by_drivable_area = traj_points[i].pose;
+
+      // NOTE: traj_points does not have valid z for efficient calculation of trajectory
+      if (!planner_data.path.points.empty()) {
+        const size_t path_idx =
+          motion_utils::findNearestIndex(planner_data.path.points, traj_points[i].pose.position);
+        debug_data_.stop_pose_by_drivable_area->position.z =
+          planner_data.path.points.at(path_idx).pose.position.z;
+      }
       break;
     }
   }

--- a/planning/obstacle_avoidance_planner/src/utils/debug_utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/debug_utils.cpp
@@ -688,6 +688,7 @@ visualization_msgs::msg::MarkerArray getVirtualWallMarkerArray(
     createMarkerScale(0.1, 5.0, 2.0), createMarkerColor(r, g, b, 0.5));
   marker.lifetime = rclcpp::Duration::from_seconds(1.5);
   marker.pose = pose;
+  marker.pose.position.z += 1.0;
 
   visualization_msgs::msg::MarkerArray msg;
   msg.markers.push_back(marker);
@@ -704,6 +705,7 @@ visualization_msgs::msg::MarkerArray getVirtualWallTextMarkerArray(
     createMarkerScale(0.0, 0.0, 1.0), createMarkerColor(r, g, b, 0.99));
   marker.lifetime = rclcpp::Duration::from_seconds(1.5);
   marker.pose = pose;
+  marker.pose.position.z += 2.0;
   marker.text = "drivable area";
 
   visualization_msgs::msg::MarkerArray msg;


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

Without this PR, the z position of the drivable area virutual wall is not valid, and in the ThirdPersonFollower view the wall is out of sight.

With this PR, z position is based on the path and we can see the wall in the ThirdPersonFollower view.
![image](https://user-images.githubusercontent.com/20228327/195973142-cfff0b2a-193a-4abb-b15b-8fdc6fcaad54.png)

FYI.
Ideally, the virtual wall should be calculated with motion_utils's function as in other packages.
However, I'm working on refactoring obstacle avoidance planner.
Therefore, this time I created a PR with a least change for the fix of the z position.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
