### PR TITLE
fix(external_cmd_selector): add diagnostic force_update

### DIFF
--- a/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
+++ b/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
@@ -185,7 +185,11 @@ bool ExternalCmdSelector::onSelectExternalCommandService(
   return true;
 }
 
-void ExternalCmdSelector::onTimer() { pub_current_selector_mode_->publish(current_selector_mode_); }
+void ExternalCmdSelector::onTimer()
+{
+  pub_current_selector_mode_->publish(current_selector_mode_);
+  updater_.force_update();
+}
 
 ExternalCmdSelector::InternalGearShift ExternalCmdSelector::convert(
   const ExternalGearShift & command)


### PR DESCRIPTION
Signed-off-by: Azumi Suzuki <azumi.suzuki@tier4.jp>

## Description

The external_cmd_selector diagnostics are randomly stale because the diag topic rate and timeout settings are the same 1Hz.

So I'll add foce_update to timer function.

https://github.com/autowarefoundation/autoware.universe/blob/7e37a6c65a6a72ddf537ac673bf76cd3ff7ae581/system/system_error_monitor/config/diagnostic_aggregator/control.param.yaml#L72-L73

TierIV Internal Link:
https://tier4.atlassian.net/browse/T4PB-23255

<!-- Write a brief description of this PR. -->

## Tests performed

1. Launch the planning simulator
2. Set the vehicle`s self position
3. Make sure the diag topic rate from external_cmd_selector is increasing
   - `ros2 topic echo /diagnostics | grep -B 7 "external_cmd_selector: heartbeat"`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
