### PR TITLE
fix(intersection): fixed stuck vehicle stop line and refactor stop line logic

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -71,7 +71,7 @@ struct StopLineIdx
  * @param original_path   ego-car lane
  * @param target_path     target lane to insert stop point (part of ego-car lane or same to ego-car
  * lane)
- * @return nullopt if path is not interseting with detection areas
+ * @return nullopt if path is not intersecting with detection areas
  */
 std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
   const int lane_id, const std::vector<lanelet::CompoundPolygon3d> & detection_areas,

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -58,7 +58,6 @@ std::tuple<lanelet::ConstLanelets, lanelet::ConstLanelets> getObjectiveLanelets(
 
 struct StopLineIdx
 {
-  size_t stuck_stop_line = 0;
   size_t pass_judge_line = 0;
   size_t stop_line = 0;
   size_t keep_detection_line = 0;
@@ -71,9 +70,9 @@ struct StopLineIdx
  * @param original_path   ego-car lane
  * @param target_path     target lane to insert stop point (part of ego-car lane or same to ego-car
  * lane)
- * @return false if path is not interseting with areas
+ * @return nullopt if path is not interseting with detection areas
  */
-std::tuple<bool, StopLineIdx> generateStopLine(
+std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
   const int lane_id, const std::vector<lanelet::CompoundPolygon3d> & detection_areas,
   const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
   const std::shared_ptr<const PlannerData> & planner_data, const double stop_line_margin,
@@ -88,7 +87,7 @@ std::tuple<bool, StopLineIdx> generateStopLine(
  * @param output_path     output path
  * @return valid value in pass_judge_line_idx and stop_line_idx field
  */
-std::tuple<bool, StopLineIdx> generateStopLineBeforeIntersection(
+std::optional<StopLineIdx> generateStopLineBeforeIntersection(
   const int lane_id, lanelet::LaneletMapConstPtr lanelet_map_ptr,
   const std::shared_ptr<const PlannerData> & planner_data,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path,

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -38,7 +38,7 @@ namespace behavior_velocity_planner
 {
 namespace util
 {
-int insertPoint(
+std::optional<size_t> insertPoint(
   const geometry_msgs::msg::Pose & in_pose,
   autoware_auto_planning_msgs::msg::PathWithLaneId * inout_path);
 

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -71,28 +71,17 @@ struct StopLineIdx
  * @param original_path   ego-car lane
  * @param target_path     target lane to insert stop point (part of ego-car lane or same to ego-car
  * lane)
+ " @param use_stuck_stopline if true, a stop line is generated at the beginning of intersection lane
  * @return nullopt if path is not intersecting with detection areas
  */
 std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
   const int lane_id, const std::vector<lanelet::CompoundPolygon3d> & detection_areas,
   const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
   const std::shared_ptr<const PlannerData> & planner_data, const double stop_line_margin,
-  const double keep_detection_line_margin,
+  const double keep_detection_line_margin, const bool use_stuck_stopline,
   autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & target_path,
   const rclcpp::Logger logger);
-
-/**
- * @brief If use_stuck_stopline is true, a stop line is generated before the intersection.
- * @param input_path      input path
- * @param output_path     output path
- * @return valid value in pass_judge_line_idx and stop_line_idx field
- */
-std::optional<StopLineIdx> generateStopLineBeforeIntersection(
-  const int lane_id, lanelet::LaneletMapConstPtr lanelet_map_ptr,
-  const std::shared_ptr<const PlannerData> & planner_data,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path,
-  autoware_auto_planning_msgs::msg::PathWithLaneId * output_path, const rclcpp::Logger logger);
 
 /**
  * @brief Calculate first path index that is in the polygon.

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -80,8 +80,8 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
   const std::shared_ptr<const PlannerData> & planner_data, const double stop_line_margin,
   const double keep_detection_line_margin, const bool use_stuck_stopline,
   autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & target_path,
-  const rclcpp::Logger logger);
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & target_path, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock);
 
 /**
  * @brief Calculate first path index that is in the polygon.

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -155,6 +155,7 @@ lanelet::ConstLanelets extendedAdjacentDirectionLanes(
 std::optional<Polygon2d> getIntersectionArea(
   lanelet::ConstLanelet assigned_lane, lanelet::LaneletMapConstPtr lanelet_map_ptr);
 
+bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane);
 bool isTrafficLightArrowActivated(
   lanelet::ConstLanelet lane,
   const std::map<int, autoware_auto_perception_msgs::msg::TrafficSignalStamped> & tl_infos);

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -58,6 +58,7 @@ std::tuple<lanelet::ConstLanelets, lanelet::ConstLanelets> getObjectiveLanelets(
 
 struct StopLineIdx
 {
+  size_t first_inside_lane = 0;
   size_t pass_judge_line = 0;
   size_t stop_line = 0;
   size_t keep_detection_line = 0;
@@ -114,8 +115,8 @@ std::optional<size_t> getFirstPointInsidePolygons(
 bool getStopLineIndexFromMap(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t lane_interval_start,
   const size_t lane_interval_end, const int lane_id,
-  const std::shared_ptr<const PlannerData> & planner_data, int * stop_idx_ip, int dist_thr,
-  const rclcpp::Logger logger);
+  const std::shared_ptr<const PlannerData> & planner_data, size_t * stop_idx_ip,
+  const double dist_thr, const rclcpp::Logger logger);
 
 std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLaneletsVec(
   const std::vector<lanelet::ConstLanelets> & ll_vec, double clip_length);

--- a/planning/behavior_velocity_planner/intersection-design.md
+++ b/planning/behavior_velocity_planner/intersection-design.md
@@ -60,6 +60,7 @@ The following process is performed for the attention targets to determine whethe
    2. calculate the passing area of the target object $A_{target}$ at $t_s$ - `collision_start_margin_time` ~ $t_e$ + `collision_end_margin_time` for each predicted path (\*1).
    3. check if $A_{ego}$ and $A_{target}$ regions are overlapped (has collision).
 4. when a collision is detected, the module inserts a stop velocity in front of the intersection. Note that there is a time margin for the stop release (\*2).
+5. If ego is over the `pass_judge_line`, collision checking is not processed to avoid sudden braking. However if ego velocity is lower than the threshold `keep_detection_vel_thr` then this module continues collision checking.
 
 (\*1) The parameters `collision_start_margin_time` and `collision_end_margin_time` can be interpreted as follows:
 
@@ -102,6 +103,7 @@ As a related case, if the object in front of the ego vehicle is turning the same
 | `intersection/min_predicted_path_confidence`  | double | [-] minimum confidence value of predicted path to use for collision detection                  |
 | `merge_from_private_road/stop_duration_sec`   | double | [s] duration to stop                                                                           |
 | `assumed_front_car_decel: 1.0`                | double | [m/s^2] deceleration of front car used to check if it could stop in the stuck area at the exit |
+| `keep_detection_vel_threshold`                | double | [m/s] the threshold for ego vehicle for keeping detection after passing `pass_judge_line`      |
 
 ### How To Tune Parameters
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -177,7 +177,7 @@ bool IntersectionModule::modifyPathVelocity(
         "over the pass judge line, but before keep detection line and low speed, "
         "continue planning");
       // no return here, keep planning
-    } else if (is_go_out_ && !external_stop) {
+    } else if (is_over_pass_judge_line && is_go_out_ && !external_stop) {
       RCLCPP_INFO(logger_, "over the keep_detection line and not low speed. no plan needed.");
       RCLCPP_DEBUG(logger_, "===== plan end =====");
       setSafe(true);
@@ -202,7 +202,6 @@ bool IntersectionModule::modifyPathVelocity(
   const bool is_stuck = checkStuckVehicleInIntersection(objects_ptr, stuck_vehicle_detect_area);
   int stop_line_idx_final = -1;
   int pass_judge_line_idx_final = -1;
-  std::cout << "is_stuck = " << is_stuck << std::endl;
   if (external_go) {
     is_entry_prohibited = false;
   } else if (external_stop) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -140,6 +140,12 @@ bool IntersectionModule::modifyPathVelocity(
     setDistance(std::numeric_limits<double>::lowest());
     return false;
   }
+  if (!stop_lines_idx_opt.has_value()) {
+    RCLCPP_DEBUG(logger_, "stop line is at path[0], ignore planning\n===== plan end =====");
+    setSafe(true);
+    setDistance(std::numeric_limits<double>::lowest());
+    return false;
+  }
   const auto stuck_line_idx = stuck_line_idx_opt.value();
 
   /* calc closest index */

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -140,12 +140,6 @@ bool IntersectionModule::modifyPathVelocity(
     setDistance(std::numeric_limits<double>::lowest());
     return false;
   }
-  if (!stop_lines_idx_opt.has_value()) {
-    RCLCPP_DEBUG(logger_, "stop line is at path[0], ignore planning\n===== plan end =====");
-    setSafe(true);
-    setDistance(std::numeric_limits<double>::lowest());
-    return false;
-  }
   const auto stuck_line_idx = stuck_line_idx_opt.value();
 
   /* calc closest index */
@@ -162,7 +156,7 @@ bool IntersectionModule::modifyPathVelocity(
   const size_t closest_idx = closest_idx_opt.get();
 
   bool keep_detection = false;
-  if (!can_go_through) {
+  if (!can_go_through && stop_lines_idx_opt.has_value()) {
     const auto & stop_lines = stop_lines_idx_opt.value();
     const size_t stop_line_idx = stop_lines.stop_line;
     const size_t pass_judge_line_idx = stop_lines.pass_judge_line;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -133,7 +133,7 @@ bool IntersectionModule::modifyPathVelocity(
     planner_param_.keep_detection_line_margin, path, *path, logger_.get_child("util"));
   if (!stuck_line_idx_opt.has_value()) {
     // returns here if path is not intersecting with conflicting areas
-    RCLCPP_WARN_SKIPFIRST_THROTTLE(
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
       logger_, *clock_, 1000 /* ms */, "setStopLineIdx for stuck line fail");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     setSafe(true);
@@ -178,7 +178,7 @@ bool IntersectionModule::modifyPathVelocity(
         "continue planning");
       // no return here, keep planning
     } else if (is_go_out_ && !external_stop) {
-      RCLCPP_DEBUG(logger_, "over the keep_detection line and not low speed. no plan needed.");
+      RCLCPP_INFO(logger_, "over the keep_detection line and not low speed. no plan needed.");
       RCLCPP_DEBUG(logger_, "===== plan end =====");
       setSafe(true);
       setDistance(motion_utils::calcSignedArcLength(
@@ -202,6 +202,7 @@ bool IntersectionModule::modifyPathVelocity(
   const bool is_stuck = checkStuckVehicleInIntersection(objects_ptr, stuck_vehicle_detect_area);
   int stop_line_idx_final = -1;
   int pass_judge_line_idx_final = -1;
+  std::cout << "is_stuck = " << is_stuck << std::endl;
   if (external_go) {
     is_entry_prohibited = false;
   } else if (external_stop) {
@@ -224,13 +225,15 @@ bool IntersectionModule::modifyPathVelocity(
       lanelet_map_ptr, *path, detection_lanelets, adjacent_lanelets, intersection_area, objects_ptr,
       closest_idx, stuck_vehicle_detect_area);
     is_entry_prohibited = (has_collision || is_stuck);
-    const auto & stop_lines_idx = stop_lines_idx_opt.value();
-    if (keep_detection) {
-      stop_line_idx_final = stop_lines_idx.keep_detection_line;
-      pass_judge_line_idx_final = stop_lines_idx.keep_detection_line;
-    } else {
-      stop_line_idx_final = stop_lines_idx.stop_line;
-      pass_judge_line_idx_final = stop_lines_idx.pass_judge_line;
+    if (stop_lines_idx_opt.has_value()) {
+      const auto & stop_lines_idx = stop_lines_idx_opt.value();
+      if (keep_detection) {
+        stop_line_idx_final = stop_lines_idx.keep_detection_line;
+        pass_judge_line_idx_final = stop_lines_idx.keep_detection_line;
+      } else {
+        stop_line_idx_final = stop_lines_idx.stop_line;
+        pass_judge_line_idx_final = stop_lines_idx.pass_judge_line;
+      }
     }
   }
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -126,7 +126,8 @@ bool IntersectionModule::modifyPathVelocity(
   /* set stop lines for base_link */
   const auto [stuck_line_idx_opt, stop_lines_idx_opt] = util::generateStopLine(
     lane_id_, detection_area, conflicting_area, planner_data_, planner_param_.stop_line_margin,
-    planner_param_.keep_detection_line_margin, path, *path, logger_.get_child("util"));
+    planner_param_.keep_detection_line_margin, planner_param_.use_stuck_stopline, path, *path,
+    logger_.get_child("util"));
   if (!stuck_line_idx_opt.has_value()) {
     // returns here if path is not intersecting with conflicting areas
     RCLCPP_INFO_SKIPFIRST_THROTTLE(
@@ -206,15 +207,6 @@ bool IntersectionModule::modifyPathVelocity(
     is_entry_prohibited = true;
     stop_line_idx_final = stuck_line_idx;
     pass_judge_line_idx_final = stuck_line_idx;
-    if (planner_param_.use_stuck_stopline) {
-      // TODO(Mamoru Sobue): pass this flag to generateStopLine instead
-      const auto stop_lines_before_int_opt = util::generateStopLineBeforeIntersection(
-        lane_id_, lanelet_map_ptr, planner_data_, *path, path, logger_.get_child("util"));
-      if (stop_lines_before_int_opt.has_value()) {
-        stop_line_idx_final = stop_lines_before_int_opt.value().stop_line;
-        pass_judge_line_idx_final = stop_lines_before_int_opt.value().pass_judge_line;
-      }
-    }
   } else {
     /* calculate dynamic collision around detection area */
     const bool has_collision = checkCollision(
@@ -238,7 +230,8 @@ bool IntersectionModule::modifyPathVelocity(
         setDistance(std::numeric_limits<double>::lowest());
         return false;
       } else {
-        RCLCPP_DEBUG(logger_, "no need to stop\n===== plan end =====");
+        RCLCPP_DEBUG(logger_, "no need to stop");
+        RCLCPP_DEBUG(logger_, "===== plan end =====");
         setSafe(true);
         setDistance(std::numeric_limits<double>::lowest());
         return true;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -99,7 +99,7 @@ bool IntersectionModule::modifyPathVelocity(
 
   /* get detection area*/
   /* dynamically change detection area based on tl_arrow_solid_on */
-  const bool has_tl = true;  // TODO(Mamoru Sobue): implement this
+  const bool has_tl = util::hasAssociatedTrafficLight(assigned_lanelet);
   const bool tl_arrow_solid_on =
     util::isTrafficLightArrowActivated(assigned_lanelet, planner_data_->traffic_light_id_map);
   auto && [detection_lanelets, conflicting_lanelets] = util::getObjectiveLanelets(

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -127,10 +127,10 @@ bool IntersectionModule::modifyPathVelocity(
   const auto [stuck_line_idx_opt, stop_lines_idx_opt] = util::generateStopLine(
     lane_id_, detection_area, conflicting_area, planner_data_, planner_param_.stop_line_margin,
     planner_param_.keep_detection_line_margin, planner_param_.use_stuck_stopline, path, *path,
-    logger_.get_child("util"));
+    logger_.get_child("util"), clock_);
   if (!stuck_line_idx_opt.has_value()) {
     // returns here if path is not intersecting with conflicting areas
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(
       logger_, *clock_, 1000 /* ms */, "setStopLineIdx for stuck line fail");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     setSafe(true);
@@ -168,13 +168,13 @@ bool IntersectionModule::modifyPathVelocity(
     if (is_over_pass_judge_line && keep_detection) {
       // in case ego could not stop exactly before the stop line, but with some overshoot,
       // keep detection within some margin under low velocity threshold
-      RCLCPP_INFO(
+      RCLCPP_DEBUG(
         logger_,
         "over the pass judge line, but before keep detection line and low speed, "
         "continue planning");
       // no return here, keep planning
     } else if (is_over_pass_judge_line && is_go_out_ && !external_stop) {
-      RCLCPP_INFO(logger_, "over the keep_detection line and not low speed. no plan needed.");
+      RCLCPP_DEBUG(logger_, "over the keep_detection line and not low speed. no plan needed.");
       RCLCPP_DEBUG(logger_, "===== plan end =====");
       setSafe(true);
       setDistance(motion_utils::calcSignedArcLength(

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -85,7 +85,7 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   const auto [stuck_line_idx_opt, stop_lines_idx_opt] = util::generateStopLine(
     lane_id_, detection_area, conflicting_area, planner_data_, planner_param_.stop_line_margin,
     0.0 /* unnecessary in merge_from_private */, false /* same */, path, *path,
-    logger_.get_child("util"));
+    logger_.get_child("util"), clock_);
   if (!stop_lines_idx_opt.has_value()) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000 /* ms */, "setStopLineIdx fail");
     return false;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -75,22 +75,24 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   }
   const auto detection_area =
     util::getPolygon3dFromLanelets(detection_lanelets, planner_param_.detection_area_length);
+  const std::vector<lanelet::CompoundPolygon3d> conflicting_area =
+    util::getPolygon3dFromLanelets(conflicting_lanelets);
   debug_data_.detection_area = detection_area;
 
   /* set stop-line and stop-judgement-line for base_link */
-  util::StopLineIdx stop_line_idxs;
   const auto private_path =
     extractPathNearExitOfPrivateRoad(*path, planner_data_->vehicle_info_.vehicle_length_m);
-  if (!util::generateStopLine(
-        lane_id_, detection_area, planner_data_, planner_param_.stop_line_margin,
-        0.0 /* unnecessary in merge_from_private */, path, private_path, &stop_line_idxs,
-        logger_.get_child("util"))) {
+  const auto [stuck_line_idx_opt, stop_lines_idx_opt] = util::generateStopLine(
+    lane_id_, detection_area, conflicting_area, planner_data_, planner_param_.stop_line_margin,
+    0.0 /* unnecessary in merge_from_private */, path, *path, logger_.get_child("util"));
+  if (!stop_lines_idx_opt.has_value()) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000 /* ms */, "setStopLineIdx fail");
     return false;
   }
 
-  const int stop_line_idx = stop_line_idxs.stop_line_idx;
-  if (stop_line_idx <= 0) {
+  const auto & stop_lines_idx = stop_lines_idx_opt.value();
+  const size_t stop_line_idx = stop_lines_idx.stop_line;
+  if (stop_line_idx == 0) {
     RCLCPP_DEBUG(logger_, "stop line is at path[0], ignore planning.");
     return true;
   }
@@ -98,10 +100,8 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   debug_data_.virtual_wall_pose = planning_utils::getAheadPose(
     stop_line_idx, planner_data_->vehicle_info_.max_longitudinal_offset_m, *path);
   debug_data_.stop_point_pose = path->points.at(stop_line_idx).point.pose;
-  const int first_idx_inside_lane = stop_line_idxs.first_idx_inside_lane;
-  if (first_idx_inside_lane != -1) {
-    debug_data_.first_collision_point = path->points.at(first_idx_inside_lane).point.pose.position;
-  }
+  const size_t first_inside_lane_idx = stop_lines_idx.first_inside_lane;
+  debug_data_.first_collision_point = path->points.at(first_inside_lane_idx).point.pose.position;
 
   /* set stop speed */
   if (state_machine_.getState() == StateMachine::State::STOP) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -84,7 +84,8 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
     extractPathNearExitOfPrivateRoad(*path, planner_data_->vehicle_info_.vehicle_length_m);
   const auto [stuck_line_idx_opt, stop_lines_idx_opt] = util::generateStopLine(
     lane_id_, detection_area, conflicting_area, planner_data_, planner_param_.stop_line_margin,
-    0.0 /* unnecessary in merge_from_private */, path, *path, logger_.get_child("util"));
+    0.0 /* unnecessary in merge_from_private */, false /* same */, path, *path,
+    logger_.get_child("util"));
   if (!stop_lines_idx_opt.has_value()) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000 /* ms */, "setStopLineIdx fail");
     return false;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -185,7 +185,7 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
     path_ip, lane_interval_start, lane_interval_end, lane_id, conflicting_areas);
   if (!stuck_stop_line_idx_ip_opt.has_value()) {
     RCLCPP_DEBUG(
-      logger, "Path is not intersecting with conflictign area, not genearting stuck_stop_line");
+      logger, "Path is not intersecting with conflicting area, not generating stuck_stop_line");
     return {std::nullopt, std::nullopt};
   }
   int stuck_stop_line_idx = 0;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -101,21 +101,20 @@ std::optional<std::pair<size_t, size_t>> findLaneIdInterval(
   return found ? std::make_optional(std::make_pair(start, end)) : std::nullopt;
 }
 
-bool getDuplicatedPointIdx(
+std::optional<size_t> getDuplicatedPointIdx(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const geometry_msgs::msg::Point & point, int * duplicated_point_idx)
+  const geometry_msgs::msg::Point & point)
 {
   for (size_t i = 0; i < path.points.size(); i++) {
     const auto & p = path.points.at(i).point.pose.position;
 
     constexpr double min_dist = 0.001;
     if (tier4_autoware_utils::calcDistance2d(p, point) < min_dist) {
-      *duplicated_point_idx = static_cast<int>(i);
-      return true;
+      return i;
     }
   }
 
-  return false;
+  return std::nullopt;
 }
 
 std::optional<size_t> getFirstPointInsidePolygons(
@@ -142,13 +141,13 @@ std::optional<size_t> getFirstPointInsidePolygons(
   return first_idx_inside_lanelet;
 }
 
-bool generateStopLine(
-  const int lane_id, const std::vector<lanelet::CompoundPolygon3d> detection_areas,
+std::tuple<bool, StopLineIdx> generateStopLine(
+  const int lane_id, const std::vector<lanelet::CompoundPolygon3d> & detection_areas,
+  const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
   const std::shared_ptr<const PlannerData> & planner_data, const double stop_line_margin,
   const double keep_detection_line_margin,
   autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & target_path,
-  StopLineIdx * stop_line_idxs, const rclcpp::Logger logger)
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & target_path, const rclcpp::Logger logger)
 {
   /* set judge line dist */
   const double current_vel = planner_data->current_velocity->twist.linear.x;
@@ -172,102 +171,137 @@ bool generateStopLine(
     std::ceil(planner_data->vehicle_info_.max_longitudinal_offset_m / interval);
   const int pass_judge_idx_dist = std::ceil(pass_judge_line_dist / interval);
 
-  int * first_idx_inside_lane = &(stop_line_idxs->first_idx_inside_lane);
-  int * pass_judge_line_idx = &(stop_line_idxs->pass_judge_line_idx);
-  int * stop_line_idx = &(stop_line_idxs->stop_line_idx);
-  int * keep_detection_line_idx = &(stop_line_idxs->keep_detection_line_idx);
-
   /* generate stop point */
   // If a stop_line tag is defined on lanelet_map, use it.
-  // else generate a stop_line behind the intersection of path and detection area (by margin
-  // stop_line_margin).
-  // stop point index for interpolated(ip) path.
-  int stop_idx_ip;
+  // else generate a stop_line behind the intersection of path and detection area
   const auto lane_interval_opt = util::findLaneIdInterval(path_ip, lane_id);
   if (!lane_interval_opt.has_value()) {
     RCLCPP_INFO(logger, "Path has no interval on intersection lane %d", lane_id);
-    return false;
+    return {false, util::StopLineIdx{}};
   }
+
   const auto [lane_interval_start, lane_interval_end] = lane_interval_opt.value();
+  // stop point index on interpolated(ip) path.
+  size_t stop_idx_ip;
   if (getStopLineIndexFromMap(
         path_ip, lane_interval_start, lane_interval_end, lane_id, planner_data, &stop_idx_ip, 10.0,
         logger)) {
     stop_idx_ip = std::max(stop_idx_ip - base2front_idx_dist, 0);
   } else {
     // find the index of the first point that intersects with detection_areas
-    const auto first_idx_ip_inside_lane_opt = getFirstPointInsidePolygons(
+    const auto first_inside_lane_idx_ip_opt = getFirstPointInsidePolygons(
       path_ip, lane_interval_start, lane_interval_end, lane_id, detection_areas);
     // if path is not intersecting with detection_area, skip
-    if (!first_idx_ip_inside_lane_opt.has_value()) {
+    if (!first_inside_lane_idx_ip_opt.has_value()) {
       RCLCPP_DEBUG(
         logger, "Path is not intersecting with detection_area, not generating stop_line");
-      return false;
+      return {false, util::StopLineIdx{}};
     }
-    const auto first_idx_ip_inside_lane = first_idx_ip_inside_lane_opt.value();
-    const auto & first_inside_point = path_ip.points.at(first_idx_ip_inside_lane).point.pose;
-    const auto first_idx_inside_lane_opt =
-      motion_utils::findNearestIndex(original_path->points, first_inside_point, 10.0, M_PI_4);
-    if (first_idx_inside_lane_opt) {
-      *first_idx_inside_lane = first_idx_inside_lane_opt.get();
-    }
-    stop_idx_ip = static_cast<size_t>(std::max<int>(
-      static_cast<int>(first_idx_ip_inside_lane) - 1 - stop_line_margin_idx_dist -
+
+    const auto first_inside_lane_idx_ip = first_inside_lane_idx_ip_opt.value();
+    stop_idx_ip = static_cast<size_t>(std::max(
+      static_cast<int>(first_inside_lane_idx_ip) - 1 - stop_line_margin_idx_dist -
         base2front_idx_dist,
       0));
   }
 
   if (stop_idx_ip == 0) {
     RCLCPP_DEBUG(logger, "stop line is at path[0], ignore planning.");
-    return false;
+    return {false, util::StopLineIdx{}};
   }
 
-  /* insert keep_detection_line */
-  const int keep_detection_idx_ip = std::min(
-    stop_idx_ip + keep_detection_line_margin_idx_dist, static_cast<int>(path_ip.points.size()) - 1);
-  if (const auto inserted_point = path_ip.points.at(keep_detection_idx_ip).point.pose;
-      !util::getDuplicatedPointIdx(
-        *original_path, inserted_point.position, keep_detection_line_idx)) {
-    *keep_detection_line_idx = util::insertPoint(inserted_point, original_path);
+  util::StopLineIdx idxs;
+
+  const auto stuck_stop_line_idx_ip_opt = util::getFirstPointInsidePolygons(
+    path_ip, lane_interval_start, lane_interval_end, lane_id, conflicting_areas);
+  if (!stuck_stop_line_idx_ip_opt.has_value()) {
+    RCLCPP_DEBUG(
+      logger, "Path is not intersecting with conflictign area, not genearting stuck_stop_line");
+    return {false, util::StopLineIdx{}};
   }
 
-  /* insert stop_point */
-  if (const auto inserted_point = path_ip.points.at(stop_idx_ip).point.pose;
-      !util::getDuplicatedPointIdx(*original_path, inserted_point.position, stop_line_idx)) {
-    *stop_line_idx = util::insertPoint(inserted_point, original_path);
-    (*keep_detection_line_idx)++;  // the index is incremented by judge stop line insertion
-  }
-
-  /* if another stop point exist before intersection stop_line, disable judge_line. */
-  bool has_prior_stopline = false;
-  for (int i = 0; i < *stop_line_idx; ++i) {
-    if (std::fabs(original_path->points.at(i).point.longitudinal_velocity_mps) < 0.1) {
-      has_prior_stopline = true;
-      break;
+  {
+    /* insert stuck_stop_line */
+    const int stuck_stop_line_idx_ip = stuck_stop_line_idx_ip_opt.value();
+    const auto & insert_point = path_ip.points.at(stuck_stop_line_idx_ip).point.pose;
+    const auto insert_idx_opt = util::getDuplicatedPointIdx(*original_path, insert_point.position);
+    if (insert_idx_opt.has_value()) {
+      idxs.stuck_stop_line = insert_idx_opt.value();
+    } else {
+      idxs.stuck_stop_line = util::insertPoint(insert_point, original_path);
     }
   }
+
+  {
+    /* insert keep_detection_line */
+    const int keep_detection_idx_ip = std::min(
+      stop_idx_ip + keep_detection_line_margin_idx_dist,
+      static_cast<int>(path_ip.points.size()) - 1);
+    const auto & insert_point = path_ip.points.at(keep_detection_idx_ip).point.pose;
+    const auto insert_idx_opt = util::getDuplicatedPointIdx(*original_path, insert_point.position);
+    if (insert_idx_opt.has_value()) {
+      idxs.keep_detection_line = insert_idx_opt.value();
+    } else {
+      idxs.keep_detection_line = util::insertPoint(inserted_point, original_path);
+      if (idxs.stuck_stop_line >= idxs.keep_detection_line) {
+        idxs.stuck_stop_line =
+          std::min<size_t>(idxs.stuck_stop_line + 1, original_path.points.size() - 1);
+      }
+    }
+  }
+
+  {
+    /* insert stop_point */
+    const auto & insert_point = path_ip.points.at(stop_idx_ip).point.pose;
+    const auto insert_idx_opt = util::getDuplicatedPointIdx(*original_path, insert_point.position);
+    if (insert_idx_opt.has_value()) {
+      idxs.stop_line = insert_idx_opt.value();
+    } else {
+      idxs.stop_line = util::insertPoint(inserted_point, original_path);
+      // the index is incremented by judge stop line insertion
+      idxs.keep_detection_line =
+        std::min<size_t>(idxs.keep_detection_line + 1, original_path.points.size() - 1);
+      if (idxs.stuck_stop_line >= idxs.stop_line) {
+        idxs.stuck_stop_line =
+          std::min<size_t>(idxs.stuck_stop_line + 1, original_path.points.size() - 1);
+      }
+    }
+  }
+
+  const bool has_prior_stopline = std::any_of(
+    original_path->points.begin(), original_path->points.begin() + idxs.stop_line_idx.value(),
+    [](const auto & p) { return std::fabs(p.longitudional_velocity) < 0.1; });
 
   /* insert judge point */
   const int pass_judge_idx_ip = std::min(
     static_cast<int>(path_ip.points.size()) - 1, std::max(stop_idx_ip - pass_judge_idx_dist, 0));
+  /* if another stop point exist before intersection stop_line, disable judge_line. */
   if (has_prior_stopline || pass_judge_idx_ip == stop_idx_ip) {
-    *pass_judge_line_idx = *stop_line_idx;
+    idxs.pass_judge_line = idxs.stop_line;
   } else {
-    if (const auto inserted_point = path_ip.points.at(pass_judge_idx_ip).point.pose;
-        !util::getDuplicatedPointIdx(
-          *original_path, inserted_point.position, pass_judge_line_idx)) {
-      *pass_judge_line_idx = util::insertPoint(inserted_point, original_path);
-      (*stop_line_idx)++;            // stop index is incremented by judge line insertion
-      (*keep_detection_line_idx)++;  // same.
+    const auto & insert_point = path_ip.points.at(pass_judge_idx_ip).point.pose;
+    const auto insert_idx_opt = util::getDuplicatedPointIdx(*original_path, insert_point.position);
+    if (insert_idx_opt.has_value()) {
+      idxs.pass_judge_line = insert_idx_opt.value();
+    } else {
+      idxs.pass_judge_line = util::insertPoint(inserted_point, original_path);
+      idxs.stop_line = std::min<size_t>(idxs.stop_line + 1, original_path.size() - 1);
+      idxs.keep_detection_line =
+        std::min<size_t>(idxs.keep_detection_line + 1, original_path.points.size() - 1);
+      if (idxs.stuck_stop_line >= idxs.keep_detection_line) {
+        idxs.stuck_stop_line =
+          std::min<size_t>(idxs.stuck_stop_line + 1, original_path.points.size() - 1);
+      }
     }
   }
-
   RCLCPP_DEBUG(
     logger,
-    "generateStopLine() : stop_idx = %d, pass_judge_idx = %d, stop_idx_ip = "
-    "%d, pass_judge_idx_ip = %d, has_prior_stopline = %d",
-    *stop_line_idx, *pass_judge_line_idx, stop_idx_ip, pass_judge_idx_ip, has_prior_stopline);
+    "generateStopLine() : keep_detection_idx = %d, stop_idx = %d, pass_judge_idx = %d"
+    ", stuck_stop_line_idx = %d, has_prior_stopline = %d",
+    idxs.keep_detection_line, idxs.stop_line, idxs.pass_judge_line, idxs.stuck_stop_line,
+    has_prior_stopline);
 
-  return true;
+  return {true, idxs};
 }
 
 bool getStopLineIndexFromMap(
@@ -463,12 +497,11 @@ std::vector<int> getLaneletIdsFromLanelets(lanelet::ConstLanelets ll)
   return id_list;
 }
 
-bool generateStopLineBeforeIntersection(
+std::tuple<bool, StopLineIdx> generateStopLineBeforeIntersection(
   const int lane_id, lanelet::LaneletMapConstPtr lanelet_map_ptr,
   const std::shared_ptr<const PlannerData> & planner_data,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path,
-  autoware_auto_planning_msgs::msg::PathWithLaneId * output_path, int * stuck_stop_line_idx,
-  int * pass_judge_line_idx, const rclcpp::Logger logger)
+  autoware_auto_planning_msgs::msg::PathWithLaneId * output_path, const rclcpp::Logger logger)
 {
   /* set judge line dist */
   const double current_vel = planner_data->current_velocity->twist.linear.x;
@@ -488,64 +521,67 @@ bool generateStopLineBeforeIntersection(
   /* spline interpolation */
   autoware_auto_planning_msgs::msg::PathWithLaneId path_ip;
   if (!splineInterpolate(input_path, interval, path_ip, logger)) {
-    return false;
+    return {false, StopLineIdx{}};
   }
+
   const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id);
-  for (size_t i = 0; i < path_ip.points.size(); i++) {
-    const auto & p = path_ip.points.at(i).point.pose;
-    if (lanelet::utils::isInLanelet(p, assigned_lanelet, 0.1)) {
-      if (static_cast<int>(i) <= 0) {
-        RCLCPP_DEBUG(logger, "generate stopline, but no within lanelet.");
-        return false;
-      }
-      int stop_idx_ip;  // stop point index for interpolated path.
-      stop_idx_ip = std::max(static_cast<int>(i) - base2front_idx_dist, 0);
+  const auto [lane_interval_start, lane_interval_end] = findLaneInterval(path_ip, lane_id);
+  const auto lane_start_it = path_ip.points.begin() + lane_interval_start;
+  const auto lane_end_it = path_ip.points.begin() + lane_interval_end;
+  const auto first_lane_point_it = std::find(lane_start_it, lane_end_it, [&](const auto & p) {
+    return lanelet::utils::isInLanelet(p, assigned_lanelet, 0.1);
+  });
+  if (lane_interval_start == 0 || first_lane_point_it == lane_end_it) {
+    RCLCPP_DEBUG(
+      logger,
+      "generate stopline before intersection, but ego is already in the intersection or path "
+      "is "
+      "not in the intersection");
+    return {false, StopLineIdx{}};
+  }
 
-      /* insert stop_point */
-      const auto inserted_stop_point = path_ip.points.at(stop_idx_ip).point.pose;
-      // if path has too close (= duplicated) point to the stop point, do not insert it
-      // and consider the index of the duplicated point as *stuck_stop_line_idx
-      if (!util::getDuplicatedPointIdx(
-            *output_path, inserted_stop_point.position, stuck_stop_line_idx)) {
-        *stuck_stop_line_idx = util::insertPoint(inserted_stop_point, output_path);
-      }
+  StopLineIdx idxs;
 
-      /* if another stop point exist before intersection stop_line, disable judge_line. */
-      bool has_prior_stopline = false;
-      for (int i = 0; i < *stuck_stop_line_idx; ++i) {
-        if (std::fabs(output_path->points.at(i).point.longitudinal_velocity_mps) < 0.1) {
-          has_prior_stopline = true;
-          break;
-        }
-      }
-
-      /* insert judge point */
-      const int pass_judge_idx_ip = std::min(
-        static_cast<int>(path_ip.points.size()) - 1,
-        std::max(stop_idx_ip - pass_judge_idx_dist, 0));
-      if (has_prior_stopline || stop_idx_ip == pass_judge_idx_ip) {
-        *pass_judge_line_idx = *stuck_stop_line_idx;
-      } else {
-        const auto inserted_pass_judge_point = path_ip.points.at(pass_judge_idx_ip).point.pose;
-        // if path has too close (= duplicated) point to the pass judge point, do not insert it
-        // and consider the index of the duplicated point as pass_judge_line_idx
-        if (!util::getDuplicatedPointIdx(
-              *output_path, inserted_pass_judge_point.position, pass_judge_line_idx)) {
-          *pass_judge_line_idx = util::insertPoint(inserted_pass_judge_point, output_path);
-          ++(*stuck_stop_line_idx);  // stop index is incremented by judge line insertion
-        }
-      }
-
-      RCLCPP_DEBUG(
-        logger,
-        "generateStopLineBeforeIntersection() : stuck_stop_line_idx = %d, pass_judge_idx = %d,"
-        "stop_idx_ip = %d, pass_judge_idx_ip = %d, has_prior_stopline = %d",
-        *stuck_stop_line_idx, *pass_judge_line_idx, stop_idx_ip, pass_judge_idx_ip,
-        has_prior_stopline);
-      return true;
+  const int stop_idx_ip =
+    std::max<int>(std::distance(lane_start_it, first_lane_point_it) - base2front_idx_dist, 0);
+  {
+    /* insert stop_point */
+    const auto & insert_point = path_ip.points.at(stop_idx_ip).point.pose;
+    const auto insert_idx_opt = util::getDuplicatedPointIdx(*output_path, insert_point.position);
+    if (insert_idx_opt.has_value()) {
+      idxs.stop_line = insert_idx_opt.value();
+    } else {
+      idxs.stop_line = util::insertPoint(inserted_stop_point, output_path);
     }
   }
-  return false;
+
+  const bool has_prior_stopline = std::any_of(
+    output_path.points.begin(), output_path.points.begin() + idxs.stop_line,
+    [](const auto & p) { return std::fabs(p.longitudional_velocity_mps) < 0.1; });
+  /* insert judge point */
+  const int pass_judge_idx_ip = std::min(
+    static_cast<int>(path_ip.points.size()) - 1, std::max(stop_idx_ip - pass_judge_idx_dist, 0));
+  /* if another stop point exist before intersection stop_line, disable judge_line. */
+  if (has_prior_stopline || stop_idx_ip == pass_judge_idx_ip) {
+    idxs.pass_judge_line = idxs.stop_line;
+  } else {
+    const auto & insert_point = path_ip.points.at(pass_judge_idx_ip).point.pose;
+    const auto insert_idx_opt = util::getDuplicatedPointIdx(*output_path, insert_point.position);
+    if (insert_idx_opt.has_value()) {
+      idxs.pass_judge_line = insert_idx_opt.value();
+    } else {
+      idxs.pass_judge_line = util::insertPoint(insert_point, output_path);
+      idxs.stop_line = std::min<size_t>(idxs.stop_line + 1, output_path.size() - 1);
+    }
+  }
+
+  RCLCPP_DEBUG(
+    logger,
+    "generateStopLineBeforeIntersection() : stop_line_idx = %d, pass_judge_idx = %d, "
+    "has_prior_stopline = %d",
+    idxs.stop_line, idxs.pass_judge_line, has_prior_stopline);
+
+  return {true, idxs};
 }
 
 geometry_msgs::msg::Pose toPose(const geometry_msgs::msg::Point & p)

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -240,8 +240,7 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
       path_ip, lane_interval_start, lane_interval_end, lane_id, detection_areas);
     // if path is not intersecting with detection_area, skip
     if (!first_inside_detection_idx_ip_opt.has_value()) {
-      RCLCPP_DEBUG(
-        logger, "Path is not intersecting with detection_area, not generating stop_line");
+      RCLCPP_INFO(logger, "Path is not intersecting with detection_area, not generating stop_line");
       return {stuck_stop_line_idx, std::nullopt};
     }
 
@@ -252,6 +251,7 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
       0));
   }
   if (stop_idx_ip == 0) {
+    RCLCPP_INFO(logger, "stop line is at path[0], ignore planning\n===== plan end =====");
     return {stuck_stop_line_idx, std::nullopt};
   }
 
@@ -320,7 +320,7 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
       }
     }
   }
-  RCLCPP_DEBUG(
+  RCLCPP_INFO(
     logger,
     "generateStopLine() : keep_detection_idx = %ld, stop_idx = %ld, pass_judge_idx = %ld"
     ", stuck_stop_idx = %ld, has_prior_stopline = %d",
@@ -371,7 +371,7 @@ bool getStopLineIndexFromMap(
 
     *stop_idx_ip = i;
 
-    RCLCPP_DEBUG(logger, "found collision point");
+    RCLCPP_INFO(logger, "found collision point");
 
     return true;
   }
@@ -384,12 +384,12 @@ bool getStopLineIndexFromMap(
   const auto stop_idx_ip_opt =
     motion_utils::findNearestIndex(path.points, stop_point_from_map, static_cast<double>(dist_thr));
   if (!stop_idx_ip_opt) {
-    RCLCPP_DEBUG(logger, "found stop line, but not found stop index");
+    RCLCPP_INFO(logger, "found stop line, but not found stop index");
     return false;
   }
   *stop_idx_ip = stop_idx_ip_opt.get();
 
-  RCLCPP_DEBUG(logger, "found stop line and stop index");
+  RCLCPP_INFO(logger, "found stop line and stop index");
 
   return true;
 }
@@ -553,13 +553,13 @@ std::optional<StopLineIdx> generateStopLineBeforeIntersection(
   const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id);
   const auto lane_interval_opt = findLaneIdInterval(path_ip, lane_id);
   if (!lane_interval_opt.has_value()) {
-    RCLCPP_DEBUG(
+    RCLCPP_INFO(
       logger, "generate stopline before intersection, but ego is not in the intersection");
     return std::nullopt;
   }
   const auto [lane_interval_start, lane_interval_end] = lane_interval_opt.value();
   if (lane_interval_start == 0) {
-    RCLCPP_DEBUG(
+    RCLCPP_INFO(
       logger,
       "generate stopline before intersection, but ego is already in the intersection or path "
       "is "
@@ -607,7 +607,7 @@ std::optional<StopLineIdx> generateStopLineBeforeIntersection(
     }
   }
 
-  RCLCPP_DEBUG(
+  RCLCPP_INFO(
     logger,
     "generateStopLineBeforeIntersection() : stop_line_idx = %ld, pass_judge_idx = %ld, "
     "has_prior_stopline = %d",

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -184,8 +184,11 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
   const auto stuck_stop_line_idx_ip_opt = util::getFirstPointInsidePolygons(
     path_ip, lane_interval_start, lane_interval_end, lane_id, conflicting_areas);
   if (!stuck_stop_line_idx_ip_opt.has_value()) {
-    RCLCPP_DEBUG(
-      logger, "Path is not intersecting with conflicting area, not generating stuck_stop_line");
+    RCLCPP_INFO(
+      logger,
+      "Path is not intersecting with conflicting area, not generating stuck_stop_line. start = "
+      "%ld, end = %ld",
+      lane_interval_start, lane_interval_end);
     return {std::nullopt, std::nullopt};
   }
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -207,8 +207,10 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
   size_t stuck_stop_line_idx = 0;
   {
     /* insert stuck stop line */
-    const size_t insert_idx_ip = std::max<size_t>(
-      stuck_stop_line_idx_ip_opt.value() - 1 - stop_line_margin_idx_dist - base2front_idx_dist, 0);
+    const size_t insert_idx_ip = static_cast<size_t>(std::max(
+      static_cast<int>(stuck_stop_line_idx_ip_opt.value()) - 1 - stop_line_margin_idx_dist -
+        base2front_idx_dist,
+      0));
     const auto & insert_point = path_ip.points.at(insert_idx_ip).point.pose;
     const auto insert_idx_opt = util::getDuplicatedPointIdx(*original_path, insert_point.position);
     if (insert_idx_opt.has_value()) {
@@ -222,7 +224,6 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
   /* generate stop points */
   util::StopLineIdx idxs;
   idxs.first_inside_lane = first_inside_lane_idx;
-  ;
 
   // If a stop_line tag is defined on lanelet_map, use it.
   // else generate a stop_line behind the intersection of path and detection area
@@ -233,12 +234,6 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
         logger)) {
     stop_idx_ip =
       static_cast<size_t>(std::max<int>(static_cast<int>(stop_idx_ip) - base2front_idx_dist, 0));
-    const auto & first_inside_point = path_ip.points.at(stop_idx_ip).point.pose;
-    const auto first_inside_lane_idx_opt =
-      motion_utils::findNearestIndex(original_path->points, first_inside_point, 10.0, M_PI_4);
-    if (first_inside_lane_idx_opt) {
-      idxs.first_inside_lane = first_inside_lane_idx_opt.get();
-    }
   } else {
     // find the index of the first point that intersects with detection_areas
     const auto first_inside_detection_idx_ip_opt = getFirstPointInsidePolygons(
@@ -257,7 +252,6 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
       0));
   }
   if (stop_idx_ip == 0) {
-    RCLCPP_DEBUG(logger, "stop line is at path[0], ignore planning.");
     return {stuck_stop_line_idx, std::nullopt};
   }
 


### PR DESCRIPTION
## Description

The stop position for stuck vehicle is the point which is `stop_line_margin` [m] behind the intersection point of `conflicting lanes` and `path` as in the attached image, but previously this stop position was the intersection point of `detection lanes` and `path`, so ego was entering the intersection improperly.

![Screenshot from 2022-11-08 19-59-58](https://user-images.githubusercontent.com/28677420/201912168-4a27dbf4-8651-4aba-b9bf-c0c811dc0a5e.png)

## Related links

[Jira link](https://tier4.atlassian.net/browse/T4PB-23096)

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

With retry=0, all related scenarios succeeded without degradation.

https://evaluation.tier4.jp/evaluation/reports/25940db8-a2ee-5760-af58-a303da3d7488?project_id=prd_jt

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
