### PR TITLE
feat(operation_mode_transition_manager): add guard to invalid parameter

### DIFF
--- a/control/operation_mode_transition_manager/src/node.cpp
+++ b/control/operation_mode_transition_manager/src/node.cpp
@@ -50,12 +50,23 @@ OperationModeTransitionManager::OperationModeTransitionManager(const rclcpp::Nod
   }
 
   // initialize state
-  transition_timeout_ = declare_parameter<double>("transition_timeout");
   current_mode_ = OperationMode::STOP;
   transition_ = nullptr;
   gate_operation_mode_.mode = OperationModeState::UNKNOWN;
   gate_operation_mode_.is_in_transition = false;
   control_mode_report_.mode = ControlModeReport::NO_COMMAND;
+  transition_timeout_ = declare_parameter<double>("transition_timeout");
+  {
+    // check `transition_timeout` value
+    const auto stable_duration = declare_parameter<double>("stable_check.duration");
+    const double TIMEOUT_MARGIN = 0.5;
+    if (transition_timeout_ < stable_duration + TIMEOUT_MARGIN) {
+      transition_timeout_ = stable_duration + TIMEOUT_MARGIN;
+      RCLCPP_WARN(
+        get_logger(), "`transition_timeout` must be somewhat larger than `stable_check.duration`");
+      RCLCPP_WARN_STREAM(get_logger(), "transition_timeout is set to " << transition_timeout_);
+    }
+  }
 
   // modes
   modes_[OperationMode::STOP] = std::make_unique<StopMode>();

--- a/control/operation_mode_transition_manager/src/state.cpp
+++ b/control/operation_mode_transition_manager/src/state.cpp
@@ -63,7 +63,7 @@ AutonomousMode::AutonomousMode(rclcpp::Node * node)
   // params for mode change completed
   {
     auto & p = stable_check_param_;
-    p.duration = node->declare_parameter<double>("stable_check.duration");
+    p.duration = node->get_parameter("stable_check.duration").as_double();
     p.dist_threshold = node->declare_parameter<double>("stable_check.dist_threshold");
     p.speed_upper_threshold = node->declare_parameter<double>("stable_check.speed_upper_threshold");
     p.speed_lower_threshold = node->declare_parameter<double>("stable_check.speed_lower_threshold");


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
In operation_mode_transition_manager node,  if `transition_timeout` is less than or equal to `stable_check.duration`, Autoware never succeeds to engage. 
I added a function to forcibly rewrite `transition_timeout`  parameter if such a parameter is set, 

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
