### PR TITLE
feat(pure_pursuit): adding average trajectory smoother

### DIFF
--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -44,6 +44,7 @@
 
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
+#include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -89,6 +90,8 @@ struct Param
   double resampling_ds;
   double curvature_calculation_distance;
   double long_ld_lateral_error_threshold;
+  bool enable_path_smoothing;
+  int path_filter_moving_ave_num;
 };
 
 struct DebugData
@@ -173,6 +176,8 @@ private:
     const bool is_control_cmd);
 
   double calcCurvature(const size_t closest_idx);
+
+  void averageFilterTrajectory(autoware_auto_planning_msgs::msg::Trajectory & u);
 
   // Debug
   mutable DebugData debug_data_;

--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -44,7 +44,6 @@
 
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -16,7 +16,6 @@
   <build_depend>autoware_cmake</build_depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
-  <depend>autoware_auto_system_msgs</depend>
   <depend>boost</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -16,6 +16,7 @@
   <build_depend>autoware_cmake</build_depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_auto_system_msgs</depend>
   <depend>boost</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Average trajectory smoother has been using in MPC. This PR adds this feature to `pure_pursuit_lateral_controller` as optional.
Function in MPC [here](https://github.com/autowarefoundation/autoware.universe/blob/main/control/trajectory_follower/src/lowpass_filter.cpp#L116)!

This PR depends following pull requests:
#2115
#2127

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
