### PR TITLE
chore(motion_velocity_smoother): add debug print for non-supported function

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -344,6 +344,13 @@ void MotionVelocitySmootherNode::calcExternalVelocityLimit()
         // TODO(mkuri) If v0 < external_velocity_limit_ptr_->max_velocity <
         // max_velocity_with_deceleration_ meets, stronger jerk than expected may be applied to
         // external velocity limit.
+        if (v0 < external_velocity_limit_ptr_->max_velocity) {
+          RCLCPP_WARN(
+            get_logger(),
+            "Stronger jerk than expected may be applied to external velocity limit in this "
+            "condition.");
+        }
+
         double stop_dist = 0.0;
         std::map<double, double> jerk_profile;
         if (!trajectory_utils::calcStopDistWithJerkConstraints(


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

Without this PR, we don't know whether the external velocity limit calculation in motion_velocity_smoother is working well or not.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
