### PR TITLE
fix: sync stored_commands to cooperate status

### DIFF
--- a/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
+++ b/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
@@ -67,6 +67,7 @@ private:
   std::vector<CooperateResponse> validateCooperateCommands(
     const std::vector<CooperateCommand> & commands);
   void updateCooperateCommandStatus(const std::vector<CooperateCommand> & commands);
+  void removeStoredCommand(const UUID & uuid);
   rclcpp::Logger getLogger() const;
   bool isLocked() const;
 

--- a/planning/rtc_interface/src/rtc_interface.cpp
+++ b/planning/rtc_interface/src/rtc_interface.cpp
@@ -208,6 +208,7 @@ void RTCInterface::updateCooperateStatus(
 void RTCInterface::removeCooperateStatus(const UUID & uuid)
 {
   std::lock_guard<std::mutex> lock(mutex_);
+  removeStoredCommand(uuid);
   // Find registered status which has same uuid and erase it
   const auto itr = std::find_if(
     registered_status_.statuses.begin(), registered_status_.statuses.end(),
@@ -223,10 +224,24 @@ void RTCInterface::removeCooperateStatus(const UUID & uuid)
     "[removeCooperateStatus] uuid : " << to_string(uuid) << " is not found." << std::endl);
 }
 
+void RTCInterface::removeStoredCommand(const UUID & uuid)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  // Find stored command which has same uuid and erase it
+  const auto itr = std::find_if(
+    stored_commands_.begin(), stored_commands_.end(), [uuid](auto & s) { return s.uuid == uuid; });
+
+  if (itr != stored_commands_.end()) {
+    stored_commands_.erase(itr);
+    return;
+  }
+}
+
 void RTCInterface::clearCooperateStatus()
 {
   std::lock_guard<std::mutex> lock(mutex_);
   registered_status_.statuses.clear();
+  stored_commands_.clear();
 }
 
 bool RTCInterface::isActivated(const UUID & uuid)

--- a/planning/rtc_interface/src/rtc_interface.cpp
+++ b/planning/rtc_interface/src/rtc_interface.cpp
@@ -226,7 +226,6 @@ void RTCInterface::removeCooperateStatus(const UUID & uuid)
 
 void RTCInterface::removeStoredCommand(const UUID & uuid)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
   // Find stored command which has same uuid and erase it
   const auto itr = std::find_if(
     stored_commands_.begin(), stored_commands_.end(), [uuid](auto & s) { return s.uuid == uuid; });


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
In rtc_interface, ```stored_commands``` is updated only when ```onCooperateCommandService()``` is called and ```is_locked_``` is true.
However, the stored_commands are copied to the cooperate command status every time ```unlockCommandUpdate()``` is called.

> void RTCInterface::unlockCommandUpdate()
{
  is_locked_ = false;
  updateCooperateCommandStatus(stored_commands_);
}

As a result, the cooperate commands that are cleared once may be re-registered through ```stored_commands_```.
I fixed this by properly clearing the stored_command.

Note: This bug is caused by performing lane-change in the same direction more than once.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Using planning simulator, set the lane change module to RTC Approval mode and make sure that a lane change is not performed without approval.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
