### PR TITLE
feat(behavior_path_planner): abort lane change function

### DIFF
--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -17,13 +17,37 @@
       maximum_deceleration: 1.0                 # [m/s2]
       lane_change_sampling_num: 10
 
+      # collision check
+      enable_collision_check_at_prepare_phase: false
+      prepare_phase_ignore_target_speed_thresh: 0.1 # [m/s]
+      use_predicted_path_outside_lanelet: true
+      use_all_predicted_path: true
+
+      # abort
+      enable_cancel_lane_change: true
+      enable_abort_lane_change: true
+
       abort_lane_change_velocity_thresh: 0.5
       abort_lane_change_angle_thresh: 10.0      # [deg]
       abort_lane_change_distance_thresh: 0.3    # [m]
       prepare_phase_ignore_target_speed_thresh: 0.1 # [m/s]
 
-      enable_abort_lane_change: true
-      enable_collision_check_at_prepare_phase: true
-      use_predicted_path_outside_lanelet: true
-      use_all_predicted_path: false
+      abort_lane_change_velocity_thresh: 0.5    # [m]
+      abort_lane_change_angle_thresh: 0.174533  # [rad]
+      abort_lane_change_distance_thresh: 0.3    # [m]
+
+      abort_begin_min_longitudinal_thresh: 4.0  # [m]
+      abort_begin_max_longitudinal_thresh: 6.0  # [m]
+      abort_begin_duration: 3.0                 # [s]
+
+      abort_return_min_longitudinal_thresh: 12.0 # [m]
+      abort_return_max_longitudinal_thresh: 16.0 # [m]
+      abort_return_duration: 6.0                 # [s]
+
+      abort_expected_deceleration: 0.1           # [m/s2]
+      abort_longitudinal_jerk: 0.5               # [m/s3]
+
+      abort_max_lateral_jerk: 5.0                # [m/s3]
+
+      # debug
       publish_debug_marker: false

--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -25,28 +25,9 @@
 
       # abort
       enable_cancel_lane_change: true
-      enable_abort_lane_change: true
+      enable_abort_lane_change: false
 
-      abort_lane_change_velocity_thresh: 0.5
-      abort_lane_change_angle_thresh: 10.0      # [deg]
-      abort_lane_change_distance_thresh: 0.3    # [m]
-      prepare_phase_ignore_target_speed_thresh: 0.1 # [m/s]
-
-      abort_lane_change_velocity_thresh: 0.5    # [m]
-      abort_lane_change_angle_thresh: 0.174533  # [rad]
-      abort_lane_change_distance_thresh: 0.3    # [m]
-
-      abort_begin_min_longitudinal_thresh: 4.0  # [m]
-      abort_begin_max_longitudinal_thresh: 6.0  # [m]
-      abort_begin_duration: 3.0                 # [s]
-
-      abort_return_min_longitudinal_thresh: 12.0 # [m]
-      abort_return_max_longitudinal_thresh: 16.0 # [m]
-      abort_return_duration: 6.0                 # [s]
-
-      abort_expected_deceleration: 0.1           # [m/s2]
-      abort_longitudinal_jerk: 0.5               # [m/s3]
-
+      abort_delta_time: 3.0                      # [s]
       abort_max_lateral_jerk: 5.0                # [m/s3]
 
       # debug

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -47,16 +47,16 @@ using marker_utils::CollisionCheckDebug;
 using tier4_planning_msgs::msg::LaneChangeDebugMsg;
 using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
 
