### PR TITLE
fix(raw_vehicle_cmd_converter): wrong for-loop bound in getColumnIndex

### DIFF
--- a/vehicle/raw_vehicle_cmd_converter/src/csv_loader.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/csv_loader.cpp
@@ -78,7 +78,7 @@ std::vector<double> CSVLoader::getRowIndex(const Table & table)
 std::vector<double> CSVLoader::getColumnIndex(const Table & table)
 {
   std::vector<double> index = {};
-  for (unsigned int i = 1; i < table[0].size(); i++) {
+  for (unsigned int i = 1; i < table.size(); i++) {
     index.push_back(std::stod(table[i][0]));
   }
   return index;


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
Fix a bug that crashes the `raw_vehicle_cmd_converter` at startup.
The bound for the for-loop variable is changed from `table[0].size()` to `table.size()`.
This error was introduced by https://github.com/autowarefoundation/autoware.universe/pull/2074

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
