### PR TITLE
fix(tier4_control_rviz_plugin): add time stamp for control command

### DIFF
--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
@@ -109,8 +109,10 @@ ManualController::ManualController(QWidget * parent) : rviz_common::Panel(parent
 
 void ManualController::update()
 {
+  if (!raw_node_) return;
   AckermannControlCommand ackermann;
   {
+    ackermann.stamp = raw_node_->get_clock()->now();
     ackermann.lateral.steering_tire_angle = steering_angle_;
     ackermann.longitudinal.speed = cruise_velocity_;
     if (current_acceleration_) {


### PR DESCRIPTION
## Description

add missing time stamp for plugin

This is found while testing acc_cmd to acc_current map calibrator


![image](https://user-images.githubusercontent.com/65527974/197988826-52b3ecd7-101c-4690-b9fa-253f4bd2c695.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
