### PR TITLE
refactor(trajectory_follower/trajectory_follower_nodes): remove autoware_auto_common dependency

### DIFF
--- a/control/trajectory_follower/include/trajectory_follower/debug_values.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/debug_values.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__DEBUG_VALUES_HPP_
 #define TRAJECTORY_FOLLOWER__DEBUG_VALUES_HPP_
 
-#include "common/types.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
 #include <array>
@@ -28,7 +27,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::float64_t;
+
 /// Debug Values used for debugging or controller tuning
 class TRAJECTORY_FOLLOWER_PUBLIC DebugValues
 {
@@ -77,13 +76,13 @@ public:
    * @brief get all the debug values as an std::array
    * @return array of all debug values
    */
-  std::array<float64_t, static_cast<size_t>(TYPE::SIZE)> getValues() const { return m_values; }
+  std::array<double, static_cast<size_t>(TYPE::SIZE)> getValues() const { return m_values; }
   /**
    * @brief set the given type to the given value
    * @param [in] type TYPE of the value
    * @param [in] value value to set
    */
-  void setValues(const TYPE type, const float64_t value)
+  void setValues(const TYPE type, const double value)
   {
     m_values.at(static_cast<size_t>(type)) = value;
   }
@@ -92,10 +91,10 @@ public:
    * @param [in] type index of the type
    * @param [in] value value to set
    */
-  void setValues(const size_t type, const float64_t value) { m_values.at(type) = value; }
+  void setValues(const size_t type, const double value) { m_values.at(type) = value; }
 
 private:
-  std::array<float64_t, static_cast<size_t>(TYPE::SIZE)> m_values;
+  std::array<double, static_cast<size_t>(TYPE::SIZE)> m_values;
 };
 }  // namespace trajectory_follower
 }  // namespace control

--- a/control/trajectory_follower/include/trajectory_follower/interpolate.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/interpolate.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__INTERPOLATE_HPP_
 #define TRAJECTORY_FOLLOWER__INTERPOLATE_HPP_
 
-#include "common/types.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
 #include <cmath>
@@ -30,8 +29,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 /**
  * @brief linearly interpolate the given values assuming a base indexing and a new desired indexing
  * @param [in] base_index indexes for each base value
@@ -39,9 +37,9 @@ using autoware::common::types::float64_t;
  * @param [in] return_index desired interpolated indexes
  * @param [out] return_value resulting interpolated values
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t linearInterpolate(
-  const std::vector<float64_t> & base_index, const std::vector<float64_t> & base_value,
-  const std::vector<float64_t> & return_index, std::vector<float64_t> & return_value);
+TRAJECTORY_FOLLOWER_PUBLIC bool linearInterpolate(
+  const std::vector<double> & base_index, const std::vector<double> & base_value,
+  const std::vector<double> & return_index, std::vector<double> & return_value);
 /**
  * @brief linearly interpolate the given values assuming a base indexing and a new desired index
  * @param [in] base_index indexes for each base value
@@ -49,9 +47,9 @@ TRAJECTORY_FOLLOWER_PUBLIC bool8_t linearInterpolate(
  * @param [in] return_index desired interpolated index
  * @param [out] return_value resulting interpolated value
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t linearInterpolate(
-  const std::vector<float64_t> & base_index, const std::vector<float64_t> & base_value,
-  const float64_t & return_index, float64_t & return_value);
+TRAJECTORY_FOLLOWER_PUBLIC bool linearInterpolate(
+  const std::vector<double> & base_index, const std::vector<double> & base_value,
+  const double & return_index, double & return_value);
 }  // namespace trajectory_follower
 }  // namespace control
 }  // namespace motion

--- a/control/trajectory_follower/include/trajectory_follower/longitudinal_controller_utils.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/longitudinal_controller_utils.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__LONGITUDINAL_CONTROLLER_UTILS_HPP_
 #define TRAJECTORY_FOLLOWER__LONGITUDINAL_CONTROLLER_UTILS_HPP_
 
-#include "common/types.hpp"
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Geometry"
 #include "geometry/common_2d.hpp"
@@ -42,8 +41,7 @@ namespace trajectory_follower
 {
 namespace longitudinal_utils
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Point;
@@ -53,19 +51,18 @@ using geometry_msgs::msg::Quaternion;
 /**
  * @brief check if trajectory is invalid or not
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t isValidTrajectory(const Trajectory & traj);
+TRAJECTORY_FOLLOWER_PUBLIC bool isValidTrajectory(const Trajectory & traj);
 
 /**
  * @brief calculate distance to stopline from current vehicle position where velocity is 0
  */
-TRAJECTORY_FOLLOWER_PUBLIC float64_t calcStopDistance(
-  const Pose & current_pose, const Trajectory & traj, const float64_t max_dist,
-  const float64_t max_yaw);
+TRAJECTORY_FOLLOWER_PUBLIC double calcStopDistance(
+  const Pose & current_pose, const Trajectory & traj, const double max_dist, const double max_yaw);
 
 /**
  * @brief calculate pitch angle from estimated current pose
  */
-TRAJECTORY_FOLLOWER_PUBLIC float64_t getPitchByPose(const Quaternion & quaternion);
+TRAJECTORY_FOLLOWER_PUBLIC double getPitchByPose(const Quaternion & quaternion);
 
 /**
  * @brief calculate pitch angle from trajectory on map
@@ -74,21 +71,21 @@ TRAJECTORY_FOLLOWER_PUBLIC float64_t getPitchByPose(const Quaternion & quaternio
  * @param [in] closest_idx nearest index to current vehicle position
  * @param [in] wheel_base length of wheel base
  */
-TRAJECTORY_FOLLOWER_PUBLIC float64_t
-getPitchByTraj(const Trajectory & trajectory, const size_t closest_idx, const float64_t wheel_base);
+TRAJECTORY_FOLLOWER_PUBLIC double getPitchByTraj(
+  const Trajectory & trajectory, const size_t closest_idx, const double wheel_base);
 
 /**
  * @brief calculate elevation angle
  */
-TRAJECTORY_FOLLOWER_PUBLIC float64_t
-calcElevationAngle(const TrajectoryPoint & p_from, const TrajectoryPoint & p_to);
+TRAJECTORY_FOLLOWER_PUBLIC double calcElevationAngle(
+  const TrajectoryPoint & p_from, const TrajectoryPoint & p_to);
 
 /**
  * @brief calculate vehicle pose after time delay by moving the vehicle at current velocity for
  * delayed time
  */
 TRAJECTORY_FOLLOWER_PUBLIC Pose calcPoseAfterTimeDelay(
-  const Pose & current_pose, const float64_t delay_time, const float64_t current_vel);
+  const Pose & current_pose, const double delay_time, const double current_vel);
 
 /**
  * @brief apply linear interpolation to orientation
@@ -97,7 +94,7 @@ TRAJECTORY_FOLLOWER_PUBLIC Pose calcPoseAfterTimeDelay(
  * @param [in] ratio ratio between o_from and o_to for interpolation
  */
 TRAJECTORY_FOLLOWER_PUBLIC Quaternion
-lerpOrientation(const Quaternion & o_from, const Quaternion & o_to, const float64_t ratio);
+lerpOrientation(const Quaternion & o_from, const Quaternion & o_to, const double ratio);
 
 /**
  * @brief apply linear interpolation to trajectory point that is nearest to a certain point
@@ -106,16 +103,16 @@ lerpOrientation(const Quaternion & o_from, const Quaternion & o_to, const float6
  */
 template <class T>
 TRAJECTORY_FOLLOWER_PUBLIC TrajectoryPoint lerpTrajectoryPoint(
-  const T & points, const Pose & pose, const float64_t max_dist, const float64_t max_yaw)
+  const T & points, const Pose & pose, const double max_dist, const double max_yaw)
 {
   TrajectoryPoint interpolated_point;
   const size_t seg_idx =
     motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(points, pose, max_dist, max_yaw);
 
-  const float64_t len_to_interpolated =
+  const double len_to_interpolated =
     motion_utils::calcLongitudinalOffsetToSegment(points, seg_idx, pose.position);
-  const float64_t len_segment = motion_utils::calcSignedArcLength(points, seg_idx, seg_idx + 1);
-  const float64_t interpolate_ratio = std::clamp(len_to_interpolated / len_segment, 0.0, 1.0);
+  const double len_segment = motion_utils::calcSignedArcLength(points, seg_idx, seg_idx + 1);
+  const double interpolate_ratio = std::clamp(len_to_interpolated / len_segment, 0.0, 1.0);
 
   {
     const size_t i = seg_idx;
@@ -147,8 +144,8 @@ TRAJECTORY_FOLLOWER_PUBLIC TrajectoryPoint lerpTrajectoryPoint(
  * @param [in] dt time between current and previous one
  * @param [in] lim_val limitation value for differential
  */
-TRAJECTORY_FOLLOWER_PUBLIC float64_t applyDiffLimitFilter(
-  const float64_t input_val, const float64_t prev_val, const float64_t dt, const float64_t lim_val);
+TRAJECTORY_FOLLOWER_PUBLIC double applyDiffLimitFilter(
+  const double input_val, const double prev_val, const double dt, const double lim_val);
 
 /**
  * @brief limit variable whose differential is within a certain value
@@ -158,9 +155,9 @@ TRAJECTORY_FOLLOWER_PUBLIC float64_t applyDiffLimitFilter(
  * @param [in] max_val maximum value for differential
  * @param [in] min_val minimum value for differential
  */
-TRAJECTORY_FOLLOWER_PUBLIC float64_t applyDiffLimitFilter(
-  const float64_t input_val, const float64_t prev_val, const float64_t dt, const float64_t max_val,
-  const float64_t min_val);
+TRAJECTORY_FOLLOWER_PUBLIC double applyDiffLimitFilter(
+  const double input_val, const double prev_val, const double dt, const double max_val,
+  const double min_val);
 }  // namespace longitudinal_utils
 }  // namespace trajectory_follower
 }  // namespace control

--- a/control/trajectory_follower/include/trajectory_follower/lowpass_filter.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/lowpass_filter.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__LOWPASS_FILTER_HPP_
 #define TRAJECTORY_FOLLOWER__LOWPASS_FILTER_HPP_
 
-#include "common/types.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
 #include <algorithm>
@@ -31,8 +30,6 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
 
 /**
  * @brief Simple filter with gain on the first derivative of the value
@@ -40,8 +37,8 @@ using autoware::common::types::float64_t;
 class LowpassFilter1d
 {
 private:
-  float64_t m_x;     //!< @brief current filtered value
-  float64_t m_gain;  //!< @brief gain value of first-order low-pass filter
+  double m_x;     //!< @brief current filtered value
+  double m_gain;  //!< @brief gain value of first-order low-pass filter
 
 public:
   /**
@@ -49,26 +46,26 @@ public:
    * @param [in] x initial value
    * @param [in] gain first-order gain
    */
-  LowpassFilter1d(const float64_t x, const float64_t gain) : m_x(x), m_gain(gain) {}
+  LowpassFilter1d(const double x, const double gain) : m_x(x), m_gain(gain) {}
 
   /**
    * @brief set the current value of the filter
    * @param [in] x new value
    */
-  void reset(const float64_t x) { m_x = x; }
+  void reset(const double x) { m_x = x; }
 
   /**
    * @brief get the current value of the filter
    */
-  float64_t getValue() const { return m_x; }
+  double getValue() const { return m_x; }
 
   /**
    * @brief filter a new value
    * @param [in] u new value
    */
-  float64_t filter(const float64_t u)
+  double filter(const double u)
   {
-    const float64_t ret = m_gain * m_x + (1.0 - m_gain) * u;
+    const double ret = m_gain * m_x + (1.0 - m_gain) * u;
     m_x = ret;
     return ret;
   }
@@ -81,16 +78,16 @@ public:
 class TRAJECTORY_FOLLOWER_PUBLIC Butterworth2dFilter
 {
 private:
-  float64_t m_y1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  float64_t m_y2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  float64_t m_u1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  float64_t m_u2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  float64_t m_a0;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  float64_t m_a1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  float64_t m_a2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  float64_t m_b0;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  float64_t m_b1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  float64_t m_b2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_y1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_y2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_u1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_u2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_a0;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_a1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_a2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_b0;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_b1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
+  double m_b2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
 
 public:
   /**
@@ -98,7 +95,7 @@ public:
    * @param [in] dt sampling time
    * @param [in] f_cutoff_hz cutoff frequency [Hz]
    */
-  explicit Butterworth2dFilter(float64_t dt = 0.01, float64_t f_cutoff_hz = 5.0);
+  explicit Butterworth2dFilter(double dt = 0.01, double f_cutoff_hz = 5.0);
 
   /**
    * @brief destructor
@@ -110,21 +107,21 @@ public:
    * @param [in] dt sampling time
    * @param [in] f_cutoff_hz cutoff frequency [Hz]
    */
-  void initialize(const float64_t & dt, const float64_t & f_cutoff_hz);
+  void initialize(const double & dt, const double & f_cutoff_hz);
 
   /**
    * @brief filtering (call this function at each sampling time with input)
    * @param [in] u scalar input for filter
    * @return filtered scalar value
    */
-  float64_t filter(const float64_t & u);
+  double filter(const double & u);
 
   /**
    * @brief filtering for time-series data
    * @param [in] t time-series data for input vector
    * @param [out] u object vector
    */
-  void filt_vector(const std::vector<float64_t> & t, std::vector<float64_t> & u) const;
+  void filt_vector(const std::vector<double> & t, std::vector<double> & u) const;
 
   /**
    * @brief filtering for time-series data from both forward-backward direction for zero phase delay
@@ -132,14 +129,14 @@ public:
    * @param [out] u object vector
    */
   void filtfilt_vector(
-    const std::vector<float64_t> & t,
-    std::vector<float64_t> & u) const;  // filtering forward and backward direction
+    const std::vector<double> & t,
+    std::vector<double> & u) const;  // filtering forward and backward direction
 
   /**
    * @brief get filter coefficients
    * @param [out] coeffs coefficients of filter [a0, a1, a2, b0, b1, b2].
    */
-  void getCoefficients(std::vector<float64_t> & coeffs) const;
+  void getCoefficients(std::vector<double> & coeffs) const;
 };
 
 /**
@@ -152,7 +149,7 @@ namespace MoveAverageFilter
  * @param [in] num index distance for moving average filter
  * @param [out] u object vector
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t filt_vector(const int64_t num, std::vector<float64_t> & u);
+TRAJECTORY_FOLLOWER_PUBLIC bool filt_vector(const int num, std::vector<double> & u);
 }  // namespace MoveAverageFilter
 }  // namespace trajectory_follower
 }  // namespace control

--- a/control/trajectory_follower/include/trajectory_follower/mpc.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__MPC_HPP_
 #define TRAJECTORY_FOLLOWER__MPC_HPP_
 
-#include "common/types.hpp"
 #include "geometry/common_2d.hpp"
 #include "helper_functions/angle_utils.hpp"
 #include "osqp_interface/osqp_interface.hpp"
@@ -53,79 +52,78 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 struct MPCParam
 {
   //!< @brief prediction horizon step
-  int64_t prediction_horizon;
+  int prediction_horizon;
   //!< @brief prediction horizon sampling time
-  float64_t prediction_dt;
+  double prediction_dt;
   //!< @brief threshold that feed-forward angle becomes zero
-  float64_t zero_ff_steer_deg;
+  double zero_ff_steer_deg;
   //!< @brief delay time for steering input to be compensated
-  float64_t input_delay;
+  double input_delay;
   //!< @brief for trajectory velocity calculation
-  float64_t acceleration_limit;
+  double acceleration_limit;
   //!< @brief for trajectory velocity calculation
-  float64_t velocity_time_constant;
+  double velocity_time_constant;
   //!< @brief minimum prediction dist for low velocity
-  float64_t min_prediction_length;
+  double min_prediction_length;
   //!< @brief time constant for steer model
-  float64_t steer_tau;
+  double steer_tau;
   // for weight matrix Q
   //!< @brief lateral error weight
-  float64_t weight_lat_error;
+  double weight_lat_error;
   //!< @brief heading error weight
-  float64_t weight_heading_error;
+  double weight_heading_error;
   //!< @brief heading error * velocity weight
-  float64_t weight_heading_error_squared_vel;
+  double weight_heading_error_squared_vel;
   //!< @brief terminal lateral error weight
-  float64_t weight_terminal_lat_error;
+  double weight_terminal_lat_error;
   //!< @brief terminal heading error weight
-  float64_t weight_terminal_heading_error;
+  double weight_terminal_heading_error;
   //!< @brief lateral error weight in matrix Q in low curvature point
-  float64_t low_curvature_weight_lat_error;
+  double low_curvature_weight_lat_error;
   //!< @brief heading error weight in matrix Q in low curvature point
-  float64_t low_curvature_weight_heading_error;
+  double low_curvature_weight_heading_error;
   //!< @brief heading error * velocity weight in matrix Q in low curvature point
-  float64_t low_curvature_weight_heading_error_squared_vel;
+  double low_curvature_weight_heading_error_squared_vel;
   // for weight matrix R
   //!< @brief steering error weight
-  float64_t weight_steering_input;
+  double weight_steering_input;
   //!< @brief steering error * velocity weight
-  float64_t weight_steering_input_squared_vel;
+  double weight_steering_input_squared_vel;
   //!< @brief lateral jerk weight
-  float64_t weight_lat_jerk;
+  double weight_lat_jerk;
   //!< @brief steering rate weight
-  float64_t weight_steer_rate;
+  double weight_steer_rate;
   //!< @brief steering angle acceleration weight
-  float64_t weight_steer_acc;
+  double weight_steer_acc;
   //!< @brief steering error weight in matrix R in low curvature point
-  float64_t low_curvature_weight_steering_input;
+  double low_curvature_weight_steering_input;
   //!< @brief steering error * velocity weight in matrix R in low curvature point
-  float64_t low_curvature_weight_steering_input_squared_vel;
+  double low_curvature_weight_steering_input_squared_vel;
   //!< @brief lateral jerk weight in matrix R in low curvature point
-  float64_t low_curvature_weight_lat_jerk;
+  double low_curvature_weight_lat_jerk;
   //!< @brief steering rate weight in matrix R in low curvature point
-  float64_t low_curvature_weight_steer_rate;
+  double low_curvature_weight_steer_rate;
   //!< @brief steering angle acceleration weight in matrix R in low curvature
-  float64_t low_curvature_weight_steer_acc;
+  double low_curvature_weight_steer_acc;
   //!< @brief threshold of curvature to use "low curvature" parameter
-  float64_t low_curvature_thresh_curvature;
+  double low_curvature_thresh_curvature;
 };
 /**
  * MPC problem data
  */
 struct MPCData
 {
-  int64_t nearest_idx;
-  float64_t nearest_time;
+  int nearest_idx;
+  double nearest_time;
   geometry_msgs::msg::Pose nearest_pose;
-  float64_t steer;
-  float64_t predicted_steer;
-  float64_t lateral_err;
-  float64_t yaw_err;
+  double steer;
+  double predicted_steer;
+  double lateral_err;
+  double yaw_err;
 };
 /**
  * Matrices used for MPC optimization
@@ -167,42 +165,42 @@ private:
   trajectory_follower::Butterworth2dFilter m_lpf_yaw_error;
 
   //!< @brief raw output computed two iterations ago
-  float64_t m_raw_steer_cmd_pprev = 0.0;
+  double m_raw_steer_cmd_pprev = 0.0;
   //!< @brief previous lateral error for derivative
-  float64_t m_lateral_error_prev = 0.0;
+  double m_lateral_error_prev = 0.0;
   //!< @brief previous lateral error for derivative
-  float64_t m_yaw_error_prev = 0.0;
+  double m_yaw_error_prev = 0.0;
   //!< @brief previous predicted steering
-  std::shared_ptr<float64_t> m_steer_prediction_prev;
+  std::shared_ptr<double> m_steer_prediction_prev;
   //!< @brief previous computation time
   rclcpp::Time m_time_prev = rclcpp::Time(0, 0, RCL_ROS_TIME);
   //!< @brief shift is forward or not.
-  bool8_t m_is_forward_shift = true;
+  bool m_is_forward_shift = true;
   //!< @brief buffer of sent command
   std::vector<autoware_auto_control_msgs::msg::AckermannLateralCommand> m_ctrl_cmd_vec;
   //!< @brief minimum prediction distance
-  float64_t m_min_prediction_length = 5.0;
+  double m_min_prediction_length = 5.0;
 
   /**
    * @brief get variables for mpc calculation
    */
