### PR TITLE
fix(tier4_perception_launch): fix missing container argument

### DIFF
--- a/launch/tier4_perception_launch/launch/occupancy_grid_map/pointcloud_based_occupancy_grid_map.launch.py
+++ b/launch/tier4_perception_launch/launch/occupancy_grid_map/pointcloud_based_occupancy_grid_map.launch.py
@@ -16,8 +16,6 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import SetLaunchConfiguration
 from launch.conditions import IfCondition
-from launch.conditions import LaunchConfigurationEquals
-from launch.conditions import LaunchConfigurationNotEquals
 from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer

--- a/launch/tier4_perception_launch/launch/occupancy_grid_map/pointcloud_based_occupancy_grid_map.launch.py
+++ b/launch/tier4_perception_launch/launch/occupancy_grid_map/pointcloud_based_occupancy_grid_map.launch.py
@@ -62,26 +62,27 @@ def generate_launch_description():
     ]
 
     occupancy_grid_map_container = ComposableNodeContainer(
-        condition=LaunchConfigurationEquals("container", ""),
-        name="occupancy_grid_map_container",
+        name=LaunchConfiguration("container_name"),
         namespace="",
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=composable_nodes,
+        condition=UnlessCondition(LaunchConfiguration("use_pointcloud_container")),
         output="screen",
     )
 
     load_composable_nodes = LoadComposableNodes(
-        condition=LaunchConfigurationNotEquals("container", ""),
         composable_node_descriptions=composable_nodes,
-        target_container=LaunchConfiguration("container"),
+        target_container=LaunchConfiguration("container_name"),
+        condition=IfCondition(LaunchConfiguration("use_pointcloud_container")),
     )
 
     return LaunchDescription(
         [
-            add_launch_arg("container", ""),
-            add_launch_arg("use_multithread", "false"),
-            add_launch_arg("use_intra_process", "false"),
+            add_launch_arg("use_multithread", "False"),
+            add_launch_arg("use_intra_process", "True"),
+            add_launch_arg("use_pointcloud_container", "False"),
+            add_launch_arg("container_name", "occupancy_grid_map_container"),
             add_launch_arg("input/obstacle_pointcloud", "no_ground/oneshot/pointcloud"),
             add_launch_arg("input/raw_pointcloud", "concatenated/pointcloud"),
             add_launch_arg("output", "occupancy_grid"),


### PR DESCRIPTION
The arguments given in `perception.launch.xml` and accepted in `pointcloud_based_occupancy_grid_map.launch.py` are incompatible with each other. It is impossible to pass pointcloud_container as a parameter to `probabilistic_occupancy_grid_map` package.

Relevant parameters :

[perception.launch.xml#L70](https://github.com/autowarefoundation/autoware.universe/blob/main/launch/tier4_perception_launch/launch/perception.launch.xml#L70)

[pointcloud_based_occupancy_grid_map.launch.py#L82](https://github.com/autowarefoundation/autoware.universe/blob/main/launch/tier4_perception_launch/launch/occupancy_grid_map/pointcloud_based_occupancy_grid_map.launch.py#L82)



 
Signed-off-by: Kaan Colak <kcolak@leodrive.ai>

## Description

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
