### PR TITLE
fix(ndt_scan_matcher): add regularization_scale_factor declaration

### DIFF
--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -117,7 +117,7 @@ NDTScanMatcher::NDTScanMatcher()
   ndt_params_.search_method = static_cast<pclomp::NeighborSearchMethod>(search_method);
   ndt_params_.num_threads = this->declare_parameter<int>("num_threads");
   ndt_params_.num_threads = std::max(ndt_params_.num_threads, 1);
-  ndt_params.regularization_scale_factor = this->declare_parameter<float>("regularization_scale_factor");
+  ndt_params_.regularization_scale_factor = this->declare_parameter<float>("regularization_scale_factor");
 
   ndt_ptr_->setTransformationEpsilon(ndt_params_.trans_epsilon);
   ndt_ptr_->setStepSize(ndt_params_.step_size);

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -117,6 +117,7 @@ NDTScanMatcher::NDTScanMatcher()
   ndt_params_.search_method = static_cast<pclomp::NeighborSearchMethod>(search_method);
   ndt_params_.num_threads = this->declare_parameter<int>("num_threads");
   ndt_params_.num_threads = std::max(ndt_params_.num_threads, 1);
+  ndt_params.regularization_scale_factor = this->declare_parameter<float>("regularization_scale_factor");
 
   ndt_ptr_->setTransformationEpsilon(ndt_params_.trans_epsilon);
   ndt_ptr_->setStepSize(ndt_params_.step_size);


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
I mistakenly removed the declaration of `regularization_scale_factor` in the previous PR: https://github.com/autowarefoundation/autoware.universe/pull/2053 :cry: 
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
