### PR TITLE
feat(behavior_path_planner): debug message for lane change

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -36,6 +36,7 @@ ament_auto_add_library(behavior_path_planner_node SHARED
   src/scene_module/utils/geometric_parallel_parking.cpp
   src/scene_module/utils/occupancy_grid_based_collision_detector.cpp
   src/scene_module/utils/path_shifter.cpp
+  src/scene_module/scene_module_visitor.cpp
 )
 
 target_include_directories(behavior_path_planner_node SYSTEM PUBLIC

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -184,6 +184,11 @@ private:
    */
   void publish_steering_factor(const TurnIndicatorsCommand & turn_signal);
 
+  /**
+   * @brief publish debug messages
+   */
+  void publishSceneModuleDebugMsg();
+
   template <class T>
   size_t findEgoIndex(const std::vector<T> & points) const
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -28,6 +28,7 @@
 
 #include <tier4_autoware_utils/ros/self_pose_listener.hpp>
 
+#include "tier4_planning_msgs/msg/detail/lane_change_debug_msg_array__struct.hpp"
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/had_map_route.hpp>
@@ -39,6 +40,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/approval.hpp>
 #include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
+#include <tier4_planning_msgs/msg/lane_change_debug_msg_array.hpp>
 #include <tier4_planning_msgs/msg/path_change_module.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
 
@@ -75,6 +77,7 @@ using nav_msgs::msg::Odometry;
 using rcl_interfaces::msg::SetParametersResult;
 using steering_factor_interface::SteeringFactorInterface;
 using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
+using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
 using tier4_planning_msgs::msg::PathChangeModule;
 using tier4_planning_msgs::msg::Scenario;
 using visualization_msgs::msg::MarkerArray;
@@ -169,6 +172,8 @@ private:
   // debug
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_drivable_area_lanelets_publisher_;
   rclcpp::Publisher<AvoidanceDebugMsgArray>::SharedPtr debug_avoidance_msg_array_publisher_;
+  rclcpp::Publisher<LaneChangeDebugMsgArray>::SharedPtr debug_lane_change_msg_array_publisher_;
+
   /**
    * @brief check path if it is unsafe or forced
    */

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
@@ -62,7 +62,7 @@ private:
   std::vector<std::shared_ptr<SceneModuleStatus>> modules_status_;
   rclcpp::Logger logger_;
   rclcpp::Clock clock_;
-  std::shared_ptr<SceneModuleVisitor> scene_module_visior_ptr_;
+  std::shared_ptr<SceneModuleVisitor> scene_module_visitor_ptr_;
 
   BT::BehaviorTreeFactory bt_factory_;
   BT::Tree bt_tree_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
@@ -50,7 +50,7 @@ public:
 
   BehaviorModuleOutput run(const std::shared_ptr<PlannerData> & data);
   std::vector<std::shared_ptr<SceneModuleStatus>> getModulesStatus();
-  std::shared_ptr<BehaviorTreeVisitorInterface> get_all_debug_data();
+  std::shared_ptr<SceneModuleVisitor> get_all_debug_data();
   void get_debug_msg_array();
 
   AvoidanceDebugMsgArray getAvoidanceDebugMsgArray();
@@ -62,7 +62,7 @@ private:
   std::vector<std::shared_ptr<SceneModuleStatus>> modules_status_;
   rclcpp::Logger logger_;
   rclcpp::Clock clock_;
-  std::shared_ptr<BehaviorTreeVisitorInterface> bt_visitor_interface_;
+  std::shared_ptr<SceneModuleVisitor> scene_module_visior_ptr_;
 
   BT::BehaviorTreeFactory bt_factory_;
   BT::Tree bt_tree_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
@@ -50,8 +50,7 @@ public:
 
   BehaviorModuleOutput run(const std::shared_ptr<PlannerData> & data);
   std::vector<std::shared_ptr<SceneModuleStatus>> getModulesStatus();
-  std::shared_ptr<SceneModuleVisitor> get_all_debug_data();
-  void get_debug_msg_array();
+  std::shared_ptr<SceneModuleVisitor> getAllSceneModuleDebugMsgData();
 
   AvoidanceDebugMsgArray getAvoidanceDebugMsgArray();
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
@@ -17,6 +17,7 @@
 
 #include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/scene_module/scene_module_bt_node_interface.hpp"
+#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -49,6 +50,9 @@ public:
 
   BehaviorModuleOutput run(const std::shared_ptr<PlannerData> & data);
   std::vector<std::shared_ptr<SceneModuleStatus>> getModulesStatus();
+  std::shared_ptr<BehaviorTreeVisitorInterface> get_all_debug_data();
+  void get_debug_msg_array();
+
   AvoidanceDebugMsgArray getAvoidanceDebugMsgArray();
 
 private:
@@ -58,6 +62,7 @@ private:
   std::vector<std::shared_ptr<SceneModuleStatus>> modules_status_;
   rclcpp::Logger logger_;
   rclcpp::Clock clock_;
+  std::shared_ptr<BehaviorTreeVisitorInterface> bt_visitor_interface_;
 
   BT::BehaviorTreeFactory bt_factory_;
   BT::Tree bt_tree_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/debug_utilities.hpp
@@ -52,6 +52,7 @@ struct CollisionCheckDebug
   std::size_t lane_id{0};
   Pose current_pose{};
   Twist current_twist{};
+  Twist object_twist{};
   Pose expected_ego_pose{};
   Pose expected_obj_pose{};
   Pose relative_to_ego{};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -17,6 +17,7 @@
 
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp"
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/scene_module/utils/path_shifter.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -49,6 +50,11 @@ public:
   void onEntry() override;
   void onExit() override;
   void updateData() override;
+  void accept_visitor(
+    [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
+  {
+    std::cerr << "visited avoidance module\n";
+  }
 
   void publishRTCStatus() override
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -51,7 +51,7 @@ public:
   void onEntry() override;
   void onExit() override;
   void updateData() override;
-  void accept_visitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const override;
+  void acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const override;
 
   void publishRTCStatus() override
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -26,6 +26,7 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 
 #include <memory>
 #include <string>
@@ -50,11 +51,7 @@ public:
   void onEntry() override;
   void onExit() override;
   void updateData() override;
-  void accept_visitor(
-    [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
-  {
-    std::cerr << "visited avoidance module\n";
-  }
+  void accept_visitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const override;
 
   void publishRTCStatus() override
   {
@@ -84,6 +81,7 @@ public:
     rtc_interface_left_.unlockCommandUpdate();
     rtc_interface_right_.unlockCommandUpdate();
   }
+  std::shared_ptr<AvoidanceDebugMsgArray> get_debug_msg_array() const;
 
 private:
   struct RegisteredShiftLine
@@ -289,6 +287,7 @@ private:
 
   // debug
   mutable DebugData debug_data_;
+  mutable std::shared_ptr<AvoidanceDebugMsgArray> debug_msg_ptr_;
   void setDebugData(const PathShifter & shifter, const DebugData & debug);
   void updateAvoidanceDebugData(std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const;
   mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_line_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -62,7 +62,7 @@ public:
   void onExit() override;
 
   std::shared_ptr<LaneChangeDebugMsgArray> get_debug_msg_array() const;
-  void accept_visitor(
+  void acceptVisitor(
     [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override;
 
   void publishRTCStatus() override

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -98,7 +98,7 @@ private:
   std::shared_ptr<LaneChangeParameters> parameters_;
   LaneChangeStatus status_;
   PathShifter path_shifter_;
-  mutable std::shared_ptr<LaneChangeDebugMsgArray> debug_msg_ptr_;
+  mutable LaneChangeDebugMsgArray lane_change_debug_msg_array_;
 
   double lane_change_lane_length_{200.0};
   double check_distance_{100.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -23,6 +23,9 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include "tier4_planning_msgs/msg/detail/lane_change_debug_msg_array__struct.hpp"
+#include "tier4_planning_msgs/msg/lane_change_debug_msg.hpp"
+#include "tier4_planning_msgs/msg/lane_change_debug_msg_array.hpp"
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <tf2/utils.h>
@@ -37,6 +40,8 @@ namespace behavior_path_planner
 {
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using marker_utils::CollisionCheckDebug;
+using tier4_planning_msgs::msg::LaneChangeDebugMsg;
+using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
 
 class LaneChangeModule : public SceneModuleInterface
 {
@@ -55,6 +60,10 @@ public:
   CandidateOutput planCandidate() const override;
   void onEntry() override;
   void onExit() override;
+
+  std::shared_ptr<LaneChangeDebugMsgArray> get_debug_msg_array() const;
+  void accept_visitor(
+    [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override;
 
   void publishRTCStatus() override
   {
@@ -89,6 +98,7 @@ private:
   std::shared_ptr<LaneChangeParameters> parameters_;
   LaneChangeStatus status_;
   PathShifter path_shifter_;
+  mutable std::shared_ptr<LaneChangeDebugMsgArray> debug_msg_ptr_;
 
   double lane_change_lane_length_{200.0};
   double check_distance_{100.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
@@ -51,7 +51,7 @@ public:
   void onExit() override;
 
   void setParameters(const LaneFollowingParameters & parameters);
-  void accept_visitor(
+  void acceptVisitor(
     [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
   {
   }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
@@ -54,7 +54,6 @@ public:
   void accept_visitor(
     [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
   {
-    std::cerr << "visited lane following module\n";
   }
 
 private:

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
@@ -21,6 +21,7 @@
 
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 
+#include <memory>
 #include <string>
 
 namespace behavior_path_planner
@@ -50,6 +51,11 @@ public:
   void onExit() override;
 
   void setParameters(const LaneFollowingParameters & parameters);
+  void accept_visitor(
+    [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
+  {
+    std::cerr << "visited lane following module\n";
+  }
 
 private:
   LaneFollowingParameters parameters_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
@@ -80,6 +80,12 @@ public:
   void setParameters(const PullOutParameters & parameters) { parameters_ = parameters; }
   void resetStatus();
 
+  void accept_visitor(
+    [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
+  {
+    std::cerr << "visited pull out module\n";
+  }
+
 private:
   PullOutParameters parameters_;
   vehicle_info_util::VehicleInfo vehicle_info_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
@@ -80,7 +80,7 @@ public:
   void setParameters(const PullOutParameters & parameters) { parameters_ = parameters; }
   void resetStatus();
 
-  void accept_visitor(
+  void acceptVisitor(
     [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
   {
   }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
@@ -83,7 +83,6 @@ public:
   void accept_visitor(
     [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
   {
-    std::cerr << "visited pull out module\n";
   }
 
 private:

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
@@ -92,7 +92,6 @@ public:
   void accept_visitor(
     [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
   {
-    std::cerr << "visited pull over module\n";
   }
 
 private:

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
@@ -89,7 +89,7 @@ public:
 
   void setParameters(const PullOverParameters & parameters);
 
-  void accept_visitor(
+  void acceptVisitor(
     [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
   {
   }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
@@ -89,6 +89,12 @@ public:
 
   void setParameters(const PullOverParameters & parameters);
 
+  void accept_visitor(
+    [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
+  {
+    std::cerr << "visited pull over module\n";
+  }
+
 private:
   PullOverParameters parameters_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -226,13 +226,6 @@ public:
 
   std::shared_ptr<const PlannerData> planner_data_;
 
-  AvoidanceDebugMsgArray::SharedPtr getAvoidanceDebugMsgArray()
-  {
-    if (debug_avoidance_msg_array_ptr_) {
-      debug_avoidance_msg_array_ptr_->header.stamp = clock_->now();
-    }
-    return debug_avoidance_msg_array_ptr_;
-  }
   bool isWaitingApproval() const { return is_waiting_approval_; }
 
   virtual void lockRTCCommand()
@@ -259,7 +252,6 @@ private:
 protected:
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_debug_marker_;
-  mutable AvoidanceDebugMsgArray::SharedPtr debug_avoidance_msg_array_ptr_{};
   mutable MarkerArray debug_marker_;
 
   std::shared_ptr<RTCInterface> rtc_interface_ptr_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -16,6 +16,7 @@
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_INTERFACE_HPP_
 
 #include "behavior_path_planner/data_manager.hpp"
+#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utilities.hpp"
 
 #include <behavior_path_planner/steering_factor_interface.hpp>
@@ -249,6 +250,7 @@ public:
     }
     rtc_interface_ptr_->unlockCommandUpdate();
   }
+  virtual void accept_visitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const = 0;
 
 private:
   std::string name_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -243,7 +243,7 @@ public:
     }
     rtc_interface_ptr_->unlockCommandUpdate();
   }
-  virtual void accept_visitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const = 0;
+  virtual void acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const = 0;
 
 private:
   std::string name_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
@@ -58,18 +58,11 @@ protected:
   mutable std::shared_ptr<AvoidanceDebugMsgArray> avoidance_visitor_;
 };
 
-class AvoidanceVisitor : public SceneModuleVisitor
-{
-public:
-  void visit_avoidance_module(const AvoidanceModule * module) const override;
-  void visit_lane_change_module([[maybe_unused]] const LaneChangeModule * module) const override;
-};
-
-class LaneChangeVisitor : public SceneModuleVisitor
+class DebugMessageReader : public SceneModuleVisitor
 {
 public:
   void visit_lane_change_module(const LaneChangeModule * module) const override;
-  void visit_avoidance_module([[maybe_unused]] const AvoidanceModule * module) const override;
+  void visit_avoidance_module(const AvoidanceModule * module) const override;
 };
 
 class BehaviorTreeVisitorInterface : public SceneModuleVisitor

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
@@ -41,14 +41,11 @@ using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
 class SceneModuleVisitor
 {
 public:
-  void visit_lane_change_module(const LaneChangeModule * module) const;
-  void visit_avoidance_module(const AvoidanceModule * module) const;
+  void visitLaneChangeModule(const LaneChangeModule * module) const;
+  void visitAvoidanceModule(const AvoidanceModule * module) const;
 
-  std::shared_ptr<AvoidanceDebugMsgArray> get_avoidance_debug_msg_array() const;
-  std::shared_ptr<LaneChangeDebugMsgArray> get_lane_change_debug_msg_array() const;
-
-  void set_lane_change_debug_ptr(const std::shared_ptr<LaneChangeDebugMsgArray> & debug_msg_ptr);
-  void set_avoidance_debug_ptr(const std::shared_ptr<AvoidanceDebugMsgArray> & debug_msg_ptr);
+  std::shared_ptr<AvoidanceDebugMsgArray> getAvoidanceModuleDebugMsg() const;
+  std::shared_ptr<LaneChangeDebugMsgArray> getLaneChangeModuleDebugMsg() const;
 
 protected:
   mutable std::shared_ptr<LaneChangeDebugMsgArray> lane_change_visitor_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
@@ -41,37 +41,18 @@ using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
 class SceneModuleVisitor
 {
 public:
-  virtual void visit_avoidance_module(const AvoidanceModule * module) const = 0;
-  virtual void visit_lane_change_module(const LaneChangeModule * module) const = 0;
-  // getter
-  [[nodiscard]] std::shared_ptr<AvoidanceDebugMsgArray> get_avoidance_debug_msg_array() const
-  {
-    return avoidance_visitor_;
-  }
-  [[nodiscard]] std::shared_ptr<LaneChangeDebugMsgArray> get_lane_change_debug_msg_array() const
-  {
-    return lane_change_visitor_;
-  }
+  void visit_lane_change_module(const LaneChangeModule * module) const;
+  void visit_avoidance_module(const AvoidanceModule * module) const;
+
+  std::shared_ptr<AvoidanceDebugMsgArray> get_avoidance_debug_msg_array() const;
+  std::shared_ptr<LaneChangeDebugMsgArray> get_lane_change_debug_msg_array() const;
+
+  void set_lane_change_debug_ptr(const std::shared_ptr<LaneChangeDebugMsgArray> & debug_msg_ptr);
+  void set_avoidance_debug_ptr(const std::shared_ptr<AvoidanceDebugMsgArray> & debug_msg_ptr);
 
 protected:
   mutable std::shared_ptr<LaneChangeDebugMsgArray> lane_change_visitor_;
   mutable std::shared_ptr<AvoidanceDebugMsgArray> avoidance_visitor_;
-};
-
-class DebugMessageReader : public SceneModuleVisitor
-{
-public:
-  void visit_lane_change_module(const LaneChangeModule * module) const override;
-  void visit_avoidance_module(const AvoidanceModule * module) const override;
-};
-
-class BehaviorTreeVisitorInterface : public SceneModuleVisitor
-{
-public:
-  void visit_avoidance_module([[maybe_unused]] const AvoidanceModule * module) const override;
-  void visit_lane_change_module([[maybe_unused]] const LaneChangeModule * module) const override;
-  void set_lane_change_debug_ptr(const std::shared_ptr<LaneChangeDebugMsgArray> & debug_msg_ptr);
-  void set_avoidance_debug_ptr(const std::shared_ptr<AvoidanceDebugMsgArray> & debug_msg_ptr);
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
@@ -41,9 +41,8 @@ using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
 class SceneModuleVisitor
 {
 public:
-  // virtual void visit_avoidance_module([[maybe_unused]] const AvoidanceModule * module) const = 0;
-  virtual void visit_lane_change_module([[maybe_unused]] const LaneChangeModule * module) const = 0;
-
+  virtual void visit_avoidance_module(const AvoidanceModule * module) const = 0;
+  virtual void visit_lane_change_module(const LaneChangeModule * module) const = 0;
   // getter
   [[nodiscard]] std::shared_ptr<AvoidanceDebugMsgArray> get_avoidance_debug_msg_array() const
   {
@@ -59,15 +58,24 @@ protected:
   mutable std::shared_ptr<AvoidanceDebugMsgArray> avoidance_visitor_;
 };
 
+class AvoidanceVisitor : public SceneModuleVisitor
+{
+public:
+  void visit_avoidance_module(const AvoidanceModule * module) const override;
+  void visit_lane_change_module([[maybe_unused]] const LaneChangeModule * module) const override;
+};
+
 class LaneChangeVisitor : public SceneModuleVisitor
 {
 public:
-  void visit_lane_change_module([[maybe_unused]] const LaneChangeModule * module) const override;
+  void visit_lane_change_module(const LaneChangeModule * module) const override;
+  void visit_avoidance_module([[maybe_unused]] const AvoidanceModule * module) const override;
 };
 
 class BehaviorTreeVisitorInterface : public SceneModuleVisitor
 {
 public:
+  void visit_avoidance_module([[maybe_unused]] const AvoidanceModule * module) const override;
   void visit_lane_change_module([[maybe_unused]] const LaneChangeModule * module) const override;
   void set_lane_change_debug_ptr(const std::shared_ptr<LaneChangeDebugMsgArray> & debug_msg_ptr);
   void set_avoidance_debug_ptr(const std::shared_ptr<AvoidanceDebugMsgArray> & debug_msg_ptr);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
@@ -1,0 +1,77 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_VISITOR_HPP_
+#define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_VISITOR_HPP_
+
+#include "tier4_planning_msgs/msg/avoidance_debug_msg.hpp"
+#include "tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp"
+#include "tier4_planning_msgs/msg/detail/avoidance_debug_msg_array__struct.hpp"
+#include "tier4_planning_msgs/msg/detail/lane_change_debug_msg_array__struct.hpp"
+#include "tier4_planning_msgs/msg/lane_change_debug_msg.hpp"
+#include "tier4_planning_msgs/msg/lane_change_debug_msg_array.hpp"
+
+#include <memory>
+namespace behavior_path_planner
+{
+// Forward Declaration
+class AvoidanceModule;
+class LaneChangeModule;
+class LaneFollowingModule;
+class PullOutModule;
+class PullOverModule;
+class SideShiftModule;
+
+using tier4_planning_msgs::msg::AvoidanceDebugMsg;
+using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
+using tier4_planning_msgs::msg::LaneChangeDebugMsg;
+using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
+
+class SceneModuleVisitor
+{
+public:
+  // virtual void visit_avoidance_module([[maybe_unused]] const AvoidanceModule * module) const = 0;
+  virtual void visit_lane_change_module([[maybe_unused]] const LaneChangeModule * module) const = 0;
+
+  // getter
+  [[nodiscard]] std::shared_ptr<AvoidanceDebugMsgArray> get_avoidance_debug_msg_array() const
+  {
+    return avoidance_visitor_;
+  }
+  [[nodiscard]] std::shared_ptr<LaneChangeDebugMsgArray> get_lane_change_debug_msg_array() const
+  {
+    return lane_change_visitor_;
+  }
+
+protected:
+  mutable std::shared_ptr<LaneChangeDebugMsgArray> lane_change_visitor_;
+  mutable std::shared_ptr<AvoidanceDebugMsgArray> avoidance_visitor_;
+};
+
+class LaneChangeVisitor : public SceneModuleVisitor
+{
+public:
+  void visit_lane_change_module([[maybe_unused]] const LaneChangeModule * module) const override;
+};
+
+class BehaviorTreeVisitorInterface : public SceneModuleVisitor
+{
+public:
+  void visit_lane_change_module([[maybe_unused]] const LaneChangeModule * module) const override;
+  void set_lane_change_debug_ptr(const std::shared_ptr<LaneChangeDebugMsgArray> & debug_msg_ptr);
+  void set_avoidance_debug_ptr(const std::shared_ptr<AvoidanceDebugMsgArray> & debug_msg_ptr);
+};
+}  // namespace behavior_path_planner
+
+#endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__SCENE_MODULE_VISITOR_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -70,7 +70,7 @@ public:
 
   void setParameters(const SideShiftParameters & parameters);
 
-  void accept_visitor(
+  void acceptVisitor(
     [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
   {
   }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -70,6 +70,12 @@ public:
 
   void setParameters(const SideShiftParameters & parameters);
 
+  void accept_visitor(
+    [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
+  {
+    std::cerr << "visited side shift module\n";
+  }
+
 private:
   rclcpp::Subscription<LateralOffset>::SharedPtr lateral_offset_subscriber_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -73,7 +73,6 @@ public:
   void accept_visitor(
     [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
   {
-    std::cerr << "visited side shift module\n";
   }
 
 private:

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -649,20 +649,7 @@ void BehaviorPathPlannerNode::run()
     publish_steering_factor(turn_signal);
   }
 
-  // for debug
-  {
-    const auto debug_messages_data_ptr = bt_manager_->get_all_debug_data();
-    const auto avoidance_debug_message = debug_messages_data_ptr->get_avoidance_debug_msg_array();
-    if (avoidance_debug_message) {
-      debug_avoidance_msg_array_publisher_->publish(*avoidance_debug_message);
-    }
-
-    const auto lane_change_debug_message =
-      debug_messages_data_ptr->get_lane_change_debug_msg_array();
-    if (lane_change_debug_message) {
-      debug_lane_change_msg_array_publisher_->publish(*lane_change_debug_message);
-    }
-  }
+  publishSceneModuleDebugMsg();
 
   if (planner_data->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
     const auto drivable_area_lines = marker_utils::createFurthestLineStringMarkerArray(
@@ -702,6 +689,22 @@ void BehaviorPathPlannerNode::publish_steering_factor(const TurnIndicatorsComman
     steering_factor_interface_ptr_->clearSteeringFactors();
   }
   steering_factor_interface_ptr_->publishSteeringFactor(get_clock()->now());
+}
+
+void BehaviorPathPlannerNode::publishSceneModuleDebugMsg(){
+  {
+    const auto debug_messages_data_ptr = bt_manager_->getAllSceneModuleDebugMsgData();
+    const auto avoidance_debug_message = debug_messages_data_ptr->getAvoidanceModuleDebugMsg();
+    if (avoidance_debug_message) {
+      debug_avoidance_msg_array_publisher_->publish(*avoidance_debug_message);
+    }
+
+    const auto lane_change_debug_message =
+      debug_messages_data_ptr->getLaneChangeModuleDebugMsg();
+    if (lane_change_debug_message) {
+      debug_lane_change_msg_array_publisher_->publish(*lane_change_debug_message);
+    }
+  }
 }
 
 PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPath(

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -67,6 +67,8 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
   hazard_signal_publisher_ = create_publisher<HazardLightsCommand>("~/output/hazard_lights_cmd", 1);
   debug_avoidance_msg_array_publisher_ =
     create_publisher<AvoidanceDebugMsgArray>("~/debug/avoidance_debug_message_array", 1);
+  debug_lane_change_msg_array_publisher_ =
+    create_publisher<LaneChangeDebugMsgArray>("~/debug/lane_change_debug_message_array", 1);
 
   if (planner_data_->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
     debug_drivable_area_lanelets_publisher_ =
@@ -649,6 +651,12 @@ void BehaviorPathPlannerNode::run()
 
   // for debug
   debug_avoidance_msg_array_publisher_->publish(bt_manager_->getAvoidanceDebugMsgArray());
+
+  const auto debug_data = bt_manager_->get_all_debug_data();
+  const auto & lc_debug = debug_data->get_lane_change_debug_msg_array();
+  if (lc_debug) {
+    debug_lane_change_msg_array_publisher_->publish(*lc_debug);
+  }
 
   if (planner_data->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {
     const auto drivable_area_lines = marker_utils::createFurthestLineStringMarkerArray(

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -691,7 +691,8 @@ void BehaviorPathPlannerNode::publish_steering_factor(const TurnIndicatorsComman
   steering_factor_interface_ptr_->publishSteeringFactor(get_clock()->now());
 }
 
-void BehaviorPathPlannerNode::publishSceneModuleDebugMsg(){
+void BehaviorPathPlannerNode::publishSceneModuleDebugMsg()
+{
   {
     const auto debug_messages_data_ptr = bt_manager_->getAllSceneModuleDebugMsgData();
     const auto avoidance_debug_message = debug_messages_data_ptr->getAvoidanceModuleDebugMsg();
@@ -699,8 +700,7 @@ void BehaviorPathPlannerNode::publishSceneModuleDebugMsg(){
       debug_avoidance_msg_array_publisher_->publish(*avoidance_debug_message);
     }
 
-    const auto lane_change_debug_message =
-      debug_messages_data_ptr->getLaneChangeModuleDebugMsg();
+    const auto lane_change_debug_message = debug_messages_data_ptr->getLaneChangeModuleDebugMsg();
     if (lane_change_debug_message) {
       debug_lane_change_msg_array_publisher_->publish(*lane_change_debug_message);
     }

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -650,16 +650,18 @@ void BehaviorPathPlannerNode::run()
   }
 
   // for debug
+  {
+    const auto debug_messages_data_ptr = bt_manager_->get_all_debug_data();
+    const auto avoidance_debug_message = debug_messages_data_ptr->get_avoidance_debug_msg_array();
+    if (avoidance_debug_message) {
+      debug_avoidance_msg_array_publisher_->publish(*avoidance_debug_message);
+    }
 
-  const auto debug_data = bt_manager_->get_all_debug_data();
-  const auto avoidance_debug = debug_data->get_avoidance_debug_msg_array();
-  if (avoidance_debug) {
-    debug_avoidance_msg_array_publisher_->publish(*avoidance_debug);
-  }
-
-  const auto lc_debug = debug_data->get_lane_change_debug_msg_array();
-  if (lc_debug) {
-    debug_lane_change_msg_array_publisher_->publish(*lc_debug);
+    const auto lane_change_debug_message =
+      debug_messages_data_ptr->get_lane_change_debug_msg_array();
+    if (lane_change_debug_message) {
+      debug_lane_change_msg_array_publisher_->publish(*lane_change_debug_message);
+    }
   }
 
   if (planner_data->parameters.visualize_drivable_area_for_shared_linestrings_lanelet) {

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -650,10 +650,14 @@ void BehaviorPathPlannerNode::run()
   }
 
   // for debug
-  debug_avoidance_msg_array_publisher_->publish(bt_manager_->getAvoidanceDebugMsgArray());
 
   const auto debug_data = bt_manager_->get_all_debug_data();
-  const auto & lc_debug = debug_data->get_lane_change_debug_msg_array();
+  const auto avoidance_debug = debug_data->get_avoidance_debug_msg_array();
+  if (avoidance_debug) {
+    debug_avoidance_msg_array_publisher_->publish(*avoidance_debug);
+  }
+
+  const auto lc_debug = debug_data->get_lane_change_debug_msg_array();
   if (lc_debug) {
     debug_lane_change_msg_array_publisher_->publish(*lc_debug);
   }

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -148,14 +148,14 @@ void BehaviorTreeManager::get_debug_msg_array()
   bt_visitor_interface_ = std::make_shared<BehaviorTreeVisitorInterface>();
   for (const auto & module : scene_modules_) {
     if (module->name() == "LaneChange") {
-      auto visitor_ptr = std::make_shared<LaneChangeVisitor>();
+      auto visitor_ptr = std::make_shared<DebugMessageReader>();
       module->accept_visitor(visitor_ptr);
       const auto get_ptr = visitor_ptr->get_lane_change_debug_msg_array();
       if (get_ptr) {
         bt_visitor_interface_->set_lane_change_debug_ptr(get_ptr);
       }
     } else if (module->name() == "Avoidance") {
-      auto visitor_ptr = std::make_shared<AvoidanceVisitor>();
+      auto visitor_ptr = std::make_shared<DebugMessageReader>();
       module->accept_visitor(visitor_ptr);
       const auto get_ptr = visitor_ptr->get_avoidance_debug_msg_array();
       if (get_ptr) {

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -143,31 +143,12 @@ void BehaviorTreeManager::resetGrootMonitor()
   }
 }
 
-void BehaviorTreeManager::get_debug_msg_array()
+std::shared_ptr<SceneModuleVisitor> BehaviorTreeManager::getAllSceneModuleDebugMsgData()
 {
   scene_module_visitor_ptr_ = std::make_shared<SceneModuleVisitor>();
   for (const auto & module : scene_modules_) {
-    if (module->name() == "LaneChange") {
-      auto visitor_ptr = std::make_shared<SceneModuleVisitor>();
-      module->accept_visitor(visitor_ptr);
-      const auto get_ptr = visitor_ptr->get_lane_change_debug_msg_array();
-      if (get_ptr) {
-        scene_module_visitor_ptr_->set_lane_change_debug_ptr(get_ptr);
-      }
-    } else if (module->name() == "Avoidance") {
-      auto visitor_ptr = std::make_shared<SceneModuleVisitor>();
-      module->accept_visitor(visitor_ptr);
-      const auto get_ptr = visitor_ptr->get_avoidance_debug_msg_array();
-      if (get_ptr) {
-        scene_module_visitor_ptr_->set_avoidance_debug_ptr(get_ptr);
-      }
-    }
+    module->acceptVisitor(scene_module_visitor_ptr_);
   }
-}
-
-std::shared_ptr<SceneModuleVisitor> BehaviorTreeManager::get_all_debug_data()
-{
-  get_debug_msg_array();
   return scene_module_visitor_ptr_;
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -145,21 +145,21 @@ void BehaviorTreeManager::resetGrootMonitor()
 
 void BehaviorTreeManager::get_debug_msg_array()
 {
-  scene_module_visior_ptr_ = std::make_shared<SceneModuleVisitor>();
+  scene_module_visitor_ptr_ = std::make_shared<SceneModuleVisitor>();
   for (const auto & module : scene_modules_) {
     if (module->name() == "LaneChange") {
       auto visitor_ptr = std::make_shared<SceneModuleVisitor>();
       module->accept_visitor(visitor_ptr);
       const auto get_ptr = visitor_ptr->get_lane_change_debug_msg_array();
       if (get_ptr) {
-        scene_module_visior_ptr_->set_lane_change_debug_ptr(get_ptr);
+        scene_module_visitor_ptr_->set_lane_change_debug_ptr(get_ptr);
       }
     } else if (module->name() == "Avoidance") {
       auto visitor_ptr = std::make_shared<SceneModuleVisitor>();
       module->accept_visitor(visitor_ptr);
       const auto get_ptr = visitor_ptr->get_avoidance_debug_msg_array();
       if (get_ptr) {
-        scene_module_visior_ptr_->set_avoidance_debug_ptr(get_ptr);
+        scene_module_visitor_ptr_->set_avoidance_debug_ptr(get_ptr);
       }
     }
   }
@@ -168,6 +168,6 @@ void BehaviorTreeManager::get_debug_msg_array()
 std::shared_ptr<SceneModuleVisitor> BehaviorTreeManager::get_all_debug_data()
 {
   get_debug_msg_array();
-  return scene_module_visior_ptr_;
+  return scene_module_visitor_ptr_;
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -115,22 +115,6 @@ BehaviorTreeManager::getModulesStatus()
   return modules_status_;
 }
 
-AvoidanceDebugMsgArray BehaviorTreeManager::getAvoidanceDebugMsgArray()
-{
-  const auto avoidance_module = std::find_if(
-    scene_modules_.begin(), scene_modules_.end(),
-    [](const std::shared_ptr<SceneModuleInterface> & module_ptr) {
-      return module_ptr->name() == "Avoidance";
-    });
-  if (avoidance_module != scene_modules_.end()) {
-    const auto & ptr = avoidance_module->get()->getAvoidanceDebugMsgArray();
-    if (ptr) {
-      return *ptr;
-    }
-  }
-  return AvoidanceDebugMsgArray();
-}
-
 BT::NodeStatus BehaviorTreeManager::checkForceApproval(const std::string & name)
 {
   const auto & approval = current_planner_data_->approval.is_force_approved;
@@ -164,11 +148,18 @@ void BehaviorTreeManager::get_debug_msg_array()
   bt_visitor_interface_ = std::make_shared<BehaviorTreeVisitorInterface>();
   for (const auto & module : scene_modules_) {
     if (module->name() == "LaneChange") {
-      std::shared_ptr<LaneChangeVisitor> visitor_ptr = std::make_shared<LaneChangeVisitor>();
+      auto visitor_ptr = std::make_shared<LaneChangeVisitor>();
       module->accept_visitor(visitor_ptr);
       const auto get_ptr = visitor_ptr->get_lane_change_debug_msg_array();
       if (get_ptr) {
         bt_visitor_interface_->set_lane_change_debug_ptr(get_ptr);
+      }
+    } else if (module->name() == "Avoidance") {
+      auto visitor_ptr = std::make_shared<AvoidanceVisitor>();
+      module->accept_visitor(visitor_ptr);
+      const auto get_ptr = visitor_ptr->get_avoidance_debug_msg_array();
+      if (get_ptr) {
+        bt_visitor_interface_->set_avoidance_debug_ptr(get_ptr);
       }
     }
   }

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -16,6 +16,7 @@
 
 #include "behavior_path_planner/scene_module/scene_module_bt_node_interface.hpp"
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utilities.hpp"
 
 #include <algorithm>
@@ -158,4 +159,24 @@ void BehaviorTreeManager::resetGrootMonitor()
   }
 }
 
+void BehaviorTreeManager::get_debug_msg_array()
+{
+  bt_visitor_interface_ = std::make_shared<BehaviorTreeVisitorInterface>();
+  for (const auto & module : scene_modules_) {
+    if (module->name() == "LaneChange") {
+      std::shared_ptr<LaneChangeVisitor> visitor_ptr = std::make_shared<LaneChangeVisitor>();
+      module->accept_visitor(visitor_ptr);
+      const auto get_ptr = visitor_ptr->get_lane_change_debug_msg_array();
+      if (get_ptr) {
+        bt_visitor_interface_->set_lane_change_debug_ptr(get_ptr);
+      }
+    }
+  }
+}
+
+std::shared_ptr<BehaviorTreeVisitorInterface> BehaviorTreeManager::get_all_debug_data()
+{
+  get_debug_msg_array();
+  return bt_visitor_interface_;
+}
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -145,29 +145,29 @@ void BehaviorTreeManager::resetGrootMonitor()
 
 void BehaviorTreeManager::get_debug_msg_array()
 {
-  bt_visitor_interface_ = std::make_shared<BehaviorTreeVisitorInterface>();
+  scene_module_visior_ptr_ = std::make_shared<SceneModuleVisitor>();
   for (const auto & module : scene_modules_) {
     if (module->name() == "LaneChange") {
-      auto visitor_ptr = std::make_shared<DebugMessageReader>();
+      auto visitor_ptr = std::make_shared<SceneModuleVisitor>();
       module->accept_visitor(visitor_ptr);
       const auto get_ptr = visitor_ptr->get_lane_change_debug_msg_array();
       if (get_ptr) {
-        bt_visitor_interface_->set_lane_change_debug_ptr(get_ptr);
+        scene_module_visior_ptr_->set_lane_change_debug_ptr(get_ptr);
       }
     } else if (module->name() == "Avoidance") {
-      auto visitor_ptr = std::make_shared<DebugMessageReader>();
+      auto visitor_ptr = std::make_shared<SceneModuleVisitor>();
       module->accept_visitor(visitor_ptr);
       const auto get_ptr = visitor_ptr->get_avoidance_debug_msg_array();
       if (get_ptr) {
-        bt_visitor_interface_->set_avoidance_debug_ptr(get_ptr);
+        scene_module_visior_ptr_->set_avoidance_debug_ptr(get_ptr);
       }
     }
   }
 }
 
-std::shared_ptr<BehaviorTreeVisitorInterface> BehaviorTreeManager::get_all_debug_data()
+std::shared_ptr<SceneModuleVisitor> BehaviorTreeManager::get_all_debug_data()
 {
   get_debug_msg_array();
-  return bt_visitor_interface_;
+  return scene_module_visior_ptr_;
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2732,14 +2732,14 @@ std::shared_ptr<AvoidanceDebugMsgArray> AvoidanceModule::get_debug_msg_array() c
   return std::make_shared<AvoidanceDebugMsgArray>(debug_data_.avoidance_debug_msg_array);
 }
 
-void AvoidanceModule::accept_visitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const
+void AvoidanceModule::acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const
 {
   if (visitor) {
-    visitor->visit_avoidance_module(this);
+    visitor->visitAvoidanceModule(this);
   }
 }
 
-void SceneModuleVisitor::visit_avoidance_module(const AvoidanceModule * module) const
+void SceneModuleVisitor::visitAvoidanceModule(const AvoidanceModule * module) const
 {
   avoidance_visitor_ = module->get_debug_msg_array();
 }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -17,6 +17,7 @@
 #include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp"
 #include "behavior_path_planner/scene_module/avoidance/debug.hpp"
+#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utilities.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
@@ -24,6 +25,8 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <tier4_planning_msgs/msg/avoidance_debug_factor.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
 
 #include <algorithm>
 #include <limits>
@@ -306,8 +309,6 @@ ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
   // debug
   {
     updateAvoidanceDebugData(avoidance_debug_msg_array);
-    debug_avoidance_msg_array_ptr_ =
-      std::make_shared<AvoidanceDebugMsgArray>(debug_data_.avoidance_debug_msg_array);
     debug.farthest_linestring_from_overhang =
       std::make_shared<lanelet::ConstLineStrings3d>(debug_linestring);
     debug.current_lanelets = std::make_shared<lanelet::ConstLanelets>(current_lanes);
@@ -2527,7 +2528,6 @@ void AvoidanceModule::initVariables()
   left_shift_array_.clear();
   right_shift_array_.clear();
 
-  debug_avoidance_msg_array_ptr_.reset();
   debug_data_ = DebugData();
   debug_marker_.markers.clear();
   registered_raw_shift_lines_ = {};
@@ -2726,4 +2726,26 @@ void AvoidanceModule::updateAvoidanceDebugData(
   }
 }
 
+std::shared_ptr<AvoidanceDebugMsgArray> AvoidanceModule::get_debug_msg_array() const
+{
+  debug_data_.avoidance_debug_msg_array.header.stamp = clock_->now();
+  return std::make_shared<AvoidanceDebugMsgArray>(debug_data_.avoidance_debug_msg_array);
+}
+
+void AvoidanceModule::accept_visitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const
+{
+  if (visitor) {
+    visitor->visit_avoidance_module(this);
+  }
+}
+
+void AvoidanceVisitor::visit_lane_change_module(
+  [[maybe_unused]] const LaneChangeModule * module) const
+{
+}
+
+void AvoidanceVisitor::visit_avoidance_module(const AvoidanceModule * module) const
+{
+  avoidance_visitor_ = module->get_debug_msg_array();
+}
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2739,7 +2739,7 @@ void AvoidanceModule::accept_visitor(const std::shared_ptr<SceneModuleVisitor> &
   }
 }
 
-void DebugMessageReader::visit_avoidance_module(const AvoidanceModule * module) const
+void SceneModuleVisitor::visit_avoidance_module(const AvoidanceModule * module) const
 {
   avoidance_visitor_ = module->get_debug_msg_array();
 }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2739,12 +2739,7 @@ void AvoidanceModule::accept_visitor(const std::shared_ptr<SceneModuleVisitor> &
   }
 }
 
-void AvoidanceVisitor::visit_lane_change_module(
-  [[maybe_unused]] const LaneChangeModule * module) const
-{
-}
-
-void AvoidanceVisitor::visit_avoidance_module(const AvoidanceModule * module) const
+void DebugMessageReader::visit_avoidance_module(const AvoidanceModule * module) const
 {
   avoidance_visitor_ = module->get_debug_msg_array();
 }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -25,8 +25,8 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <tier4_planning_msgs/msg/avoidance_debug_factor.hpp>
-#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 #include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 
 #include <algorithm>
 #include <limits>

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -604,14 +604,14 @@ std::shared_ptr<LaneChangeDebugMsgArray> LaneChangeModule::get_debug_msg_array()
   return std::make_shared<LaneChangeDebugMsgArray>(lane_change_debug_msg_array_);
 }
 
-void LaneChangeModule::accept_visitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const
+void LaneChangeModule::acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const
 {
   if (visitor) {
-    visitor->visit_lane_change_module(this);
+    visitor->visitLaneChangeModule(this);
   }
 }
 
-void SceneModuleVisitor::visit_lane_change_module(const LaneChangeModule * module) const
+void SceneModuleVisitor::visitLaneChangeModule(const LaneChangeModule * module) const
 {
   lane_change_visitor_ = module->get_debug_msg_array();
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -609,4 +609,9 @@ void LaneChangeVisitor::visit_lane_change_module(const LaneChangeModule * module
 {
   lane_change_visitor_ = module->get_debug_msg_array();
 }
+
+void LaneChangeVisitor::visit_avoidance_module(
+  [[maybe_unused]] const AvoidanceModule * module) const
+{
+}
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -611,13 +611,8 @@ void LaneChangeModule::accept_visitor(const std::shared_ptr<SceneModuleVisitor> 
   }
 }
 
-void LaneChangeVisitor::visit_lane_change_module(const LaneChangeModule * module) const
+void DebugMessageReader::visit_lane_change_module(const LaneChangeModule * module) const
 {
   lane_change_visitor_ = module->get_debug_msg_array();
-}
-
-void LaneChangeVisitor::visit_avoidance_module(
-  [[maybe_unused]] const AvoidanceModule * module) const
-{
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -611,7 +611,7 @@ void LaneChangeModule::accept_visitor(const std::shared_ptr<SceneModuleVisitor> 
   }
 }
 
-void DebugMessageReader::visit_lane_change_module(const LaneChangeModule * module) const
+void SceneModuleVisitor::visit_lane_change_module(const LaneChangeModule * module) const
 {
   lane_change_visitor_ = module->get_debug_msg_array();
 }

--- a/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
+++ b/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
@@ -1,0 +1,39 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
+
+#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+
+namespace behavior_path_planner
+{
+
+void BehaviorTreeVisitorInterface::visit_lane_change_module(
+  [[maybe_unused]] const LaneChangeModule * module) const
+{
+}
+
+void BehaviorTreeVisitorInterface::set_avoidance_debug_ptr(
+  const std::shared_ptr<AvoidanceDebugMsgArray> & debug_msg_ptr)
+{
+  avoidance_visitor_ = debug_msg_ptr;
+}
+
+void BehaviorTreeVisitorInterface::set_lane_change_debug_ptr(
+  const std::shared_ptr<LaneChangeDebugMsgArray> & debug_msg_ptr)
+{
+  lane_change_visitor_ = debug_msg_ptr;
+}
+
+}  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
+++ b/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
@@ -18,24 +18,23 @@
 
 namespace behavior_path_planner
 {
-
-void BehaviorTreeVisitorInterface::visit_lane_change_module(
-  [[maybe_unused]] const LaneChangeModule * module) const
+std::shared_ptr<AvoidanceDebugMsgArray> SceneModuleVisitor::get_avoidance_debug_msg_array() const
 {
+  return avoidance_visitor_;
 }
 
-void BehaviorTreeVisitorInterface::visit_avoidance_module(
-  [[maybe_unused]] const AvoidanceModule * module) const
+std::shared_ptr<LaneChangeDebugMsgArray> SceneModuleVisitor::get_lane_change_debug_msg_array() const
 {
+  return lane_change_visitor_;
 }
 
-void BehaviorTreeVisitorInterface::set_avoidance_debug_ptr(
+void SceneModuleVisitor::set_avoidance_debug_ptr(
   const std::shared_ptr<AvoidanceDebugMsgArray> & debug_msg_ptr)
 {
   avoidance_visitor_ = debug_msg_ptr;
 }
 
-void BehaviorTreeVisitorInterface::set_lane_change_debug_ptr(
+void SceneModuleVisitor::set_lane_change_debug_ptr(
   const std::shared_ptr<LaneChangeDebugMsgArray> & debug_msg_ptr)
 {
   lane_change_visitor_ = debug_msg_ptr;

--- a/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
+++ b/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
@@ -18,26 +18,13 @@
 
 namespace behavior_path_planner
 {
-std::shared_ptr<AvoidanceDebugMsgArray> SceneModuleVisitor::get_avoidance_debug_msg_array() const
+std::shared_ptr<AvoidanceDebugMsgArray> SceneModuleVisitor::getAvoidanceModuleDebugMsg() const
 {
   return avoidance_visitor_;
 }
 
-std::shared_ptr<LaneChangeDebugMsgArray> SceneModuleVisitor::get_lane_change_debug_msg_array() const
+std::shared_ptr<LaneChangeDebugMsgArray> SceneModuleVisitor::getLaneChangeModuleDebugMsg() const
 {
   return lane_change_visitor_;
 }
-
-void SceneModuleVisitor::set_avoidance_debug_ptr(
-  const std::shared_ptr<AvoidanceDebugMsgArray> & debug_msg_ptr)
-{
-  avoidance_visitor_ = debug_msg_ptr;
-}
-
-void SceneModuleVisitor::set_lane_change_debug_ptr(
-  const std::shared_ptr<LaneChangeDebugMsgArray> & debug_msg_ptr)
-{
-  lane_change_visitor_ = debug_msg_ptr;
-}
-
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
+++ b/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
@@ -24,6 +24,11 @@ void BehaviorTreeVisitorInterface::visit_lane_change_module(
 {
 }
 
+void BehaviorTreeVisitorInterface::visit_avoidance_module(
+  [[maybe_unused]] const AvoidanceModule * module) const
+{
+}
+
 void BehaviorTreeVisitorInterface::set_avoidance_debug_ptr(
   const std::shared_ptr<AvoidanceDebugMsgArray> & debug_msg_ptr)
 {

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "behavior_path_planner/utilities.hpp"
-
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2385,6 +2385,7 @@ bool hasEnoughDistance(
 
   const auto rear_vehicle_velocity =
     (is_obj_in_front) ? ego_current_twist.linear : object_current_twist.linear;
+  debug.object_twist.linear = (is_obj_in_front) ? front_vehicle_velocity : rear_vehicle_velocity;
 
   const auto front_vehicle_accel = param.expected_front_deceleration;
   const auto rear_vehicle_accel = param.expected_rear_deceleration;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "behavior_path_planner/utilities.hpp"
+
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>


### PR DESCRIPTION
## Description

Previously only avoidance module publishes debug messages that outputs collision check related stats.

This PR aims to extend debug message to lane change module as well.

Due to the different data structure, it is necessary to consider a proper interface to extract the data in each module while code . Therefore, `visitor design pattern` is used to achieve this.

## Related links

New msg is needed. Please cherry-pick it here. https://github.com/tier4/tier4_autoware_msgs/pull/62

## Tests performed

1. use planning simulator to simulate the following scenario
![Screenshot from 2022-10-25 14-45-23](https://user-images.githubusercontent.com/93502286/197692565-b5335239-f133-49cc-ae82-504efe970592.png)
2. Execute the following command
```
ros2 topic echo /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lane_change_debug_message_array
```
3. The output should be as follows
![Screenshot from 2022-10-25 14-47-32](https://user-images.githubusercontent.com/93502286/197692913-60818648-4762-482b-b6ff-7b8c41912550.png)


## Notes for reviewers

Since avoidance module's debug message follows similar interface, the reviewer should also test avoidance module debug message
```
ros2 topic echo /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance_debug_message_array
```
![Screenshot from 2022-10-25 14-49-16](https://user-images.githubusercontent.com/93502286/197693131-bbf068fe-6472-422a-a988-442f46926866.png)
![Screenshot from 2022-10-25 14-49-27](https://user-images.githubusercontent.com/93502286/197693137-30c707d7-ab86-460c-87a6-51e665789a75.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
