### PR TITLE
feat(mission_planner): add another initialization function

### DIFF
--- a/planning/mission_planner/include/mission_planner/mission_planner_plugin.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_plugin.hpp
@@ -17,6 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_auto_planning_msgs/msg/had_map_route.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
@@ -31,10 +32,13 @@ class PlannerPlugin
 public:
   using RoutePoints = std::vector<geometry_msgs::msg::Pose>;
   using HADMapRoute = autoware_auto_planning_msgs::msg::HADMapRoute;
+  using HADMapBin = autoware_auto_mapping_msgs::msg::HADMapBin;
   using MarkerArray = visualization_msgs::msg::MarkerArray;
 
   virtual ~PlannerPlugin() = default;
   virtual void initialize(rclcpp::Node * node) = 0;
+  virtual void initialize(
+    rclcpp::Node * node, const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg) = 0;
   virtual bool ready() const = 0;
   virtual HADMapRoute plan(const RoutePoints & points) = 0;
   virtual MarkerArray visualize(const HADMapRoute & route) const = 0;

--- a/planning/mission_planner/include/mission_planner/mission_planner_plugin.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_plugin.hpp
@@ -38,7 +38,7 @@ public:
   virtual ~PlannerPlugin() = default;
   virtual void initialize(rclcpp::Node * node) = 0;
   virtual void initialize(
-    rclcpp::Node * node, const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg) = 0;
+    rclcpp::Node * node, const HADMapBin::ConstSharedPtr msg) = 0;
   virtual bool ready() const = 0;
   virtual HADMapRoute plan(const RoutePoints & points) = 0;
   virtual MarkerArray visualize(const HADMapRoute & route) const = 0;

--- a/planning/mission_planner/include/mission_planner/mission_planner_plugin.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_plugin.hpp
@@ -37,8 +37,7 @@ public:
 
   virtual ~PlannerPlugin() = default;
   virtual void initialize(rclcpp::Node * node) = 0;
-  virtual void initialize(
-    rclcpp::Node * node, const HADMapBin::ConstSharedPtr msg) = 0;
+  virtual void initialize(rclcpp::Node * node, const HADMapBin::ConstSharedPtr msg) = 0;
   virtual bool ready() const = 0;
   virtual HADMapRoute plan(const RoutePoints & points) = 0;
   virtual MarkerArray visualize(const HADMapRoute & route) const = 0;

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -115,6 +115,14 @@ void DefaultPlanner::initialize(rclcpp::Node * node)
     std::bind(&DefaultPlanner::map_callback, this, std::placeholders::_1));
 }
 
+void DefaultPlanner::initialize(
+  rclcpp::Node * node, const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg)
+{
+  is_graph_ready_ = false;
+  node_ = node;
+  map_callback(msg);
+}
+
 bool DefaultPlanner::ready() const { return is_graph_ready_; }
 
 void DefaultPlanner::map_callback(

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -110,13 +110,12 @@ void DefaultPlanner::initialize(rclcpp::Node * node)
 {
   is_graph_ready_ = false;
   node_ = node;
-  map_subscriber_ = node_->create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
+  map_subscriber_ = node_->create_subscription<HADMapBin>(
     "input/vector_map", rclcpp::QoS{10}.transient_local(),
     std::bind(&DefaultPlanner::map_callback, this, std::placeholders::_1));
 }
 
-void DefaultPlanner::initialize(
-  rclcpp::Node * node, const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg)
+void DefaultPlanner::initialize(rclcpp::Node * node, const HADMapBin::ConstSharedPtr msg)
 {
   is_graph_ready_ = false;
   node_ = node;
@@ -125,8 +124,7 @@ void DefaultPlanner::initialize(
 
 bool DefaultPlanner::ready() const { return is_graph_ready_; }
 
-void DefaultPlanner::map_callback(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg)
+void DefaultPlanner::map_callback(const HADMapBin::ConstSharedPtr msg)
 {
   route_handler_.setMap(*msg);
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
@@ -254,7 +252,7 @@ PlannerPlugin::HADMapRoute DefaultPlanner::plan(const RoutePoints & points)
     logger, "start planning route with check points: " << std::endl
                                                        << log_ss.str());
 
-  autoware_auto_planning_msgs::msg::HADMapRoute route_msg;
+  HADMapRoute route_msg;
   RouteSections route_sections;
 
   if (!is_goal_valid(points.back())) {

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -36,6 +36,9 @@ class DefaultPlanner : public mission_planner::PlannerPlugin
 {
 public:
   void initialize(rclcpp::Node * node) override;
+  void initialize(
+    rclcpp::Node * node,
+    const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg) override;
   bool ready() const override;
   HADMapRoute plan(const RoutePoints & points) override;
   MarkerArray visualize(const HADMapRoute & route) const override;

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -36,9 +36,7 @@ class DefaultPlanner : public mission_planner::PlannerPlugin
 {
 public:
   void initialize(rclcpp::Node * node) override;
-  void initialize(
-    rclcpp::Node * node,
-    const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg) override;
+  void initialize(rclcpp::Node * node, const HADMapBin::ConstSharedPtr msg) override;
   bool ready() const override;
   HADMapRoute plan(const RoutePoints & points) override;
   MarkerArray visualize(const HADMapRoute & route) const override;
@@ -55,9 +53,9 @@ private:
   route_handler::RouteHandler route_handler_;
 
   rclcpp::Node * node_;
-  rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr map_subscriber_;
+  rclcpp::Subscription<HADMapBin>::SharedPtr map_subscriber_;
 
-  void map_callback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
+  void map_callback(const HADMapBin::ConstSharedPtr msg);
   bool is_goal_valid(const geometry_msgs::msg::Pose & goal) const;
   Pose refine_goal_height(const Pose & goal, const RouteSections & route_sections);
 };


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

To realize static center line optimizer as follows, mission_planner has to be called statically.
https://github.com/autowarefoundation/autoware.universe/issues/1942

Therefore, I created this PR to ask mission_planner to plan route statically without runtime callback.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
