### PR TITLE
feat(trajectory_follower): use tier4_debug_msgs instead of autoware_auto_system_msgs

### DIFF
--- a/control/trajectory_follower/include/trajectory_follower/mpc.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc.hpp
@@ -37,9 +37,9 @@
 
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+#include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
 
 #include <deque>
 #include <memory>
@@ -395,7 +395,7 @@ public:
     const float64_t current_velocity, const geometry_msgs::msg::Pose & current_pose,
     autoware_auto_control_msgs::msg::AckermannLateralCommand & ctrl_cmd,
     autoware_auto_planning_msgs::msg::Trajectory & predicted_traj,
-    autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic & diagnostic);
+    tier4_debug_msgs::msg::Float32MultiArrayStamped & diagnostic);
   /**
    * @brief set the reference trajectory to follow
    */

--- a/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
@@ -37,13 +37,13 @@
 
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
+#include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
 
 #include <deque>
 #include <memory>
@@ -80,9 +80,8 @@ private:
 
   //!< @brief topic publisher for predicted trajectory
   rclcpp::Publisher<autoware_auto_planning_msgs::msg::Trajectory>::SharedPtr m_pub_predicted_traj;
-  //!< @brief topic publisher for control diagnostic
-  rclcpp::Publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>::SharedPtr
-    m_pub_diagnostic;
+  //!< @brief topic publisher for control debug values
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr m_pub_debug_values;
   //!< @brief subscription for transform messages
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr m_tf_sub;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr m_tf_static_sub;
@@ -175,8 +174,7 @@ private:
    * @brief publish diagnostic message
    * @param [in] diagnostic published diagnostic
    */
-  void publishDiagnostic(
-    autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic & diagnostic) const;
+  void publishDebugValues(tier4_debug_msgs::msg::Float32MultiArrayStamped & diagnostic) const;
 
   /**
    * @brief get stop command

--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -34,11 +34,11 @@
 
 #include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
+#include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
 
 #include <deque>
 #include <memory>
@@ -87,10 +87,8 @@ private:
   };
   rclcpp::Node * node_;
   // ros variables
-  rclcpp::Publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>::SharedPtr
-    m_pub_slope;
-  rclcpp::Publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>::SharedPtr
-    m_pub_debug;
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr m_pub_slope;
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr m_pub_debug;
 
   rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr m_set_param_res;
   rcl_interfaces::msg::SetParametersResult paramCallback(

--- a/control/trajectory_follower/package.xml
+++ b/control/trajectory_follower/package.xml
@@ -24,7 +24,6 @@
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_geometry</depend>
   <depend>autoware_auto_planning_msgs</depend>
-  <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
@@ -40,6 +39,7 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
+  <depend>tier4_debug_msgs</depend>
   <depend>vehicle_info_util</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/control/trajectory_follower/src/mpc.cpp
+++ b/control/trajectory_follower/src/mpc.cpp
@@ -43,7 +43,7 @@ bool8_t MPC::calculateMPC(
   const float64_t current_velocity, const geometry_msgs::msg::Pose & current_pose,
   autoware_auto_control_msgs::msg::AckermannLateralCommand & ctrl_cmd,
   autoware_auto_planning_msgs::msg::Trajectory & predicted_traj,
-  autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic & diagnostic)
+  tier4_debug_msgs::msg::Float32MultiArrayStamped & diagnostic)
 {
   /* recalculate velocity from ego-velocity with dynamics */
   trajectory_follower::MPCTrajectory reference_trajectory =
