### PR TITLE
refactor(behavior_path_planner): move turn_signal_on_swerving param to bpp.param.yaml

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -49,7 +49,6 @@
       longitudinal_collision_margin_min_distance: 0.0          # [m]
       longitudinal_collision_margin_time: 0.0
 
-      turn_signal_on_swerving: true # turn signal on while swerving
 
       # avoidance is performed for the object type with true
       target_object:

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -18,5 +18,5 @@
     turn_signal_minimum_search_distance: 10.0
     turn_signal_search_time: 3.0
     turn_signal_shift_length_threshold: 0.3
-    turn_signal_on_swerving: false # turn signal on while swerving
+    turn_signal_on_swerving: true
     path_interval: 2.0

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -18,4 +18,5 @@
     turn_signal_minimum_search_distance: 10.0
     turn_signal_search_time: 3.0
     turn_signal_shift_length_threshold: 0.3
+    turn_signal_on_swerving: false # turn signal on while swerving
     path_interval: 2.0

--- a/planning/behavior_path_planner/behavior_path_planner_turn_signal-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_turn_signal-design.md
@@ -21,7 +21,7 @@ Currently, this algorithm can sometimes give unnatural (not wrong) blinkers in a
 ## Parameters for turn signal decider
 
 | Name                                            | Unit | Type   | Description                                                                  | Default value |
-|:------------------------------------------------|:-----| :----- | :--------------------------------------------------------------------------- | :------------ |
+| :---------------------------------------------- | :--- | :----- | :--------------------------------------------------------------------------- | :------------ |
 | turn_signal_intersection_search_distance        | [m]  | double | constant search distance to decide activation of blinkers at intersections   | 30            |
 | turn_signal_intersection_angle_threshold_degree | deg  | double | angle threshold to determined the end point of intersection required section | 15            |
 | turn_signal_minimum_search_distance             | [m]  | double | minimum search distance for avoidance and lane change                        | 10            |

--- a/planning/behavior_path_planner/behavior_path_planner_turn_signal-design.md
+++ b/planning/behavior_path_planner/behavior_path_planner_turn_signal-design.md
@@ -21,12 +21,13 @@ Currently, this algorithm can sometimes give unnatural (not wrong) blinkers in a
 ## Parameters for turn signal decider
 
 | Name                                            | Unit | Type   | Description                                                                  | Default value |
-| :---------------------------------------------- | :--- | :----- | :--------------------------------------------------------------------------- | :------------ |
+|:------------------------------------------------|:-----| :----- | :--------------------------------------------------------------------------- | :------------ |
 | turn_signal_intersection_search_distance        | [m]  | double | constant search distance to decide activation of blinkers at intersections   | 30            |
 | turn_signal_intersection_angle_threshold_degree | deg  | double | angle threshold to determined the end point of intersection required section | 15            |
 | turn_signal_minimum_search_distance             | [m]  | double | minimum search distance for avoidance and lane change                        | 10            |
 | turn_signal_search_time                         | [s]  | double | search time for to decide activation of blinkers                             | 3.0           |
 | turn_signal_shift_length_threshold              | [m]  | double | shift length threshold to decide activation of blinkers                      | 0.3           |
+| turn_signal_on_swerving                         | [-]  | bool   | flag to activate blinkers when swerving                                      | true          |
 
 Note that the default values for `turn_signal_intersection_search_distance` and `turn_signal_search_time` is strictly followed by [Japanese Road Traffic Laws](https://www.japaneselawtranslation.go.jp/ja/laws/view/2962). So if your country does not allow to use these default values, you should change these values in configuration files.
 

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -47,8 +47,6 @@
       longitudinal_collision_margin_min_distance: 0.0          # [m]
       longitudinal_collision_margin_time: 0.0
 
-      turn_signal_on_swerving: true # turn signal on while swerving
-
       # avoidance is performed for the object type with true
       target_object:
         car: true

--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -22,6 +22,7 @@
     turn_signal_minimum_search_distance: 10.0
     turn_signal_search_time: 3.0
     turn_signal_shift_length_threshold: 0.3
+    turn_signal_on_swerving: true # turn signal on while swerving
 
     path_interval: 2.0
 

--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -22,7 +22,7 @@
     turn_signal_minimum_search_distance: 10.0
     turn_signal_search_time: 3.0
     turn_signal_shift_length_threshold: 0.3
-    turn_signal_on_swerving: true # turn signal on while swerving
+    turn_signal_on_swerving: true
 
     path_interval: 2.0
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -41,6 +41,7 @@ struct BehaviorPathPlannerParameters
   double turn_signal_search_time;
   double turn_signal_minimum_search_distance;
   double turn_signal_shift_length_threshold;
+  bool turn_signal_on_swerving;
 
   double path_interval;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -173,7 +173,6 @@ struct AvoidanceParameters
   bool publish_debug_marker = false;
   bool print_debug_info = false;
 
-  bool turn_signal_on_swerving = true;
 };
 
 struct ObjectData  // avoidance target

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -172,7 +172,6 @@ struct AvoidanceParameters
   // debug
   bool publish_debug_marker = false;
   bool print_debug_info = false;
-
 };
 
 struct ObjectData  // avoidance target

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -221,6 +221,8 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.turn_signal_search_time = declare_parameter("turn_signal_search_time", 3.0);
   p.turn_signal_shift_length_threshold =
     declare_parameter("turn_signal_shift_length_threshold", 0.3);
+  p.turn_signal_on_swerving = declare_parameter("turn_signal_on_swerving", false);
+
   p.path_interval = declare_parameter<double>("path_interval");
   p.visualize_drivable_area_for_shared_linestrings_lanelet =
     declare_parameter("visualize_drivable_area_for_shared_linestrings_lanelet", true);
@@ -328,8 +330,6 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);
 
   p.avoidance_execution_lateral_threshold = dp("avoidance_execution_lateral_threshold", 0.499);
-
-  p.turn_signal_on_swerving = dp("turn_signal_on_swerving", true);
 
   return p;
 }

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -221,7 +221,7 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.turn_signal_search_time = declare_parameter("turn_signal_search_time", 3.0);
   p.turn_signal_shift_length_threshold =
     declare_parameter("turn_signal_shift_length_threshold", 0.3);
-  p.turn_signal_on_swerving = declare_parameter("turn_signal_on_swerving", false);
+  p.turn_signal_on_swerving = declare_parameter("turn_signal_on_swerving", true);
 
   p.path_interval = declare_parameter<double>("path_interval");
   p.visualize_drivable_area_for_shared_linestrings_lanelet =

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2744,8 +2744,10 @@ TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) con
     return {};
   }
 
+  bool turn_signal_on_swerving = planner_data_->parameters.turn_signal_on_swerving;
+
   TurnSignalInfo turn_signal_info{};
-  if (parameters_->turn_signal_on_swerving) {
+  if (turn_signal_on_swerving) {
     if (segment_shift_length > 0.0) {
       turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
     } else {


### PR DESCRIPTION
Signed-off-by: beyza <bnk@leodrive.ai>

## Description

I moved turn_signal_on_swerving param to bpp.param.yaml

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
