### PR TITLE
feat(behavior_path_planner): add turn signal parameters

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -13,5 +13,8 @@
     drivable_lane_margin: 3.0
     drivable_area_margin: 6.0
     refine_goal_search_radius_range: 7.5
-    intersection_search_distance: 30.0
+    turn_signal_intersection_search_distance: 30.0
+    turn_signal_minimum_search_distance: 10.0
+    turn_signal_search_time: 3.0
+    turn_signal_shift_length_threshold: 0.3
     path_interval: 2.0

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -14,6 +14,7 @@
     drivable_area_margin: 6.0
     refine_goal_search_radius_range: 7.5
     turn_signal_intersection_search_distance: 30.0
+    turn_signal_intersection_angle_threshold_deg: 15.0
     turn_signal_minimum_search_distance: 10.0
     turn_signal_search_time: 3.0
     turn_signal_shift_length_threshold: 0.3

--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -18,6 +18,7 @@
 
     # parameters for turn signal decider
     turn_signal_intersection_search_distance: 30.0
+    turn_signal_intersection_angle_threshold_deg: 15.0
     turn_signal_minimum_search_distance: 10.0
     turn_signal_search_time: 3.0
     turn_signal_shift_length_threshold: 0.3

--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -15,7 +15,12 @@
     drivable_area_margin: 6.0
 
     refine_goal_search_radius_range: 7.5
-    intersection_search_distance: 30.0
+
+    # parameters for turn signal decider
+    turn_signal_intersection_search_distance: 30.0
+    turn_signal_minimum_search_distance: 10.0
+    turn_signal_search_time: 3.0
+    turn_signal_shift_length_threshold: 0.3
 
     path_interval: 2.0
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -36,6 +36,8 @@ struct BehaviorPathPlannerParameters
 
   double refine_goal_search_radius_range;
 
+  double turn_signal_intersection_search_distance;
+  double turn_signal_intersection_angle_threshold_deg;
   double turn_signal_search_time;
   double turn_signal_minimum_search_distance;
   double turn_signal_shift_length_threshold;

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -35,9 +35,10 @@ struct BehaviorPathPlannerParameters
   double drivable_area_margin;
 
   double refine_goal_search_radius_range;
-  double turn_light_on_threshold_dis_lat;
-  double turn_light_on_threshold_dis_long;
-  double turn_light_on_threshold_time;
+
+  double turn_signal_search_time;
+  double turn_signal_minimum_search_distance;
+  double turn_signal_shift_length_threshold;
 
   double path_interval;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
@@ -73,10 +73,13 @@ public:
     const PathWithLaneId & path, const Pose & current_pose, const size_t current_seg_idx,
     const TurnSignalInfo & intersection_signal_info, const TurnSignalInfo & behavior_signal_info);
 
-  void setParameters(const double base_link2front, const double intersection_search_distance)
+  void setParameters(
+    const double base_link2front, const double intersection_search_distance,
+    const double intersection_search_time)
   {
     base_link2front_ = base_link2front;
     intersection_search_distance_ = intersection_search_distance;
+    intersection_search_time_ = intersection_search_time;
   }
 
   std::pair<bool, bool> getIntersectionTurnSignalFlag();
@@ -103,6 +106,7 @@ private:
 
   // data
   double intersection_search_distance_{0.0};
+  double intersection_search_time_{0.0};
   double base_link2front_{0.0};
   std::map<lanelet::Id, geometry_msgs::msg::Point> desired_start_point_map_;
   mutable bool intersection_turn_signal_ = false;

--- a/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
@@ -75,11 +75,12 @@ public:
 
   void setParameters(
     const double base_link2front, const double intersection_search_distance,
-    const double intersection_search_time)
+    const double intersection_search_time, const double intersection_angle_threshold_deg)
   {
     base_link2front_ = base_link2front;
     intersection_search_distance_ = intersection_search_distance;
     intersection_search_time_ = intersection_search_time;
+    intersection_angle_threshold_deg_ = intersection_angle_threshold_deg;
   }
 
   std::pair<bool, bool> getIntersectionTurnSignalFlag();
@@ -107,6 +108,7 @@ private:
   // data
   double intersection_search_distance_{0.0};
   double intersection_search_time_{0.0};
