### PR TITLE
refactor(front_vehicle_velocity_estimator): delete unused cmake option

### DIFF
--- a/perception/front_vehicle_velocity_estimator/CMakeLists.txt
+++ b/perception/front_vehicle_velocity_estimator/CMakeLists.txt
@@ -1,17 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(front_vehicle_velocity_estimator)
 
-# Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 # Dependencies
 find_package(autoware_cmake REQUIRED)
 autoware_package()

--- a/perception/front_vehicle_velocity_estimator/package.xml
+++ b/perception/front_vehicle_velocity_estimator/package.xml
@@ -5,7 +5,9 @@
   <version>0.1.0</version>
   <description>front_vehicle_velocity_estimator</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
+  <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>
   <license>Apache License 2.0</license>
+  <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 

--- a/perception/front_vehicle_velocity_estimator/package.xml
+++ b/perception/front_vehicle_velocity_estimator/package.xml
@@ -8,7 +8,6 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -21,6 +20,7 @@
   <depend>sensor_msgs</depend>
   <depend>tier4_autoware_utils</depend>
 
+  <build_depend>autoware_cmake</build_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 


### PR DESCRIPTION
Signed-off-by: scepter914 <scepter914@gmail.com>

## Description

Delete unused option according to https://github.com/autowarefoundation/autoware.universe/pull/2362#discussion_r1031082306 .
Refactor package.xml and CMakeLists.txt to align to other packages.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
