### PR TITLE
feat(behavior_path_planner): abort deceleration for abort condition 

### DIFF
--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -33,8 +33,8 @@
     expected_front_deceleration: -1.0
     expected_rear_deceleration: -1.0
 
-    front_abort_deceleration: -2.0
-    rear_abort_deceleration: -2.5
+    expected_front_deceleration_for_abort: -2.0
+    expected_rear_deceleration_for_abort: -2.5
 
     rear_vehicle_reaction_time: 2.0
     rear_vehicle_safety_time_margin: 2.0

--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -29,7 +29,12 @@
 
     lateral_distance_max_threshold: 2.0
     longitudinal_distance_min_threshold: 3.0
-    expected_front_deceleration: -0.5
+
+    expected_front_deceleration: -1.0
     expected_rear_deceleration: -1.0
+
+    front_abort_deceleration: -2.0
+    rear_abort_deceleration: -2.5
+
     rear_vehicle_reaction_time: 2.0
     rear_vehicle_safety_time_margin: 2.0

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -70,8 +70,8 @@ struct BehaviorPathPlannerParameters
   double expected_front_deceleration;  // brake parameter under normal lane change
   double expected_rear_deceleration;   // brake parameter under normal lane change
 
-  double front_abort_deceleration;  // hard brake parameter for abort
-  double rear_abort_deceleration;   // hard brake parameter for abort
+  double expected_front_deceleration_for_abort;  // hard brake parameter for abort
+  double expected_rear_deceleration_for_abort;   // hard brake parameter for abort
 
   double rear_vehicle_reaction_time;
   double rear_vehicle_safety_time_margin;

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -66,8 +66,13 @@ struct BehaviorPathPlannerParameters
   // collision check
   double lateral_distance_max_threshold;
   double longitudinal_distance_min_threshold;
-  double expected_front_deceleration;
-  double expected_rear_deceleration;
+
+  double expected_front_deceleration;  // brake parameter under normal lane change
+  double expected_rear_deceleration;   // brake parameter under normal lane change
+
+  double front_abort_deceleration;  // hard brake parameter for abort
+  double rear_abort_deceleration;   // hard brake parameter for abort
+
   double rear_vehicle_reaction_time;
   double rear_vehicle_safety_time_margin;
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -91,9 +91,10 @@ bool isLaneChangePathSafe(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
   const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
-  const size_t & current_seg_idx, const Twist & current_twist,
+  const size_t current_seg_idx, const Twist & current_twist,
   const BehaviorPathPlannerParameters & common_parameters,
   const behavior_path_planner::LaneChangeParameters & lane_change_parameters,
+  const double front_decel, const double rear_decel,
   std::unordered_map<std::string, CollisionCheckDebug> & debug_data, const bool use_buffer = true,
   const double acceleration = 0.0);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -456,7 +456,8 @@ bool isLongitudinalDistanceEnough(
 bool hasEnoughDistance(
   const Pose & expected_ego_pose, const Twist & ego_current_twist,
   const Pose & expected_object_pose, const Twist & object_current_twist,
-  const BehaviorPathPlannerParameters & param, CollisionCheckDebug & debug);
+  const BehaviorPathPlannerParameters & param, const double front_decel, const double rear_decel,
+  CollisionCheckDebug & debug);
 
 bool isLateralDistanceEnough(
   const double & relative_lateral_distance, const double & lateral_distance_threshold);
@@ -464,17 +465,17 @@ bool isLateralDistanceEnough(
 bool isSafeInLaneletCollisionCheck(
   const Pose & ego_current_pose, const Twist & ego_current_twist,
   const PredictedPath & ego_predicted_path, const VehicleInfo & ego_info,
-  const double & check_start_time, const double & check_end_time,
-  const double & check_time_resolution, const PredictedObject & target_object,
-  const PredictedPath & target_object_path, const BehaviorPathPlannerParameters & common_parameters,
-  CollisionCheckDebug & debug);
+  const double check_start_time, const double check_end_time, const double check_time_resolution,
+  const PredictedObject & target_object, const PredictedPath & target_object_path,
+  const BehaviorPathPlannerParameters & common_parameters, const double front_decel,
+  const double rear_decel, CollisionCheckDebug & debug);
 
 bool isSafeInFreeSpaceCollisionCheck(
   const Pose & ego_current_pose, const Twist & ego_current_twist,
   const PredictedPath & ego_predicted_path, const VehicleInfo & ego_info,
-  const double & check_start_time, const double & check_end_time,
-  const double & check_time_resolution, const PredictedObject & target_object,
-  const BehaviorPathPlannerParameters & common_parameters, CollisionCheckDebug & debug);
+  const double check_start_time, const double check_end_time, const double check_time_resolution,
+  const PredictedObject & target_object, const BehaviorPathPlannerParameters & common_parameters,
+  const double front_decel, const double rear_decel, CollisionCheckDebug & debug);
 }  // namespace behavior_path_planner::util
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -230,8 +230,15 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.lateral_distance_max_threshold = declare_parameter("lateral_distance_max_threshold", 2.0);
   p.longitudinal_distance_min_threshold =
     declare_parameter("longitudinal_distance_min_threshold", 3.0);
