### PR TITLE
refactor(pure_pursuit): make lookahead distance calculation more tunable

### DIFF
--- a/control/pure_pursuit/config/pure_pursuit_lateral_controller_plotjuggler_debug.xml
+++ b/control/pure_pursuit/config/pure_pursuit_lateral_controller_plotjuggler_debug.xml
@@ -1,0 +1,114 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<root>
+ <tabbed_widget parent="main_window" name="Main Window">
+  <Tab containers="1" tab_name="tab1">
+   <Container>
+    <DockSplitter sizes="0.5;0.5" orientation="-" count="2">
+     <DockArea name="Lookahead Distance">
+      <plot flip_y="false" mode="TimeSeries" flip_x="false" style="Lines">
+       <range right="80.040302" top="4.460166" bottom="-0.166817" left="0.000000"/>
+       <limitY/>
+       <curve color="#1f77b4" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.0">
+         <transform alias="Velocity_LD" name="Scale/Offset">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+       </curve>
+       <curve color="#d62728" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.1">
+         <transform alias="Curvature_LD" name="Scale/Offset">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+       </curve>
+       <curve color="#1ac938" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.2">
+         <transform alias="Lateral_Error_LD" name="Scale/Offset">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+       </curve>
+       <curve color="#ff7f0e" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.3">
+         <transform alias="Total_LD" name="Scale/Offset">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+       </curve>
+      </plot>
+     </DockArea>
+     <DockSplitter sizes="0.333538;0.332925;0.333538" orientation="|" count="3">
+      <DockArea name="Velocity">
+       <plot flip_y="false" mode="TimeSeries" flip_x="false" style="Lines">
+        <range right="80.040302" top="0.100000" bottom="-0.100000" left="0.000000"/>
+        <limitY/>
+        <curve color="#f14cc1" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.6">
+         <transform alias="Velocity" name="Scale/Offset">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+       </curve>
+       </plot>
+      </DockArea>
+      <DockArea name="Lateral Error">
+       <plot flip_y="false" mode="TimeSeries" flip_x="false" style="Lines">
+        <range right="80.040302" top="0.537336" bottom="0.537336" left="0.000000"/>
+        <limitY/>
+        <curve color="#9467bd" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.5">
+         <transform alias="Lateral_Error" name="Scale/Offset">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+       </curve>
+       </plot>
+      </DockArea>
+      <DockArea name="Curvature">
+       <plot flip_y="false" mode="TimeSeries" flip_x="false" style="Lines">
+        <range right="80.040302" top="0.000473" bottom="0.000426" left="0.000000"/>
+        <limitY/>
+        <curve color="#17becf" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.4">
+         <transform alias="Curvature" name="Scale/Offset">
+          <options value_scale="1.0" time_offset="0" value_offset="0"/>
+         </transform>
+       </curve>
+       </plot>
+      </DockArea>
+     </DockSplitter>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <currentTabIndex index="0"/>
+ </tabbed_widget>
+ <use_relative_time_offset enabled="1"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <!-- - - - - - - - - - - - - - - -->
+ <Plugins>
+  <plugin ID="DataLoad CSV">
+   <default time_axis="" delimiter="0"/>
+  </plugin>
+  <plugin ID="DataLoad ROS2 bags">
+   <use_header_stamp value="false"/>
+   <discard_large_arrays value="true"/>
+   <max_array_size value="100"/>
+   <boolean_strings_to_number value="true"/>
+   <remove_suffix_from_strings value="true"/>
+  </plugin>
+  <plugin ID="DataLoad ULog"/>
+  <plugin ID="ROS2 Topic Subscriber">
+   <use_header_stamp value="true"/>
+   <discard_large_arrays value="true"/>
+   <max_array_size value="100"/>
+   <boolean_strings_to_number value="true"/>
+   <remove_suffix_from_strings value="true"/>
+  </plugin>
+  <plugin ID="UDP Server"/>
+  <plugin ID="WebSocket Server"/>
+  <plugin ID="ZMQ Subscriber"/>
+  <plugin ID="Fast Fourier Transform"/>
+  <plugin ID="Quaternion to RPY"/>
+  <plugin ID="Reactive Script Editor">
+   <library code="--[[ Helper function to create a series from arrays&#xa;&#xa; new_series: a series previously created with ScatterXY.new(name)&#xa; prefix:     prefix of the timeseries, before the index of the array&#xa; suffix_X:   suffix to complete the name of the series containing the X value. If [nil], use the index of the array.&#xa; suffix_Y:   suffix to complete the name of the series containing the Y value&#xa; timestamp:   usually the tracker_time variable&#xa;              &#xa; Example:&#xa; &#xa; Assuming we have multiple series in the form:&#xa; &#xa;   /trajectory/node.{X}/position/x&#xa;   /trajectory/node.{X}/position/y&#xa;   &#xa; where {N} is the index of the array (integer). We can create a reactive series from the array with:&#xa; &#xa;   new_series = ScatterXY.new(&quot;my_trajectory&quot;) &#xa;   CreateSeriesFromArray( new_series, &quot;/trajectory/node&quot;, &quot;position/x&quot;, &quot;position/y&quot;, tracker_time );&#xa;--]]&#xa;&#xa;function CreateSeriesFromArray( new_series, prefix, suffix_X, suffix_Y, timestamp )&#xa;  &#xa;  --- clear previous values&#xa;  new_series:clear()&#xa;  &#xa;  --- Append points to new_series&#xa;  index = 0&#xa;  while(true) do&#xa;&#xa;    x = index;&#xa;    -- if not nil, get the X coordinate from a series&#xa;    if suffix_X ~= nil then &#xa;      series_x = TimeseriesView.find( string.format( &quot;%s.%d/%s&quot;, prefix, index, suffix_X) )&#xa;      if series_x == nil then break end&#xa;      x = series_x:atTime(timestamp)&#x9; &#xa;    end&#xa;    &#xa;    series_y = TimeseriesView.find( string.format( &quot;%s.%d/%s&quot;, prefix, index, suffix_Y) )&#xa;    if series_y == nil then break end &#xa;    y = series_y:atTime(timestamp)&#xa;    &#xa;    new_series:push_back(x,y)&#xa;    index = index+1&#xa;  end&#xa;end&#xa;&#xa;--[[ Similar to the built-in function GetSeriesNames(), but select only the names with a give prefix. --]]&#xa;&#xa;function GetSeriesNamesByPrefix(prefix)&#xa;  -- GetSeriesNames(9 is a built-in function&#xa;  all_names = GetSeriesNames()&#xa;  filtered_names = {}&#xa;  for i, name in ipairs(all_names)  do&#xa;    -- check the prefix&#xa;    if name:find(prefix, 1, #prefix) then&#xa;      table.insert(filtered_names, name);&#xa;    end&#xa;  end&#xa;  return filtered_names&#xa;end&#xa;&#xa;--[[ Modify an existing series, applying offsets to all their X and Y values&#xa;&#xa; series: an existing timeseries, obtained with TimeseriesView.find(name)&#xa; delta_x: offset to apply to each x value&#xa; delta_y: offset to apply to each y value &#xa;  &#xa;--]]&#xa;&#xa;function ApplyOffsetInPlace(series, delta_x, delta_y)&#xa;  -- use C++ indeces, not Lua indeces&#xa;  for index=0, series:size()-1 do&#xa;    x,y = series:at(index)&#xa;    series:set(index, x + delta_x, y + delta_y)&#xa;  end&#xa;end&#xa;"/>
+   <scripts/>
+  </plugin>
+  <plugin ID="CSV Exporter"/>
+  <plugin ID="ROS2 Topic Re-Publisher"/>
+ </Plugins>
+ <!-- - - - - - - - - - - - - - - -->
+ <previouslyLoaded_Datafiles/>
+ <previouslyLoaded_Streamer name="ROS2 Topic Subscriber"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <customMathEquations/>
+ <snippets/>
+ <!-- - - - - - - - - - - - - - - -->
+</root>

