### PR TITLE
fix(stop_line): z position of stop point

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -64,7 +64,6 @@ bool StopLineModule::modifyPathVelocity(
 
   const auto stop_point_idx = stop_point->first;
   auto stop_pose = stop_point->second;
-  stop_pose.position.z = (stop_line_[0].z() + stop_line_[1].z()) / 2.0;
 
   /**
    * @brief : calculate signed arc length consider stop margin from stop line


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description
Currently z position of stop line is used as the z position of inserted point, but it causes z position error.
(e.g. when there is a stop line in a slope.)
That resulted in strange pitch due to the high elevation angle. 

z position of stop point is calculated [here](https://github.com/autowarefoundation/autoware.universe/blob/7829c07d9a982054638312a44d4f6c374f8aa04d/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp#L55-L57), so I think [this calculation](https://github.com/autowarefoundation/autoware.universe/blob/7829c07d9a982054638312a44d4f6c374f8aa04d/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp#L67) is not needed.


before this change:
I visualized the output path poses from stop_line module.
![image](https://user-images.githubusercontent.com/11865769/200457845-e2627cb3-9e2a-4241-ae6b-9f10752bc436.png)

after this change:
![image](https://user-images.githubusercontent.com/11865769/200457878-864bbabc-e618-489b-bc70-158e0d31f8cd.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