+  double intersection_angle_threshold_deg_{0.0};
   double base_link2front_{0.0};
   std::map<lanelet::Id, geometry_msgs::msg::Point> desired_start_point_map_;
   mutable bool intersection_turn_signal_ = false;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -144,11 +144,11 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
   // turn signal decider
   {
-    double turn_signal_intersection_search_distance{
-      declare_parameter("turn_signal_intersection_search_distance", 30.0)};
-    double turn_signal_search_time{declare_parameter("turn_signal_search_time", 3.0)};
-    double turn_signal_intersection_angle_threshold_deg{
-      declare_parameter("turn_signal_intersection_angle_threshold_deg", 15.0)};
+    const double turn_signal_intersection_search_distance =
+      planner_data_->parameters.turn_signal_intersection_search_distance;
+    const double turn_signal_intersection_angle_threshold_deg =
+      planner_data_->parameters.turn_signal_intersection_angle_threshold_deg;
+    const double turn_signal_search_time = planner_data_->parameters.turn_signal_search_time;
     turn_signal_decider_.setParameters(
       planner_data_->parameters.base_link2front, turn_signal_intersection_search_distance,
       turn_signal_search_time, turn_signal_intersection_angle_threshold_deg);
@@ -210,9 +210,13 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.drivable_lane_margin = declare_parameter<double>("drivable_lane_margin");
   p.drivable_area_margin = declare_parameter<double>("drivable_area_margin");
   p.refine_goal_search_radius_range = declare_parameter("refine_goal_search_radius_range", 7.5);
-  p.turn_signal_search_time = declare_parameter("turn_signal_search_time", 3.0);
+  p.turn_signal_intersection_search_distance =
+    declare_parameter("turn_signal_intersection_search_distance", 30.0);
+  p.turn_signal_intersection_angle_threshold_deg =
+    declare_parameter("turn_signal_intersection_angle_threshold_deg", 15.0);
   p.turn_signal_minimum_search_distance =
     declare_parameter("turn_signal_minimum_search_distance", 10.0);
+  p.turn_signal_search_time = declare_parameter("turn_signal_search_time", 3.0);
   p.turn_signal_shift_length_threshold =
     declare_parameter("turn_signal_shift_length_threshold", 0.3);
   p.path_interval = declare_parameter<double>("path_interval");

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -144,9 +144,12 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
   // turn signal decider
   {
-    double intersection_search_distance{declare_parameter("intersection_search_distance", 30.0)};
+    double turn_signal_intersection_search_distance{
+      declare_parameter("turn_signal_intersection_search_distance", 30.0)};
+    double turn_signal_search_time{declare_parameter("turn_signal_search_time", 3.0)};
     turn_signal_decider_.setParameters(
-      planner_data_->parameters.base_link2front, intersection_search_distance);
+      planner_data_->parameters.base_link2front, turn_signal_intersection_search_distance,
+      turn_signal_search_time);
   }
 
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(this, "intersection");
@@ -205,9 +208,11 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.drivable_lane_margin = declare_parameter<double>("drivable_lane_margin");
   p.drivable_area_margin = declare_parameter<double>("drivable_area_margin");
   p.refine_goal_search_radius_range = declare_parameter("refine_goal_search_radius_range", 7.5);
-  p.turn_light_on_threshold_dis_lat = declare_parameter("turn_light_on_threshold_dis_lat", 0.3);
-  p.turn_light_on_threshold_dis_long = declare_parameter("turn_light_on_threshold_dis_long", 10.0);
-  p.turn_light_on_threshold_time = declare_parameter("turn_light_on_threshold_time", 3.0);
+  p.turn_signal_search_time = declare_parameter("turn_signal_search_time", 3.0);
+  p.turn_signal_minimum_search_distance =
+    declare_parameter("turn_signal_minimum_search_distance", 10.0);
+  p.turn_signal_shift_length_threshold =
+    declare_parameter("turn_signal_shift_length_threshold", 0.3);
   p.path_interval = declare_parameter<double>("path_interval");
   p.visualize_drivable_area_for_shared_linestrings_lanelet =
     declare_parameter("visualize_drivable_area_for_shared_linestrings_lanelet", true);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -147,9 +147,11 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     double turn_signal_intersection_search_distance{
       declare_parameter("turn_signal_intersection_search_distance", 30.0)};
     double turn_signal_search_time{declare_parameter("turn_signal_search_time", 3.0)};