--- a/control/pure_pursuit/config/pure_pursuit_lateral_controller_plotjuggler_debug.xml
+++ b/control/pure_pursuit/config/pure_pursuit_lateral_controller_plotjuggler_debug.xml
@@ -8,22 +8,22 @@
       <plot flip_y="false" mode="TimeSeries" flip_x="false" style="Lines">
        <range right="80.040302" top="4.460166" bottom="-0.166817" left="0.000000"/>
        <limitY/>
-       <curve color="#1f77b4" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.0">
+       <curve color="#1f77b4" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/data.0">
          <transform alias="Velocity_LD" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
        </curve>
-       <curve color="#d62728" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.1">
+       <curve color="#d62728" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/data.1">
          <transform alias="Curvature_LD" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
        </curve>
-       <curve color="#1ac938" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.2">
+       <curve color="#1ac938" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/data.2">
          <transform alias="Lateral_Error_LD" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
        </curve>
-       <curve color="#ff7f0e" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.3">
+       <curve color="#ff7f0e" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/data.3">
          <transform alias="Total_LD" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -35,7 +35,7 @@
        <plot flip_y="false" mode="TimeSeries" flip_x="false" style="Lines">
         <range right="80.040302" top="0.100000" bottom="-0.100000" left="0.000000"/>
         <limitY/>
