### PR TITLE
feat(avoidance): improve avoidance target filter

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -15,6 +15,8 @@
       threshold_time_object_is_moving: 1.0        # [s]
       object_check_forward_distance: 150.0        # [m]
       object_check_backward_distance: 2.0         # [m]
+      object_check_shiftable_ratio: 0.6           # [-]
+      object_check_min_road_shoulder_width: 0.5   # [m]
       object_envelope_buffer: 0.3                 # [m]
       lateral_collision_margin: 1.0               # [m]
       lateral_collision_safety_buffer: 0.7        # [m]

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -10,13 +10,19 @@
       enable_avoidance_over_same_direction: true
       enable_avoidance_over_opposite_direction: true
 
-      threshold_distance_object_is_on_center: 1.0 # [m]
+      # For target object filtering
       threshold_speed_object_is_stopped: 1.0      # [m/s]
       threshold_time_object_is_moving: 1.0        # [s]
+
       object_check_forward_distance: 150.0        # [m]
       object_check_backward_distance: 2.0         # [m]
+
+      threshold_distance_object_is_on_center: 1.0 # [m]
+
       object_check_shiftable_ratio: 0.6           # [-]
       object_check_min_road_shoulder_width: 0.5   # [m]
+
+      # For lateral margin
       object_envelope_buffer: 0.3                 # [m]
       lateral_collision_margin: 1.0               # [m]
       lateral_collision_safety_buffer: 0.7        # [m]

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -10,10 +10,20 @@
       enable_avoidance_over_same_direction: true
       enable_avoidance_over_opposite_direction: true
 
-      threshold_distance_object_is_on_center: 1.0 # [m]
+      # For target object filtering
       threshold_speed_object_is_stopped: 1.0      # [m/s]
+      threshold_time_object_is_moving: 1.0        # [s]
+
       object_check_forward_distance: 150.0        # [m]
       object_check_backward_distance: 2.0         # [m]
+
+      threshold_distance_object_is_on_center: 1.0 # [m]
+
+      object_check_shiftable_ratio: 0.6           # [-]
+      object_check_min_road_shoulder_width: 0.5   # [m]
+
+      # For lateral margin
+      object_envelope_buffer: 0.3                 # [m]
       lateral_collision_margin: 1.0               # [m]
       lateral_collision_safety_buffer: 0.7        # [m]
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -35,6 +35,7 @@ namespace behavior_path_planner
 using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 
+using tier4_autoware_utils::Point2d;
 using tier4_autoware_utils::Polygon2d;
 using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
 
@@ -76,6 +77,12 @@ struct AvoidanceParameters
 
   // continue to detect backward vehicles as avoidance targets until they are this distance away
   double object_check_backward_distance;
+
+  // use in judge whether the vehicle is parking object on road shoulder
+  double object_check_shiftable_ratio;
+
+  // minimum road shoulder width. maybe 0.5 [m]
+  double object_check_min_road_shoulder_width;
 
   // object's enveloped polygon
   double object_envelope_buffer;
@@ -196,6 +203,9 @@ struct ObjectData  // avoidance target
   // lateral distance to the closest footprint, in Frenet coordinate
   double overhang_dist;
 
+  // lateral shiftable ratio
+  double shiftable_ratio{0.0};
+
   // count up when object disappeared. Removed when it exceeds threshold.
   rclcpp::Time last_seen;
   double lost_time{0.0};
@@ -212,6 +222,9 @@ struct ObjectData  // avoidance target
 
   // envelope polygon
   Polygon2d envelope_poly{};
+
+  // envelope polygon centroid
+  Point2d centroid{};
 
   // lateral distance from overhang to the road shoulder
   double to_road_shoulder_distance{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -37,6 +37,7 @@ namespace marker_utils::avoidance_marker
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using behavior_path_planner::AvoidLineArray;
+using behavior_path_planner::ObjectDataArray;
 using behavior_path_planner::ShiftLineArray;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Polygon;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -284,6 +284,8 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.threshold_time_object_is_moving = dp("threshold_time_object_is_moving", 1.0);
   p.object_check_forward_distance = dp("object_check_forward_distance", 150.0);
   p.object_check_backward_distance = dp("object_check_backward_distance", 2.0);
+  p.object_check_shiftable_ratio = dp("object_check_shiftable_ratio", 1.0);
+  p.object_check_min_road_shoulder_width = dp("object_check_min_road_shoulder_width", 0.5);
   p.object_envelope_buffer = dp("object_envelope_buffer", 0.1);
   p.lateral_collision_margin = dp("lateral_collision_margin", 2.0);
   p.lateral_collision_safety_buffer = dp("lateral_collision_safety_buffer", 0.5);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -244,7 +244,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
     fillObjectMovingTime(object_data);
 
     if (object_data.move_time > parameters_->threshold_time_object_is_moving) {
-      avoidance_debug_array_false_and_push_back("MovingObject");
+      avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::MOVING_OBJECT);
       data.other_objects.push_back(object_data);
       continue;
     }
