### PR TITLE
fix(blind_spot): stop line and area generation

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
@@ -198,7 +198,7 @@ private:
    * @param lane_id lane id of objective lanelet
    * @return end point of lanelet
    */
-  boost::optional<geometry_msgs::msg::Point> getStartPointFromLaneLet(const int lane_id) const;
+  boost::optional<geometry_msgs::msg::Pose> getStartPointFromLaneLet(const int lane_id) const;
 
   /**
    * @brief get straight lanelets in intersection


### PR DESCRIPTION
Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

(1) fixed `generateStopLine`: it was failing with `findNearestIndex` because `getStartPointFromMap` was returning geometry_msgs::Point and so angle threshold was not satisfied.
(2) fixed conflict/detection area generation
 
## Tests performed

Using scenario (ego was not stopping previously)

https://user-images.githubusercontent.com/28677420/198266669-6983a844-de35-48be-8c9e-95081d9000a3.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
