### PR TITLE
feat(tier4_localization_launch): pass pc container to localization

### DIFF
--- a/launch/tier4_localization_launch/launch/localization.launch.xml
+++ b/launch/tier4_localization_launch/launch/localization.launch.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="input/pointcloud" default="/sensing/lidar/top/outlier_filtered/pointcloud" description="The topic will be used in the localization util module"/>
-  <arg name="container" default="/sensing/lidar/top/pointcloud_preprocessor/velodyne_node_container"/>
+  <arg name="use_pointcloud_container" default="true" description="launch pointcloud container"/>
+  <arg name="pointcloud_container_name" default="pointcloud_container"/>
 
   <arg name="tier4_localization_launch_param_path" default="$(find-pkg-share tier4_localization_launch)/config" description="tier4_localization_launch parameter path"/>
 
@@ -13,7 +14,8 @@
       <push-ros-namespace namespace="util"/>
       <include file="$(find-pkg-share tier4_localization_launch)/launch/util/util.launch.xml">
         <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
-        <arg name="container" value="$(var container)"/>
+        <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+        <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
         <arg name="tier4_localization_launch_param_path" value="$(var tier4_localization_launch_param_path)"/>
       </include>
     </group>

--- a/launch/tier4_localization_launch/launch/util/util.launch.py
+++ b/launch/tier4_localization_launch/launch/util/util.launch.py
@@ -15,7 +15,7 @@
 import launch
 from launch.actions import DeclareLaunchArgument
 from launch.actions import OpaqueFunction
-from launch.conditions import LaunchConfigurationNotEquals
+from launch.conditions import LaunchConfigurationNotEquals, UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
@@ -71,10 +71,16 @@ def launch_setup(context, *args, **kwargs):
         random_downsample_component,
     ]
 
+    target_container = (
+        "/sensing/lidar/top/pointcloud_preprocessor/pointcloud_container"
+        if UnlessCondition(LaunchConfiguration("use_pointcloud_container")).evaluate(context)
+        else LaunchConfiguration("pointcloud_container_name")
+    )
+
     load_composable_nodes = LoadComposableNodes(
-        condition=LaunchConfigurationNotEquals("container", ""),
+        condition=LaunchConfigurationNotEquals(target_container, ""),
         composable_node_descriptions=composable_nodes,
-        target_container=LaunchConfiguration("container"),
+        target_container=target_container,
     )
 
     return [load_composable_nodes]
@@ -117,11 +123,13 @@ def generate_launch_description():
         "path to the parameter file of random_downsample_filter",
     )
     add_launch_arg("use_intra_process", "true", "use ROS2 component container communication")
+    add_launch_arg("use_pointcloud_container", "True", "use pointcloud container")
     add_launch_arg(
-        "container",
-        "/sensing/lidar/top/pointcloud_preprocessor/velodyne_node_container",
+        "pointcloud_container_name",
+        "/pointcloud_container",
         "container name",
     )
+
     add_launch_arg(
         "output/pointcloud",
         "downsample/pointcloud",

--- a/launch/tier4_localization_launch/launch/util/util.launch.py
+++ b/launch/tier4_localization_launch/launch/util/util.launch.py
@@ -15,7 +15,8 @@
 import launch
 from launch.actions import DeclareLaunchArgument
 from launch.actions import OpaqueFunction
-from launch.conditions import LaunchConfigurationNotEquals, UnlessCondition
+from launch.conditions import LaunchConfigurationNotEquals
+from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode

--- a/launch/tier4_localization_launch/launch/util/util.launch.xml
+++ b/launch/tier4_localization_launch/launch/util/util.launch.xml
@@ -6,7 +6,7 @@
   <arg name="output/pointcloud" default="downsample/pointcloud" description="final output topic name"/>
 
   <!-- container -->
-  <arg name="use_pointcloud_container" default="False" description="launch pointcloud container"/>
+  <arg name="use_pointcloud_container" default="True" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="/pointcloud_container" description="container name"/>
 
   <!-- option -->

--- a/launch/tier4_localization_launch/launch/util/util.launch.xml
+++ b/launch/tier4_localization_launch/launch/util/util.launch.xml
@@ -6,7 +6,8 @@
   <arg name="output/pointcloud" default="downsample/pointcloud" description="final output topic name"/>
 
   <!-- container -->
-  <arg name="container" default="/sensing/lidar/top/pointcloud_preprocessor/velodyne_node_container" description="container name"/>
+  <arg name="use_pointcloud_container" default="False" description="launch pointcloud container"/>
+  <arg name="pointcloud_container_name" default="/pointcloud_container" description="container name"/>
 
   <!-- option -->
   <arg name="use_intra_process" default="true" description="use ROS2 component container communication"/>
@@ -31,7 +32,8 @@
       <arg name="tier4_localization_launch_param_path" value="$(var tier4_localization_launch_param_path)"/>
       <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
       <arg name="output/pointcloud" value="$(var output/pointcloud)"/>
-      <arg name="container" value="$(var container)"/>
+      <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+      <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
       <arg name="use_intra_process" value="$(var use_intra_process)"/>
     </include>
   </group>


### PR DESCRIPTION
Signed-off-by: Kaan Colak <kcolak@leodrive.ai>

## Description

<!-- Write a brief description of this PR. -->

 Make it possible to pass `pointcloud_container` to velodyne nodes. 


 Under tier4_localization_launch utils, some preprocessor nodes uses velodyne container. If velodyne drivers use pointcloud_container use it, otherwise use default one   `/sensing/lidar/top/pointcloud_preprocessor/pointcloud_container`

This issue must be merged after this PR :  [https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/48]( https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/48)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
