### PR TITLE
feat(perception_utils): enable tracker to track smaller object by adapting min_union_area

### DIFF
--- a/common/perception_utils/include/perception_utils/matching.hpp
+++ b/common/perception_utils/include/perception_utils/matching.hpp
@@ -63,7 +63,7 @@ inline double getUnionArea(const Polygon2d & source_polygon, const Polygon2d & t
 }
 
 template <class T1, class T2>
-double get2dIoU(const T1 source_object, const T2 target_object)
+double get2dIoU(const T1 source_object, const T2 target_object, const double min_union_area = 0.01)
 {
   const auto source_polygon = tier4_autoware_utils::toPolygon2d(source_object);
   const auto target_polygon = tier4_autoware_utils::toPolygon2d(target_object);
@@ -72,7 +72,8 @@ double get2dIoU(const T1 source_object, const T2 target_object)
   if (intersection_area == 0.0) return 0.0;
   const double union_area = getUnionArea(source_polygon, target_polygon);
 
-  const double iou = union_area < 0.01 ? 0.0 : std::min(1.0, intersection_area / union_area);
+  const double iou =
+    union_area < min_union_area ? 0.0 : std::min(1.0, intersection_area / union_area);
   return iou;
 }
 

--- a/perception/multi_object_tracker/src/data_association/data_association.cpp
+++ b/perception/multi_object_tracker/src/data_association/data_association.cpp
@@ -206,7 +206,9 @@ Eigen::MatrixXd DataAssociation::calcScoreMatrix(
         // 2d iou gate
         if (passed_gate) {
           const double min_iou = min_iou_matrix_(tracker_label, measurement_label);
-          const double iou = perception_utils::get2dIoU(measurement_object, tracked_object);
+          const double min_union_iou_area = 1e-2;
+          const double iou =
+            perception_utils::get2dIoU(measurement_object, tracked_object, min_union_iou_area);
           if (iou < min_iou) passed_gate = false;
         }
 

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -262,7 +262,8 @@ void MultiObjectTracker::sanitizeTracker(
         continue;
       }
 
-      const auto iou = perception_utils::get2dIoU(object1, object2);
+      const double min_union_iou_area = 1e-2;
+      const auto iou = perception_utils::get2dIoU(object1, object2, min_union_iou_area);
       const auto & label1 = (*itr1)->getHighestProbLabel();
       const auto & label2 = (*itr2)->getHighestProbLabel();
       bool should_delete_tracker1 = false;

--- a/perception/object_merger/src/object_association_merger/data_association/data_association.cpp
+++ b/perception/object_merger/src/object_association_merger/data_association/data_association.cpp
@@ -154,7 +154,8 @@ Eigen::MatrixXd DataAssociation::calcScoreMatrix(
         // 2d iou gate
         if (passed_gate) {
           const double min_iou = min_iou_matrix_(object1_label, object0_label);
-          const double iou = perception_utils::get2dIoU(object0, object1);
+          const double min_union_iou_area = 1e-2;
+          const double iou = perception_utils::get2dIoU(object0, object1, min_union_iou_area);
           if (iou < min_iou) passed_gate = false;
         }
 


### PR DESCRIPTION
Signed-off-by: Yoshi Ri <yoshi.ri@tier4.jp>

## Description

Currently `get2dIoU` function return zero iou when union_area is below $0.01 m^2$.
This sometimes prevent tracking thin objects such as sign pole. 

This PR makes the min_union_area threshold adjustable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
