### PR TITLE
feat(operation_mode_transition_manager): modify transition timeout

### DIFF
--- a/control/operation_mode_transition_manager/config/operation_mode_transition_manager.param.yaml
+++ b/control/operation_mode_transition_manager/config/operation_mode_transition_manager.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    transition_timeout: 3.0
+    transition_timeout: 10.0
     frequency_hz: 10.0
     engage_acceptable_limits:
       allow_autonomous_in_stopped: true  # no check if the velocity is zero, always allowed.

--- a/control/operation_mode_transition_manager/src/node.hpp
+++ b/control/operation_mode_transition_manager/src/node.hpp
@@ -71,6 +71,7 @@ private:
 
   std::optional<OperationModeStateAPI::Message> prev_state_;
 
+  static constexpr double compatibility_timeout_ = 1.0;
   Compatibility compatibility_;
   std::optional<rclcpp::Time> compatibility_transition_;
 };

--- a/launch/tier4_control_launch/config/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
+++ b/launch/tier4_control_launch/config/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    transition_timeout: 3.0
+    transition_timeout: 10.0
     frequency_hz: 10.0
     engage_acceptable_limits:
       allow_autonomous_in_stopped: true  # no check if the velocity is zero, always allowed.


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

- Modify operation mode change transition timeout because it wasn't enough.
- Allow change operation mode to stop during transition.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