+    double turn_signal_intersection_angle_threshold_deg{
+      declare_parameter("turn_signal_intersection_angle_threshold_deg", 15.0)};
     turn_signal_decider_.setParameters(
       planner_data_->parameters.base_link2front, turn_signal_intersection_search_distance,
-      turn_signal_search_time);
+      turn_signal_search_time, turn_signal_intersection_angle_threshold_deg);
   }
 
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(this, "intersection");

--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -198,9 +198,11 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   const auto base_link2front = common_parameter.base_link2front;
   const auto vehicle_width = common_parameter.vehicle_width;
   const auto shift_to_outside = vehicle_width / 2;
-  const auto tl_on_threshold_lat = common_parameter.turn_light_on_threshold_dis_lat;
-  const auto tl_on_threshold_long = common_parameter.turn_light_on_threshold_dis_long;
-  const auto prev_sec = common_parameter.turn_light_on_threshold_time;
+  const auto turn_signal_shift_length_threshold =
+    common_parameter.turn_signal_shift_length_threshold;
+  const auto turn_signal_minimum_search_distance =
+    common_parameter.turn_signal_minimum_search_distance;
+  const auto turn_signal_search_time = common_parameter.turn_signal_search_time;
   constexpr double epsilon = 1e-6;
   const auto arc_position_current_pose = lanelet::utils::getArcCoordinates(current_lanes, pose);
 
@@ -277,10 +279,12 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
       right_start_point_is_in_lane != right_end_point_is_in_lane);
   });
 