-        <curve color="#f14cc1" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.6">
+        <curve color="#f14cc1" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/data.6">
          <transform alias="Velocity" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -46,7 +46,7 @@
        <plot flip_y="false" mode="TimeSeries" flip_x="false" style="Lines">
         <range right="80.040302" top="0.537336" bottom="0.537336" left="0.000000"/>
         <limitY/>
-        <curve color="#9467bd" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.5">
+        <curve color="#9467bd" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/data.5">
          <transform alias="Lateral_Error" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -57,7 +57,7 @@
        <plot flip_y="false" mode="TimeSeries" flip_x="false" style="Lines">
         <range right="80.040302" top="0.000473" bottom="0.000426" left="0.000000"/>
         <limitY/>
-        <curve color="#17becf" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/diag_array/data.4">
+        <curve color="#17becf" name="/control/trajectory_follower/controller_node_exe/debug/ld_outputs/data.4">
          <transform alias="Curvature" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>

--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -44,6 +44,7 @@
 
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
+#include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -76,13 +77,18 @@ struct Param
   double max_steering_angle;  // [rad]
 
   // Algorithm Parameters
-  double lookahead_distance_ratio;
+  double ld_velocity_ratio;
+  double ld_lateral_error_ratio;
+  double ld_curvature_ratio;
   double min_lookahead_distance;
+  double max_lookahead_distance;
   double reverse_min_lookahead_distance;  // min_lookahead_distance in reverse gear
   double converged_steer_rad_;
   double prediction_ds;
   double prediction_distance_length;  // Total distance of prediction trajectory
   double resampling_ds;
+  double curvature_calculation_distance;
+  double long_ld_lateral_error_threshold;
 };
 
 struct DebugData
@@ -105,6 +111,10 @@ private:
   autoware_auto_vehicle_msgs::msg::SteeringReport::ConstSharedPtr current_steering_;
   boost::optional<AckermannLateralCommand> prev_cmd_;
 
+  // Debug Publisher
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_debug_marker_;
+  rclcpp::Publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>::SharedPtr
+    pub_debug_values_;
   // Predicted Trajectory publish
   rclcpp::Publisher<autoware_auto_planning_msgs::msg::Trajectory>::SharedPtr
     pub_predicted_trajectory_;
@@ -121,9 +131,6 @@ private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
   geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
-
-  // Debug Publisher
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_debug_marker_;
 
   void publishDebugMarker() const;
 
