### PR TITLE
feat(obstacle_avoidance_planner): parameterize non_fixed_trajectory_length

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -39,6 +39,8 @@
       num_fix_points_for_extending: 50 # number of fixing points when extending
       max_dist_for_extending_end_point: 0.0001 # minimum delta dist thres for extending last point [m]
 
+      non_fixed_trajectory_length: 5.0 # length of the trajectory merging optimized mpt trajectory to original(not optimized) trajectory
+
     object:  # avoiding object
       max_avoiding_objects_velocity_ms: 0.5 # maximum velocity for avoiding objects [m/s]
       max_avoiding_ego_velocity_ms: 6.0 # maximum ego velocity when avoiding objects [m/s]

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -39,6 +39,8 @@
       num_fix_points_for_extending: 50 # number of fixing points when extending
       max_dist_for_extending_end_point: 0.0001 # minimum delta dist thres for extending last point [m]
 
+      non_fixed_trajectory_length: 5.0 # length of the trajectory merging optimized mpt trajectory to original(not optimized) trajectory
+
     object:  # avoiding object
       max_avoiding_objects_velocity_ms: 0.5 # maximum velocity for avoiding objects [m/s]
       max_avoiding_ego_velocity_ms: 6.0 # maximum ego velocity when avoiding objects [m/s]

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
@@ -206,6 +206,7 @@ struct TrajectoryParam
   double acceleration_for_non_deceleration_range;
   int num_fix_points_for_extending;
   double max_dist_for_extending_end_point;
+  double non_fixed_trajectory_length;
 
   double ego_nearest_dist_threshold;
   double ego_nearest_yaw_threshold;

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -315,6 +315,8 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
       declare_parameter<int>("common.num_fix_points_for_extending");
     traj_param_.max_dist_for_extending_end_point =
       declare_parameter<double>("common.max_dist_for_extending_end_point");
+    traj_param_.non_fixed_trajectory_length =
+      declare_parameter<double>("common.non_fixed_trajectory_length");
 
     // object
     traj_param_.max_avoiding_ego_velocity_ms =
@@ -1412,10 +1414,9 @@ std::vector<TrajectoryPoint> ObstacleAvoidancePlanner::getExtendedTrajectory(
   }
 
   auto extended_traj_points = [&]() -> std::vector<TrajectoryPoint> {
-    constexpr double non_fixed_traj_length = 5.0;  // TODO(murooka) may be better to tune
     const size_t non_fixed_begin_path_idx = opt_end_path_idx.get();
-    const size_t non_fixed_end_path_idx =
-      points_utils::findForwardIndex(path_points, non_fixed_begin_path_idx, non_fixed_traj_length);
+    const size_t non_fixed_end_path_idx = points_utils::findForwardIndex(
+      path_points, non_fixed_begin_path_idx, traj_param_.non_fixed_trajectory_length);
 
     if (
       non_fixed_begin_path_idx == path_points.size() - 1 ||


### PR DESCRIPTION
Signed-off-by: Mehmet Dogru <42mehmetdogru42@gmail.com>

## Description

This PR parameterize `non_fixed_trajectory_length` to be able to tune it easier.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
