### PR TITLE
ci(sync-files): sync .pre-commit-config.yaml

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -86,6 +86,7 @@
     - source: .github/workflows/clang-tidy-pr-comments.yaml
     - source: .github/workflows/clang-tidy-pr-comments-manually.yaml
     - source: .github/workflows/update-codeowners-from-packages.yaml
+    - source: .pre-commit-config.yaml
     - source: codecov.yaml
 
 - repository: autowarefoundation/autoware-documentation


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Previously, there were some differences in the configuration to ignore Autoware.Auto packages, but I think we can unify them now.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
