### PR TITLE
fix(lidar_centerpoint_tvm): make sure ament_auto_package() is called in CMakeLists.txt

### DIFF
--- a/perception/lidar_centerpoint_tvm/CMakeLists.txt
+++ b/perception/lidar_centerpoint_tvm/CMakeLists.txt
@@ -74,4 +74,5 @@ if((NOT NN_DEPENDENCY_ENCODER STREQUAL "") AND (NOT NN_DEPENDENCY_BACKBONE STREQ
   )
 else()
   message(WARNING "Neural network not found, skipping package.")
+  ament_auto_package()
 endif()


### PR DESCRIPTION
Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>

## Description

After merging https://github.com/autowarefoundation/autoware.universe/pull/2385, autoware outputs the following error when sourcing the workspace:
```
$ source install/setup.bash 
not found: "/home/mitsudome-r/autoware.universe/install/lidar_centerpoint_tvm/share/lidar_centerpoint_tvm/local_setup.bash"
```

This is due to lidar_centerpoint_tvm not installed properly without `DOWNLOAD_ARTIFACTS` variable is set.
This PR will make sure that `ament_auto_package()` is called regardless of the variable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
