### PR TITLE
fix(default_ad_api): fix adapi web server creates two nodes

### DIFF
--- a/system/default_ad_api/launch/default_ad_api.launch.py
+++ b/system/default_ad_api/launch/default_ad_api.launch.py
@@ -46,6 +46,7 @@ def generate_launch_description():
         composable_node_descriptions=components,
     )
     web_server = Node(
+        namespace="default_ad_api",
         package="default_ad_api",
         name="web_server",
         executable="web_server.py",

--- a/system/default_ad_api/script/web_server.py
+++ b/system/default_ad_api/script/web_server.py
@@ -49,15 +49,15 @@ def convert_dict(msg):
 
 def spin_ros_node():
     global cli
-    rclpy.init(args=sys.argv)
     node = Node("ad_api_default_web_server")
     cli = create_service(node, InterfaceVersion, "/api/interface/version")
     rclpy.spin(node)
 
 
 if __name__ == "__main__":
+    rclpy.init(args=sys.argv, signal_handler_options=rclpy.signals.SignalHandlerOptions.NO)
     thread = Thread(target=spin_ros_node)
     thread.start()
-    app.run(host="localhost", port=8888, debug=True)
+    app.run(host="localhost", port=8888, debug=False)
     rclpy.shutdown()
     thread.join()


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Fix adapi web server creates two nodes.

```bash
$ ros2 node list | grep web_server
WARNING: Be aware that are nodes in the graph that share an exact name, this can have unintended side effects.
/web_server
/web_server

$ ros2 node list | grep web_server
/default_ad_api/web_server
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