-  if (time_to_shift_start < prev_sec || distance_to_shift_start < tl_on_threshold_long) {
-    if (diff > tl_on_threshold_lat && cross_line) {
+  if (
+    time_to_shift_start < turn_signal_search_time ||
+    distance_to_shift_start < turn_signal_minimum_search_distance) {
+    if (diff > turn_signal_shift_length_threshold && cross_line) {
       turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
-    } else if (diff < -tl_on_threshold_lat && cross_line) {
+    } else if (diff < -turn_signal_shift_length_threshold && cross_line) {
       turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
     }
   }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2563,8 +2563,14 @@ TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) con
   const double end_shift_length = path.shift_length.at(end_idx);
   const double segment_shift_length = end_shift_length - start_shift_length;
 
+  const double turn_signal_shift_length_threshold =
+    planner_data_->parameters.turn_signal_shift_length_threshold;
+  const double turn_signal_search_time = planner_data_->parameters.turn_signal_search_time;
+  const double turn_signal_minimum_search_distance =
+    planner_data_->parameters.turn_signal_minimum_search_distance;
+
   // If shift length is shorter than the threshold, it does not need to turn on blinkers
-  if (std::fabs(segment_shift_length) < 1.0) {
+  if (std::fabs(segment_shift_length) < turn_signal_shift_length_threshold) {
     return {};
   }
 
@@ -2590,7 +2596,8 @@ TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) con
 
   const double ego_vehicle_offset =
     planner_data_->parameters.vehicle_info.max_longitudinal_offset_m;
-  const auto signal_prepare_distance = std::max(getEgoSpeed() * 3.0, 10.0);
+  const auto signal_prepare_distance =
+    std::max(getEgoSpeed() * turn_signal_search_time, turn_signal_minimum_search_distance);
   const auto ego_front_to_shift_start =
     calcSignedArcLength(path.path.points, getEgoPosition(), blinker_start_pose.position) -
     ego_vehicle_offset;

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -396,7 +396,7 @@ BehaviorModuleOutput PullOverModule::plan()
       // if using arc_path and finishing current_path, get next path
       // enough time for turn signal
       const bool has_passed_enough_time = (clock_->now() - *last_approved_time_).seconds() >
-                                          planner_data_->parameters.turn_light_on_threshold_time;
+                                          planner_data_->parameters.turn_signal_search_time;
 
       if (hasFinishedCurrentPath() && has_passed_enough_time) {
         incrementPathIndex();
@@ -593,7 +593,7 @@ PathWithLaneId PullOverModule::getReferencePath() const
 
   // slow down for turn signal, insert stop point to stop_pose
   reference_path = util::setDecelerationVelocityForTurnSignal(
-    reference_path, stop_pose, planner_data_->parameters.turn_light_on_threshold_time);
+    reference_path, stop_pose, planner_data_->parameters.turn_signal_search_time);
 
   // slow down before the search area.
   if (stop_pose != search_start_pose) {

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -329,7 +329,7 @@ geometry_msgs::msg::Point TurnSignalDecider::get_required_end_point(
   for (size_t i = 0; i < resampled_centerline.size(); ++i) {
     const double yaw = tf2::getYaw(resampled_centerline.at(i).orientation);
     const double yaw_diff = tier4_autoware_utils::normalizeRadian(yaw - terminal_yaw);
-    if (std::fabs(yaw_diff) < tier4_autoware_utils::deg2rad(15)) {
+    if (std::fabs(yaw_diff) < tier4_autoware_utils::deg2rad(intersection_angle_threshold_deg_)) {
       return resampled_centerline.at(i).position;
     }
   }

--- a/planning/behavior_path_planner/test/test_turn_signal.cpp
+++ b/planning/behavior_path_planner/test/test_turn_signal.cpp
@@ -70,7 +70,7 @@ TEST(BehaviorPathPlanningTurnSignal, Condition1)
 {
   PathWithLaneId path = generateStraightSamplePathWithLaneId(0.0f, 1.0f, 70u);
   TurnSignalDecider turn_signal_decider;
-  turn_signal_decider.setParameters(1.0, 30.0);
+  turn_signal_decider.setParameters(1.0, 30.0, 3.0);
 
   TurnSignalInfo intersection_signal_info;
   intersection_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
@@ -191,7 +191,7 @@ TEST(BehaviorPathPlanningTurnSignal, Condition2)
 {
   PathWithLaneId path = generateStraightSamplePathWithLaneId(0.0f, 1.0f, 70u);
   TurnSignalDecider turn_signal_decider;
-  turn_signal_decider.setParameters(1.0, 30.0);
+  turn_signal_decider.setParameters(1.0, 30.0, 3.0);
 
   TurnSignalInfo intersection_signal_info;
   intersection_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
@@ -282,7 +282,7 @@ TEST(BehaviorPathPlanningTurnSignal, Condition3)
 {
   PathWithLaneId path = generateStraightSamplePathWithLaneId(0.0f, 1.0f, 70u);
   TurnSignalDecider turn_signal_decider;
-  turn_signal_decider.setParameters(1.0, 30.0);
+  turn_signal_decider.setParameters(1.0, 30.0, 3.0);
 
   TurnSignalInfo intersection_signal_info;
   intersection_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;

--- a/planning/behavior_path_planner/test/test_turn_signal.cpp
+++ b/planning/behavior_path_planner/test/test_turn_signal.cpp
@@ -70,7 +70,7 @@ TEST(BehaviorPathPlanningTurnSignal, Condition1)
 {
   PathWithLaneId path = generateStraightSamplePathWithLaneId(0.0f, 1.0f, 70u);
   TurnSignalDecider turn_signal_decider;
-  turn_signal_decider.setParameters(1.0, 30.0, 3.0);
+  turn_signal_decider.setParameters(1.0, 30.0, 3.0, 15.0);
 
   TurnSignalInfo intersection_signal_info;
   intersection_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
@@ -191,7 +191,7 @@ TEST(BehaviorPathPlanningTurnSignal, Condition2)
 {
   PathWithLaneId path = generateStraightSamplePathWithLaneId(0.0f, 1.0f, 70u);
   TurnSignalDecider turn_signal_decider;
-  turn_signal_decider.setParameters(1.0, 30.0, 3.0);
+  turn_signal_decider.setParameters(1.0, 30.0, 3.0, 15.0);
 
   TurnSignalInfo intersection_signal_info;
   intersection_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
@@ -282,7 +282,7 @@ TEST(BehaviorPathPlanningTurnSignal, Condition3)
 {
   PathWithLaneId path = generateStraightSamplePathWithLaneId(0.0f, 1.0f, 70u);
   TurnSignalDecider turn_signal_decider;
-  turn_signal_decider.setParameters(1.0, 30.0, 3.0);
+  turn_signal_decider.setParameters(1.0, 30.0, 3.0, 15.0);
 
   TurnSignalInfo intersection_signal_info;
   intersection_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;


### PR DESCRIPTION
## Description

Since the current Autoware does not have appropriate parameters for the turn signal decider, I add the necessary parameters in this PR. They are

```
turn_signal_intersection_search_distance
turn_signal_intersection_angle_threshold_deg
turn_signal_minimum_search_distance
turn_signal_search_time
turn_signal_shift_length_threshold
```

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
