### PR TITLE
refactor: use type alias in behavior modules

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
@@ -78,9 +78,7 @@ public:
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
    * and object predicted path
    */
-  bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -52,8 +52,6 @@ using autoware_auto_perception_msgs::msg::TrafficLight;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using tier4_api_msgs::msg::CrosswalkStatus;
 using tier4_autoware_utils::StopWatch;
-using tier4_planning_msgs::msg::StopFactor;
-using tier4_planning_msgs::msg::StopReason;
 
 class CrosswalkModule : public SceneModuleInterface
 {

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
@@ -34,9 +34,6 @@
 namespace behavior_velocity_planner
 {
 
-using autoware_auto_planning_msgs::msg::PathWithLaneId;
-using tier4_planning_msgs::msg::StopReason;
-
 class WalkwayModule : public SceneModuleInterface
 {
 public:

--- a/planning/behavior_velocity_planner/include/scene_module/detection_area/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/detection_area/scene.hpp
@@ -37,8 +37,6 @@ using PathIndexWithPose = std::pair<size_t, geometry_msgs::msg::Pose>;  // front
 using PathIndexWithPoint2d = std::pair<size_t, Point2d>;                // front index, point2d
 using PathIndexWithOffset = std::pair<size_t, double>;                  // front index, offset
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
-using tier4_planning_msgs::msg::StopFactor;
-using tier4_planning_msgs::msg::StopReason;
 
 class DetectionAreaModule : public SceneModuleInterface
 {

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -107,9 +107,7 @@ public:
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
    * and object predicted path
    */
-  bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.hpp
@@ -80,9 +80,7 @@ public:
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
    * and object predicted path
    */
-  bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;

--- a/planning/behavior_velocity_planner/include/scene_module/no_stopping_area/scene_no_stopping_area.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/no_stopping_area/scene_no_stopping_area.hpp
@@ -84,9 +84,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/scene_occlusion_spot.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/scene_occlusion_spot.hpp
@@ -52,9 +52,8 @@ public:
   /**
    * @brief plan occlusion spot velocity at unknown area in occupancy grid
    */
-  bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;
 

--- a/planning/behavior_velocity_planner/include/scene_module/run_out/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/run_out/scene.hpp
@@ -44,9 +44,7 @@ public:
     std::unique_ptr<DynamicObstacleCreator> dynamic_obstacle_creator,
     const std::shared_ptr<RunOutDebug> & debug_ptr, const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;

--- a/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
@@ -47,11 +47,14 @@
 namespace behavior_velocity_planner
 {
 
+using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using builtin_interfaces::msg::Time;
 using rtc_interface::RTCInterface;
 using tier4_autoware_utils::DebugPublisher;
 using tier4_autoware_utils::StopWatch;
 using tier4_debug_msgs::msg::Float64Stamped;
+using tier4_planning_msgs::msg::StopFactor;
+using tier4_planning_msgs::msg::StopReason;
 using unique_identifier_msgs::msg::UUID;
 
 class SceneModuleInterface
@@ -68,9 +71,8 @@ public:
   }
   virtual ~SceneModuleInterface() = default;
 
-  virtual bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) = 0;
+  virtual bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) = 0;
+
   virtual visualization_msgs::msg::MarkerArray createDebugMarkerArray() = 0;
   virtual visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() = 0;
 

--- a/planning/behavior_velocity_planner/include/scene_module/stop_line/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/stop_line/scene.hpp
@@ -83,9 +83,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;

--- a/planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
@@ -73,9 +73,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;

--- a/planning/behavior_velocity_planner/include/scene_module/virtual_traffic_light/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/virtual_traffic_light/scene.hpp
@@ -80,9 +80,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(
-    autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;
@@ -99,8 +97,7 @@ private:
 
   void updateInfrastructureCommand();
 
-  void setStopReason(
-    const geometry_msgs::msg::Pose & stop_pose, tier4_planning_msgs::msg::StopReason * stop_reason);
+  void setStopReason(const Pose & stop_pose, StopReason * stop_reason);
 
   boost::optional<size_t> getPathIndexOfFirstEndLine();
 

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -64,6 +64,7 @@ BlindSpotModule::BlindSpotModule(
   is_over_pass_judge_line_(false)
 {
   planner_param_ = planner_param;
+
   const auto & assigned_lanelet =
     planner_data->route_handler_->getLaneletMapPtr()->laneletLayer.get(lane_id);
   const std::string turn_direction = assigned_lanelet.attributeOr("turn_direction", "else");
@@ -76,13 +77,10 @@ BlindSpotModule::BlindSpotModule(
     !(assigned_lanelet.regulatoryElementsAs<const lanelet::TrafficLight>().empty());
 }
 
-bool BlindSpotModule::modifyPathVelocity(
-  autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-  tier4_planning_msgs::msg::StopReason * stop_reason)
+bool BlindSpotModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
 {
   debug_data_ = DebugData();
-  *stop_reason =
-    planning_utils::initializeStopReason(tier4_planning_msgs::msg::StopReason::BLIND_SPOT);
+  *stop_reason = planning_utils::initializeStopReason(StopReason::BLIND_SPOT);
 
   const auto input_path = *path;
   debug_data_.path_raw = input_path;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -58,6 +58,7 @@ IntersectionModule::IntersectionModule(
 : SceneModuleInterface(module_id, logger, clock), lane_id_(lane_id), is_go_out_(false)
 {
   planner_param_ = planner_param;
+
   const auto & assigned_lanelet =
     planner_data->route_handler_->getLaneletMapPtr()->laneletLayer.get(lane_id);
   turn_direction_ = assigned_lanelet.attributeOr("turn_direction", "else");
@@ -66,9 +67,7 @@ IntersectionModule::IntersectionModule(
   state_machine_.setMarginTime(planner_param_.state_transit_margin_time);
 }
 
-bool IntersectionModule::modifyPathVelocity(
-  autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-  tier4_planning_msgs::msg::StopReason * stop_reason)
+bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
 {
   RCLCPP_DEBUG(logger_, "===== plan start =====");
 
@@ -80,8 +79,7 @@ bool IntersectionModule::modifyPathVelocity(
   debug_data_ = DebugData();
   debug_data_.path_raw = *path;
 
-  *stop_reason =
-    planning_utils::initializeStopReason(tier4_planning_msgs::msg::StopReason::INTERSECTION);
+  *stop_reason = planning_utils::initializeStopReason(StopReason::INTERSECTION);
 
   RCLCPP_DEBUG(
     logger_, "lane_id = %ld, state = %s", lane_id_, StateMachine::toString(current_state).c_str());

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -43,13 +43,10 @@ MergeFromPrivateRoadModule::MergeFromPrivateRoadModule(
   state_machine_.setState(StateMachine::State::STOP);
 }
 
-bool MergeFromPrivateRoadModule::modifyPathVelocity(
-  autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-  tier4_planning_msgs::msg::StopReason * stop_reason)
+bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
 {
   debug_data_ = DebugData();
-  *stop_reason = planning_utils::initializeStopReason(
-    tier4_planning_msgs::msg::StopReason::MERGE_FROM_PRIVATE_ROAD);
+  *stop_reason = planning_utils::initializeStopReason(StopReason::MERGE_FROM_PRIVATE_ROAD);
 
   const auto input_path = *path;
   debug_data_.path_raw = input_path;

--- a/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/scene_no_stopping_area.cpp
@@ -107,9 +107,7 @@ boost::optional<LineString2d> NoStoppingAreaModule::getStopLineGeometry2d(
   return {};
 }
 
-bool NoStoppingAreaModule::modifyPathVelocity(
-  autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-  tier4_planning_msgs::msg::StopReason * stop_reason)
+bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
 {
   // Store original path
   const auto original_path = *path;
@@ -121,8 +119,8 @@ bool NoStoppingAreaModule::modifyPathVelocity(
   // Reset data
   debug_data_ = DebugData();
   debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
-  *stop_reason =
-    planning_utils::initializeStopReason(tier4_planning_msgs::msg::StopReason::NO_STOPPING_AREA);
+  *stop_reason = planning_utils::initializeStopReason(StopReason::NO_STOPPING_AREA);
+
   // Get stop line geometry
   const auto stop_line = getStopLineGeometry2d(original_path, planner_param_.stop_line_margin);
   if (!stop_line) {

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
@@ -78,8 +78,7 @@ OcclusionSpotModule::OcclusionSpotModule(
 }
 
 bool OcclusionSpotModule::modifyPathVelocity(
-  autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-  [[maybe_unused]] tier4_planning_msgs::msg::StopReason * stop_reason)
+  PathWithLaneId * path, [[maybe_unused]] StopReason * stop_reason)
 {
   if (param_.is_show_processing_time) stop_watch_.tic("total_processing_time");
   debug_data_.resetData();

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/scene.cpp
@@ -45,8 +45,7 @@ void RunOutModule::setPlannerParam(const PlannerParam & planner_param)
 }
 
 bool RunOutModule::modifyPathVelocity(
-  autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-  [[maybe_unused]] tier4_planning_msgs::msg::StopReason * stop_reason)
+  PathWithLaneId * path, [[maybe_unused]] StopReason * stop_reason)
 {
   // timer starts
   const auto t1_modify_path = std::chrono::system_clock::now();

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -36,17 +36,14 @@ StopLineModule::StopLineModule(
   planner_param_ = planner_param;
 }
 
-bool StopLineModule::modifyPathVelocity(
-  autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-  tier4_planning_msgs::msg::StopReason * stop_reason)
+bool StopLineModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
 {
   debug_data_ = DebugData();
   if (path->points.empty()) return true;
   const auto base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
   debug_data_.base_link2front = base_link2front;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
-  *stop_reason =
-    planning_utils::initializeStopReason(tier4_planning_msgs::msg::StopReason::STOP_LINE);
+  *stop_reason = planning_utils::initializeStopReason(StopReason::STOP_LINE);
 
   const LineString2d stop_line = planning_utils::extendLine(
     stop_line_[0], stop_line_[1], planner_data_->stop_line_extend_length);

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
@@ -45,14 +45,15 @@ void TrafficLightModuleManager::modifyPathVelocity(
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
   visualization_msgs::msg::MarkerArray virtual_wall_marker_array;
-  tier4_planning_msgs::msg::StopReasonArray stop_reason_array;
-  autoware_auto_perception_msgs::msg::LookingTrafficSignal tl_state;
 
+  autoware_auto_perception_msgs::msg::LookingTrafficSignal tl_state;
   tl_state.header.stamp = path->header.stamp;
   tl_state.is_module_running = false;
 
+  tier4_planning_msgs::msg::StopReasonArray stop_reason_array;
   stop_reason_array.header.frame_id = "map";
   stop_reason_array.header.stamp = path->header.stamp;
+
   first_stop_path_point_index_ = static_cast<int>(path->points.size() - 1);
   first_ref_stop_path_point_index_ = static_cast<int>(path->points.size() - 1);
   for (const auto & scene_module : scene_modules_) {
@@ -61,7 +62,10 @@ void TrafficLightModuleManager::modifyPathVelocity(
       std::dynamic_pointer_cast<TrafficLightModule>(scene_module));
     traffic_light_scene_module->setPlannerData(planner_data_);
     traffic_light_scene_module->modifyPathVelocity(path, &stop_reason);
-    stop_reason_array.stop_reasons.emplace_back(stop_reason);
+
+    if (stop_reason.reason != "") {
+      stop_reason_array.stop_reasons.emplace_back(stop_reason);
+    }
 
     if (traffic_light_scene_module->getFirstStopPathPointIndex() < first_stop_path_point_index_) {
       first_stop_path_point_index_ = traffic_light_scene_module->getFirstStopPathPointIndex();

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -202,17 +202,14 @@ TrafficLightModule::TrafficLightModule(
   planner_param_ = planner_param;
 }
 
-bool TrafficLightModule::modifyPathVelocity(
-  autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-  tier4_planning_msgs::msg::StopReason * stop_reason)
+bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
 {
   looking_tl_state_ = initializeTrafficSignal(path->header.stamp);
   debug_data_ = DebugData();
   debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
   first_ref_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
-  *stop_reason =
-    planning_utils::initializeStopReason(tier4_planning_msgs::msg::StopReason::TRAFFIC_LIGHT);
+  *stop_reason = planning_utils::initializeStopReason(StopReason::TRAFFIC_LIGHT);
 
   const auto input_path = *path;
 

--- a/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/scene.cpp
@@ -244,14 +244,11 @@ VirtualTrafficLightModule::VirtualTrafficLightModule(
   logger_ = logger_.get_child((map_data_.instrument_type + "_" + map_data_.instrument_id).c_str());
 }
 
-bool VirtualTrafficLightModule::modifyPathVelocity(
-  autoware_auto_planning_msgs::msg::PathWithLaneId * path,
-  tier4_planning_msgs::msg::StopReason * stop_reason)
+bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
 {
   // Initialize
   setInfrastructureCommand({});
-  *stop_reason = planning_utils::initializeStopReason(
-    tier4_planning_msgs::msg::StopReason::VIRTUAL_TRAFFIC_LIGHT);
+  *stop_reason = planning_utils::initializeStopReason(StopReason::VIRTUAL_TRAFFIC_LIGHT);
   module_data_ = {};
 
   // Copy data

--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/debug_marker.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/debug_marker.hpp
@@ -63,6 +63,7 @@ private:
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_virtual_wall_pub_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_viz_pub_;
   rclcpp::Publisher<StopReasonArray>::SharedPtr stop_reason_pub_;
+
   rclcpp::Publisher<PolygonStamped>::SharedPtr vehicle_footprint_pub_;
   rclcpp::Publisher<PolygonStamped>::SharedPtr vehicle_footprint_offset_pub_;
   rclcpp::Publisher<PolygonStamped>::SharedPtr vehicle_footprint_recover_offset_pub_;


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Unify the `modifyPathVelocity` function to use type alias.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