-  bool8_t getData(
+  bool getData(
     const trajectory_follower::MPCTrajectory & traj,
     const autoware_auto_vehicle_msgs::msg::SteeringReport & current_steer,
     const geometry_msgs::msg::Pose & current_pose, MPCData * data);
   /**
    * @brief calculate predicted steering
    */
-  float64_t calcSteerPrediction();
+  double calcSteerPrediction();
   /**
    * @brief get the sum of all steering commands over the given time range
    */
-  float64_t getSteerCmdSum(
-    const rclcpp::Time & t_start, const rclcpp::Time & t_end, const float64_t time_constant) const;
+  double getSteerCmdSum(
+    const rclcpp::Time & t_start, const rclcpp::Time & t_end, const double time_constant) const;
   /**
    * @brief set the reference trajectory to follow
    */
-  void storeSteerCmd(const float64_t steer);
+  void storeSteerCmd(const double steer);
   /**
    * @brief reset previous result of MPC
    */
@@ -218,15 +216,15 @@ private:
    * @param [in] start_time start time for update
    * @param [out] x updated state at delayed_time
    */
-  bool8_t updateStateForDelayCompensation(
-    const trajectory_follower::MPCTrajectory & traj, const float64_t & start_time,
+  bool updateStateForDelayCompensation(
+    const trajectory_follower::MPCTrajectory & traj, const double & start_time,
     Eigen::VectorXd * x);
   /**
    * @brief generate MPC matrix with trajectory and vehicle model
    * @param [in] reference_trajectory used for linearization around reference trajectory
    */
   MPCMatrix generateMPCMatrix(
-    const trajectory_follower::MPCTrajectory & reference_trajectory, const float64_t prediction_dt);
+    const trajectory_follower::MPCTrajectory & reference_trajectory, const double prediction_dt);
   /**
    * @brief generate MPC matrix with trajectory and vehicle model
    * @param [in] mpc_matrix parameters matrix to use for optimization
@@ -234,14 +232,14 @@ private:
    * @param [in] prediction_dt prediction delta time
    * @param [out] Uex optimized input vector
    */
-  bool8_t executeOptimization(
-    const MPCMatrix & mpc_matrix, const Eigen::VectorXd & x0, const float64_t prediction_dt,
+  bool executeOptimization(
+    const MPCMatrix & mpc_matrix, const Eigen::VectorXd & x0, const double prediction_dt,
     Eigen::VectorXd * Uex);
   /**
    * @brief resample trajectory with mpc resampling time
    */
-  bool8_t resampleMPCTrajectoryByTime(
-    const float64_t start_time, const float64_t prediction_dt,
+  bool resampleMPCTrajectoryByTime(
+    const double start_time, const double prediction_dt,
     const trajectory_follower::MPCTrajectory & input,
     trajectory_follower::MPCTrajectory * output) const;
   /**
@@ -249,45 +247,45 @@ private:
    */
   trajectory_follower::MPCTrajectory applyVelocityDynamicsFilter(
     const trajectory_follower::MPCTrajectory & trajectory,
-    const geometry_msgs::msg::Pose & current_pose, const float64_t v0) const;
+    const geometry_msgs::msg::Pose & current_pose, const double v0) const;
   /**
    * @brief get prediction delta time of mpc.
    * If trajectory length is shorter than min_prediction length, adjust delta time.
    */
-  float64_t getPredictionDeltaTime(
-    const float64_t start_time, const trajectory_follower::MPCTrajectory & input,
+  double getPredictionDeltaTime(
+    const double start_time, const trajectory_follower::MPCTrajectory & input,
     const geometry_msgs::msg::Pose & current_pose) const;
   /**
    * @brief add weights related to lateral_jerk, steering_rate, steering_acc into R
    */
-  void addSteerWeightR(const float64_t prediction_dt, Eigen::MatrixXd * R) const;
+  void addSteerWeightR(const double prediction_dt, Eigen::MatrixXd * R) const;
   /**
    * @brief add weights related to lateral_jerk, steering_rate, steering_acc into f
    */
-  void addSteerWeightF(const float64_t prediction_dt, Eigen::MatrixXd * f) const;
+  void addSteerWeightF(const double prediction_dt, Eigen::MatrixXd * f) const;
 
   /**
    * @brief calculate desired steering rate.
    */
-  float64_t calcDesiredSteeringRate(
+  double calcDesiredSteeringRate(
     const MPCMatrix & m, const Eigen::MatrixXd & x0, const Eigen::MatrixXd & Uex,
-    const float64_t u_filtered, const float current_steer, const float64_t predict_dt) const;
+    const double u_filtered, const float current_steer, const double predict_dt) const;
 
   /**
    * @brief check if the matrix has invalid value
    */
-  bool8_t isValid(const MPCMatrix & m) const;
+  bool isValid(const MPCMatrix & m) const;
   /**
    * @brief return true if the given curvature is considered low
    */
-  inline bool8_t isLowCurvature(const float64_t curvature)
+  inline bool isLowCurvature(const double curvature)
   {
     return std::fabs(curvature) < m_param.low_curvature_thresh_curvature;
   }
   /**
    * @brief return the weight of the lateral error for the given curvature
    */
-  inline float64_t getWeightLatError(const float64_t curvature)
+  inline double getWeightLatError(const double curvature)
   {
     return isLowCurvature(curvature) ? m_param.low_curvature_weight_lat_error
                                      : m_param.weight_lat_error;
@@ -295,7 +293,7 @@ private:
   /**
    * @brief return the weight of the heading error for the given curvature
    */
-  inline float64_t getWeightHeadingError(const float64_t curvature)
+  inline double getWeightHeadingError(const double curvature)
   {
     return isLowCurvature(curvature) ? m_param.low_curvature_weight_heading_error
                                      : m_param.weight_heading_error;
@@ -303,7 +301,7 @@ private:
   /**
    * @brief return the squared velocity weight of the heading error for the given curvature
    */
-  inline float64_t getWeightHeadingErrorSqVel(const float64_t curvature)
+  inline double getWeightHeadingErrorSqVel(const double curvature)
   {
     return isLowCurvature(curvature) ? m_param.low_curvature_weight_heading_error_squared_vel
                                      : m_param.weight_heading_error_squared_vel;
@@ -311,7 +309,7 @@ private:
   /**
    * @brief return the weight of the steer input for the given curvature
    */
-  inline float64_t getWeightSteerInput(const float64_t curvature)
+  inline double getWeightSteerInput(const double curvature)
   {
     return isLowCurvature(curvature) ? m_param.low_curvature_weight_steering_input
                                      : m_param.weight_steering_input;
@@ -319,7 +317,7 @@ private:
   /**
    * @brief return the squared velocity weight of the steer input for the given curvature
    */
-  inline float64_t getWeightSteerInputSqVel(const float64_t curvature)
+  inline double getWeightSteerInputSqVel(const double curvature)
   {
     return isLowCurvature(curvature) ? m_param.low_curvature_weight_steering_input_squared_vel
                                      : m_param.weight_steering_input_squared_vel;
@@ -327,7 +325,7 @@ private:
   /**
    * @brief return the weight of the lateral jerk for the given curvature
    */
-  inline float64_t getWeightLatJerk(const float64_t curvature)
+  inline double getWeightLatJerk(const double curvature)
   {
     return isLowCurvature(curvature) ? m_param.low_curvature_weight_lat_jerk
                                      : m_param.weight_lat_jerk;
@@ -335,7 +333,7 @@ private:
   /**
    * @brief return the weight of the steering rate for the given curvature
    */
-  inline float64_t getWeightSteerRate(const float64_t curvature)
+  inline double getWeightSteerRate(const double curvature)
   {
     return isLowCurvature(curvature) ? m_param.low_curvature_weight_steer_rate
                                      : m_param.weight_steer_rate;
@@ -343,7 +341,7 @@ private:
   /**
    * @brief return the weight of the steering acceleration for the given curvature
    */
-  inline float64_t getWeightSteerAcc(const float64_t curvature)
+  inline double getWeightSteerAcc(const double curvature)
   {
     return isLowCurvature(curvature) ? m_param.low_curvature_weight_steer_acc
                                      : m_param.weight_steer_acc;
@@ -355,23 +353,23 @@ public:
   //!< @brief MPC design parameter
   MPCParam m_param;
   //!< @brief mpc_output buffer for delay time compensation
-  std::deque<float64_t> m_input_buffer;
+  std::deque<double> m_input_buffer;
   //!< @brief mpc raw output in previous period
-  float64_t m_raw_steer_cmd_prev = 0.0;
+  double m_raw_steer_cmd_prev = 0.0;
   /* parameters for control*/
   //!< @brief use stop cmd when lateral error exceeds this [m]
-  float64_t m_admissible_position_error;
+  double m_admissible_position_error;
   //!< @brief use stop cmd when yaw error exceeds this [rad]
-  float64_t m_admissible_yaw_error_rad;
+  double m_admissible_yaw_error_rad;
   //!< @brief steering command limit [rad]
-  float64_t m_steer_lim;
+  double m_steer_lim;
   //!< @brief steering rate limit [rad/s]
-  float64_t m_steer_rate_lim;
+  double m_steer_rate_lim;
   //!< @brief control frequency [s]
-  float64_t m_ctrl_period;
+  double m_ctrl_period;
   /* parameters for path smoothing */
   //!< @brief flag to use predicted steer, not measured steer.
-  bool8_t m_use_steer_prediction;
+  bool m_use_steer_prediction;
   //!< @brief parameters for nearest index search
   double ego_nearest_dist_threshold;
   double ego_nearest_yaw_threshold;
@@ -389,9 +387,9 @@ public:
    * @param [out] predicted_traj predicted MPC trajectory
    * @param [out] diagnostic diagnostic msg to be filled-out
    */
-  bool8_t calculateMPC(
+  bool calculateMPC(
     const autoware_auto_vehicle_msgs::msg::SteeringReport & current_steer,
-    const float64_t current_velocity, const geometry_msgs::msg::Pose & current_pose,
+    const double current_velocity, const geometry_msgs::msg::Pose & current_pose,
     autoware_auto_control_msgs::msg::AckermannLateralCommand & ctrl_cmd,
     autoware_auto_planning_msgs::msg::Trajectory & predicted_traj,
     tier4_debug_msgs::msg::Float32MultiArrayStamped & diagnostic);
@@ -400,9 +398,9 @@ public:
    */
   void setReferenceTrajectory(
     const autoware_auto_planning_msgs::msg::Trajectory & trajectory_msg,
-    const float64_t traj_resample_dist, const bool8_t enable_path_smoothing,
-    const int64_t path_filter_moving_ave_num, const int64_t curvature_smoothing_num_traj,
-    const int64_t curvature_smoothing_num_ref_steer);
+    const double traj_resample_dist, const bool enable_path_smoothing,
+    const int path_filter_moving_ave_num, const int curvature_smoothing_num_traj,
+    const int curvature_smoothing_num_ref_steer);
   /**
    * @brief set the vehicle model of this MPC
    */
@@ -424,7 +422,7 @@ public:
    * @brief initialize low pass filters
    */
   inline void initializeLowPassFilters(
-    const float64_t steering_lpf_cutoff_hz, const float64_t error_deriv_lpf_cutoff_hz)
+    const double steering_lpf_cutoff_hz, const double error_deriv_lpf_cutoff_hz)
   {
     m_lpf_steering_cmd.initialize(m_ctrl_period, steering_lpf_cutoff_hz);
     m_lpf_lateral_error.initialize(m_ctrl_period, error_deriv_lpf_cutoff_hz);
@@ -433,11 +431,11 @@ public:
   /**
    * @brief return true if the vehicle model of this MPC is set
    */
-  inline bool8_t hasVehicleModel() const { return m_vehicle_model_ptr != nullptr; }
+  inline bool hasVehicleModel() const { return m_vehicle_model_ptr != nullptr; }
   /**
    * @brief return true if the QP solver of this MPC is set
    */
-  inline bool8_t hasQPSolver() const { return m_qpsolver_ptr != nullptr; }
+  inline bool hasQPSolver() const { return m_qpsolver_ptr != nullptr; }
   /**
    * @brief set the RCLCPP logger to use for logging
    */

--- a/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_lateral_controller.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__MPC_LATERAL_CONTROLLER_HPP_
 #define TRAJECTORY_FOLLOWER__MPC_LATERAL_CONTROLLER_HPP_
 
-#include "common/types.hpp"
 #include "osqp_interface/osqp_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
@@ -58,8 +57,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 
 class TRAJECTORY_FOLLOWER_PUBLIC MpcLateralController : public LateralControllerBase
@@ -88,23 +86,23 @@ private:
 
   /* parameters for path smoothing */
   //!< @brief flag for path smoothing
-  bool8_t m_enable_path_smoothing;
+  bool m_enable_path_smoothing;
   //!< @brief param of moving average filter for path smoothing
-  int64_t m_path_filter_moving_ave_num;
+  int m_path_filter_moving_ave_num;
   //!< @brief point-to-point index distance for curvature calculation for trajectory  //NOLINT
-  int64_t m_curvature_smoothing_num_traj;
+  int m_curvature_smoothing_num_traj;
   //!< @brief point-to-point index distance for curvature calculation for reference steer command
   //!< //NOLINT
-  int64_t m_curvature_smoothing_num_ref_steer;
+  int m_curvature_smoothing_num_ref_steer;
   //!< @brief path resampling interval [m]
-  float64_t m_traj_resample_dist;
+  double m_traj_resample_dist;
 
   /* parameters for stop state */
-  float64_t m_stop_state_entry_ego_speed;
-  float64_t m_stop_state_entry_target_speed;
-  float64_t m_converged_steer_rad;
-  float64_t m_new_traj_duration_time;  // check trajectory shape change
-  float64_t m_new_traj_end_dist;       // check trajectory shape change
+  double m_stop_state_entry_ego_speed;
+  double m_stop_state_entry_target_speed;
+  double m_converged_steer_rad;
+  double m_new_traj_duration_time;  // check trajectory shape change
+  double m_new_traj_end_dist;       // check trajectory shape change
   bool m_keep_steer_control_until_converged;
 
   // trajectory buffer for detecting new trajectory
@@ -121,10 +119,10 @@ private:
   autoware_auto_planning_msgs::msg::Trajectory::SharedPtr m_current_trajectory_ptr;
 
   //!< @brief mpc filtered output in previous period
-  float64_t m_steer_cmd_prev = 0.0;
+  double m_steer_cmd_prev = 0.0;
 
   //!< @brief flag of m_ctrl_cmd_prev initialization
-  bool8_t m_is_ctrl_cmd_prev_initialized = false;
+  bool m_is_ctrl_cmd_prev_initialized = false;
   //!< @brief previous control command
   autoware_auto_control_msgs::msg::AckermannLateralCommand m_ctrl_cmd_prev;
 
@@ -136,7 +134,7 @@ private:
   double m_ego_nearest_yaw_threshold;
 
   //!< initialize timer to work in real, simulation, and replay
-  void initTimer(float64_t period_s);
+  void initTimer(double period_s);
   /**
    * @brief compute control command for path follow with a constant control period
    */
@@ -155,7 +153,7 @@ private:
   /**
    * @brief check if the received data is valid.
    */
-  bool8_t checkData() const;
+  bool checkData() const;
 
   /**
    * @brief create control command
@@ -189,14 +187,14 @@ private:
   /**
    * @brief check ego car is in stopped state
    */
-  bool8_t isStoppedState() const;
+  bool isStoppedState() const;
 
   /**
    * @brief check if the trajectory has valid value
    */
-  bool8_t isValidTrajectory(const autoware_auto_planning_msgs::msg::Trajectory & traj) const;
+  bool isValidTrajectory(const autoware_auto_planning_msgs::msg::Trajectory & traj) const;
 
-  bool8_t isTrajectoryShapeChanged() const;
+  bool isTrajectoryShapeChanged() const;
 
   bool isSteerConverged(const autoware_auto_control_msgs::msg::AckermannLateralCommand & cmd) const;
 

--- a/control/trajectory_follower/include/trajectory_follower/mpc_trajectory.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_trajectory.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__MPC_TRAJECTORY_HPP_
 #define TRAJECTORY_FOLLOWER__MPC_TRAJECTORY_HPP_
 
-#include "common/types.hpp"
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
@@ -32,7 +31,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::float64_t;
+
 /**
  * Trajectory class for mpc follower
  * @brief calculate control command to follow reference waypoints
@@ -40,21 +39,21 @@ using autoware::common::types::float64_t;
 class TRAJECTORY_FOLLOWER_PUBLIC MPCTrajectory
 {
 public:
-  std::vector<float64_t> x;              //!< @brief x position x vector
-  std::vector<float64_t> y;              //!< @brief y position y vector
-  std::vector<float64_t> z;              //!< @brief z position z vector
-  std::vector<float64_t> yaw;            //!< @brief yaw pose yaw vector
-  std::vector<float64_t> vx;             //!< @brief vx velocity vx vector
-  std::vector<float64_t> k;              //!< @brief k curvature k vector
-  std::vector<float64_t> smooth_k;       //!< @brief k smoothed-curvature k vector
-  std::vector<float64_t> relative_time;  //!< @brief relative_time duration time from start point
+  std::vector<double> x;              //!< @brief x position x vector
+  std::vector<double> y;              //!< @brief y position y vector
+  std::vector<double> z;              //!< @brief z position z vector
+  std::vector<double> yaw;            //!< @brief yaw pose yaw vector
+  std::vector<double> vx;             //!< @brief vx velocity vx vector
+  std::vector<double> k;              //!< @brief k curvature k vector
+  std::vector<double> smooth_k;       //!< @brief k smoothed-curvature k vector
+  std::vector<double> relative_time;  //!< @brief relative_time duration time from start point
 
   /**
    * @brief push_back for all values
    */
   void push_back(
-    const float64_t & xp, const float64_t & yp, const float64_t & zp, const float64_t & yawp,
-    const float64_t & vxp, const float64_t & kp, const float64_t & smooth_kp, const float64_t & tp);
+    const double & xp, const double & yp, const double & zp, const double & yawp,
+    const double & vxp, const double & kp, const double & smooth_kp, const double & tp);
   /**
    * @brief clear for all values
    */

--- a/control/trajectory_follower/include/trajectory_follower/mpc_utils.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_utils.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__MPC_UTILS_HPP_
 #define TRAJECTORY_FOLLOWER__MPC_UTILS_HPP_
 
-#include "common/types.hpp"
 #include "eigen3/Eigen/Core"
 #include "geometry/common_2d.hpp"
 #include "helper_functions/angle_utils.hpp"
@@ -53,27 +52,25 @@ namespace trajectory_follower
 {
 namespace MPCUtils
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 /**
  * @brief convert from yaw to ros-Quaternion
  * @param [in] yaw input yaw angle
  * @return quaternion
  */
-TRAJECTORY_FOLLOWER_PUBLIC geometry_msgs::msg::Quaternion getQuaternionFromYaw(
-  const float64_t & yaw);
+TRAJECTORY_FOLLOWER_PUBLIC geometry_msgs::msg::Quaternion getQuaternionFromYaw(const double & yaw);
 /**
  * @brief convert Euler angle vector including +-2pi to 0 jump to continuous series data
  * @param [inout] a input angle vector
  */
-TRAJECTORY_FOLLOWER_PUBLIC void convertEulerAngleToMonotonic(std::vector<float64_t> * a);
+TRAJECTORY_FOLLOWER_PUBLIC void convertEulerAngleToMonotonic(std::vector<double> * a);
 /**
  * @brief calculate the lateral error of the given pose relative to the given reference pose
  * @param [in] ego_pose pose to check for error
  * @param [in] ref_pose reference pose
  * @return lateral distance between the two poses
  */
-TRAJECTORY_FOLLOWER_PUBLIC float64_t calcLateralError(
+TRAJECTORY_FOLLOWER_PUBLIC double calcLateralError(
   const geometry_msgs::msg::Pose & ego_pose, const geometry_msgs::msg::Pose & ref_pose);
 /**
  * @brief convert the given Trajectory msg to a MPCTrajectory object
@@ -81,7 +78,7 @@ TRAJECTORY_FOLLOWER_PUBLIC float64_t calcLateralError(
  * @param [out] output resulting MPCTrajectory
  * @return true if the conversion was successful
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t convertToMPCTrajectory(
+TRAJECTORY_FOLLOWER_PUBLIC bool convertToMPCTrajectory(
   const autoware_auto_planning_msgs::msg::Trajectory & input, MPCTrajectory & output);
 /**
  * @brief convert the given MPCTrajectory to a Trajectory msg
@@ -89,7 +86,7 @@ TRAJECTORY_FOLLOWER_PUBLIC bool8_t convertToMPCTrajectory(
  * @param [out] output resulting Trajectory msg
  * @return true if the conversion was successful
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t convertToAutowareTrajectory(
+TRAJECTORY_FOLLOWER_PUBLIC bool convertToAutowareTrajectory(
   const MPCTrajectory & input, autoware_auto_planning_msgs::msg::Trajectory & output);
 /**
  * @brief calculate the arc length at each point of the given trajectory
@@ -97,15 +94,15 @@ TRAJECTORY_FOLLOWER_PUBLIC bool8_t convertToAutowareTrajectory(
  * @param [out] arclength the cummulative arc length at each point of the trajectory
  */
 TRAJECTORY_FOLLOWER_PUBLIC void calcMPCTrajectoryArclength(
-  const MPCTrajectory & trajectory, std::vector<float64_t> * arclength);
+  const MPCTrajectory & trajectory, std::vector<double> * arclength);
 /**
  * @brief resample the given trajectory with the given fixed interval
  * @param [in] input trajectory to resample
  * @param [in] resample_interval_dist the desired distance between two successive trajectory points
  * @param [out] output the resampled trajectory
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t resampleMPCTrajectoryByDistance(
-  const MPCTrajectory & input, const float64_t resample_interval_dist, MPCTrajectory * output);
+TRAJECTORY_FOLLOWER_PUBLIC bool resampleMPCTrajectoryByDistance(
+  const MPCTrajectory & input, const double resample_interval_dist, MPCTrajectory * output);
 /**
  * @brief linearly interpolate the given trajectory assuming a base indexing and a new desired
  * indexing
@@ -114,15 +111,15 @@ TRAJECTORY_FOLLOWER_PUBLIC bool8_t resampleMPCTrajectoryByDistance(
  * @param [in] out_index desired interpolated indexes
  * @param [out] out_traj resulting interpolated MPCTrajectory
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t linearInterpMPCTrajectory(
-  const std::vector<float64_t> & in_index, const MPCTrajectory & in_traj,
-  const std::vector<float64_t> & out_index, MPCTrajectory * out_traj);
+TRAJECTORY_FOLLOWER_PUBLIC bool linearInterpMPCTrajectory(
+  const std::vector<double> & in_index, const MPCTrajectory & in_traj,
+  const std::vector<double> & out_index, MPCTrajectory * out_traj);
 /**
  * @brief fill the relative_time field of the given MPCTrajectory
  * @param [in] traj MPCTrajectory for which to fill in the relative_time
  * @return true if the calculation was successful
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t calcMPCTrajectoryTime(MPCTrajectory & traj);
+TRAJECTORY_FOLLOWER_PUBLIC bool calcMPCTrajectoryTime(MPCTrajectory & traj);
 /**
  * @brief recalculate the velocity field (vx) of the MPCTrajectory with dynamic smoothing
  * @param [in] start_idx index of the trajectory point from which to start smoothing
@@ -132,7 +129,7 @@ TRAJECTORY_FOLLOWER_PUBLIC bool8_t calcMPCTrajectoryTime(MPCTrajectory & traj);
  * @param [inout] traj MPCTrajectory for which to calculate the smoothed velocity
  */
 TRAJECTORY_FOLLOWER_PUBLIC void dynamicSmoothingVelocity(
-  const size_t start_idx, const float64_t start_vel, const float64_t acc_lim, const float64_t tau,
+  const size_t start_idx, const double start_vel, const double acc_lim, const double tau,
   MPCTrajectory & traj);
 /**
  * @brief calculate yaw angle in MPCTrajectory from xy vector
@@ -149,7 +146,7 @@ TRAJECTORY_FOLLOWER_PUBLIC void calcTrajectoryYawFromXY(
  * calculation
  * @param [inout] traj object trajectory
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t calcTrajectoryCurvature(
+TRAJECTORY_FOLLOWER_PUBLIC bool calcTrajectoryCurvature(
   const size_t curvature_smoothing_num_traj, const size_t curvature_smoothing_num_ref_steer,
   MPCTrajectory * traj);
 /**
@@ -159,7 +156,7 @@ TRAJECTORY_FOLLOWER_PUBLIC bool8_t calcTrajectoryCurvature(
  * @param [in] traj input trajectory
  * @return vector of curvatures at each point of the given trajectory
  */
-TRAJECTORY_FOLLOWER_PUBLIC std::vector<float64_t> calcTrajectoryCurvature(
+TRAJECTORY_FOLLOWER_PUBLIC std::vector<double> calcTrajectoryCurvature(
   const size_t curvature_smoothing_num, const MPCTrajectory & traj);
 /**
  * @brief calculate nearest pose on MPCTrajectory with linear interpolation
@@ -172,16 +169,16 @@ TRAJECTORY_FOLLOWER_PUBLIC std::vector<float64_t> calcTrajectoryCurvature(
  * @param [in] clock to throttle log output
  * @return false when nearest pose couldn't find for some reasons
  */
-TRAJECTORY_FOLLOWER_PUBLIC bool8_t calcNearestPoseInterp(
+TRAJECTORY_FOLLOWER_PUBLIC bool calcNearestPoseInterp(
   const MPCTrajectory & traj, const geometry_msgs::msg::Pose & self_pose,
-  geometry_msgs::msg::Pose * nearest_pose, size_t * nearest_index, float64_t * nearest_time,
+  geometry_msgs::msg::Pose * nearest_pose, size_t * nearest_index, double * nearest_time,
   const double max_dist, const double max_yaw, const rclcpp::Logger & logger,
   rclcpp::Clock & clock);
 // /**
 //  * @brief calculate distance to stopped point
 //  */
-TRAJECTORY_FOLLOWER_PUBLIC float64_t calcStopDistance(
-  const autoware_auto_planning_msgs::msg::Trajectory & current_trajectory, const int64_t origin);
+TRAJECTORY_FOLLOWER_PUBLIC double calcStopDistance(
+  const autoware_auto_planning_msgs::msg::Trajectory & current_trajectory, const int origin);
 }  // namespace MPCUtils
 }  // namespace trajectory_follower
 }  // namespace control

--- a/control/trajectory_follower/include/trajectory_follower/pid.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__PID_HPP_
 #define TRAJECTORY_FOLLOWER__PID_HPP_
 
-#include "common/types.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
 #include <vector>
@@ -28,8 +27,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 /// @brief implementation of a PID controller
 class TRAJECTORY_FOLLOWER_PUBLIC PIDController
 {
@@ -45,16 +43,16 @@ public:
    * @return PID output
    * @throw std::runtime_error if gains or limits have not been set
    */
-  float64_t calculate(
-    const float64_t error, const float64_t dt, const bool8_t is_integrated,
-    std::vector<float64_t> & pid_contributions);
+  double calculate(
+    const double error, const double dt, const bool is_integrated,
+    std::vector<double> & pid_contributions);
   /**
    * @brief set the coefficients for the P (proportional) I (integral) D (derivative) terms
    * @param [in] kp proportional coefficient
    * @param [in] ki integral coefficient
    * @param [in] kd derivative coefficient
    */
-  void setGains(const float64_t kp, const float64_t ki, const float64_t kd);
+  void setGains(const double kp, const double ki, const double kd);
   /**
    * @brief set limits on the total, proportional, integral, and derivative components
    * @param [in] max_ret maximum return value of this PID
@@ -67,9 +65,8 @@ public:
    * @param [in] min_ret_d minimum value of the derivative component
    */
   void setLimits(
-    const float64_t max_ret, const float64_t min_ret, const float64_t max_ret_p,
-    const float64_t min_ret_p, const float64_t max_ret_i, const float64_t min_ret_i,
-    const float64_t max_ret_d, const float64_t min_ret_d);
+    const double max_ret, const double min_ret, const double max_ret_p, const double min_ret_p,
+    const double max_ret_i, const double min_ret_i, const double max_ret_d, const double min_ret_d);
   /**
    * @brief reset this PID to its initial state
    */
@@ -79,26 +76,26 @@ private:
   // PID parameters
   struct Params
   {
-    float64_t kp;
-    float64_t ki;
-    float64_t kd;
-    float64_t max_ret_p;
-    float64_t min_ret_p;
-    float64_t max_ret_i;
-    float64_t min_ret_i;
-    float64_t max_ret_d;
-    float64_t min_ret_d;
-    float64_t max_ret;
-    float64_t min_ret;
+    double kp;
+    double ki;
+    double kd;
+    double max_ret_p;
+    double min_ret_p;
+    double max_ret_i;
+    double min_ret_i;
+    double max_ret_d;
+    double min_ret_d;
+    double max_ret;
+    double min_ret;
   };
   Params m_params;
 
   // state variables
-  float64_t m_error_integral;
-  float64_t m_prev_error;
-  bool8_t m_is_first_time;
-  bool8_t m_is_gains_set;
-  bool8_t m_is_limits_set;
+  double m_error_integral;
+  double m_prev_error;
+  bool m_is_first_time;
+  bool m_is_gains_set;
+  bool m_is_limits_set;
 };
 }  // namespace trajectory_follower
 }  // namespace control

--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -52,8 +52,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 
 /// \class PidLongitudinalController
@@ -66,21 +65,21 @@ public:
 private:
   struct Motion
   {
-    float64_t vel{0.0};
-    float64_t acc{0.0};
+    double vel{0.0};
+    double acc{0.0};
   };
 
   enum class Shift { Forward = 0, Reverse };
 
   struct ControlData
   {
-    bool8_t is_far_from_trajectory{false};
+    bool is_far_from_trajectory{false};
     size_t nearest_idx{0};  // nearest_idx = 0 when nearest_idx is not found with findNearestIdx
     Motion current_motion{};
     Shift shift{Shift::Forward};  // shift is used only to calculate the sign of pitch compensation
-    float64_t stop_dist{0.0};  // signed distance that is positive when car is before the stopline
-    float64_t slope_angle{0.0};
-    float64_t dt{0.0};
+    double stop_dist{0.0};  // signed distance that is positive when car is before the stopline
+    double slope_angle{0.0};
+    double dt{0.0};
   };
   rclcpp::Node * node_;
   // ros variables
@@ -97,7 +96,7 @@ private:
   autoware_auto_planning_msgs::msg::Trajectory::ConstSharedPtr m_trajectory_ptr{nullptr};
 
   // vehicle info
-  float64_t m_wheel_base;
+  double m_wheel_base;
 
   // control state
   enum class ControlState { DRIVE = 0, STOPPING, STOPPED, EMERGENCY };
@@ -112,43 +111,43 @@ private:
   };
 
   // control period
-  float64_t m_longitudinal_ctrl_period;
+  double m_longitudinal_ctrl_period;
 
   // delay compensation
-  float64_t m_delay_compensation_time;
+  double m_delay_compensation_time;
 
   // enable flags
-  bool8_t m_enable_smooth_stop;
-  bool8_t m_enable_overshoot_emergency;
-  bool8_t m_enable_slope_compensation;
-  bool8_t m_enable_large_tracking_error_emergency;
-  bool8_t m_enable_keep_stopped_until_steer_convergence;
+  bool m_enable_smooth_stop;
+  bool m_enable_overshoot_emergency;
+  bool m_enable_slope_compensation;
+  bool m_enable_large_tracking_error_emergency;
+  bool m_enable_keep_stopped_until_steer_convergence;
 
   // smooth stop transition
   struct StateTransitionParams
   {
     // drive
-    float64_t drive_state_stop_dist;
-    float64_t drive_state_offset_stop_dist;
+    double drive_state_stop_dist;
+    double drive_state_offset_stop_dist;
     // stopping
-    float64_t stopping_state_stop_dist;
+    double stopping_state_stop_dist;
     // stop
-    float64_t stopped_state_entry_duration_time;
-    float64_t stopped_state_entry_vel;
-    float64_t stopped_state_entry_acc;
+    double stopped_state_entry_duration_time;
+    double stopped_state_entry_vel;
+    double stopped_state_entry_acc;
     // emergency
-    float64_t emergency_state_overshoot_stop_dist;
-    float64_t emergency_state_traj_trans_dev;
-    float64_t emergency_state_traj_rot_dev;
+    double emergency_state_overshoot_stop_dist;
+    double emergency_state_traj_trans_dev;
+    double emergency_state_traj_rot_dev;
   };
   StateTransitionParams m_state_transition_params;
 
   // drive
   trajectory_follower::PIDController m_pid_vel;
   std::shared_ptr<trajectory_follower::LowpassFilter1d> m_lpf_vel_error{nullptr};
-  float64_t m_current_vel_threshold_pid_integrate;
-  bool8_t m_enable_brake_keeping_before_stop;
-  float64_t m_brake_keeping_acc;
+  double m_current_vel_threshold_pid_integrate;
+  bool m_enable_brake_keeping_before_stop;
+  double m_brake_keeping_acc;
 
   // smooth stop
   trajectory_follower::SmoothStop m_smooth_stop;
@@ -156,34 +155,34 @@ private:
   // stop
   struct StoppedStateParams
   {
-    float64_t vel;
-    float64_t acc;
-    float64_t jerk;
+    double vel;
+    double acc;
+    double jerk;
   };
   StoppedStateParams m_stopped_state_params;
 
   // emergency
   struct EmergencyStateParams
   {
-    float64_t vel;
-    float64_t acc;
-    float64_t jerk;
+    double vel;
+    double acc;
+    double jerk;
   };
   EmergencyStateParams m_emergency_state_params;
 
   // acceleration limit
-  float64_t m_max_acc;
-  float64_t m_min_acc;
+  double m_max_acc;
+  double m_min_acc;
 
   // jerk limit
-  float64_t m_max_jerk;
-  float64_t m_min_jerk;
+  double m_max_jerk;
+  double m_min_jerk;
 
   // slope compensation
-  bool8_t m_use_traj_for_pitch;
+  bool m_use_traj_for_pitch;
   std::shared_ptr<trajectory_follower::LowpassFilter1d> m_lpf_pitch{nullptr};
-  float64_t m_max_pitch_rad;
-  float64_t m_min_pitch_rad;
+  double m_max_pitch_rad;
+  double m_min_pitch_rad;
 
   // ego nearest index search
   double m_ego_nearest_dist_threshold;
@@ -201,7 +200,7 @@ private:
   // diff limit
   Motion m_prev_ctrl_cmd{};      // with slope compensation
   Motion m_prev_raw_ctrl_cmd{};  // without slope compensation
-  std::vector<std::pair<rclcpp::Time, float64_t>> m_vel_hist;
+  std::vector<std::pair<rclcpp::Time, double>> m_vel_hist;
 
   // debug values
   trajectory_follower::DebugValues m_debug_values;
@@ -213,8 +212,8 @@ private:
   diagnostic_updater::Updater diagnostic_updater_;
   struct DiagnosticData
   {
-    float64_t trans_deviation{0.0};  // translation deviation between nearest point and current_pose
-    float64_t rot_deviation{0.0};    // rotation deviation between nearest point and current_pose
+    double trans_deviation{0.0};  // translation deviation between nearest point and current_pose
+    double rot_deviation{0.0};    // rotation deviation between nearest point and current_pose
   };
   DiagnosticData m_diagnostic_data;
   void setupDiagnosticUpdater();
@@ -259,7 +258,7 @@ private:
    * @brief calculate control command in emergency state
    * @param [in] dt time between previous and current one
    */
-  Motion calcEmergencyCtrlCmd(const float64_t dt) const;
+  Motion calcEmergencyCtrlCmd(const double dt) const;
 
   /**
    * @brief update control state according to the current situation
@@ -281,7 +280,7 @@ private:
    * @param [in] current_vel current velocity of the vehicle
    */
   autoware_auto_control_msgs::msg::LongitudinalCommand createCtrlCmdMsg(
-    const Motion & ctrl_cmd, const float64_t & current_vel);
+    const Motion & ctrl_cmd, const double & current_vel);
 
   /**
    * @brief publish debug data
@@ -293,7 +292,7 @@ private:
   /**
    * @brief calculate time between current and previous one
    */
-  float64_t getDt();
+  double getDt();
 
   /**
    * @brief calculate current velocity and acceleration
@@ -312,13 +311,13 @@ private:
    * @param [in] raw_acc acceleration before filtered
    * @param [in] control_data data for control calculation
    */
-  float64_t calcFilteredAcc(const float64_t raw_acc, const ControlData & control_data);
+  double calcFilteredAcc(const double raw_acc, const ControlData & control_data);
 
   /**
    * @brief store acceleration command before slope compensation
    * @param [in] accel command before slope compensation
    */
-  void storeAccelCmd(const float64_t accel);
+  void storeAccelCmd(const double accel);
 
   /**
    * @brief add acceleration to compensate for slope
@@ -326,8 +325,7 @@ private:
    * @param [in] pitch pitch angle (upward is negative)
    * @param [in] shift direction that vehicle move (forward or backward)
    */
-  float64_t applySlopeCompensation(
-    const float64_t acc, const float64_t pitch, const Shift shift) const;
+  double applySlopeCompensation(const double acc, const double pitch, const Shift shift) const;
 
   /**
    * @brief keep target motion acceleration negative before stop
@@ -353,8 +351,8 @@ private:
    * @param [in] current_motion current velocity and acceleration of the vehicle
    * @param [in] delay_compensation_time predicted time delay
    */
-  float64_t predictedVelocityInTargetPoint(
-    const Motion current_motion, const float64_t delay_compensation_time) const;
+  double predictedVelocityInTargetPoint(
+    const Motion current_motion, const double delay_compensation_time) const;
 
   /**
    * @brief calculate velocity feedback with feed forward and pid controller
@@ -363,8 +361,8 @@ private:
    * @param [in] dt time step to use
    * @param [in] current_vel current velocity of the vehicle
    */
-  float64_t applyVelocityFeedback(
-    const Motion target_motion, const float64_t dt, const float64_t current_vel);
+  double applyVelocityFeedback(
+    const Motion target_motion, const double dt, const double current_vel);
 
   /**
    * @brief update variables for debugging about pitch
@@ -372,8 +370,7 @@ private:
    * @param [in] traj_pitch current trajectory pitch
    * @param [in] raw_pitch current raw pitch of the vehicle (unfiltered)
    */
-  void updatePitchDebugValues(
-    const float64_t pitch, const float64_t traj_pitch, const float64_t raw_pitch);
+  void updatePitchDebugValues(const double pitch, const double traj_pitch, const double raw_pitch);
 
   /**
    * @brief update variables for velocity and acceleration

--- a/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_interface.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_interface.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__QP_SOLVER__QP_SOLVER_INTERFACE_HPP_
 #define TRAJECTORY_FOLLOWER__QP_SOLVER__QP_SOLVER_INTERFACE_HPP_
 
-#include "common/types.hpp"
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Dense"
 #include "eigen3/Eigen/LU"
@@ -29,7 +28,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
+
 /// Interface for solvers of Quadratic Programming (QP) problems
 class TRAJECTORY_FOLLOWER_PUBLIC QPSolverInterface
 {
@@ -51,7 +50,7 @@ public:
    * @param [out] u optimal variable vector
    * @return ture if the problem was solved
    */
-  virtual bool8_t solve(
+  virtual bool solve(
     const Eigen::MatrixXd & h_mat, const Eigen::MatrixXd & f_vec, const Eigen::MatrixXd & a,
     const Eigen::VectorXd & lb, const Eigen::VectorXd & ub, const Eigen::VectorXd & lb_a,
     const Eigen::VectorXd & ub_a, Eigen::VectorXd & u) = 0;

--- a/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_osqp.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_osqp.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__QP_SOLVER__QP_SOLVER_OSQP_HPP_
 #define TRAJECTORY_FOLLOWER__QP_SOLVER__QP_SOLVER_OSQP_HPP_
 
-#include "common/types.hpp"
 #include "eigen3/Eigen/Dense"
 #include "osqp_interface/osqp_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -30,8 +29,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 /// Solver for QP problems using the OSQP library
 class TRAJECTORY_FOLLOWER_PUBLIC QPSolverOSQP : public QPSolverInterface
 {
@@ -58,7 +56,7 @@ public:
    * @param [out] u optimal variable vector
    * @return true if the problem was solved
    */
-  bool8_t solve(
+  bool solve(
     const Eigen::MatrixXd & h_mat, const Eigen::MatrixXd & f_vec, const Eigen::MatrixXd & a,
     const Eigen::VectorXd & lb, const Eigen::VectorXd & ub, const Eigen::VectorXd & lb_a,
     const Eigen::VectorXd & ub_a, Eigen::VectorXd & u) override;

--- a/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_unconstr_fast.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/qp_solver/qp_solver_unconstr_fast.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__QP_SOLVER__QP_SOLVER_UNCONSTR_FAST_HPP_
 #define TRAJECTORY_FOLLOWER__QP_SOLVER__QP_SOLVER_UNCONSTR_FAST_HPP_
 
-#include "common/types.hpp"
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Dense"
 #include "eigen3/Eigen/LU"
@@ -32,7 +31,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
+
 /**
  * Solver for QP problems using least square decomposition
  * implement with Eigen's standard Cholesky decomposition (LLT)
@@ -62,7 +61,7 @@ public:
    * @param [out] u optimal variable vector
    * @return true if the problem was solved
    */
-  bool8_t solve(
+  bool solve(
     const Eigen::MatrixXd & h_mat, const Eigen::MatrixXd & f_vec, const Eigen::MatrixXd & a,
     const Eigen::VectorXd & lb, const Eigen::VectorXd & ub, const Eigen::VectorXd & lb_a,
     const Eigen::VectorXd & ub_a, Eigen::VectorXd & u) override;

--- a/control/trajectory_follower/include/trajectory_follower/smooth_stop.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/smooth_stop.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__SMOOTH_STOP_HPP_
 #define TRAJECTORY_FOLLOWER__SMOOTH_STOP_HPP_
 
-#include "common/types.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "trajectory_follower/visibility_control.hpp"
 
@@ -35,8 +34,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 /**
  * @brief Smooth stop class to implement vehicle specific deceleration profiles
  */
@@ -48,7 +46,7 @@ public:
    * @param [in] pred_vel_in_target predicted ego velocity when the stop command will be executed
    * @param [in] pred_stop_dist predicted stop distance when the stop command will be executed
    */
-  void init(const float64_t pred_vel_in_target, const float64_t pred_stop_dist);
+  void init(const double pred_vel_in_target, const double pred_stop_dist);
 
   /**
    * @brief set the parameters of this smooth stop
@@ -66,19 +64,18 @@ public:
    * [m]
    */
   void setParams(
-    float64_t max_strong_acc, float64_t min_strong_acc, float64_t weak_acc, float64_t weak_stop_acc,
-    float64_t strong_stop_acc, float64_t min_fast_vel, float64_t min_running_vel,
-    float64_t min_running_acc, float64_t weak_stop_time, float64_t weak_stop_dist,
-    float64_t strong_stop_dist);
+    double max_strong_acc, double min_strong_acc, double weak_acc, double weak_stop_acc,
+    double strong_stop_acc, double min_fast_vel, double min_running_vel, double min_running_acc,
+    double weak_stop_time, double weak_stop_dist, double strong_stop_dist);
 
   /**
    * @brief predict time when car stops by fitting some latest observed velocity history
    *        with linear function (v = at + b)
-   * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, float64_t[m/s]) pairs
+   * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, double[m/s]) pairs
    * @throw std::runtime_error if parameters have not been set
    */
-  std::experimental::optional<float64_t> calcTimeToStop(
-    const std::vector<std::pair<rclcpp::Time, float64_t>> & vel_hist) const;
+  std::experimental::optional<double> calcTimeToStop(
+    const std::vector<std::pair<rclcpp::Time, double>> & vel_hist) const;
 
   /**
    * @brief calculate accel command while stopping
@@ -89,36 +86,36 @@ public:
    * @param [in] stop_dist distance left to travel before stopping [m]
    * @param [in] current_vel current velocity of ego [m/s]
    * @param [in] current_acc current acceleration of ego [m/s²]
-   * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, float64_t[m/s]) pairs
+   * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, double[m/s]) pairs
    * @param [in] delay_time assumed time delay when the stop command will actually be executed
    * @throw std::runtime_error if parameters have not been set
    */
-  float64_t calculate(
-    const float64_t stop_dist, const float64_t current_vel, const float64_t current_acc,
-    const std::vector<std::pair<rclcpp::Time, float64_t>> & vel_hist, const float64_t delay_time);
+  double calculate(
+    const double stop_dist, const double current_vel, const double current_acc,
+    const std::vector<std::pair<rclcpp::Time, double>> & vel_hist, const double delay_time);
 
 private:
   struct Params
   {
-    float64_t max_strong_acc;
-    float64_t min_strong_acc;
-    float64_t weak_acc;
-    float64_t weak_stop_acc;
-    float64_t strong_stop_acc;
+    double max_strong_acc;
+    double min_strong_acc;
+    double weak_acc;
+    double weak_stop_acc;
+    double strong_stop_acc;
 
-    float64_t min_fast_vel;
-    float64_t min_running_vel;
-    float64_t min_running_acc;
-    float64_t weak_stop_time;
+    double min_fast_vel;
+    double min_running_vel;
+    double min_running_acc;
+    double weak_stop_time;
 
-    float64_t weak_stop_dist;
-    float64_t strong_stop_dist;
+    double weak_stop_dist;
+    double strong_stop_dist;
   };
   Params m_params;
 
-  float64_t m_strong_acc;
+  double m_strong_acc;
   rclcpp::Time m_weak_acc_time;
-  bool8_t m_is_set_params = false;
+  bool m_is_set_params = false;
 };
 }  // namespace trajectory_follower
 }  // namespace control

--- a/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_dynamics.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_dynamics.hpp
@@ -47,7 +47,6 @@
 #ifndef TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_DYNAMICS_HPP_
 #define TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_DYNAMICS_HPP_
 
-#include "common/types.hpp"
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/LU"
 #include "trajectory_follower/vehicle_model/vehicle_model_interface.hpp"
@@ -61,7 +60,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::float64_t;
+
 /**
  * Vehicle model class of bicycle dynamics
  * @brief calculate model-related values
@@ -80,8 +79,8 @@ public:
    * @param [in] cr rear cornering power [N/rad]
    */
   DynamicsBicycleModel(
-    const float64_t wheelbase, const float64_t mass_fl, const float64_t mass_fr,
-    const float64_t mass_rl, const float64_t mass_rr, const float64_t cf, const float64_t cr);
+    const double wheelbase, const double mass_fl, const double mass_fr, const double mass_rl,
+    const double mass_rr, const double cf, const double cr);
 
   /**
    * @brief destructor
@@ -98,7 +97,7 @@ public:
    */
   void calculateDiscreteMatrix(
     Eigen::MatrixXd & a_d, Eigen::MatrixXd & b_d, Eigen::MatrixXd & w_d, Eigen::MatrixXd & c_d,
-    const float64_t dt) override;
+    const double dt) override;
 
   /**
    * @brief calculate reference input
@@ -107,12 +106,12 @@ public:
   void calculateReferenceInput(Eigen::MatrixXd & u_ref) override;
 
 private:
-  float64_t m_lf;    //!< @brief length from center of mass to front wheel [m]
-  float64_t m_lr;    //!< @brief length from center of mass to rear wheel [m]
-  float64_t m_mass;  //!< @brief total mass of vehicle [kg]
-  float64_t m_iz;    //!< @brief moment of inertia [kg * m2]
-  float64_t m_cf;    //!< @brief front cornering power [N/rad]
-  float64_t m_cr;    //!< @brief rear cornering power [N/rad]
+  double m_lf;    //!< @brief length from center of mass to front wheel [m]
+  double m_lr;    //!< @brief length from center of mass to rear wheel [m]
+  double m_mass;  //!< @brief total mass of vehicle [kg]
+  double m_iz;    //!< @brief moment of inertia [kg * m2]
+  double m_cf;    //!< @brief front cornering power [N/rad]
+  double m_cr;    //!< @brief rear cornering power [N/rad]
 };
 }  // namespace trajectory_follower
 }  // namespace control

--- a/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_kinematics.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_kinematics.hpp
@@ -41,7 +41,6 @@
 #ifndef TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 #define TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 
-#include "common/types.hpp"
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/LU"
 #include "trajectory_follower/vehicle_model/vehicle_model_interface.hpp"
@@ -55,7 +54,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::float64_t;
+
 /**
  * Vehicle model class of bicycle kinematics
  * @brief calculate model-related values
@@ -69,8 +68,7 @@ public:
    * @param [in] steer_lim steering angle limit [rad]
    * @param [in] steer_tau steering time constant for 1d-model [s]
    */
-  KinematicsBicycleModel(
-    const float64_t wheelbase, const float64_t steer_lim, const float64_t steer_tau);
+  KinematicsBicycleModel(const double wheelbase, const double steer_lim, const double steer_tau);
 
   /**
    * @brief destructor
@@ -87,7 +85,7 @@ public:
    */
   void calculateDiscreteMatrix(
     Eigen::MatrixXd & a_d, Eigen::MatrixXd & b_d, Eigen::MatrixXd & c_d, Eigen::MatrixXd & w_d,
-    const float64_t dt) override;
+    const double dt) override;
 
   /**
    * @brief calculate reference input
@@ -96,8 +94,8 @@ public:
   void calculateReferenceInput(Eigen::MatrixXd & u_ref) override;
 
 private:
-  float64_t m_steer_lim;  //!< @brief steering angle limit [rad]
-  float64_t m_steer_tau;  //!< @brief steering time constant for 1d-model [s]
+  double m_steer_lim;  //!< @brief steering angle limit [rad]
+  double m_steer_tau;  //!< @brief steering time constant for 1d-model [s]
 };
 }  // namespace trajectory_follower
 }  // namespace control

--- a/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp
@@ -38,7 +38,6 @@
 #ifndef TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_NO_DELAY_HPP_
 #define TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_NO_DELAY_HPP_
 
-#include "common/types.hpp"
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/LU"
 #include "trajectory_follower/vehicle_model/vehicle_model_interface.hpp"
@@ -52,7 +51,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::float64_t;
+
 /**
  * Vehicle model class of bicycle kinematics without steering delay
  * @brief calculate model-related values
@@ -65,7 +64,7 @@ public:
    * @param [in] wheelbase wheelbase length [m]
    * @param [in] steer_lim steering angle limit [rad]
    */
-  KinematicsBicycleModelNoDelay(const float64_t wheelbase, const float64_t steer_lim);
+  KinematicsBicycleModelNoDelay(const double wheelbase, const double steer_lim);
 
   /**
    * @brief destructor
@@ -82,7 +81,7 @@ public:
    */
   void calculateDiscreteMatrix(
     Eigen::MatrixXd & a_d, Eigen::MatrixXd & b_d, Eigen::MatrixXd & c_d, Eigen::MatrixXd & w_d,
-    const float64_t dt) override;
+    const double dt) override;
 
   /**
    * @brief calculate reference input
@@ -91,7 +90,7 @@ public:
   void calculateReferenceInput(Eigen::MatrixXd & u_ref) override;
 
 private:
-  float64_t m_steer_lim;  //!< @brief steering angle limit [rad]
+  double m_steer_lim;  //!< @brief steering angle limit [rad]
 };
 }  // namespace trajectory_follower
 }  // namespace control

--- a/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_interface.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/vehicle_model/vehicle_model_interface.hpp
@@ -15,7 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_INTERFACE_HPP_
 #define TRAJECTORY_FOLLOWER__VEHICLE_MODEL__VEHICLE_MODEL_INTERFACE_HPP_
 
-#include "common/types.hpp"
 #include "eigen3/Eigen/Core"
 #include "trajectory_follower/visibility_control.hpp"
 
@@ -27,7 +26,7 @@ namespace control
 {
 namespace trajectory_follower
 {
-using autoware::common::types::float64_t;
+
 /**
  * Vehicle model class
  * @brief calculate model-related values
@@ -35,12 +34,12 @@ using autoware::common::types::float64_t;
 class TRAJECTORY_FOLLOWER_PUBLIC VehicleModelInterface
 {
 protected:
-  const int64_t m_dim_x;  //!< @brief dimension of state x
-  const int64_t m_dim_u;  //!< @brief dimension of input u
-  const int64_t m_dim_y;  //!< @brief dimension of output y
-  float64_t m_velocity;   //!< @brief vehicle velocity [m/s]
-  float64_t m_curvature;  //!< @brief curvature on the linearized point on path
-  float64_t m_wheelbase;  //!< @brief wheelbase of the vehicle [m]
+  const int m_dim_x;   //!< @brief dimension of state x
+  const int m_dim_u;   //!< @brief dimension of input u
+  const int m_dim_y;   //!< @brief dimension of output y
+  double m_velocity;   //!< @brief vehicle velocity [m/s]
+  double m_curvature;  //!< @brief curvature on the linearized point on path
+  double m_wheelbase;  //!< @brief wheelbase of the vehicle [m]
 
 public:
   /**
@@ -50,7 +49,7 @@ public:
    * @param [in] dim_y dimension of output y
    * @param [in] wheelbase wheelbase of the vehicle [m]
    */
-  VehicleModelInterface(int64_t dim_x, int64_t dim_u, int64_t dim_y, float64_t wheelbase);
+  VehicleModelInterface(int dim_x, int dim_u, int dim_y, double wheelbase);
 
   /**
    * @brief destructor
@@ -61,37 +60,37 @@ public:
    * @brief get state x dimension
    * @return state dimension
    */
-  int64_t getDimX();
+  int getDimX();
 
   /**
    * @brief get input u dimension
    * @return input dimension
    */
-  int64_t getDimU();
+  int getDimU();
 
   /**
    * @brief get output y dimension
    * @return output dimension
    */
-  int64_t getDimY();
+  int getDimY();
 
   /**
    * @brief get wheelbase of the vehicle
    * @return wheelbase value [m]
    */
-  float64_t getWheelbase();
+  double getWheelbase();
 
   /**
    * @brief set velocity
    * @param [in] velocity vehicle velocity
    */
-  void setVelocity(const float64_t velocity);
+  void setVelocity(const double velocity);
 
   /**
    * @brief set curvature
    * @param [in] curvature curvature on the linearized point on path
    */
-  void setCurvature(const float64_t curvature);
+  void setCurvature(const double curvature);
 
   /**
    * @brief calculate discrete model matrix of x_k+1 = a_d * xk + b_d * uk + w_d, yk = c_d * xk
@@ -103,7 +102,7 @@ public:
    */
   virtual void calculateDiscreteMatrix(
     Eigen::MatrixXd & a_d, Eigen::MatrixXd & b_d, Eigen::MatrixXd & c_d, Eigen::MatrixXd & w_d,
-    const float64_t dt) = 0;
+    const double dt) = 0;
 
   /**
    * @brief calculate reference input

--- a/control/trajectory_follower/package.xml
+++ b/control/trajectory_follower/package.xml
@@ -20,7 +20,6 @@
 
   <build_depend>autoware_cmake</build_depend>
 
-  <depend>autoware_auto_common</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_geometry</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/trajectory_follower/src/interpolate.cpp
+++ b/control/trajectory_follower/src/interpolate.cpp
@@ -32,7 +32,7 @@ namespace trajectory_follower
 {
 namespace
 {
-bool8_t isIncrease(const std::vector<float64_t> & x)
+bool isIncrease(const std::vector<double> & x)
 {
   for (size_t i = 0; i < x.size() - 1; ++i) {
     if (x.at(i) > x.at(i + 1)) {
@@ -42,9 +42,9 @@ bool8_t isIncrease(const std::vector<float64_t> & x)
   return true;
 }
 
-bool8_t isValidInput(
-  const std::vector<float64_t> & base_index, const std::vector<float64_t> & base_value,
-  const std::vector<float64_t> & return_index)
+bool isValidInput(
+  const std::vector<double> & base_index, const std::vector<double> & base_value,
+  const std::vector<double> & return_index)
 {
   if (base_index.empty() || base_value.empty() || return_index.empty()) {
     std::cerr << "mpc bad index : some vector is empty. base_index: " << base_index.size()
@@ -79,9 +79,9 @@ bool8_t isValidInput(
 }
 }  // namespace
 
-bool8_t linearInterpolate(
-  const std::vector<float64_t> & base_index, const std::vector<float64_t> & base_value,
-  const std::vector<float64_t> & return_index, std::vector<float64_t> & return_value)
+bool linearInterpolate(
+  const std::vector<double> & base_index, const std::vector<double> & base_value,
+  const std::vector<double> & return_index, std::vector<double> & return_value)
 {
   // check if inputs are valid
   if (!isValidInput(base_index, base_value, return_index)) {
@@ -111,11 +111,11 @@ bool8_t linearInterpolate(
       continue;
     }
 
-    const float64_t dist_base_idx = base_index.at(i) - base_index.at(i - 1);
-    const float64_t dist_to_forward = base_index.at(i) - idx;
-    const float64_t dist_to_backward = idx - base_index.at(i - 1);
+    const double dist_base_idx = base_index.at(i) - base_index.at(i - 1);
+    const double dist_to_forward = base_index.at(i) - idx;
+    const double dist_to_backward = idx - base_index.at(i - 1);
 
-    const float64_t value =
+    const double value =
       (dist_to_backward * base_value.at(i) + dist_to_forward * base_value.at(i - 1)) /
       dist_base_idx;
     return_value.push_back(value);
@@ -123,14 +123,14 @@ bool8_t linearInterpolate(
   return true;
 }
 
-bool8_t linearInterpolate(
-  const std::vector<float64_t> & base_index, const std::vector<float64_t> & base_value,
-  const float64_t & return_index, float64_t & return_value)
+bool linearInterpolate(
+  const std::vector<double> & base_index, const std::vector<double> & base_value,
+  const double & return_index, double & return_value)
 {
-  std::vector<float64_t> return_index_v;
+  std::vector<double> return_index_v;
   return_index_v.push_back(return_index);
 
-  std::vector<float64_t> return_value_v;
+  std::vector<double> return_value_v;
   if (!linearInterpolate(base_index, base_value, return_index_v, return_value_v)) {
     return false;
   }

--- a/control/trajectory_follower/src/lowpass_filter.cpp
+++ b/control/trajectory_follower/src/lowpass_filter.cpp
@@ -24,14 +24,14 @@ namespace control
 {
 namespace trajectory_follower
 {
-Butterworth2dFilter::Butterworth2dFilter(float64_t dt, float64_t f_cutoff_hz)
+Butterworth2dFilter::Butterworth2dFilter(double dt, double f_cutoff_hz)
 {
   initialize(dt, f_cutoff_hz);
 }
 
 Butterworth2dFilter::~Butterworth2dFilter() {}
 
-void Butterworth2dFilter::initialize(const float64_t & dt, const float64_t & f_cutoff_hz)
+void Butterworth2dFilter::initialize(const double & dt, const double & f_cutoff_hz)
 {
   m_y1 = 0.0;
   m_y2 = 0.0;
@@ -39,8 +39,8 @@ void Butterworth2dFilter::initialize(const float64_t & dt, const float64_t & f_c
   m_u1 = 0.0;
 
   /* 2d butterworth lowpass filter with bi-linear transformation */
