### PR TITLE
feat(pure_pursuit): add predicted trajectory

### DIFF
--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -159,6 +159,12 @@ private:
   TrajectoryPoint calcNextPose(
     const double ds, TrajectoryPoint & point, AckermannLateralCommand cmd) const;
 
+  boost::optional<Trajectory> generatePredictedTrajectory();
+
+  boost::optional<AckermannLateralCommand> generateOutputControlCmd();
+
+  bool calcIsSteerConverged(const AckermannLateralCommand & cmd);
+
   // Debug
   mutable DebugData debug_data_;
 };

--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020-2022 Tier IV, Inc., Leo Drive Teknoloji A.Ş.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,10 @@
 #include "tier4_autoware_utils/ros/self_pose_listener.hpp"
 #include "trajectory_follower/lateral_controller_base.hpp"
 
+#include <motion_utils/resample/resample.hpp>
+#include <motion_utils/trajectory/tmp_conversion.hpp>
+#include <motion_utils/trajectory/trajectory.hpp>
+
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -53,9 +57,18 @@ using autoware::motion::control::trajectory_follower::InputData;
 using autoware::motion::control::trajectory_follower::LateralControllerBase;
 using autoware::motion::control::trajectory_follower::LateralOutput;
 using autoware_auto_control_msgs::msg::AckermannLateralCommand;
