### PR TITLE
feat(avoidance): improve avoidance target filter

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -12,8 +12,10 @@
 
       threshold_distance_object_is_on_center: 1.0 # [m]
       threshold_speed_object_is_stopped: 1.0      # [m/s]
+      threshold_time_object_is_moving: 1.0        # [s]
       object_check_forward_distance: 150.0        # [m]
       object_check_backward_distance: 2.0         # [m]
+      object_envelope_buffer: 0.3                 # [m]
       lateral_collision_margin: 1.0               # [m]
       lateral_collision_safety_buffer: 0.7        # [m]
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -195,7 +195,11 @@ private:
   /**
    * object pre-process
    */
+  void fillAvoidanceTargetObjects(AvoidancePlanningData & data, DebugData & debug) const;
   void fillObjectEnvelopePolygon(const Pose & closest_pose, ObjectData & object_data) const;
+  void fillObjectMovingTime(ObjectData & object_data) const;
+  void compensateDetectionLost(
+    ObjectDataArray & target_objects, ObjectDataArray & other_objects) const;
 
   // data used in previous planning
   ShiftedPath prev_output_;
@@ -214,13 +218,9 @@ private:
   // -- for pre-processing --
   void initVariables();
   AvoidancePlanningData calcAvoidancePlanningData(DebugData & debug) const;
-  ObjectDataArray calcAvoidanceTargetObjects(
-    const lanelet::ConstLanelets & lanelets, const PathWithLaneId & reference_path,
-    DebugData & debug) const;
 
   ObjectDataArray registered_objects_;
   void updateRegisteredObject(const ObjectDataArray & objects);
-  void CompensateDetectionLost(ObjectDataArray & objects) const;
 
   // -- for shift point generation --
   AvoidLineArray calcShiftLines(AvoidLineArray & current_raw_shift_lines, DebugData & debug) const;
@@ -293,7 +293,8 @@ private:
   // debug
   mutable DebugData debug_data_;
   mutable std::shared_ptr<AvoidanceDebugMsgArray> debug_msg_ptr_;
-  void setDebugData(const PathShifter & shifter, const DebugData & debug);
+  void setDebugData(
+    const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug) const;
   void updateAvoidanceDebugData(std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const;
   mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_line_;
   mutable rclcpp::Time debug_avoidance_initializer_for_shift_line_time_;
@@ -323,6 +324,11 @@ private:
   double getCurrentBaseShift() const { return path_shifter_.getBaseOffset(); }
   double getCurrentShift() const;
   double getCurrentLinearShift() const;
+
+  /**
+   * avoidance module misc data
+   */
+  mutable ObjectDataArray stopped_objects_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -192,6 +192,11 @@ private:
     }
   }
 
+  /**
+   * object pre-process
+   */
+  void fillObjectEnvelopePolygon(const Pose & closest_pose, ObjectData & object_data) const;
+
   // data used in previous planning
   ShiftedPath prev_output_;
   ShiftedPath prev_linear_shift_path_;  // used for shift point check

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -80,6 +80,9 @@ struct AvoidanceParameters
   // object's enveloped polygon
   double object_envelope_buffer;
 
+  // vehicles which is moving more than this parameter will not be avoided
+  double threshold_time_object_is_moving;
+
   // we want to keep this lateral margin when avoiding
   double lateral_collision_margin;
   // a buffer in case lateral_collision_margin is set to 0. Will throw error
@@ -197,6 +200,10 @@ struct ObjectData  // avoidance target
   rclcpp::Time last_seen;
   double lost_time{0.0};
 
+  // count up when object moved. Removed when it exceeds threshold.
+  rclcpp::Time last_stop;
+  double move_time{0.0};
+
   // store the information of the lanelet which the object's overhang is currently occupying
   lanelet::ConstLanelet overhang_lanelet;
 
@@ -261,7 +268,10 @@ struct AvoidancePlanningData
   lanelet::ConstLanelets current_lanelets;
 
   // avoidance target objects
