### PR TITLE
refactor(radar_tracks_msgs_converter): delete unused cmake option

### DIFF
--- a/perception/radar_tracks_msgs_converter/CMakeLists.txt
+++ b/perception/radar_tracks_msgs_converter/CMakeLists.txt
@@ -4,20 +4,6 @@ project(radar_tracks_msgs_converter)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-## Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
-
-include_directories(
-  include
-)
-
 ## Targets
 ament_auto_add_library(radar_tracks_msgs_converter_node_component SHARED
   src/radar_tracks_msgs_converter_node/radar_tracks_msgs_converter_node.cpp

--- a/perception/radar_tracks_msgs_converter/package.xml
+++ b/perception/radar_tracks_msgs_converter/package.xml
@@ -5,6 +5,7 @@
   <version>0.0.1</version>
   <description>radar_tracks_msgs_converter</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
+  <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>
   <license>Apache License 2.0</license>
   <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
 

--- a/perception/radar_tracks_msgs_converter/package.xml
+++ b/perception/radar_tracks_msgs_converter/package.xml
@@ -6,12 +6,9 @@
   <description>radar_tracks_msgs_converter</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
   <license>Apache License 2.0</license>
-
   <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
-  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -24,6 +21,7 @@
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
 
+  <build_depend>autoware_cmake</build_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 


### PR DESCRIPTION
Signed-off-by: scepter914 <scepter914@gmail.com>

## Description

Delete unused option according to https://github.com/autowarefoundation/autoware.universe/pull/2362#discussion_r1031082306 .
Refactor package.xml and CMakeLists.txt to align to other packages.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
