### PR TITLE
fix(behavior_path_planner): node died when change ego behavior

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -49,9 +49,18 @@ TurnIndicatorsCommand TurnSignalDecider::getTurnSignal(
   const double backward_length = 50.0;
   const lanelet::ConstLanelets current_lanes = util::calcLaneAroundPose(
     planner_data->route_handler, current_pose, forward_length, backward_length);
+
+  if (current_lanes.empty()) {
+    return turn_signal_info.turn_signal;
+  }
+
   const PathWithLaneId extended_path = util::getCenterLinePath(
     route_handler, current_lanes, current_pose, backward_length, forward_length,
     planner_data->parameters);
+
+  if (extended_path.points.empty()) {
+    return turn_signal_info.turn_signal;
+  }
 
   // Closest ego segment
   const size_t ego_seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

Solve #2381 

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Test the behavior similar to below's video. It is expected that autoware process works properly now.

### Before PR

Process died in the end. Lane change not executed.

https://user-images.githubusercontent.com/93502286/204183623-f8aa4d53-57e6-40b6-9725-526151e9da21.mp4

### After PR

Lane change able to be run when changing ego location

https://user-images.githubusercontent.com/93502286/204196243-9aceb712-9e06-48bc-8169-3faf7bed8570.mp4


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