-  float64_t wc = 2.0 * M_PI * f_cutoff_hz;
-  float64_t n = 2 / dt;
+  double wc = 2.0 * M_PI * f_cutoff_hz;
+  double n = 2 / dt;
   m_a0 = n * n + sqrt(2) * wc * n + wc * wc;
   m_a1 = 2 * wc * wc - 2 * n * n;
   m_a2 = n * n - sqrt(2) * wc * n + wc * wc;
@@ -49,9 +49,9 @@ void Butterworth2dFilter::initialize(const float64_t & dt, const float64_t & f_c
   m_b2 = m_b0;
 }
 
-float64_t Butterworth2dFilter::filter(const float64_t & u0)
+double Butterworth2dFilter::filter(const double & u0)
 {
-  float64_t y0 = (m_b2 * m_u2 + m_b1 * m_u1 + m_b0 * u0 - m_a2 * m_y2 - m_a1 * m_y1) / m_a0;
+  double y0 = (m_b2 * m_u2 + m_b1 * m_u1 + m_b0 * u0 - m_a2 * m_y2 - m_a1 * m_y1) / m_a0;
   m_y2 = m_y1;
   m_y1 = y0;
   m_u2 = m_u1;
@@ -59,16 +59,15 @@ float64_t Butterworth2dFilter::filter(const float64_t & u0)
   return y0;
 }
 
