### PR TITLE
feat(behavior_path_planner): update path when object is gone

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -9,6 +9,7 @@
 
       enable_avoidance_over_same_direction: true
       enable_avoidance_over_opposite_direction: true
+      enable_update_path_when_object_is_gone: false
 
       threshold_distance_object_is_on_center: 1.0 # [m]
       threshold_speed_object_is_stopped: 1.0      # [m/s]

--- a/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
@@ -391,7 +391,7 @@ The avoidance specific parameter configuration file can be located at `src/autow
 ### Avoidance path generation
 
 | Name                                       | Unit   | Type   | Description                                                                                                                                      | Default value |
-| :----------------------------------------- | :----- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| :----------------------------------------- | :----- | :----- |:-------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|
 | resample_interval_for_planning             | [m]    | double | Path resample interval for avoidance planning path.                                                                                              | 0.3           |
 | resample_interval_for_output               | [m]    | double | Path resample interval for output path. Too short interval increases computational cost for latter modules.                                      | 4.0           |
 | lateral_collision_margin                   | [m]    | double | The lateral distance between ego and avoidance targets.                                                                                          | 1.0           |
@@ -411,6 +411,7 @@ The avoidance specific parameter configuration file can be located at `src/autow
 | avoidance_execution_lateral_threshold      | [m]    | double | The lateral distance deviation threshold between the current path and suggested avoidance point to execute avoidance. (\*2)                      | 0.499         |
 | enable_avoidance_over_same_direction       | [-]    | bool   | Extend avoidance trajectory to adjacent lanes that has same direction. If false, avoidance only happen in current lane.                          | true          |
 | enable_avoidance_over_opposite_direction   | [-]    | bool   | Extend avoidance trajectory to adjacent lanes that has opposite direction. `enable_avoidance_over_same_direction` must be `true` to take effects | true          |
+| enable_update_path_when_object_is_gone     | [-]    | bool   | Reset trajectory when avoided objects are gone. If false, shifted path points remain same even though the avoided objects are gone.              | false         |
 
 (\*2) If there are multiple vehicles in a row to be avoided, no new avoidance path will be generated unless their lateral margin difference exceeds this value.
 

--- a/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
@@ -385,8 +385,8 @@ The shift points are modified by a filtering process in order to get the expecte
 If `enable_update_path_when_object_is_gone` parameter is true, Avoidance Module takes different actions according to the situations as follows:
 
 - If vehicle stops: If there is any object in the path of the vehicle, the avoidance path is generated. If this object goes away while the vehicle is stopping, the avoidance path will cancelled.
-- If vehcile is in motion, but avoidance maneuver doesn't started: If there is any object in the path of the vehicle, the avoidance path is generated. If this object goes away while the vehicle is not started avoidance maneuver, the avoidance path will cancelled.
-- If vehcile is in motion, avoidance maneuver started: If there is any object in the path of the vehicle, the avoidance path is generated,but if this object goes away while the vehicle is started avoidance maneuver, the avoidance path will not cancelled.
+- If vehicle is in motion, but avoidance maneuver doesn't started: If there is any object in the path of the vehicle, the avoidance path is generated. If this object goes away while the vehicle is not started avoidance maneuver, the avoidance path will cancelled.
+- If vehicle is in motion, avoidance maneuver started: If there is any object in the path of the vehicle, the avoidance path is generated,but if this object goes away while the vehicle is started avoidance maneuver, the avoidance path will not cancelled.
 
 If `enable_update_path_when_object_is_gone` parameter is false, Avoidance Module doesn't revert generated avoidance path even if path objects are gone.
 

