### PR TITLE
refactor(obstacle_velocity_limiter): use motion_utils instead of motion_common

### DIFF
--- a/planning/obstacle_velocity_limiter/include/obstacle_velocity_limiter/obstacle_velocity_limiter_node.hpp
+++ b/planning/obstacle_velocity_limiter/include/obstacle_velocity_limiter/obstacle_velocity_limiter_node.hpp
@@ -19,7 +19,6 @@
 #include "obstacle_velocity_limiter/parameters.hpp"
 #include "obstacle_velocity_limiter/types.hpp"
 
-#include <experimental/optional>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/ros/self_pose_listener.hpp>
 #include <tier4_autoware_utils/ros/transform_listener.hpp>
@@ -31,6 +30,8 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <std_msgs/msg/int64.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
+
+#include <boost/optional.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 
@@ -101,7 +102,7 @@ private:
   /// @brief validate the inputs of the node
   /// @param[in] ego_idx trajectory index closest to the current ego pose
   /// @return true if the inputs are valid
-  bool validInputs(const std::experimental::fundamentals_v1::optional<size_t> & ego_idx);
+  bool validInputs(const boost::optional<size_t> & ego_idx);
 };
 }  // namespace obstacle_velocity_limiter
 

--- a/planning/obstacle_velocity_limiter/package.xml
+++ b/planning/obstacle_velocity_limiter/package.xml
@@ -20,7 +20,7 @@
   <depend>lanelet2_core</depend>
   <depend>lanelet2_extension</depend>
   <depend>libboost-dev</depend>
-  <depend>motion_common</depend>
+  <depend>motion_utils</depend>
   <depend>nav_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>

--- a/planning/obstacle_velocity_limiter/src/obstacle_velocity_limiter_node.cpp
+++ b/planning/obstacle_velocity_limiter/src/obstacle_velocity_limiter_node.cpp
@@ -23,7 +23,7 @@
 #include "obstacle_velocity_limiter/types.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
-#include <motion_common/trajectory_common.hpp>
+#include <motion_utils/motion_utils.hpp>
 #include <rclcpp/duration.hpp>
 #include <rclcpp/logging.hpp>
 #include <rclcpp/qos.hpp>
@@ -177,8 +177,7 @@ void ObstacleVelocityLimiterNode::onTrajectory(const Trajectory::ConstSharedPtr 
       get_logger(), *get_clock(), rcutils_duration_value_t(1000), "Waiting for current pose");
     return;
   }
-  const auto ego_idx =
-    autoware::motion::motion_common::findNearestIndex(msg->points, current_pose_ptr->pose);
+  const auto ego_idx = motion_utils::findNearestIndex(msg->points, current_pose_ptr->pose);
   if (!validInputs(ego_idx)) return;
   auto original_traj = *msg;
   if (preprocessing_params_.calculate_steering_angles)
@@ -235,8 +234,7 @@ void ObstacleVelocityLimiterNode::onTrajectory(const Trajectory::ConstSharedPtr 
   }
 }
 
-bool ObstacleVelocityLimiterNode::validInputs(
-  const std::experimental::fundamentals_v1::optional<size_t> & ego_idx)
+bool ObstacleVelocityLimiterNode::validInputs(const boost::optional<size_t> & ego_idx)
 {
   constexpr auto one_sec = rcutils_duration_value_t(1000);
   if (!occupancy_grid_ptr_)


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

use motion_utils package instead of motion_common
https://github.com/autowarefoundation/autoware.universe/issues/2229

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
