### PR TITLE
fix(behavior_path_planner): fix-lane-follow-in-behavior-path-planner

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1830,7 +1830,7 @@ bool checkLaneIsInIntersection(
       return false;
     }
 
-    auto back_lanelet_length = lanelet::utils::getLaneletLength2d(lanelet_sequence.back());
+    const auto back_lanelet_length = lanelet::utils::getLaneletLength2d(lanelet_sequence.back());
     if (back_lanelet_length > min_lane_change_distance) 
     {
       return false;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1830,8 +1830,8 @@ bool checkLaneIsInIntersection(
       return false;
     }
 
-    auto backlanelet_length = lanelet::utils::getLaneletLength2d(lanelet_sequence.back());
-    if (backlanelet_length > min_lane_change_distance) 
+    auto back_lanelet_length = lanelet::utils::getLaneletLength2d(lanelet_sequence.back());
+    if (back_lanelet_length > min_lane_change_distance) 
     {
       return false;
     }

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1829,6 +1829,12 @@ bool checkLaneIsInIntersection(
     if (get_signed_distance > min_lane_change_distance) {
       return false;
     }
+
+    auto backlanelet_length = lanelet::utils::getLaneletLength2d(lanelet_sequence.back());
+    if (backlanelet_length > min_lane_change_distance) 
+    {
+      return false;
+    }
   }
   // if you come to here, basically either back lane is goal, or back lane to goal is not enough
   // distance

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1831,8 +1831,7 @@ bool checkLaneIsInIntersection(
     }
 
     const auto back_lanelet_length = lanelet::utils::getLaneletLength2d(lanelet_sequence.back());
-    if (back_lanelet_length > min_lane_change_distance) 
-    {
+    if (back_lanelet_length > min_lane_change_distance) {
       return false;
     }
   }


### PR DESCRIPTION
Signed-off-by: jack.song <jack.song@autocore.ai>

## Description
When the global route includes the changing lane,the function of "checkLaneIsInIntersection" will return true(because the distance is not enough by calculation) by the current code in some positions as the target and the path by "lane_following" will be wrong. But the distance of the lanes is actual enough.
The simulation is shown as below:

![image](https://user-images.githubusercontent.com/102840938/203251677-413b6cc2-b21b-47fe-abaf-b9110584a687.png)


![image](https://user-images.githubusercontent.com/102840938/203253521-452307f9-1fcc-4fee-adda-2be88a7cabe8.png)



<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/issues/2310
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
By changing the judgment of the "checkLaneIsInIntersection",the simulation is shown as below:
case1:

![lane_fowwing](https://user-images.githubusercontent.com/102840938/203252207-ba86d9f3-f527-4335-94f0-c662e7f5f846.png)


case2:

![lane_follow_2](https://user-images.githubusercontent.com/102840938/203252338-a141c7f9-a56e-4579-ba0d-5af84901939a.png)


<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
