### PR TITLE
refactor(lidar_apollo_segmentation_tvm/_nodes): remove autoware_auto_common dependency

### DIFF
--- a/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/cluster2d.hpp
+++ b/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/cluster2d.hpp
@@ -36,7 +36,6 @@ namespace perception
 {
 namespace lidar_apollo_segmentation_tvm
 {
-
 using autoware::common::types::char8_t;
 
 /// \brief Internal obstacle classification categories.

--- a/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/cluster2d.hpp
+++ b/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/cluster2d.hpp
@@ -15,7 +15,6 @@
 #ifndef LIDAR_APOLLO_SEGMENTATION_TVM__CLUSTER2D_HPP_
 #define LIDAR_APOLLO_SEGMENTATION_TVM__CLUSTER2D_HPP_
 
-#include <common/types.hpp>
 #include <lidar_apollo_segmentation_tvm/disjoint_set.hpp>
 #include <lidar_apollo_segmentation_tvm/util.hpp>
 #include <lidar_apollo_segmentation_tvm/visibility_control.hpp>
@@ -37,9 +36,8 @@ namespace perception
 {
 namespace lidar_apollo_segmentation_tvm
 {
-using autoware::common::types::bool8_t;
+
 using autoware::common::types::char8_t;
-using autoware::common::types::float32_t;
 
 /// \brief Internal obstacle classification categories.
 enum class MetaType {
@@ -56,11 +54,11 @@ struct Obstacle
 {
   std::vector<int32_t> grids;
   pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_ptr;
-  float32_t score;
-  float32_t height;
-  float32_t heading;
+  float score;
+  float height;
+  float heading;
   MetaType meta_type;
-  std::vector<float32_t> meta_type_probs;
+  std::vector<float> meta_type_probs;
 
   Obstacle() : score(0.0), height(-5.0), heading(0.0), meta_type(MetaType::META_UNKNOWN)
   {
@@ -78,7 +76,7 @@ public:
   /// \param[in] rows The number of rows in the cluster.
   /// \param[in] cols The number of columns in the cluster.
   /// \param[in] range Scaling factor.
-  explicit Cluster2D(int32_t rows, int32_t cols, float32_t range);
+  explicit Cluster2D(int32_t rows, int32_t cols, float range);
 
   /// \brief Construct a directed graph and search the connected components for candidate object
   ///        clusters.
@@ -88,17 +86,17 @@ public:
   /// \param[in] objectness_thresh Threshold for filtering out non-object cells.
   /// \param[in] use_all_grids_for_clustering
   void cluster(
-    const float32_t * inferred_data, const pcl::PointCloud<pcl::PointXYZI>::ConstPtr & pc_ptr,
-    const pcl::PointIndices & valid_indices, float32_t objectness_thresh,
-    bool8_t use_all_grids_for_clustering);
+    const float * inferred_data, const pcl::PointCloud<pcl::PointXYZI>::ConstPtr & pc_ptr,
+    const pcl::PointIndices & valid_indices, float objectness_thresh,
+    bool use_all_grids_for_clustering);
 
   /// \brief Populate the fields of obstacles_ elements.
   /// \param[in] inferred_data Prediction information from the neural network inference.
-  void filter(const float32_t * inferred_data);
+  void filter(const float * inferred_data);
 
   /// \brief Assign a classification type to the obstacles_ elements.
   /// \param[in] inferred_data Prediction information from the neural network inference.
-  void classify(const float32_t * inferred_data);
+  void classify(const float * inferred_data);
 
   /// \brief Remove the candidate clusters that don't meet the parameters' requirements.
   /// \param[in] confidence_thresh The detection confidence score threshold.
@@ -107,7 +105,7 @@ public:
   /// \param[in] min_pts_num The candidate clusters with less than min_pts_num points are removed.
   /// \return The detected objects.
   std::shared_ptr<tier4_perception_msgs::msg::DetectedObjectsWithFeature> getObjects(
-    float32_t confidence_thresh, float32_t height_thresh, int32_t min_pts_num);
+    float confidence_thresh, float height_thresh, int32_t min_pts_num);
 
   /// \brief Transform an obstacle from the internal representation to the external one.
   /// \param[in] in_obstacle
@@ -119,10 +117,10 @@ private:
   const int32_t rows_;
   const int32_t cols_;
   const int32_t siz_;
-  const float32_t range_;
-  const float32_t scale_;
-  const float32_t inv_res_x_;
-  const float32_t inv_res_y_;
+  const float range_;
+  const float scale_;
+  const float inv_res_x_;
+  const float inv_res_y_;
   std::vector<int32_t> point2grid_;
   std::vector<Obstacle> obstacles_;
   std::vector<int32_t> id_img_;
@@ -137,8 +135,8 @@ private:
     Node * parent;
     char8_t node_rank;
     char8_t traversed;
-    bool8_t is_center;
-    bool8_t is_object;
+    bool is_center;
+    bool is_object;
     int32_t point_num;
     int32_t obstacle_id;
 

--- a/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/feature_generator.hpp
+++ b/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/feature_generator.hpp
@@ -15,7 +15,6 @@
 #ifndef LIDAR_APOLLO_SEGMENTATION_TVM__FEATURE_GENERATOR_HPP_
 #define LIDAR_APOLLO_SEGMENTATION_TVM__FEATURE_GENERATOR_HPP_
 
-#include <common/types.hpp>
 #include <lidar_apollo_segmentation_tvm/feature_map.hpp>
 #include <lidar_apollo_segmentation_tvm/util.hpp>
 #include <lidar_apollo_segmentation_tvm/visibility_control.hpp>
@@ -33,17 +32,15 @@ namespace perception
 {
 namespace lidar_apollo_segmentation_tvm
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float32_t;
 
 /// \brief A FeatureMap generator based on channel feature information.
 class LIDAR_APOLLO_SEGMENTATION_TVM_LOCAL FeatureGenerator
 {
 private:
-  const bool8_t use_intensity_feature_;
-  const bool8_t use_constant_feature_;
-  const float32_t min_height_;
-  const float32_t max_height_;
+  const bool use_intensity_feature_;
+  const bool use_constant_feature_;
+  const float min_height_;
+  const float max_height_;
   std::shared_ptr<FeatureMapInterface> map_ptr_;
 
 public:
@@ -56,8 +53,8 @@ public:
   /// \param[in] min_height The minimum height.
   /// \param[in] max_height The maximum height.
   explicit FeatureGenerator(
-    int32_t width, int32_t height, int32_t range, bool8_t use_intensity_feature,
-    bool8_t use_constant_feature, float32_t min_height, float32_t max_height);
+    int32_t width, int32_t height, int32_t range, bool use_intensity_feature,
+    bool use_constant_feature, float min_height, float max_height);
 
   /// \brief Generate a FeatureMap based on the configured features of this object.
   /// \param[in] pc_ptr Pointcloud used to populate the generated FeatureMap.

--- a/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/feature_map.hpp
+++ b/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/feature_map.hpp
@@ -15,8 +15,6 @@
 #ifndef LIDAR_APOLLO_SEGMENTATION_TVM__FEATURE_MAP_HPP_
 #define LIDAR_APOLLO_SEGMENTATION_TVM__FEATURE_MAP_HPP_
 
-#include <common/types.hpp>
-
 #include <memory>
 #include <vector>
 
@@ -26,7 +24,6 @@ namespace perception
 {
 namespace lidar_apollo_segmentation_tvm
 {
-using autoware::common::types::float32_t;
 
 /// \brief Abstract interface for FeatureMap.
 struct FeatureMapInterface
@@ -36,17 +33,17 @@ public:
   const int32_t width;
   const int32_t height;
   const int32_t range;
-  float32_t * max_height_data;      // channel 0
-  float32_t * mean_height_data;     // channel 1
-  float32_t * count_data;           // channel 2
-  float32_t * direction_data;       // channel 3
-  float32_t * top_intensity_data;   // channel 4
-  float32_t * mean_intensity_data;  // channel 5
-  float32_t * distance_data;        // channel 6
-  float32_t * nonempty_data;        // channel 7
-  std::vector<float32_t> map_data;
-  virtual void initializeMap(std::vector<float32_t> & map) = 0;
-  virtual void resetMap(std::vector<float32_t> & map) = 0;
+  float * max_height_data;      // channel 0
+  float * mean_height_data;     // channel 1
+  float * count_data;           // channel 2
+  float * direction_data;       // channel 3
+  float * top_intensity_data;   // channel 4
+  float * mean_intensity_data;  // channel 5
+  float * distance_data;        // channel 6
+  float * nonempty_data;        // channel 7
+  std::vector<float> map_data;
+  virtual void initializeMap(std::vector<float> & map) = 0;
+  virtual void resetMap(std::vector<float> & map) = 0;
   explicit FeatureMapInterface(int32_t _channels, int32_t _width, int32_t _height, int32_t _range);
 };
 
@@ -54,32 +51,32 @@ public:
 struct FeatureMap : public FeatureMapInterface
 {
   explicit FeatureMap(int32_t width, int32_t height, int32_t range);
-  void initializeMap(std::vector<float32_t> & map) override;
-  void resetMap(std::vector<float32_t> & map) override;
+  void initializeMap(std::vector<float> & map) override;
+  void resetMap(std::vector<float> & map) override;
 };
 
 /// \brief FeatureMap with an intensity feature channel.
 struct FeatureMapWithIntensity : public FeatureMapInterface
 {
   explicit FeatureMapWithIntensity(int32_t width, int32_t height, int32_t range);
-  void initializeMap(std::vector<float32_t> & map) override;
-  void resetMap(std::vector<float32_t> & map) override;
+  void initializeMap(std::vector<float> & map) override;
+  void resetMap(std::vector<float> & map) override;
 };
 
 /// \brief FeatureMap with a constant feature channel.
 struct FeatureMapWithConstant : public FeatureMapInterface
 {
   explicit FeatureMapWithConstant(int32_t width, int32_t height, int32_t range);
-  void initializeMap(std::vector<float32_t> & map) override;
-  void resetMap(std::vector<float32_t> & map) override;
+  void initializeMap(std::vector<float> & map) override;
+  void resetMap(std::vector<float> & map) override;
 };
 
 /// \brief FeatureMap with constant and intensity feature channels.
 struct FeatureMapWithConstantAndIntensity : public FeatureMapInterface
 {
   explicit FeatureMapWithConstantAndIntensity(int32_t width, int32_t height, int32_t range);
-  void initializeMap(std::vector<float32_t> & map) override;
-  void resetMap(std::vector<float32_t> & map) override;
+  void initializeMap(std::vector<float> & map) override;
+  void resetMap(std::vector<float> & map) override;
 };
 }  // namespace lidar_apollo_segmentation_tvm
 }  // namespace perception

--- a/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/lidar_apollo_segmentation_tvm.hpp
+++ b/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/lidar_apollo_segmentation_tvm.hpp
@@ -15,7 +15,6 @@
 #ifndef LIDAR_APOLLO_SEGMENTATION_TVM__LIDAR_APOLLO_SEGMENTATION_TVM_HPP_
 #define LIDAR_APOLLO_SEGMENTATION_TVM__LIDAR_APOLLO_SEGMENTATION_TVM_HPP_
 
-#include <common/types.hpp>
 #include <lidar_apollo_segmentation_tvm/cluster2d.hpp>
 #include <lidar_apollo_segmentation_tvm/feature_generator.hpp>
 #include <lidar_apollo_segmentation_tvm/visibility_control.hpp>
@@ -46,8 +45,7 @@ namespace perception
 {
 namespace lidar_apollo_segmentation_tvm
 {
-using autoware::common::types::bool8_t;
-using autoware::common::types::float32_t;
+
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
 using tvm_utility::pipeline::TVMArrayContainer;
 using tvm_utility::pipeline::TVMArrayContainerVector;
@@ -66,8 +64,7 @@ public:
   /// \param[in] max_height The maximum height.
   explicit ApolloLidarSegmentationPreProcessor(
     const tvm_utility::pipeline::InferenceEngineTVMConfig & config, int32_t range,
-    bool8_t use_intensity_feature, bool8_t use_constant_feature, float32_t min_height,
-    float32_t max_height);
+    bool use_intensity_feature, bool use_constant_feature, float min_height, float max_height);
 
   /// \brief Transfer the input data to a TVM array.
   /// \param[in] pc_ptr Input pointcloud.
@@ -103,8 +100,7 @@ public:
   explicit ApolloLidarSegmentationPostProcessor(
     const tvm_utility::pipeline::InferenceEngineTVMConfig & config,
     const pcl::PointCloud<pcl::PointXYZI>::ConstPtr & pc_ptr, int32_t range,
-    float32_t objectness_thresh, float32_t score_threshold, float32_t height_thresh,
-    int32_t min_pts_num);
+    float objectness_thresh, float score_threshold, float height_thresh, int32_t min_pts_num);
 
   /// \brief Copy the inference result.
   /// \param[in] input The result of the inference engine.
@@ -116,9 +112,9 @@ private:
   const int64_t output_width;
   const int64_t output_height;
   const int64_t output_datatype_bytes;
-  const float32_t objectness_thresh_;
-  const float32_t score_threshold_;
-  const float32_t height_thresh_;
+  const float objectness_thresh_;
+  const float score_threshold_;
+  const float height_thresh_;
   const int32_t min_pts_num_;
   const pcl::PointCloud<pcl::PointXYZI>::ConstPtr pc_ptr_;
   const std::shared_ptr<Cluster2D> cluster2d_;
@@ -145,9 +141,9 @@ public:
   ///                          object height by height_thresh are filtered out in the
   ///                          post-processing step.
   explicit ApolloLidarSegmentation(
-    int32_t range, float32_t score_threshold, bool8_t use_intensity_feature,
-    bool8_t use_constant_feature, float32_t z_offset, float32_t min_height, float32_t max_height,
-    float32_t objectness_thresh, int32_t min_pts_num, float32_t height_thresh);
+    int32_t range, float score_threshold, bool use_intensity_feature, bool use_constant_feature,
+    float z_offset, float min_height, float max_height, float objectness_thresh,
+    int32_t min_pts_num, float height_thresh);
 
   /// \brief Detect obstacles.
   /// \param[in] input Input pointcloud.
@@ -167,11 +163,11 @@ public:
 
 private:
   const int32_t range_;
-  const float32_t score_threshold_;
-  const float32_t z_offset_;
-  const float32_t objectness_thresh_;
+  const float score_threshold_;
+  const float z_offset_;
+  const float objectness_thresh_;
   const int32_t min_pts_num_;
-  const float32_t height_thresh_;
+  const float height_thresh_;
   const pcl::PointCloud<pcl::PointXYZI>::Ptr pcl_pointcloud_ptr_;
   // Earliest supported model version.
   const std::array<char8_t, 3> model_version_from{2, 0, 0};
@@ -194,7 +190,7 @@ private:
   /// \throw tf2::TransformException If the pointcloud transformation fails.
   void LIDAR_APOLLO_SEGMENTATION_TVM_LOCAL transformCloud(
     const sensor_msgs::msg::PointCloud2 & input, sensor_msgs::msg::PointCloud2 & transformed_cloud,
-    float32_t z_offset);
+    float z_offset);
 
   rclcpp::Clock::SharedPtr clock_ = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_ = std::make_unique<tf2_ros::Buffer>(clock_);

--- a/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/log_table.hpp
+++ b/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/log_table.hpp
@@ -15,20 +15,17 @@
 #ifndef LIDAR_APOLLO_SEGMENTATION_TVM__LOG_TABLE_HPP_
 #define LIDAR_APOLLO_SEGMENTATION_TVM__LOG_TABLE_HPP_
 
-#include <common/types.hpp>
-
 namespace autoware
 {
 namespace perception
 {
 namespace lidar_apollo_segmentation_tvm
 {
-using autoware::common::types::float32_t;
 
 /// \brief Use a lookup table to compute the natural logarithm of 1+num.
 /// \param[in] num
 /// \return ln(1+num)
-float32_t calcApproximateLog(float32_t num);
+float calcApproximateLog(float num);
 }  // namespace lidar_apollo_segmentation_tvm
 }  // namespace perception
 }  // namespace autoware

--- a/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/util.hpp
+++ b/perception/lidar_apollo_segmentation_tvm/include/lidar_apollo_segmentation_tvm/util.hpp
@@ -15,8 +15,6 @@
 #ifndef LIDAR_APOLLO_SEGMENTATION_TVM__UTIL_HPP_
 #define LIDAR_APOLLO_SEGMENTATION_TVM__UTIL_HPP_
 
-#include <common/types.hpp>
-
 #include <cmath>
 #include <string>
 
@@ -26,14 +24,13 @@ namespace perception
 {
 namespace lidar_apollo_segmentation_tvm
 {
-using autoware::common::types::float32_t;
 
 /// \brief Project a point from a pointcloud to a 2D map.
 /// \param[in] val Coordinate of the point in the pointcloud.
 /// \param[in] ori Diameter of area containing the pointcloud.
 /// \param[in] scale Scaling factor from pointcloud size to grid size.
 /// \return The grid in which the point is.
-inline int32_t F2I(float32_t val, float32_t ori, float32_t scale)
+inline int32_t F2I(float val, float ori, float scale)
 {
   return static_cast<int32_t>(std::floor((ori - val) * scale));
 }
@@ -43,9 +40,9 @@ inline int32_t F2I(float32_t val, float32_t ori, float32_t scale)
 /// \param[in] in_range Range of the pointcloud.
 /// \param[in] out_size Size of the grid.
 /// \return The distance to the point in pixel scale.
-inline int32_t Pc2Pixel(float32_t in_pc, float32_t in_range, float32_t out_size)
+inline int32_t Pc2Pixel(float in_pc, float in_range, float out_size)
 {
-  float32_t inv_res = 0.5f * out_size / in_range;
+  float inv_res = 0.5f * out_size / in_range;
   return static_cast<int32_t>(std::floor((in_range - in_pc) * inv_res));
 }
 
@@ -54,10 +51,10 @@ inline int32_t Pc2Pixel(float32_t in_pc, float32_t in_range, float32_t out_size)
 /// \param[in] in_size Size of the grid.
 /// \param[in] out_range Range of the pointcloud.
 /// \return The distance to the cell in pointcloud scale.
-inline float32_t Pixel2Pc(int32_t in_pixel, float32_t in_size, float32_t out_range)
+inline float Pixel2Pc(int32_t in_pixel, float in_size, float out_range)
 {
-  float32_t res = 2.0f * out_range / in_size;
-  return out_range - (static_cast<float32_t>(in_pixel) + 0.5f) * res;
+  float res = 2.0f * out_range / in_size;
+  return out_range - (static_cast<float>(in_pixel) + 0.5f) * res;
 }
 }  // namespace lidar_apollo_segmentation_tvm
 }  // namespace perception

--- a/perception/lidar_apollo_segmentation_tvm/package.xml
+++ b/perception/lidar_apollo_segmentation_tvm/package.xml
@@ -12,7 +12,6 @@
   <build_depend>autoware_cmake</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
 
-  <depend>autoware_auto_common</depend>
   <depend>autoware_auto_geometry</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/perception/lidar_apollo_segmentation_tvm/src/feature_generator.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/src/feature_generator.cpp
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <common/types.hpp>
 #include <lidar_apollo_segmentation_tvm/feature_generator.hpp>
 #include <lidar_apollo_segmentation_tvm/log_table.hpp>
 
 #include <memory>
 #include <vector>
-
-using autoware::common::types::bool8_t;
-using autoware::common::types::float32_t;
-using autoware::common::types::float64_t;
 
 namespace autoware
 {
@@ -31,13 +26,12 @@ namespace lidar_apollo_segmentation_tvm
 {
 namespace
 {
-inline float32_t normalizeIntensity(float32_t intensity) { return intensity / 255; }
+inline float normalizeIntensity(float intensity) { return intensity / 255; }
 }  // namespace
 
 FeatureGenerator::FeatureGenerator(
-  const int32_t width, const int32_t height, const int32_t range,
-  const bool8_t use_intensity_feature, const bool8_t use_constant_feature,
-  const float32_t min_height, const float32_t max_height)
+  const int32_t width, const int32_t height, const int32_t range, const bool use_intensity_feature,
+  const bool use_constant_feature, const float min_height, const float max_height)
 : use_intensity_feature_(use_intensity_feature),
   use_constant_feature_(use_constant_feature),
   min_height_(min_height),
@@ -59,13 +53,13 @@ FeatureGenerator::FeatureGenerator(
 std::shared_ptr<FeatureMapInterface> FeatureGenerator::generate(
   const pcl::PointCloud<pcl::PointXYZI>::ConstPtr & pc_ptr)
 {
-  const float64_t epsilon = 1e-6;
+  const double epsilon = 1e-6;
   map_ptr_->resetMap(map_ptr_->map_data);
 
   const int32_t size = map_ptr_->height * map_ptr_->width;
 
-  const float32_t inv_res_x = 0.5f * map_ptr_->width / map_ptr_->range;
-  const float32_t inv_res_y = 0.5f * map_ptr_->height / map_ptr_->range;
+  const float inv_res_x = 0.5f * map_ptr_->width / map_ptr_->range;
+  const float inv_res_y = 0.5f * map_ptr_->height / map_ptr_->range;
 
   for (size_t i = 0; i < pc_ptr->points.size(); ++i) {
     if (pc_ptr->points[i].z <= min_height_ || max_height_ <= pc_ptr->points[i].z) {
@@ -74,10 +68,10 @@ std::shared_ptr<FeatureMapInterface> FeatureGenerator::generate(
 
     // x on grid
     const int32_t pos_x = static_cast<int32_t>(
-      std::floor((static_cast<float32_t>(map_ptr_->range) - pc_ptr->points[i].y) * inv_res_x));
+      std::floor((static_cast<float>(map_ptr_->range) - pc_ptr->points[i].y) * inv_res_x));
     // y on grid
     const int32_t pos_y = static_cast<int32_t>(
-      std::floor((static_cast<float32_t>(map_ptr_->range) - pc_ptr->points[i].x) * inv_res_y));
+      std::floor((static_cast<float>(map_ptr_->range) - pc_ptr->points[i].x) * inv_res_y));
     if (pos_x < 0 || map_ptr_->width <= pos_x || pos_y < 0 || map_ptr_->height <= pos_y) {
       continue;
     }
@@ -98,7 +92,7 @@ std::shared_ptr<FeatureMapInterface> FeatureGenerator::generate(
   }
 
   for (int32_t i = 0; i < size; ++i) {
-    if (static_cast<float64_t>(map_ptr_->count_data[i]) < epsilon) {
+    if (static_cast<double>(map_ptr_->count_data[i]) < epsilon) {
       map_ptr_->max_height_data[i] = 0.0f;
     } else {
       map_ptr_->mean_height_data[i] /= map_ptr_->count_data[i];

--- a/perception/lidar_apollo_segmentation_tvm/src/feature_map.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/src/feature_map.cpp
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <common/types.hpp>
 #include <lidar_apollo_segmentation_tvm/feature_map.hpp>
 #include <lidar_apollo_segmentation_tvm/util.hpp>
 
 #include <cmath>
 #include <vector>
-
-using autoware::common::types::float32_t;
 
 namespace autoware
 {
@@ -53,8 +50,8 @@ FeatureMap::FeatureMap(const int32_t width, const int32_t height, const int32_t 
   count_data = &(map_data[0]) + width * height * 2;
   nonempty_data = &(map_data[0]) + width * height * 3;
 }
-void FeatureMap::initializeMap(std::vector<float32_t> & map) { (void)map; }
-void FeatureMap::resetMap(std::vector<float32_t> & map)
+void FeatureMap::initializeMap(std::vector<float> & map) { (void)map; }
+void FeatureMap::resetMap(std::vector<float> & map)
 {
   const int32_t size = width * height;
   (void)map;
@@ -77,8 +74,8 @@ FeatureMapWithIntensity::FeatureMapWithIntensity(
   mean_intensity_data = &(map_data[0]) + width * height * 4;
   nonempty_data = &(map_data[0]) + width * height * 5;
 }
-void FeatureMapWithIntensity::initializeMap(std::vector<float32_t> & map) { (void)map; }
-void FeatureMapWithIntensity::resetMap(std::vector<float32_t> & map)
+void FeatureMapWithIntensity::initializeMap(std::vector<float> & map) { (void)map; }
+void FeatureMapWithIntensity::resetMap(std::vector<float> & map)
 {
   const int32_t size = width * height;
   (void)map;
@@ -103,7 +100,7 @@ FeatureMapWithConstant::FeatureMapWithConstant(
   distance_data = &(map_data[0]) + width * height * 4;
   nonempty_data = &(map_data[0]) + width * height * 5;
 }
-void FeatureMapWithConstant::initializeMap(std::vector<float32_t> & map)
+void FeatureMapWithConstant::initializeMap(std::vector<float> & map)
 {
   (void)map;
   for (int32_t row = 0; row < height; ++row) {
@@ -113,16 +110,16 @@ void FeatureMapWithConstant::initializeMap(std::vector<float32_t> & map)
       // return the distance from the car to center of the grid.
       // Pc means point cloud = real world scale. so transform pixel scale to
       // real world scale
-      float32_t center_x = Pixel2Pc(row, height, range);
-      float32_t center_y = Pixel2Pc(col, width, range);
+      float center_x = Pixel2Pc(row, height, range);
+      float center_y = Pixel2Pc(col, width, range);
       // normalization. -0.5~0.5
-      direction_data[idx] = std::atan2(center_y, center_x) / static_cast<float32_t>(2.0 * M_PI);
+      direction_data[idx] = std::atan2(center_y, center_x) / static_cast<float>(2.0 * M_PI);
       distance_data[idx] = std::hypot(center_x, center_y) / 60.0f - 0.5f;
     }
   }
 }
 
-void FeatureMapWithConstant::resetMap(std::vector<float32_t> & map)
+void FeatureMapWithConstant::resetMap(std::vector<float> & map)
 {
   const int32_t size = width * height;
   (void)map;
@@ -147,7 +144,7 @@ FeatureMapWithConstantAndIntensity::FeatureMapWithConstantAndIntensity(
   distance_data = &(map_data[0]) + width * height * 6;
   nonempty_data = &(map_data[0]) + width * height * 7;
 }
-void FeatureMapWithConstantAndIntensity::initializeMap(std::vector<float32_t> & map)
+void FeatureMapWithConstantAndIntensity::initializeMap(std::vector<float> & map)
 {
   (void)map;
   for (int32_t row = 0; row < height; ++row) {
@@ -157,16 +154,16 @@ void FeatureMapWithConstantAndIntensity::initializeMap(std::vector<float32_t> & 
       // return the distance from the car to center of the grid.
       // Pc means point cloud = real world scale. so transform pixel scale to
       // real world scale
-      float32_t center_x = Pixel2Pc(row, height, range);
-      float32_t center_y = Pixel2Pc(col, width, range);
+      float center_x = Pixel2Pc(row, height, range);
+      float center_y = Pixel2Pc(col, width, range);
       // normalization. -0.5~0.5
-      direction_data[idx] = std::atan2(center_y, center_x) / static_cast<float32_t>(2.0 * M_PI);
+      direction_data[idx] = std::atan2(center_y, center_x) / static_cast<float>(2.0 * M_PI);
       distance_data[idx] = std::hypot(center_x, center_y) / 60.0f - 0.5f;
     }
   }
 }
 
-void FeatureMapWithConstantAndIntensity::resetMap(std::vector<float32_t> & map)
+void FeatureMapWithConstantAndIntensity::resetMap(std::vector<float> & map)
 {
   const int32_t size = width * height;
   (void)map;

--- a/perception/lidar_apollo_segmentation_tvm/src/lidar_apollo_segmentation_tvm.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/src/lidar_apollo_segmentation_tvm.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <baidu_cnn/inference_engine_tvm_config.hpp>
-#include <common/types.hpp>
 #include <lidar_apollo_segmentation_tvm/feature_map.hpp>
 #include <lidar_apollo_segmentation_tvm/lidar_apollo_segmentation_tvm.hpp>
 #include <tvm_utility/pipeline.hpp>
@@ -22,8 +21,6 @@
 #include <string>
 #include <vector>
 
-using autoware::common::types::bool8_t;
-using autoware::common::types::float32_t;
 using model_zoo::perception::lidar_obstacle_detection::baidu_cnn::onnx_bcnn::config;
 
 namespace autoware
@@ -34,8 +31,8 @@ namespace lidar_apollo_segmentation_tvm
 {
 ApolloLidarSegmentationPreProcessor::ApolloLidarSegmentationPreProcessor(
   const tvm_utility::pipeline::InferenceEngineTVMConfig & config, int32_t range,
-  bool8_t use_intensity_feature, bool8_t use_constant_feature, float32_t min_height,
-  float32_t max_height)
+  bool use_intensity_feature, bool use_constant_feature, float min_height,
+  float max_height)
 : input_channels(config.network_inputs[0].node_shape[1]),
   input_width(config.network_inputs[0].node_shape[2]),
   input_height(config.network_inputs[0].node_shape[3]),
@@ -76,7 +73,7 @@ TVMArrayContainerVector ApolloLidarSegmentationPreProcessor::schedule(
 ApolloLidarSegmentationPostProcessor::ApolloLidarSegmentationPostProcessor(
   const tvm_utility::pipeline::InferenceEngineTVMConfig & config,
   const pcl::PointCloud<pcl::PointXYZI>::ConstPtr & pc_ptr, int32_t range,
-  float32_t objectness_thresh, float32_t score_threshold, float32_t height_thresh,
+  float objectness_thresh, float score_threshold, float height_thresh,
   int32_t min_pts_num)
 : output_channels(config.network_outputs[0].node_shape[1]),
   output_width(config.network_outputs[0].node_shape[2]),
@@ -109,9 +106,9 @@ std::shared_ptr<DetectedObjectsWithFeature> ApolloLidarSegmentationPostProcessor
 }
 
 ApolloLidarSegmentation::ApolloLidarSegmentation(
-  int32_t range, float32_t score_threshold, bool8_t use_intensity_feature,
-  bool8_t use_constant_feature, float32_t z_offset, float32_t min_height, float32_t max_height,
-  float32_t objectness_thresh, int32_t min_pts_num, float32_t height_thresh)
+  int32_t range, float score_threshold, bool use_intensity_feature, bool use_constant_feature,
+  float z_offset, float min_height, float max_height, float objectness_thresh, int32_t min_pts_num,
+  float height_thresh)
 : range_(range),
   score_threshold_(score_threshold),
   z_offset_(z_offset),
@@ -132,7 +129,7 @@ ApolloLidarSegmentation::ApolloLidarSegmentation(
 
 void ApolloLidarSegmentation::transformCloud(
   const sensor_msgs::msg::PointCloud2 & input, sensor_msgs::msg::PointCloud2 & transformed_cloud,
-  float32_t z_offset)
+  float z_offset)
 {
   if (target_frame_ == input.header.frame_id && z_offset == 0) {
     transformed_cloud = input;
@@ -149,7 +146,7 @@ void ApolloLidarSegmentation::transformCloud(
       transform_stamped =
         tf_buffer_->lookupTransform(target_frame_, input.header.frame_id, time_point);
       Eigen::Matrix4f affine_matrix =
-        tf2::transformToEigen(transform_stamped.transform).matrix().cast<float32_t>();
+        tf2::transformToEigen(transform_stamped.transform).matrix().cast<float>();
       pcl::transformPointCloud(in_cluster, transformed_cloud_cluster, affine_matrix);
       transformed_cloud_cluster.header.frame_id = target_frame_;
     } else {

--- a/perception/lidar_apollo_segmentation_tvm/src/log_table.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/src/log_table.cpp
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <common/types.hpp>
 #include <lidar_apollo_segmentation_tvm/log_table.hpp>
 
 #include <cmath>
 #include <string>
 #include <vector>
-
-using autoware::common::types::float32_t;
 
 namespace autoware
 {
@@ -29,19 +26,19 @@ namespace lidar_apollo_segmentation_tvm
 {
 struct LogTable
 {
-  std::vector<float32_t> data;
+  std::vector<float> data;
   LogTable()
   {
     data.resize(256 * 10);
     for (size_t i = 0; i < data.size(); ++i) {
-      data[i] = std::log1p(static_cast<float32_t>(i) / 10);
+      data[i] = std::log1p(static_cast<float>(i) / 10);
     }
   }
 };
 
 static LogTable log_table;
 
-float32_t calcApproximateLog(float32_t num)
+float calcApproximateLog(float num)
 {
   if (num >= 0) {
     size_t integer_num = static_cast<size_t>(num * 10.0f);

--- a/perception/lidar_apollo_segmentation_tvm/test/main.cpp
+++ b/perception/lidar_apollo_segmentation_tvm/test/main.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <common/types.hpp>
 #include <lidar_apollo_segmentation_tvm/lidar_apollo_segmentation_tvm.hpp>
 #include <tvm_utility/pipeline.hpp>
 
@@ -23,8 +22,6 @@
 #include <string>
 #include <vector>
 
-using autoware::common::types::float32_t;
-using autoware::common::types::uchar8_t;
 using autoware::perception::lidar_apollo_segmentation_tvm::ApolloLidarSegmentation;
 
 void test_segmentation(bool use_intensity_feature, bool use_constant_feature, bool expect_throw)
@@ -35,11 +32,11 @@ void test_segmentation(bool use_intensity_feature, bool use_constant_feature, bo
   const int range = 70;
   const float score_threshold = 0.8f;
   const float z_offset = 1.0f;
-  const float32_t min_height = -5.0f;
-  const float32_t max_height = 5.0f;
-  const float32_t objectness_thresh = 0.5f;
+  const float min_height = -5.0f;
+  const float max_height = 5.0f;
+  const float objectness_thresh = 0.5f;
   const int32_t min_pts_num = 3;
-  const float32_t height_thresh = 0.5f;
+  const float height_thresh = 0.5f;
   ApolloLidarSegmentation segmentation(
     range, score_threshold, use_intensity_feature, use_constant_feature, z_offset, min_height,
     max_height, objectness_thresh, min_pts_num, height_thresh);
@@ -49,10 +46,10 @@ void test_segmentation(bool use_intensity_feature, bool use_constant_feature, bo
 
   std::random_device rd;
   std::mt19937 gen(42);
-  std::uniform_real_distribution<float32_t> dis(-50.0, 50.0);
-  std::vector<uchar8_t> v(width * height * sizeof(float32_t) * 4);
+  std::uniform_real_distribution<float> dis(-50.0, 50.0);
+  std::vector<unsigned char> v(width * height * sizeof(float) * 4);
   for (size_t i = 0; i < width * height * 4; i++) {
-    reinterpret_cast<float32_t *>(v.data())[i] = dis(gen);
+    reinterpret_cast<float *>(v.data())[i] = dis(gen);
   }
 
   sensor_msgs::msg::PointCloud2 input{};
@@ -63,10 +60,10 @@ void test_segmentation(bool use_intensity_feature, bool use_constant_feature, bo
   input.fields[2U].name = "z";
   input.fields[3U].name = "intensity";
   for (uint32_t idx = 0U; idx < 4U; ++idx) {
-    input.fields[idx].offset = static_cast<uint32_t>(idx * sizeof(float32_t));
+    input.fields[idx].offset = static_cast<uint32_t>(idx * sizeof(float));
     input.fields[idx].datatype = sensor_msgs::msg::PointField::FLOAT32;
     input.fields[idx].count = 1U;
-    input.point_step += static_cast<uint32_t>(sizeof(float32_t));
+    input.point_step += static_cast<uint32_t>(sizeof(float));
   }
   input.height = static_cast<uint32_t>(height);
   input.width = static_cast<uint32_t>(width);

--- a/perception/lidar_apollo_segmentation_tvm_nodes/package.xml
+++ b/perception/lidar_apollo_segmentation_tvm_nodes/package.xml
@@ -12,7 +12,6 @@
 
   <build_depend>autoware_cmake</build_depend>
 
-  <depend>autoware_auto_common</depend>
   <depend>lidar_apollo_segmentation_tvm</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/lidar_apollo_segmentation_tvm_nodes/src/lidar_apollo_segmentation_tvm_node.cpp
+++ b/perception/lidar_apollo_segmentation_tvm_nodes/src/lidar_apollo_segmentation_tvm_node.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <common/types.hpp>
 #include <lidar_apollo_segmentation_tvm/lidar_apollo_segmentation_tvm.hpp>
 #include <lidar_apollo_segmentation_tvm_nodes/lidar_apollo_segmentation_tvm_node.hpp>
 #include <rclcpp/logging.hpp>
@@ -20,9 +19,6 @@
 
 #include <memory>
 
-using autoware::common::types::bool8_t;
-using autoware::common::types::float32_t;
-using autoware::common::types::float64_t;
 using autoware::perception::lidar_apollo_segmentation_tvm::ApolloLidarSegmentation;
 
 namespace autoware
@@ -41,15 +37,15 @@ ApolloLidarSegmentationNode::ApolloLidarSegmentationNode(const rclcpp::NodeOptio
     "objects_out", rclcpp::QoS{1})},
   m_detector_ptr{std::make_shared<lidar_apollo_segmentation_tvm::ApolloLidarSegmentation>(
     declare_parameter("range", rclcpp::ParameterValue{70}).get<int32_t>(),
-    declare_parameter("score_threshold", rclcpp::ParameterValue{0.8}).get<float32_t>(),
-    declare_parameter("use_intensity_feature", rclcpp::ParameterValue{true}).get<bool8_t>(),
-    declare_parameter("use_constant_feature", rclcpp::ParameterValue{false}).get<bool8_t>(),
-    declare_parameter("z_offset", rclcpp::ParameterValue{0.0}).get<float32_t>(),
-    declare_parameter("min_height", rclcpp::ParameterValue{-5.0}).get<float32_t>(),
-    declare_parameter("max_height", rclcpp::ParameterValue{5.0}).get<float32_t>(),
-    declare_parameter("objectness_thresh", rclcpp::ParameterValue{0.5}).get<float32_t>(),
+    declare_parameter("score_threshold", rclcpp::ParameterValue{0.8}).get<float>(),
+    declare_parameter("use_intensity_feature", rclcpp::ParameterValue{true}).get<bool>(),
+    declare_parameter("use_constant_feature", rclcpp::ParameterValue{false}).get<bool>(),
+    declare_parameter("z_offset", rclcpp::ParameterValue{0.0}).get<float>(),
+    declare_parameter("min_height", rclcpp::ParameterValue{-5.0}).get<float>(),
+    declare_parameter("max_height", rclcpp::ParameterValue{5.0}).get<float>(),
+    declare_parameter("objectness_thresh", rclcpp::ParameterValue{0.5}).get<float>(),
     declare_parameter("min_pts_num", rclcpp::ParameterValue{3}).get<int32_t>(),
-    declare_parameter("height_thresh", rclcpp::ParameterValue{0.5}).get<float32_t>())}
+    declare_parameter("height_thresh", rclcpp::ParameterValue{0.5}).get<float>())}
 {
   // Log unexpected versions of the neural network.
   auto version_status = m_detector_ptr->version_check();


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description
related to https://github.com/autowarefoundation/autoware.universe/issues/2229
remove autoware_auto_common from lidar_apollo_segmentation_tvm/_nodes

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
