### PR TITLE
refactor(euclidean_cluster): devide operations into methods

### DIFF
--- a/perception/euclidean_cluster/CMakeLists.txt
+++ b/perception/euclidean_cluster/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(
 )
 
 ament_auto_add_library(cluster_lib SHARED
+  lib/euclidean_cluster_interface.cpp
   lib/utils.cpp
   lib/euclidean_cluster.cpp
   lib/voxel_grid_based_euclidean_cluster.cpp

--- a/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster.hpp
@@ -17,8 +17,6 @@
 #include "euclidean_cluster/euclidean_cluster_interface.hpp"
 #include "euclidean_cluster/utils.hpp"
 
-#include <pcl/point_types.h>
-
 #include <vector>
 
 namespace euclidean_cluster
@@ -32,10 +30,11 @@ public:
   bool cluster(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) override;
-  void setTolerance(float tolerance) { tolerance_ = tolerance; }
 
 private:
-  float tolerance_;
+  void setPointcloud(
+    const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
+    pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr) override;
 };
 
 }  // namespace euclidean_cluster

--- a/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster.hpp
@@ -32,7 +32,7 @@ public:
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) override;
 
 private:
-  void setPointcloud(
+  void preparePointcloud(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr) override;
 };

--- a/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster_interface.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster_interface.hpp
@@ -16,35 +16,54 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <pcl/kdtree/kdtree.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+#include <pcl/segmentation/extract_clusters.h>
 
 #include <vector>
 
 namespace euclidean_cluster
 {
+struct ClusterParameters
+{
+  bool use_height;
+  int min_cluster_size;
+  int max_cluster_size;
+  float tolerance;
+};  // stuct ClusterParameters
+
 class EuclideanClusterInterface
 {
 public:
   EuclideanClusterInterface() = default;
   EuclideanClusterInterface(bool use_height, int min_cluster_size, int max_cluster_size)
-  : use_height_(use_height),
-    min_cluster_size_(min_cluster_size),
-    max_cluster_size_(max_cluster_size)
+  : params_{use_height, min_cluster_size, max_cluster_size, 0.7}
+  {
+  }
+  EuclideanClusterInterface(
+    bool use_height, int min_cluster_size, int max_cluster_size, float tolerance)
+  : params_{use_height, min_cluster_size, max_cluster_size, tolerance}
   {
   }
   virtual ~EuclideanClusterInterface() = default;
-  void setUseHeight(bool use_height) { use_height_ = use_height; }
-  void setMinClusterSize(int size) { min_cluster_size_ = size; }
-  void setMaxClusterSize(int size) { max_cluster_size_ = size; }
+  void setUseHeight(bool use_height) { params_.use_height = use_height; }
+  void setMinClusterSize(int size) { params_.min_cluster_size = size; }
+  void setMaxClusterSize(int size) { params_.max_cluster_size = size; }
+  void setTolerance(float tolerance) { params_.tolerance = tolerance; }
   virtual bool cluster(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) = 0;
+  void solveEuclideanClustering(
+    pcl::EuclideanClusterExtraction<pcl::PointXYZ> & pcl_euclidean_cluster,
+    std::vector<pcl::PointIndices> & cluster_indices,
+    pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr);
 
 protected:
-  bool use_height_ = true;
-  int min_cluster_size_;
-  int max_cluster_size_;
-};
+  ClusterParameters params_;
+  virtual void setPointcloud(
+    const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
+    pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr) = 0;
+};  // class EuclideanClusterInterface
 
 }  // namespace euclidean_cluster

--- a/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster_interface.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster_interface.hpp
@@ -61,7 +61,7 @@ public:
 
 protected:
   ClusterParameters params_;
-  virtual void setPointcloud(
+  virtual void preparePointcloud(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr) = 0;
 };  // class EuclideanClusterInterface

--- a/perception/euclidean_cluster/include/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
@@ -45,7 +45,7 @@ private:
   float voxel_leaf_size_;
   int min_points_number_per_voxel_;
 
-  void setPointcloud(
+  void preparePointcloud(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr) override;
   void solveVoxelBasedClustering(

--- a/perception/euclidean_cluster/include/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
@@ -18,7 +18,6 @@
 #include "euclidean_cluster/utils.hpp"
 
 #include <pcl/filters/voxel_grid.h>
-#include <pcl/point_types.h>
 
 #include <vector>
 
@@ -36,7 +35,6 @@ public:
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) override;
   void setVoxelLeafSize(float voxel_leaf_size) { voxel_leaf_size_ = voxel_leaf_size; }
-  void setTolerance(float tolerance) { tolerance_ = tolerance; }
   void setMinPointsNumberPerVoxel(int min_points_number_per_voxel)
   {
     min_points_number_per_voxel_ = min_points_number_per_voxel;
@@ -44,9 +42,15 @@ public:
 
 private:
   pcl::VoxelGrid<pcl::PointXYZ> voxel_grid_;
-  float tolerance_;
   float voxel_leaf_size_;
   int min_points_number_per_voxel_;
+
+  void setPointcloud(
+    const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
+    pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr) override;
+  void solveVoxelBasedClustering(
+    pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr,
+    std::vector<pcl::PointCloud<pcl::PointXYZ>> & temporary_clusters);
 };
 
 }  // namespace euclidean_cluster

