### PR TITLE
fix(system_monitor): add parameter to launch system_monitor and fix hdd_monitor

### DIFF
--- a/launch/tier4_system_launch/config/system_monitor/hdd_monitor.param.yaml
+++ b/launch/tier4_system_launch/config/system_monitor/hdd_monitor.param.yaml
@@ -4,7 +4,7 @@
     num_disks: 1
     disks: # Until multi type lists are allowed, name N the disks as disk0...disk{N-1}
       disk0:
-        name: /dev/sda3
+        name: /
         temp_attribute_id: 0xC2
         temp_warn: 55.0
         temp_error: 70.0

--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
+  <arg name="launch_system_monitor" default="true" description="launch system monitor"/>
   <arg name="run_mode" default="online" description="options: online, planning_simulation"/>
   <arg name="sensor_model" description="sensor model name"/>
   <arg name="tier4_system_launch_param_path" default="$(find-pkg-share tier4_system_launch)/config" description="tier4_system_launch parameter path"/>
@@ -10,7 +11,7 @@
     <push-ros-namespace namespace="/system"/>
 
     <!-- System Monitor -->
-    <group>
+    <group if="$(var launch_system_monitor)">
       <push-ros-namespace namespace="system_monitor"/>
       <include file="$(find-pkg-share system_monitor)/launch/system_monitor.launch.py">
         <arg name="cpu_monitor_config_file" value="$(var tier4_system_launch_param_path)/system_monitor/cpu_monitor.param.yaml"/>


### PR DESCRIPTION
Signed-off-by: ito-san <fumihito.ito@tier4.jp>

## Description
- Add launch parameter to launch system_monitor or not.
  The system monitor should be configured according to system configuration but it it difficult to cover all system configurations all over the world, so we made the system_monitor optional.
  - The system_monitor launches by default but it does not launch in planning_simulator and logging_simulator.

- Fixed the error regarding hdd_monitor because old parameter is used.
  ```console
  [system.system_monitor.hdd_monitor] getDeviceFromMountPoint(): Failed to execute findmnt. /dev/sda3
  ``` 

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/630

## Tests performed

### [Planning simulation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- Default (without system_monitor)
  ```console
  ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
  ```
- With system_monitor (`launch_system_monitor:=true`)
  ```console
  ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit launch_system_monitor:=true
  ```
### [Rosbag replay simulation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- Default (without system_monitor)
  ```console
  ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
  (another console) ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 1 -s sqlite3
  ```
- With system_monitor (`launch_system_monitor:=true`)
  ```console
  ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit launch_system_monitor:=true
  (another console) ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 1 -s sqlite3
  ```
---
### Verification
- Default (without system_monitor)
   1. Verify no nodes of system_monitor running.
       ```console
       ros2 node list | grep system_monitor
        
        
       ```
   2. Verify no error in console regarding system_monitor.
   3. Verify stales are reported in robot_monitor regarding system_monitor.
       ```console
       ros2 run rqt_robot_monitor rqt_robot_monitor
       ```
      ![image](https://user-images.githubusercontent.com/57388357/201616985-6f94af59-6932-47f7-b88d-5407a72d2bbd.png)

- With system_monitor
   1. Verify all nodes of system_monitor running.
       ```console
       ros2 node list | grep system_monitor
       /system/system_monitor/cpu_monitor
       /system/system_monitor/gpu_monitor
       /system/system_monitor/hdd_monitor
       /system/system_monitor/mem_monitor
       /system/system_monitor/net_monitor
       /system/system_monitor/ntp_monitor
       /system/system_monitor/process_monitor
       /system/system_monitor/system_monitor/system_monitor_container
       /system/system_monitor/voltage_monitor
       ```
   2. Verify no error in console regarding system_monitor.
   3. Verify no error in robot_monitor regarding system_monitor.
       ```console
       ros2 run rqt_robot_monitor rqt_robot_monitor
       ```
      ![image](https://user-images.githubusercontent.com/57388357/201618597-83f5a4f5-3d34-4dea-a07f-15857c08c790.png)

## Notes for reviewers

Here is related PR that should be merged at the same time.
https://github.com/autowarefoundation/autoware_launch/pull/113

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
