### PR TITLE
fix(ground segmentation): correct initial condition of ground grid

### DIFF
--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -314,9 +314,7 @@ void ScanGroundFilterComponent::classifyPointCloudGridScan(
         continue;
       }
 
-      if (
-        !initialized_first_gnd_grid && global_slope_p < -global_slope_max_angle_rad_ &&
-        p->orig_point->z < -non_ground_height_threshold_local) {
+      if (!initialized_first_gnd_grid) {
         prev_p = p;
         continue;
       }


### PR DESCRIPTION
Signed-off-by: badai-nguyen <dai.nguyen@tier4.jp>

## Description

This PR to fix a refactoring bug at #1899 
Make the result the same as before refactoring at [52a2b86](https://github.com/badai-nguyen/autoware.universe/tree/52a2b8604652e3fee4d0f05b6329442a1b93eec7)  

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
