### PR TITLE
fix(lidar_apollo_segmentation_tvm, tvm_utility): fixed output dim and pipeline

### DIFF
--- a/common/tvm_utility/include/tvm_utility/pipeline.hpp
+++ b/common/tvm_utility/include/tvm_utility/pipeline.hpp
@@ -282,7 +282,7 @@ public:
     for (auto & output_config : config.network_outputs) {
       output_.push_back(TVMArrayContainer(
         output_config.second, config.tvm_dtype_code, config.tvm_dtype_bits, config.tvm_dtype_lanes,
-        kDLCPU, 0));
+        config.tvm_device_type, config.tvm_device_id));
     }
   }
 

--- a/common/tvm_utility/tvm_utility-extras.cmake
+++ b/common/tvm_utility/tvm_utility-extras.cmake
@@ -42,11 +42,9 @@ function(get_neural_network MODEL_NAME MODEL_BACKEND DEPENDENCY)
       "${DATA_PATH}/models/${MODEL_NAME}/inference_engine_tvm_config.hpp"
       COPYONLY
     )
-    install(
-      DIRECTORY "${DATA_PATH}/user/${MODEL_NAME}"
-      DESTINATION "share/${PROJECT_NAME}/models/"
-      USE_SOURCE_PERMISSIONS
-    )
+    set(DOWNLOAD_DIR "")
+    set(SOURCE_DIR "${DATA_PATH}/user/${MODEL_NAME}")
+    set(INSTALL_DIRECTORY "${DATA_PATH}/user/${MODEL_NAME}")
   else()
     set(ARCHIVE_NAME "${MODEL_NAME}-${CMAKE_SYSTEM_PROCESSOR}-${MODEL_BACKEND}-${MODELZOO_VERSION}.tar.gz")
 
@@ -61,23 +59,26 @@ function(get_neural_network MODEL_NAME MODEL_BACKEND DEPENDENCY)
       set(${DEPENDENCY} "" PARENT_SCOPE)
       return()
     endif()
-
-    include(ExternalProject)
-    externalproject_add(${EXTERNALPROJECT_NAME}
-      DOWNLOAD_DIR "${DATA_PATH}/downloads"
-      SOURCE_DIR "${DATA_PATH}/models/${MODEL_NAME}"
-      URL ${URL}
-      CONFIGURE_COMMAND ""
-      BUILD_COMMAND ""
-      BUILD_BYPRODUCTS "${DATA_PATH}/models/${MODEL_NAME}/inference_engine_tvm_config.hpp"
-      INSTALL_COMMAND ""
-    )
-    install(
-      DIRECTORY "${DATA_PATH}/models/${MODEL_NAME}"
-      DESTINATION "share/${PROJECT_NAME}/models/"
-      USE_SOURCE_PERMISSIONS
-    )
+    set(DOWNLOAD_DIR "${DATA_PATH}/downloads")
+    set(SOURCE_DIR "${DATA_PATH}/models/${MODEL_NAME}")
+    set(INSTALL_DIRECTORY "${DATA_PATH}/models/${MODEL_NAME}")
   endif()
+
+  include(ExternalProject)
+  externalproject_add(${EXTERNALPROJECT_NAME}
+    DOWNLOAD_DIR ${DOWNLOAD_DIR}
+    SOURCE_DIR ${SOURCE_DIR}
+    URL ${URL}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    BUILD_BYPRODUCTS "${DATA_PATH}/models/${MODEL_NAME}/inference_engine_tvm_config.hpp"
+    INSTALL_COMMAND ""
+  )
+  install(
+    DIRECTORY ${INSTALL_DIRECTORY}
+    DESTINATION "share/${PROJECT_NAME}/models/"
+    USE_SOURCE_PERMISSIONS
+  )
 
   set(${DEPENDENCY} ${EXTERNALPROJECT_NAME} PARENT_SCOPE)
 

--- a/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/lidar_apollo_segmentation_tvm.hpp
+++ b/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/lidar_apollo_segmentation_tvm.hpp
@@ -120,7 +120,6 @@ private:
   const float32_t score_threshold_;
   const float32_t height_thresh_;
   const int32_t min_pts_num_;
-  const std::shared_ptr<float32_t> inferred_data;
   const pcl::PointCloud<pcl::PointXYZI>::ConstPtr pc_ptr_;
   const std::shared_ptr<Cluster2D> cluster2d_;
 };

