### PR TITLE
refactor(ekf_localizer): remove the prediction function to improve referential transparency 

### DIFF
--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -397,28 +397,6 @@ void EKFLocalizer::initEKF()
   ekf_.init(X, P, params_.extend_state_step);
 }
 
-/*  == Nonlinear model ==
- *
- * x_{k+1}   = x_k + vx_k * cos(yaw_k + b_k) * dt
- * y_{k+1}   = y_k + vx_k * sin(yaw_k + b_k) * dt
- * yaw_{k+1} = yaw_k + (wz_k) * dt
- * b_{k+1}   = b_k
- * vx_{k+1}  = vz_k
- * wz_{k+1}  = wz_k
- *
- * (b_k : yaw_bias_k)
- */
-
-/*  == Linearized model ==
- *
- * A = [ 1, 0, -vx*sin(yaw+b)*dt, -vx*sin(yaw+b)*dt, cos(yaw+b)*dt,  0]
- *     [ 0, 1,  vx*cos(yaw+b)*dt,  vx*cos(yaw+b)*dt, sin(yaw+b)*dt,  0]
- *     [ 0, 0,                 1,                 0,             0, dt]
- *     [ 0, 0,                 0,                 1,             0,  0]
- *     [ 0, 0,                 0,                 0,             1,  0]
- *     [ 0, 0,                 0,                 0,             0,  1]
- */
-
 /*
  * measurementUpdatePose
  */

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -151,7 +151,24 @@ void EKFLocalizer::timerCallback()
   /* predict model in EKF */
   stop_watch_.tic();
   DEBUG_INFO(get_logger(), "------------------------- start prediction -------------------------");
-  predictKinematicsModel();
+
+  const Eigen::MatrixXd X_curr = ekf_.getLatestX();
+  DEBUG_PRINT_MAT(X_curr.transpose());
+
+  const Eigen::MatrixXd P_curr = ekf_.getLatestP();
+
+  const double dt = ekf_dt_;
+
+  const Vector6d X_next = predictNextState(X_curr, dt);
+  const Matrix6d A = createStateTransitionMatrix(X_curr, dt);
+  const Matrix6d Q = processNoiseCovariance(proc_cov_yaw_d_, proc_cov_vx_d_, proc_cov_wz_d_);
+
+  ekf_.predictWithDelay(X_next, A, Q);
+
+  // debug
+  const Eigen::MatrixXd X_result = ekf_.getLatestX();
+  DEBUG_PRINT_MAT(X_result.transpose());
+  DEBUG_PRINT_MAT((X_result - X_curr).transpose());
   DEBUG_INFO(get_logger(), "[EKF] predictKinematicsModel calc time = %f [ms]", stop_watch_.toc());
   DEBUG_INFO(get_logger(), "------------------------- end prediction -------------------------\n");
 
@@ -380,51 +397,27 @@ void EKFLocalizer::initEKF()
   ekf_.init(X, P, params_.extend_state_step);
 }
 
-/*
- * predictKinematicsModel
+/*  == Nonlinear model ==
+ *
+ * x_{k+1}   = x_k + vx_k * cos(yaw_k + b_k) * dt
+ * y_{k+1}   = y_k + vx_k * sin(yaw_k + b_k) * dt
+ * yaw_{k+1} = yaw_k + (wz_k) * dt
+ * b_{k+1}   = b_k
+ * vx_{k+1}  = vz_k
+ * wz_{k+1}  = wz_k
+ *
+ * (b_k : yaw_bias_k)
  */
-void EKFLocalizer::predictKinematicsModel()
-{
-  /*  == Nonlinear model ==
-   *
-   * x_{k+1}   = x_k + vx_k * cos(yaw_k + b_k) * dt
-   * y_{k+1}   = y_k + vx_k * sin(yaw_k + b_k) * dt
-   * yaw_{k+1} = yaw_k + (wz_k) * dt
-   * b_{k+1}   = b_k
-   * vx_{k+1}  = vz_k
-   * wz_{k+1}  = wz_k
-   *
-   * (b_k : yaw_bias_k)
-   */
 
-  /*  == Linearized model ==
-   *
-   * A = [ 1, 0, -vx*sin(yaw+b)*dt, -vx*sin(yaw+b)*dt, cos(yaw+b)*dt,  0]
-   *     [ 0, 1,  vx*cos(yaw+b)*dt,  vx*cos(yaw+b)*dt, sin(yaw+b)*dt,  0]
-   *     [ 0, 0,                 1,                 0,             0, dt]
-   *     [ 0, 0,                 0,                 1,             0,  0]
-   *     [ 0, 0,                 0,                 0,             1,  0]
-   *     [ 0, 0,                 0,                 0,             0,  1]
-   */
-
-  const Eigen::MatrixXd X_curr = ekf_.getLatestX();
-  DEBUG_PRINT_MAT(X_curr.transpose());
-
-  const Eigen::MatrixXd P_curr = ekf_.getLatestP();
-
-  const double dt = ekf_dt_;
-
-  const Vector6d X_next = predictNextState(X_curr, dt);
-  const Matrix6d A = createStateTransitionMatrix(X_curr, dt);
-  const Matrix6d Q = processNoiseCovariance(proc_cov_yaw_d_, proc_cov_vx_d_, proc_cov_wz_d_);
-
-  ekf_.predictWithDelay(X_next, A, Q);
-
-  // debug
-  const Eigen::MatrixXd X_result = ekf_.getLatestX();
-  DEBUG_PRINT_MAT(X_result.transpose());
-  DEBUG_PRINT_MAT((X_result - X_curr).transpose());
-}
+/*  == Linearized model ==
+ *
+ * A = [ 1, 0, -vx*sin(yaw+b)*dt, -vx*sin(yaw+b)*dt, cos(yaw+b)*dt,  0]
+ *     [ 0, 1,  vx*cos(yaw+b)*dt,  vx*cos(yaw+b)*dt, sin(yaw+b)*dt,  0]
+ *     [ 0, 0,                 1,                 0,             0, dt]
+ *     [ 0, 0,                 0,                 1,             0,  0]
+ *     [ 0, 0,                 0,                 0,             1,  0]
+ *     [ 0, 0,                 0,                 0,             0,  1]
+ */
 
 /*
  * measurementUpdatePose
@@ -482,8 +475,10 @@ void EKFLocalizer::measurementUpdatePose(const geometry_msgs::msg::PoseWithCovar
 
   /* Gate */
   Eigen::MatrixXd y_ekf(dim_y, 1);
