### PR TITLE
fix: skip building tensorrt yolox packages if cuda is not found

### DIFF
--- a/common/cuda_utils/CMakeLists.txt
+++ b/common/cuda_utils/CMakeLists.txt
@@ -4,7 +4,12 @@ project(cuda_utils)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-find_package(CUDA REQUIRED)
+find_package(CUDA)
+
+if(NOT ${CUDA_FOUND})
+  message(WARNING "cuda is not found, so The cuda_utils package won't be built.")
+  return()
+endif()
 
 install(
   DIRECTORY include/${PROJECT_NAME}/

--- a/common/cuda_utils/CMakeLists.txt
+++ b/common/cuda_utils/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(CUDA)
 
 if(NOT ${CUDA_FOUND})
-  message(WARNING "cuda is not found, so The cuda_utils package won't be built.")
+  message(WARNING "cuda is not found, so the cuda_utils package won't be built.")
   return()
 endif()
 

--- a/common/tensorrt_common/CMakeLists.txt
+++ b/common/tensorrt_common/CMakeLists.txt
@@ -4,9 +4,9 @@ project(tensorrt_common)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-find_package(CUDA REQUIRED)
-find_package(CUDNN REQUIRED)
-find_package(TENSORRT REQUIRED)
+find_package(CUDA)
+find_package(CUDNN)
+find_package(TENSORRT)
 
 if(NOT (${CUDA_FOUND} AND ${CUDNN_FOUND} AND ${TENSORRT_FOUND}))
   message(WARNING "cuda, cudnn, tensorrt libraries are not found")

--- a/perception/tensorrt_yolox/CMakeLists.txt
+++ b/perception/tensorrt_yolox/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 project(tensorrt_yolox)
 
+find_package(tensorrt_common)
+if(NOT ${tensorrt_common_FOUND})
+  message(WARNING "The tensorrt_common package is not found. Please check its dependencies.")
+  return()
+endif()
+
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 


### PR DESCRIPTION
Signed-off-by: Daisuke Nishimatsu <border_goldenmarket@yahoo.co.jp>

## Description

skip building `cuda_utils`, `tensorrt_common`, `tensorrt_yolox` if cuda is not found.

Related:
- https://github.com/autowarefoundation/autoware.universe/pull/2370
- https://github.com/autowarefoundation/autoware.universe/actions/runs/3583250712
- https://github.com/autowarefoundation/autoware.universe/issues/2409

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
