### PR TITLE
perf(intersection): reduce bg::within call

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -31,6 +31,7 @@
 #include <optional>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 namespace behavior_velocity_planner
@@ -42,6 +43,8 @@ int insertPoint(
   autoware_auto_planning_msgs::msg::PathWithLaneId * inout_path);
 
 bool hasLaneId(const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p, const int id);
+std::optional<std::pair<int, int>> findLaneIdInterval(
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const int lane_id);
 bool getDuplicatedPointIdx(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const geometry_msgs::msg::Point & point, int * duplicated_point_idx);
@@ -98,11 +101,14 @@ bool generateStopLineBeforeIntersection(
 /**
  * @brief Calculate first path index that is in the polygon.
  * @param path     target path
+ * @param lane_interval_start the start index of point on the lane
+ * @param lane_interval_end the last index of point on the lane
  * @param polygons target polygon
  * @return path point index
  */
 std::optional<int> getFirstPointInsidePolygons(
-  const int lane_id, const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int lane_interval_start,
+  const int lane_interval_end, const int lane_id,
   const std::vector<lanelet::CompoundPolygon3d> & polygons);
 
 /**
@@ -111,7 +117,8 @@ std::optional<int> getFirstPointInsidePolygons(
  * @return true when the stop point is defined on map.
  */
 bool getStopLineIndexFromMap(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int lane_id,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int lane_interval_start,
+  const int lane_interval_end, const int lane_id,
   const std::shared_ptr<const PlannerData> & planner_data, int * stop_idx_ip, int dist_thr,
   const rclcpp::Logger logger);
 

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -43,7 +43,7 @@ int insertPoint(
   autoware_auto_planning_msgs::msg::PathWithLaneId * inout_path);
 
 bool hasLaneId(const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p, const int id);
-std::optional<std::pair<int, int>> findLaneIdInterval(
+std::optional<std::pair<size_t, size_t>> findLaneIdInterval(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const int lane_id);
 bool getDuplicatedPointIdx(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
@@ -58,6 +58,7 @@ std::tuple<lanelet::ConstLanelets, lanelet::ConstLanelets> getObjectiveLanelets(
 
 struct StopLineIdx
 {
+  // TODO(Mamoru Sobue): replace optional<size_t>
   int first_idx_inside_lane = -1;
   int pass_judge_line_idx = -1;
   int stop_line_idx = -1;
@@ -106,9 +107,9 @@ bool generateStopLineBeforeIntersection(
  * @param polygons target polygon
  * @return path point index
  */
-std::optional<int> getFirstPointInsidePolygons(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int lane_interval_start,
-  const int lane_interval_end, const int lane_id,
+std::optional<size_t> getFirstPointInsidePolygons(
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t lane_interval_start,
+  const size_t lane_interval_end, const int lane_id,
   const std::vector<lanelet::CompoundPolygon3d> & polygons);
 
 /**
@@ -117,8 +118,8 @@ std::optional<int> getFirstPointInsidePolygons(
  * @return true when the stop point is defined on map.
  */
 bool getStopLineIndexFromMap(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int lane_interval_start,
-  const int lane_interval_end, const int lane_id,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t lane_interval_start,
+  const size_t lane_interval_end, const int lane_id,
   const std::shared_ptr<const PlannerData> & planner_data, int * stop_idx_ip, int dist_thr,
   const rclcpp::Logger logger);
 

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -101,8 +101,8 @@ bool generateStopLineBeforeIntersection(
  * @param polygons target polygon
  * @return path point index
  */
-int getFirstPointInsidePolygons(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+std::optional<int> getFirstPointInsidePolygons(
+  const int lane_id, const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const std::vector<lanelet::CompoundPolygon3d> & polygons);
 
 /**

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -80,12 +80,12 @@ std::optional<std::pair<size_t, size_t>> findLaneIdInterval(
   bool found = false;
   size_t start = 0;
   size_t end = p.points.size() - 1;
-  for (unsigned i = 0; i < p.points.size(); ++i) {
+  for (size_t i = 0; i < p.points.size(); ++i) {
     if (hasLaneId(p.points.at(i), lane_id)) {
       if (!found) {
         // found interval for the first time
         found = true;
-        start = static_cast<int>(i);
+        start = i;
       }
     } else if (found) {
       // prior point was in the interval. interval ended
@@ -127,7 +127,7 @@ std::optional<size_t> getFirstPointInsidePolygons(
       const auto polygon_2d = lanelet::utils::to2D(polygon);
       is_in_lanelet = bg::within(to_bg2d(p), polygon_2d);
       if (is_in_lanelet) {
-        first_idx_inside_lanelet = static_cast<size_t>(i);
+        first_idx_inside_lanelet = i;
         break;
       }
     }
@@ -206,8 +206,10 @@ bool generateStopLine(
     if (first_idx_inside_lane_opt) {
       *first_idx_inside_lane = first_idx_inside_lane_opt.get();
     }
-    stop_idx_ip = std::max<size_t>(
-      first_idx_ip_inside_lane - 1 - stop_line_margin_idx_dist - base2front_idx_dist, 0);
+    stop_idx_ip = static_cast<size_t>(std::max<int>(
+      static_cast<int>(first_idx_ip_inside_lane) - 1 - stop_line_margin_idx_dist -
+        base2front_idx_dist,
+      0));
   }
 
   if (stop_idx_ip == 0) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -74,12 +74,12 @@ bool hasLaneId(const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p, 
   return false;
 }
 
-std::optional<std::pair<int, int>> findLaneIdInterval(
+std::optional<std::pair<size_t, size_t>> findLaneIdInterval(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const int lane_id)
 {
   bool found = false;
-  int start = 0;
-  int end = p.points.size() - 1;
+  size_t start = 0;
+  size_t end = p.points.size() - 1;
   for (unsigned i = 0; i < p.points.size(); ++i) {
     if (hasLaneId(p.points.at(i), lane_id)) {
       if (!found) {
@@ -93,7 +93,7 @@ std::optional<std::pair<int, int>> findLaneIdInterval(
       break;
     }
   }
-  start = std::max(0, start - 1);  // the idx of last point before the interval
+  start = std::max<size_t>(0, start - 1);  // the idx of last point before the interval
   return found ? std::make_optional(std::make_pair(start, end)) : std::nullopt;
 }
 
@@ -114,20 +114,20 @@ bool getDuplicatedPointIdx(
   return false;
 }
 
-std::optional<int> getFirstPointInsidePolygons(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int lane_interval_start,
-  const int lane_interval_end, [[maybe_unused]] const int lane_id,
+std::optional<size_t> getFirstPointInsidePolygons(
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t lane_interval_start,
+  const size_t lane_interval_end, [[maybe_unused]] const int lane_id,
   const std::vector<lanelet::CompoundPolygon3d> & polygons)
 {
-  std::optional<int> first_idx_inside_lanelet = std::nullopt;
-  for (int i = lane_interval_start; i <= lane_interval_end; ++i) {
+  std::optional<size_t> first_idx_inside_lanelet = std::nullopt;
+  for (size_t i = lane_interval_start; i <= lane_interval_end; ++i) {
     bool is_in_lanelet = false;
     auto p = path.points.at(i).point.pose.position;
     for (const auto & polygon : polygons) {
       const auto polygon_2d = lanelet::utils::to2D(polygon);
       is_in_lanelet = bg::within(to_bg2d(p), polygon_2d);
       if (is_in_lanelet) {
-        first_idx_inside_lanelet = static_cast<int>(i);
+        first_idx_inside_lanelet = static_cast<size_t>(i);
         break;
       }
     }
@@ -206,8 +206,8 @@ bool generateStopLine(
     if (first_idx_inside_lane_opt) {
       *first_idx_inside_lane = first_idx_inside_lane_opt.get();
     }
-    stop_idx_ip =
-      std::max(first_idx_ip_inside_lane - 1 - stop_line_margin_idx_dist - base2front_idx_dist, 0);
+    stop_idx_ip = std::max<size_t>(
+      first_idx_ip_inside_lane - 1 - stop_line_margin_idx_dist - base2front_idx_dist, 0);
   }
 
   if (stop_idx_ip == 0) {
@@ -265,8 +265,8 @@ bool generateStopLine(
 }
 
 bool getStopLineIndexFromMap(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int lane_interval_start,
-  const int lane_interval_end, const int lane_id,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t lane_interval_start,
+  const size_t lane_interval_end, const int lane_id,
   const std::shared_ptr<const PlannerData> & planner_data, int * stop_idx_ip, int dist_thr,
   const rclcpp::Logger logger)
 {
@@ -291,7 +291,7 @@ bool getStopLineIndexFromMap(
   const LineString2d extended_stop_line =
     planning_utils::extendLine(p_start, p_end, planner_data->stop_line_extend_length);
 
-  for (int i = lane_interval_start; i <= lane_interval_end; i++) {
+  for (size_t i = lane_interval_start; i <= lane_interval_end; i++) {
     const auto & p_front = path.points.at(i).point.pose.position;
     const auto & p_back = path.points.at(i + 1).point.pose.position;
 


### PR DESCRIPTION
Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

cc: @veqcc

In `getFirstPointInsidePolygons` function, I added `lane_id` argument in order to call `boost::within` only to those points which are inside the lane of interest.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/2097

## Tests performed

Tested in kashiwanoha map used in tutorial. The number of calls to `boost::within` reduced from 7103 to 1273.
![Screenshot from 2022-11-01 18-13-00](https://user-images.githubusercontent.com/28677420/199200832-24fd8f8a-4815-45d6-9ccb-6dff9f5153b1.png)

The time for `getStopLineFromMap` reduce from ~9ms to ~1ms.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
