### PR TITLE
refactor(radar_threshold_filter): fix changing to autoware_cmake dependency

### DIFF
--- a/sensing/radar_threshold_filter/CMakeLists.txt
+++ b/sensing/radar_threshold_filter/CMakeLists.txt
@@ -1,20 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(radar_threshold_filter)
 
-## Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
-## Dependencies
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+# Dependencies
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 ## Targets
 ament_auto_add_library(radar_threshold_filter_node_component SHARED

--- a/sensing/radar_threshold_filter/package.xml
+++ b/sensing/radar_threshold_filter/package.xml
@@ -13,6 +13,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 
+  <build_depend>autoware_cmake</build_depend>
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/sensing/radar_threshold_filter/package.xml
+++ b/sensing/radar_threshold_filter/package.xml
@@ -4,6 +4,7 @@
   <version>0.1.0</version>
   <description>radar_threshold_filter</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
+  <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>
   <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
   <license>Apache License 2.0</license>
 


### PR DESCRIPTION

Signed-off-by: scepter914 <scepter914@gmail.com>

## Description

Fix changing to autoware_cmake dependency according to https://github.com/autowarefoundation/autoware.universe/pull/2362#discussion_r1031082306

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