-  ObjectDataArray objects;
+  ObjectDataArray target_objects;
+
+  // the others
+  ObjectDataArray other_objects;
 };
 
 /*

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -18,6 +18,7 @@
 #include "behavior_path_planner/scene_module/utils/path_shifter.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
@@ -34,10 +35,12 @@ namespace behavior_path_planner
 using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 
+using tier4_autoware_utils::Polygon2d;
 using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
 
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
+using geometry_msgs::msg::TransformStamped;
 
 struct AvoidanceParameters
 {
@@ -73,6 +76,9 @@ struct AvoidanceParameters
 
   // continue to detect backward vehicles as avoidance targets until they are this distance away
   double object_check_backward_distance;
+
+  // object's enveloped polygon
+  double object_envelope_buffer;
 
   // we want to keep this lateral margin when avoiding
   double lateral_collision_margin;
@@ -196,6 +202,9 @@ struct ObjectData  // avoidance target
 
   // the position of the overhang
   Pose overhang_pose;
+
+  // envelope polygon
+  Polygon2d envelope_poly{};
 
   // lateral distance from overhang to the road shoulder
   double to_road_shoulder_distance{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -50,7 +50,13 @@ void fillLongitudinalAndLengthByClosestFootprint(
   const PathWithLaneId & path, const PredictedObject & object, const Point & ego_pos,
   ObjectData & obj);
 
+void fillLongitudinalAndLengthByClosestEnvelopeFootprint(
+  const PathWithLaneId & path, const Point & ego_pos, ObjectData & obj);
+
 double calcOverhangDistance(
+  const ObjectData & object_data, const Pose & base_pose, Point & overhang_pose);
+
+double calcEnvelopeOverhangDistance(
   const ObjectData & object_data, const Pose & base_pose, Point & overhang_pose);
 
 void setEndData(
@@ -64,6 +70,9 @@ void setStartData(
 std::string getUuidStr(const ObjectData & obj);
 
 std::vector<std::string> getUuidStr(const ObjectDataArray & objs);
+
+Polygon2d createEnvelopePolygon(
+  const ObjectData & object_data, const Pose & closest_pose, const double envelope_buffer);
 }  // namespace behavior_path_planner
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__AVOIDANCE_UTILS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -47,7 +47,10 @@ MarkerArray createAvoidLineMarkerArray(
   const AvoidLineArray & shift_points, std::string && ns, const float & r, const float & g,
   const float & b, const double & w);
 
-MarkerArray createAvoidanceObjectsMarkerArray(
+MarkerArray createTargetObjectsMarkerArray(
+  const behavior_path_planner::ObjectDataArray & objects, std::string && ns);
+
+MarkerArray createOtherObjectsMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects, std::string && ns);
 
 MarkerArray makeOverhangToRoadShoulderMarkerArray(

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -44,6 +44,7 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_auto_tf2</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>behaviortree_cpp_v3</depend>
   <depend>geometry_msgs</depend>

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -276,6 +276,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.threshold_speed_object_is_stopped = dp("threshold_speed_object_is_stopped", 1.0);
   p.object_check_forward_distance = dp("object_check_forward_distance", 150.0);
   p.object_check_backward_distance = dp("object_check_backward_distance", 2.0);
+  p.object_envelope_buffer = dp("object_envelope_buffer", 0.1);
   p.lateral_collision_margin = dp("lateral_collision_margin", 2.0);
   p.lateral_collision_safety_buffer = dp("lateral_collision_safety_buffer", 0.5);
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -274,6 +274,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
 
   p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 1.0);
   p.threshold_speed_object_is_stopped = dp("threshold_speed_object_is_stopped", 1.0);
+  p.threshold_time_object_is_moving = dp("threshold_time_object_is_moving", 1.0);
   p.object_check_forward_distance = dp("object_check_forward_distance", 150.0);
   p.object_check_backward_distance = dp("object_check_backward_distance", 2.0);
   p.object_envelope_buffer = dp("object_envelope_buffer", 0.1);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -71,11 +71,13 @@ bool AvoidanceModule::isExecutionRequested() const
     return true;
   }
 
-  DebugData debug;
-  const auto avoid_data = calcAvoidancePlanningData(debug);
+  const auto avoid_data = calcAvoidancePlanningData(debug_data_);
 
-  const bool has_avoidance_target = !avoid_data.objects.empty();
-  return has_avoidance_target ? true : false;
+  if (parameters_->publish_debug_marker) {
+    setDebugData(avoid_data, path_shifter_, debug_data_);
+  }
+
+  return !avoid_data.target_objects.empty();
 }
 
 bool AvoidanceModule::isExecutionReady() const
@@ -100,7 +102,7 @@ BT::NodeStatus AvoidanceModule::updateState()
 
   DebugData debug;
   const auto avoid_data = calcAvoidancePlanningData(debug);
-  const bool has_avoidance_target = !avoid_data.objects.empty();
+  const bool has_avoidance_target = !avoid_data.target_objects.empty();
   if (!is_plan_running && !has_avoidance_target) {
     current_state_ = BT::NodeStatus::SUCCESS;
   } else {
@@ -161,39 +163,33 @@ AvoidancePlanningData AvoidanceModule::calcAvoidancePlanningData(DebugData & deb
     planner_data_->parameters.forward_path_length, planner_data_->parameters.backward_path_length);
 
   // target objects for avoidance
-  data.objects = calcAvoidanceTargetObjects(data.current_lanelets, data.reference_path, debug);
+  fillAvoidanceTargetObjects(data, debug);
 
-  DEBUG_PRINT("target object size = %lu", data.objects.size());
+  DEBUG_PRINT("target object size = %lu", data.target_objects.size());
 
   return data;
 }
 
-ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
-  const lanelet::ConstLanelets & current_lanes, const PathWithLaneId & reference_path,
-  DebugData & debug) const
+void AvoidanceModule::fillAvoidanceTargetObjects(
+  AvoidancePlanningData & data, DebugData & debug) const
 {
   using lanelet::geometry::distance2d;
   using lanelet::utils::getId;
   using lanelet::utils::to2D;
 
-  const auto & path_points = reference_path.points;
+  const auto & path_points = data.reference_path.points;
   const auto & ego_pos = getEgoPosition();
-
-  // velocity filter: only for stopped vehicle
-  const auto objects_candidate = util::filterObjectsByVelocity(
-    *planner_data_->dynamic_object, parameters_->threshold_speed_object_is_stopped);
 
   // detection area filter
   // when expanding lanelets, right_offset must be minus.
   // This is because y axis is positive on the left.
   const auto expanded_lanelets = lanelet::utils::getExpandedLanelets(
-    current_lanes, parameters_->detection_area_left_expand_dist,
+    data.current_lanelets, parameters_->detection_area_left_expand_dist,
     parameters_->detection_area_right_expand_dist * (-1.0));
   const auto lane_filtered_objects_index =
-    util::filterObjectIndicesByLanelets(objects_candidate, expanded_lanelets);
+    util::filterObjectIndicesByLanelets(*planner_data_->dynamic_object, expanded_lanelets);
 
   DEBUG_PRINT("dynamic_objects size = %lu", planner_data_->dynamic_object->objects.size());
-  DEBUG_PRINT("object_candidate size = %lu", objects_candidate.objects.size());
   DEBUG_PRINT("lane_filtered_objects size = %lu", lane_filtered_objects_index.size());
 
   // for goal
@@ -209,7 +205,7 @@ ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
   ObjectDataArray target_objects;
   std::vector<AvoidanceDebugMsg> avoidance_debug_msg_array;
   for (const auto & i : lane_filtered_objects_index) {
-    const auto & object = objects_candidate.objects.at(i);
+    const auto & object = planner_data_->dynamic_object->objects.at(i);
     const auto & object_pos = object.kinematics.initial_pose_with_covariance.pose.position;
     AvoidanceDebugMsg avoidance_debug_msg;
     const auto avoidance_debug_array_false_and_push_back =
@@ -235,22 +231,34 @@ ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
     fillObjectEnvelopePolygon(object_closest_pose, object_data);
 
     // calc longitudinal distance from ego to closest target object footprint point.
-    fillLongitudinalAndLengthByClosestEnvelopeFootprint(reference_path, ego_pos, object_data);
+    fillLongitudinalAndLengthByClosestEnvelopeFootprint(data.reference_path, ego_pos, object_data);
     avoidance_debug_msg.longitudinal_distance = object_data.longitudinal;
+
+    // Calc moving time.
+    fillObjectMovingTime(object_data);
+
+    if (object_data.move_time > parameters_->threshold_time_object_is_moving) {
+      avoidance_debug_array_false_and_push_back("MovingObject");
+      data.other_objects.push_back(object_data);
+      continue;
+    }
 
     // object is behind ego or too far.
     if (object_data.longitudinal < -parameters_->object_check_backward_distance) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_IS_BEHIND_THRESHOLD);
+      data.other_objects.push_back(object_data);
       continue;
     }
     if (object_data.longitudinal > parameters_->object_check_forward_distance) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_IS_IN_FRONT_THRESHOLD);
+      data.other_objects.push_back(object_data);
       continue;
     }
 
     // Target object is behind the path goal -> ignore.
     if (object_data.longitudinal > dist_to_goal) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_BEHIND_PATH_GOAL);
+      data.other_objects.push_back(object_data);
       continue;
     }
 
@@ -302,13 +310,14 @@ ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
     avoidance_debug_msg.lateral_distance_from_centerline = object_data.lateral;
     if (std::abs(object_data.lateral) < parameters_->threshold_distance_object_is_on_center) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE);
+      data.other_objects.push_back(object_data);
       continue;
     }
 
     object_data.last_seen = clock_->now();
 
     // set data
-    target_objects.push_back(object_data);
+    data.target_objects.push_back(object_data);
   }
 
   // debug
@@ -316,11 +325,9 @@ ObjectDataArray AvoidanceModule::calcAvoidanceTargetObjects(
     updateAvoidanceDebugData(avoidance_debug_msg_array);
     debug.farthest_linestring_from_overhang =
       std::make_shared<lanelet::ConstLineStrings3d>(debug_linestring);
-    debug.current_lanelets = std::make_shared<lanelet::ConstLanelets>(current_lanes);
+    debug.current_lanelets = std::make_shared<lanelet::ConstLanelets>(data.current_lanelets);
     debug.expanded_lanelets = std::make_shared<lanelet::ConstLanelets>(expanded_lanelets);
   }
-
-  return target_objects;
 }
 
 void AvoidanceModule::fillObjectEnvelopePolygon(
@@ -349,6 +356,44 @@ void AvoidanceModule::fillObjectEnvelopePolygon(
   }
 
   object_data.envelope_poly = same_id_obj->envelope_poly;
+}
+
+void AvoidanceModule::fillObjectMovingTime(ObjectData & object_data) const
+{
+  const auto & object_vel =
+    object_data.object.kinematics.initial_twist_with_covariance.twist.linear.x;
+  const auto is_faster_than_threshold = object_vel > parameters_->threshold_speed_object_is_stopped;
+
+  const auto id = object_data.object.object_id;
+  const auto same_id_obj = std::find_if(
+    stopped_objects_.begin(), stopped_objects_.end(),
+    [&id](const auto & o) { return o.object.object_id == id; });
+
+  const auto is_new_object = same_id_obj == stopped_objects_.end();
+
+  if (!is_faster_than_threshold) {
+    object_data.last_stop = clock_->now();
+    object_data.move_time = 0.0;
+    if (is_new_object) {
+      stopped_objects_.push_back(object_data);
+    } else {
+      same_id_obj->last_stop = clock_->now();
+      same_id_obj->move_time = 0.0;
+    }
+    return;
+  }
+
+  if (is_new_object) {
+    object_data.move_time = std::numeric_limits<double>::max();
+    return;
+  }
+
+  object_data.last_stop = same_id_obj->last_stop;
+  object_data.move_time = (clock_->now() - same_id_obj->last_stop).seconds();
+
+  if (object_data.move_time > parameters_->threshold_time_object_is_moving) {
+    stopped_objects_.erase(same_id_obj);
+  }
 }
 
 /**
@@ -390,7 +435,7 @@ AvoidLineArray AvoidanceModule::calcShiftLines(
    * Generate raw_shift_lines (shift length, avoidance start point, end point, return point, etc)
    * for each object. These raw shift points are merged below to compute appropriate shift points.
    */
