### PR TITLE
fix(detection_area): add color debug markers

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -18,10 +18,9 @@
 #include <utilization/util.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
-#include <std_msgs/color_rgba.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
-#include <std_msgs/color_rgba.hpp>
+#include <std_msgs/msg/color_rgba.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
@@ -59,7 +58,7 @@ geometry_msgs::msg::Point toMsg(const lanelet::BasicPoint3d & point)
 
 visualization_msgs::msg::MarkerArray createCorrespondenceMarkerArray(
   const lanelet::autoware::DetectionArea & detection_area_reg_elem, const rclcpp::Time & now,
-  ColorRGBA marker_color)
+  ColorRGBA & marker_color)
 {
   visualization_msgs::msg::MarkerArray msg;
 

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -20,9 +20,9 @@
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
-#include <std_msgs/msg/color_rgba.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
+#include <std_msgs/msg/color_rgba.hpp>
 
 #include <vector>
 

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -18,8 +18,10 @@
 #include <utilization/util.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
+#include <std_msgs/color_rgba.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
+#include <std_msgs/color_rgba.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
@@ -27,6 +29,7 @@
 
 namespace behavior_velocity_planner
 {
+using std_msgs::msg::ColorRGBA;
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
@@ -55,7 +58,8 @@ geometry_msgs::msg::Point toMsg(const lanelet::BasicPoint3d & point)
 }
 
 visualization_msgs::msg::MarkerArray createCorrespondenceMarkerArray(
-  const lanelet::autoware::DetectionArea & detection_area_reg_elem, const rclcpp::Time & now)
+  const lanelet::autoware::DetectionArea & detection_area_reg_elem, const rclcpp::Time & now,
+  ColorRGBA marker_color)
 {
   visualization_msgs::msg::MarkerArray msg;
 
@@ -87,7 +91,7 @@ visualization_msgs::msg::MarkerArray createCorrespondenceMarkerArray(
     auto marker = createDefaultMarker(
       "map", now, "detection_area_polygon", detection_area_reg_elem.id(),
       visualization_msgs::msg::Marker::LINE_LIST, createMarkerScale(0.1, 0.0, 0.0),
-      createMarkerColor(0.1, 0.1, 1.0, 0.500));
+      createMarkerColor(marker_color.r, marker_color.g, marker_color.b, marker_color.a));
     marker.lifetime = rclcpp::Duration::from_seconds(0.5);
 
     for (const auto & detection_area : detection_area_reg_elem.detectionAreas()) {
@@ -113,7 +117,7 @@ visualization_msgs::msg::MarkerArray createCorrespondenceMarkerArray(
     auto marker = createDefaultMarker(
       "map", now, "detection_area_correspondence", detection_area_reg_elem.id(),
       visualization_msgs::msg::Marker::LINE_LIST, createMarkerScale(0.1, 0.0, 0.0),
-      createMarkerColor(0.1, 0.1, 1.0, 0.500));
+      createMarkerColor(marker_color.r, marker_color.g, marker_color.b, marker_color.a));
     marker.lifetime = rclcpp::Duration::from_seconds(0.5);
 
     for (const auto & detection_area : detection_area_reg_elem.detectionAreas()) {
@@ -138,13 +142,28 @@ visualization_msgs::msg::MarkerArray DetectionAreaModule::createDebugMarkerArray
   const rclcpp::Time now = clock_->now();
 
   if (!debug_data_.stop_poses.empty()) {
+    ColorRGBA marker_color;
+    marker_color.r = 1.0;
+    marker_color.g = 0.0;
+    marker_color.b = 0.0;
+    marker_color.a = 1.0;
+
     appendMarkerArray(
-      createCorrespondenceMarkerArray(detection_area_reg_elem_, now), &wall_marker, now);
+      createCorrespondenceMarkerArray(detection_area_reg_elem_, now, marker_color), &wall_marker);
 
     appendMarkerArray(
       debug::createPointsMarkerArray(
         debug_data_.obstacle_points, "obstacles", module_id_, now, 0.6, 0.6, 0.6, 1.0, 0.0, 0.0),
       &wall_marker, now);
+  } else {
+    ColorRGBA marker_color;
+    marker_color.r = 0.0;
+    marker_color.g = 1.0;
+    marker_color.b = 0.0;
+    marker_color.a = 1.0;
+
+    appendMarkerArray(
+      createCorrespondenceMarkerArray(detection_area_reg_elem_, now, marker_color), &wall_marker);
   }
 
   return wall_marker;


### PR DESCRIPTION
This PR is related to the detection area highlighting requirement for RViz where the required specification is as follows:

Closes: https://github.com/autowarefoundation/autoware.universe/issues/1121

**Expected behavior**

I can decide whether obstacles are not detected, module is unregistered or ego vehicle goes over the dead line from debug markers.

My proposal is

- module is registered but not detected: detection area marker is green
- detected: detection area marker is red
- go over the dead line: detection area marker is grey
- unregistered: delete