### PR TITLE
feat(raw_vehicle_cmd_converter): add validation to same column value case

### DIFF
--- a/vehicle/raw_vehicle_cmd_converter/src/csv_loader.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/csv_loader.cpp
@@ -62,11 +62,11 @@ bool CSVLoader::validateMap(const Map & map, const bool is_row_decent, const boo
     // validate row data
     for (size_t j = 1; j < vec.size(); j++) {
       // validate col
-      if (vec.at(j) < prev_vec.at(j) && is_col_decent) {
+      if (vec.at(j) <= prev_vec.at(j) && is_col_decent) {
         invalid_index_pair = std::make_pair(i, j);
         is_invalid = true;
       }
-      if (vec.at(j) > prev_vec.at(j) && !is_col_decent) {
+      if (vec.at(j) >= prev_vec.at(j) && !is_col_decent) {
         invalid_index_pair = std::make_pair(i, j);
         is_invalid = true;
       }


### PR DESCRIPTION
- consider same value case for same column values case

![image](https://user-images.githubusercontent.com/65527974/198227921-1a9340d9-ec33-45ac-914e-abaf0ecf0f79.png)

https://github.com/tier4/autoware_individual_params.rd/tree/rx3-main/individual_params/config/13/pacmod
Expected test result if you replace example map
```
default,0,1.39,2.78,4.17,5.56,6.94,8.33,9.72,11.11,12.5,13.89
0,0.3,-0.05,-0.164,-0.39,-0.391,-0.392,-0.393,-0.397,-0.46,-0.461,-0.5
0.1,0.29,-0.06,-0.31,-0.391,-0.401,-0.406,-0.421,-0.45,-0.47,-0.49,-0.51
0.2,-0.38,-0.4,-0.709,-0.71,-0.78,-0.848,-0.864,-0.89,-0.91,-0.94,-0.96
0.3,-0.874,-1.03,-1.48,-1.48,-1.48,-1.48,-1.61,-1.61,-1.61,-1.61,-1.63
0.4,-1.46,-1.57,-1.9,-2.05,-2.07,-2.07,-2.07,-2.09,-2.09,-2.11,-2.11
0.5,-1.49,-1.57,-1.91,-2.22,-2.27,-2.27,-2.27,-2.27,-2.27,-2.28,-2.28
0.6,-1.5,-1.57,-1.91,-2.22,-2.27,-2.27,-2.27,-2.27,-2.28,-2.28,-2.28
0.7,-1.51,-1.57,-1.91,-2.22,-2.27,-2.27,-2.27,-2.28,-2.28,-2.28,-2.28
0.8,-2.18,-2.2,-2.7,-2.8,-2.9,-2.95,-2.95,-2.95,-2.95,-2.95,-2.96
```


```
1: [==========] Running 5 tests from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 5 tests from ConverterTests
1: [ RUN      ] ConverterTests.LoadExampleMap
1: index around (i,j) is invalid ( 7, 10 )
1: /home/t4tanaka/workspace/autoware/src/universe/autoware.universe/vehicle/raw_vehicle_cmd_converter/test/test_raw_vehicle_cmd_converter.cpp:82: Failure

```