-  current_raw_shift_lines = calcRawShiftLinesFromObjects(avoidance_data_.objects);
+  current_raw_shift_lines = calcRawShiftLinesFromObjects(avoidance_data_.target_objects);
   debug.current_raw_shift = current_raw_shift_lines;
 
   /**
@@ -1991,7 +2036,7 @@ boost::optional<AvoidLine> AvoidanceModule::calcIntersectionShiftLine(
     constexpr double intersection_shift_margin = 1.0;
 
     double shift_length = 0.0;  // default (no obstacle) is zero.
-    for (const auto & obj : avoidance_data_.objects) {
+    for (const auto & obj : avoidance_data_.target_objects) {
       if (
         std::abs(obj.longitudinal - ego_to_intersection_dist) > intersection_obstacle_check_dist) {
         continue;
@@ -2075,7 +2120,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
     path_shifter_.generate(&prev_linear_shift_path_, true, SHIFT_TYPE::LINEAR);
     prev_reference_ = avoidance_data_.reference_path;
     if (parameters_->publish_debug_marker) {
-      setDebugData(path_shifter_, debug_data_);
+      setDebugData(avoidance_data_, path_shifter_, debug_data_);
     } else {
       debug_marker_.markers.clear();
     }
@@ -2416,8 +2461,8 @@ void AvoidanceModule::updateData()
   avoidance_data_ = calcAvoidancePlanningData(debug_data_);
 
   // TODO(Horibe): this is not tested yet, disable now.
-  updateRegisteredObject(avoidance_data_.objects);
-  CompensateDetectionLost(avoidance_data_.objects);
+  updateRegisteredObject(avoidance_data_.target_objects);
+  compensateDetectionLost(avoidance_data_.target_objects, avoidance_data_.other_objects);
 
   path_shifter_.setPath(avoidance_data_.reference_path);
 
@@ -2517,7 +2562,8 @@ void AvoidanceModule::updateRegisteredObject(const ObjectDataArray & now_objects
  * add registered object if the now_objects does not contain the same object_id.
  *
  */