@@ -686,7 +686,7 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(const ObjectDataArr
     const auto is_object_on_right = isOnRight(o);
     const auto shift_length = getShiftLength(o, is_object_on_right, avoid_margin);
     if (isSameDirectionShift(is_object_on_right, shift_length)) {
-      avoidance_debug_array_false_and_push_back("IgnoreSameDirectionShift");
+      avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::SAME_DIRECTION_SHIFT);
       continue;
     }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -173,7 +173,10 @@ AvoidancePlanningData AvoidanceModule::calcAvoidancePlanningData(DebugData & deb
 void AvoidanceModule::fillAvoidanceTargetObjects(
   AvoidancePlanningData & data, DebugData & debug) const
 {
+  using boost::geometry::return_centroid;
+  using boost::geometry::within;
   using lanelet::geometry::distance2d;
+  using lanelet::geometry::toArcCoordinates;
   using lanelet::utils::getId;
   using lanelet::utils::to2D;
 
@@ -206,7 +209,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
   std::vector<AvoidanceDebugMsg> avoidance_debug_msg_array;
   for (const auto & i : lane_filtered_objects_index) {
     const auto & object = planner_data_->dynamic_object->objects.at(i);
-    const auto & object_pos = object.kinematics.initial_pose_with_covariance.pose.position;
+    const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     AvoidanceDebugMsg avoidance_debug_msg;
     const auto avoidance_debug_array_false_and_push_back =
       [&avoidance_debug_msg, &avoidance_debug_msg_array](const std::string & failed_reason) {
@@ -224,11 +227,14 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
     object_data.object = object;
     avoidance_debug_msg.object_id = getUuidStr(object_data);
 
-    const auto object_closest_index = findNearestIndex(path_points, object_pos);
+    const auto object_closest_index = findNearestIndex(path_points, object_pose.position);
     const auto object_closest_pose = path_points.at(object_closest_index).point.pose;
 
     // Calc envelop polygon.
     fillObjectEnvelopePolygon(object_closest_pose, object_data);
+
+    // calc object centroid.
+    object_data.centroid = return_centroid<Point2d>(object_data.envelope_poly);
 
     // calc longitudinal distance from ego to closest target object footprint point.
     fillLongitudinalAndLengthByClosestEnvelopeFootprint(data.reference_path, ego_pos, object_data);
@@ -263,7 +269,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
     }
 
     // Calc lateral deviation from path to target object.
-    object_data.lateral = calcLateralDeviation(object_closest_pose, object_pos);
+    object_data.lateral = calcLateralDeviation(object_closest_pose, object_pose.position);
     avoidance_debug_msg.lateral_distance_from_centerline = object_data.lateral;
 
     // Find the footprint point closest to the path, set to object_data.overhang_distance.
@@ -312,6 +318,89 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE);
       data.other_objects.push_back(object_data);
       continue;
+    }
+
+    lanelet::ConstLanelet object_closest_lanelet;
+    const auto lanelet_map = rh->getLaneletMapPtr();
+    if (!lanelet::utils::query::getClosestLanelet(
+          lanelet::utils::query::laneletLayer(lanelet_map), object_pose, &object_closest_lanelet)) {
+      continue;
+    }
+
+    lanelet::BasicPoint2d object_centroid(object_data.centroid.x(), object_data.centroid.y());
+
+    /**
+     * Is not object in adjacent lane?
+     *   - Yes -> Is parking object?
+     *     - Yes -> the object is avoidance target.
+     *     - No -> ignore this object.
+     *   - No -> the object is avoidance target no matter whether it is parking object or not.
+     */
+    const auto is_in_ego_lane =
+      within(object_centroid, overhang_lanelet.polygon2d().basicPolygon());
+    if (is_in_ego_lane) {
+      /**
+       * TODO(Satoshi Ota) use intersection area
+       * under the assumption that there is no parking vehicle inside intersection,
+       * ignore all objects that is in the ego lane as not parking objects.
+       */
+      std::string turn_direction = overhang_lanelet.attributeOr("turn_direction", "else");
+      if (turn_direction == "right" || turn_direction == "left" || turn_direction == "straight") {
+        avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::NOT_PARKING_OBJECT);
+        data.other_objects.push_back(object_data);
+        continue;
+      }
+
+      const auto centerline_pose =
+        lanelet::utils::getClosestCenterPose(object_closest_lanelet, object_pose.position);
+      lanelet::BasicPoint3d centerline_point(
+        centerline_pose.position.x, centerline_pose.position.y, centerline_pose.position.z);
+
+      // ============================================ <- most_left_lanelet.leftBound()
+      // y              road shoulder
+      // ^ ------------------------------------------
+      // |   x                                +
+      // +---> --- object closest lanelet --- o ----- <- object_closest_lanelet.centerline()
+      //
+      // --------------------------------------------
+      // +: object position
+      // o: nearest point on centerline
+
+      const auto most_left_road_lanelet = rh->getMostLeftLanelet(object_closest_lanelet);
+      const auto most_left_lanelet_candidates =
+        rh->getLaneletMapPtr()->laneletLayer.findUsages(most_left_road_lanelet.leftBound());
+
+      lanelet::ConstLanelet most_left_lanelet = most_left_road_lanelet;
+
+      for (const auto & ll : most_left_lanelet_candidates) {
+        const lanelet::Attribute sub_type = ll.attribute(lanelet::AttributeName::Subtype);
+        if (sub_type.value() == "road_shoulder") {
+          most_left_lanelet = ll;
+        }
+      }
+
+      const auto center_to_left_boundary =
+        distance2d(to2D(most_left_lanelet.leftBound().basicLineString()), to2D(centerline_point));
+      double object_shiftable_distance = center_to_left_boundary - 0.5 * object.shape.dimensions.y;
+
+      const lanelet::Attribute sub_type =
+        most_left_lanelet.attribute(lanelet::AttributeName::Subtype);
+      if (sub_type.value() != "road_shoulder") {
+        object_shiftable_distance += parameters_->object_check_min_road_shoulder_width;
+      }
+
+      const auto arc_coordinates = toArcCoordinates(
+        to2D(object_closest_lanelet.centerline().basicLineString()), object_centroid);
+      object_data.shiftable_ratio = arc_coordinates.distance / object_shiftable_distance;
+
+      const auto is_parking_object =
+        object_data.shiftable_ratio > parameters_->object_check_shiftable_ratio;
+
+      if (!is_parking_object) {
+        avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::NOT_PARKING_OBJECT);
+        data.other_objects.push_back(object_data);
+        continue;
+      }
     }
 
     object_data.last_seen = clock_->now();

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -24,13 +24,71 @@
 
 namespace marker_utils::avoidance_marker
 {
+
 using behavior_path_planner::AvoidLine;
 using behavior_path_planner::util::shiftPose;
+using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerScale;
 using tier4_autoware_utils::createPoint;
 using visualization_msgs::msg::Marker;
+
+namespace
+{
+
+int32_t uuidToInt32(const unique_identifier_msgs::msg::UUID & uuid)
+{
+  int32_t ret = 0;
+
+  for (size_t i = 0; i < sizeof(int32_t) / sizeof(int8_t); ++i) {
+    ret <<= sizeof(int8_t);
+    ret |= uuid.uuid.at(i);
+  }
+
+  return ret;
+}
+
+MarkerArray createObjectsCubeMarkerArray(
+  const ObjectDataArray & objects, std::string && ns, const Vector3 & scale,
+  const ColorRGBA & color)
+{
+  MarkerArray msg;
+
+  auto marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE, scale, color);
+  for (const auto & object : objects) {
+    marker.id = uuidToInt32(object.object.object_id);
+    marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
+    msg.markers.push_back(marker);
+  }
+
+  return msg;
+}
+
+MarkerArray createObjectInfoMarkerArray(const ObjectDataArray & objects, std::string && ns)
+{
+  MarkerArray msg;
+
+  Marker marker = createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::TEXT_VIEW_FACING,
+    createMarkerScale(0.5, 0.5, 0.5), createMarkerColor(1.0, 1.0, 0.0, 1.0));
+
+  for (const auto & object : objects) {
+    marker.id = uuidToInt32(object.object.object_id);
+    marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
+    std::ostringstream string_stream;
+    string_stream << std::fixed << std::setprecision(2);
+    string_stream << "ratio:" << object.shiftable_ratio << " [-]\n"
+                  << "lateral: " << object.lateral << " [-]";
+    marker.text = string_stream.str();
+    msg.markers.push_back(marker);
+  }
+
+  return msg;
+}
+
+}  // namespace
 
 MarkerArray createAvoidLineMarkerArray(
   const AvoidLineArray & shift_lines, std::string && ns, const float & r, const float & g,
@@ -85,35 +143,16 @@ MarkerArray createAvoidLineMarkerArray(
 MarkerArray createTargetObjectsMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects, std::string && ns)
 {
-  const auto normal_color = tier4_autoware_utils::createMarkerColor(0.9, 0.0, 0.0, 0.8);
-  const auto disappearing_color = tier4_autoware_utils::createMarkerColor(0.9, 0.5, 0.9, 0.6);
-
-  const auto uuid_to_id = [](const unique_identifier_msgs::msg::UUID & object_id) {
-    int32_t ret = 0;
-
-    for (size_t i = 0; i < sizeof(int32_t) / sizeof(int8_t); ++i) {
-      ret <<= sizeof(int8_t);
-      ret |= object_id.uuid.at(i);
-    }
-
-    return ret;
-  };
-
   MarkerArray msg;
-  msg.markers.reserve(objects.size() * 2);
+  msg.markers.reserve(objects.size() * 3);
 
-  {
-    auto marker = createDefaultMarker(
-      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE,
-      createMarkerScale(3.0, 1.5, 1.5), normal_color);
-    for (const auto & object : objects) {
-      marker.id = uuid_to_id(object.object.object_id);
-      marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
-      marker.scale = tier4_autoware_utils::createMarkerScale(3.0, 1.5, 1.5);
-      marker.color = std::fabs(object.lost_time) < 1e-2 ? normal_color : disappearing_color;
-      msg.markers.push_back(marker);
-    }
-  }
+  appendMarkerArray(
+    createObjectsCubeMarkerArray(
+      objects, ns + "_cube", createMarkerScale(3.0, 1.5, 1.5),
+      createMarkerColor(1.0, 0.0, 0.0, 0.8)),
+    &msg);
+
+  appendMarkerArray(createObjectInfoMarkerArray(objects, ns + "_info"), &msg);
 
   {
     for (const auto & object : objects) {
@@ -130,7 +169,7 @@ MarkerArray createTargetObjectsMarkerArray(
         }
 
         marker.points.push_back(marker.points.front());
-        marker.id = uuid_to_id(object.object.object_id);
+        marker.id = uuidToInt32(object.object.object_id);
         msg.markers.push_back(marker);
       }
     }
@@ -142,34 +181,16 @@ MarkerArray createTargetObjectsMarkerArray(
 MarkerArray createOtherObjectsMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects, std::string && ns)
 {
-  const auto normal_color = tier4_autoware_utils::createMarkerColor(0.0, 1.0, 0.0, 0.8);
-
-  const auto uuid_to_id = [](const unique_identifier_msgs::msg::UUID & object_id) {
-    int32_t ret = 0;
-
-    for (size_t i = 0; i < sizeof(int32_t) / sizeof(int8_t); ++i) {
-      ret <<= sizeof(int8_t);
-      ret |= object_id.uuid.at(i);
-    }
-
-    return ret;
-  };
-
   MarkerArray msg;
-  msg.markers.reserve(objects.size());
+  msg.markers.reserve(objects.size() * 2);
 
-  {
-    Marker marker = createDefaultMarker(
-      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::CUBE,
-      createMarkerScale(3.0, 1.5, 1.5), normal_color);
-    for (const auto & object : objects) {
-      marker.id = uuid_to_id(object.object.object_id);
-      marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
-      marker.scale = tier4_autoware_utils::createMarkerScale(3.0, 1.5, 1.5);
-      marker.color = normal_color;
-      msg.markers.push_back(marker);
-    }
-  }
+  appendMarkerArray(
+    createObjectsCubeMarkerArray(
+      objects, ns + "_cube", createMarkerScale(3.0, 1.5, 1.5),
+      createMarkerColor(0.0, 1.0, 0.0, 0.8)),
+    &msg);
+
+  appendMarkerArray(createObjectInfoMarkerArray(objects, ns + "_info"), &msg);
 
   return msg;
 }

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -177,6 +177,15 @@ public:
     bool is_opposite = true, const bool & invert_opposite = false) const noexcept;
 
   /**
+   * @brief Check if same-direction lane is available at the left side of the lanelet
+   * Searches for any lanes regardless of whether it is lane-changeable or not.
+   * Required the linestring to be shared(same line ID) between the lanelets.
+   * @param the lanelet of interest
+   * @return vector of lanelet having same direction if true
+   */
+  lanelet::ConstLanelet getMostLeftLanelet(const lanelet::ConstLanelet & lanelet) const;
+
+  /**
    * @brief Searches the furthest linestring to the right side of the lanelet
    * Only lanelet with same direction is considered
    * @param the lanelet of interest

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -999,6 +999,17 @@ lanelet::Lanelets RouteHandler::getLeftOppositeLanelets(const lanelet::ConstLane
   return opposite_lanelets;
 }
 
+lanelet::ConstLanelet RouteHandler::getMostLeftLanelet(const lanelet::ConstLanelet & lanelet) const
+{
+  // recursively compute the width of the lanes
+  const auto & same = getLeftLanelet(lanelet);
+
+  if (same) {
+    return getMostLeftLanelet(same.get());
+  }
+  return lanelet;
+}
+
 lanelet::ConstLineString3d RouteHandler::getRightMostSameDirectionLinestring(
   const lanelet::ConstLanelet & lanelet) const noexcept
 {


### PR DESCRIPTION
## Description

 add new filtering process in `fillAvoindanceTargetObjects()`

- https://github.com/tier4/autoware_launch/pull/569
- https://github.com/tier4/tier4_autoware_msgs/pull/64

### Judge whether the object is parking vehicle on road shoulder

In the original implementation, if the length between the object's center and the center line of Ego's lane is less than `threshold_distance_object_is_on_center`, avoidance module determined that the vehicle was not a roadside parked vehicle and don't excute avoidance.

In this PR, not only the length from the centerline, but also the length from the road shoulder is calculated and used in the filtering process. It calculates the ratio of _the actual length between the the object's center and the center line_ `shift_length` and _the maximum length the object can shift_  `shiftable_length`. 

$$ l_D = l_a - \frac{width}{2} $$

$$ ratio =  {l_d \over l_D}$$

$l_d$ : actual shift length
$l_D$ : shiftable length
$l_a$ : distance between centerline and most left boundary.
$width$ : object width

![image](https://user-images.githubusercontent.com/44889564/202837399-b39fe10f-5891-49a0-8209-e6f5d008d400.png)

```yaml
# default
object_check_shiftable_ratio: 0.6 # [-]
```

The closer the object is to the shoulder, the larger the value of $ratio$ (theoretical max value is 1.0), and it compares the value and `object_check_shiftable_ratio` to determine whether the object is a road-parked vehicle.

![image](https://user-images.githubusercontent.com/44889564/202838696-53ead03a-8be1-4f4a-b482-154ec71543e6.png)

If there is no `road_shoulder` lanelet in the map, sum `object_check_min_road_shoulder_width` to $l_a$, assuming that the shoulder exists.

```yaml
object_check_min_road_shoulder_width: 0.5 # [m]
```

In addition, it is assumed in the filtering process that there are no parked vehicles within the intersection. Therefor, the filtering flow is as shown in the following figure.

![image](https://user-images.githubusercontent.com/44889564/202839117-74823065-05cf-4b42-b0de-f27a51074bb0.png)

<!-- Write a brief description of this PR. -->

## Related links

- https://github.com/tier4/autoware_launch/pull/569
- https://github.com/tier4/tier4_autoware_msgs/pull/64

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

**green cube: NOT AVOIDANCE TARGET
red cube: AVOIDANCE TARGET** 

```yaml
# default
object_check_shiftable_ratio: 0.6 # [-]
```

Since the object's shiftable ratio is 0.49 (< 0.6), it is determined that the object is not a parking vehicle.

![Screenshot from 2022-11-18 16-24-46](https://user-images.githubusercontent.com/44889564/202837161-607e437b-aa1a-416d-9782-8670128e8f0f.png)

```yaml
# default
object_check_shiftable_ratio: 0.0 # [-]
```

If the value of object_check_shiftable_ratio is set to 0.0, all vehicles are judged as road-parked vehicles.

![Screenshot from 2022-11-19 13-41-41](https://user-images.githubusercontent.com/44889564/202839154-3b2e0174-ec57-4f1b-a254-f75b14fea7d7.png)

The module determines that any vehicle in the intersection is not a parked vehicle, regardless of the value of `shift_length` and `shiftable_ratio`.

![Screenshot from 2022-11-20 12-43-39](https://user-images.githubusercontent.com/44889564/202882889-1085d52b-5bdb-4e5e-9987-c417c49b0f46.png)


<!-- Describe how you have tested this PR. -->

## Notes for reviewers

have to checkout `tier4_autoware_msgs` to [this](https://github.com/tier4/tier4_autoware_msgs/tree/feat/improve-avoidance-target-filter) branch. (https://github.com/tier4/tier4_autoware_msgs/pull/64)

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
