### PR TITLE
refactor(ndt_scan_matcher): isolate align function into ndt_omp

### DIFF
--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -66,15 +66,6 @@ enum class ConvergedParamType {
   NEAREST_VOXEL_TRANSFORMATION_LIKELIHOOD = 1
 };
 
-struct NdtResult
-{
-  geometry_msgs::msg::Pose pose;
-  float transform_probability;
-  float nearest_voxel_transformation_likelihood;
-  int iteration_num;
-  std::vector<geometry_msgs::msg::Pose> transformation_array;
-};
-
 struct NDTParams
 {
   double trans_epsilon;
@@ -111,7 +102,6 @@ private:
   void callback_regularization_pose(
     geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr pose_conv_msg_ptr);
 
-  NdtResult align(const geometry_msgs::msg::Pose & initial_pose_msg);
   geometry_msgs::msg::PoseWithCovarianceStamped align_using_monte_carlo(
     const std::shared_ptr<NormalDistributionsTransform> & ndt_ptr,
     const geometry_msgs::msg::PoseWithCovarianceStamped & initial_pose_with_cov);

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -443,7 +443,7 @@ void NDTScanMatcher::callback_sensor_points(
 
   const geometry_msgs::msg::Pose result_pose_msg = matrix4f_to_pose(ndt_result.pose);
   std::vector<geometry_msgs::msg::Pose> transformation_msg_array;
-  for (auto pose_matrix : ndt_result.transformation_array) {
+  for (const auto & pose_matrix : ndt_result.transformation_array) {
     geometry_msgs::msg::Pose pose_ros = matrix4f_to_pose(pose_matrix);
     transformation_msg_array.push_back(pose_ros);
   }

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -429,13 +429,21 @@ void NDTScanMatcher::callback_sensor_points(
 
   // perform ndt scan matching
   key_value_stdmap_["state"] = "Aligning";
-  const NdtResult ndt_result = align(interpolator.get_current_pose().pose.pose);
+  const Eigen::Matrix4f initial_pose_matrix = pose_to_matrix4f(interpolator.get_current_pose().pose.pose);
+  const pclomp::NdtResult ndt_result = ndt_ptr_->executeScanMatching(initial_pose_matrix);
   key_value_stdmap_["state"] = "Sleeping";
 
   const auto exe_end_time = std::chrono::system_clock::now();
   const double exe_time =
     std::chrono::duration_cast<std::chrono::microseconds>(exe_end_time - exe_start_time).count() /
     1000.0;
+
+  const geometry_msgs::msg::Pose result_pose_msg = matrix4f_to_pose(ndt_result.pose);
+  std::vector<geometry_msgs::msg::Pose> transformation_array_msg;
+  for (auto pose_matrix : ndt_result.transformation_array) {
+    geometry_msgs::msg::Pose pose_ros = matrix4f_to_pose(pose_matrix);
+    transformation_array_msg.push_back(pose_ros);
+  }
 
   // perform several validations
   /*****************************************************************************
@@ -455,7 +463,7 @@ void NDTScanMatcher::callback_sensor_points(
   bool is_local_optimal_solution_oscillation = false;
   if (!is_ok_iteration_num) {
     is_local_optimal_solution_oscillation = validate_local_optimal_solution_oscillation(
-      ndt_result.transformation_array, oscillation_threshold_, inversion_vector_threshold_);
+      transformation_array_msg, oscillation_threshold_, inversion_vector_threshold_);
   }
   bool is_ok_converged_param = validate_converged_param(
     ndt_result.transform_probability, ndt_result.nearest_voxel_transformation_likelihood);
@@ -476,16 +484,16 @@ void NDTScanMatcher::callback_sensor_points(
   nearest_voxel_transformation_likelihood_pub_->publish(
     make_float32_stamped(sensor_ros_time, ndt_result.nearest_voxel_transformation_likelihood));
   iteration_num_pub_->publish(make_int32_stamped(sensor_ros_time, ndt_result.iteration_num));
-  publish_tf(sensor_ros_time, ndt_result.pose);
-  publish_pose(sensor_ros_time, ndt_result.pose, is_converged);
-  publish_marker(sensor_ros_time, ndt_result.transformation_array);
+  publish_tf(sensor_ros_time, result_pose_msg);
+  publish_pose(sensor_ros_time, result_pose_msg, is_converged);
+  publish_marker(sensor_ros_time, transformation_array_msg);
   publish_initial_to_result_distances(
-    sensor_ros_time, ndt_result.pose, interpolator.get_current_pose(), interpolator.get_old_pose(),
+    sensor_ros_time, result_pose_msg, interpolator.get_current_pose(), interpolator.get_old_pose(),
     interpolator.get_new_pose());
 
   auto sensor_points_mapTF_ptr = std::make_shared<pcl::PointCloud<PointSource>>();
   pcl::transformPointCloud(
-    *sensor_points_baselinkTF_ptr, *sensor_points_mapTF_ptr, pose_to_matrix4f(ndt_result.pose));
+    *sensor_points_baselinkTF_ptr, *sensor_points_mapTF_ptr, ndt_result.pose);
   publish_point_cloud(sensor_ros_time, map_frame_, sensor_points_mapTF_ptr);
 
   key_value_stdmap_["transform_probability"] = std::to_string(ndt_result.transform_probability);
@@ -516,31 +524,6 @@ void NDTScanMatcher::transform_sensor_measurement(
     *sensor_points_input_ptr, *sensor_points_output_ptr, base_to_sensor_matrix);
 }
 
-NdtResult NDTScanMatcher::align(const geometry_msgs::msg::Pose & initial_pose_msg)
-{
-  const Eigen::Matrix4f initial_pose_matrix = pose_to_matrix4f(initial_pose_msg);
-
-  auto output_cloud = std::make_shared<pcl::PointCloud<PointSource>>();
-  ndt_ptr_->align(*output_cloud, initial_pose_matrix);
-
-  const std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
-    transformation_array_matrix = ndt_ptr_->getFinalTransformationArray();
-  std::vector<geometry_msgs::msg::Pose> transformation_array_msg;
-  for (auto pose_matrix : transformation_array_matrix) {
-    geometry_msgs::msg::Pose pose_ros = matrix4f_to_pose(pose_matrix);
-    transformation_array_msg.push_back(pose_ros);
-  }
-
-  NdtResult ndt_result;
-  ndt_result.pose = matrix4f_to_pose(ndt_ptr_->getFinalTransformation());
-  ndt_result.transformation_array = transformation_array_msg;
-  ndt_result.transform_probability = ndt_ptr_->getTransformationProbability();
-  ndt_result.nearest_voxel_transformation_likelihood =
-    ndt_ptr_->getNearestVoxelTransformationLikelihood();
-  ndt_result.iteration_num = ndt_ptr_->getFinalNumIteration();
-  return ndt_result;
-}
-
 geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::align_using_monte_carlo(
   const std::shared_ptr<NormalDistributionsTransform> & ndt_ptr,
   const geometry_msgs::msg::PoseWithCovarianceStamped & initial_pose_with_cov)
@@ -559,10 +542,11 @@ geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::align_using_monte_
 
   for (unsigned int i = 0; i < initial_poses.size(); i++) {
     const auto & initial_pose = initial_poses[i];
-    const NdtResult ndt_result = align(initial_pose);
+    const Eigen::Matrix4f initial_pose_matrix = pose_to_matrix4f(initial_pose);
+    const pclomp::NdtResult ndt_result = ndt_ptr_->executeScanMatching(initial_pose_matrix);
 
     Particle particle(
-      initial_pose, ndt_result.pose, ndt_result.transform_probability, ndt_result.iteration_num);
+      initial_pose, matrix4f_to_pose(ndt_result.pose), ndt_result.transform_probability, ndt_result.iteration_num);
     particle_array.push_back(particle);
     const auto marker_array = make_debug_markers(
       this->now(), map_frame_, tier4_autoware_utils::createMarkerScale(0.3, 0.1, 0.1), particle, i);
@@ -570,7 +554,7 @@ geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::align_using_monte_
 
     auto sensor_points_mapTF_ptr = std::make_shared<pcl::PointCloud<PointSource>>();
     pcl::transformPointCloud(
-      *ndt_ptr->getInputSource(), *sensor_points_mapTF_ptr, pose_to_matrix4f(ndt_result.pose));
+      *ndt_ptr->getInputSource(), *sensor_points_mapTF_ptr, ndt_result.pose);
     publish_point_cloud(initial_pose_with_cov.header.stamp, map_frame_, sensor_points_mapTF_ptr);
   }
 

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -429,7 +429,8 @@ void NDTScanMatcher::callback_sensor_points(
 
   // perform ndt scan matching
   key_value_stdmap_["state"] = "Aligning";
-  const Eigen::Matrix4f initial_pose_matrix = pose_to_matrix4f(interpolator.get_current_pose().pose.pose);
+  const Eigen::Matrix4f initial_pose_matrix =
+    pose_to_matrix4f(interpolator.get_current_pose().pose.pose);
   const pclomp::NdtResult ndt_result = ndt_ptr_->executeScanMatching(initial_pose_matrix);
   key_value_stdmap_["state"] = "Sleeping";
 
@@ -546,15 +547,15 @@ geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::align_using_monte_
     const pclomp::NdtResult ndt_result = ndt_ptr_->executeScanMatching(initial_pose_matrix);
 
     Particle particle(
-      initial_pose, matrix4f_to_pose(ndt_result.pose), ndt_result.transform_probability, ndt_result.iteration_num);
+      initial_pose, matrix4f_to_pose(ndt_result.pose), ndt_result.transform_probability,
+      ndt_result.iteration_num);
     particle_array.push_back(particle);
     const auto marker_array = make_debug_markers(
       this->now(), map_frame_, tier4_autoware_utils::createMarkerScale(0.3, 0.1, 0.1), particle, i);
     ndt_monte_carlo_initial_pose_marker_pub_->publish(marker_array);
 
     auto sensor_points_mapTF_ptr = std::make_shared<pcl::PointCloud<PointSource>>();
-    pcl::transformPointCloud(
-      *ndt_ptr->getInputSource(), *sensor_points_mapTF_ptr, ndt_result.pose);
+    pcl::transformPointCloud(*ndt_ptr->getInputSource(), *sensor_points_mapTF_ptr, ndt_result.pose);
     publish_point_cloud(initial_pose_with_cov.header.stamp, map_frame_, sensor_points_mapTF_ptr);
   }
 

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -439,10 +439,10 @@ void NDTScanMatcher::callback_sensor_points(
     1000.0;
 
   const geometry_msgs::msg::Pose result_pose_msg = matrix4f_to_pose(ndt_result.pose);
-  std::vector<geometry_msgs::msg::Pose> transformation_array_msg;
+  std::vector<geometry_msgs::msg::Pose> transformation_msg_array;
   for (auto pose_matrix : ndt_result.transformation_array) {
     geometry_msgs::msg::Pose pose_ros = matrix4f_to_pose(pose_matrix);
-    transformation_array_msg.push_back(pose_ros);
+    transformation_msg_array.push_back(pose_ros);
   }
 
   // perform several validations
@@ -463,7 +463,7 @@ void NDTScanMatcher::callback_sensor_points(
   bool is_local_optimal_solution_oscillation = false;
   if (!is_ok_iteration_num) {
     is_local_optimal_solution_oscillation = validate_local_optimal_solution_oscillation(
-      transformation_array_msg, oscillation_threshold_, inversion_vector_threshold_);
+      transformation_msg_array, oscillation_threshold_, inversion_vector_threshold_);
   }
   bool is_ok_converged_param = validate_converged_param(
     ndt_result.transform_probability, ndt_result.nearest_voxel_transformation_likelihood);
@@ -486,7 +486,7 @@ void NDTScanMatcher::callback_sensor_points(
   iteration_num_pub_->publish(make_int32_stamped(sensor_ros_time, ndt_result.iteration_num));
   publish_tf(sensor_ros_time, result_pose_msg);
   publish_pose(sensor_ros_time, result_pose_msg, is_converged);
-  publish_marker(sensor_ros_time, transformation_array_msg);
+  publish_marker(sensor_ros_time, transformation_msg_array);
   publish_initial_to_result_distances(
     sensor_ros_time, result_pose_msg, interpolator.get_current_pose(), interpolator.get_old_pose(),
     interpolator.get_new_pose());

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -546,7 +546,6 @@ geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::align_using_monte_
   for (unsigned int i = 0; i < initial_poses.size(); i++) {
     const auto & initial_pose = initial_poses[i];
     const Eigen::Matrix4f initial_pose_matrix = pose_to_matrix4f(initial_pose);
-    auto output_cloud = std::make_shared<pcl::PointCloud<PointSource>>();
     ndt_ptr_->align(*output_cloud, initial_pose_matrix);
     const pclomp::NdtResult ndt_result = ndt_ptr_->getResult();
 


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
I would like to isolate the align function in the current ndt_scan_matcher (and also the `NdtResult` class) to `ndt_omp`.

This PR should be merged at the same time as https://github.com/tier4/ndt_omp/pull/16.

(side note: This PR may induce a build error due to the version mismatch between autoware.universe and ndt_omp, only when the newer universe used with the older ndt_omp)
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
