### PR TITLE
docs(planning): add limitation of path points size

### DIFF
--- a/planning/behavior_path_planner/behavior_path_planner_design_limitations.md
+++ b/planning/behavior_path_planner/behavior_path_planner_design_limitations.md
@@ -56,3 +56,7 @@ Currently, the implementation doesn't cover avoidance at corners and intersectio
 There are possibilities that the shifted path chatters as a result of various factors. For example, bounded box shape or position from the perception input. Sometimes, it is difficult for the perception to get complete information about the object's size. As the object size is updated, the object length will also be updated. This might cause shifts point to be re-calculated, therefore resulting in chattering shift points.
 
 ![limitation-chattering-shift](./image/limitations/limitation-chattering_shifts.png)
+
+## Limitation: Size of Path Points
+
+Some modules and functions do not support paths with only one point. Therefore, this module should generate the path with more than two path points.

--- a/planning/freespace_planner/README.md
+++ b/planning/freespace_planner/README.md
@@ -127,3 +127,7 @@ endif
 stop
 @enduml
 ```
+
+### Limitation
+
+Some modules and functions do not support paths with only one point. Therefore, this module should generate the path with more than two path points.


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

Currently, some modules and functions do not support paths with only one point, so add it to the limitations of docs.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
