### PR TITLE
fix(ekf_localizer): lowpass filter initialization

### DIFF
--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -271,6 +271,11 @@ private:
   void updateSimple1DFilters(const geometry_msgs::msg::PoseWithCovarianceStamped & pose);
 
   /**
+   * @brief initialize simple1DFilter
+   */
+  void initSimple1DFilters(const geometry_msgs::msg::PoseWithCovarianceStamped & pose)
+
+  /**
    * @brief trigger node
    */
   void serviceTriggerNode(

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -275,12 +275,12 @@ private:
    */
   void initSimple1DFilters(const geometry_msgs::msg::PoseWithCovarianceStamped & pose);
 
-    /**
-     * @brief trigger node
-     */
-    void serviceTriggerNode(
-      const std_srvs::srv::SetBool::Request::SharedPtr req,
-      std_srvs::srv::SetBool::Response::SharedPtr res);
+  /**
+   * @brief trigger node
+   */
+  void serviceTriggerNode(
+    const std_srvs::srv::SetBool::Request::SharedPtr req,
+    std_srvs::srv::SetBool::Response::SharedPtr res);
 
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
 

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -275,12 +275,12 @@ private:
    */
   void initSimple1DFilters(const geometry_msgs::msg::PoseWithCovarianceStamped & pose)
 
-  /**
-   * @brief trigger node
-   */
-  void serviceTriggerNode(
-    const std_srvs::srv::SetBool::Request::SharedPtr req,
-    std_srvs::srv::SetBool::Response::SharedPtr res);
+    /**
+     * @brief trigger node
+     */
+    void serviceTriggerNode(
+      const std_srvs::srv::SetBool::Request::SharedPtr req,
+      std_srvs::srv::SetBool::Response::SharedPtr res);
 
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
 

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -273,7 +273,7 @@ private:
   /**
    * @brief initialize simple1DFilter
    */
-  void initSimple1DFilters(const geometry_msgs::msg::PoseWithCovarianceStamped & pose)
+  void initSimple1DFilters(const geometry_msgs::msg::PoseWithCovarianceStamped & pose);
 
     /**
      * @brief trigger node

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -334,7 +334,7 @@ void EKFLocalizer::callbackInitialPose(
 
   ekf_.init(X, P, params_.extend_state_step);
 
-  updateSimple1DFilters(*initialpose);
+  initSimple1DFilters(*initialpose);
 }
 
 /*
@@ -679,6 +679,25 @@ void EKFLocalizer::updateSimple1DFilters(const geometry_msgs::msg::PoseWithCovar
   z_filter_.update(z, z_dev, pose.header.stamp);
   roll_filter_.update(roll, roll_dev, pose.header.stamp);
   pitch_filter_.update(pitch, pitch_dev, pose.header.stamp);
+}
+
+void EKFLocalizer::initSimple1DFilters(const geometry_msgs::msg::PoseWithCovarianceStamped & pose)
+{
+  double z = pose.pose.pose.position.z;
+  double roll = 0.0, pitch = 0.0, yaw_tmp = 0.0;
+
+  tf2::Quaternion q_tf;
+  tf2::fromMsg(pose.pose.pose.orientation, q_tf);
+  tf2::Matrix3x3(q_tf).getRPY(roll, pitch, yaw_tmp);
+
+  using COV_IDX = tier4_autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  double z_dev = pose.pose.covariance[COV_IDX::Z_Z];
+  double roll_dev = pose.pose.covariance[COV_IDX::ROLL_ROLL];
+  double pitch_dev = pose.pose.covariance[COV_IDX::PITCH_PITCH];
+
+  z_filter_.init(z, z_dev, pose.header.stamp);
+  roll_filter_.init(roll, roll_dev, pose.header.stamp);
+  pitch_filter_.init(pitch, pitch_dev, pose.header.stamp);
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
Initialize 1D_filter (for z, roll, and pitch) in initial pose callback function.

This would make a difference when performing pose estimation for two or more times.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