+using autoware_auto_planning_msgs::msg::Trajectory;
+using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 
 namespace pure_pursuit
 {
+
+struct PpOutput
+{
+  double curvature;
+  double velocity;
+};
+
 struct Param
 {
   // Global Parameters
@@ -67,6 +80,9 @@ struct Param
   double min_lookahead_distance;
   double reverse_min_lookahead_distance;  // min_lookahead_distance in reverse gear
   double converged_steer_rad_;
+  double prediction_ds;
+  double prediction_distance_length;  // Total distance of prediction trajectory
+  double resampling_ds;
 };
 
 struct DebugData
@@ -82,15 +98,24 @@ public:
 private:
   rclcpp::Node::SharedPtr node_;
   tier4_autoware_utils::SelfPoseListener self_pose_listener_;
-
+  boost::optional<std::vector<TrajectoryPoint>> output_tp_array_;
+  autoware_auto_planning_msgs::msg::Trajectory::SharedPtr trajectory_resampled_;
   autoware_auto_planning_msgs::msg::Trajectory::ConstSharedPtr trajectory_;
   nav_msgs::msg::Odometry::ConstSharedPtr current_odometry_;
   autoware_auto_vehicle_msgs::msg::SteeringReport::ConstSharedPtr current_steering_;
+  boost::optional<AckermannLateralCommand> prev_cmd_;
+
+  // Predicted Trajectory publish
+  rclcpp::Publisher<autoware_auto_planning_msgs::msg::Trajectory>::SharedPtr
+    pub_predicted_trajectory_;
 
   bool isDataReady();
 
   void onTrajectory(const autoware_auto_planning_msgs::msg::Trajectory::ConstSharedPtr msg);
+
   void onCurrentOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
+
+  void setResampledTrajectory();
 
   // TF
   tf2_ros::Buffer tf_buffer_;
@@ -106,6 +131,7 @@ private:
    * @brief compute control command for path follow with a constant control period
    */
   boost::optional<LateralOutput> run() override;
+
   AckermannLateralCommand generateCtrlCmdMsg(const double target_curvature);
 
   /**
@@ -114,13 +140,24 @@ private:
   void setInputData(InputData const & input_data) override;
 
   // Parameter
-  Param param_;
+  Param param_{};
 
   // Algorithm
   std::unique_ptr<PurePursuit> pure_pursuit_;
 
-  boost::optional<double> calcTargetCurvature();
-  boost::optional<autoware_auto_planning_msgs::msg::TrajectoryPoint> calcTargetPoint() const;
+  boost::optional<PpOutput> calcTargetCurvature(
+    bool is_control_output, geometry_msgs::msg::Pose pose);
+
+  boost::optional<autoware_auto_planning_msgs::msg::TrajectoryPoint> calcTargetPoint(
+    geometry_msgs::msg::Pose pose) const;
+
+  /**
+   * @brief It takes current pose, control command, and delta distance. Then it calculates next pose
+   * of vehicle.
+   */
+
+  TrajectoryPoint calcNextPose(
+    const double ds, TrajectoryPoint & point, AckermannLateralCommand cmd) const;
 
   // Debug
   mutable DebugData debug_data_;

--- a/control/pure_pursuit/include/pure_pursuit/util/planning_utils.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/util/planning_utils.hpp
@@ -50,7 +50,9 @@ namespace pure_pursuit
 namespace planning_utils
 {
 constexpr double ERROR = 1e-6;
-
+double calcArcLengthFromWayPoint(
+  const autoware_auto_planning_msgs::msg::Trajectory & input_path, const size_t src_idx,
+  const size_t dst_idx);
 double calcCurvature(
   const geometry_msgs::msg::Point & target, const geometry_msgs::msg::Pose & curr_pose);
 double calcDistance2D(const geometry_msgs::msg::Point & p, const geometry_msgs::msg::Point & q);

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -6,7 +6,7 @@
   <description>The pure_pursuit package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <license>Apache License 2.0</license>
-  
+
   <author email="berkay@leodrive.ai">Berkay Karaman</author>
   <author email="kenji.miyake@tier4.jp">Kenji Miyake</author>
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
@@ -17,8 +17,8 @@
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
-  <depend>geometry_msgs</depend>
   <depend>boost</depend>
+  <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>motion_common</depend>
   <depend>motion_utils</depend>

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -6,7 +6,8 @@
   <description>The pure_pursuit package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <license>Apache License 2.0</license>
-
+  
+  <author email="berkay@leodrive.ai">Berkay Karaman</author>
   <author email="kenji.miyake@tier4.jp">Kenji Miyake</author>
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
 
@@ -17,6 +18,11 @@
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>boost</depend>
+  <depend>libboost-dev</depend>
+  <depend>motion_common</depend>
+  <depend>motion_utils</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -234,7 +234,7 @@ boost::optional<LateralOutput> PurePursuitLateralController::run()
     return boost::none;
   }
   setResampledTrajectory();
-  if (!output_tp_array_ or !trajectory_resampled_) {
+  if (!output_tp_array_ || !trajectory_resampled_) {
     return boost::none;
   }
   const auto cmd_msg = generateOutputControlCmd();

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020-2022 Tier IV, Inc., Leo Drive Teknoloji A.Ş.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,10 +70,17 @@ PurePursuitLateralController::PurePursuitLateralController(rclcpp::Node & node)
   param_.reverse_min_lookahead_distance =
     node_->declare_parameter<double>("reverse_min_lookahead_distance", 7.0);
   param_.converged_steer_rad_ = node_->declare_parameter<double>("converged_steer_rad", 0.1);
+  param_.prediction_ds = node_->declare_parameter<double>("prediction_ds", 0.3);
+  param_.prediction_distance_length =
+    node_->declare_parameter<double>("prediction_distance_length", 21.0);
+  param_.resampling_ds = node_->declare_parameter<double>("resampling_ds", 0.1);
 
   // Debug Publishers
   pub_debug_marker_ =
     node_->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/markers", 0);
+  // Publish predicted trajectory
+  pub_predicted_trajectory_ = node_->create_publisher<autoware_auto_planning_msgs::msg::Trajectory>(
+    "~/output/predicted_trajectory", 1);
 
   //  Wait for first current pose
   tf_utils::waitForTransform(tf_buffer_, "map", "base_link");
@@ -99,6 +106,12 @@ bool PurePursuitLateralController::isDataReady()
     return false;
   }
 
+  if (!current_steering_) {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), 5000, "waiting for current_steering...");
+    return false;
+  }
+
   return true;
 }
 
@@ -109,6 +122,41 @@ void PurePursuitLateralController::setInputData(InputData const & input_data)
   current_steering_ = input_data.current_steering_ptr;
 }
 