-void AvoidanceModule::CompensateDetectionLost(ObjectDataArray & now_objects) const
+void AvoidanceModule::compensateDetectionLost(
+  ObjectDataArray & now_objects, ObjectDataArray & other_objects) const
 {
   const auto old_size = now_objects.size();  // for debug
 
@@ -2527,8 +2573,15 @@ void AvoidanceModule::CompensateDetectionLost(ObjectDataArray & now_objects) con
       n.begin(), n.end(), [&r_id](const auto & o) { return o.object.object_id == r_id; });
   };
 
+  const auto isIgnoreObject = [&](const auto & r_id) {
+    const auto & n = other_objects;
+    return std::any_of(
+      n.begin(), n.end(), [&r_id](const auto & o) { return o.object.object_id == r_id; });
+  };
+
   for (const auto & registered : registered_objects_) {
-    if (!isDetectedNow(registered.object.object_id)) {
+    if (
+      !isDetectedNow(registered.object.object_id) && !isIgnoreObject(registered.object.object_id)) {
       now_objects.push_back(registered);
     }
   }
@@ -2673,7 +2726,8 @@ double AvoidanceModule::getCurrentLinearShift() const
     findNearestIndex(prev_linear_shift_path_.path.points, getEgoPosition()));
 }
 
-void AvoidanceModule::setDebugData(const PathShifter & shifter, const DebugData & debug)
+void AvoidanceModule::setDebugData(
+  const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug) const
 {
   using marker_utils::createLaneletsAreaMarkerArray;
   using marker_utils::createObjectsMarkerArray;
@@ -2681,9 +2735,10 @@ void AvoidanceModule::setDebugData(const PathShifter & shifter, const DebugData 
   using marker_utils::createPoseMarkerArray;
   using marker_utils::createShiftLengthMarkerArray;
   using marker_utils::createShiftLineMarkerArray;
-  using marker_utils::avoidance_marker::createAvoidanceObjectsMarkerArray;
   using marker_utils::avoidance_marker::createAvoidLineMarkerArray;
+  using marker_utils::avoidance_marker::createOtherObjectsMarkerArray;
   using marker_utils::avoidance_marker::createOverhangFurthestLineStringMarkerArray;
+  using marker_utils::avoidance_marker::createTargetObjectsMarkerArray;
   using marker_utils::avoidance_marker::makeOverhangToRoadShoulderMarkerArray;
 
   debug_marker_.markers.clear();
@@ -2702,16 +2757,17 @@ void AvoidanceModule::setDebugData(const PathShifter & shifter, const DebugData 
       add(createShiftLineMarkerArray(sl_arr, shifter.getBaseOffset(), ns, r, g, b, w));
     };
 
-  const auto & path = avoidance_data_.reference_path;
+  const auto & path = data.reference_path;
   add(createPathMarkerArray(debug.center_line, "centerline", 0, 0.0, 0.5, 0.9));
   add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
   add(createPathMarkerArray(prev_linear_shift_path_.path, "prev_linear_shift", 0, 0.5, 0.4, 0.6));
-  add(createPoseMarkerArray(avoidance_data_.reference_pose, "reference_pose", 0, 0.9, 0.3, 0.3));
+  add(createPoseMarkerArray(data.reference_pose, "reference_pose", 0, 0.9, 0.3, 0.3));
 
   add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
   add(createLaneletsAreaMarkerArray(*debug.expanded_lanelets, "expanded_lanelet", 0.8, 0.8, 0.0));
-  add(createAvoidanceObjectsMarkerArray(avoidance_data_.objects, "avoidance_object"));
-  add(makeOverhangToRoadShoulderMarkerArray(avoidance_data_.objects, "overhang"));
+  add(createTargetObjectsMarkerArray(data.target_objects, "target_objects"));
+  add(createOtherObjectsMarkerArray(data.other_objects, "other_objects"));
+  add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
   add(createOverhangFurthestLineStringMarkerArray(
     *debug.farthest_linestring_from_overhang, "farthest_linestring_from_overhang", 1.0, 0.0, 1.0));
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -100,6 +100,7 @@ MarkerArray createTargetObjectsMarkerArray(
   };
 
   MarkerArray msg;
+  msg.markers.reserve(objects.size() * 2);
 
   {
     auto marker = createDefaultMarker(
@@ -155,6 +156,7 @@ MarkerArray createOtherObjectsMarkerArray(
   };
 
   MarkerArray msg;
+  msg.markers.reserve(objects.size());
 
   {
     Marker marker = createDefaultMarker(

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -82,7 +82,7 @@ MarkerArray createAvoidLineMarkerArray(
   return msg;
 }
 
-MarkerArray createAvoidanceObjectsMarkerArray(
+MarkerArray createTargetObjectsMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects, std::string && ns)
 {
   const auto normal_color = tier4_autoware_utils::createMarkerColor(0.9, 0.0, 0.0, 0.8);
@@ -132,6 +132,40 @@ MarkerArray createAvoidanceObjectsMarkerArray(
         marker.id = uuid_to_id(object.object.object_id);
         msg.markers.push_back(marker);
       }
+    }
+  }
+
+  return msg;
+}
+
+MarkerArray createOtherObjectsMarkerArray(
+  const behavior_path_planner::ObjectDataArray & objects, std::string && ns)
+{
+  const auto normal_color = tier4_autoware_utils::createMarkerColor(0.0, 1.0, 0.0, 0.8);
+
+  const auto uuid_to_id = [](const unique_identifier_msgs::msg::UUID & object_id) {
+    int32_t ret = 0;
+
+    for (size_t i = 0; i < sizeof(int32_t) / sizeof(int8_t); ++i) {
+      ret <<= sizeof(int8_t);
+      ret |= object_id.uuid.at(i);
+    }
+
+    return ret;
+  };
+
+  MarkerArray msg;
+
+  {
+    Marker marker = createDefaultMarker(
+      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE,
+      createMarkerScale(3.0, 1.5, 1.5), normal_color);
+    for (const auto & object : objects) {
+      marker.id = uuid_to_id(object.object.object_id);
+      marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
+      marker.scale = tier4_autoware_utils::createMarkerScale(3.0, 1.5, 1.5);
+      marker.color = normal_color;
+      msg.markers.push_back(marker);
     }
   }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -88,17 +88,51 @@ MarkerArray createAvoidanceObjectsMarkerArray(
   const auto normal_color = tier4_autoware_utils::createMarkerColor(0.9, 0.0, 0.0, 0.8);
   const auto disappearing_color = tier4_autoware_utils::createMarkerColor(0.9, 0.5, 0.9, 0.6);
 
-  Marker marker = createDefaultMarker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE,
-    createMarkerScale(3.0, 1.5, 1.5), normal_color);
-  int32_t i{0};
+  const auto uuid_to_id = [](const unique_identifier_msgs::msg::UUID & object_id) {
+    int32_t ret = 0;
+
+    for (size_t i = 0; i < sizeof(int32_t) / sizeof(int8_t); ++i) {
+      ret <<= sizeof(int8_t);
+      ret |= object_id.uuid.at(i);
+    }
+
+    return ret;
+  };
+
   MarkerArray msg;
-  for (const auto & object : objects) {
-    marker.id = ++i;
-    marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
-    marker.scale = tier4_autoware_utils::createMarkerScale(3.0, 1.5, 1.5);
-    marker.color = std::fabs(object.lost_time) < 1e-2 ? normal_color : disappearing_color;
-    msg.markers.push_back(marker);
+
+  {
+    auto marker = createDefaultMarker(
+      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE,
+      createMarkerScale(3.0, 1.5, 1.5), normal_color);
+    for (const auto & object : objects) {
+      marker.id = uuid_to_id(object.object.object_id);
+      marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
+      marker.scale = tier4_autoware_utils::createMarkerScale(3.0, 1.5, 1.5);
+      marker.color = std::fabs(object.lost_time) < 1e-2 ? normal_color : disappearing_color;
+      msg.markers.push_back(marker);
+    }
+  }
+
+  {
+    for (const auto & object : objects) {
+      const auto pos = object.object.kinematics.initial_pose_with_covariance.pose.position;
+
+      {
+        auto marker = createDefaultMarker(
+          "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns + "_envelope_polygon", 0L,
+          Marker::LINE_STRIP, createMarkerScale(0.1, 0.0, 0.0),
+          createMarkerColor(1.0, 1.0, 1.0, 0.999));
+
+        for (const auto & p : object.envelope_poly.outer()) {
+          marker.points.push_back(createPoint(p.x(), p.y(), pos.z));
+        }
+
+        marker.points.push_back(marker.points.front());
+        marker.id = uuid_to_id(object.object.object_id);
+        msg.markers.push_back(marker);
+      }
+    }
   }
 
   return msg;


### PR DESCRIPTION
## Description

- This PR contains two improvement

### 1. Use Envelope Polygon for measure against perception noise

Since object recognition results contain noise related to position ,orientation and boundary size, if the raw object recognition results are used in path generation, the avoidance path will be directly affected by the noise. 

Therefore, in order to reduce the influence of the noise, avoidance module generate a envelope polygon for the avoidance target that covers it, and the avoidance path should be generated based on that polygon. The envelope polygons are generated so that they are parallel to the reference path and the polygon size is larger than the avoidance target (define by `object_envelope_buffer`). The position and size of the polygon is not updated as long as the avoidance target exists within that polygon.

```yaml
# default value
object_envelope_buffer: 0.3 # [m]
```

![image](https://user-images.githubusercontent.com/44889564/201563746-141bc55e-7a65-476d-b4f0-2c364b2d2d7c.png)


![image](https://user-images.githubusercontent.com/44889564/201563764-921bf7d8-273d-421f-a64a-b594a0cf9ceb.png)

### 2. Use moving time for measure against perception noise

Since object recognition results contain noise related to object velocity, if only the object raw velocity are used in avoidance target filtering process, the results will be directly affected by the noise. 

Therefore, even if a stopped object starts moving, it is judged to be stopped as long as it does not continue to move more than `threshold_time_object_is_moving` sec.

```yaml
# default value
threshold_time_object_is_moving: 1.0 # [s]
```

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

envelope polygon is included in topic `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance` and the namespace is `target_objects_envelope_polygon`.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

https://user-images.githubusercontent.com/44889564/201569698-709d31d0-9d97-484e-b49c-e926fbe03fb5.mp4

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