-inline std::string toStr(const LaneChangeStates state)
+inline std::string_view toStr(const LaneChangeStates state)
 {
-  if (state == LaneChangeStates::Trying) {
-    return "Trying";
-  } else if (state == LaneChangeStates::Success) {
-    return "Success";
+  if (state == LaneChangeStates::Normal) {
+    return "Normal";
   } else if (state == LaneChangeStates::Cancel) {
     return "Cancel";
   } else if (state == LaneChangeStates::Abort) {
     return "Abort";
+  } else if (state == LaneChangeStates::Stop) {
+    return "Stop";
   }
   return "UNKNOWN";
 }
@@ -252,8 +252,9 @@ private:
   bool isCurrentSpeedLow() const;
   bool isAbortConditionSatisfied();
   bool hasFinishedLaneChange() const;
-  bool isCancel() const;
-  bool isAbort() const;
+  bool isCancelState() const;
+  bool isAbortState() const;
+  bool isStopState() const;
   // getter
   Pose getEgoPose() const;
   Twist getEgoTwist() const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -115,7 +115,6 @@ private:
   LaneChangeStatus status_;
   PathShifter path_shifter_;
   mutable LaneChangeDebugMsgArray lane_change_debug_msg_array_;
-  LaneDepartureChecker lane_departure_checker_;
   mutable LaneChangeStates current_lane_change_state_;
   mutable std::shared_ptr<LaneChangePath> abort_path_;
   PathWithLaneId prev_approved_path_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -132,6 +132,7 @@ private:
 
   bool is_abort_path_approved_ = false;
   bool is_abort_approval_requested_ = false;
+  bool is_abort_condition_satisfied_ = false;
 
   bool is_activated_ = false;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -47,20 +47,6 @@ using marker_utils::CollisionCheckDebug;
 using tier4_planning_msgs::msg::LaneChangeDebugMsg;
 using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
 
-inline std::string_view toStr(const LaneChangeStates state)
-{
-  if (state == LaneChangeStates::Normal) {
-    return "Normal";
-  } else if (state == LaneChangeStates::Cancel) {
-    return "Cancel";
-  } else if (state == LaneChangeStates::Abort) {
-    return "Abort";
-  } else if (state == LaneChangeStates::Stop) {
-    return "Stop";
-  }
-  return "UNKNOWN";
-}
-
 class LaneChangeModule : public SceneModuleInterface
 {
 public:
@@ -115,25 +101,22 @@ private:
   LaneChangeStatus status_;
   PathShifter path_shifter_;
   mutable LaneChangeDebugMsgArray lane_change_debug_msg_array_;
-  mutable LaneChangeStates current_lane_change_state_;
-  mutable std::shared_ptr<LaneChangePath> abort_path_;
+  LaneChangeStates current_lane_change_state_;
+  std::shared_ptr<LaneChangePath> abort_path_;
   PathWithLaneId prev_approved_path_;
-  mutable Pose abort_non_collision_pose_;
 
   double lane_change_lane_length_{200.0};
   double check_distance_{100.0};
+  bool is_abort_path_approved_{false};
+  bool is_abort_approval_requested_{false};
+  bool is_abort_condition_satisfied_{false};
+  bool is_activated_ = false;
 
   RTCInterface rtc_interface_left_;
   RTCInterface rtc_interface_right_;
   UUID uuid_left_;
   UUID uuid_right_;
   UUID candidate_uuid_;
-
-  bool is_abort_path_approved_ = false;
-  bool is_abort_approval_requested_ = false;
-  bool is_abort_condition_satisfied_ = false;
-
-  bool is_activated_ = false;
 
   void resetParameters();
 
@@ -263,11 +246,9 @@ private:
   void resetPathIfAbort(PathWithLaneId & selected_path);
 
   // debug
-  void append_marker_array(const MarkerArray & marker_array) const;
+  void setObjectDebugVisualization() const;
   mutable std::unordered_map<std::string, CollisionCheckDebug> object_debug_;
   mutable std::vector<LaneChangePath> debug_valid_path_;
-
-  void setObjectDebugVisualization() const;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -53,8 +53,8 @@ inline std::string toStr(const LaneChangeStates state)
     return "Trying";
   } else if (state == LaneChangeStates::Success) {
     return "Success";
-  } else if (state == LaneChangeStates::Revert) {
-    return "Revert";
+  } else if (state == LaneChangeStates::Cancel) {
+    return "Cancel";
   } else if (state == LaneChangeStates::Abort) {
     return "Abort";
   }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -244,6 +244,7 @@ private:
   void generateExtendedDrivableArea(PathWithLaneId & path);
   void updateOutputTurnSignal(BehaviorModuleOutput & output);
   void updateSteeringFactorPtr(const BehaviorModuleOutput & output);
+  bool isApprovedPathSafe(Pose & ego_pose_before_collision) const;
 
   void updateSteeringFactorPtr(
     const CandidateOutput & output, const LaneChangePath & selected_path) const;
@@ -253,9 +254,9 @@ private:
   bool isCurrentSpeedLow() const;
   bool isAbortConditionSatisfied();
   bool hasFinishedLaneChange() const;
-  bool isCancelState() const;
-  bool isAbortState() const;
   bool isStopState() const;
+  bool isAbortState() const;
+
   // getter
   Pose getEgoPose() const;
   Twist getEgoTwist() const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
@@ -62,10 +62,10 @@ struct LaneChangeStatus
 };
 
 enum class LaneChangeStates {
-  Trying = 0,
-  Success,
+  Normal = 0,
   Cancel,
   Abort,
+  Stop,
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
@@ -64,7 +64,7 @@ struct LaneChangeStatus
 enum class LaneChangeStates {
   Trying = 0,
   Success,
-  Revert,
+  Cancel,
   Abort,
 };
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
@@ -38,7 +38,8 @@ struct LaneChangeParameters
   double abort_lane_change_angle_thresh{0.174533};
   double abort_lane_change_distance_thresh{0.3};
   double prepare_phase_ignore_target_speed_thresh{0.1};
-  bool enable_abort_lane_change{true};
+  bool enable_cancel_lane_change{true};
+  bool enable_abort_lane_change{false};
   bool enable_collision_check_at_prepare_phase{true};
   bool use_predicted_path_outside_lanelet{false};
   bool use_all_predicted_path{false};
@@ -59,6 +60,14 @@ struct LaneChangeStatus
   bool is_safe;
   double start_distance;
 };