+
   p.expected_front_deceleration = declare_parameter("expected_front_deceleration", -0.5);
   p.expected_rear_deceleration = declare_parameter("expected_rear_deceleration", -1.0);
+
+  p.expected_front_deceleration_for_abort =
+    declare_parameter("expected_front_deceleration_for_abort", -2.0);
+  p.expected_rear_deceleration_for_abort =
+    declare_parameter("expected_rear_deceleration_for_abort", -2.5);
+
   p.rear_vehicle_reaction_time = declare_parameter("rear_vehicle_reaction_time", 2.0);
   p.rear_vehicle_safety_time_margin = declare_parameter("rear_vehicle_safety_time_margin", 2.0);
   return p;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -509,7 +509,8 @@ bool LaneChangeModule::isAbortConditionSatisfied() const
       common_parameters.ego_nearest_yaw_threshold);
     return lane_change_utils::isLaneChangePathSafe(
       path.path, current_lanes, check_lanes, dynamic_objects, current_pose, current_seg_idx,
-      current_twist, common_parameters, *parameters_, debug_data, false,
+      current_twist, common_parameters, *parameters_, common_parameters.front_abort_deceleration,
+      common_parameters.front_abort_deceleration, debug_data, false,
       status_.lane_change_path.acceleration);
   });
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -509,8 +509,9 @@ bool LaneChangeModule::isAbortConditionSatisfied() const
       common_parameters.ego_nearest_yaw_threshold);
     return lane_change_utils::isLaneChangePathSafe(
       path.path, current_lanes, check_lanes, dynamic_objects, current_pose, current_seg_idx,
-      current_twist, common_parameters, *parameters_, common_parameters.front_abort_deceleration,
-      common_parameters.front_abort_deceleration, debug_data, false,
+      current_twist, common_parameters, *parameters_,
+      common_parameters.expected_front_deceleration_for_abort,
+      common_parameters.expected_rear_deceleration_for_abort, debug_data, false,
       status_.lane_change_path.acceleration);
   });
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -292,7 +292,9 @@ bool selectSafePath(
       common_parameters.ego_nearest_yaw_threshold);
     if (isLaneChangePathSafe(
           path.path, current_lanes, target_lanes, dynamic_objects, current_pose, current_seg_idx,
-          current_twist, common_parameters, ros_parameters, debug_data, true, path.acceleration)) {
+          current_twist, common_parameters, ros_parameters,
+          common_parameters.expected_front_deceleration,
+          common_parameters.expected_rear_deceleration, debug_data, true, path.acceleration)) {
       *selected_path = path;
       return true;
     }
@@ -348,11 +350,11 @@ bool isLaneChangePathSafe(
   const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
   const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
-  const size_t & current_seg_idx, const Twist & current_twist,
+  const size_t current_seg_idx, const Twist & current_twist,
   const BehaviorPathPlannerParameters & common_parameters,
-  const LaneChangeParameters & lane_change_parameters,
-  std::unordered_map<std::string, CollisionCheckDebug> & debug_data, const bool use_buffer,
-  const double acceleration)
+  const LaneChangeParameters & lane_change_parameters, const double front_decel,
+  const double rear_decel, std::unordered_map<std::string, CollisionCheckDebug> & debug_data,
+  const bool use_buffer, const double acceleration)
 {
   if (dynamic_objects == nullptr) {
     return true;
@@ -428,8 +430,8 @@ bool isLaneChangePathSafe(
     for (const auto & obj_path : predicted_paths) {
       if (!util::isSafeInLaneletCollisionCheck(
             current_pose, current_twist, vehicle_predicted_path, vehicle_info, check_start_time,
-            check_end_time, time_resolution, obj, obj_path, common_parameters,
-            current_debug_data.second)) {
+            check_end_time, time_resolution, obj, obj_path, common_parameters, front_decel,
+            rear_decel, current_debug_data.second)) {
         appendDebugInfo(current_debug_data, false);
         return false;
       }
@@ -465,8 +467,8 @@ bool isLaneChangePathSafe(
       for (const auto & obj_path : predicted_paths) {
         if (!util::isSafeInLaneletCollisionCheck(
               current_pose, current_twist, vehicle_predicted_path, vehicle_info, check_start_time,
-              check_end_time, time_resolution, obj, obj_path, common_parameters,
-              current_debug_data.second)) {
+              check_end_time, time_resolution, obj, obj_path, common_parameters, front_decel,
+              rear_decel, current_debug_data.second)) {
           appendDebugInfo(current_debug_data, false);
           return false;
         }
@@ -474,7 +476,8 @@ bool isLaneChangePathSafe(
     } else {
       if (!util::isSafeInFreeSpaceCollisionCheck(
             current_pose, current_twist, vehicle_predicted_path, vehicle_info, check_start_time,
-            check_end_time, time_resolution, obj, common_parameters, current_debug_data.second)) {
+            check_end_time, time_resolution, obj, common_parameters, front_decel, rear_decel,
+            current_debug_data.second)) {
         appendDebugInfo(current_debug_data, false);
         return false;
       }


### PR DESCRIPTION
## Description

For unsafe path assessment for `isAbortConditionSatisfied`, we should use harder braking parameter. This PR aims to separate the soft braking parameter used for lane changing safe path assessment, and hard braking parameter used for assessing unsafe approved path.

Required #2287 to be merged.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
