### PR TITLE
fix(gnss_poser): fix mgrs zone conversion

### DIFF
--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -143,7 +143,7 @@ GNSSStat UTM2MGRS(
     std::string mgrs_code;
     GeographicLib::MGRS::Forward(
       utm.zone, utm.northup, utm.x, utm.y, utm.latitude, static_cast<int>(precision), mgrs_code);
-    mgrs.zone = std::stod(mgrs_code.substr(0, GZD_ID_size));
+    mgrs.mgrs_zone = std::string(mgrs_code.substr(0, GZD_ID_size));
     mgrs.x = std::stod(mgrs_code.substr(GZD_ID_size, static_cast<int>(precision))) *
              std::pow(
                10, static_cast<int>(MGRSPrecision::_1_METER) -

--- a/sensing/gnss_poser/include/gnss_poser/gnss_stat.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/gnss_stat.hpp
@@ -14,6 +14,8 @@
 #ifndef GNSS_POSER__GNSS_STAT_HPP_
 #define GNSS_POSER__GNSS_STAT_HPP_
 
+#include <string>
+
 namespace gnss_poser
 {
 enum class CoordinateSystem {
@@ -30,6 +32,7 @@ struct GNSSStat
   : coordinate_system(CoordinateSystem::MGRS),
     northup(true),
     zone(0),
+    mgrs_zone(""),
     x(0),
     y(0),
     z(0),
@@ -42,6 +45,7 @@ struct GNSSStat
   CoordinateSystem coordinate_system;
   bool northup;
   int zone;
+  std::string mgrs_zone;
   double x;
   double y;
   double z;


### PR DESCRIPTION
Signed-off-by: Vincent Richard <richard-v@macnica.co.jp>

## Description

Fix MGRS code conversion.
- before fix: "53SPU" would be parsed as 53 (int)
- after fix: the whole "53SPU" string is stored in a new mgrs_zone field

See https://github.com/autowarefoundation/autoware.universe/issues/2085

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
