### PR TITLE
fix(obstacle_avoidance_planner): add guard for failed optimized trajectory

### DIFF
--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -296,6 +296,15 @@ boost::optional<MPTOptimizer::MPTTrajs> MPTOptimizer::getModelPredictiveTrajecto
     fixed_ref_points, non_fixed_ref_points, optimized_control_variables.get(), mpt_matrix,
     debug_data);
 
+  // NOTE: Sometimes optimization failed without failed status.
+  //       Therefore, we have to check if optimization was solved correctly by the result.
+  constexpr double max_lateral_deviation = 3.0;
+  for (const double lateral_error : debug_data_ptr->lateral_errors) {
+    if (max_lateral_deviation < std::abs(lateral_error)) {
+      return boost::none;
+    }
+  }
+
   auto full_optimized_ref_points = fixed_ref_points;
   full_optimized_ref_points.insert(
     full_optimized_ref_points.end(), non_fixed_ref_points.begin(), non_fixed_ref_points.end());

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -301,6 +301,9 @@ boost::optional<MPTOptimizer::MPTTrajs> MPTOptimizer::getModelPredictiveTrajecto
   constexpr double max_lateral_deviation = 3.0;
   for (const double lateral_error : debug_data.lateral_errors) {
     if (max_lateral_deviation < std::abs(lateral_error)) {
+      RCLCPP_ERROR(
+        rclcpp::get_logger("mpt_optimizer"),
+        "return boost::none since lateral deviation is too large.");
       return boost::none;
     }
   }

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -299,7 +299,7 @@ boost::optional<MPTOptimizer::MPTTrajs> MPTOptimizer::getModelPredictiveTrajecto
   // NOTE: Sometimes optimization failed without failed status.
   //       Therefore, we have to check if optimization was solved correctly by the result.
   constexpr double max_lateral_deviation = 3.0;
-  for (const double lateral_error : debug_data_ptr->lateral_errors) {
+  for (const double lateral_error : debug_data.lateral_errors) {
     if (max_lateral_deviation < std::abs(lateral_error)) {
       return boost::none;
     }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

commit to apply https://github.com/tier4/autoware.universe/pull/194 to main

> fix for https://tier4.atlassian.net/browse/T4PB-23420 (TIER IV internal link)

> When optimization failed, trajectory sometimes diverged.
> In order to send this kind of trajectory to the latter module, I added a guard seeing how much deviation the trajectory has against the reference path.
> If the deviation is too large, sends a previously planned path to the latter module.



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
