### PR TITLE
fix(behavior_path_planner): consider almost zero longitudinal start l…

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2381,7 +2381,9 @@ boost::optional<AvoidLineArray> AvoidanceModule::findNewShiftLine(
     }
 
     // new shift points must exist in front of Ego
-    if (candidate.start_longitudinal < 0.0) {
+    // this value should be larger than -eps consider path shifter calculation error.
+    const double eps = 0.01;
+    if (candidate.start_longitudinal < -eps) {
       continue;
     }
 


### PR DESCRIPTION
## Description

resolve #2389

consider almost zero start longitudinal shift candidate.

[tier4 internal](https://tier4.atlassian.net/browse/T4PB-23560)

this PR can remove old shift point candidate to filter negative start longitudinal
but with path shifter start longitudinal can be  very small negative value if start longitudinal is almost zero.
so I add a bit of margin for threshold
https://github.com/autowarefoundation/autoware.universe/pull/2012

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
