### PR TITLE
feat(behavior_path_planner): add option to turn signal while obstacle swerving

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -48,6 +48,8 @@
       longitudinal_collision_margin_min_distance: 0.0          # [m]
       longitudinal_collision_margin_time: 0.0
 
+      turn_signal_on_swerving: true # turn signal on while swerving
+
       # avoidance is performed for the object type with true
       target_object:
         car: true

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -46,6 +46,8 @@
       longitudinal_collision_margin_min_distance: 0.0          # [m]
       longitudinal_collision_margin_time: 0.0
 
+      turn_signal_on_swerving: true # turn signal on while swerving
+
       # avoidance is performed for the object type with true
       target_object:
         car: true

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -172,6 +172,8 @@ struct AvoidanceParameters
   // debug
   bool publish_debug_marker = false;
   bool print_debug_info = false;
+
+  bool turn_signal_on_swerving = true;
 };
 
 struct ObjectData  // avoidance target

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -322,6 +322,8 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
 
   p.avoidance_execution_lateral_threshold = dp("avoidance_execution_lateral_threshold", 0.499);
 
+  p.turn_signal_on_swerving = dp("turn_signal_on_swerving", true);
+
   return p;
 }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2743,12 +2743,16 @@ TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) con
   }
 
   TurnSignalInfo turn_signal_info{};
-
-  if (segment_shift_length > 0.0) {
-    turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+  if(parameters_->turn_signal_on_swerving){
+    if (segment_shift_length > 0.0) {
+      turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+    } else {
+      turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
+    }
   } else {
-    turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
+    turn_signal_info.turn_signal.command = TurnIndicatorsCommand::DISABLE;
   }
+
 
   if (ego_front_to_shift_start > 0.0) {
     turn_signal_info.desired_start_point = planner_data_->self_pose->pose;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2743,7 +2743,7 @@ TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) con
   }
 
   TurnSignalInfo turn_signal_info{};
-  if(parameters_->turn_signal_on_swerving){
+  if (parameters_->turn_signal_on_swerving) {
     if (segment_shift_length > 0.0) {
       turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
     } else {
@@ -2752,7 +2752,6 @@ TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) con
   } else {
     turn_signal_info.turn_signal.command = TurnIndicatorsCommand::DISABLE;
   }
-
 
   if (ego_front_to_shift_start > 0.0) {
     turn_signal_info.desired_start_point = planner_data_->self_pose->pose;


### PR DESCRIPTION
## Description

Fixes: #2321

If you set `turn_signal_on_swerving` param to `true`, turn signal will be on while obstacle swerving, but you set to `false`, turn signal only will be on if there is a turn.

set true:

https://user-images.githubusercontent.com/32412808/203320475-da069c12-8b6d-4184-ac3e-cffd2d201ce6.mp4

set false:

https://user-images.githubusercontent.com/32412808/203320490-14ba5c06-39e2-4535-8ac3-ff98701aed52.mp4



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
