### PR TITLE
fix(multi_object_tracker): fix reversed width and length in bounding box

### DIFF
--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/bicycle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/bicycle_tracker.hpp
@@ -64,8 +64,8 @@ private:
 private:
   struct BoundingBox
   {
-    double width;
     double length;
+    double width;
     double height;
   };
   BoundingBox bounding_box_;

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/big_vehicle_tracker.hpp
@@ -65,8 +65,8 @@ private:
 private:
   struct BoundingBox
   {
-    double width;
     double length;
+    double width;
     double height;
   };
   BoundingBox bounding_box_;

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp
@@ -66,8 +66,8 @@ private:
 private:
   struct BoundingBox
   {
-    double width;
     double length;
+    double width;
     double height;
   };
   BoundingBox bounding_box_;

--- a/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/tracker/model/pedestrian_tracker.hpp
@@ -64,8 +64,8 @@ private:
 private:
   struct BoundingBox
   {
-    double width;
     double length;
+    double width;
     double height;
   };
   struct Cylinder

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -301,8 +301,8 @@ bool BicycleTracker::measureWithShape(
   }
   constexpr float gain = 0.9;
 
-  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.x;
-  bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.y;
+  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
+  bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.x;
   bounding_box_.height = gain * bounding_box_.height + (1.0 - gain) * object.shape.dimensions.z;
 
   return true;
@@ -400,8 +400,8 @@ bool BicycleTracker::getTrackedObject(
   twist_with_cov.covariance[utils::MSG_COV_IDX::YAW_YAW] = P(IDX::WZ, IDX::WZ);
 
   // set shape
-  object.shape.dimensions.x = bounding_box_.width;
-  object.shape.dimensions.y = bounding_box_.length;
+  object.shape.dimensions.x = bounding_box_.length;
+  object.shape.dimensions.y = bounding_box_.width;
   object.shape.dimensions.z = bounding_box_.height;
   const auto origin_yaw = tf2::getYaw(object_.kinematics.pose_with_covariance.pose.orientation);
   const auto ekf_pose_yaw = tf2::getYaw(pose_with_cov.pose.orientation);

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -130,9 +130,9 @@ BicycleTracker::BicycleTracker(
 
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
-      object.shape.dimensions.y, object.shape.dimensions.x, object.shape.dimensions.z};
+      object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
   } else {
-    bounding_box_ = {1.0, 0.5, 1.7};
+    bounding_box_ = {0.5, 1.0, 1.7};
   }
   ekf_.init(X, P);
 }
@@ -301,8 +301,8 @@ bool BicycleTracker::measureWithShape(
   }
   constexpr float gain = 0.9;
 
-  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
   bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.x;
+  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
   bounding_box_.height = gain * bounding_box_.height + (1.0 - gain) * object.shape.dimensions.z;
 
   return true;

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -130,7 +130,7 @@ BicycleTracker::BicycleTracker(
 
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
-      object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
+      object.shape.dimensions.y, object.shape.dimensions.x, object.shape.dimensions.z};
   } else {
     bounding_box_ = {1.0, 0.5, 1.7};
   }

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -132,7 +132,7 @@ BicycleTracker::BicycleTracker(
     bounding_box_ = {
       object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
   } else {
-    bounding_box_ = {0.5, 1.0, 1.7};
+    bounding_box_ = {1.0, 0.5, 1.7};
   }
   ekf_.init(X, P);
 }

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -345,8 +345,8 @@ bool BigVehicleTracker::measureWithShape(
   }
   constexpr float gain = 0.9;
 
-  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.x;
-  bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.y;
+  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
+  bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.x;
   bounding_box_.height = gain * bounding_box_.height + (1.0 - gain) * object.shape.dimensions.z;
 
   return true;
@@ -444,8 +444,8 @@ bool BigVehicleTracker::getTrackedObject(
   twist_with_cov.covariance[utils::MSG_COV_IDX::YAW_YAW] = P(IDX::WZ, IDX::WZ);
 
   // set shape
-  object.shape.dimensions.x = bounding_box_.width;
-  object.shape.dimensions.y = bounding_box_.length;
+  object.shape.dimensions.x = bounding_box_.length;
+  object.shape.dimensions.y = bounding_box_.width;
   object.shape.dimensions.z = bounding_box_.height;
   const auto origin_yaw = tf2::getYaw(object_.kinematics.pose_with_covariance.pose.orientation);
   const auto ekf_pose_yaw = tf2::getYaw(pose_with_cov.pose.orientation);

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -130,7 +130,7 @@ BigVehicleTracker::BigVehicleTracker(
 
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
-      object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
+      object.shape.dimensions.y, object.shape.dimensions.x, object.shape.dimensions.z};
   } else {
     bounding_box_ = {2.0, 7.0, 2.0};
   }

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -130,9 +130,9 @@ BigVehicleTracker::BigVehicleTracker(
 
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
-      object.shape.dimensions.y, object.shape.dimensions.x, object.shape.dimensions.z};
+      object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
   } else {
-    bounding_box_ = {2.0, 7.0, 2.0};
+    bounding_box_ = {7.0, 2.0, 2.0};
   }
   ekf_.init(X, P);
 }
