### PR TITLE
fix(behavior_path_planner): delete unnecessary codes

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -435,10 +435,6 @@ void PullOutModule::updatePullOutStatus()
   status_.current_lanes = util::getExtendedCurrentLanes(planner_data_);
   status_.pull_out_lanes = pull_out_utils::getPullOutLanes(status_.current_lanes, planner_data_);
 
-  // Get pull_out lanes
-  const auto pull_out_lanes = pull_out_utils::getPullOutLanes(status_.current_lanes, planner_data_);
-  status_.pull_out_lanes = pull_out_lanes;
-
   // combine road and shoulder lanes
   status_.lanes = status_.current_lanes;
   status_.lanes.insert(


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
When generating a drivable area in the pull-out module, it has unnecessary procedures.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
