### PR TITLE
fix: avoid same value in accel and brake map

### DIFF
--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/config/accel_brake_map_calibrator.param.yaml
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/config/accel_brake_map_calibrator.param.yaml
@@ -13,6 +13,7 @@
     max_accel: 5.0
     min_accel: -5.0
     max_data_count: 100
+    precision: 3
     update_method: "update_offset_each_cell" # or "update_offset_each_cell", "update_offset_total"
     update_suggest_thresh: 0.7 # threshold of rmse rate that update suggest flag becomes true. ( rmse_rate: [rmse of update map] / [rmse of original map] )
     progress_file_output: false # flag to output log file

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
@@ -139,6 +139,7 @@ private:
   double max_accel_;
   double min_accel_;
   double pedal_to_accel_delay_;
+  int precision_;
   std::string csv_calibrated_map_dir_;
   std::string output_accel_file_;
   std::string output_brake_file_;

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -46,6 +46,7 @@ AccelBrakeMapCalibrator::AccelBrakeMapCalibrator(const rclcpp::NodeOptions & nod
   max_data_count_ = this->declare_parameter<int>("max_data_count", 200);
   pedal_accel_graph_output_ = this->declare_parameter<bool>("pedal_accel_graph_output", false);
   progress_file_output_ = this->declare_parameter<bool>("progress_file_output", false);
+  precision_ = this->declare_parameter<int>("precision", 3);
   const auto get_pitch_method_str =
     this->declare_parameter<std::string>("get_pitch_method", std::string("tf"));
   if (get_pitch_method_str == std::string("tf")) {
@@ -651,7 +652,7 @@ int AccelBrakeMapCalibrator::nearestVelSearch()
 
 void AccelBrakeMapCalibrator::takeConsistencyOfAccelMap()
 {
-  const double bit = 1e-03;
+  const double bit = std::pow(1e-01, precision_);
   for (std::size_t ped_idx = 0; ped_idx < update_accel_map_value_.size() - 1; ped_idx++) {
     for (std::size_t vel_idx = 0; vel_idx < update_accel_map_value_.at(0).size() - 1; vel_idx++) {
       const double current_acc = update_accel_map_value_.at(ped_idx).at(vel_idx);
@@ -673,7 +674,7 @@ void AccelBrakeMapCalibrator::takeConsistencyOfAccelMap()
 
 void AccelBrakeMapCalibrator::takeConsistencyOfBrakeMap()
 {
-  const double bit = 1e-03;
+  const double bit = std::pow(1e-01, precision_);
   for (std::size_t ped_idx = 0; ped_idx < update_brake_map_value_.size() - 1; ped_idx++) {
     for (std::size_t vel_idx = 0; vel_idx < update_brake_map_value_.at(0).size() - 1; vel_idx++) {
       const double current_acc = update_brake_map_value_.at(ped_idx).at(vel_idx);
@@ -1389,7 +1390,7 @@ bool AccelBrakeMapCalibrator::writeMapToCSV(
   for (std::size_t p = 0; p < pedal_index.size(); p++) {
     csv_file << pedal_index.at(p) << ",";
     for (std::size_t v = 0; v < vel_index.size(); v++) {
-      csv_file << std::setprecision(3) << value_map.at(p).at(v);
+      csv_file << std::fixed << std::setprecision(precision_) << value_map.at(p).at(v);
       if (v != vel_index.size() - 1) {
         csv_file << ",";
       }


### PR DESCRIPTION
## Description

The accelration values in accel_map.csv, and brake_map.csv for https://github.com/autowarefoundation/autoware.universe/pull/2152 
are required to increase monotonically with increasing velocity or stepping on the pedal.

The monotonic increase of acceleration shoule have been guaranteed  in accel_brake_map_calibrator, but the acceleration that did not increase was sometimes input due to precision when writing to csv.

In this PR , I guaranteed monotonic increase of acceleration in accel_map.csv / brake_map.csv with considering the precision of writing to csv

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