@@ -345,8 +345,8 @@ bool BigVehicleTracker::measureWithShape(
   }
   constexpr float gain = 0.9;
 
-  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
   bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.x;
+  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
   bounding_box_.height = gain * bounding_box_.height + (1.0 - gain) * object.shape.dimensions.z;
 
   return true;

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -347,8 +347,8 @@ bool NormalVehicleTracker::measureWithShape(
   }
   constexpr float gain = 0.9;
 
-  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.x;
-  bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.y;
+  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
+  bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.x;
   bounding_box_.height = gain * bounding_box_.height + (1.0 - gain) * object.shape.dimensions.z;
 
   return true;
@@ -446,8 +446,8 @@ bool NormalVehicleTracker::getTrackedObject(
   twist_with_cov.covariance[utils::MSG_COV_IDX::YAW_YAW] = P(IDX::WZ, IDX::WZ);
 
   // set shape
-  object.shape.dimensions.x = bounding_box_.width;
-  object.shape.dimensions.y = bounding_box_.length;
+  object.shape.dimensions.x = bounding_box_.length;
+  object.shape.dimensions.y = bounding_box_.width;
   object.shape.dimensions.z = bounding_box_.height;
   const auto origin_yaw = tf2::getYaw(object_.kinematics.pose_with_covariance.pose.orientation);
   const auto ekf_pose_yaw = tf2::getYaw(pose_with_cov.pose.orientation);

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -130,7 +130,7 @@ NormalVehicleTracker::NormalVehicleTracker(
 
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
-      object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
+      object.shape.dimensions.y, object.shape.dimensions.x, object.shape.dimensions.z};
   } else {
     bounding_box_ = {1.7, 4.0, 2.0};
   }

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -130,9 +130,9 @@ NormalVehicleTracker::NormalVehicleTracker(
 
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
     bounding_box_ = {
-      object.shape.dimensions.y, object.shape.dimensions.x, object.shape.dimensions.z};
+      object.shape.dimensions.x, object.shape.dimensions.y, object.shape.dimensions.z};
   } else {
-    bounding_box_ = {1.7, 4.0, 2.0};
+    bounding_box_ = {4.0, 1.7, 2.0};
   }
   ekf_.init(X, P);
 }
@@ -347,8 +347,8 @@ bool NormalVehicleTracker::measureWithShape(
   }
   constexpr float gain = 0.9;
 
-  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
   bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.x;
+  bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
   bounding_box_.height = gain * bounding_box_.height + (1.0 - gain) * object.shape.dimensions.z;
 
   return true;

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -299,8 +299,8 @@ bool PedestrianTracker::measureWithShape(
 {
   constexpr float gain = 0.9;
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.x;
-    bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.y;
+    bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
+    bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.x;
     bounding_box_.height = gain * bounding_box_.height + (1.0 - gain) * object.shape.dimensions.z;
   } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
     cylinder_.width = gain * cylinder_.width + (1.0 - gain) * object.shape.dimensions.x;
@@ -405,8 +405,8 @@ bool PedestrianTracker::getTrackedObject(
 
   // set shape
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    object.shape.dimensions.x = bounding_box_.width;
-    object.shape.dimensions.y = bounding_box_.length;
+    object.shape.dimensions.x = bounding_box_.length;
+    object.shape.dimensions.y = bounding_box_.width;
     object.shape.dimensions.z = bounding_box_.height;
   } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
     object.shape.dimensions.x = cylinder_.width;

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -299,8 +299,8 @@ bool PedestrianTracker::measureWithShape(
 {
   constexpr float gain = 0.9;
   if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
     bounding_box_.length = gain * bounding_box_.length + (1.0 - gain) * object.shape.dimensions.x;
+    bounding_box_.width = gain * bounding_box_.width + (1.0 - gain) * object.shape.dimensions.y;
     bounding_box_.height = gain * bounding_box_.height + (1.0 - gain) * object.shape.dimensions.z;
   } else if (object.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
     cylinder_.width = gain * cylinder_.width + (1.0 - gain) * object.shape.dimensions.x;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Solved the problem of width and length in member variable `bonding_box_` being reversed.

- Fix the description in which `bounding_box_.width` and `object.shape.dimensions.x`(representing length) was associated with each other.



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
