### PR TITLE
chore: fix typos

### DIFF
--- a/common/perception_utils/test/src/test_matching.cpp
+++ b/common/perception_utils/test/src/test_matching.cpp
@@ -97,8 +97,8 @@ TEST(perception_utils, test_get2dGeneralizedIoU)
   // TODO(Shin-kyoto):
   // get2dGeneralizedIoU uses outer points of each polygon.
   // But these points contain an sampling error of outer line,
-  // so get2dGeneralizedIoU icludes an error of about 0.03.
-  // Threfore, in this test, epsilon is set to 0.04.
+  // so get2dGeneralizedIoU includes an error of about 0.03.
+  // Therefore, in this test, epsilon is set to 0.04.
   constexpr double epsilon_giou = 4 * 1e-02;
   const double quart_circle = 0.16237976320958225;
 

--- a/launch/tier4_perception_launch/config/object_recognition/tracking/multi_object_tracker/data_association_matrix.param.yaml
+++ b/launch/tier4_perception_launch/config/object_recognition/tracking/multi_object_tracker/data_association_matrix.param.yaml
@@ -22,8 +22,8 @@
        3.0,     1.0, 1.0,   1.0,  1.0,     3.0,       3.0,     2.0,       #BICYCLE
        2.0,     1.0, 1.0,   1.0,  1.0,     3.0,       3.0,     2.0]       #PEDESTRIAN
     max_area_matrix:
-      # NOTE(yukke42): The size of truck is 12 m length x 3 m width.
-      # NOTE(yukke42): The size of trailer is 20 m length x 3 m width.
+      # NOTE: The size of truck is 12 m length x 3 m width.
+      # NOTE: The size of trailer is 20 m length x 3 m width.
       #UNKNOWN,  CAR,      TRUCK,    BUS,      TRAILER,   MOTORBIKE, BICYCLE,  PEDESTRIAN
         [100.00,   100.00,   100.00,   100.00,   100.00,    100.00,    100.00,   100.00,   #UNKNOWN
           12.10,    12.10,    36.00,    60.00,    60.00,  10000.00,  10000.00, 10000.00,   #CAR

--- a/perception/ground_segmentation/docs/scan-ground-filter.md
+++ b/perception/ground_segmentation/docs/scan-ground-filter.md
@@ -58,6 +58,8 @@ The input_frame is set as parameter but it must be fixed as base_link for the cu
 
 ## (Optional) References/External links
 
+<!-- cspell: ignore Shen Liang -->
+
 The elevation grid idea is referred from "Shen Z, Liang H, Lin L, Wang Z, Huang W, Yu J. Fast Ground Segmentation for 3D LiDAR Point Cloud Based on Jump-Convolution-Process. Remote Sensing. 2021; 13(16):3239. <https://doi.org/10.3390/rs13163239>"
 
 ## (Optional) Future extensions / Unimplemented parts

--- a/perception/lidar_centerpoint/lib/postprocess/non_maximum_suppression.cpp
+++ b/perception/lidar_centerpoint/lib/postprocess/non_maximum_suppression.cpp
@@ -57,7 +57,7 @@ bool NonMaximumSuppression::isTargetPairObject(
 Eigen::MatrixXd NonMaximumSuppression::generateIoUMatrix(
   const std::vector<DetectedObject> & input_objects)
 {
-  // NOTE(yukke42): row = target objects to be suppressed, col = source objects to be compared
+  // NOTE: row = target objects to be suppressed, col = source objects to be compared
   Eigen::MatrixXd triangular_matrix =
     Eigen::MatrixXd::Zero(input_objects.size(), input_objects.size());
   for (std::size_t target_i = 0; target_i < input_objects.size(); ++target_i) {
@@ -71,7 +71,7 @@ Eigen::MatrixXd NonMaximumSuppression::generateIoUMatrix(
       if (params_.nms_type_ == NMS_TYPE::IoU_BEV) {
         const double iou = perception_utils::get2dIoU(target_obj, source_obj);
         triangular_matrix(target_i, source_i) = iou;
-        // NOTE(yukke42): If the target object has any objects with iou > iou_threshold, it
+        // NOTE: If the target object has any objects with iou > iou_threshold, it
         // will be suppressed regardless of later results.
         if (iou > params_.iou_threshold_) {
           break;

--- a/perception/multi_object_tracker/config/data_association_matrix.param.yaml
+++ b/perception/multi_object_tracker/config/data_association_matrix.param.yaml
@@ -22,8 +22,8 @@
        3.0,     1.0, 1.0,   1.0,  1.0,     3.0,       3.0,     2.0,       #BICYCLE
        2.0,     1.0, 1.0,   1.0,  1.0,     3.0,       3.0,     2.0]       #PEDESTRIAN
     max_area_matrix:
-      # NOTE(yukke42): The size of truck is 12 m length x 3 m width.
-      # NOTE(yukke42): The size of trailer is 20 m length x 3 m width.
+      # NOTE: The size of truck is 12 m length x 3 m width.
+      # NOTE: The size of trailer is 20 m length x 3 m width.
       #UNKNOWN,  CAR,      TRUCK,    BUS,      TRAILER,   MOTORBIKE, BICYCLE,  PEDESTRIAN
         [100.00,   100.00,   100.00,   100.00,   100.00,    100.00,    100.00,   100.00,   #UNKNOWN
           12.10,    12.10,    36.00,    60.00,    60.00,  10000.00,  10000.00, 10000.00,   #CAR

--- a/planning/behavior_velocity_planner/intersection-design.md
+++ b/planning/behavior_velocity_planner/intersection-design.md
@@ -29,8 +29,8 @@ Objects that satisfy all of the following conditions are considered as target ob
     - To deal with objects that is in the area not covered by the lanelets in the intersection.
 - The posture of object is **the same direction as the attention lane** (threshold = `detection_area_angle_threshold`).
   - The orientation of the target is recalculated in this module according to the `orientation_reliable` and the sign of the velocity of the target.
-- Not being **in the neighbouring lanes of the ego vehicle**.
-  - neighbouring lanes include the ego lane of the vehicle and the adjacent lanes of it with turn_direction as the ego lane.
+- Not being **in the neighboring lanes of the ego vehicle**.
+  - neighboring lanes include the ego lane of the vehicle and the adjacent lanes of it with turn_direction as the ego lane.
 
 #### How to Define Attention Lanes
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

There were some spell-check errors.

```
perception/multi_object_tracker/config/data_association_matrix.param.yaml:25:14 Unknown word (yukke)
perception/multi_object_tracker/config/data_association_matrix.param.yaml:26:14 Unknown word (yukke)
common/perception_utils/test/src/test_matching.cpp:100:29 Unknown word (icludes)
common/perception_utils/test/src/test_matching.cpp:101:6 Unknown word (Threfore)
perception/ground_segmentation/docs/scan-ground-filter.md:61:43 Unknown word (Shen)
perception/ground_segmentation/docs/scan-ground-filter.md:61:51 Unknown word (Liang)
planning/behavior_velocity_planner/intersection-design.md:32:22 Unknown word (neighbouring)
planning/behavior_velocity_planner/intersection-design.md:33:5 Unknown word (neighbouring)
```

Actually, `neighbouring` isn't completely wrong, but we should use American spelling.
https://developers.google.com/style/spelling

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