@@ -133,9 +133,9 @@ bool8_t MPC::calculateMPC(
   const float64_t steer_cmd = ctrl_cmd.steering_tire_angle;
   const float64_t wb = m_vehicle_model_ptr->getWheelbase();
 
-  typedef decltype(diagnostic.diag_array.data)::value_type DiagnosticValueType;
+  typedef decltype(diagnostic.data)::value_type DiagnosticValueType;
   auto append_diag_data = [&](const auto & val) -> void {
-    diagnostic.diag_array.data.push_back(static_cast<DiagnosticValueType>(val));
+    diagnostic.data.push_back(static_cast<DiagnosticValueType>(val));
   };
   // [0] final steering command (MPC + LPF)
   append_diag_data(steer_cmd);

--- a/control/trajectory_follower/src/pid_longitudinal_controller.cpp
+++ b/control/trajectory_follower/src/pid_longitudinal_controller.cpp
@@ -190,12 +190,10 @@ PidLongitudinalController::PidLongitudinalController(rclcpp::Node & node)
       : node_->declare_parameter<double>("ego_nearest_yaw_threshold");  // [rad]
 
   // subscriber, publisher
-  m_pub_slope =
-    node_->create_publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>(
-      "~/output/slope_angle", rclcpp::QoS{1});
-  m_pub_debug =
-    node_->create_publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>(
-      "~/output/longitudinal_diagnostic", rclcpp::QoS{1});
+  m_pub_slope = node_->create_publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>(
+    "~/output/slope_angle", rclcpp::QoS{1});
+  m_pub_debug = node_->create_publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>(
+    "~/output/longitudinal_diagnostic", rclcpp::QoS{1});
 
   // set parameter callback
   m_set_param_res = node_->add_on_set_parameters_callback(
@@ -684,19 +682,18 @@ void PidLongitudinalController::publishDebugData(
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PUBLISHED, ctrl_cmd.acc);
 
   // publish debug values
-  autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic debug_msg{};
-  debug_msg.diag_header.data_stamp = node_->now();
+  tier4_debug_msgs::msg::Float32MultiArrayStamped debug_msg{};
+  debug_msg.stamp = node_->now();
   for (const auto & v : m_debug_values.getValues()) {
-    debug_msg.diag_array.data.push_back(
-      static_cast<decltype(debug_msg.diag_array.data)::value_type>(v));
+    debug_msg.data.push_back(static_cast<decltype(debug_msg.data)::value_type>(v));
   }
   m_pub_debug->publish(debug_msg);
 
   // slope angle
-  autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic slope_msg{};
-  slope_msg.diag_header.data_stamp = node_->now();
-  slope_msg.diag_array.data.push_back(
-    static_cast<decltype(slope_msg.diag_array.data)::value_type>(control_data.slope_angle));
+  tier4_debug_msgs::msg::Float32MultiArrayStamped slope_msg{};
+  slope_msg.stamp = node_->now();
+  slope_msg.data.push_back(
+    static_cast<decltype(slope_msg.data)::value_type>(control_data.slope_angle));
   m_pub_slope->publish(slope_msg);
 }
 

--- a/control/trajectory_follower/test/test_mpc.cpp
+++ b/control/trajectory_follower/test/test_mpc.cpp
@@ -22,9 +22,9 @@
 #include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
-#include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+#include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
 
 #ifdef ROS_DISTRO_GALACTIC
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
@@ -47,7 +47,7 @@ typedef autoware_auto_vehicle_msgs::msg::SteeringReport SteeringReport;
 typedef geometry_msgs::msg::Pose Pose;
 typedef geometry_msgs::msg::PoseStamped PoseStamped;
 typedef autoware_auto_control_msgs::msg::AckermannLateralCommand AckermannLateralCommand;
-typedef autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic Float32MultiArrayDiagnostic;
+typedef tier4_debug_msgs::msg::Float32MultiArrayStamped Float32MultiArrayStamped;
 
 class MPCTest : public ::testing::Test
 {
@@ -206,7 +206,7 @@ TEST_F(MPCTest, InitializeAndCalculate)
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
-  Float32MultiArrayDiagnostic diag;
+  Float32MultiArrayStamped diag;
   ASSERT_TRUE(
     mpc.calculateMPC(neutral_steer, default_velocity, pose_zero, ctrl_cmd, pred_traj, diag));
   EXPECT_EQ(ctrl_cmd.steering_tire_angle, 0.0f);
@@ -240,7 +240,7 @@ TEST_F(MPCTest, InitializeAndCalculateRightTurn)
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
-  Float32MultiArrayDiagnostic diag;
+  Float32MultiArrayStamped diag;
   ASSERT_TRUE(
     mpc.calculateMPC(neutral_steer, default_velocity, pose_zero, ctrl_cmd, pred_traj, diag));
   EXPECT_LT(ctrl_cmd.steering_tire_angle, 0.0f);
@@ -270,7 +270,7 @@ TEST_F(MPCTest, OsqpCalculate)
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
-  Float32MultiArrayDiagnostic diag;
+  Float32MultiArrayStamped diag;
   // with OSQP this function returns false despite finding correct solutions
   EXPECT_FALSE(
     mpc.calculateMPC(neutral_steer, default_velocity, pose_zero, ctrl_cmd, pred_traj, diag));
@@ -301,7 +301,7 @@ TEST_F(MPCTest, OsqpCalculateRightTurn)
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
-  Float32MultiArrayDiagnostic diag;
+  Float32MultiArrayStamped diag;
   ASSERT_TRUE(
     mpc.calculateMPC(neutral_steer, default_velocity, pose_zero, ctrl_cmd, pred_traj, diag));
   EXPECT_LT(ctrl_cmd.steering_tire_angle, 0.0f);
@@ -333,7 +333,7 @@ TEST_F(MPCTest, KinematicsNoDelayCalculate)
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
-  Float32MultiArrayDiagnostic diag;
+  Float32MultiArrayStamped diag;
   ASSERT_TRUE(
     mpc.calculateMPC(neutral_steer, default_velocity, pose_zero, ctrl_cmd, pred_traj, diag));
   EXPECT_EQ(ctrl_cmd.steering_tire_angle, 0.0f);
@@ -365,7 +365,7 @@ TEST_F(MPCTest, KinematicsNoDelayCalculateRightTurn)
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
-  Float32MultiArrayDiagnostic diag;
+  Float32MultiArrayStamped diag;
   ASSERT_TRUE(
     mpc.calculateMPC(neutral_steer, default_velocity, pose_zero, ctrl_cmd, pred_traj, diag));
   EXPECT_LT(ctrl_cmd.steering_tire_angle, 0.0f);
@@ -392,7 +392,7 @@ TEST_F(MPCTest, DynamicCalculate)
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
-  Float32MultiArrayDiagnostic diag;
+  Float32MultiArrayStamped diag;
   ASSERT_TRUE(
     mpc.calculateMPC(neutral_steer, default_velocity, pose_zero, ctrl_cmd, pred_traj, diag));
   EXPECT_EQ(ctrl_cmd.steering_tire_angle, 0.0f);
@@ -418,7 +418,7 @@ TEST_F(MPCTest, MultiSolveWithBuffer)
   // Calculate MPC
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
-  Float32MultiArrayDiagnostic diag;
+  Float32MultiArrayStamped diag;
   ASSERT_TRUE(
     mpc.calculateMPC(neutral_steer, default_velocity, pose_zero, ctrl_cmd, pred_traj, diag));
   EXPECT_EQ(ctrl_cmd.steering_tire_angle, 0.0f);
@@ -462,7 +462,7 @@ TEST_F(MPCTest, FailureCases)
   pose_far.position.y = pose_zero.position.y - admissible_position_error - 1.0;
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
-  Float32MultiArrayDiagnostic diag;
+  Float32MultiArrayStamped diag;
   EXPECT_FALSE(
     mpc.calculateMPC(neutral_steer, default_velocity, pose_far, ctrl_cmd, pred_traj, diag));
 

--- a/control/trajectory_follower_nodes/config/plot_juggler_trajectory_follower.xml
+++ b/control/trajectory_follower_nodes/config/plot_juggler_trajectory_follower.xml
@@ -9,37 +9,37 @@
        <plot mode="TimeSeries" style="Lines">
         <range bottom="-1.152264" top="1.022526" right="118.796638" left="76.172500"/>
         <limitY/>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.5" color="#1f77b4">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.5" color="#1f77b4">
          <transform alias="lateral error" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.8" color="#d62728">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.8" color="#d62728">
          <transform alias="yaw error" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.0" color="#1ac938">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.0" color="#1ac938">
          <transform alias="steer cmd (final)" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.2" color="#ff7f0e">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.2" color="#ff7f0e">
          <transform alias="steer cmd (FF-filtered)" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.3" color="#f14cc1">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.3" color="#f14cc1">
          <transform alias="steer cmd (FF-raw)" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.4" color="#9467bd">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.4" color="#9467bd">
          <transform alias="steer measured" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.1" color="#17becf">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.1" color="#17becf">
          <transform alias="steer cmd (mpc-raw)" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -50,12 +50,12 @@
        <plot mode="TimeSeries" style="Lines">
         <range bottom="-0.069444" top="2.847222" right="118.796638" left="76.172500"/>
         <limitY/>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.9" color="#1f77b4">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.9" color="#1f77b4">
          <transform alias="trajectory velocity" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.10" color="#d62728">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.10" color="#d62728">
          <transform alias="current velocity" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -66,12 +66,12 @@
        <plot mode="TimeSeries" style="Lines">
         <range bottom="-0.460804" top="0.984813" right="118.796638" left="76.172500"/>
         <limitY/>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.14" color="#d62728">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.14" color="#d62728">
          <transform alias="smoothed" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.15" color="#1f77b4">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.15" color="#1f77b4">
          <transform alias="raw" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -84,22 +84,22 @@
        <plot mode="TimeSeries" style="Lines">
         <range bottom="-0.045019" top="1.491571" right="118.796638" left="76.172500"/>
         <limitY/>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.11" color="#1ac938">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.11" color="#1ac938">
          <transform alias="steering cmd" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.12" color="#ff7f0e">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.12" color="#ff7f0e">
          <transform alias="steering measured " name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.13" color="#d62728">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.13" color="#d62728">
          <transform alias="path curvature (smoothed)" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.17" color="#1f77b4">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.17" color="#1f77b4">
          <transform alias="steering predicted" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -110,12 +110,12 @@
        <plot mode="TimeSeries" style="Lines">
         <range bottom="-3.295688" top="3.281428" right="118.796638" left="76.172500"/>
         <limitY/>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.7" color="#1ac938">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.7" color="#1ac938">
          <transform alias="desired yaw" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/lateral/diagnostic/diag_array/data.6" color="#ff7f0e">
+        <curve name="/control/trajectory_follower/lateral/diagnostic/data.6" color="#ff7f0e">
          <transform alias="current yaw" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -141,52 +141,52 @@
        <plot mode="TimeSeries" style="Lines">
         <range bottom="-46.710209" top="91.855136" right="109.929097" left="76.129089"/>
         <limitY/>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.3" color="#1ac938">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.3" color="#1ac938">
          <transform alias="FF" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.14" color="#ff7f0e">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.14" color="#ff7f0e">
          <transform alias="FF+FB" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.19" color="#f14cc1">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.19" color="#f14cc1">
          <transform alias="FB-P" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.20" color="#9467bd">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.20" color="#9467bd">
          <transform alias="FB-I" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.21" color="#17becf">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.21" color="#17becf">
          <transform alias="FB-D" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.15" color="#bcbd22">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.15" color="#bcbd22">
          <transform alias="acc filtered" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.16" color="#1f77b4">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.16" color="#1f77b4">
          <transform alias="jerk filtered" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.17" color="#d62728">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.17" color="#d62728">
          <transform alias="slope added" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.18" color="#1ac938">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.18" color="#1ac938">
          <transform alias="final" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
         </curve>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.25" color="#ff7f0e">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.25" color="#ff7f0e">
          <transform alias="calculated" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -197,7 +197,7 @@
        <plot mode="TimeSeries" style="Lines">
         <range bottom="-0.050000" top="2.050000" right="109.929097" left="76.129089"/>
         <limitY/>
-        <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.13" color="#d62728">
+        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.13" color="#d62728">
          <transform alias="0:Drive 1:Stopping 2:Stopped 3:Emergency" name="Scale/Offset">
           <options value_scale="1.0" time_offset="0" value_offset="0"/>
          </transform>
@@ -209,22 +209,22 @@
       <plot mode="TimeSeries" style="Lines">
        <range bottom="-0.070625" top="2.895625" right="109.929097" left="76.129089"/>
        <limitY/>
-       <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.2" color="#17becf">
+       <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.2" color="#17becf">
         <transform alias="target" name="Scale/Offset">
          <options value_scale="1.0" time_offset="0" value_offset="0"/>
         </transform>
        </curve>
-       <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.1" color="#9467bd">
+       <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.1" color="#9467bd">
         <transform alias="current" name="Scale/Offset">
          <options value_scale="1.0" time_offset="0" value_offset="0"/>
         </transform>
        </curve>
-       <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.4" color="#bcbd22">
+       <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.4" color="#bcbd22">
         <transform alias="closest" name="Scale/Offset">
          <options value_scale="1.0" time_offset="0" value_offset="0"/>
         </transform>
        </curve>
-       <curve name="/control/trajectory_follower/longitudinal/diagnostic/diag_array/data.24" color="#1f77b4">
+       <curve name="/control/trajectory_follower/longitudinal/diagnostic/data.24" color="#1f77b4">
         <transform alias="predicted" name="Scale/Offset">
          <options value_scale="1.0" time_offset="0" value_offset="0"/>
         </transform>

--- a/control/trajectory_follower_nodes/design/trajectory_follower-design.md
+++ b/control/trajectory_follower_nodes/design/trajectory_follower-design.md
@@ -52,7 +52,7 @@ Giving the longitudinal controller information about steer convergence allows it
 
 ## Debugging
 
-Debug information are published by the lateral and longitudinal controller using `autoware_auto_msgs/Float32MultiArrayDiagnostic` messages.
+Debug information are published by the lateral and longitudinal controller using `tier4_debug_msgs/Float32MultiArrayStamped` messages.
 
 A configuration file for [PlotJuggler](https://github.com/facontidavide/PlotJuggler) is provided in the `config` folder which, when loaded, allow to automatically subscribe and visualize information useful for debugging.
 


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

For float32 multi array, use tier4_debug_msgs to use pie chart visualization
https://github.com/autowarefoundation/autoware.universe/pull/2055

FYI: float32 multi array in autoware_auto_system_msgs is only used in trajectory_follower. Therefore, this message seems not an official one.

Plot juggler also works well
![image](https://user-images.githubusercontent.com/20228327/200296285-2d5660d1-104d-4185-bc80-a9b51643a5a4.png)
![image](https://user-images.githubusercontent.com/20228327/200296332-8c5d730e-2f4a-4074-9cd4-e768e9ac9915.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
