### PR TITLE
fix(obstacle_avoidance_planner): use fisrt ref point to find nearest bounds

### DIFF
--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -1389,7 +1389,7 @@ void MPTOptimizer::calcBounds(
         if (prev_trajs && !prev_trajs->mpt_ref_points.empty()) {
           return prev_trajs->mpt_ref_points.front().p;
         }
-        return current_ego_pose_.position;
+        return ref_points.at(i).p;
       }();
 
       geometry_msgs::msg::Pose ref_pose;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

When the back lanes are diverging, it looks for the bond closer to ego, so the wrong one may be selected.
In this PR, the bound closer to the first point of ref points is selected.

![Screenshot from 2022-11-08 13-19-10](https://user-images.githubusercontent.com/39142679/200543058-a575b977-a9fb-472d-8a6b-6b71a79d7d3f.png)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
- psim
- tier4 internal sceneari tests https://evaluation.tier4.jp/evaluation/reports/73e19782-8ed3-5ac2-982a-cdc1505bf2b6?project_id=prd_jt
  - 809/825 no degradation 
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
