### PR TITLE
feat(behavior_velocity_planner): output stop reason of traffic light whenever a stop point is inserted

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -489,8 +489,9 @@ autoware_auto_planning_msgs::msg::PathWithLaneId TrafficLightModule::insertStopP
   if (debug_data_.highest_confidence_traffic_light_point != std::nullopt) {
     stop_factor.stop_factor_points = std::vector<geometry_msgs::msg::Point>{
       debug_data_.highest_confidence_traffic_light_point.value()};
-    planning_utils::appendStopReason(stop_factor, stop_reason);
   }
+  planning_utils::appendStopReason(stop_factor, stop_reason);
+
   return modified_path;
 }
 


### PR DESCRIPTION
## Description

In the current implementation, when the car stops by the traffic light module and its stop reason is RTC, the ```stop_reasons``` of traffic light is not output.
As other behavior modules, I changed that in cases like the above ```stop_reasons``` with empty ```stop_factor_points``` is output.

## Review
1,
Comment out ```default_enable_list."traffic_light"``` in rtc_auto_mode_manager.param.yaml

2.
Set a route including stop lines for traffic lights

3. 
Confirm the stop_reason of traffic light is output

ros2 topic echo /planning/scenario_planning/status/stop_reasons|grep TrafficLight -A 11

![image](https://user-images.githubusercontent.com/59680180/202667896-935226cd-b768-4aca-a060-1616372003e0.png)


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