@@ -148,9 +155,6 @@ private:
   boost::optional<PpOutput> calcTargetCurvature(
     bool is_control_output, geometry_msgs::msg::Pose pose);
 
-  boost::optional<autoware_auto_planning_msgs::msg::TrajectoryPoint> calcTargetPoint(
-    geometry_msgs::msg::Pose pose) const;
-
   /**
    * @brief It takes current pose, control command, and delta distance. Then it calculates next pose
    * of vehicle.
@@ -165,6 +169,12 @@ private:
 
   bool calcIsSteerConverged(const AckermannLateralCommand & cmd);
 
+  double calcLookaheadDistance(
+    const double lateral_error, const double curvature, const double velocity,
+    const bool is_control_cmd);
+
+  double calcCurvature(
+    const TrajectoryPoint & p1, const TrajectoryPoint & p2, const TrajectoryPoint & p3);
   // Debug
   mutable DebugData debug_data_;
 };

--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -44,10 +44,10 @@
 
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
 
 #include <boost/optional.hpp>  // To be replaced by std::optional in C++17
 
@@ -113,8 +113,7 @@ private:
 
   // Debug Publisher
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_debug_marker_;
-  rclcpp::Publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>::SharedPtr
-    pub_debug_values_;
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr pub_debug_values_;
   // Predicted Trajectory publish
   rclcpp::Publisher<autoware_auto_planning_msgs::msg::Trajectory>::SharedPtr
     pub_predicted_trajectory_;
@@ -170,11 +169,11 @@ private:
   bool calcIsSteerConverged(const AckermannLateralCommand & cmd);
 
   double calcLookaheadDistance(
-    const double lateral_error, const double curvature, const double velocity,
+    const double lateral_error, const double curvature, const double velocity, const double min_ld,
     const bool is_control_cmd);
 
-  double calcCurvature(
-    const TrajectoryPoint & p1, const TrajectoryPoint & p2, const TrajectoryPoint & p3);
+  double calcCurvature(const size_t closest_idx);
+
   // Debug
   mutable DebugData debug_data_;
 };

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <build_depend>autoware_cmake</build_depend>
-  autoware_auto_system_msgs
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -16,7 +16,6 @@
   <build_depend>autoware_cmake</build_depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
-  <depend>autoware_auto_system_msgs</depend>
   <depend>boost</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
@@ -31,6 +30,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
+  <depend>tier4_debug_msgs</depend>
   <depend>trajectory_follower</depend>
   <depend>vehicle_info_util</depend>
   <depend>visualization_msgs</depend>

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -14,9 +14,10 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <build_depend>autoware_cmake</build_depend>
-
+  autoware_auto_system_msgs
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_auto_system_msgs</depend>
   <depend>boost</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -42,13 +42,16 @@
 
 namespace
 {
-double calcLookaheadDistance(
-  const double velocity, const double lookahead_distance_ratio, const double min_lookahead_distance)
-{
-  const double lookahead_distance = lookahead_distance_ratio * std::abs(velocity);
-  return std::max(lookahead_distance, min_lookahead_distance);
-}
-
+enum TYPE {
+  VEL_LD = 0,
+  CURVATURE_LD = 1,
+  LATERAL_ERROR_LD = 2,
+  TOTAL_LD = 3,
+  CURVATURE = 4,
+  LATERAL_ERROR = 5,
+  VELOCITY = 6,
+  SIZE  // this is the number of enum elements
+};
 }  // namespace
 
 namespace pure_pursuit
@@ -64,9 +67,13 @@ PurePursuitLateralController::PurePursuitLateralController(rclcpp::Node & node)
   param_.max_steering_angle = vehicle_info.max_steer_angle_rad;
 
   // Algorithm Parameters
-  param_.lookahead_distance_ratio =
-    node_->declare_parameter<double>("lookahead_distance_ratio", 2.2);
-  param_.min_lookahead_distance = node_->declare_parameter<double>("min_lookahead_distance", 2.5);
+  param_.ld_velocity_ratio = node_->declare_parameter<double>("ld_velocity_ratio", 2.4);
+  param_.ld_lateral_error_ratio = node_->declare_parameter<double>("ld_lateral_error_ratio", 3.6);
+  param_.ld_curvature_ratio = node_->declare_parameter<double>("ld_curvature_ratio", 120.0);
+  param_.long_ld_lateral_error_threshold =
+    node_->declare_parameter<double>("long_ld_lateral_error_threshold", 0.5);
+  param_.min_lookahead_distance = node_->declare_parameter<double>("min_lookahead_distance", 4.35);
+  param_.max_lookahead_distance = node_->declare_parameter<double>("max_lookahead_distance", 15.0);
   param_.reverse_min_lookahead_distance =
     node_->declare_parameter<double>("reverse_min_lookahead_distance", 7.0);
   param_.converged_steer_rad_ = node_->declare_parameter<double>("converged_steer_rad", 0.1);
@@ -74,10 +81,16 @@ PurePursuitLateralController::PurePursuitLateralController(rclcpp::Node & node)
   param_.prediction_distance_length =
     node_->declare_parameter<double>("prediction_distance_length", 21.0);
   param_.resampling_ds = node_->declare_parameter<double>("resampling_ds", 0.1);
+  param_.curvature_calculation_distance =
+    node_->declare_parameter<double>("curvature_calculation_distance", 4.0);
 
   // Debug Publishers
   pub_debug_marker_ =
     node_->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/markers", 0);
+  pub_debug_values_ =
+    node_->create_publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>(
+      "~/debug/ld_outputs", rclcpp::QoS{1});
+
   // Publish predicted trajectory
   pub_predicted_trajectory_ = node_->create_publisher<autoware_auto_planning_msgs::msg::Trajectory>(
     "~/output/predicted_trajectory", 1);
@@ -113,6 +126,45 @@ bool PurePursuitLateralController::isDataReady()
   }
 
   return true;
+}
+
+double PurePursuitLateralController::calcLookaheadDistance(
+  const double lateral_error, const double curvature, const double velocity,
+  const bool is_control_cmd)
+{
+  const double vel_ld = abs(param_.ld_velocity_ratio * velocity);
+  const double curvature_ld = -abs(param_.ld_curvature_ratio * curvature);
+  double lateral_error_ld = 0.0;
+
+  if (abs(lateral_error) >= param_.long_ld_lateral_error_threshold) {
+    // If lateral error is higher than threshold, we should make ld larger to prevent entering the
+    // road with high heading error.
+    lateral_error_ld = abs(param_.ld_lateral_error_ratio * lateral_error);
+  }
+
+  const double total_ld = std::clamp(
+    vel_ld + curvature_ld + lateral_error_ld, param_.min_lookahead_distance,
+    param_.max_lookahead_distance);
+
+  auto pubDebugValues = [&]() {
+    autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic debug_msg{};
+    debug_msg.diag_array.data.resize(TYPE::SIZE);
+    debug_msg.diag_array.data.at(TYPE::VEL_LD) = static_cast<float>(vel_ld);
+    debug_msg.diag_array.data.at(TYPE::CURVATURE_LD) = static_cast<float>(curvature_ld);
+    debug_msg.diag_array.data.at(TYPE::LATERAL_ERROR_LD) = static_cast<float>(lateral_error_ld);
+    debug_msg.diag_array.data.at(TYPE::TOTAL_LD) = static_cast<float>(total_ld);
+    debug_msg.diag_array.data.at(TYPE::VELOCITY) = static_cast<float>(velocity);
+    debug_msg.diag_array.data.at(TYPE::CURVATURE) = static_cast<float>(curvature);
+    debug_msg.diag_array.data.at(TYPE::LATERAL_ERROR) = static_cast<float>(lateral_error);
+    debug_msg.diag_header.data_stamp = node_->now();
+    pub_debug_values_->publish(debug_msg);
+  };
+
+  if (is_control_cmd) {
+    pubDebugValues();
+  }
+
+  return total_ld;
 }
 
 void PurePursuitLateralController::setInputData(InputData const & input_data)
@@ -155,6 +207,23 @@ void PurePursuitLateralController::setResampledTrajectory()
   trajectory_resampled_->header = trajectory_->header;
   output_tp_array_ = boost::optional<std::vector<TrajectoryPoint>>(
     motion_utils::convertToTrajectoryPointArray(*trajectory_resampled_));
+}
+
+double PurePursuitLateralController::calcCurvature(
+  const TrajectoryPoint & p1, const TrajectoryPoint & p2, const TrajectoryPoint & p3)
+{
+  // Calculation details are described in the following page
+  // https://en.wikipedia.org/wiki/Menger_curvature
+  const double denominator = tier4_autoware_utils::calcDistance2d(p1, p2) *
+                             tier4_autoware_utils::calcDistance2d(p2, p3) *
+                             tier4_autoware_utils::calcDistance2d(p3, p1);
+  if (std::fabs(denominator) < 1e-10) {
+    throw std::runtime_error("points are too close for curvature calculation.");
+  }
+  return 2.0 *
+         ((p2.pose.position.x - p1.pose.position.x) * (p3.pose.position.y - p1.pose.position.y) -
+          (p2.pose.position.y - p1.pose.position.y) * (p3.pose.position.x - p1.pose.position.x)) /
+         denominator;
 }
 
 boost::optional<Trajectory> PurePursuitLateralController::generatePredictedTrajectory()
@@ -315,6 +384,8 @@ void PurePursuitLateralController::publishDebugMarker() const
 boost::optional<PpOutput> PurePursuitLateralController::calcTargetCurvature(
   bool is_control_output, geometry_msgs::msg::Pose pose)
 {
+  constexpr double threshold = 1e-5;  // 0.00001
+
   // Ignore invalid trajectory
   if (trajectory_resampled_->points.size() < 3) {
     RCLCPP_WARN_THROTTLE(
@@ -323,12 +394,69 @@ boost::optional<PpOutput> PurePursuitLateralController::calcTargetCurvature(
   }
 
   // Calculate target point for velocity/acceleration
-  const auto target_point = calcTargetPoint(pose);
-  if (!target_point) {
+
+  const auto closest_idx_result =
+    motion_utils::findNearestIndex(*output_tp_array_, pose, 3.0, M_PI_4);
+  if (!closest_idx_result) {
+    RCLCPP_ERROR(node_->get_logger(), "cannot find closest waypoint");
     return {};
   }
 
-  const double target_vel = target_point->longitudinal_velocity_mps;
+  const double && target_vel =
+    trajectory_resampled_->points.at(*closest_idx_result).longitudinal_velocity_mps;
+
+  // calculate the lateral error
+
+  geometry_msgs::msg::Point vec_end;
+  geometry_msgs::msg::Point vec_start;
+
+  if (*closest_idx_result == output_tp_array_->size() - 1) {
+    vec_end = output_tp_array_->at(*closest_idx_result).pose.position;
+    vec_start = output_tp_array_->at(*closest_idx_result - 1).pose.position;
+  } else {
+    vec_start = output_tp_array_->at(*closest_idx_result).pose.position;
+    vec_end = output_tp_array_->at(*closest_idx_result + 1).pose.position;
+  }
+
+  Eigen::Vector3d vec_a(
+    (vec_end.x - vec_start.x), (vec_end.y - vec_start.y), (vec_end.z - vec_start.z));
+
+  if (vec_a.norm() < threshold) {
+    RCLCPP_ERROR(node_->get_logger(), "Trajectory point interval is almost 0.");
+    return {};
+  }
+
+  const double lateral_error =
+    planning_utils::calcLateralError2D(vec_start, vec_end, pose.position);
+
+  // Calculate current curvature
+  const size_t idx_dist = static_cast<size_t>(
+    std::max(static_cast<int>((param_.curvature_calculation_distance) / param_.resampling_ds), 1));
+
+  // Find the points in trajectory to calculate curvature
+  size_t next_idx = trajectory_resampled_->points.size() - 1;
+  size_t prev_idx = 0;
+
+  if (static_cast<size_t>(*closest_idx_result) >= idx_dist) {
+    prev_idx = *closest_idx_result - idx_dist;
+  }
+  if (trajectory_resampled_->points.size() - 1 >= *closest_idx_result + idx_dist) {
+    next_idx = *closest_idx_result + idx_dist;
+  }
+
+  // Calculate curvature assuming the trajectory points interval is constant
+  double current_curvature = 0.0;
+
+  try {
+    current_curvature = calcCurvature(
+      trajectory_resampled_->points.at(prev_idx),
+      trajectory_resampled_->points.at(*closest_idx_result),
+      trajectory_resampled_->points.at(next_idx));
+  } catch (std::exception const & e) {
+    // ...code that handles the error...
+    RCLCPP_WARN(rclcpp::get_logger("pure_pursuit"), "%s", e.what());
+    current_curvature = 0.0;
+  }
 
   // Calculate lookahead distance
   const bool is_reverse = (target_vel < 0);
@@ -337,11 +465,10 @@ boost::optional<PpOutput> PurePursuitLateralController::calcTargetCurvature(
   double lookahead_distance = min_lookahead_distance;
   if (is_control_output) {
     lookahead_distance = calcLookaheadDistance(
-      current_odometry_->twist.twist.linear.x, param_.lookahead_distance_ratio,
-      min_lookahead_distance);
+      lateral_error, current_curvature, current_odometry_->twist.twist.linear.x, is_control_output);
   } else {
     lookahead_distance =
-      calcLookaheadDistance(target_vel, param_.lookahead_distance_ratio, min_lookahead_distance);
+      calcLookaheadDistance(lateral_error, current_curvature, target_vel, is_control_output);
   }
 
   // Set PurePursuit data
@@ -370,18 +497,5 @@ boost::optional<PpOutput> PurePursuitLateralController::calcTargetCurvature(
   }
 
   return output;
-}
-
-boost::optional<autoware_auto_planning_msgs::msg::TrajectoryPoint>
-PurePursuitLateralController::calcTargetPoint(geometry_msgs::msg::Pose pose) const
-{
-  const auto closest_idx_result =
-    motion_utils::findNearestIndex(*output_tp_array_, pose, 3.0, M_PI_4);
-  if (!closest_idx_result) {
-    RCLCPP_ERROR(node_->get_logger(), "cannot find closest waypoint");
-    return {};
-  }
-
-  return trajectory_resampled_->points.at(*closest_idx_result);
 }
 }  // namespace pure_pursuit


### PR DESCRIPTION
## Description
Closes #2116 

<!-- Write a brief description of this PR. -->
In current implementation of Autoware Universe, lookahead distance in pure_pursuit just depend the velocity. This causes unwanted behaviors. For example, if lookahead_distance_ratio is low, when lateral error high in beginning (think that vehicle in side of road), vehicle enters the road with high heading error. If you increase the lookahead_distance_ratio to smoother entrance to road, It causes increasing lateral error in high curvature part of road.

To avoid this, lookahead_distance should depend more variables (like lateral error and curvature of road). This will make the pure_pursuit more tunable.

lookahead_distance = lookahead_distance_ratio * velocity + lateral_error_ratio * lateral_error - curvature_ratio * curvature

If there is high lateral error in curvature, you can increase the curvature_ratio, If vehicle enters the road with high heading error, you can increase the lateral_error_ratio for smooth entrance to road.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

Tested in planning_simulator, I couldn't see any problem.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
To make tuning easier, I added plotjuggler layout for lookahead distances. You can import the `config/pure_pursuit_lateral_controller_plotjuggler_debug.xml`.

Note: Before merge this PR, we should merge [this](https://github.com/autowarefoundation/autoware.universe/pull/2115).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
