### PR TITLE
fix(behavior_velocity_planner): fix intersection interval in getStopLineFromMap

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -293,7 +293,7 @@ bool getStopLineIndexFromMap(
   const LineString2d extended_stop_line =
     planning_utils::extendLine(p_start, p_end, planner_data->stop_line_extend_length);
 
-  for (size_t i = lane_interval_start; i <= lane_interval_end - 1; i++) {
+  for (size_t i = lane_interval_start; i < lane_interval_end; i++) {
     const auto & p_front = path.points.at(i).point.pose.position;
     const auto & p_back = path.points.at(i + 1).point.pose.position;
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -293,7 +293,7 @@ bool getStopLineIndexFromMap(
   const LineString2d extended_stop_line =
     planning_utils::extendLine(p_start, p_end, planner_data->stop_line_extend_length);
 
-  for (size_t i = lane_interval_start; i <= lane_interval_end; i++) {
+  for (size_t i = lane_interval_start; i <= lane_interval_end - 1; i++) {
     const auto & p_front = path.points.at(i).point.pose.position;
     const auto & p_back = path.points.at(i + 1).point.pose.position;
 


### PR DESCRIPTION

Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

Additional fix for these:
- https://github.com/autowarefoundation/autoware.universe/pull/2190
- https://github.com/autowarefoundation/autoware.universe/pull/2221

## Tests performed

Checked that the behavior_velocity_planner does not die on the evaluator.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