--- a/perception/euclidean_cluster/lib/euclidean_cluster.cpp
+++ b/perception/euclidean_cluster/lib/euclidean_cluster.cpp
@@ -38,7 +38,7 @@ bool EuclideanCluster::cluster(
 {
   // convert 2d pointcloud
   pcl::PointCloud<pcl::PointXYZ>::ConstPtr pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
-  setPointcloud(pointcloud, pointcloud_ptr);
+  preparePointcloud(pointcloud, pointcloud_ptr);
 
   pcl::EuclideanClusterExtraction<pcl::PointXYZ> pcl_euclidean_cluster;
   std::vector<pcl::PointIndices> cluster_indices;
@@ -60,7 +60,7 @@ bool EuclideanCluster::cluster(
   return true;
 }
 
-void EuclideanCluster::setPointcloud(
+void EuclideanCluster::preparePointcloud(
   const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
   pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr)
 {

--- a/perception/euclidean_cluster/lib/euclidean_cluster_interface.cpp
+++ b/perception/euclidean_cluster/lib/euclidean_cluster_interface.cpp
@@ -1,0 +1,36 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "euclidean_cluster/euclidean_cluster_interface.hpp"
+
+namespace euclidean_cluster
+{
+void EuclideanClusterInterface::solveEuclideanClustering(
+  pcl::EuclideanClusterExtraction<pcl::PointXYZ> & pcl_euclidean_cluster,
+  std::vector<pcl::PointIndices> & cluster_indices,
+  pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr)
+{
+  // create tree
+  pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
+  tree->setInputCloud(pointcloud_ptr);
+
+  // clustering
+  pcl_euclidean_cluster.setClusterTolerance(params_.tolerance);
+  pcl_euclidean_cluster.setMinClusterSize(params_.min_cluster_size);
+  pcl_euclidean_cluster.setMaxClusterSize(params_.max_cluster_size);
+  pcl_euclidean_cluster.setSearchMethod(tree);
+  pcl_euclidean_cluster.setInputCloud(pointcloud_ptr);
+  pcl_euclidean_cluster.extract(cluster_indices);
+}
+}  // namespace euclidean_cluster

--- a/perception/euclidean_cluster/lib/utils.cpp
+++ b/perception/euclidean_cluster/lib/utils.cpp
@@ -68,10 +68,11 @@ void convertObjectMsg2SensorMsg(
 {
   output.header = input.header;
 
-  size_t pointcloud_size = 0;
-  for (const auto & feature_object : input.feature_objects) {
-    pointcloud_size += feature_object.feature.cluster.width * feature_object.feature.cluster.height;
-  }
+  const size_t pointcloud_size = std::accumulate(
+    input.feature_objects.begin(), input.feature_objects.end(), 0,
+    [](size_t acc, const auto & obj) {
+      return acc + obj.feature.cluster.width * obj.feature.cluster.height;
+    });
 
   sensor_msgs::PointCloud2Modifier modifier(output);
   modifier.setPointCloud2Fields(

--- a/perception/euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -40,7 +40,7 @@ bool VoxelGridBasedEuclideanCluster::cluster(
   std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters)
 {
   pcl::PointCloud<pcl::PointXYZ>::ConstPtr pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
-  setPointcloud(pointcloud, pointcloud_ptr);
+  preparePointcloud(pointcloud, pointcloud_ptr);
 
   std::vector<pcl::PointCloud<pcl::PointXYZ>> temporary_clusters;  // no check about cluster size
   solveVoxelBasedClustering(pointcloud_ptr, temporary_clusters);
@@ -62,7 +62,7 @@ bool VoxelGridBasedEuclideanCluster::cluster(
   return true;
 }
 
-void VoxelGridBasedEuclideanCluster::setPointcloud(
+void VoxelGridBasedEuclideanCluster::preparePointcloud(
   const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
   pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud_ptr)
 {

--- a/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
@@ -57,10 +57,7 @@ void EuclideanClusterNode::onPointCloud(
   cluster_pub_->publish(output);
 
   // build debug msg
-  if (debug_pub_->get_subscription_count() < 1) {
-    return;
-  }
-  {
+  if (debug_pub_->get_subscription_count() >= 1) {
     sensor_msgs::msg::PointCloud2 debug;
     convertObjectMsg2SensorMsg(output, debug);
     debug_pub_->publish(debug);

--- a/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
@@ -57,7 +57,7 @@ void EuclideanClusterNode::onPointCloud(
   cluster_pub_->publish(output);
 
   // build debug msg
-  if (debug_pub_->get_subscription_count() >= 1) {
+  if (1 <= debug_pub_->get_subscription_count()) {
     sensor_msgs::msg::PointCloud2 debug;
     convertObjectMsg2SensorMsg(output, debug);
     debug_pub_->publish(debug);

--- a/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
@@ -61,7 +61,7 @@ void VoxelGridBasedEuclideanClusterNode::onPointCloud(
   cluster_pub_->publish(output);
 
   // build debug msg
-  if (debug_pub_->get_subscription_count() >= 1) {
+  if (1 <= debug_pub_->get_subscription_count()) {
     sensor_msgs::msg::PointCloud2 debug;
     convertObjectMsg2SensorMsg(output, debug);
     debug_pub_->publish(debug);

--- a/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
@@ -61,10 +61,7 @@ void VoxelGridBasedEuclideanClusterNode::onPointCloud(
   cluster_pub_->publish(output);
 
   // build debug msg
-  if (debug_pub_->get_subscription_count() < 1) {
-    return;
-  }
-  {
+  if (debug_pub_->get_subscription_count() >= 1) {
     sensor_msgs::msg::PointCloud2 debug;
     convertObjectMsg2SensorMsg(output, debug);
     debug_pub_->publish(debug);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- [x] add struct to define parametes for clustering in euclidean_cluster_interface.hpp
- [x] devide some operations into methods to have a similar format beteween euclidean_cluster and voxel_based one.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
