### PR TITLE
fix(tensorrt): update tensorrt code of traffic_light_classifier

### DIFF
--- a/perception/traffic_light_classifier/utils/trt_common.cpp
+++ b/perception/traffic_light_classifier/utils/trt_common.cpp
@@ -75,8 +75,16 @@ void TrtCommon::setup()
   }
 
   context_ = UniquePtr<nvinfer1::IExecutionContext>(engine_->createExecutionContext());
-  input_dims_ = engine_->getBindingDimensions(getInputBindingIndex());
-  output_dims_ = engine_->getBindingDimensions(getOutputBindingIndex());
+
+#if (NV_TENSORRT_MAJOR * 10000) + (NV_TENSORRT_MINOR * 100) + NV_TENSOR_PATCH >= 80500
+  input_dims_ = engine_->getTensorShape(input_name_.c_str());
+  output_dims_ = engine_->getTensorShape(output_name_.c_str());
+#else
+  // Deprecated since 8.5
+  input_dims_ = engine_->getBindingDimensions(engine_->getBindingIndex(input_name_.c_str());
+  output_dims_ = engine_->getBindingDimensions(engine_->getBindingIndex(output_name_.c_str());
+#endif
+
   is_initialized_ = true;
 }
 
@@ -154,9 +162,5 @@ int TrtCommon::getNumOutput()
   return std::accumulate(
     output_dims_.d, output_dims_.d + output_dims_.nbDims, 1, std::multiplies<int>());
 }
-
-int TrtCommon::getInputBindingIndex() { return engine_->getBindingIndex(input_name_.c_str()); }
-
-int TrtCommon::getOutputBindingIndex() { return engine_->getBindingIndex(output_name_.c_str()); }
 
 }  // namespace Tn

--- a/perception/traffic_light_classifier/utils/trt_common.cpp
+++ b/perception/traffic_light_classifier/utils/trt_common.cpp
@@ -81,8 +81,8 @@ void TrtCommon::setup()
   output_dims_ = engine_->getTensorShape(output_name_.c_str());
 #else
   // Deprecated since 8.5
-  input_dims_ = engine_->getBindingDimensions(engine_->getBindingIndex(input_name_.c_str());
-  output_dims_ = engine_->getBindingDimensions(engine_->getBindingIndex(output_name_.c_str());
+  input_dims_ = engine_->getBindingDimensions(engine_->getBindingIndex(input_name_.c_str()));
+  output_dims_ = engine_->getBindingDimensions(engine_->getBindingIndex(output_name_.c_str()));
 #endif
 
   is_initialized_ = true;

--- a/perception/traffic_light_classifier/utils/trt_common.hpp
+++ b/perception/traffic_light_classifier/utils/trt_common.hpp
@@ -118,8 +118,6 @@ public:
   bool isInitialized();
   int getNumInput();
   int getNumOutput();
-  int getInputBindingIndex();
-  int getOutputBindingIndex();
 
   UniquePtr<nvinfer1::IExecutionContext> context_;
 


### PR DESCRIPTION
Signed-off-by: M. Fatih Cırıt <mfc@leodrive.ai>

## Description

Part of: https://github.com/autowarefoundation/autoware.universe/issues/2330

Updating the code to compile with https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ TensorRT version.

We can remove the deprecated code when we update the ansible installation to use native 22.04 cuda.

Updated TensorRT version is `tensorrt-dev_8.5.1.7-1+cuda11.8` for now.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