+TrajectoryPoint PurePursuitLateralController::calcNextPose(
+  const double ds, TrajectoryPoint & point, AckermannLateralCommand cmd) const
+{
+  geometry_msgs::msg::Transform transform;
+  transform.translation = tier4_autoware_utils::createTranslation(ds, 0.0, 0.0);
+  transform.rotation =
+    planning_utils::getQuaternionFromYaw(((tan(cmd.steering_tire_angle) * ds) / param_.wheel_base));
+  TrajectoryPoint output_p;
+
+  tf2::Transform tf_pose;
+  tf2::Transform tf_offset;
+  tf2::fromMsg(transform, tf_offset);
+  tf2::fromMsg(point.pose, tf_pose);
+  tf2::toMsg(tf_pose * tf_offset, output_p.pose);
+  return output_p;
+}
+
+void PurePursuitLateralController::setResampledTrajectory()
+{
+  // Interpolate with constant interval distance for lateral acceleration calculation.
+  std::vector<double> out_arclength;
+  const auto input_tp_array = motion_utils::convertToTrajectoryPointArray(*trajectory_);
+  const auto traj_length = motion_utils::calcArcLength(input_tp_array);
+  for (double s = 0; s < traj_length; s += param_.resampling_ds) {
+    out_arclength.push_back(s);
+  }
+  trajectory_resampled_ =
+    std::make_shared<autoware_auto_planning_msgs::msg::Trajectory>(motion_utils::resampleTrajectory(
+      motion_utils::convertToTrajectory(input_tp_array), out_arclength));
+  trajectory_resampled_->points.back() = trajectory_->points.back();
+  trajectory_resampled_->header = trajectory_->header;
+  output_tp_array_ = boost::optional<std::vector<TrajectoryPoint>>(
+    motion_utils::convertToTrajectoryPointArray(*trajectory_resampled_));
+}
+
 boost::optional<LateralOutput> PurePursuitLateralController::run()
 {
   current_pose_ = self_pose_listener_.getCurrentPose();
@@ -116,16 +164,80 @@ boost::optional<LateralOutput> PurePursuitLateralController::run()
     return boost::none;
   }
 
