### PR TITLE
refactor(radar_fusion_to_detected_object): delete unused cmake option

### DIFF
--- a/perception/radar_fusion_to_detected_object/CMakeLists.txt
+++ b/perception/radar_fusion_to_detected_object/CMakeLists.txt
@@ -1,17 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(radar_fusion_to_detected_object)
 
-# Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 # Dependencies
 find_package(autoware_cmake REQUIRED)
 autoware_package()

--- a/perception/radar_fusion_to_detected_object/package.xml
+++ b/perception/radar_fusion_to_detected_object/package.xml
@@ -9,7 +9,6 @@
   <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>
@@ -20,6 +19,7 @@
   <depend>std_msgs</depend>
   <depend>tier4_autoware_utils</depend>
 
+  <build_depend>autoware_cmake</build_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/perception/radar_fusion_to_detected_object/package.xml
+++ b/perception/radar_fusion_to_detected_object/package.xml
@@ -5,6 +5,7 @@
   <version>0.0.0</version>
   <description>radar_fusion_to_detected_object</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
+  <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>
   <license>Apache License 2.0</license>
   <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
 


### PR DESCRIPTION

Signed-off-by: scepter914 <scepter914@gmail.com>

## Description

Delete unused option according to https://github.com/autowarefoundation/autoware.universe/pull/2362#discussion_r1031082306 .
Refactor package.xml and CMakeLists.txt to align to other packages.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
