### PR TITLE
fix(behavior_path_planner): fix expandLanelets for drivable lanes

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1829,11 +1829,11 @@ std::vector<DrivableLanes> expandLanelets(
       expanded_lanes.left_lane =
         lanelet::utils::getExpandedLanelet(lanes.left_lane, l_offset, r_offset);
       expanded_lanes.right_lane =
-        lanelet::utils::getExpandedLanelet(lanes.left_lane, l_offset, r_offset);
+        lanelet::utils::getExpandedLanelet(lanes.right_lane, l_offset, r_offset);
     } else {
       expanded_lanes.left_lane = lanelet::utils::getExpandedLanelet(lanes.left_lane, l_offset, 0.0);
       expanded_lanes.right_lane =
-        lanelet::utils::getExpandedLanelet(lanes.left_lane, 0.0, r_offset);
+        lanelet::utils::getExpandedLanelet(lanes.right_lane, 0.0, r_offset);
     }
     expanded_lanes.middle_lanes = lanes.middle_lanes;
     expanded_drivable_lanes.push_back(expanded_lanes);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

fix expandLanelets for drivable lanes.
In https://github.com/autowarefoundation/autoware.universe/pull/2320, left_lanes was used for expanded_lanes.right_lane mistakenly.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

 https://github.com/autowarefoundation/autoware.universe/pull/2320

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