-  y_ekf << ekf_.getXelement(delay_step * dim_x_ + IDX::X),
-    ekf_.getXelement(delay_step * dim_x_ + IDX::Y), ekf_yaw;
+  y_ekf <<
+    ekf_.getXelement(delay_step * dim_x_ + IDX::X),
+    ekf_.getXelement(delay_step * dim_x_ + IDX::Y),
+    ekf_yaw;
   const Eigen::MatrixXd P_curr = ekf_.getLatestP();
   const Eigen::MatrixXd P_y = P_curr.block(0, 0, dim_y, dim_y);
   if (!mahalanobisGate(params_.pose_gate_dist, y_ekf, y, P_y)) {
@@ -561,7 +556,8 @@ void EKFLocalizer::measurementUpdateTwist(
 
   /* Gate */
   Eigen::MatrixXd y_ekf(dim_y, 1);
-  y_ekf << ekf_.getXelement(delay_step * dim_x_ + IDX::VX),
+  y_ekf <<
+    ekf_.getXelement(delay_step * dim_x_ + IDX::VX),
     ekf_.getXelement(delay_step * dim_x_ + IDX::WZ);
   const Eigen::MatrixXd P_curr = ekf_.getLatestP();
   const Eigen::MatrixXd P_y = P_curr.block(4, 4, dim_y, dim_y);

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -475,10 +475,8 @@ void EKFLocalizer::measurementUpdatePose(const geometry_msgs::msg::PoseWithCovar
 
   /* Gate */
   Eigen::MatrixXd y_ekf(dim_y, 1);
-  y_ekf <<
-    ekf_.getXelement(delay_step * dim_x_ + IDX::X),
-    ekf_.getXelement(delay_step * dim_x_ + IDX::Y),
-    ekf_yaw;
+  y_ekf << ekf_.getXelement(delay_step * dim_x_ + IDX::X),
+    ekf_.getXelement(delay_step * dim_x_ + IDX::Y), ekf_yaw;
   const Eigen::MatrixXd P_curr = ekf_.getLatestP();
   const Eigen::MatrixXd P_y = P_curr.block(0, 0, dim_y, dim_y);
   if (!mahalanobisGate(params_.pose_gate_dist, y_ekf, y, P_y)) {
@@ -556,8 +554,7 @@ void EKFLocalizer::measurementUpdateTwist(
 
   /* Gate */
   Eigen::MatrixXd y_ekf(dim_y, 1);
-  y_ekf <<
-    ekf_.getXelement(delay_step * dim_x_ + IDX::VX),
+  y_ekf << ekf_.getXelement(delay_step * dim_x_ + IDX::VX),
     ekf_.getXelement(delay_step * dim_x_ + IDX::WZ);
   const Eigen::MatrixXd P_curr = ekf_.getLatestP();
   const Eigen::MatrixXd P_y = P_curr.block(4, 4, dim_y, dim_y);

--- a/localization/ekf_localizer/src/state_transition.cpp
+++ b/localization/ekf_localizer/src/state_transition.cpp
@@ -24,6 +24,18 @@ double normalizeYaw(const double & yaw)
   return std::atan2(std::sin(yaw), std::cos(yaw));
 }
 
+/*  == Nonlinear model ==
+ *
+ * x_{k+1}   = x_k + vx_k * cos(yaw_k + b_k) * dt
+ * y_{k+1}   = y_k + vx_k * sin(yaw_k + b_k) * dt
+ * yaw_{k+1} = yaw_k + (wz_k) * dt
+ * b_{k+1}   = b_k
+ * vx_{k+1}  = vz_k
+ * wz_{k+1}  = wz_k
+ *
+ * (b_k : yaw_bias_k)
+ */
+
 Vector6d predictNextState(const Vector6d & X_curr, const double dt)
 {
   const double x = X_curr(IDX::X);
@@ -43,7 +55,15 @@ Vector6d predictNextState(const Vector6d & X_curr, const double dt)
   return X_next;
 }
 
-// TODO(TakeshiIshita) show where the equation come from
+/*  == Linearized model ==
+ *
+ * A = [ 1, 0, -vx*sin(yaw+b)*dt, -vx*sin(yaw+b)*dt, cos(yaw+b)*dt,  0]
+ *     [ 0, 1,  vx*cos(yaw+b)*dt,  vx*cos(yaw+b)*dt, sin(yaw+b)*dt,  0]
+ *     [ 0, 0,                 1,                 0,             0, dt]
+ *     [ 0, 0,                 0,                 1,             0,  0]
+ *     [ 0, 0,                 0,                 0,             1,  0]
+ *     [ 0, 0,                 0,                 0,             0,  1]
+ */
 Matrix6d createStateTransitionMatrix(const Vector6d & X_curr, const double dt)
 {
   const double yaw = X_curr(IDX::YAW);


### PR DESCRIPTION
## Description

This PR removes the 'predictKinematicsModel' function to improve referential transparency 

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

No tests preformed yet, but this modification improves testability in the future.
I checked the behavior in the logging simulator.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
