### PR TITLE
refactor(trajectory_follower/trajectory_follower_nodes): remove motion_common

### DIFF
--- a/control/trajectory_follower/include/trajectory_follower/longitudinal_controller_utils.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/longitudinal_controller_utils.hpp
@@ -19,8 +19,7 @@
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Geometry"
 #include "geometry/common_2d.hpp"
-#include "motion_common/motion_common.hpp"
-#include "motion_common/trajectory_common.hpp"
+#include "interpolation/linear_interpolation.hpp"
 #include "motion_utils/trajectory/trajectory.hpp"
 #include "tf2/utils.h"
 #include "trajectory_follower/visibility_control.hpp"
@@ -50,8 +49,6 @@ using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Quaternion;
-namespace motion_common = ::motion::motion_common;
-namespace trajectory_common = ::autoware::motion::motion_common;
 
 /**
  * @brief check if trajectory is invalid or not
@@ -117,27 +114,26 @@ TRAJECTORY_FOLLOWER_PUBLIC TrajectoryPoint lerpTrajectoryPoint(
 
   const float64_t len_to_interpolated =
     motion_utils::calcLongitudinalOffsetToSegment(points, seg_idx, pose.position);
-  const float64_t len_segment =
-    trajectory_common::calcSignedArcLength(points, seg_idx, seg_idx + 1);
+  const float64_t len_segment = motion_utils::calcSignedArcLength(points, seg_idx, seg_idx + 1);
   const float64_t interpolate_ratio = std::clamp(len_to_interpolated / len_segment, 0.0, 1.0);
 
   {
     const size_t i = seg_idx;
 
-    interpolated_point.pose.position.x = motion_common::interpolate(
+    interpolated_point.pose.position.x = interpolation::lerp(
       points.at(i).pose.position.x, points.at(i + 1).pose.position.x, interpolate_ratio);
-    interpolated_point.pose.position.y = motion_common::interpolate(
+    interpolated_point.pose.position.y = interpolation::lerp(
       points.at(i).pose.position.y, points.at(i + 1).pose.position.y, interpolate_ratio);
     interpolated_point.pose.orientation = lerpOrientation(
       points.at(i).pose.orientation, points.at(i + 1).pose.orientation, interpolate_ratio);
-    interpolated_point.longitudinal_velocity_mps = motion_common::interpolate(
+    interpolated_point.longitudinal_velocity_mps = interpolation::lerp(
       points.at(i).longitudinal_velocity_mps, points.at(i + 1).longitudinal_velocity_mps,
       interpolate_ratio);
-    interpolated_point.lateral_velocity_mps = motion_common::interpolate(
+    interpolated_point.lateral_velocity_mps = interpolation::lerp(
       points.at(i).lateral_velocity_mps, points.at(i + 1).lateral_velocity_mps, interpolate_ratio);
-    interpolated_point.acceleration_mps2 = motion_common::interpolate(
+    interpolated_point.acceleration_mps2 = interpolation::lerp(
       points.at(i).acceleration_mps2, points.at(i + 1).acceleration_mps2, interpolate_ratio);
-    interpolated_point.heading_rate_rps = motion_common::interpolate(
+    interpolated_point.heading_rate_rps = interpolation::lerp(
       points.at(i).heading_rate_rps, points.at(i + 1).heading_rate_rps, interpolate_ratio);
   }
 

--- a/control/trajectory_follower/include/trajectory_follower/mpc.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc.hpp
@@ -18,7 +18,6 @@
 #include "common/types.hpp"
 #include "geometry/common_2d.hpp"
 #include "helper_functions/angle_utils.hpp"
-#include "motion_common/motion_common.hpp"
 #include "osqp_interface/osqp_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"

--- a/control/trajectory_follower/include/trajectory_follower/mpc_utils.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_utils.hpp
@@ -21,7 +21,6 @@
 #include "helper_functions/angle_utils.hpp"
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation.hpp"
-#include "motion_common/motion_common.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 

--- a/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/pid_longitudinal_controller.hpp
@@ -18,8 +18,6 @@
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Geometry"
-#include "motion_common/motion_common.hpp"
-#include "motion_common/trajectory_common.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tf2_ros/buffer.h"
@@ -57,7 +55,6 @@ namespace trajectory_follower
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
-namespace motion_common = ::autoware::motion::motion_common;
 
 /// \class PidLongitudinalController
 /// \brief The node class used for generating longitudinal control commands (velocity/acceleration)

--- a/control/trajectory_follower/package.xml
+++ b/control/trajectory_follower/package.xml
@@ -31,7 +31,6 @@
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>interpolation</depend>
-  <depend>motion_common</depend>
   <depend>motion_utils</depend>
   <depend>osqp_interface</depend>
   <depend>rclcpp</depend>

--- a/control/trajectory_follower/src/longitudinal_controller_utils.cpp
+++ b/control/trajectory_follower/src/longitudinal_controller_utils.cpp
@@ -14,7 +14,6 @@
 
 #include "trajectory_follower/longitudinal_controller_utils.hpp"
 
-#include "motion_common/motion_common.hpp"
 #include "tf2/LinearMath/Matrix3x3.h"
 #include "tf2/LinearMath/Quaternion.h"
 
@@ -66,8 +65,7 @@ float64_t calcStopDistance(
   const Pose & current_pose, const Trajectory & traj, const float64_t max_dist,
   const float64_t max_yaw)
 {
-  const std::experimental::optional<size_t> stop_idx_opt =
-    trajectory_common::searchZeroVelocityIndex(traj.points);
+  const auto stop_idx_opt = motion_utils::searchZeroVelocityIndex(traj.points);
 
   const size_t end_idx = stop_idx_opt ? *stop_idx_opt : traj.points.size() - 1;
   const size_t seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
@@ -142,7 +140,7 @@ Pose calcPoseAfterTimeDelay(
   const Pose & current_pose, const float64_t delay_time, const float64_t current_vel)
 {
   // simple linear prediction
-  const float64_t yaw = ::motion::motion_common::to_angle(current_pose.orientation);
+  const float64_t yaw = tf2::getYaw(current_pose.orientation);
   const float64_t running_distance = delay_time * current_vel;
   const float64_t dx = running_distance * std::cos(yaw);
   const float64_t dy = running_distance * std::sin(yaw);

--- a/control/trajectory_follower/src/mpc.cpp
+++ b/control/trajectory_follower/src/mpc.cpp
@@ -36,7 +36,6 @@ namespace control
 namespace trajectory_follower
 {
 using namespace std::literals::chrono_literals;
-using ::motion::motion_common::to_angle;
 
 bool8_t MPC::calculateMPC(
   const autoware_auto_vehicle_msgs::msg::SteeringReport & current_steer,
@@ -150,9 +149,9 @@ bool8_t MPC::calculateMPC(
   // [5] lateral error
   append_diag_data(mpc_data.lateral_err);
   // [6] current_pose yaw
-  append_diag_data(to_angle(current_pose.orientation));
+  append_diag_data(tf2::getYaw(current_pose.orientation));
   // [7] nearest_pose yaw
-  append_diag_data(to_angle(mpc_data.nearest_pose.orientation));
+  append_diag_data(tf2::getYaw(mpc_data.nearest_pose.orientation));
   // [8] yaw error
   append_diag_data(mpc_data.yaw_err);
   // [9] reference velocity
@@ -280,7 +279,7 @@ bool8_t MPC::getData(
   data->lateral_err =
     trajectory_follower::MPCUtils::calcLateralError(current_pose, data->nearest_pose);
   data->yaw_err = autoware::common::helper_functions::wrap_angle(
-    to_angle(current_pose.orientation) - to_angle(data->nearest_pose.orientation));
+    tf2::getYaw(current_pose.orientation) - tf2::getYaw(data->nearest_pose.orientation));
 
   /* get predicted steer */
   if (!m_steer_prediction_prev) {

--- a/control/trajectory_follower/src/mpc_utils.cpp
+++ b/control/trajectory_follower/src/mpc_utils.cpp
@@ -15,6 +15,7 @@
 #include "trajectory_follower/mpc_utils.hpp"
 
 #include "motion_utils/motion_utils.hpp"
+#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -56,7 +57,7 @@ float64_t calcLateralError(
 {
   const float64_t err_x = ego_pose.position.x - ref_pose.position.x;
   const float64_t err_y = ego_pose.position.y - ref_pose.position.y;
-  const float64_t ref_yaw = ::motion::motion_common::to_angle(ref_pose.orientation);
+  const float64_t ref_yaw = tf2::getYaw(ref_pose.orientation);
   const float64_t lat_err = -std::sin(ref_yaw) * err_x + std::cos(ref_yaw) * err_y;
   return lat_err;
 }
@@ -232,7 +233,7 @@ bool8_t convertToMPCTrajectory(
     const float64_t x = p.pose.position.x;
     const float64_t y = p.pose.position.y;
     const float64_t z = 0.0;
-    const float64_t yaw = ::motion::motion_common::to_angle(p.pose.orientation);
+    const float64_t yaw = tf2::getYaw(p.pose.orientation);
     const float64_t vx = p.longitudinal_velocity_mps;
     const float64_t k = 0.0;
     const float64_t t = 0.0;
@@ -252,7 +253,7 @@ bool8_t convertToAutowareTrajectory(
     p.pose.position.x = static_cast<Real>(input.x.at(i));
     p.pose.position.y = static_cast<Real>(input.y.at(i));
     p.pose.position.z = static_cast<Real>(input.z.at(i));
-    p.pose.orientation = ::motion::motion_common::from_angle(input.yaw.at(i));
+    p.pose.orientation = tier4_autoware_utils::createQuaternionFromYaw(input.yaw.at(i));
     p.longitudinal_velocity_mps =
       static_cast<decltype(p.longitudinal_velocity_mps)>(input.vx.at(i));
     output.points.push_back(p);

--- a/control/trajectory_follower/src/pid_longitudinal_controller.cpp
+++ b/control/trajectory_follower/src/pid_longitudinal_controller.cpp
@@ -14,10 +14,8 @@
 
 #include "trajectory_follower/pid_longitudinal_controller.hpp"
 
-#include "motion_common/motion_common.hpp"
-#include "motion_common/trajectory_common.hpp"
+#include "motion_utils/motion_utils.hpp"
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
-#include "time_utils/time_utils.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -735,7 +733,7 @@ float64_t PidLongitudinalController::calcFilteredAcc(
   const float64_t raw_acc, const ControlData & control_data)
 {
   using trajectory_follower::DebugValues;
-  const float64_t acc_max_filtered = ::motion::motion_common::clamp(raw_acc, m_min_acc, m_max_acc);
+  const float64_t acc_max_filtered = std::clamp(raw_acc, m_min_acc, m_max_acc);
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_ACC_LIMITED, acc_max_filtered);
 
   // store ctrl cmd without slope filter
@@ -801,7 +799,7 @@ PidLongitudinalController::Motion PidLongitudinalController::keepBrakeBeforeStop
     return output_motion;
   }
   // const auto stop_idx = motion_utils::searchZeroVelocityIndex(traj.points);
-  const auto stop_idx = motion_common::searchZeroVelocityIndex(traj.points);
+  const auto stop_idx = motion_utils::searchZeroVelocityIndex(traj.points);
   if (!stop_idx) {
     return output_motion;
   }

--- a/control/trajectory_follower_nodes/include/trajectory_follower_nodes/controller_node.hpp
+++ b/control/trajectory_follower_nodes/include/trajectory_follower_nodes/controller_node.hpp
@@ -17,8 +17,6 @@
 
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Geometry"
-#include "motion_common/motion_common.hpp"
-#include "motion_common/trajectory_common.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tf2_ros/buffer.h"
@@ -61,7 +59,6 @@ namespace trajectory_follower_nodes
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
-namespace motion_common = ::autoware::motion::motion_common;
 
 /// \classController
 /// \brief The node class used for generating longitudinal control commands (velocity/acceleration)

--- a/control/trajectory_follower_nodes/src/controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/controller_node.cpp
@@ -14,10 +14,7 @@
 
 #include "trajectory_follower_nodes/controller_node.hpp"
 
-#include "motion_common/motion_common.hpp"
-#include "motion_common/trajectory_common.hpp"
 #include "pure_pursuit/pure_pursuit_lateral_controller.hpp"
-#include "time_utils/time_utils.hpp"
 #include "trajectory_follower/mpc_lateral_controller.hpp"
 #include "trajectory_follower/pid_longitudinal_controller.hpp"
 


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

related to https://github.com/autowarefoundation/autoware.universe/issues/2229

remove motion_common dependency, which is added in autoware.auto, from trajectory_follower/trajectory_follower_nodes
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