--- a/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
@@ -391,7 +391,7 @@ The avoidance specific parameter configuration file can be located at `src/autow
 ### Avoidance path generation
 
 | Name                                       | Unit   | Type   | Description                                                                                                                                      | Default value |
-| :----------------------------------------- | :----- | :----- |:-------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|
+| :----------------------------------------- | :----- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
 | resample_interval_for_planning             | [m]    | double | Path resample interval for avoidance planning path.                                                                                              | 0.3           |
 | resample_interval_for_output               | [m]    | double | Path resample interval for output path. Too short interval increases computational cost for latter modules.                                      | 4.0           |
 | lateral_collision_margin                   | [m]    | double | The lateral distance between ego and avoidance targets.                                                                                          | 1.0           |

--- a/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
@@ -380,6 +380,14 @@ The shift points are modified by a filtering process in order to get the expecte
 - Similar gradient removal: Connect two shift points with a straight line, and remove the shift points in between if their shift amount is in the vicinity of the straight line.
 - Remove momentary returns: For shift points that reduce the avoidance width (for going back to the center line), if there is enough long distance in the longitudinal direction, remove them.
 
+##### Avoidance Cancelling
+
+If `enable_update_path_when_object_is_gone` parameter is true,  Avoidance Module takes different actions according to the situations as follows:
+- If vehicle stops: If there is any object in the path of the vehicle, the avoidance path is generated. If this object goes away while the vehicle is stopping, the avoidance path will cancelled.
+- If vehcile is in motion, but avoidance maneuver doesn't started: If there is any object in the path of the vehicle, the avoidance path is generated. If this object goes away while the vehicle is not started avoidance maneuver, the avoidance path will cancelled.
+- If vehcile is in motion, avoidance maneuver started: If there is any object in the path of the vehicle, the avoidance path is generated,but if this object goes away while the vehicle is started avoidance maneuver, the avoidance path will not cancelled.
+
+If `enable_update_path_when_object_is_gone` parameter is false, Avoidance Module doesn't revert generated avoidance path even if path objects are gone.
 #### How to keep the consistency of the planning
 
 TODO

--- a/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_avoidance-design.md
@@ -382,12 +382,14 @@ The shift points are modified by a filtering process in order to get the expecte
 
 ##### Avoidance Cancelling
 
-If `enable_update_path_when_object_is_gone` parameter is true,  Avoidance Module takes different actions according to the situations as follows:
+If `enable_update_path_when_object_is_gone` parameter is true, Avoidance Module takes different actions according to the situations as follows:
+
 - If vehicle stops: If there is any object in the path of the vehicle, the avoidance path is generated. If this object goes away while the vehicle is stopping, the avoidance path will cancelled.
 - If vehcile is in motion, but avoidance maneuver doesn't started: If there is any object in the path of the vehicle, the avoidance path is generated. If this object goes away while the vehicle is not started avoidance maneuver, the avoidance path will cancelled.
 - If vehcile is in motion, avoidance maneuver started: If there is any object in the path of the vehicle, the avoidance path is generated,but if this object goes away while the vehicle is started avoidance maneuver, the avoidance path will not cancelled.
 
 If `enable_update_path_when_object_is_gone` parameter is false, Avoidance Module doesn't revert generated avoidance path even if path objects are gone.
+
 #### How to keep the consistency of the planning
 
 TODO

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -9,6 +9,7 @@
 
       enable_avoidance_over_same_direction: true
       enable_avoidance_over_opposite_direction: true
+      enable_update_path_when_object_is_gone: false
 
       threshold_distance_object_is_on_center: 1.0 # [m]
       threshold_speed_object_is_stopped: 1.0      # [m/s]

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -209,11 +209,13 @@ private:
   // for raw_shift_line registration
   AvoidLineArray registered_raw_shift_lines_;
   AvoidLineArray current_raw_shift_lines_;
+  AvoidLineArray init_raw_shift_lines_;
   void registerRawShiftLines(const AvoidLineArray & future_registered);
   void updateRegisteredRawShiftLines();
 
   // -- for state management --
   bool isAvoidancePlanRunning() const;
+  bool isAvoidanceManeuverRunning() const;
 
   // -- for pre-processing --
   void initVariables();

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -209,13 +209,13 @@ private:
   // for raw_shift_line registration
   AvoidLineArray registered_raw_shift_lines_;
   AvoidLineArray current_raw_shift_lines_;
-  AvoidLineArray init_raw_shift_lines_;
   void registerRawShiftLines(const AvoidLineArray & future_registered);
   void updateRegisteredRawShiftLines();
 
   // -- for state management --
+  bool is_avoidance_maneuver_starts;
+  bool isAvoidanceManeuverRunning();
   bool isAvoidancePlanRunning() const;
-  bool isAvoidanceManeuverRunning() const;
 
   // -- for pre-processing --
   void initVariables();

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -64,6 +64,9 @@ struct AvoidanceParameters
   // to use this, enable_avoidance_over_same_direction need to be set to true.
   bool enable_avoidance_over_opposite_direction{true};
 
+  // enable update path when if detected objects on planner data is gone.
+  bool enable_update_path_when_object_is_gone{false};
+
   // Vehicles whose distance to the center of the path is
   // less than this will not be considered for avoidance.
   double threshold_distance_object_is_on_center;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -271,6 +271,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.detection_area_left_expand_dist = dp("detection_area_left_expand_dist", 1.0);
   p.enable_avoidance_over_same_direction = dp("enable_avoidance_over_same_direction", true);
   p.enable_avoidance_over_opposite_direction = dp("enable_avoidance_over_opposite_direction", true);
+  p.enable_update_path_when_object_is_gone = dp("enable_update_path_when_object_is_gone", false);
 
   p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 1.0);
   p.threshold_speed_object_is_stopped = dp("threshold_speed_object_is_stopped", 1.0);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -109,6 +109,12 @@ BT::NodeStatus AvoidanceModule::updateState()
     current_state_ = BT::NodeStatus::RUNNING;
   }
 
+  // if dynamic objects are removed on path, change current state and reset path
+  if(planner_data_->dynamic_object->objects.size() == 0 &&
+      parameters_->enable_update_path_when_object_is_gone){
+    current_state_ = BT::NodeStatus::SUCCESS;
+  }
+
   DEBUG_PRINT(
     "is_plan_running = %d, has_avoidance_target = %d", is_plan_running, has_avoidance_target);
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -103,17 +103,14 @@ BT::NodeStatus AvoidanceModule::updateState()
   DebugData debug;
   const auto avoid_data = calcAvoidancePlanningData(debug);
   const bool has_avoidance_target = !avoid_data.target_objects.empty();
+
   if (!is_plan_running && !has_avoidance_target) {
+    current_state_ = BT::NodeStatus::SUCCESS;
+  } else if (!has_avoidance_target && parameters_->enable_update_path_when_object_is_gone) {
+    // if dynamic objects are removed on path, change current state to reset path
     current_state_ = BT::NodeStatus::SUCCESS;
   } else {
     current_state_ = BT::NodeStatus::RUNNING;
-  }
-
-  // if dynamic objects are removed on path, change current state and reset path
-  if (
-    planner_data_->dynamic_object->objects.size() == 0 &&
-    parameters_->enable_update_path_when_object_is_gone) {
-    current_state_ = BT::NodeStatus::SUCCESS;
   }
 
   DEBUG_PRINT(

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -127,12 +127,13 @@ bool AvoidanceModule::isAvoidancePlanRunning() const
   const bool has_shift_line = (path_shifter_.getShiftLinesSize() > 0);
   return has_base_offset || has_shift_line;
 }
-bool AvoidanceModule::isAvoidanceManeuverRunning() const
+bool AvoidanceModule::isAvoidanceManeuverRunning()
 {
   const auto path_idx = avoidance_data_.ego_closest_path_index;
 
-  for (const auto & al : init_raw_shift_lines_) {
-    if (path_idx > al.start_idx) {
+  for (const auto & al : registered_raw_shift_lines_) {
+    if (path_idx > al.start_idx || is_avoidance_maneuver_starts) {
+      is_avoidance_maneuver_starts = true;
       return true;
     }
   }
@@ -546,7 +547,6 @@ void AvoidanceModule::registerRawShiftLines(const AvoidLineArray & future)
     }
   }
 
-  init_raw_shift_lines_ = registered_raw_shift_lines_;
   DEBUG_PRINT("registered object size: %lu -> %lu", old_size, registered_raw_shift_lines_.size());
 }
 
@@ -2683,6 +2683,7 @@ void AvoidanceModule::initVariables()
   registered_raw_shift_lines_ = {};
   current_raw_shift_lines_ = {};
   original_unique_id = 0;
+  is_avoidance_maneuver_starts = false;
 }
 
 bool AvoidanceModule::isTargetObjectType(const PredictedObject & object) const

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -110,8 +110,9 @@ BT::NodeStatus AvoidanceModule::updateState()
   }
 
   // if dynamic objects are removed on path, change current state and reset path
-  if(planner_data_->dynamic_object->objects.size() == 0 &&
-      parameters_->enable_update_path_when_object_is_gone){
+  if (
+    planner_data_->dynamic_object->objects.size() == 0 &&
+    parameters_->enable_update_path_when_object_is_gone) {
     current_state_ = BT::NodeStatus::SUCCESS;
   }
 


### PR DESCRIPTION
Signed-off-by: ismet atabay <ismet@leodrive.ai>

## Description

At avoidance module in behavior_path_planner, if the detected objects occur in path,  avoidance module shift path points to around the vehicle. Moreover, if the detected objects are gone the shifted path is not updated. The reason of this, avoidance module' current state stays in the "RUNNING" state until the vehicle reach its goal. I added a feature to change this state, and this feature allows the path to be updated by completing the task of the avoidance module if the detected objects are gone.

To control this, I added a parameter with the name ```enable_update_path_when_object_is_gone``` and set the default value to ```false```. ```enable_update_path_when_object_is_gone``` must be ```true``` for this feature to be used.

## Related links

closes #2272

## Tests performed

### Before PR (```enable_update_path_when_object_is_gone``` is set to ```false```):

https://user-images.githubusercontent.com/56237550/202670238-1a310bef-5404-4c9e-95cf-10283cc2cdb6.mp4

### After PR (```enable_update_path_when_object_is_gone``` is set to ```true```):

#### Case 1: The vehicle stops.

https://user-images.githubusercontent.com/56237550/203820169-6886c14b-dd3d-49e3-9396-319ca0da52b9.mp4

#### Case 2: The vehicle moves, avoidance maneuver doesn't starts.

https://user-images.githubusercontent.com/56237550/203820408-5f751017-c268-4bd0-a541-ae70b5118c76.mp4

#### Case 3: The vehicle moves, avoidance maneuver starts.

https://user-images.githubusercontent.com/56237550/203820615-4a5c3674-bcf9-4555-8757-88ecf57bd33a.mp4

## Notes for reviewers

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
