### PR TITLE
fix(obstacle_cruise_planner): fix "process has died" in obstacle_cruise_planner

### DIFF
--- a/planning/obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/obstacle_cruise_planner/src/polygon_utils.cpp
@@ -233,16 +233,16 @@ geometry_msgs::msg::PointStamped calcNearestCollisionPoint(
                              traj_front_pose, vehicle_max_longitudinal_offset, 0.0, 0.0)
                              .position;
     if (is_driving_forward) {
-      segment_points.at(0) = traj_front_pose.position;
-      segment_points.at(1) = front_pos;
+      segment_points.push_back(traj_front_pose.position);
+      segment_points.push_back(front_pos);
     } else {
-      segment_points.at(0) = front_pos;
-      segment_points.at(1) = traj_front_pose.position;
+      segment_points.push_back(front_pos);
+      segment_points.push_back(traj_front_pose.position);
     }
   } else {
     const size_t seg_idx = first_within_idx - 1;
-    segment_points.at(0) = decimated_traj.points.at(seg_idx).pose.position;
-    segment_points.at(1) = decimated_traj.points.at(seg_idx + 1).pose.position;
+    segment_points.push_back(decimated_traj.points.at(seg_idx).pose.position);
+    segment_points.push_back(decimated_traj.points.at(seg_idx + 1).pose.position);
   }
 
   size_t min_idx = 0;


### PR DESCRIPTION
Signed-off-by: 1222-takeshi <m.takeshi1995@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
In this PR, fix to obstacle_cruise_planner process has died when pull over.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
