### PR TITLE
refactor(longitudinal_controller): add debug code velocity controller

### DIFF
--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -268,11 +268,9 @@ private:
 
   /**
    * @brief update control state according to the current situation
-   * @param [in] current_control_state current control state
    * @param [in] control_data control data
    */
-  ControlState updateControlState(
-    const ControlState current_control_state, const ControlData & control_data);
+  void updateControlState(const ControlData & control_data);
 
   /**
    * @brief calculate control command based on the current control state

--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -107,6 +107,14 @@ private:
   // control state
   enum class ControlState { DRIVE = 0, STOPPING, STOPPED, EMERGENCY };
   ControlState m_control_state{ControlState::STOPPED};
+  std::string toStr(const ControlState s)
+  {
+    if (s == ControlState::DRIVE) return "DRIVE";
+    if (s == ControlState::STOPPING) return "STOPPING";
+    if (s == ControlState::STOPPED) return "STOPPED";
+    if (s == ControlState::EMERGENCY) return "EMERGENCY";
+    return "UNDEFINED";
+  };
 
   // control period
   float64_t m_longitudinal_ctrl_period;

--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -274,13 +274,11 @@ private:
 
   /**
    * @brief calculate control command based on the current control state
-   * @param [in] current_control_state current control state
    * @param [in] current_pose current ego pose
    * @param [in] control_data control data
    */
   Motion calcCtrlCmd(
-    const ControlState & current_control_state, const geometry_msgs::msg::Pose & current_pose,
-    const ControlData & control_data);
+    const geometry_msgs::msg::Pose & current_pose, const ControlData & control_data);
 
   /**
    * @brief publish control command

--- a/control/trajectory_follower/src/pid_longitudinal_controller.cpp
+++ b/control/trajectory_follower/src/pid_longitudinal_controller.cpp
@@ -527,14 +527,15 @@ PidLongitudinalController::ControlState PidLongitudinalController::updateControl
 
   const auto print_and_return = [this, current_control_state](const auto s) {
     if (s != current_control_state) {
-      RCLCPP_DEBUG(
-        node_->get_logger(), "%s -> %s", toStr(current_control_state).c_str(), toStr(s).c_str());
+      RCLCPP_DEBUG_STREAM(
+        node_->get_logger(),
+        "controller state changed: " << toStr(current_control_state) << " -> " << toStr(s));
     }
     return s;
   };
 
   const auto info_throttle = [this](const auto & s) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(node_->get_logger(), *node_->get_clock(), 3000, "%s", s);
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000, "%s", s);
   };
 
   // transit state


### PR DESCRIPTION
## Description

- refactor: remove unnecessary arg (controller_state) from some functions
- refactor: add debug message for state transition

The issue report like "the target speed seems to be positive but the vehicle does not move" comes a lot.
The cause is mainly the state change condition (driving distance is too short, the velocity controller is waiting for steering control convergence, etc.).

So add a print for state change in the velocity controller. 

The state transition worked correctly.

![image](https://user-images.githubusercontent.com/21360593/200494653-833f226f-f48a-48d3-8c56-0e81c6ab6d1f.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
