### PR TITLE
fix(tensorrt_yolo): multi gpu on component container

### DIFF
--- a/perception/tensorrt_yolo/README.md
+++ b/perception/tensorrt_yolo/README.md
@@ -54,14 +54,14 @@ Jocher, G., et al. (2021). ultralytics/yolov5: v6.0 - YOLOv5n 'Nano' models, Rob
 ### Node Parameters
 
 | Name                    | Type   | Default Value | Description                                                        |
-|-------------------------|--------|---------------|--------------------------------------------------------------------|
+| ----------------------- | ------ | ------------- | ------------------------------------------------------------------ |
 | `onnx_file`             | string | ""            | The onnx file name for yolo model                                  |
 | `engine_file`           | string | ""            | The tensorrt engine file name for yolo model                       |
 | `label_file`            | string | ""            | The label file with label names for detected objects written on it |
 | `calib_image_directory` | string | ""            | The directory name including calibration images for int8 inference |
 | `calib_cache_file`      | string | ""            | The calibration cache file for int8 inference                      |
 | `mode`                  | string | "FP32"        | The inference mode: "FP32", "FP16", "INT8"                         |
-| `gpu_id`                | int    | 0             | GPU device ID that runs the model                             |
+| `gpu_id`                | int    | 0             | GPU device ID that runs the model                                  |
 
 ## Assumptions / Known limits
 

--- a/perception/tensorrt_yolo/README.md
+++ b/perception/tensorrt_yolo/README.md
@@ -54,13 +54,14 @@ Jocher, G., et al. (2021). ultralytics/yolov5: v6.0 - YOLOv5n 'Nano' models, Rob
 ### Node Parameters
 
 | Name                    | Type   | Default Value | Description                                                        |
-| ----------------------- | ------ | ------------- | ------------------------------------------------------------------ |
+|-------------------------|--------|---------------|--------------------------------------------------------------------|
 | `onnx_file`             | string | ""            | The onnx file name for yolo model                                  |
 | `engine_file`           | string | ""            | The tensorrt engine file name for yolo model                       |
 | `label_file`            | string | ""            | The label file with label names for detected objects written on it |
 | `calib_image_directory` | string | ""            | The directory name including calibration images for int8 inference |
 | `calib_cache_file`      | string | ""            | The calibration cache file for int8 inference                      |
 | `mode`                  | string | "FP32"        | The inference mode: "FP32", "FP16", "INT8"                         |
+| `gpu_id`                | int    | 0             | GPU device ID that runs the model                             |
 
 ## Assumptions / Known limits
 

--- a/perception/tensorrt_yolo/include/tensorrt_yolo/nodelet.hpp
+++ b/perception/tensorrt_yolo/include/tensorrt_yolo/nodelet.hpp
@@ -58,6 +58,8 @@ private:
 
   yolo::Config yolo_config_;
 
+  int gpu_device_id_;
+
   std::vector<std::string> labels_;
   std::unique_ptr<float[]> out_scores_;
   std::unique_ptr<float[]> out_boxes_;

--- a/perception/tensorrt_yolo/src/nodelet.cpp
+++ b/perception/tensorrt_yolo/src/nodelet.cpp
@@ -51,7 +51,7 @@ TensorrtYoloNodelet::TensorrtYoloNodelet(const rclcpp::NodeOptions & options)
   std::string calib_image_directory = declare_parameter("calib_image_directory", "");
   std::string calib_cache_file = declare_parameter("calib_cache_file", "");
   std::string mode = declare_parameter("mode", "FP32");
-  int gpu_device_id = declare_parameter("gpu_id", 0);
+  gpu_device_id_ = declare_parameter("gpu_id", 0);
   yolo_config_.num_anchors = declare_parameter("num_anchors", 3);
   auto anchors = declare_parameter(
     "anchors", std::vector<double>{
@@ -67,7 +67,7 @@ TensorrtYoloNodelet::TensorrtYoloNodelet(const rclcpp::NodeOptions & options)
   yolo_config_.use_darknet_layer = declare_parameter("use_darknet_layer", true);
   yolo_config_.ignore_thresh = declare_parameter("ignore_thresh", 0.5);
 
-  if (!yolo::set_cuda_device(gpu_device_id)) {
+  if (!yolo::set_cuda_device(gpu_device_id_)) {
     RCLCPP_ERROR(this->get_logger(), "Given GPU not exist or suitable");
   }
 
@@ -133,6 +133,10 @@ void TensorrtYoloNodelet::callback(const sensor_msgs::msg::Image::ConstSharedPtr
   using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
 
   tier4_perception_msgs::msg::DetectedObjectsWithFeature out_objects;
+
+  if (!yolo::set_cuda_device(gpu_device_id_)) {
+    RCLCPP_ERROR(this->get_logger(), "Given GPU not exist or suitable");
+  }
 
   cv_bridge::CvImagePtr in_image_ptr;
   try {

--- a/perception/tensorrt_yolo/src/nodelet.cpp
+++ b/perception/tensorrt_yolo/src/nodelet.cpp
@@ -136,6 +136,7 @@ void TensorrtYoloNodelet::callback(const sensor_msgs::msg::Image::ConstSharedPtr
 
   if (!yolo::set_cuda_device(gpu_device_id_)) {
     RCLCPP_ERROR(this->get_logger(), "Given GPU not exist or suitable");
+    return;
   }
 
   cv_bridge::CvImagePtr in_image_ptr;


### PR DESCRIPTION
Signed-off-by: Kaan Colak <kcolak@leodrive.ai>

When working with tensorrt_yolo on multiple GPU device without compostable node container everything works fine. 

But when I use `tensorrt_ yolo` as a component nodelet, if `gpu_device` is set to another then `0` `tensorrt_yolo` gives seg fault. 


## Description

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