-  const auto target_curvature = calcTargetCurvature();
-  AckermannLateralCommand cmd_msg;
-  if (target_curvature) {
-    cmd_msg = generateCtrlCmdMsg(*target_curvature);
-    publishDebugMarker();
-  } else {
-    RCLCPP_WARN_THROTTLE(
-      node_->get_logger(), *node_->get_clock(), 5000, "failed to solve pure_pursuit");
-    cmd_msg = generateCtrlCmdMsg({0.0});
+  setResampledTrajectory();
+
+  if (!output_tp_array_ or !trajectory_resampled_) {
+    return boost::none;
   }
+
+  const auto closest_idx_result =
+    motion_utils::findNearestIndex(*output_tp_array_, current_pose_->pose, 3.0, M_PI_4);
+
+  if (!closest_idx_result) {
+    return boost::none;
+  }
+
+  const double remaining_distance = planning_utils::calcArcLengthFromWayPoint(
+    *trajectory_resampled_, *closest_idx_result, trajectory_resampled_->points.size() - 1);
+
+  const auto num_of_iteration = std::max(
+    static_cast<int>(std::ceil(
+      std::min(remaining_distance, param_.prediction_distance_length) / param_.prediction_ds)),
+    1);
+  AckermannLateralCommand cmd_msg;
+  Trajectory predicted_trajectory;
+
+  // Iterative prediction:
+  for (int i = 0; i < num_of_iteration; i++) {
+    if (i == 0) {
+      TrajectoryPoint p;
+      p.pose = current_pose_->pose;
+      p.longitudinal_velocity_mps = current_odometry_->twist.twist.linear.x;
+      predicted_trajectory.points.push_back(p);
+
+      const auto pp_output = calcTargetCurvature(true, predicted_trajectory.points.at(i).pose);
+
+      if (pp_output) {
+        cmd_msg = generateCtrlCmdMsg(pp_output->curvature);
+        prev_cmd_ = boost::optional<AckermannLateralCommand>(cmd_msg);
+        publishDebugMarker();
+      } else {
+        RCLCPP_WARN_THROTTLE(
+          node_->get_logger(), *node_->get_clock(), 5000,
+          "failed to solve pure_pursuit for control command calculation");
+        if (prev_cmd_) {
+          cmd_msg = *prev_cmd_;
+        } else {
+          cmd_msg = generateCtrlCmdMsg(0.0);
+        }
+      }
+      TrajectoryPoint p2;
+      p2 = calcNextPose(param_.prediction_ds, predicted_trajectory.points.at(i), cmd_msg);
+      predicted_trajectory.points.push_back(p2);
+
+    } else {
+      const auto pp_output = calcTargetCurvature(false, predicted_trajectory.points.at(i).pose);
+      AckermannLateralCommand tmp_msg;
+
+      if (pp_output) {
+        tmp_msg = generateCtrlCmdMsg(pp_output->curvature);
+        predicted_trajectory.points.at(i).longitudinal_velocity_mps = pp_output->velocity;
+      } else {
+        RCLCPP_WARN_THROTTLE(
+          node_->get_logger(), *node_->get_clock(), 5000,
+          "failed to solve pure_pursuit for prediction");
+        tmp_msg = generateCtrlCmdMsg(0.0);
+      }
+      predicted_trajectory.points.push_back(
+        calcNextPose(param_.prediction_ds, predicted_trajectory.points.at(i), tmp_msg));
+    }
+  }
+
+  // for last point
+  predicted_trajectory.points.back().longitudinal_velocity_mps = 0.0;
+  predicted_trajectory.header.frame_id = trajectory_resampled_->header.frame_id;
+  predicted_trajectory.header.stamp = trajectory_resampled_->header.stamp;
+  pub_predicted_trajectory_->publish(predicted_trajectory);
 
   LateralOutput output;
   output.control_cmd = cmd_msg;
@@ -160,17 +272,18 @@ void PurePursuitLateralController::publishDebugMarker() const
   pub_debug_marker_->publish(marker_array);
 }
 
