### PR TITLE
feat(motion_velocity_smoother): change osqp parameter

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/common/motion_velocity_smoother/motion_velocity_smoother.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/common/motion_velocity_smoother/motion_velocity_smoother.param.yaml
@@ -32,8 +32,8 @@
     # resampling parameters for optimization
     max_trajectory_length: 200.0        # max trajectory length for resampling [m]
     min_trajectory_length: 150.0        # min trajectory length for resampling [m]
-    resample_time: 5.0                  # resample total time for dense sampling [s]
-    dense_resample_dt: 0.1              # resample time interval for dense sampling [s]
+    resample_time: 2.0                  # resample total time for dense sampling [s]
+    dense_resample_dt: 0.2              # resample time interval for dense sampling [s]
     dense_min_interval_distance: 0.1    # minimum points-interval length for dense sampling [m]
     sparse_resample_dt: 0.5             # resample time interval for sparse sampling [s]
     sparse_min_interval_distance: 4.0   # minimum points-interval length for sparse sampling [m]

--- a/planning/motion_velocity_smoother/config/default_motion_velocity_smoother.param.yaml
+++ b/planning/motion_velocity_smoother/config/default_motion_velocity_smoother.param.yaml
@@ -32,8 +32,8 @@
     # resampling parameters for optimization
     max_trajectory_length: 200.0        # max trajectory length for resampling [m]
     min_trajectory_length: 150.0        # min trajectory length for resampling [m]
-    resample_time: 5.0                  # resample total time for dense sampling [s]
-    dense_resample_dt: 0.1              # resample time interval for dense sampling [s]
+    resample_time: 2.0                  # resample total time for dense sampling [s]
+    dense_resample_dt: 0.2              # resample time interval for dense sampling [s]
     dense_min_interval_distance: 0.1    # minimum points-interval length for dense sampling [m]
     sparse_resample_dt: 0.5             # resample time interval for sparse sampling [s]
     sparse_min_interval_distance: 4.0   # minimum points-interval length for sparse sampling [m]

--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -37,7 +37,7 @@ JerkFilteredSmoother::JerkFilteredSmoother(rclcpp::Node & node) : SmootherBase(n
 
   qp_solver_.updateMaxIter(20000);
   qp_solver_.updateRhoInterval(0);  // 0 means automatic
-  qp_solver_.updateEpsRel(1.0e-4);  // def: 1.0e-4
+  qp_solver_.updateEpsRel(1.0e-6);  // def: 1.0e-4
   qp_solver_.updateEpsAbs(1.0e-8);  // def: 1.0e-4
   qp_solver_.updateVerbose(false);
 }


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description

Motion velocity smoother does output some weird results when the ego vehicle travels at a high speed. In this PR, I changed the OSQP `EpsRel` to a smaller value to make it possible to get smooth velocity profiles. Moreover, in order to reduce the computation time, I changed the resampling parameters. Current computation time is around 20~45[msec]. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
