### PR TITLE
feat(obstacle_stop_planner): add optional check for predicted trajectory

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/obstacle_stop_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/obstacle_stop_planner.param.yaml
@@ -4,6 +4,7 @@
     lowpass_gain: 0.9                        # gain parameter for low pass filter [-]
     max_velocity: 20.0                       # max velocity [m/s]
     enable_slow_down: False                  # whether to use slow down planner [-]
+    check_predicted_trajectory: False        # if it is "True", planner will take into account predicted trajectory of controller [-]
 
     stop_planner:
       # params for stop position

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.py
@@ -202,6 +202,10 @@ def launch_setup(context, *args, **kwargs):
             ("~/input/objects", "/perception/object_recognition/objects"),
             ("~/input/odometry", "/localization/kinematic_state"),
             ("~/input/trajectory", "obstacle_velocity_limiter/trajectory"),
+            (
+                "~/input/predicted_trajectory",
+                "/control/trajectory_follower/lateral/predicted_trajectory",
+            ),
         ],
         parameters=[
             nearest_search_param,

--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -13,14 +13,15 @@
 
 ### Input topics
 
-| Name                        | Type                                            | Description         |
-| --------------------------- | ----------------------------------------------- | ------------------- |
-| `~/input/pointcloud`        | sensor_msgs::PointCloud2                        | obstacle pointcloud |
-| `~/input/trajectory`        | autoware_auto_planning_msgs::Trajectory         | trajectory          |
-| `~/input/vector_map`        | autoware_auto_mapping_msgs::HADMapBin           | vector map          |
-| `~/input/odometry`          | nav_msgs::Odometry                              | vehicle velocity    |
-| `~/input/dynamic_objects`   | autoware_auto_perception_msgs::PredictedObjects | dynamic objects     |
-| `~/input/expand_stop_range` | tier4_planning_msgs::msg::ExpandStopRange       | expand stop range   |
+| Name                           | Type                                            | Description          |
+| ------------------------------ | ----------------------------------------------- | -------------------- |
+| `~/input/pointcloud`           | sensor_msgs::PointCloud2                        | obstacle pointcloud  |
+| `~/input/trajectory`           | autoware_auto_planning_msgs::Trajectory         | trajectory           |
+| `~/input/vector_map`           | autoware_auto_mapping_msgs::HADMapBin           | vector map           |
+| `~/input/odometry`             | nav_msgs::Odometry                              | vehicle velocity     |
+| `~/input/dynamic_objects`      | autoware_auto_perception_msgs::PredictedObjects | dynamic objects      |
+| `~/input/expand_stop_range`    | tier4_planning_msgs::msg::ExpandStopRange       | expand stop range    |
+| `~/input/predicted_trajectory` | autoware_auto_planning_msgs::Trajectory         | predicted trajectory |
 
 ### Output topics
 
@@ -31,11 +32,12 @@
 
 ### Common Parameter
 
-| Parameter           | Type   | Description                                                                            |
-| ------------------- | ------ | -------------------------------------------------------------------------------------- |
-| `enable_slow_down`  | bool   | enable slow down planner [-]                                                           |
-| `max_velocity`      | double | max velocity [m/s]                                                                     |
-| `hunting_threshold` | double | even if the obstacle disappears, the stop judgment continues for hunting_threshold [s] |
+| Parameter                    | Type   | Description                                                                            |
+| ---------------------------- | ------ | -------------------------------------------------------------------------------------- |
+| `enable_slow_down`           | bool   | enable slow down planner [-]                                                           |
+| `max_velocity`               | double | max velocity [m/s]                                                                     |
+| `hunting_threshold`          | double | even if the obstacle disappears, the stop judgment continues for hunting_threshold [s] |
+| `check_predicted_trajectory` | bool   | if it is "True", planner will take into account predicted trajectory of controller [-] |
 
 ## Obstacle Stop Planner
 

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -109,6 +109,8 @@ private:
 
   rclcpp::Subscription<ExpandStopRange>::SharedPtr sub_expand_stop_range_;
 
+  rclcpp::Subscription<Trajectory>::SharedPtr sub_predicted_trajectory_;
+
   rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_;
 
   rclcpp::Publisher<DiagnosticStatus>::SharedPtr pub_stop_reason_;
@@ -124,6 +126,7 @@ private:
   tf2_ros::Buffer tf_buffer_{get_clock()};
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
+  Trajectory::ConstSharedPtr predicted_trajectory_ptr_{nullptr};
   PredictedObjects::ConstSharedPtr object_ptr_{nullptr};
   rclcpp::Time last_detect_time_collision_point_;
   rclcpp::Time last_detect_time_slowdown_point_;
@@ -188,8 +191,19 @@ private:
   void publishDebugData(
     const PlannerData & planner_data, const double current_acc, const double current_vel);
 
+  /**
+   * @brief It updates the PlannerData of trajectory with respect to PlannerData of predicted
+   * trajectory of controller.
+   */
+  void checkPredictedTrajectory(
+    PlannerData & trajectory_data, const PlannerData & predicted_trajectory_data,
+    const TrajectoryPoints & decimate_trajectory,
+    const TrajectoryPoints & decimate_predicted_trajectory);
+
   // Callback
   void onTrigger(const Trajectory::ConstSharedPtr input_msg);
+
+  void onPredictedTrajectory(const Trajectory::ConstSharedPtr input_msg);
 
   void onOdometry(const Odometry::ConstSharedPtr input_msg);
 

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
@@ -70,6 +70,9 @@ struct NodeParam
 
   // yaw threshold for ego's nearest index
   double ego_nearest_yaw_threshold;
+
+  // set True to check predicted trajectory for obstacles
+  bool check_predicted_trajectory;
 };
 
 struct StopParam


### PR DESCRIPTION
Signed-off-by: Berkay Karaman <brkay54@gmail.com>

## Description
Related issue: https://github.com/autowarefoundation/autoware.universe/issues/2252

In current planning control design, autoware does not check the predicted trajectory for collision. Because trajectory is not draw from base_link of ego vehicle for some situations, we need to check the predicted trajectory in addition to trajectory output of planning module. 

This PR checks the predicted trajectory and motion planning trajectory for collision, then compare them. It makes decision for the nearest collision or slowdown points. 

It is optional, in default it will be disabled.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

I tested changes in planning simulator. It works good but there is a problem for some scenarios:


https://user-images.githubusercontent.com/45468306/203044604-08a24063-2cf5-4ad1-9136-b5891f482539.mp4

Controllers depend trajectory velocities while calculating the predicted trajectory. If there is a object on predicted trajectory, obstacle_stop_planner adds stop point to trajectory. Then, this affect the predicted trajectory so on.

Except this, it works as we wanted.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
