### PR TITLE
fix(tier4_planning_rviz_plugin): correct velocity text

### DIFF
--- a/common/tier4_planning_rviz_plugin/src/path_with_lane_id/display.cpp
+++ b/common/tier4_planning_rviz_plugin/src/path_with_lane_id/display.cpp
@@ -281,10 +281,10 @@ void AutowarePathWithLaneIdDisplay::processMessage(
         node->setPosition(position);
 
         rviz_rendering::MovableText * text = velocity_texts_.at(point_idx);
-        double vel = e.point.longitudinal_velocity_mps;
-        text->setCaption(
-          std::to_string(static_cast<int>(std::floor(vel))) + "." +
-          std::to_string(static_cast<int>(std::floor(vel * 100))));
+        const double vel = e.point.longitudinal_velocity_mps;
+        std::stringstream ss;
+        ss << std::fixed << std::setprecision(2) << vel;
+        text->setCaption(ss.str());
         text->setCharacterHeight(property_velocity_text_scale_->getFloat());
         text->setVisible(true);
       } else {

--- a/common/tier4_planning_rviz_plugin/src/trajectory/display.cpp
+++ b/common/tier4_planning_rviz_plugin/src/trajectory/display.cpp
@@ -287,10 +287,10 @@ void AutowareTrajectoryDisplay::processMessage(
         node->setPosition(position);
 
         rviz_rendering::MovableText * text = velocity_texts_.at(point_idx);
-        double vel = path_point.longitudinal_velocity_mps;
-        text->setCaption(
-          std::to_string(static_cast<int>(std::floor(vel))) + "." +
-          std::to_string(static_cast<int>(std::floor(vel * 100))));
+        const double vel = path_point.longitudinal_velocity_mps;
+        std::stringstream ss;
+        ss << std::fixed << std::setprecision(2) << vel;
+        text->setCaption(ss.str());
         text->setCharacterHeight(property_velocity_text_scale_->getFloat());
         text->setVisible(true);
       } else {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR fixes wrong velocity text when displaying a `PathWithLaneId` or a `Trajectory` in rviz. 

Before:
![image](https://user-images.githubusercontent.com/78338830/198967666-72f42176-500c-4a58-8241-9043e26df673.png)

After:
![image](https://user-images.githubusercontent.com/78338830/198967818-eeb6db6d-2775-452c-b836-982a0562335d.png)

### How to reproduce

Start rviz.
- `source install/setup.sh` in the Autoware workspace.
- Start `rviz2`.
- Set the fixed frame to `map`.
- Add a `Trajectory` display.
- Set the input topic to `/tmp` and enable `View Text Velocity`.

Publish a `Trajectory`.
- `source install/setup.sh` in the Autoware workspace.
- Publish a `Trajectory` message:

```
ros2 topic pub /tmp autoware_auto_planning_msgs/msg/Trajectory "header:
  frame_id: map
points:
- longitudinal_velocity_mps: 1.55"
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
