### PR TITLE
feat(tier4_planning_rviz_plugin): add offset from baselink param

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/trajectory_footprint/display.hpp
+++ b/common/tier4_planning_rviz_plugin/include/trajectory_footprint/display.hpp
@@ -67,6 +67,7 @@ protected:
   rviz_common::properties::FloatProperty * property_vehicle_length_;
   rviz_common::properties::FloatProperty * property_vehicle_width_;
   rviz_common::properties::FloatProperty * property_rear_overhang_;
+  rviz_common::properties::FloatProperty * property_offset_;
 
   Ogre::ManualObject * trajectory_point_manual_object_;
   rviz_common::properties::BoolProperty * property_trajectory_point_view_;

--- a/common/tier4_planning_rviz_plugin/src/trajectory_footprint/display.cpp
+++ b/common/tier4_planning_rviz_plugin/src/trajectory_footprint/display.cpp
@@ -44,6 +44,9 @@ AutowareTrajectoryFootprintDisplay::AutowareTrajectoryFootprintDisplay()
   property_rear_overhang_ = new rviz_common::properties::FloatProperty(
     "Rear Overhang", 1.03, "", property_trajectory_footprint_view_, SLOT(updateVehicleInfo()),
     this);
+  property_offset_ = new rviz_common::properties::FloatProperty(
+    "Offset from BaseLink", 0.0, "", property_trajectory_footprint_view_, SLOT(updateVehicleInfo()),
+    this);
   property_vehicle_length_->setMin(0.0);
   property_vehicle_width_->setMin(0.0);
   property_rear_overhang_->setMin(0.0);
@@ -158,6 +161,8 @@ void AutowareTrajectoryFootprintDisplay::processMessage(
     trajectory_point_manual_object_->begin(
       "BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);
 
+    const float offset_from_baselink = property_offset_->getFloat();
+
     for (size_t point_idx = 0; point_idx < msg_ptr->points.size(); point_idx++) {
       const auto & path_point = msg_ptr->points.at(point_idx);
       /*
@@ -169,8 +174,8 @@ void AutowareTrajectoryFootprintDisplay::processMessage(
         color.a = property_trajectory_footprint_alpha_->getFloat();
 
         const auto info = vehicle_footprint_info_;
-        const float top = info->length - info->rear_overhang;
-        const float bottom = -info->rear_overhang;
+        const float top = info->length - info->rear_overhang - offset_from_baselink;
+        const float bottom = -info->rear_overhang + offset_from_baselink;
         const float left = -info->width / 2.0;
         const float right = info->width / 2.0;
 


### PR DESCRIPTION

## Description

Add param for offset_from_baselink in the footprint visualization.

The aim is to visualize the difference in footprint when following different coordinate systems for a trajectory.
This analysis is required in path planning, e.g. the obstacle_avoidance_planner has the same parameter that sets the offset length from baselink for the path optimization algorithm.

![image](https://user-images.githubusercontent.com/21360593/204420553-66807dbc-6b5e-49f1-a436-c839dfe85ee0.png)
When the trajectory is followed in the baselink the footprint is shown as the yellow polygon, and vehicle center coodrinate makes the red one.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