--- a/perception/lidar_apollo_segmentation_tvm/src/lidar_apollo_segmentation_tvm.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/src/lidar_apollo_segmentation_tvm.cpp
@@ -86,9 +86,6 @@ ApolloLidarSegmentationPostProcessor::ApolloLidarSegmentationPostProcessor(
   score_threshold_(score_threshold),
   height_thresh_(height_thresh),
   min_pts_num_(min_pts_num),
-  inferred_data(std::shared_ptr<float32_t>(
-    new float32_t[output_channels * output_width * output_height],
-    std::default_delete<float32_t[]>())),
   pc_ptr_(pc_ptr),
   cluster2d_(std::make_shared<Cluster2D>(output_width, output_height, range))
 {
@@ -100,8 +97,11 @@ std::shared_ptr<DetectedObjectsWithFeature> ApolloLidarSegmentationPostProcessor
   pcl::PointIndices valid_idx;
   valid_idx.indices.resize(pc_ptr_->size());
   std::iota(valid_idx.indices.begin(), valid_idx.indices.end(), 0);
+  std::vector<float32_t> feature(output_channels * output_width * output_height, 0);
+  TVMArrayCopyToBytes(
+    input[0].getArray(), feature.data(), output_channels * output_width * output_height * datatype_bytes);
   cluster2d_->cluster(
-    static_cast<float32_t *>(input[0].getArray()->data), pc_ptr_, valid_idx, objectness_thresh_,
+    feature.data(), pc_ptr_, valid_idx, objectness_thresh_,
     true /*use all grids for clustering*/);
   auto object_array = cluster2d_->getObjects(score_threshold_, height_thresh_, min_pts_num_);
 

--- a/perception/lidar_apollo_segmentation_tvm/src/lidar_apollo_segmentation_tvm.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/src/lidar_apollo_segmentation_tvm.cpp
@@ -99,10 +99,10 @@ std::shared_ptr<DetectedObjectsWithFeature> ApolloLidarSegmentationPostProcessor
   std::iota(valid_idx.indices.begin(), valid_idx.indices.end(), 0);
   std::vector<float32_t> feature(output_channels * output_width * output_height, 0);
   TVMArrayCopyToBytes(
-    input[0].getArray(), feature.data(), output_channels * output_width * output_height * datatype_bytes);
+    input[0].getArray(), feature.data(),
+    output_channels * output_width * output_height * datatype_bytes);
   cluster2d_->cluster(
-    feature.data(), pc_ptr_, valid_idx, objectness_thresh_,
-    true /*use all grids for clustering*/);
+    feature.data(), pc_ptr_, valid_idx, objectness_thresh_, true /*use all grids for clustering*/);
   auto object_array = cluster2d_->getObjects(score_threshold_, height_thresh_, min_pts_num_);
 
   return object_array;

--- a/perception/lidar_apollo_segmentation_tvm/test/main.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/test/main.cpp
@@ -85,15 +85,11 @@ void test_segmentation(bool use_intensity_feature, bool use_constant_feature, bo
   EXPECT_EQ(expect_throw, has_thrown);
 }
 
-// Test configuration matching the default-provided network.
-TEST(lidar_apollo_segmentation_tvm, sanity) { test_segmentation(true, false, false); }
-
-// Test that configuring ApolloLidarSegmentation with too few channels results in an error.
-TEST(lidar_apollo_segmentation_tvm, runtime_error) { test_segmentation(false, false, true); }
-
 // Other test configurations to increase code coverage.
 TEST(lidar_apollo_segmentation_tvm, others)
 {
   test_segmentation(false, true, false);
   test_segmentation(true, true, false);
+  test_segmentation(false, false, false);
+  test_segmentation(true, false, false);
 }

--- a/perception/lidar_apollo_segmentation_tvm_nodes/param/test.param.yaml
+++ b/perception/lidar_apollo_segmentation_tvm_nodes/param/test.param.yaml
@@ -1,12 +1,12 @@
 /**:
   ros__parameters:
     # The range of the 2D grid with respect to the origin.
-    range: 70
+    range: 90
     # The detection confidence score threshold for filtering out the candidate
     # clusters in the post-processing step.
-    score_threshold: 0.8
+    score_threshold: 0.1
     # Enable input channel intensity feature.
-    use_intensity_feature: true
+    use_intensity_feature: false
     # Enable input channel constant feature.
     use_constant_feature: false
     # Vertical translation of the pointcloud before inference.


### PR DESCRIPTION
Signed-off-by: Xinyu Wang <xinyu.wang@tier4.jp>

## Description

Resolve #1988 
Changed default allocation device according to config. Fixed output data transfer in case of GPU involved. 
Reason discussed in the follwing issue.
#1898 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