-void Butterworth2dFilter::filt_vector(
-  const std::vector<float64_t> & t, std::vector<float64_t> & u) const
+void Butterworth2dFilter::filt_vector(const std::vector<double> & t, std::vector<double> & u) const
 {
   u.resize(t.size());
-  float64_t y1 = t.at(0);
-  float64_t y2 = t.at(0);
-  float64_t u2 = t.at(0);
-  float64_t u1 = t.at(0);
-  float64_t y0 = 0.0;
-  float64_t u0 = 0.0;
+  double y1 = t.at(0);
+  double y2 = t.at(0);
+  double u2 = t.at(0);
+  double u1 = t.at(0);
+  double y0 = 0.0;
+  double u0 = 0.0;
   for (size_t i = 0; i < t.size(); ++i) {
     u0 = t.at(i);
     y0 = (m_b2 * u2 + m_b1 * u1 + m_b0 * u0 - m_a2 * y2 - m_a1 * y1) / m_a0;
@@ -82,10 +81,10 @@ void Butterworth2dFilter::filt_vector(
 
 // filtering forward and backward direction
 void Butterworth2dFilter::filtfilt_vector(
-  const std::vector<float64_t> & t, std::vector<float64_t> & u) const
+  const std::vector<double> & t, std::vector<double> & u) const
 {
-  std::vector<float64_t> t_fwd(t);
-  std::vector<float64_t> t_rev(t);
+  std::vector<double> t_fwd(t);
+  std::vector<double> t_rev(t);
 
   // forward filtering
   filt_vector(t, t_fwd);
@@ -102,7 +101,7 @@ void Butterworth2dFilter::filtfilt_vector(
   }
 }
 
-void Butterworth2dFilter::getCoefficients(std::vector<float64_t> & coeffs) const
+void Butterworth2dFilter::getCoefficients(std::vector<double> & coeffs) const
 {
   coeffs.clear();
   coeffs.push_back(m_a0);
@@ -115,25 +114,25 @@ void Butterworth2dFilter::getCoefficients(std::vector<float64_t> & coeffs) const
 
 namespace MoveAverageFilter
 {
-bool8_t filt_vector(const int64_t num, std::vector<float64_t> & u)
+bool filt_vector(const int num, std::vector<double> & u)
 {
-  if (static_cast<int64_t>(u.size()) < num) {
+  if (static_cast<int>(u.size()) < num) {
     return false;
   }
-  std::vector<float64_t> filtered_u(u);
-  for (int64_t i = 0; i < static_cast<int64_t>(u.size()); ++i) {
-    float64_t tmp = 0.0;
-    int64_t num_tmp = 0;
-    float64_t count = 0;
+  std::vector<double> filtered_u(u);
+  for (int i = 0; i < static_cast<int>(u.size()); ++i) {
+    double tmp = 0.0;
+    int num_tmp = 0;
+    double count = 0;
     if (i - num < 0) {
       num_tmp = i;
-    } else if (i + num > static_cast<int64_t>(u.size()) - 1) {
-      num_tmp = static_cast<int64_t>(u.size()) - i - 1;
+    } else if (i + num > static_cast<int>(u.size()) - 1) {
+      num_tmp = static_cast<int>(u.size()) - i - 1;
     } else {
       num_tmp = num;
     }
 
-    for (int64_t j = -num_tmp; j <= num_tmp; ++j) {
+    for (int j = -num_tmp; j <= num_tmp; ++j) {
       tmp += u[static_cast<size_t>(i + j)];
       ++count;
     }

--- a/control/trajectory_follower/src/mpc_trajectory.cpp
+++ b/control/trajectory_follower/src/mpc_trajectory.cpp
@@ -23,8 +23,8 @@ namespace control
 namespace trajectory_follower
 {
 void MPCTrajectory::push_back(
-  const float64_t & xp, const float64_t & yp, const float64_t & zp, const float64_t & yawp,
-  const float64_t & vxp, const float64_t & kp, const float64_t & smooth_kp, const float64_t & tp)
+  const double & xp, const double & yp, const double & zp, const double & yawp, const double & vxp,
+  const double & kp, const double & smooth_kp, const double & tp)
 {
   x.push_back(xp);
   y.push_back(yp);

--- a/control/trajectory_follower/src/pid.cpp
+++ b/control/trajectory_follower/src/pid.cpp
@@ -37,9 +37,9 @@ PIDController::PIDController()
 {
 }
 
-float64_t PIDController::calculate(
-  const float64_t error, const float64_t dt, const bool8_t enable_integration,
-  std::vector<float64_t> & pid_contributions)
+double PIDController::calculate(
+  const double error, const double dt, const bool enable_integration,
+  std::vector<double> & pid_contributions)
 {
   if (!m_is_gains_set || !m_is_limits_set) {
     throw std::runtime_error("Trying to calculate uninitialized PID");
@@ -47,23 +47,23 @@ float64_t PIDController::calculate(
 
   const auto & p = m_params;
 
-  float64_t ret_p = p.kp * error;
+  double ret_p = p.kp * error;
   ret_p = std::min(std::max(ret_p, p.min_ret_p), p.max_ret_p);
 
   if (enable_integration) {
     m_error_integral += error * dt;
     m_error_integral = std::min(std::max(m_error_integral, p.min_ret_i / p.ki), p.max_ret_i / p.ki);
   }
-  const float64_t ret_i = p.ki * m_error_integral;
+  const double ret_i = p.ki * m_error_integral;
 
-  float64_t error_differential;
+  double error_differential;
   if (m_is_first_time) {
     error_differential = 0;
     m_is_first_time = false;
   } else {
     error_differential = (error - m_prev_error) / dt;
   }
-  float64_t ret_d = p.kd * error_differential;
+  double ret_d = p.kd * error_differential;
   ret_d = std::min(std::max(ret_d, p.min_ret_d), p.max_ret_d);
 
   m_prev_error = error;
@@ -73,13 +73,13 @@ float64_t PIDController::calculate(
   pid_contributions.at(1) = ret_i;
   pid_contributions.at(2) = ret_d;
 
-  float64_t ret = ret_p + ret_i + ret_d;
+  double ret = ret_p + ret_i + ret_d;
   ret = std::min(std::max(ret, p.min_ret), p.max_ret);
 
   return ret;
 }
 
-void PIDController::setGains(const float64_t kp, const float64_t ki, const float64_t kd)
+void PIDController::setGains(const double kp, const double ki, const double kd)
 {
   m_params.kp = kp;
   m_params.ki = ki;
@@ -88,9 +88,8 @@ void PIDController::setGains(const float64_t kp, const float64_t ki, const float
 }
 
 void PIDController::setLimits(
-  const float64_t max_ret, const float64_t min_ret, const float64_t max_ret_p,
-  const float64_t min_ret_p, const float64_t max_ret_i, const float64_t min_ret_i,
-  const float64_t max_ret_d, const float64_t min_ret_d)
+  const double max_ret, const double min_ret, const double max_ret_p, const double min_ret_p,
+  const double max_ret_i, const double min_ret_i, const double max_ret_d, const double min_ret_d)
 {
   m_params.max_ret = max_ret;
   m_params.min_ret = min_ret;

--- a/control/trajectory_follower/src/pid_longitudinal_controller.cpp
+++ b/control/trajectory_follower/src/pid_longitudinal_controller.cpp
@@ -43,103 +43,101 @@ PidLongitudinalController::PidLongitudinalController(rclcpp::Node & node)
   m_wheel_base = vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo().wheel_base_m;
 
   // parameters for delay compensation
-  m_delay_compensation_time =
-    node_->declare_parameter<float64_t>("delay_compensation_time");  // [s]
+  m_delay_compensation_time = node_->declare_parameter<double>("delay_compensation_time");  // [s]
 
   // parameters to enable functions
-  m_enable_smooth_stop = node_->declare_parameter<bool8_t>("enable_smooth_stop");
-  m_enable_overshoot_emergency = node_->declare_parameter<bool8_t>("enable_overshoot_emergency");
+  m_enable_smooth_stop = node_->declare_parameter<bool>("enable_smooth_stop");
+  m_enable_overshoot_emergency = node_->declare_parameter<bool>("enable_overshoot_emergency");
   m_enable_large_tracking_error_emergency =
-    node_->declare_parameter<bool8_t>("enable_large_tracking_error_emergency");
-  m_enable_slope_compensation = node_->declare_parameter<bool8_t>("enable_slope_compensation");
+    node_->declare_parameter<bool>("enable_large_tracking_error_emergency");
+  m_enable_slope_compensation = node_->declare_parameter<bool>("enable_slope_compensation");
   m_enable_keep_stopped_until_steer_convergence =
-    node_->declare_parameter<bool8_t>("enable_keep_stopped_until_steer_convergence");
+    node_->declare_parameter<bool>("enable_keep_stopped_until_steer_convergence");
 
   // parameters for state transition
   {
     auto & p = m_state_transition_params;
     // drive
-    p.drive_state_stop_dist = node_->declare_parameter<float64_t>("drive_state_stop_dist");  // [m]
+    p.drive_state_stop_dist = node_->declare_parameter<double>("drive_state_stop_dist");  // [m]
     p.drive_state_offset_stop_dist =
-      node_->declare_parameter<float64_t>("drive_state_offset_stop_dist");  // [m]
+      node_->declare_parameter<double>("drive_state_offset_stop_dist");  // [m]
     // stopping
     p.stopping_state_stop_dist =
-      node_->declare_parameter<float64_t>("stopping_state_stop_dist");  // [m]
+      node_->declare_parameter<double>("stopping_state_stop_dist");  // [m]
     p.stopped_state_entry_duration_time =
-      node_->declare_parameter<float64_t>("stopped_state_entry_duration_time");  // [s]
+      node_->declare_parameter<double>("stopped_state_entry_duration_time");  // [s]
     // stop
     p.stopped_state_entry_vel =
-      node_->declare_parameter<float64_t>("stopped_state_entry_vel");  // [m/s]
+      node_->declare_parameter<double>("stopped_state_entry_vel");  // [m/s]
     p.stopped_state_entry_acc =
-      node_->declare_parameter<float64_t>("stopped_state_entry_acc");  // [m/s²]
+      node_->declare_parameter<double>("stopped_state_entry_acc");  // [m/s²]
 
     // emergency
     p.emergency_state_overshoot_stop_dist =
-      node_->declare_parameter<float64_t>("emergency_state_overshoot_stop_dist");  // [m]
+      node_->declare_parameter<double>("emergency_state_overshoot_stop_dist");  // [m]
     p.emergency_state_traj_trans_dev =
-      node_->declare_parameter<float64_t>("emergency_state_traj_trans_dev");  // [m]
+      node_->declare_parameter<double>("emergency_state_traj_trans_dev");  // [m]
     p.emergency_state_traj_rot_dev =
-      node_->declare_parameter<float64_t>("emergency_state_traj_rot_dev");  // [m]
+      node_->declare_parameter<double>("emergency_state_traj_rot_dev");  // [m]
   }
 
   // parameters for drive state
   {
     // initialize PID gain
-    const float64_t kp{node_->declare_parameter<float64_t>("kp")};
-    const float64_t ki{node_->declare_parameter<float64_t>("ki")};
-    const float64_t kd{node_->declare_parameter<float64_t>("kd")};
+    const double kp{node_->declare_parameter<double>("kp")};
+    const double ki{node_->declare_parameter<double>("ki")};
+    const double kd{node_->declare_parameter<double>("kd")};
     m_pid_vel.setGains(kp, ki, kd);
 
     // initialize PID limits
-    const float64_t max_pid{node_->declare_parameter<float64_t>("max_out")};     // [m/s^2]
-    const float64_t min_pid{node_->declare_parameter<float64_t>("min_out")};     // [m/s^2]
-    const float64_t max_p{node_->declare_parameter<float64_t>("max_p_effort")};  // [m/s^2]
-    const float64_t min_p{node_->declare_parameter<float64_t>("min_p_effort")};  // [m/s^2]
-    const float64_t max_i{node_->declare_parameter<float64_t>("max_i_effort")};  // [m/s^2]
-    const float64_t min_i{node_->declare_parameter<float64_t>("min_i_effort")};  // [m/s^2]
-    const float64_t max_d{node_->declare_parameter<float64_t>("max_d_effort")};  // [m/s^2]
-    const float64_t min_d{node_->declare_parameter<float64_t>("min_d_effort")};  // [m/s^2]
+    const double max_pid{node_->declare_parameter<double>("max_out")};     // [m/s^2]
+    const double min_pid{node_->declare_parameter<double>("min_out")};     // [m/s^2]
+    const double max_p{node_->declare_parameter<double>("max_p_effort")};  // [m/s^2]
+    const double min_p{node_->declare_parameter<double>("min_p_effort")};  // [m/s^2]
+    const double max_i{node_->declare_parameter<double>("max_i_effort")};  // [m/s^2]
+    const double min_i{node_->declare_parameter<double>("min_i_effort")};  // [m/s^2]
+    const double max_d{node_->declare_parameter<double>("max_d_effort")};  // [m/s^2]
+    const double min_d{node_->declare_parameter<double>("min_d_effort")};  // [m/s^2]
     m_pid_vel.setLimits(max_pid, min_pid, max_p, min_p, max_i, min_i, max_d, min_d);
 
     // set lowpass filter for vel error and pitch
-    const float64_t lpf_vel_error_gain{node_->declare_parameter<float64_t>("lpf_vel_error_gain")};
+    const double lpf_vel_error_gain{node_->declare_parameter<double>("lpf_vel_error_gain")};
     m_lpf_vel_error =
       std::make_shared<trajectory_follower::LowpassFilter1d>(0.0, lpf_vel_error_gain);
 
     m_current_vel_threshold_pid_integrate =
-      node_->declare_parameter<float64_t>("current_vel_threshold_pid_integration");  // [m/s]
+      node_->declare_parameter<double>("current_vel_threshold_pid_integration");  // [m/s]
 
     m_enable_brake_keeping_before_stop =
-      node_->declare_parameter<bool8_t>("enable_brake_keeping_before_stop");         // [-]
-    m_brake_keeping_acc = node_->declare_parameter<float64_t>("brake_keeping_acc");  // [m/s^2]
+      node_->declare_parameter<bool>("enable_brake_keeping_before_stop");         // [-]
+    m_brake_keeping_acc = node_->declare_parameter<double>("brake_keeping_acc");  // [m/s^2]
   }
 
   // parameters for smooth stop state
   {
-    const float64_t max_strong_acc{
-      node_->declare_parameter<float64_t>("smooth_stop_max_strong_acc")};  // [m/s^2]
-    const float64_t min_strong_acc{
-      node_->declare_parameter<float64_t>("smooth_stop_min_strong_acc")};  // [m/s^2]
-    const float64_t weak_acc{
-      node_->declare_parameter<float64_t>("smooth_stop_weak_acc")};  // [m/s^2]
-    const float64_t weak_stop_acc{
-      node_->declare_parameter<float64_t>("smooth_stop_weak_stop_acc")};  // [m/s^2]
-    const float64_t strong_stop_acc{
-      node_->declare_parameter<float64_t>("smooth_stop_strong_stop_acc")};  // [m/s^2]
+    const double max_strong_acc{
+      node_->declare_parameter<double>("smooth_stop_max_strong_acc")};  // [m/s^2]
+    const double min_strong_acc{
+      node_->declare_parameter<double>("smooth_stop_min_strong_acc")};                // [m/s^2]
+    const double weak_acc{node_->declare_parameter<double>("smooth_stop_weak_acc")};  // [m/s^2]
+    const double weak_stop_acc{
+      node_->declare_parameter<double>("smooth_stop_weak_stop_acc")};  // [m/s^2]
+    const double strong_stop_acc{
+      node_->declare_parameter<double>("smooth_stop_strong_stop_acc")};  // [m/s^2]
 
-    const float64_t max_fast_vel{
-      node_->declare_parameter<float64_t>("smooth_stop_max_fast_vel")};  // [m/s]
-    const float64_t min_running_vel{
-      node_->declare_parameter<float64_t>("smooth_stop_min_running_vel")};  // [m/s]
-    const float64_t min_running_acc{
-      node_->declare_parameter<float64_t>("smooth_stop_min_running_acc")};  // [m/s^2]
-    const float64_t weak_stop_time{
-      node_->declare_parameter<float64_t>("smooth_stop_weak_stop_time")};  // [s]
+    const double max_fast_vel{
+      node_->declare_parameter<double>("smooth_stop_max_fast_vel")};  // [m/s]
+    const double min_running_vel{
+      node_->declare_parameter<double>("smooth_stop_min_running_vel")};  // [m/s]
+    const double min_running_acc{
+      node_->declare_parameter<double>("smooth_stop_min_running_acc")};  // [m/s^2]
+    const double weak_stop_time{
+      node_->declare_parameter<double>("smooth_stop_weak_stop_time")};  // [s]
 
-    const float64_t weak_stop_dist{
-      node_->declare_parameter<float64_t>("smooth_stop_weak_stop_dist")};  // [m]
-    const float64_t strong_stop_dist{
-      node_->declare_parameter<float64_t>("smooth_stop_strong_stop_dist")};  // [m]
+    const double weak_stop_dist{
+      node_->declare_parameter<double>("smooth_stop_weak_stop_dist")};  // [m]
+    const double strong_stop_dist{
+      node_->declare_parameter<double>("smooth_stop_strong_stop_dist")};  // [m]
 
     m_smooth_stop.setParams(
       max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
@@ -149,33 +147,33 @@ PidLongitudinalController::PidLongitudinalController(rclcpp::Node & node)
   // parameters for stop state
   {
     auto & p = m_stopped_state_params;
-    p.vel = node_->declare_parameter<float64_t>("stopped_vel");    // [m/s]
-    p.acc = node_->declare_parameter<float64_t>("stopped_acc");    // [m/s^2]
-    p.jerk = node_->declare_parameter<float64_t>("stopped_jerk");  // [m/s^3]
+    p.vel = node_->declare_parameter<double>("stopped_vel");    // [m/s]
+    p.acc = node_->declare_parameter<double>("stopped_acc");    // [m/s^2]
+    p.jerk = node_->declare_parameter<double>("stopped_jerk");  // [m/s^3]
   }
 
   // parameters for emergency state
   {
     auto & p = m_emergency_state_params;
-    p.vel = node_->declare_parameter<float64_t>("emergency_vel");    // [m/s]
-    p.acc = node_->declare_parameter<float64_t>("emergency_acc");    // [m/s^2]
-    p.jerk = node_->declare_parameter<float64_t>("emergency_jerk");  // [m/s^3]
+    p.vel = node_->declare_parameter<double>("emergency_vel");    // [m/s]
+    p.acc = node_->declare_parameter<double>("emergency_acc");    // [m/s^2]
+    p.jerk = node_->declare_parameter<double>("emergency_jerk");  // [m/s^3]
   }
 
   // parameters for acceleration limit
-  m_max_acc = node_->declare_parameter<float64_t>("max_acc");  // [m/s^2]
-  m_min_acc = node_->declare_parameter<float64_t>("min_acc");  // [m/s^2]
+  m_max_acc = node_->declare_parameter<double>("max_acc");  // [m/s^2]
+  m_min_acc = node_->declare_parameter<double>("min_acc");  // [m/s^2]
 
   // parameters for jerk limit
-  m_max_jerk = node_->declare_parameter<float64_t>("max_jerk");  // [m/s^3]
-  m_min_jerk = node_->declare_parameter<float64_t>("min_jerk");  // [m/s^3]
+  m_max_jerk = node_->declare_parameter<double>("max_jerk");  // [m/s^3]
+  m_min_jerk = node_->declare_parameter<double>("min_jerk");  // [m/s^3]
 
   // parameters for slope compensation
-  m_use_traj_for_pitch = node_->declare_parameter<bool8_t>("use_trajectory_for_pitch_calculation");
-  const float64_t lpf_pitch_gain{node_->declare_parameter<float64_t>("lpf_pitch_gain")};
+  m_use_traj_for_pitch = node_->declare_parameter<bool>("use_trajectory_for_pitch_calculation");
+  const double lpf_pitch_gain{node_->declare_parameter<double>("lpf_pitch_gain")};
   m_lpf_pitch = std::make_shared<trajectory_follower::LowpassFilter1d>(0.0, lpf_pitch_gain);
-  m_max_pitch_rad = node_->declare_parameter<float64_t>("max_pitch_rad");  // [rad]
-  m_min_pitch_rad = node_->declare_parameter<float64_t>("min_pitch_rad");  // [rad]
+  m_max_pitch_rad = node_->declare_parameter<double>("max_pitch_rad");  // [rad]
+  m_min_pitch_rad = node_->declare_parameter<double>("min_pitch_rad");  // [rad]
 
   // ego nearest index search
   m_ego_nearest_dist_threshold =
@@ -243,7 +241,7 @@ void PidLongitudinalController::setTrajectory(
 rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallback(
   const std::vector<rclcpp::Parameter> & parameters)
 {
-  auto update_param = [&](const std::string & name, float64_t & v) {
+  auto update_param = [&](const std::string & name, double & v) {
     auto it = std::find_if(
       parameters.cbegin(), parameters.cend(),
       [&name](const rclcpp::Parameter & parameter) { return parameter.get_name() == name; });
@@ -272,22 +270,22 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
 
   // drive state
   {
-    float64_t kp{node_->get_parameter("kp").as_double()};
-    float64_t ki{node_->get_parameter("ki").as_double()};
-    float64_t kd{node_->get_parameter("kd").as_double()};
+    double kp{node_->get_parameter("kp").as_double()};
+    double ki{node_->get_parameter("ki").as_double()};
+    double kd{node_->get_parameter("kd").as_double()};
     update_param("kp", kp);
     update_param("ki", ki);
     update_param("kd", kd);
     m_pid_vel.setGains(kp, ki, kd);
 
-    float64_t max_pid{node_->get_parameter("max_out").as_double()};
-    float64_t min_pid{node_->get_parameter("min_out").as_double()};
-    float64_t max_p{node_->get_parameter("max_p_effort").as_double()};
-    float64_t min_p{node_->get_parameter("min_p_effort").as_double()};
-    float64_t max_i{node_->get_parameter("max_i_effort").as_double()};
-    float64_t min_i{node_->get_parameter("min_i_effort").as_double()};
-    float64_t max_d{node_->get_parameter("max_d_effort").as_double()};
-    float64_t min_d{node_->get_parameter("min_d_effort").as_double()};
+    double max_pid{node_->get_parameter("max_out").as_double()};
+    double min_pid{node_->get_parameter("min_out").as_double()};
+    double max_p{node_->get_parameter("max_p_effort").as_double()};
+    double min_p{node_->get_parameter("min_p_effort").as_double()};
+    double max_i{node_->get_parameter("max_i_effort").as_double()};
+    double min_i{node_->get_parameter("min_i_effort").as_double()};
+    double max_d{node_->get_parameter("max_d_effort").as_double()};
+    double min_d{node_->get_parameter("min_d_effort").as_double()};
     update_param("max_out", max_pid);
     update_param("min_out", min_pid);
     update_param("max_p_effort", max_p);
@@ -303,17 +301,17 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
 
   // stopping state
   {
-    float64_t max_strong_acc{node_->get_parameter("smooth_stop_max_strong_acc").as_double()};
-    float64_t min_strong_acc{node_->get_parameter("smooth_stop_min_strong_acc").as_double()};
-    float64_t weak_acc{node_->get_parameter("smooth_stop_weak_acc").as_double()};
-    float64_t weak_stop_acc{node_->get_parameter("smooth_stop_weak_stop_acc").as_double()};
-    float64_t strong_stop_acc{node_->get_parameter("smooth_stop_strong_stop_acc").as_double()};
-    float64_t max_fast_vel{node_->get_parameter("smooth_stop_max_fast_vel").as_double()};
-    float64_t min_running_vel{node_->get_parameter("smooth_stop_min_running_vel").as_double()};
-    float64_t min_running_acc{node_->get_parameter("smooth_stop_min_running_acc").as_double()};
-    float64_t weak_stop_time{node_->get_parameter("smooth_stop_weak_stop_time").as_double()};
-    float64_t weak_stop_dist{node_->get_parameter("smooth_stop_weak_stop_dist").as_double()};
-    float64_t strong_stop_dist{node_->get_parameter("smooth_stop_strong_stop_dist").as_double()};
+    double max_strong_acc{node_->get_parameter("smooth_stop_max_strong_acc").as_double()};
+    double min_strong_acc{node_->get_parameter("smooth_stop_min_strong_acc").as_double()};
+    double weak_acc{node_->get_parameter("smooth_stop_weak_acc").as_double()};
+    double weak_stop_acc{node_->get_parameter("smooth_stop_weak_stop_acc").as_double()};
+    double strong_stop_acc{node_->get_parameter("smooth_stop_strong_stop_acc").as_double()};
+    double max_fast_vel{node_->get_parameter("smooth_stop_max_fast_vel").as_double()};
+    double min_running_vel{node_->get_parameter("smooth_stop_min_running_vel").as_double()};
+    double min_running_acc{node_->get_parameter("smooth_stop_min_running_acc").as_double()};
+    double weak_stop_time{node_->get_parameter("smooth_stop_weak_stop_time").as_double()};
+    double weak_stop_dist{node_->get_parameter("smooth_stop_weak_stop_dist").as_double()};
+    double strong_stop_dist{node_->get_parameter("smooth_stop_strong_stop_dist").as_double()};
     update_param("smooth_stop_max_strong_acc", max_strong_acc);
     update_param("smooth_stop_min_strong_acc", min_strong_acc);
     update_param("smooth_stop_weak_acc", weak_acc);
@@ -457,9 +455,9 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
     current_pose, *m_trajectory_ptr, m_ego_nearest_dist_threshold, m_ego_nearest_yaw_threshold);
 
   // pitch
-  const float64_t raw_pitch =
+  const double raw_pitch =
     trajectory_follower::longitudinal_utils::getPitchByPose(current_pose.orientation);
-  const float64_t traj_pitch = trajectory_follower::longitudinal_utils::getPitchByTraj(
+  const double traj_pitch = trajectory_follower::longitudinal_utils::getPitchByTraj(
     *m_trajectory_ptr, control_data.nearest_idx, m_wheel_base);
   control_data.slope_angle = m_use_traj_for_pitch ? traj_pitch : m_lpf_pitch->filter(raw_pitch);
   updatePitchDebugValues(control_data.slope_angle, traj_pitch, raw_pitch);
@@ -468,13 +466,13 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
 }
 
 PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCmd(
-  const float64_t dt) const
+  const double dt) const
 {
   // These accelerations are without slope compensation
   const auto & p = m_emergency_state_params;
-  const float64_t vel = trajectory_follower::longitudinal_utils::applyDiffLimitFilter(
+  const double vel = trajectory_follower::longitudinal_utils::applyDiffLimitFilter(
     p.vel, m_prev_raw_ctrl_cmd.vel, dt, p.acc);
-  const float64_t acc = trajectory_follower::longitudinal_utils::applyDiffLimitFilter(
+  const double acc = trajectory_follower::longitudinal_utils::applyDiffLimitFilter(
     p.acc, m_prev_raw_ctrl_cmd.acc, dt, p.jerk);
 
   RCLCPP_ERROR_THROTTLE(
@@ -486,39 +484,39 @@ PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCm
 
 void PidLongitudinalController::updateControlState(const ControlData & control_data)
 {
-  const float64_t current_vel = control_data.current_motion.vel;
-  const float64_t current_acc = control_data.current_motion.acc;
-  const float64_t stop_dist = control_data.stop_dist;
+  const double current_vel = control_data.current_motion.vel;
+  const double current_acc = control_data.current_motion.acc;
+  const double stop_dist = control_data.stop_dist;
 
   // flags for state transition
   const auto & p = m_state_transition_params;
 
-  const bool8_t departure_condition_from_stopping =
+  const bool departure_condition_from_stopping =
     stop_dist > p.drive_state_stop_dist + p.drive_state_offset_stop_dist;
-  const bool8_t departure_condition_from_stopped = stop_dist > p.drive_state_stop_dist;
+  const bool departure_condition_from_stopped = stop_dist > p.drive_state_stop_dist;
 
-  const bool8_t keep_stopped_condition =
+  const bool keep_stopped_condition =
     m_enable_keep_stopped_until_steer_convergence && !lateral_sync_data_.is_steer_converged;
 
-  const bool8_t stopping_condition = stop_dist < p.stopping_state_stop_dist;
+  const bool stopping_condition = stop_dist < p.stopping_state_stop_dist;
   if (
     std::fabs(current_vel) > p.stopped_state_entry_vel ||
     std::fabs(current_acc) > p.stopped_state_entry_acc) {
     m_last_running_time = std::make_shared<rclcpp::Time>(node_->now());
   }
-  const bool8_t stopped_condition =
+  const bool stopped_condition =
     m_last_running_time
       ? (node_->now() - *m_last_running_time).seconds() > p.stopped_state_entry_duration_time
       : false;
 
   static constexpr double vel_epsilon =
     1e-3;  // NOTE: the same velocity threshold as motion_utils::searchZeroVelocity
-  const float64_t current_vel_cmd =
+  const double current_vel_cmd =
     std::fabs(m_trajectory_ptr->points.at(control_data.nearest_idx).longitudinal_velocity_mps);
-  const bool8_t emergency_condition = m_enable_overshoot_emergency &&
+  const bool emergency_condition = m_enable_overshoot_emergency &&
                                       stop_dist < -p.emergency_state_overshoot_stop_dist &&
                                       current_vel_cmd < vel_epsilon;
-  const bool8_t has_nonzero_target_vel = std::abs(current_vel_cmd) > 1.0e-5;
+  const bool has_nonzero_target_vel = std::abs(current_vel_cmd) > 1.0e-5;
 
   const auto changeState = [this](const auto s) {
     if (s != m_control_state) {
@@ -544,9 +542,9 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
     if (m_enable_smooth_stop) {
       if (stopping_condition) {
         // predictions after input time delay
-        const float64_t pred_vel_in_target =
+        const double pred_vel_in_target =
           predictedVelocityInTargetPoint(control_data.current_motion, m_delay_compensation_time);
-        const float64_t pred_stop_dist =
+        const double pred_stop_dist =
           control_data.stop_dist -
           0.5 * (pred_vel_in_target + current_vel) * m_delay_compensation_time;
         m_smooth_stop.init(pred_vel_in_target, pred_stop_dist);
@@ -621,8 +619,8 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
   const geometry_msgs::msg::Pose & current_pose, const ControlData & control_data)
 {
   const size_t nearest_idx = control_data.nearest_idx;
-  const float64_t current_vel = control_data.current_motion.vel;
-  const float64_t current_acc = control_data.current_motion.acc;
+  const double current_vel = control_data.current_motion.vel;
+  const double current_acc = control_data.current_motion.acc;
 
   // velocity and acceleration command
   Motion raw_ctrl_cmd{};
@@ -638,7 +636,7 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
 
     target_motion = keepBrakeBeforeStop(*m_trajectory_ptr, target_motion, nearest_idx);
 
-    const float64_t pred_vel_in_target =
+    const double pred_vel_in_target =
       predictedVelocityInTargetPoint(control_data.current_motion, m_delay_compensation_time);
     m_debug_values.setValues(
       trajectory_follower::DebugValues::TYPE::PREDICTED_VEL, pred_vel_in_target);
@@ -676,7 +674,7 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
   m_prev_raw_ctrl_cmd = raw_ctrl_cmd;
 
   // apply slope compensation and filter acceleration and jerk
-  const float64_t filtered_acc_cmd = calcFilteredAcc(raw_ctrl_cmd.acc, control_data);
+  const double filtered_acc_cmd = calcFilteredAcc(raw_ctrl_cmd.acc, control_data);
   const Motion filtered_ctrl_cmd{raw_ctrl_cmd.vel, filtered_acc_cmd};
 
   // update debug visualization
@@ -687,7 +685,7 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
 
 // Do not use nearest_idx here
 autoware_auto_control_msgs::msg::LongitudinalCommand PidLongitudinalController::createCtrlCmdMsg(
-  const Motion & ctrl_cmd, const float64_t & current_vel)
+  const Motion & ctrl_cmd, const double & current_vel)
 {
   // publish control command
   autoware_auto_control_msgs::msg::LongitudinalCommand cmd{};
@@ -713,10 +711,9 @@ void PidLongitudinalController::publishDebugData(
   // set debug values
   m_debug_values.setValues(DebugValues::TYPE::DT, control_data.dt);
   m_debug_values.setValues(DebugValues::TYPE::CALCULATED_ACC, control_data.current_motion.acc);
-  m_debug_values.setValues(DebugValues::TYPE::SHIFT, static_cast<float64_t>(control_data.shift));
+  m_debug_values.setValues(DebugValues::TYPE::SHIFT, static_cast<double>(control_data.shift));
   m_debug_values.setValues(DebugValues::TYPE::STOP_DIST, control_data.stop_dist);
-  m_debug_values.setValues(
-    DebugValues::TYPE::CONTROL_STATE, static_cast<float64_t>(m_control_state));
+  m_debug_values.setValues(DebugValues::TYPE::CONTROL_STATE, static_cast<double>(m_control_state));
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PUBLISHED, ctrl_cmd.acc);
 
   // publish debug values
@@ -735,9 +732,9 @@ void PidLongitudinalController::publishDebugData(
   m_pub_slope->publish(slope_msg);
 }
 
-float64_t PidLongitudinalController::getDt()
+double PidLongitudinalController::getDt()
 {
-  float64_t dt;
+  double dt;
   if (!m_prev_control_time) {
     dt = m_longitudinal_ctrl_period;
     m_prev_control_time = std::make_shared<rclcpp::Time>(node_->now());
@@ -745,17 +742,17 @@ float64_t PidLongitudinalController::getDt()
     dt = (node_->now() - *m_prev_control_time).seconds();
     *m_prev_control_time = node_->now();
   }
-  const float64_t max_dt = m_longitudinal_ctrl_period * 2.0;
-  const float64_t min_dt = m_longitudinal_ctrl_period * 0.5;
+  const double max_dt = m_longitudinal_ctrl_period * 2.0;
+  const double min_dt = m_longitudinal_ctrl_period * 0.5;
   return std::max(std::min(dt, max_dt), min_dt);
 }
 
 enum PidLongitudinalController::Shift PidLongitudinalController::getCurrentShift(
   const size_t nearest_idx) const
 {
-  constexpr float64_t epsilon = 1e-5;
+  constexpr double epsilon = 1e-5;
 
-  const float64_t target_vel = m_trajectory_ptr->points.at(nearest_idx).longitudinal_velocity_mps;
+  const double target_vel = m_trajectory_ptr->points.at(nearest_idx).longitudinal_velocity_mps;
 
   if (target_vel > epsilon) {
     return Shift::Forward;
@@ -766,29 +763,29 @@ enum PidLongitudinalController::Shift PidLongitudinalController::getCurrentShift
   return m_prev_shift;
 }
 
-float64_t PidLongitudinalController::calcFilteredAcc(
-  const float64_t raw_acc, const ControlData & control_data)
+double PidLongitudinalController::calcFilteredAcc(
+  const double raw_acc, const ControlData & control_data)
 {
   using trajectory_follower::DebugValues;
-  const float64_t acc_max_filtered = std::clamp(raw_acc, m_min_acc, m_max_acc);
+  const double acc_max_filtered = std::clamp(raw_acc, m_min_acc, m_max_acc);
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_ACC_LIMITED, acc_max_filtered);
 
   // store ctrl cmd without slope filter
   storeAccelCmd(acc_max_filtered);
 
-  const float64_t acc_slope_filtered =
+  const double acc_slope_filtered =
     applySlopeCompensation(acc_max_filtered, control_data.slope_angle, control_data.shift);
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_SLOPE_APPLIED, acc_slope_filtered);
 
   // This jerk filter must be applied after slope compensation
-  const float64_t acc_jerk_filtered = trajectory_follower::longitudinal_utils::applyDiffLimitFilter(
+  const double acc_jerk_filtered = trajectory_follower::longitudinal_utils::applyDiffLimitFilter(
     acc_slope_filtered, m_prev_ctrl_cmd.acc, control_data.dt, m_max_jerk, m_min_jerk);
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_JERK_LIMITED, acc_jerk_filtered);
 
   return acc_jerk_filtered;
 }
 
-void PidLongitudinalController::storeAccelCmd(const float64_t accel)
+void PidLongitudinalController::storeAccelCmd(const double accel)
 {
   if (m_control_state == ControlState::DRIVE) {
     // convert format
@@ -812,17 +809,17 @@ void PidLongitudinalController::storeAccelCmd(const float64_t accel)
   }
 }
 
-float64_t PidLongitudinalController::applySlopeCompensation(
-  const float64_t input_acc, const float64_t pitch, const Shift shift) const
+double PidLongitudinalController::applySlopeCompensation(
+  const double input_acc, const double pitch, const Shift shift) const
 {
   if (!m_enable_slope_compensation) {
     return input_acc;
   }
-  const float64_t pitch_limited = std::min(std::max(pitch, m_min_pitch_rad), m_max_pitch_rad);
+  const double pitch_limited = std::min(std::max(pitch, m_min_pitch_rad), m_max_pitch_rad);
 
   // Acceleration command is always positive independent of direction (= shift) when car is running
-  float64_t sign = (shift == Shift::Forward) ? -1 : (shift == Shift::Reverse ? 1 : 0);
-  float64_t compensated_acc = input_acc + sign * 9.81 * std::sin(pitch_limited);
+  double sign = (shift == Shift::Forward) ? -1 : (shift == Shift::Reverse ? 1 : 0);
+  double compensated_acc = input_acc + sign * 9.81 * std::sin(pitch_limited);
   return compensated_acc;
 }
 
@@ -841,7 +838,7 @@ PidLongitudinalController::Motion PidLongitudinalController::keepBrakeBeforeStop
     return output_motion;
   }
 
-  float64_t min_acc_before_stop = std::numeric_limits<float64_t>::max();
+  double min_acc_before_stop = std::numeric_limits<double>::max();
   size_t min_acc_idx = std::numeric_limits<size_t>::max();
   for (int i = static_cast<int>(*stop_idx); i >= 0; --i) {
     const auto ui = static_cast<size_t>(i);
@@ -852,7 +849,7 @@ PidLongitudinalController::Motion PidLongitudinalController::keepBrakeBeforeStop
     min_acc_idx = ui;
   }
 
-  const float64_t brake_keeping_acc = std::max(m_brake_keeping_acc, min_acc_before_stop);
+  const double brake_keeping_acc = std::max(m_brake_keeping_acc, min_acc_before_stop);
   if (nearest_idx >= min_acc_idx && target_motion.acc > brake_keeping_acc) {
     output_motion.acc = brake_keeping_acc;
   }
@@ -874,24 +871,24 @@ PidLongitudinalController::calcInterpolatedTargetValue(
     traj.points, pose, m_ego_nearest_dist_threshold, m_ego_nearest_yaw_threshold);
 }
 
-float64_t PidLongitudinalController::predictedVelocityInTargetPoint(
-  const Motion current_motion, const float64_t delay_compensation_time) const
+double PidLongitudinalController::predictedVelocityInTargetPoint(
+  const Motion current_motion, const double delay_compensation_time) const
 {
-  const float64_t current_vel = current_motion.vel;
-  const float64_t current_acc = current_motion.acc;
+  const double current_vel = current_motion.vel;
+  const double current_acc = current_motion.acc;
 
   if (std::fabs(current_vel) < 1e-01) {  // when velocity is low, no prediction
     return current_vel;
   }
 
-  const float64_t current_vel_abs = std::fabs(current_vel);
+  const double current_vel_abs = std::fabs(current_vel);
   if (m_ctrl_cmd_vec.size() == 0) {
-    const float64_t pred_vel = current_vel + current_acc * delay_compensation_time;
+    const double pred_vel = current_vel + current_acc * delay_compensation_time;
     // avoid to change sign of current_vel and pred_vel
     return pred_vel > 0 ? std::copysign(pred_vel, current_vel) : 0.0;
   }
 
-  float64_t pred_vel = current_vel_abs;
+  double pred_vel = current_vel_abs;
 
   const auto past_delay_time =
     node_->now() - rclcpp::Duration::from_seconds(delay_compensation_time);
@@ -899,22 +896,22 @@ float64_t PidLongitudinalController::predictedVelocityInTargetPoint(
     if ((node_->now() - m_ctrl_cmd_vec.at(i).stamp).seconds() < m_delay_compensation_time) {
       if (i == 0) {
         // size of m_ctrl_cmd_vec is less than m_delay_compensation_time
-        pred_vel = current_vel_abs + static_cast<float64_t>(m_ctrl_cmd_vec.at(i).acceleration) *
-                                       delay_compensation_time;
+        pred_vel = current_vel_abs +
+                   static_cast<double>(m_ctrl_cmd_vec.at(i).acceleration) * delay_compensation_time;
         return pred_vel > 0 ? std::copysign(pred_vel, current_vel) : 0.0;
       }
       // add velocity to accel * dt
-      const float64_t acc = m_ctrl_cmd_vec.at(i - 1).acceleration;
+      const double acc = m_ctrl_cmd_vec.at(i - 1).acceleration;
       const auto curr_time_i = rclcpp::Time(m_ctrl_cmd_vec.at(i).stamp);
-      const float64_t time_to_next_acc = std::min(
+      const double time_to_next_acc = std::min(
         (curr_time_i - rclcpp::Time(m_ctrl_cmd_vec.at(i - 1).stamp)).seconds(),
         (curr_time_i - past_delay_time).seconds());
       pred_vel += acc * time_to_next_acc;
     }
   }
 
-  const float64_t last_acc = m_ctrl_cmd_vec.at(m_ctrl_cmd_vec.size() - 1).acceleration;
-  const float64_t time_to_current =
+  const double last_acc = m_ctrl_cmd_vec.at(m_ctrl_cmd_vec.size() - 1).acceleration;
+  const double time_to_current =
     (node_->now() - m_ctrl_cmd_vec.at(m_ctrl_cmd_vec.size() - 1).stamp).seconds();
   pred_vel += last_acc * time_to_current;
 
@@ -922,19 +919,19 @@ float64_t PidLongitudinalController::predictedVelocityInTargetPoint(
   return pred_vel > 0 ? std::copysign(pred_vel, current_vel) : 0.0;
 }
 
-float64_t PidLongitudinalController::applyVelocityFeedback(
-  const Motion target_motion, const float64_t dt, const float64_t current_vel)
+double PidLongitudinalController::applyVelocityFeedback(
+  const Motion target_motion, const double dt, const double current_vel)
 {
   using trajectory_follower::DebugValues;
-  const float64_t current_vel_abs = std::fabs(current_vel);
-  const float64_t target_vel_abs = std::fabs(target_motion.vel);
-  const bool8_t enable_integration = (current_vel_abs > m_current_vel_threshold_pid_integrate);
-  const float64_t error_vel_filtered = m_lpf_vel_error->filter(target_vel_abs - current_vel_abs);
+  const double current_vel_abs = std::fabs(current_vel);
+  const double target_vel_abs = std::fabs(target_motion.vel);
+  const bool enable_integration = (current_vel_abs > m_current_vel_threshold_pid_integrate);
+  const double error_vel_filtered = m_lpf_vel_error->filter(target_vel_abs - current_vel_abs);
 
-  std::vector<float64_t> pid_contributions(3);
-  const float64_t pid_acc =
+  std::vector<double> pid_contributions(3);
+  const double pid_acc =
     m_pid_vel.calculate(error_vel_filtered, dt, enable_integration, pid_contributions);
-  const float64_t feedback_acc = target_motion.acc + pid_acc;
+  const double feedback_acc = target_motion.acc + pid_acc;
 
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PID_APPLIED, feedback_acc);
   m_debug_values.setValues(DebugValues::TYPE::ERROR_VEL_FILTERED, error_vel_filtered);
@@ -949,10 +946,10 @@ float64_t PidLongitudinalController::applyVelocityFeedback(
 }
 
 void PidLongitudinalController::updatePitchDebugValues(
-  const float64_t pitch, const float64_t traj_pitch, const float64_t raw_pitch)
+  const double pitch, const double traj_pitch, const double raw_pitch)
 {
   using trajectory_follower::DebugValues;
-  const float64_t to_degrees = (180.0 / static_cast<float64_t>(autoware::common::types::PI));
+  const double to_degrees = (180.0 / static_cast<double>(M_PI));
   m_debug_values.setValues(DebugValues::TYPE::PITCH_LPF_RAD, pitch);
   m_debug_values.setValues(DebugValues::TYPE::PITCH_LPF_DEG, pitch * to_degrees);
   m_debug_values.setValues(DebugValues::TYPE::PITCH_RAW_RAD, raw_pitch);
@@ -966,7 +963,7 @@ void PidLongitudinalController::updateDebugVelAcc(
   const ControlData & control_data)
 {
   using trajectory_follower::DebugValues;
-  const float64_t current_vel = control_data.current_motion.vel;
+  const double current_vel = control_data.current_motion.vel;
 
   const auto interpolated_point = calcInterpolatedTargetValue(*m_trajectory_ptr, current_pose);
 

--- a/control/trajectory_follower/src/pid_longitudinal_controller.cpp
+++ b/control/trajectory_follower/src/pid_longitudinal_controller.cpp
@@ -514,8 +514,8 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
   const double current_vel_cmd =
     std::fabs(m_trajectory_ptr->points.at(control_data.nearest_idx).longitudinal_velocity_mps);
   const bool emergency_condition = m_enable_overshoot_emergency &&
-                                      stop_dist < -p.emergency_state_overshoot_stop_dist &&
-                                      current_vel_cmd < vel_epsilon;
+                                   stop_dist < -p.emergency_state_overshoot_stop_dist &&
+                                   current_vel_cmd < vel_epsilon;
   const bool has_nonzero_target_vel = std::abs(current_vel_cmd) > 1.0e-5;
 
   const auto changeState = [this](const auto s) {

--- a/control/trajectory_follower/src/qp_solver/qp_solver_osqp.cpp
+++ b/control/trajectory_follower/src/qp_solver/qp_solver_osqp.cpp
@@ -26,7 +26,7 @@ namespace control
 namespace trajectory_follower
 {
 QPSolverOSQP::QPSolverOSQP(const rclcpp::Logger & logger) : logger_{logger} {}
-bool8_t QPSolverOSQP::solve(
+bool QPSolverOSQP::solve(
   const Eigen::MatrixXd & h_mat, const Eigen::MatrixXd & f_vec, const Eigen::MatrixXd & a,
   const Eigen::VectorXd & lb, const Eigen::VectorXd & ub, const Eigen::VectorXd & lb_a,
   const Eigen::VectorXd & ub_a, Eigen::VectorXd & u)
@@ -37,17 +37,17 @@ bool8_t QPSolverOSQP::solve(
   Eigen::MatrixXd Identity = Eigen::MatrixXd::Identity(dim_u, dim_u);
 
   // convert matrix to vector for osqpsolver
-  std::vector<float64_t> f(&f_vec(0), f_vec.data() + f_vec.cols() * f_vec.rows());
+  std::vector<double> f(&f_vec(0), f_vec.data() + f_vec.cols() * f_vec.rows());
 
-  std::vector<float64_t> lower_bound;
-  std::vector<float64_t> upper_bound;
+  std::vector<double> lower_bound;
+  std::vector<double> upper_bound;
 
-  for (int64_t i = 0; i < dim_u; ++i) {
+  for (int i = 0; i < dim_u; ++i) {
     lower_bound.push_back(lb(i));
     upper_bound.push_back(ub(i));
   }
 
-  for (int64_t i = 0; i < col_a; ++i) {
+  for (int i = 0; i < col_a; ++i) {
     lower_bound.push_back(lb_a(i));
     upper_bound.push_back(ub_a(i));
   }
@@ -58,24 +58,24 @@ bool8_t QPSolverOSQP::solve(
   /* execute optimization */
   auto result = osqpsolver_.optimize(h_mat, osqpA, f, lower_bound, upper_bound);
 
-  std::vector<float64_t> U_osqp = std::get<0>(result);
-  u = Eigen::Map<Eigen::Matrix<float64_t, Eigen::Dynamic, 1>>(
+  std::vector<double> U_osqp = std::get<0>(result);
+  u = Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1>>(
     &U_osqp[0], static_cast<Eigen::Index>(U_osqp.size()), 1);
 
-  const int64_t status_val = std::get<3>(result);
+  const int status_val = std::get<3>(result);
   if (status_val != 1) {
     // TODO(Horibe): Should return false and the failure must be handled in an appropriate way.
     RCLCPP_WARN(logger_, "optimization failed : %s", osqpsolver_.getStatusMessage().c_str());
   }
 
   // polish status: successful (1), unperformed (0), (-1) unsuccessful
-  int64_t status_polish = std::get<2>(result);
+  int status_polish = std::get<2>(result);
   if (status_polish == -1) {
-    RCLCPP_WARN(logger_, "osqp status_polish = %ld (unsuccessful)", status_polish);
+    RCLCPP_WARN(logger_, "osqp status_polish = %d (unsuccessful)", status_polish);
     return false;
   }
   if (status_polish == 0) {
-    RCLCPP_WARN(logger_, "osqp status_polish = %ld (unperformed)", status_polish);
+    RCLCPP_WARN(logger_, "osqp status_polish = %d (unperformed)", status_polish);
     return true;
   }
   return true;

--- a/control/trajectory_follower/src/qp_solver/qp_solver_unconstr_fast.cpp
+++ b/control/trajectory_follower/src/qp_solver/qp_solver_unconstr_fast.cpp
@@ -23,7 +23,7 @@ namespace control
 namespace trajectory_follower
 {
 QPSolverEigenLeastSquareLLT::QPSolverEigenLeastSquareLLT() {}
-bool8_t QPSolverEigenLeastSquareLLT::solve(
+bool QPSolverEigenLeastSquareLLT::solve(
   const Eigen::MatrixXd & h_mat, const Eigen::MatrixXd & f_vec, const Eigen::MatrixXd & /*a*/,
   const Eigen::VectorXd & /*lb*/, const Eigen::VectorXd & /*ub*/, const Eigen::VectorXd & /*lb_a*/,
   const Eigen::VectorXd & /*ub_a*/, Eigen::VectorXd & u)

--- a/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_dynamics.cpp
+++ b/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_dynamics.cpp
@@ -25,12 +25,12 @@ namespace control
 namespace trajectory_follower
 {
 DynamicsBicycleModel::DynamicsBicycleModel(
-  const float64_t wheelbase, const float64_t mass_fl, const float64_t mass_fr,
-  const float64_t mass_rl, const float64_t mass_rr, const float64_t cf, const float64_t cr)
+  const double wheelbase, const double mass_fl, const double mass_fr, const double mass_rl,
+  const double mass_rr, const double cf, const double cr)
 : VehicleModelInterface(/* dim_x */ 4, /* dim_u */ 1, /* dim_y */ 2, wheelbase)
 {
-  const float64_t mass_front = mass_fl + mass_fr;
-  const float64_t mass_rear = mass_rl + mass_rr;
+  const double mass_front = mass_fl + mass_fr;
+  const double mass_rear = mass_rl + mass_rr;
 
   m_mass = mass_front + mass_rear;
   m_lf = m_wheelbase * (1.0 - mass_front / m_mass);
@@ -42,13 +42,13 @@ DynamicsBicycleModel::DynamicsBicycleModel(
 
 void DynamicsBicycleModel::calculateDiscreteMatrix(
   Eigen::MatrixXd & a_d, Eigen::MatrixXd & b_d, Eigen::MatrixXd & c_d, Eigen::MatrixXd & w_d,
-  const float64_t dt)
+  const double dt)
 {
   /*
    * x[k+1] = a_d*x[k] + b_d*u + w_d
    */
 
-  const float64_t vel = std::max(m_velocity, 0.01);
+  const double vel = std::max(m_velocity, 0.01);
 
   a_d = Eigen::MatrixXd::Zero(m_dim_x, m_dim_x);
   a_d(0, 1) = 1.0;
@@ -87,8 +87,8 @@ void DynamicsBicycleModel::calculateDiscreteMatrix(
 
 void DynamicsBicycleModel::calculateReferenceInput(Eigen::MatrixXd & u_ref)
 {
-  const float64_t vel = std::max(m_velocity, 0.01);
-  const float64_t Kv =
+  const double vel = std::max(m_velocity, 0.01);
+  const double Kv =
     m_lr * m_mass / (2 * m_cf * m_wheelbase) - m_lf * m_mass / (2 * m_cr * m_wheelbase);
   u_ref(0, 0) = m_wheelbase * m_curvature + Kv * vel * vel * m_curvature;
 }

--- a/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
+++ b/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
@@ -25,7 +25,7 @@ namespace control
 namespace trajectory_follower
 {
 KinematicsBicycleModel::KinematicsBicycleModel(
-  const float64_t wheelbase, const float64_t steer_lim, const float64_t steer_tau)
+  const double wheelbase, const double steer_lim, const double steer_tau)
 : VehicleModelInterface(/* dim_x */ 3, /* dim_u */ 1, /* dim_y */ 2, wheelbase)
 {
   m_steer_lim = steer_lim;
@@ -34,17 +34,17 @@ KinematicsBicycleModel::KinematicsBicycleModel(
 
 void KinematicsBicycleModel::calculateDiscreteMatrix(
   Eigen::MatrixXd & a_d, Eigen::MatrixXd & b_d, Eigen::MatrixXd & c_d, Eigen::MatrixXd & w_d,
-  const float64_t dt)
+  const double dt)
 {
-  auto sign = [](float64_t x) { return (x > 0.0) - (x < 0.0); };
+  auto sign = [](double x) { return (x > 0.0) - (x < 0.0); };
 
   /* Linearize delta around delta_r (reference delta) */
-  float64_t delta_r = atan(m_wheelbase * m_curvature);
+  double delta_r = atan(m_wheelbase * m_curvature);
   if (std::abs(delta_r) >= m_steer_lim) {
-    delta_r = m_steer_lim * static_cast<float64_t>(sign(delta_r));
+    delta_r = m_steer_lim * static_cast<double>(sign(delta_r));
   }
-  float64_t cos_delta_r_squared_inv = 1 / (cos(delta_r) * cos(delta_r));
-  float64_t velocity = m_velocity;
+  double cos_delta_r_squared_inv = 1 / (cos(delta_r) * cos(delta_r));
+  double velocity = m_velocity;
   if (std::abs(m_velocity) < 1e-04) {
     velocity = 1e-04 * (m_velocity >= 0 ? 1 : -1);
   }

--- a/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.cpp
+++ b/control/trajectory_follower/src/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.cpp
@@ -25,7 +25,7 @@ namespace control
 namespace trajectory_follower
 {
 KinematicsBicycleModelNoDelay::KinematicsBicycleModelNoDelay(
-  const float64_t wheelbase, const float64_t steer_lim)
+  const double wheelbase, const double steer_lim)
 : VehicleModelInterface(/* dim_x */ 2, /* dim_u */ 1, /* dim_y */ 2, wheelbase)
 {
   m_steer_lim = steer_lim;
@@ -33,16 +33,16 @@ KinematicsBicycleModelNoDelay::KinematicsBicycleModelNoDelay(
 
 void KinematicsBicycleModelNoDelay::calculateDiscreteMatrix(
   Eigen::MatrixXd & a_d, Eigen::MatrixXd & b_d, Eigen::MatrixXd & c_d, Eigen::MatrixXd & w_d,
-  const float64_t dt)
+  const double dt)
 {
-  auto sign = [](float64_t x) { return (x > 0.0) - (x < 0.0); };
+  auto sign = [](double x) { return (x > 0.0) - (x < 0.0); };
 
   /* Linearize delta around delta_r (reference delta) */
-  float64_t delta_r = atan(m_wheelbase * m_curvature);
+  double delta_r = atan(m_wheelbase * m_curvature);
   if (std::abs(delta_r) >= m_steer_lim) {
-    delta_r = m_steer_lim * static_cast<float64_t>(sign(delta_r));
+    delta_r = m_steer_lim * static_cast<double>(sign(delta_r));
   }
-  float64_t cos_delta_r_squared_inv = 1 / (cos(delta_r) * cos(delta_r));
+  double cos_delta_r_squared_inv = 1 / (cos(delta_r) * cos(delta_r));
 
   a_d << 0.0, m_velocity, 0.0, 0.0;
 

--- a/control/trajectory_follower/src/vehicle_model/vehicle_model_interface.cpp
+++ b/control/trajectory_follower/src/vehicle_model/vehicle_model_interface.cpp
@@ -22,17 +22,16 @@ namespace control
 {
 namespace trajectory_follower
 {
-VehicleModelInterface::VehicleModelInterface(
-  int64_t dim_x, int64_t dim_u, int64_t dim_y, float64_t wheelbase)
+VehicleModelInterface::VehicleModelInterface(int dim_x, int dim_u, int dim_y, double wheelbase)
 : m_dim_x(dim_x), m_dim_u(dim_u), m_dim_y(dim_y), m_wheelbase(wheelbase)
 {
 }
-int64_t VehicleModelInterface::getDimX() { return m_dim_x; }
-int64_t VehicleModelInterface::getDimU() { return m_dim_u; }
-int64_t VehicleModelInterface::getDimY() { return m_dim_y; }
-float64_t VehicleModelInterface::getWheelbase() { return m_wheelbase; }
-void VehicleModelInterface::setVelocity(const float64_t velocity) { m_velocity = velocity; }
-void VehicleModelInterface::setCurvature(const float64_t curvature) { m_curvature = curvature; }
+int VehicleModelInterface::getDimX() { return m_dim_x; }
+int VehicleModelInterface::getDimU() { return m_dim_u; }
+int VehicleModelInterface::getDimY() { return m_dim_y; }
+double VehicleModelInterface::getWheelbase() { return m_wheelbase; }
+void VehicleModelInterface::setVelocity(const double velocity) { m_velocity = velocity; }
+void VehicleModelInterface::setCurvature(const double curvature) { m_curvature = curvature; }
 }  // namespace trajectory_follower
 }  // namespace control
 }  // namespace motion

--- a/control/trajectory_follower/test/test_interpolate.cpp
+++ b/control/trajectory_follower/test/test_interpolate.cpp
@@ -12,23 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "common/types.hpp"
 #include "gtest/gtest.h"
 #include "trajectory_follower/interpolate.hpp"
 
 #include <vector>
 
-using autoware::common::types::float64_t;
 TEST(TestInterpolate, Nominal)
 {
   using autoware::motion::control::trajectory_follower::linearInterpolate;
 
   // Simple case
   {
-    std::vector<float64_t> original_indexes = {1.0, 2.0, 3.0};
-    std::vector<float64_t> original_values = {1.0, 2.0, 3.0};
-    std::vector<float64_t> target_indexes = {1.5, 2.5};
-    std::vector<float64_t> target_values;
+    std::vector<double> original_indexes = {1.0, 2.0, 3.0};
+    std::vector<double> original_values = {1.0, 2.0, 3.0};
+    std::vector<double> target_indexes = {1.5, 2.5};
+    std::vector<double> target_values;
 
     ASSERT_TRUE(
       linearInterpolate(original_indexes, original_values, target_indexes, target_values));
@@ -39,10 +37,10 @@ TEST(TestInterpolate, Nominal)
   }
   // Non regular indexes
   {
-    std::vector<float64_t> original_indexes = {1.0, 1.5, 3.0};
-    std::vector<float64_t> original_values = {1.0, 2.0, 3.5};
-    std::vector<float64_t> target_indexes = {1.25, 2.5, 3.0};
-    std::vector<float64_t> target_values;
+    std::vector<double> original_indexes = {1.0, 1.5, 3.0};
+    std::vector<double> original_values = {1.0, 2.0, 3.5};
+    std::vector<double> target_indexes = {1.25, 2.5, 3.0};
+    std::vector<double> target_values;
 
     ASSERT_TRUE(
       linearInterpolate(original_indexes, original_values, target_indexes, target_values));
@@ -53,10 +51,10 @@ TEST(TestInterpolate, Nominal)
   }
   // Single index query
   {
-    std::vector<float64_t> original_indexes = {1.0, 1.5, 3.0};
-    std::vector<float64_t> original_values = {1.0, 2.0, 3.5};
-    float64_t target_index = 1.25;
-    float64_t target_value;
+    std::vector<double> original_indexes = {1.0, 1.5, 3.0};
+    std::vector<double> original_values = {1.0, 2.0, 3.5};
+    double target_index = 1.25;
+    double target_value;
 
     ASSERT_TRUE(linearInterpolate(original_indexes, original_values, target_index, target_value));
     EXPECT_EQ(target_value, 1.5);
@@ -66,7 +64,7 @@ TEST(TestInterpolate, Failure)
 {
   using autoware::motion::control::trajectory_follower::linearInterpolate;
 
-  std::vector<float64_t> target_values;
+  std::vector<double> target_values;
 
   // Non increasing indexes
   ASSERT_FALSE(

--- a/control/trajectory_follower/test/test_lowpass_filter.cpp
+++ b/control/trajectory_follower/test/test_lowpass_filter.cpp
@@ -12,19 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "common/types.hpp"
 #include "gtest/gtest.h"
 #include "trajectory_follower/lowpass_filter.hpp"
 
 #include <vector>
 
-using autoware::common::types::float64_t;
-
 TEST(TestLowpassFilter, LowpassFilter1d)
 {
   using autoware::motion::control::trajectory_follower::LowpassFilter1d;
 
-  const float64_t epsilon = 1e-6;
+  const double epsilon = 1e-6;
   LowpassFilter1d lowpass_filter_1d(0.0, 0.1);
 
   // initial state
@@ -47,14 +44,14 @@ TEST(TestLowpassFilter, MoveAverageFilter)
   namespace MoveAverageFilter = autoware::motion::control::trajectory_follower::MoveAverageFilter;
 
   {  // Fail case: window size higher than the vector size
-    const int64_t window_size = 5;
-    std::vector<float64_t> vec = {1.0, 2.0, 3.0, 4.0};
+    const int window_size = 5;
+    std::vector<double> vec = {1.0, 2.0, 3.0, 4.0};
     EXPECT_FALSE(MoveAverageFilter::filt_vector(window_size, vec));
   }  // namespace autoware::motion::control::trajectory_follower::MoveAverageFilter;
   {
-    const int64_t window_size = 0;
-    const std::vector<float64_t> original_vec = {1.0, 3.0, 4.0, 6.0};
-    std::vector<float64_t> filtered_vec = original_vec;
+    const int window_size = 0;
+    const std::vector<double> original_vec = {1.0, 3.0, 4.0, 6.0};
+    std::vector<double> filtered_vec = original_vec;
     EXPECT_TRUE(MoveAverageFilter::filt_vector(window_size, filtered_vec));
     ASSERT_EQ(filtered_vec.size(), original_vec.size());
     for (size_t i = 0; i < filtered_vec.size(); ++i) {
@@ -62,9 +59,9 @@ TEST(TestLowpassFilter, MoveAverageFilter)
     }
   }
   {
-    const int64_t window_size = 1;
-    const std::vector<float64_t> original_vec = {1.0, 3.0, 4.0, 6.0};
-    std::vector<float64_t> filtered_vec = original_vec;
+    const int window_size = 1;
+    const std::vector<double> original_vec = {1.0, 3.0, 4.0, 6.0};
+    std::vector<double> filtered_vec = original_vec;
     EXPECT_TRUE(MoveAverageFilter::filt_vector(window_size, filtered_vec));
     ASSERT_EQ(filtered_vec.size(), original_vec.size());
     EXPECT_EQ(filtered_vec[0], original_vec[0]);
@@ -73,9 +70,9 @@ TEST(TestLowpassFilter, MoveAverageFilter)
     EXPECT_EQ(filtered_vec[3], original_vec[3]);
   }
   {
-    const int64_t window_size = 2;
-    const std::vector<float64_t> original_vec = {1.0, 3.0, 4.0, 6.0, 7.0, 10.0};
-    std::vector<float64_t> filtered_vec = original_vec;
+    const int window_size = 2;
+    const std::vector<double> original_vec = {1.0, 3.0, 4.0, 6.0, 7.0, 10.0};
+    std::vector<double> filtered_vec = original_vec;
     EXPECT_TRUE(MoveAverageFilter::filt_vector(window_size, filtered_vec));
     ASSERT_EQ(filtered_vec.size(), original_vec.size());
     EXPECT_EQ(filtered_vec[0], original_vec[0]);
@@ -89,15 +86,15 @@ TEST(TestLowpassFilter, MoveAverageFilter)
 TEST(TestLowpassFilter, Butterworth2dFilter)
 {
   using autoware::motion::control::trajectory_follower::Butterworth2dFilter;
-  const float64_t dt = 1.0;
-  const float64_t cutoff_hz = 1.0;
+  const double dt = 1.0;
+  const double cutoff_hz = 1.0;
   Butterworth2dFilter filter(dt, cutoff_hz);
-  for (float64_t i = 1.0; i < 10.0; ++i) {
+  for (double i = 1.0; i < 10.0; ++i) {
     EXPECT_LT(filter.filter(i), i);
   }
 
-  const std::vector<float64_t> original_vec = {1.0, 2.0, 3.0, 4.0};
-  std::vector<float64_t> filtered_vec;
+  const std::vector<double> original_vec = {1.0, 2.0, 3.0, 4.0};
+  std::vector<double> filtered_vec;
   filter.filt_vector(original_vec, filtered_vec);
   ASSERT_EQ(filtered_vec.size(), original_vec.size());
   EXPECT_EQ(filtered_vec[0], original_vec[0]);
@@ -109,7 +106,7 @@ TEST(TestLowpassFilter, Butterworth2dFilter)
   filter.filtfilt_vector(original_vec, filtered_vec);
   ASSERT_EQ(filtered_vec.size(), original_vec.size());
 
-  std::vector<float64_t> coefficients;
+  std::vector<double> coefficients;
   filter.getCoefficients(coefficients);
   EXPECT_EQ(coefficients.size(), size_t(6));
 }

--- a/control/trajectory_follower/test/test_mpc.cpp
+++ b/control/trajectory_follower/test/test_mpc.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "common/types.hpp"
 #include "gtest/gtest.h"
 #include "trajectory_follower/mpc.hpp"
 #include "trajectory_follower/qp_solver/qp_solver_osqp.hpp"
@@ -38,8 +37,7 @@
 
 namespace
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 typedef autoware_auto_planning_msgs::msg::Trajectory Trajectory;
 typedef autoware_auto_planning_msgs::msg::TrajectoryPoint TrajectoryPoint;
@@ -59,33 +57,33 @@ protected:
   SteeringReport neutral_steer;
   Pose pose_zero;
   PoseStamped::SharedPtr pose_zero_ptr;
-  float64_t default_velocity = 1.0;
+  double default_velocity = 1.0;
   rclcpp::Logger logger = rclcpp::get_logger("mpc_test_logger");
   // Vehicle model parameters
-  float64_t wheelbase = 2.7;
-  float64_t steer_limit = 1.0;
-  float64_t steer_tau = 0.1;
-  float64_t mass_fl = 600.0;
-  float64_t mass_fr = 600.0;
-  float64_t mass_rl = 600.0;
-  float64_t mass_rr = 600.0;
-  float64_t cf = 155494.663;
-  float64_t cr = 155494.663;
+  double wheelbase = 2.7;
+  double steer_limit = 1.0;
+  double steer_tau = 0.1;
+  double mass_fl = 600.0;
+  double mass_fr = 600.0;
+  double mass_rl = 600.0;
+  double mass_rr = 600.0;
+  double cf = 155494.663;
+  double cr = 155494.663;
   // Filters parameter
-  float64_t steering_lpf_cutoff_hz = 3.0;
-  float64_t error_deriv_lpf_cutoff_hz = 5.0;
+  double steering_lpf_cutoff_hz = 3.0;
+  double error_deriv_lpf_cutoff_hz = 5.0;
   // Test Parameters
-  float64_t admissible_position_error = 5.0;
-  float64_t admissible_yaw_error_rad = M_PI_2;
-  float64_t steer_lim = 0.610865;      // 35 degrees
-  float64_t steer_rate_lim = 2.61799;  // 150 degrees
-  float64_t ctrl_period = 0.03;
-  float64_t traj_resample_dist = 0.1;
-  int64_t path_filter_moving_ave_num = 35;
-  int64_t curvature_smoothing_num_traj = 1;
-  int64_t curvature_smoothing_num_ref_steer = 35;
-  bool8_t enable_path_smoothing = true;
-  bool8_t use_steer_prediction = true;
+  double admissible_position_error = 5.0;
+  double admissible_yaw_error_rad = M_PI_2;
+  double steer_lim = 0.610865;      // 35 degrees
+  double steer_rate_lim = 2.61799;  // 150 degrees
+  double ctrl_period = 0.03;
+  double traj_resample_dist = 0.1;
+  int path_filter_moving_ave_num = 35;
+  int curvature_smoothing_num_traj = 1;
+  int curvature_smoothing_num_ref_steer = 35;
+  bool enable_path_smoothing = true;
+  bool use_steer_prediction = true;
 
   void SetUp() override
   {

--- a/control/trajectory_follower_nodes/include/trajectory_follower_nodes/controller_node.hpp
+++ b/control/trajectory_follower_nodes/include/trajectory_follower_nodes/controller_node.hpp
@@ -56,8 +56,7 @@ using trajectory_follower::LateralOutput;
 using trajectory_follower::LongitudinalOutput;
 namespace trajectory_follower_nodes
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float64_t;
+
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 
 /// \classController

--- a/control/trajectory_follower_nodes/src/controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/controller_node.cpp
@@ -81,7 +81,7 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
   // Timer
   {
     const auto period_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-      std::chrono::duration<float64_t>(ctrl_period));
+      std::chrono::duration<double>(ctrl_period));
     timer_control_ = rclcpp::create_timer(
       this, get_clock(), period_ns, std::bind(&Controller::callbackTimerControl, this));
   }

--- a/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
+++ b/control/trajectory_follower_nodes/test/trajectory_follower_test_utils.hpp
@@ -31,7 +31,7 @@ using FakeNodeFixture = autoware::tools::testing::FakeTestNode;
 
 inline void waitForMessage(
   const std::shared_ptr<rclcpp::Node> & node, FakeNodeFixture * fixture, const bool & received_flag,
-  const std::chrono::duration<int64_t> max_wait_time = std::chrono::seconds{10LL},
+  const std::chrono::duration<int> max_wait_time = std::chrono::seconds{10LL},
   const bool fail_on_timeout = true)
 {
   const auto dt{std::chrono::milliseconds{100LL}};


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

related to https://github.com/autowarefoundation/autoware.universe/issues/2229

remove autoware_auto_common dependency, which is added in autoware.auto, from trajectory_follower/trajectory_follower_nodes
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
