### PR TITLE
feature(multi_object_tracker): use yaw information in motorcycle/bicycle tracker if available 

### DIFF
--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -214,37 +214,35 @@ bool BicycleTracker::predict(const double dt, KalmanFilter & ekf) const
   return true;
 }
 
+/**
+ * @brief measurement update with ekf on receiving detected_object
+ *
+ * @param object : Detected object
+ * @return bool : measurement is updatable
+ */
 bool BicycleTracker::measureWithPose(
   const autoware_auto_perception_msgs::msg::DetectedObject & object)
 {
-  constexpr int dim_y = 2;  // pos x, pos y, depending on Pose output
-  // double measurement_yaw =
-  //   tier4_autoware_utils::normalizeRadian(tf2::getYaw(object.state.pose_covariance.pose.orientation));
-  // {
-  //   Eigen::MatrixXd X_t(ekf_params_.dim_x, 1);
-  //   ekf_.getX(X_t);
-  //   while (M_PI_2 <= X_t(IDX::YAW) - measurement_yaw) {
-  //     measurement_yaw = measurement_yaw + M_PI;
-  //   }
-  //   while (M_PI_2 <= measurement_yaw - X_t(IDX::YAW)) {
-  //     measurement_yaw = measurement_yaw - M_PI;
-  //   }
-  //   float theta = std::acos(
-  //     std::cos(X_t(IDX::YAW)) * std::cos(measurement_yaw) +
-  //     std::sin(X_t(IDX::YAW)) * std::sin(measurement_yaw));
-  //   if (tier4_autoware_utils::deg2rad(60) < std::fabs(theta)) return false;
-  // }
+  bool use_orientation_information = false;
+  // if orientation is available
+  if (object.kinematics.orientation_availability) {
+    // TODO(yoshiri): additional check to prevent yaw update from detected object (currently
+    // nothing)
+    use_orientation_information = true;
+  }
+
+  const int dim_y =
+    use_orientation_information ? 3 : 2;  // pos x, pos y, (pos yaw) depending on Pose output
 
   /* Set measurement matrix */
   Eigen::MatrixXd Y(dim_y, 1);
-  Y << object.kinematics.pose_with_covariance.pose.position.x,
-    object.kinematics.pose_with_covariance.pose.position.y;
+  Y(IDX::X, 0) = object.kinematics.pose_with_covariance.pose.position.x;
+  Y(IDX::Y, 0) = object.kinematics.pose_with_covariance.pose.position.y;
 
   /* Set measurement matrix */
   Eigen::MatrixXd C = Eigen::MatrixXd::Zero(dim_y, ekf_params_.dim_x);
   C(0, IDX::X) = 1.0;  // for pos x
   C(1, IDX::Y) = 1.0;  // for pos y
-  // C(2, IDX::YAW) = 1.0;  // for yaw
 
   /* Set measurement noise covariance */
   Eigen::MatrixXd R = Eigen::MatrixXd::Zero(dim_y, dim_y);
@@ -254,18 +252,46 @@ bool BicycleTracker::measureWithPose(
     R(0, 1) = 0.0;                  // x - y
     R(1, 1) = ekf_params_.r_cov_y;  // y - y
     R(1, 0) = R(0, 1);              // y - x
-    // R(2, 2) = ekf_params_.r_cov_yaw;                        // yaw - yaw
   } else {
     R(0, 0) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_X];
     R(0, 1) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_Y];
-    // R(0, 2) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_YAW];
     R(1, 0) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_X];
     R(1, 1) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_Y];
-    // R(1, 2) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_YAW];
-    // R(2, 0) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_X];
-    // R(2, 1) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_Y];
-    // R(2, 2) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW];
   }
+
+  // if there are orientation available
+  if (dim_y == 3) {
+    // get compensated yaw measurement
+    double measurement_yaw = tier4_autoware_utils::normalizeRadian(
+      tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation));
+    {
+      Eigen::MatrixXd X_t(ekf_params_.dim_x, 1);
+      ekf_.getX(X_t);
+      while (M_PI_2 <= X_t(IDX::YAW) - measurement_yaw) {
+        measurement_yaw = measurement_yaw + M_PI;
+      }
+      while (M_PI_2 <= measurement_yaw - X_t(IDX::YAW)) {
+        measurement_yaw = measurement_yaw - M_PI;
+      }
+    }
+
+    // fill yaw observation and measurement matrix
+    Y(IDX::YAW, 0) = measurement_yaw;
+    C(2, IDX::YAW) = 1.0;
+
+    // fill yaw covariance
+    if (!object.kinematics.has_position_covariance) {
+      R(2, 2) = ekf_params_.r_cov_yaw;  // yaw - yaw
+    } else {
+      R(0, 2) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::X_YAW];
+      R(1, 2) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::Y_YAW];
+      R(2, 0) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_X];
+      R(2, 1) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_Y];
+      R(2, 2) = object.kinematics.pose_with_covariance.covariance[utils::MSG_COV_IDX::YAW_YAW];
+    }
+  }
+
+  // update with ekf
   if (!ekf_.update(Y, C, R)) {
     RCLCPP_WARN(logger_, "Cannot update");
   }


### PR DESCRIPTION
Signed-off-by: Yoshi Ri <yoshi.ri@tier4.jp>

## Description

Utilize yaw information if available so that it can prevent unintended rotation in some tracking situations

- use yaw information in bicycle_tracker EKF update when `orientation_availability=1`
- switch measurement dimension based on availability flag


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