-boost::optional<double> PurePursuitLateralController::calcTargetCurvature()
+boost::optional<PpOutput> PurePursuitLateralController::calcTargetCurvature(
+  bool is_control_output, geometry_msgs::msg::Pose pose)
 {
   // Ignore invalid trajectory
-  if (trajectory_->points.size() < 3) {
+  if (trajectory_resampled_->points.size() < 3) {
     RCLCPP_WARN_THROTTLE(
       node_->get_logger(), *node_->get_clock(), 5000, "received path size is < 3, ignored");
     return {};
   }
 
   // Calculate target point for velocity/acceleration
-  const auto target_point = calcTargetPoint();
+  const auto target_point = calcTargetPoint(pose);
   if (!target_point) {
     return {};
   }
@@ -181,13 +294,19 @@ boost::optional<double> PurePursuitLateralController::calcTargetCurvature()
   const bool is_reverse = (target_vel < 0);
   const double min_lookahead_distance =
     is_reverse ? param_.reverse_min_lookahead_distance : param_.min_lookahead_distance;
-  const double lookahead_distance = calcLookaheadDistance(
-    current_odometry_->twist.twist.linear.x, param_.lookahead_distance_ratio,
-    min_lookahead_distance);
+  double lookahead_distance = min_lookahead_distance;
+  if (is_control_output) {
+    lookahead_distance = calcLookaheadDistance(
+      current_odometry_->twist.twist.linear.x, param_.lookahead_distance_ratio,
+      min_lookahead_distance);
+  } else {
+    lookahead_distance =
+      calcLookaheadDistance(target_vel, param_.lookahead_distance_ratio, min_lookahead_distance);
+  }
 
   // Set PurePursuit data
-  pure_pursuit_->setCurrentPose(current_pose_->pose);
-  pure_pursuit_->setWaypoints(planning_utils::extractPoses(*trajectory_));
+  pure_pursuit_->setCurrentPose(pose);
+  pure_pursuit_->setWaypoints(planning_utils::extractPoses(*trajectory_resampled_));
   pure_pursuit_->setLookaheadDistance(lookahead_distance);
 
   // Run PurePursuit
@@ -199,22 +318,30 @@ boost::optional<double> PurePursuitLateralController::calcTargetCurvature()
   const auto kappa = pure_pursuit_result.second;
 
   // Set debug data
-  debug_data_.next_target = pure_pursuit_->getLocationOfNextTarget();
+  if (is_control_output) {
+    debug_data_.next_target = pure_pursuit_->getLocationOfNextTarget();
+  }
+  PpOutput output{};
+  output.curvature = kappa;
+  if (!is_control_output) {
+    output.velocity = current_odometry_->twist.twist.linear.x;
+  } else {
+    output.velocity = target_vel;
+  }
 
-  return kappa;
+  return output;
 }
 
 boost::optional<autoware_auto_planning_msgs::msg::TrajectoryPoint>
-PurePursuitLateralController::calcTargetPoint() const
+PurePursuitLateralController::calcTargetPoint(geometry_msgs::msg::Pose pose) const
 {
-  const auto closest_idx_result = planning_utils::findClosestIdxWithDistAngThr(
-    planning_utils::extractPoses(*trajectory_), current_pose_->pose, 3.0, M_PI_4);
-
-  if (!closest_idx_result.first) {
+  const auto closest_idx_result =
+    motion_utils::findNearestIndex(*output_tp_array_, pose, 3.0, M_PI_4);
+  if (!closest_idx_result) {
     RCLCPP_ERROR(node_->get_logger(), "cannot find closest waypoint");
     return {};
   }
 
-  return trajectory_->points.at(closest_idx_result.second);
+  return trajectory_resampled_->points.at(*closest_idx_result);
 }
 }  // namespace pure_pursuit

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -141,7 +141,7 @@ TrajectoryPoint PurePursuitLateralController::calcNextPose(
 
 void PurePursuitLateralController::setResampledTrajectory()
 {
-  // Interpolate with constant interval distance for lateral acceleration calculation.
+  // Interpolate with constant interval distance.
   std::vector<double> out_arclength;
   const auto input_tp_array = motion_utils::convertToTrajectoryPointArray(*trajectory_);
   const auto traj_length = motion_utils::calcArcLength(input_tp_array);

--- a/control/pure_pursuit/src/pure_pursuit_core/planning_utils.cpp
+++ b/control/pure_pursuit/src/pure_pursuit_core/planning_utils.cpp
@@ -22,6 +22,21 @@ namespace pure_pursuit
 {
 namespace planning_utils
 {
+double calcArcLengthFromWayPoint(
+  const autoware_auto_planning_msgs::msg::Trajectory & input_path, const size_t src_idx,
+  const size_t dst_idx)
+{
+  double length = 0;
+  for (size_t i = src_idx; i < dst_idx; ++i) {
+    const double dx_wp =
+      input_path.points.at(i + 1).pose.position.x - input_path.points.at(i).pose.position.x;
+    const double dy_wp =
+      input_path.points.at(i + 1).pose.position.y - input_path.points.at(i).pose.position.y;
+    length += std::hypot(dx_wp, dy_wp);
+  }
+  return length;
+}
+
 double calcCurvature(
   const geometry_msgs::msg::Point & target, const geometry_msgs::msg::Pose & current_pose)
 {


### PR DESCRIPTION
Signed-off-by: Berkay Karaman [berkay@leodrive.ai](mailto:berkay@leodrive.ai)

## Description

<!-- Write a brief description of this PR. -->
Closes #2066 

In current implementation of autoware universe, `pure_pursuit` does not create predicted trajectory. In this PR, `pure_pursuit` creates predicted trajectory by iterating estimated pose.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
Tested in real vehicle tests, worked good.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
