### PR TITLE
feat: remove launch for old routing api

### DIFF
--- a/launch/tier4_autoware_api_launch/launch/include/internal_api_adaptor.launch.py
+++ b/launch/tier4_autoware_api_launch/launch/include/internal_api_adaptor.launch.py
@@ -31,7 +31,6 @@ def generate_launch_description():
     components = [
         _create_api_node("iv_msgs", "IVMsgs"),
         _create_api_node("operator", "Operator"),
-        _create_api_node("route", "Route"),
         _create_api_node("velocity", "Velocity"),
     ]
     container = ComposableNodeContainer(


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Remove launch for old routing api node.
https://github.com/tier4/tier4_ad_api_adaptor/pull/75

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