+
+enum class LaneChangeStates {
+  Trying = 0,
+  Success,
+  Revert,
+  Abort,
+};
+
 }  // namespace behavior_path_planner
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__LANE_CHANGE_MODULE_DATA_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
@@ -25,6 +25,7 @@ namespace behavior_path_planner
 {
 struct LaneChangeParameters
 {
+  // trajectory generation
   double lane_change_prepare_duration{2.0};
   double lane_changing_safety_check_duration{4.0};
   double lane_changing_lateral_jerk{0.5};
@@ -34,19 +35,40 @@ struct LaneChangeParameters
   double prediction_time_resolution{0.5};
   double maximum_deceleration{1.0};
   int lane_change_sampling_num{10};
+
+  // collision check
+  bool enable_collision_check_at_prepare_phase{true};
+  double prepare_phase_ignore_target_speed_thresh{0.1};
+  bool use_predicted_path_outside_lanelet{false};
+  bool use_all_predicted_path{false};
+
+  // abort
+  bool enable_cancel_lane_change{true};
+  bool enable_abort_lane_change{false};
+
   double abort_lane_change_velocity_thresh{0.5};
   double abort_lane_change_angle_thresh{0.174533};
   double abort_lane_change_distance_thresh{0.3};
-  double prepare_phase_ignore_target_speed_thresh{0.1};
-  bool enable_cancel_lane_change{true};
-  bool enable_abort_lane_change{false};
-  bool enable_collision_check_at_prepare_phase{true};
-  bool use_predicted_path_outside_lanelet{false};
-  bool use_all_predicted_path{false};
-  bool publish_debug_marker{false};
+
+  double abort_begin_min_longitudinal_thresh{4.0};
+  double abort_begin_max_longitudinal_thresh{6.0};
+  double abort_begin_duration{3.0};
+
+  double abort_return_min_longitudinal_thresh{12.0};
+  double abort_return_max_longitudinal_thresh{16.0};
+  double abort_return_duration{6.0};
+
+  double abort_expected_deceleration{0.1};
+  double abort_longitudinal_jerk{0.5};
+
+  double abort_max_lateral_jerk{5.0};
+
   // drivable area expansion
   double drivable_area_right_bound_offset{0.0};
   double drivable_area_left_bound_offset{0.0};
+
+  // debug marker
+  bool publish_debug_marker{false};
 };
 
 struct LaneChangeStatus

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
@@ -46,22 +46,8 @@ struct LaneChangeParameters
   bool enable_cancel_lane_change{true};
   bool enable_abort_lane_change{false};
 
-  double abort_lane_change_velocity_thresh{0.5};
-  double abort_lane_change_angle_thresh{0.174533};
-  double abort_lane_change_distance_thresh{0.3};
-
-  double abort_begin_min_longitudinal_thresh{4.0};
-  double abort_begin_max_longitudinal_thresh{6.0};
-  double abort_begin_duration{3.0};
-
-  double abort_return_min_longitudinal_thresh{12.0};
-  double abort_return_max_longitudinal_thresh{16.0};
-  double abort_return_duration{6.0};
-
-  double abort_expected_deceleration{0.1};
-  double abort_longitudinal_jerk{0.5};
-
-  double abort_max_lateral_jerk{5.0};
+  double abort_delta_time{3.0};
+  double abort_max_lateral_jerk{10.0};
 
   // drivable area expansion
   double drivable_area_right_bound_offset{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_path.hpp
@@ -29,12 +29,15 @@ using behavior_path_planner::TurnSignalInfo;
 struct LaneChangePath
 {
   PathWithLaneId path;
+  lanelet::ConstLanelets reference_lanelets;
+  lanelet::ConstLanelets target_lanelets;
   ShiftedPath shifted_path;
   ShiftLine shift_line;
   double acceleration{0.0};
   double preparation_length{0.0};
   double lane_change_length{0.0};
   TurnSignalInfo turn_signal_info;
+  PathWithLaneId prev_path;
 };
 using LaneChangePaths = std::vector<LaneChangePath>;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -162,8 +162,7 @@ double getLateralShift(const LaneChangePath & path);
 bool hasEnoughDistanceToLaneChangeAfterAbort(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const Pose & curent_pose, const double abort_return_dist,
-  const BehaviorPathPlannerParameters & common_param,
-  const LaneChangeParameters & lane_change_param);
+  const BehaviorPathPlannerParameters & common_param);
 }  // namespace behavior_path_planner::lane_change_utils
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -97,7 +97,7 @@ bool isLaneChangePathSafe(
   const size_t current_seg_idx, const Twist & current_twist,
   const BehaviorPathPlannerParameters & common_parameters,
   const behavior_path_planner::LaneChangeParameters & lane_change_parameters,
-  const double front_decel, const double rear_decel,
+  const double front_decel, const double rear_decel, Pose & ego_pose_before_collision,
   std::unordered_map<std::string, CollisionCheckDebug> & debug_data, const bool use_buffer = true,
   const double acceleration = 0.0);
 
