### PR TITLE
ci(labeler): fix labeler target

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -6,9 +6,8 @@ ci:
   - .clang-format
   - .gitignore
   - .prettierignore
-document:
+documentation:
   - docs/**/*
-  - "**/*.txt"
   - "**/*.md"
   - "**/*.rst"
   - "**/*.jpg"


### PR DESCRIPTION
Signed-off-by: Shumpei Wakabayashi <shumpei.wakabayashi@tier4.jp>

## Description
- Exclude `"**/*.txt"` from documentation label since this always indicates CMakeLists.txt and is also categorized as component label. 
- Change the label name from `document` to `documentation` to deply mkdocs.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
