### PR TITLE
refactor(motion_utils, obstacle_cruise_planner): add offset to virtual wall utils func

### DIFF
--- a/common/motion_utils/include/motion_utils/marker/marker_helper.hpp
+++ b/common/motion_utils/include/motion_utils/marker/marker_helper.hpp
@@ -15,7 +15,7 @@
 #ifndef MOTION_UTILS__MARKER__MARKER_HELPER_HPP_
 #define MOTION_UTILS__MARKER__MARKER_HELPER_HPP_
 
-#include "tier4_autoware_utils/ros/marker_helper.hpp"
+#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 
 #include <string>
 
@@ -23,15 +23,15 @@ namespace motion_utils
 {
 visualization_msgs::msg::MarkerArray createStopVirtualWallMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
-  const int32_t id);
+  const int32_t id, const double longitudinal_offset = 0.0);
 
 visualization_msgs::msg::MarkerArray createSlowDownVirtualWallMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
-  const int32_t id);
+  const int32_t id, const double longitudinal_offset = 0.0);
 
 visualization_msgs::msg::MarkerArray createDeadLineVirtualWallMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
-  const int32_t id);
+  const int32_t id, const double longitudinal_offset = 0.0);
 
 visualization_msgs::msg::MarkerArray createDeletedStopVirtualWallMarker(
   const rclcpp::Time & now, const int32_t id);

--- a/common/motion_utils/src/marker/marker_helper.cpp
+++ b/common/motion_utils/src/marker/marker_helper.cpp
@@ -83,26 +83,32 @@ namespace motion_utils
 {
 visualization_msgs::msg::MarkerArray createStopVirtualWallMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
-  const int32_t id)
+  const int32_t id, const double longitudinal_offset)
 {
+  const auto pose_with_offset =
+    tier4_autoware_utils::calcOffsetPose(pose, longitudinal_offset, 0.0, 0.0);
   return createVirtualWallMarkerArray(
-    pose, module_name, "stop_", now, id, createMarkerColor(1.0, 0.0, 0.0, 0.5));
+    pose_with_offset, module_name, "stop_", now, id, createMarkerColor(1.0, 0.0, 0.0, 0.5));
 }
 
 visualization_msgs::msg::MarkerArray createSlowDownVirtualWallMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
-  const int32_t id)
+  const int32_t id, const double longitudinal_offset)
 {
+  const auto pose_with_offset =
+    tier4_autoware_utils::calcOffsetPose(pose, longitudinal_offset, 0.0, 0.0);
   return createVirtualWallMarkerArray(
-    pose, module_name, "slow_down_", now, id, createMarkerColor(1.0, 1.0, 0.0, 0.5));
+    pose_with_offset, module_name, "slow_down_", now, id, createMarkerColor(1.0, 1.0, 0.0, 0.5));
 }
 
 visualization_msgs::msg::MarkerArray createDeadLineVirtualWallMarker(
   const geometry_msgs::msg::Pose & pose, const std::string & module_name, const rclcpp::Time & now,
-  const int32_t id)
+  const int32_t id, const double longitudinal_offset)
 {
+  const auto pose_with_offset =
+    tier4_autoware_utils::calcOffsetPose(pose, longitudinal_offset, 0.0, 0.0);
   return createVirtualWallMarkerArray(
-    pose, module_name, "dead_line_", now, id, createMarkerColor(0.0, 1.0, 0.0, 0.5));
+    pose_with_offset, module_name, "dead_line_", now, id, createMarkerColor(0.0, 1.0, 0.0, 0.5));
 }
 
 visualization_msgs::msg::MarkerArray createDeletedStopVirtualWallMarker(

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -238,11 +238,10 @@ VelocityLimit PIDBasedPlanner::doCruise(
                                   : std::abs(vehicle_info_.min_longitudinal_offset_m);
   const double dist_to_rss_wall =
     std::min(dist_to_cruise + abs_ego_offset, dist_to_obstacle + abs_ego_offset);
-  const size_t wall_idx = obstacle_cruise_utils::getIndexWithLongitudinalOffset(
-    planner_data.traj.points, dist_to_rss_wall, ego_idx);
 
   const auto markers = motion_utils::createSlowDownVirtualWallMarker(
-    planner_data.traj.points.at(wall_idx).pose, "obstacle cruise", planner_data.current_time, 0);
+    planner_data.traj.points.at(ego_idx).pose, "obstacle cruise", planner_data.current_time, 0,
+    dist_to_rss_wall);
   tier4_autoware_utils::appendMarkerArray(markers, &debug_wall_marker);
 
   debug_obstacles_to_cruise.push_back(cruise_obstacle_info.obstacle);

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -195,13 +195,10 @@ Trajectory PlannerInterface::generateStopTrajectory(
     std::max(0.0, closest_obstacle_dist - abs_ego_offset - feasible_margin_from_obstacle);
   const auto zero_vel_idx = motion_utils::insertStopPoint(0, zero_vel_dist, output_traj.points);
   if (zero_vel_idx) {
-    const auto wall_idx = obstacle_cruise_utils::getIndexWithLongitudinalOffset(
-      output_traj.points, abs_ego_offset, *zero_vel_idx);
-
     // virtual wall marker for stop obstacle
-    const auto marker_pose = output_traj.points.at(wall_idx).pose;
     const auto markers = motion_utils::createStopVirtualWallMarker(
-      marker_pose, "obstacle stop", planner_data.current_time, 0);
+      output_traj.points.at(*zero_vel_idx).pose, "obstacle stop", planner_data.current_time, 0,
+      abs_ego_offset);
     tier4_autoware_utils::appendMarkerArray(markers, &debug_data.stop_wall_marker);
     debug_data.obstacles_to_stop.push_back(*closest_stop_obstacle);
 


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

In most cases, when creating a virtual wall, the offset from the base link to vehicle front is added to the stop point or slow down point using `calcOffsetPose`.
To decrease the code of this offset calculation in each node, I added an offset argument to virtual wall utils functions, and use it in obstacle_cruise_planner as an example.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