@@ -151,6 +151,12 @@ void get_turn_signal_info(
 std::vector<DrivableLanes> generateDrivableLanes(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & lane_change_lanes);
+
+std::optional<LaneChangePath> getAbortPaths(
+  const std::shared_ptr<const PlannerData> & planner_data, const LaneChangePath & selected_path,
+  const Pose & ego_lerp_pose_before_collision, ShiftLine & shift);
+double getLateralShift(const LaneChangePath & path);
+
 }  // namespace behavior_path_planner::lane_change_utils
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -158,6 +158,12 @@ std::optional<LaneChangePath> getAbortPaths(
   const LaneChangeParameters & lane_change_param);
 
 double getLateralShift(const LaneChangePath & path);
+
+bool hasEnoughDistanceToLaneChangeAfterAbort(
+  const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
+  const Pose & curent_pose, const double abort_return_dist,
+  const BehaviorPathPlannerParameters & common_param,
+  const LaneChangeParameters & lane_change_param);
 }  // namespace behavior_path_planner::lane_change_utils
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -133,12 +133,6 @@ PathWithLaneId getLaneChangePathLaneChangingSegment(
 bool isEgoWithinOriginalLane(
   const lanelet::ConstLanelets & current_lanes, const Pose & current_pose,
   const BehaviorPathPlannerParameters & common_param);
-bool isEgoDistanceNearToCenterline(
-  const lanelet::ConstLanelet & closest_lanelet, const Pose & current_pose,
-  const LaneChangeParameters & lane_change_param);
-bool isEgoHeadingAngleLessThanThreshold(
-  const lanelet::ConstLanelet & closest_lanelet, const Pose & current_pose,
-  const LaneChangeParameters & lane_change_param);
 
 TurnSignalInfo calc_turn_signal_info(
   const PathWithLaneId & prepare_path, const double prepare_velocity,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -154,9 +154,10 @@ std::vector<DrivableLanes> generateDrivableLanes(
 
 std::optional<LaneChangePath> getAbortPaths(
   const std::shared_ptr<const PlannerData> & planner_data, const LaneChangePath & selected_path,
-  const Pose & ego_lerp_pose_before_collision, ShiftLine & shift);
-double getLateralShift(const LaneChangePath & path);
+  const Pose & ego_lerp_pose_before_collision, const BehaviorPathPlannerParameters & common_param,
+  const LaneChangeParameters & lane_change_param);
 
+double getLateralShift(const LaneChangePath & path);
 }  // namespace behavior_path_planner::lane_change_utils
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -202,6 +202,9 @@ bool calcObjectPolygon(const PredictedObject & object, Polygon2d * object_polygo
 bool calcObjectPolygon(
   const Shape & object_shape, const Pose & object_pose, Polygon2d * object_polygon);
 
+bool calcObjectPolygon(
+  const Shape & object_shape, const Pose & object_pose, Polygon2d * object_polygon);
+
 PredictedPath resamplePredictedPath(
   const PredictedPath & input_path, const double resolution, const double duration);
 
@@ -478,7 +481,7 @@ bool isSafeInLaneletCollisionCheck(
   const double check_start_time, const double check_end_time, const double check_time_resolution,
   const PredictedObject & target_object, const PredictedPath & target_object_path,
   const BehaviorPathPlannerParameters & common_parameters, const double front_decel,
-  const double rear_decel, CollisionCheckDebug & debug);
+  const double rear_decel, Pose & ego_pose_before_collision, CollisionCheckDebug & debug);
 
 bool isSafeInFreeSpaceCollisionCheck(
   const Pose & ego_current_pose, const Twist & ego_current_twist,

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -395,7 +395,8 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
     dp("abort_lane_change_angle_thresh", tier4_autoware_utils::deg2rad(10.0));
   p.abort_lane_change_distance_thresh = dp("abort_lane_change_distance_thresh", 0.3);
   p.prepare_phase_ignore_target_speed_thresh = dp("prepare_phase_ignore_target_speed_thresh", 0.1);
-  p.enable_abort_lane_change = dp("enable_abort_lane_change", true);
+  p.enable_cancel_lane_change = dp("enable_cancel_lane_change", true);
+  p.enable_abort_lane_change = dp("enable_abort_lane_change", false);
   p.enable_collision_check_at_prepare_phase = dp("enable_collision_check_at_prepare_phase", true);
   p.use_predicted_path_outside_lanelet = dp("use_predicted_path_outside_lanelet", true);
   p.use_all_predicted_path = dp("use_all_predicted_path", true);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -403,23 +403,8 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.enable_cancel_lane_change = dp("enable_cancel_lane_change", true);
   p.enable_abort_lane_change = dp("enable_abort_lane_change", false);
 
-  p.abort_lane_change_velocity_thresh = dp("abort_lane_change_velocity_thresh", 0.5);
-  p.abort_lane_change_angle_thresh =
-    dp("abort_lane_change_angle_thresh", tier4_autoware_utils::deg2rad(10.0));
-  p.abort_lane_change_distance_thresh = dp("abort_lane_change_distance_thresh", 0.3);
-
-  p.abort_begin_min_longitudinal_thresh = dp("abort_begin_min_longitudinal_thresh", 4.0);
-  p.abort_begin_max_longitudinal_thresh = dp("abort_begin_max_longitudinal_thresh", 6.0);
-  p.abort_begin_duration = dp("abort_begin_duration", 3.0);
-
-  p.abort_return_min_longitudinal_thresh = dp("abort_return_min_longitudinal_thresh", 12.0);
-  p.abort_return_max_longitudinal_thresh = dp("abort_return_max_longitudinal_thresh", 16.0);
-  p.abort_return_duration = dp("abort_return_duration", 6.0);
-
-  p.abort_expected_deceleration = dp("abort_expected_deceleration", 0.1);
-  p.abort_longitudinal_jerk = dp("abort_longitudinal_jerk", 0.5);
-
-  p.abort_max_lateral_jerk = dp("abort_max_lateral_jerk", 5.0);
+  p.abort_delta_time = dp("abort_delta_time", 3.0);
+  p.abort_max_lateral_jerk = dp("abort_max_lateral_jerk", 10.0);
 
   // drivable area expansion
   p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
@@ -444,19 +429,10 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
     exit(EXIT_FAILURE);
   }
 
-  if (p.abort_expected_deceleration < 0.0) {
+  if (p.abort_delta_time < 1.0) {
     RCLCPP_FATAL_STREAM(
-      get_logger(), "abort_expected_deceleration cannot be negative value. Given parameter: "
-                      << p.maximum_deceleration << std::endl
-                      << "Terminating the program...");
-    exit(EXIT_FAILURE);
-  }
-
-  if (p.abort_return_duration <= p.abort_begin_duration) {
-    RCLCPP_FATAL_STREAM(
-      get_logger(), "abort_return_duration must be more than abort_begin_duration: "
-                      << p.maximum_deceleration << std::endl
-                      << "Terminating the program...");
+      get_logger(), "abort_delta_time: " << p.abort_delta_time << ", is too short.\n"
+                                         << "Terminating the program...");
     exit(EXIT_FAILURE);
   }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -530,7 +530,7 @@ bool LaneChangeModule::isAbortConditionSatisfied()
   // abort only if velocity is low or vehicle pose is close enough
   if (!is_path_safe) {
     // check vehicle velocity thresh
-    current_lane_change_state_ = LaneChangeStates::Revert;
+    current_lane_change_state_ = LaneChangeStates::Cancel;
     const bool is_velocity_low =
       util::l2Norm(current_twist.linear) < parameters_->abort_lane_change_velocity_thresh;
     const bool is_within_original_lane =
@@ -582,7 +582,7 @@ bool LaneChangeModule::isAbort() const
 
 bool LaneChangeModule::isCancel() const
 {
-  return current_lane_change_state_ == LaneChangeStates::Revert;
+  return current_lane_change_state_ == LaneChangeStates::Cancel;
 }
 
 bool LaneChangeModule::hasFinishedLaneChange() const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -155,7 +155,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
     }
     generateExtendedDrivableArea(path);
     prev_approved_path_ = path;
-    if (is_abort_condition_satisfied_ && (isNearEndOfLane() && isCurrentSpeedLow())) {
+    if(is_abort_condition_satisfied_){
       const auto stop_point = util::insertStopPoint(0.1, &path);
     }
   } else {
@@ -537,27 +537,26 @@ bool LaneChangeModule::isAbortConditionSatisfied()
 
     current_lane_change_state_ = LaneChangeStates::Cancel;
 
-    // const bool is_velocity_low =
-    //   util::l2Norm(current_twist.linear) < parameters_->abort_lane_change_velocity_thresh;
+    const bool is_velocity_low =
+      util::l2Norm(current_twist.linear) < parameters_->abort_lane_change_velocity_thresh;
 
     const bool is_within_original_lane =
       lane_change_utils::isEgoWithinOriginalLane(current_lanes, current_pose, common_parameters);
 
-    if (is_within_original_lane) {
+    if (is_velocity_low && is_within_original_lane) {
       return true;
     }
 
-    // const bool is_distance_small =
-    //   lane_change_utils::isEgoDistanceNearToCenterline(closest_lanelet, current_pose,
-    //   *parameters_);
+    const bool is_distance_small =
+      lane_change_utils::isEgoDistanceNearToCenterline(closest_lanelet, current_pose, *parameters_);
 
     // check angle thresh from original lane
-    // const bool is_angle_diff_small = lane_change_utils::isEgoHeadingAngleLessThanThreshold(
-    //   closest_lanelet, current_pose, *parameters_);
+    const bool is_angle_diff_small = lane_change_utils::isEgoHeadingAngleLessThanThreshold(
+      closest_lanelet, current_pose, *parameters_);
 
-    // if (is_angle_diff_small) {
-    //   return true;
-    // }
+    if (is_distance_small && is_angle_diff_small) {
+      return true;
+    }
 
     if (!parameters_->enable_abort_lane_change) {
       return true;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -171,6 +171,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
   if (!isSafe()) {
     current_state_ = BT::NodeStatus::SUCCESS;  // for breaking loop
   }
+  updateSteeringFactorPtr(output);
 
   return output;
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -155,7 +155,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
     }
     generateExtendedDrivableArea(path);
     prev_approved_path_ = path;
-    if(is_abort_condition_satisfied_){
+    if (is_abort_condition_satisfied_ && (isNearEndOfLane() && isCurrentSpeedLow())) {
       const auto stop_point = util::insertStopPoint(0.1, &path);
     }
   } else {
@@ -537,26 +537,27 @@ bool LaneChangeModule::isAbortConditionSatisfied()
 
     current_lane_change_state_ = LaneChangeStates::Cancel;
 
-    const bool is_velocity_low =
-      util::l2Norm(current_twist.linear) < parameters_->abort_lane_change_velocity_thresh;
+    // const bool is_velocity_low =
+    //   util::l2Norm(current_twist.linear) < parameters_->abort_lane_change_velocity_thresh;
 
     const bool is_within_original_lane =
       lane_change_utils::isEgoWithinOriginalLane(current_lanes, current_pose, common_parameters);
 
-    if (is_velocity_low && is_within_original_lane) {
+    if (is_within_original_lane) {
       return true;
     }
 
-    const bool is_distance_small =
-      lane_change_utils::isEgoDistanceNearToCenterline(closest_lanelet, current_pose, *parameters_);
+    // const bool is_distance_small =
+    //   lane_change_utils::isEgoDistanceNearToCenterline(closest_lanelet, current_pose,
+    //   *parameters_);
 
     // check angle thresh from original lane
-    const bool is_angle_diff_small = lane_change_utils::isEgoHeadingAngleLessThanThreshold(
-      closest_lanelet, current_pose, *parameters_);
+    // const bool is_angle_diff_small = lane_change_utils::isEgoHeadingAngleLessThanThreshold(
+    //   closest_lanelet, current_pose, *parameters_);
 
-    if (is_distance_small && is_angle_diff_small) {
-      return true;
-    }
+    // if (is_angle_diff_small) {
+    //   return true;
+    // }
 
     if (!parameters_->enable_abort_lane_change) {
       return true;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -117,7 +117,7 @@ BT::NodeStatus LaneChangeModule::updateState()
   }
 
   if (isAbortConditionSatisfied()) {
-    if ((isNearEndOfLane() && isCurrentSpeedLow()) || isAbortState() || isStopState()) {
+    if ((isNearEndOfLane() && isCurrentSpeedLow()) || isAbortState()) {
       current_state_ = BT::NodeStatus::RUNNING;
       return current_state_;
     }
@@ -138,7 +138,6 @@ BehaviorModuleOutput LaneChangeModule::plan()
 {
   resetPathCandidate();
 
-  auto path = status_.lane_change_path.path;
   is_activated_ = isActivated();
 
   PathWithLaneId selected_path = status_.lane_change_path.path;
@@ -152,9 +151,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
     }
     generateExtendedDrivableArea(path);
     prev_approved_path_ = path;
-    if (
-      (is_abort_condition_satisfied_ && isNearEndOfLane() && isCurrentSpeedLow()) ||
-      isStopState()) {
+    if ((is_abort_condition_satisfied_ && isNearEndOfLane() && isCurrentSpeedLow())) {
       const auto stop_point = util::insertStopPoint(0.1, &path);
     }
   } else {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -155,7 +155,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
     }
     generateExtendedDrivableArea(path);
     prev_approved_path_ = path;
-    if (is_abort_condition_satisfied_) {
+    if (is_abort_condition_satisfied_ && (isNearEndOfLane() && isCurrentSpeedLow())) {
       const auto stop_point = util::insertStopPoint(0.1, &path);
     }
   } else {
@@ -537,26 +537,27 @@ bool LaneChangeModule::isAbortConditionSatisfied()
 
     current_lane_change_state_ = LaneChangeStates::Cancel;
 
-    const bool is_velocity_low =
-      util::l2Norm(current_twist.linear) < parameters_->abort_lane_change_velocity_thresh;
+    // const bool is_velocity_low =
+    //   util::l2Norm(current_twist.linear) < parameters_->abort_lane_change_velocity_thresh;
 
     const bool is_within_original_lane =
       lane_change_utils::isEgoWithinOriginalLane(current_lanes, current_pose, common_parameters);
 
-    if (is_velocity_low && is_within_original_lane) {
+    if (is_within_original_lane) {
       return true;
     }
 
-    const bool is_distance_small =
-      lane_change_utils::isEgoDistanceNearToCenterline(closest_lanelet, current_pose, *parameters_);
+    // const bool is_distance_small =
+    //   lane_change_utils::isEgoDistanceNearToCenterline(closest_lanelet, current_pose,
+    //   *parameters_);
 
     // check angle thresh from original lane
-    const bool is_angle_diff_small = lane_change_utils::isEgoHeadingAngleLessThanThreshold(
-      closest_lanelet, current_pose, *parameters_);
+    // const bool is_angle_diff_small = lane_change_utils::isEgoHeadingAngleLessThanThreshold(
+    //   closest_lanelet, current_pose, *parameters_);
 
-    if (is_distance_small && is_angle_diff_small) {
-      return true;
-    }
+    // if (is_angle_diff_small) {
+    //   return true;
+    // }
 
     if (!parameters_->enable_abort_lane_change) {
       return true;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -155,7 +155,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
     }
     generateExtendedDrivableArea(path);
     prev_approved_path_ = path;
-    if(is_abort_condition_satisfied_){
+    if (is_abort_condition_satisfied_) {
       const auto stop_point = util::insertStopPoint(0.1, &path);
     }
   } else {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -187,18 +187,18 @@ void LaneChangeModule::resetPathIfAbort()
       removePreviousRTCStatusLeft();
       uuid_left_ = generateUUID();
     }
-    RCLCPP_ERROR(getLogger(), "[plan] uuid is reset to request abort approval.");
+    RCLCPP_DEBUG(getLogger(), "[abort] uuid is reset to request abort approval.");
     is_abort_approval_requested_ = true;
     is_abort_path_approved_ = false;
     return;
   }
 
   if (isActivated()) {
-    RCLCPP_INFO(getLogger(), "[plan] isActivated() is true. set is_abort_path_approved to true.");
+    RCLCPP_DEBUG(getLogger(), "[abort] isActivated() is true. set is_abort_path_approved to true.");
     is_abort_path_approved_ = true;
     clearWaitingApproval();
   } else {
-    RCLCPP_INFO(getLogger(), "[plan] isActivated() is False.");
+    RCLCPP_DEBUG(getLogger(), "[abort] isActivated() is False.");
     is_abort_path_approved_ = false;
     waitApproval();
   }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -782,7 +782,7 @@ std::optional<LaneChangePath> getAbortPaths(
   const auto abort_point_dist =
     [&](const double param_accel, const double param_jerk, const double param_time) {
       return current_speed * param_time + (-param_accel) * std::pow(param_time, 2) / 2. -
-             param_jerk * std::pow(param_jerk, 3) / 6.;
+             param_jerk * std::pow(param_time, 3) / 6.;
     };
 
   const auto ego_nearest_dist_threshold = planner_data->parameters.ego_nearest_dist_threshold;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -777,7 +777,8 @@ std::optional<LaneChangePath> getAbortPaths(
       return ego_pose_idx;
     }
 
-    const auto desired_distance = std::max(2.77, current_speed) * param_time;
+    constexpr auto min_speed = 2.77;
+    const auto desired_distance = std::max(min_speed, current_speed) * param_time;
     const auto & points = resampled_selected_path.points;
     size_t idx{0};
     for (idx = ego_pose_idx; idx < lane_changing_end_pose_idx; ++idx) {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -789,8 +789,7 @@ std::optional<LaneChangePath> getAbortPaths(
   const auto ego_nearest_dist_threshold = planner_data->parameters.ego_nearest_dist_threshold;
   const auto ego_nearest_yaw_threshold = planner_data->parameters.ego_nearest_yaw_threshold;
 
-  constexpr double resample_path{1.0};
-  auto resampled_selected_path = util::resamplePathWithSpline(selected_path.path, resample_path);
+  auto resampled_selected_path = selected_path.path;
 
   const auto ego_pose_idx = motion_utils::findFirstNearestIndexWithSoftConstraints(
     resampled_selected_path.points, current_pose, ego_nearest_dist_threshold,
@@ -850,8 +849,7 @@ std::optional<LaneChangePath> getAbortPaths(
   }
 
   if (!hasEnoughDistanceToLaneChangeAfterAbort(
-        *route_handler, current_lanes, current_pose, abort_return_dist, common_param,
-        lane_change_param)) {
+        *route_handler, current_lanes, current_pose, abort_return_dist, common_param)) {
     return std::nullopt;
   }
 
@@ -927,10 +925,9 @@ double getLateralShift(const LaneChangePath & path)
 bool hasEnoughDistanceToLaneChangeAfterAbort(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const Pose & current_pose, const double abort_return_dist,
-  const BehaviorPathPlannerParameters & common_param,
-  const LaneChangeParameters & lane_change_param)
+  const BehaviorPathPlannerParameters & common_param)
 {
-  const auto minimum_lane_change_distance = lane_change_param.minimum_lane_change_prepare_distance +
+  const auto minimum_lane_change_distance = common_param.minimum_lane_change_prepare_distance +
                                             common_param.minimum_lane_change_length +
                                             common_param.backward_length_buffer_for_end_of_lane;
   const auto abort_plus_lane_change_distance = abort_return_dist + minimum_lane_change_distance;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -829,9 +829,14 @@ std::optional<LaneChangePath> getAbortPaths(
       common_param.backward_length_buffer_for_end_of_lane + common_param.minimum_lane_change_length;
 
     const double s_start = arc_position.length;
-    const double s_end =
+    double s_end =
       lanelet::utils::getLaneletLength2d(reference_lanelets) - minimum_lane_change_length;
 
+    if (route_handler->isInGoalRouteSection(selected_path.target_lanelets.back())) {
+      const auto goal_arc_coordinates = lanelet::utils::getArcCoordinates(
+        selected_path.target_lanelets, route_handler->getGoalPose());
+      s_end = std::min(s_end, goal_arc_coordinates.length) - minimum_lane_change_length;
+    }
     PathWithLaneId ref = route_handler->getCenterLinePath(reference_lanelets, s_start, s_end);
     ref.points.back().point.longitudinal_velocity_mps = std::min(
       ref.points.back().point.longitudinal_velocity_mps,

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2462,7 +2462,7 @@ bool isSafeInLaneletCollisionCheck(
   const double check_start_time, const double check_end_time, const double check_time_resolution,
   const PredictedObject & target_object, const PredictedPath & target_object_path,
   const BehaviorPathPlannerParameters & common_parameters, const double front_decel,
-  const double rear_decel, CollisionCheckDebug & debug)
+  const double rear_decel, Pose & ego_pose_before_collision, CollisionCheckDebug & debug)
 {
   const auto lerp_path_reserve = (check_end_time - check_start_time) / check_time_resolution;
   if (lerp_path_reserve > 1e-3) {
@@ -2502,6 +2502,7 @@ bool isSafeInLaneletCollisionCheck(
       debug.failed_reason = "not_enough_longitudinal";
       return false;
     }
+    ego_pose_before_collision = expected_ego_pose;
   }
   return true;
 }


### PR DESCRIPTION
## Description

Current lane change abort function only cancels unsafe lane change path when ego is still relatively close to the current reference lane (preparation phase). While ego is lane changing, there is no action to respond to the unsafe lane change path. Therefore the aim of this PR is to introduce a function that allows ego vehicle to return to original lane should abort is needed.

Note that this function "DOESN'T GUARANTEE SAFE ABORT"

![abort-illustration](https://user-images.githubusercontent.com/93502286/204440957-3cb494a3-9d34-496d-9a72-bf6e717a7596.png)

The parameter `abort_begin_dist` and `abort_return_dist` are computed as follows
```
dist = current_vel * time + 0.5 * accel * time ^ 2 - (1/6) * jerk * time ^ 3
```

are subjected to the following constraints

```
abort_begin_min_longitudinal_thresh < abort_begin_dist < abort_begin_max_longitudinal_thresh
abort_return_min_longitudinal_thresh < abort_return_dist < abort_return_max_longitudinal_thresh
```



### Flowchart

![flowchart-abort-process](https://user-images.githubusercontent.com/93502286/204444526-6b22d8f7-ea43-413e-b58a-0010d3ee9fe4.png)

The abort process may result in two different outcome. If ego as yet no depart from the reference lane, the result is `CANCEL` process. (Note that this is the original abort function that has already available in the `main` branch)

The following illustrates the `CANCEL` process

https://user-images.githubusercontent.com/93502286/204445547-4518113a-00b1-4040-ba19-59679755e316.mp4

If ego depart from the current lane, then the result will be `Abort` process.

https://user-images.githubusercontent.com/93502286/204446006-2a45edf8-f06b-4093-b4ad-a1741eb420f8.mp4

## Related links

Parameters: https://github.com/tier4/autoware_launch/pull/583
[TIER4 Internal Link
](https://tier4.atlassian.net/browse/T4PB-21434)

## Tests performed

https://user-images.githubusercontent.com/93502286/203713966-6a5e8030-942b-400e-95cb-490f240e81f7.mp4

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
