### PR TITLE
fix: add check for external_emergency_stop_heartbeat_received_time to isDataReady

### DIFF
--- a/control/vehicle_cmd_gate/README.md
+++ b/control/vehicle_cmd_gate/README.md
@@ -66,4 +66,6 @@
 
 ## Assumptions / Known limits
 
-TBD.
+`use_external_emergency_stop` is true by default, as it is assumed that an external module will instruct emergency stop.
+Also, the `~/input/external_emergency_stop_heartbeat` topic is required for the external module's health monitoring.
+If you don't use this, set `use_external_emergency_stop` to false.

--- a/control/vehicle_cmd_gate/README.md
+++ b/control/vehicle_cmd_gate/README.md
@@ -66,6 +66,6 @@
 
 ## Assumptions / Known limits
 
-`use_external_emergency_stop` is true by default, as it is assumed that an external module will instruct emergency stop.
-Also, the `~/input/external_emergency_stop_heartbeat` topic is required for the external module's health monitoring.
-If you don't use this, set `use_external_emergency_stop` to false.
+The parameter `use_external_emergency_stop` (true by default) enables an emergency stop request from external modules.
+This feature requires a `~/input/external_emergency_stop_heartbeat` topic for health monitoring of the external module, and the vehicle_cmd_gate module will not start without the topic.
+The `use_external_emergency_stop` parameter must be false when the "external emergency stop" function is not used.

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -224,6 +224,13 @@ bool VehicleCmdGate::isDataReady()
     }
   }
 
+  if (use_external_emergency_stop_) {
+    if (!external_emergency_stop_heartbeat_received_time_) {
+      RCLCPP_WARN(get_logger(), "external_emergency_stop_heartbeat_received_time_ is false");
+      return false;
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Description

The vehicle_cmd_gate node periodically checks two heartbeat topics: system emergency heartbeat and external emergency stop heartbeat.
However, in the initialization function (isDataReady) only checks for system emergency heartbeat.
So I`ll add a check for the external emergency stop heartbeat to the initialization function.

TierIV Internal Link
https://tier4.atlassian.net/browse/T4PB-21179

<!-- Write a brief description of this PR. -->

## Tests performed

1. Make sure the `use_external_emergency_stop` argument in [control.launch.py](https://github.com/autowarefoundation/autoware.universe/blob/730848dd88ea86298a941191201801dec964b44c/launch/tier4_control_launch/launch/control.launch.py#L336) is `true`.
2. Launch planning_simulator, set Ego and Goal position.
3. You can see the message `external_emergency_stop_heartbeat_received_time_ is false` in the terminal.
   1. If `use_external_emergency_stop` is `false`, then you can engage the vehicle on simulaotr.
4. Publish `/external/selected/heartbeat` topic(e.g. by rqt Message Publisher), then you can engage the vehicle.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
