### PR TITLE
fix(behavior_path_planner): die when using getExtendedCurrentLanes in the last lane

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2030,11 +2030,15 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
 
   // Add next lane
   const auto next_lanes = route_handler->getNextLanelets(current_lanes.back());
-  current_lanes.push_back(next_lanes.front());
+  if (!next_lanes.empty()) {
+    current_lanes.push_back(next_lanes.front());
+  }
 
   // Add previous lane
   const auto prev_lanes = route_handler->getPreviousLanelets(current_lanes.front());
-  current_lanes.insert(current_lanes.begin(), prev_lanes.front());
+  if (!prev_lanes.empty()) {
+    current_lanes.insert(current_lanes.begin(), prev_lanes.front());
+  }
 
   return current_lanes;
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

In https://github.com/autowarefoundation/autoware.universe/pull/2207 added front() of next/prev lanes to current_lanes. but when these lanes are empty, the node dies. In this PR, changed next/prev lanes are empty.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
psim
![Screenshot from 2022-11-09 19-05-54](https://user-images.githubusercontent.com/39142679/200802352-ce45c401-92ed-4287-9e90-3450b568e670.png)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
