### PR TITLE
feat(map_loader): add downsampled pointcloud publisher

### DIFF
--- a/launch/tier4_map_launch/config/pointcloud_map_loader.param.yaml
+++ b/launch/tier4_map_launch/config/pointcloud_map_loader.param.yaml
@@ -1,4 +1,8 @@
 /**:
   ros__parameters:
     enable_whole_load: true
+    enable_downsampled_whole_load: false
     enable_partial_load: true
+
+    # only used when downsample_whole_load enabled
+    leaf_size: 3.0 # downsample leaf size [m]

--- a/launch/tier4_map_launch/config/pointcloud_map_loader.param.yaml
+++ b/launch/tier4_map_launch/config/pointcloud_map_loader.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     enable_whole_load: true
     enable_downsampled_whole_load: false
-    enable_partial_load: true
+    enable_partial_load: false
 
     # only used when downsample_whole_load enabled
     leaf_size: 3.0 # downsample leaf size [m]

--- a/map/map_loader/README.md
+++ b/map/map_loader/README.md
@@ -30,11 +30,11 @@ Please see [the description of `GetPartialPointCloudMap.srv`](https://github.com
 
 ### Parameters
 
-| Name                | Type | Description                                    | Default value |
-| :------------------ | :--- | :--------------------------------------------- | :------------ |
-| enable_whole_load   | bool | A flag to enable raw pointcloud map publishing | true          |
-| enable_downsampled_whole_load | bool   | A flag to enable downsampled pointcloud map publishing                            | true          |
-| enable_partial_load | bool | A flag to enable partial pointcloud map server | true          |
+| Name                          | Type  | Description                                                                       | Default value |
+| :---------------------------- | :---- | :-------------------------------------------------------------------------------- | :------------ |
+| enable_whole_load             | bool  | A flag to enable raw pointcloud map publishing                                    | true          |
+| enable_downsampled_whole_load | bool  | A flag to enable downsampled pointcloud map publishing                            | true          |
+| enable_partial_load           | bool  | A flag to enable partial pointcloud map server                                    | true          |
 | leaf_size                     | float | Downsampling leaf size (only used when enable_downsampled_whole_load is set true) | 3.0           |
 
 ### Interfaces

--- a/map/map_loader/README.md
+++ b/map/map_loader/README.md
@@ -10,11 +10,16 @@ This package provides the features of loading various maps.
 Currently, it supports the following two types:
 
 - Publish raw pointcloud map
+- Publish downsampled pointcloud map
 - Send partial pointcloud map loading via ROS 2 service
 
 #### Publish raw pointcloud map (ROS 2 topic)
 
 The node publishes the raw pointcloud map loaded from the `.pcd` file(s).
+
+#### Publish downsampled pointcloud map (ROS 2 topic)
+
+The node publishes the downsampled pointcloud map loaded from the `.pcd` file(s). You can specify the downsample resolution by changing the `leaf_size` parameter.
 
 #### Send partial pointcloud map (ROS 2 service)
 
@@ -28,11 +33,14 @@ Please see [the description of `GetPartialPointCloudMap.srv`](https://github.com
 | Name                | Type | Description                                    | Default value |
 | :------------------ | :--- | :--------------------------------------------- | :------------ |
 | enable_whole_load   | bool | A flag to enable raw pointcloud map publishing | true          |
+| enable_downsampled_whole_load | bool   | A flag to enable downsampled pointcloud map publishing                            | true          |
 | enable_partial_load | bool | A flag to enable partial pointcloud map server | true          |
+| leaf_size                     | float | Downsampling leaf size (only used when enable_downsampled_whole_load is set true) | 3.0           |
 
 ### Interfaces
 
 - `output/pointcloud_map` (sensor_msgs/msg/PointCloud2) : Raw pointcloud map
+- `output/debug/downsampled_pointcloud_map` (sensor_msgs/msg/PointCloud2) : Downsampled pointcloud map
 - `service/get_partial_pcd_map` (autoware_map_msgs/srv/GetPartialPointCloudMap) : Partial pointcloud map
 
 ---

--- a/map/map_loader/README.md
+++ b/map/map_loader/README.md
@@ -33,8 +33,8 @@ Please see [the description of `GetPartialPointCloudMap.srv`](https://github.com
 | Name                          | Type  | Description                                                                       | Default value |
 | :---------------------------- | :---- | :-------------------------------------------------------------------------------- | :------------ |
 | enable_whole_load             | bool  | A flag to enable raw pointcloud map publishing                                    | true          |
-| enable_downsampled_whole_load | bool  | A flag to enable downsampled pointcloud map publishing                            | false          |
-| enable_partial_load           | bool  | A flag to enable partial pointcloud map server                                    | false          |
+| enable_downsampled_whole_load | bool  | A flag to enable downsampled pointcloud map publishing                            | false         |
+| enable_partial_load           | bool  | A flag to enable partial pointcloud map server                                    | false         |
 | leaf_size                     | float | Downsampling leaf size (only used when enable_downsampled_whole_load is set true) | 3.0           |
 
 ### Interfaces

--- a/map/map_loader/README.md
+++ b/map/map_loader/README.md
@@ -33,8 +33,8 @@ Please see [the description of `GetPartialPointCloudMap.srv`](https://github.com
 | Name                          | Type  | Description                                                                       | Default value |
 | :---------------------------- | :---- | :-------------------------------------------------------------------------------- | :------------ |
 | enable_whole_load             | bool  | A flag to enable raw pointcloud map publishing                                    | true          |
-| enable_downsampled_whole_load | bool  | A flag to enable downsampled pointcloud map publishing                            | true          |
-| enable_partial_load           | bool  | A flag to enable partial pointcloud map server                                    | true          |
+| enable_downsampled_whole_load | bool  | A flag to enable downsampled pointcloud map publishing                            | false          |
+| enable_partial_load           | bool  | A flag to enable partial pointcloud map server                                    | false          |
 | leaf_size                     | float | Downsampling leaf size (only used when enable_downsampled_whole_load is set true) | 3.0           |
 
 ### Interfaces

--- a/map/map_loader/config/pointcloud_map_loader.param.yaml
+++ b/map/map_loader/config/pointcloud_map_loader.param.yaml
@@ -1,4 +1,8 @@
 /**:
   ros__parameters:
     enable_whole_load: true
+    enable_downsampled_whole_load: false
     enable_partial_load: true
+
+    # only used when downsample_whole_load enabled
+    leaf_size: 3.0 # downsample leaf size [m]

--- a/map/map_loader/config/pointcloud_map_loader.param.yaml
+++ b/map/map_loader/config/pointcloud_map_loader.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     enable_whole_load: true
     enable_downsampled_whole_load: false
-    enable_partial_load: true
+    enable_partial_load: false
 
     # only used when downsample_whole_load enabled
     leaf_size: 3.0 # downsample leaf size [m]

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.cpp
@@ -15,14 +15,33 @@
 #include "pointcloud_map_loader_module.hpp"
 
 #include <fmt/format.h>
+#include <pcl/filters/voxel_grid.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <string>
 #include <vector>
 
+sensor_msgs::msg::PointCloud2 downsample(
+  const sensor_msgs::msg::PointCloud2 & msg_input, const float leaf_size)
+{
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::fromROSMsg(msg_input, *pcl_input);
+  pcl::VoxelGrid<pcl::PointXYZ> filter;
+  filter.setInputCloud(pcl_input);
+  filter.setLeafSize(leaf_size, leaf_size, leaf_size);
+  filter.filter(*pcl_output);
+
+  sensor_msgs::msg::PointCloud2 msg_output;
+  pcl::toROSMsg(*pcl_output, msg_output);
+  msg_output.header = msg_input.header;
+  return msg_output;
+}
+
 PointcloudMapLoaderModule::PointcloudMapLoaderModule(
-  rclcpp::Node * node, const std::vector<std::string> & pcd_paths, const std::string publisher_name)
+  rclcpp::Node * node, const std::vector<std::string> & pcd_paths, const std::string publisher_name,
+  const bool use_downsample)
 : logger_(node->get_logger())
 {
   rclcpp::QoS durable_qos{1};
@@ -30,7 +49,13 @@ PointcloudMapLoaderModule::PointcloudMapLoaderModule(
   pub_pointcloud_map_ =
     node->create_publisher<sensor_msgs::msg::PointCloud2>(publisher_name, durable_qos);
 
-  sensor_msgs::msg::PointCloud2 pcd = loadPCDFiles(pcd_paths);
+  sensor_msgs::msg::PointCloud2 pcd;
+  if (use_downsample) {
+    float leaf_size = node->declare_parameter<float>("leaf_size");
+    pcd = loadPCDFiles(pcd_paths, leaf_size);
+  } else {
+    pcd = loadPCDFiles(pcd_paths, boost::none);
+  }
 
   if (pcd.width == 0) {
     RCLCPP_ERROR(logger_, "No PCD was loaded: pcd_paths.size() = %zu", pcd_paths.size());

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.cpp
@@ -67,7 +67,7 @@ PointcloudMapLoaderModule::PointcloudMapLoaderModule(
 }
 
 sensor_msgs::msg::PointCloud2 PointcloudMapLoaderModule::loadPCDFiles(
-  const std::vector<std::string> & pcd_paths) const
+  const std::vector<std::string> & pcd_paths, const boost::optional<float> leaf_size) const
 {
   sensor_msgs::msg::PointCloud2 whole_pcd;
   sensor_msgs::msg::PointCloud2 partial_pcd;
@@ -82,6 +82,10 @@ sensor_msgs::msg::PointCloud2 PointcloudMapLoaderModule::loadPCDFiles(
 
     if (pcl::io::loadPCDFile(path, partial_pcd) == -1) {
       RCLCPP_ERROR_STREAM(logger_, "PCD load failed: " << path);
+    }
+
+    if (leaf_size) {
+      partial_pcd = downsample(partial_pcd, leaf_size.get());
     }
 
     if (whole_pcd.width == 0) {

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.cpp
@@ -51,7 +51,7 @@ PointcloudMapLoaderModule::PointcloudMapLoaderModule(
 
   sensor_msgs::msg::PointCloud2 pcd;
   if (use_downsample) {
-    float leaf_size = node->declare_parameter<float>("leaf_size");
+    const float leaf_size = node->declare_parameter<float>("leaf_size");
     pcd = loadPCDFiles(pcd_paths, leaf_size);
   } else {
     pcd = loadPCDFiles(pcd_paths, boost::none);

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.hpp
@@ -29,7 +29,7 @@ class PointcloudMapLoaderModule
 public:
   explicit PointcloudMapLoaderModule(
     rclcpp::Node * node, const std::vector<std::string> & pcd_paths,
-    const std::string publisher_name);
+    const std::string publisher_name, const bool use_downsample);
 
 private:
   rclcpp::Logger logger_;

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.hpp
@@ -35,7 +35,8 @@ private:
   rclcpp::Logger logger_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_pointcloud_map_;
 
-  sensor_msgs::msg::PointCloud2 loadPCDFiles(const std::vector<std::string> & pcd_paths) const;
+  sensor_msgs::msg::PointCloud2 loadPCDFiles(
+    const std::vector<std::string> & pcd_paths, const boost::optional<float> leaf_size) const;
 };
 
 #endif  // POINTCLOUD_MAP_LOADER__POINTCLOUD_MAP_LOADER_MODULE_HPP_

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -50,11 +50,18 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
   const auto pcd_paths =
     getPcdPaths(declare_parameter<std::vector<std::string>>("pcd_paths_or_directory"));
   bool enable_whole_load = declare_parameter<bool>("enable_whole_load");
+  bool enable_downsample_whole_load = declare_parameter<bool>("enable_downsampled_whole_load");
   bool enable_partial_load = declare_parameter<bool>("enable_partial_load");
 
   if (enable_whole_load) {
     std::string publisher_name = "output/pointcloud_map";
-    pcd_map_loader_ = std::make_unique<PointcloudMapLoaderModule>(this, pcd_paths, publisher_name);
+    pcd_map_loader_ = std::make_unique<PointcloudMapLoaderModule>(this, pcd_paths, publisher_name, false);
+  }
+
+  if (enable_downsample_whole_load) {
+    std::string publisher_name = "output/debug/downsampled_pointcloud_map";
+    downsampled_pcd_map_loader_ =
+      std::make_unique<PointcloudMapLoaderModule>(this, pcd_paths, publisher_name, true);
   }
 
   if (enable_partial_load) {

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -55,7 +55,8 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
 
   if (enable_whole_load) {
     std::string publisher_name = "output/pointcloud_map";
-    pcd_map_loader_ = std::make_unique<PointcloudMapLoaderModule>(this, pcd_paths, publisher_name, false);
+    pcd_map_loader_ =
+      std::make_unique<PointcloudMapLoaderModule>(this, pcd_paths, publisher_name, false);
   }
 
   if (enable_downsample_whole_load) {

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.hpp
@@ -41,6 +41,7 @@ private:
   std::map<std::string, PCDFileMetadata> pcd_metadata_dict_;
 
   std::unique_ptr<PointcloudMapLoaderModule> pcd_map_loader_;
+  std::unique_ptr<PointcloudMapLoaderModule> downsampled_pcd_map_loader_;
   std::unique_ptr<PartialMapLoaderModule> partial_map_loader_;
 
   std::vector<std::string> getPcdPaths(


### PR DESCRIPTION
## Description
I would like to add a downsampled pointcloud publisher as an option.
Since some of the maps are getting too large to display on RViz, it is necessary to be able to publish downsampled pointcloud maps for debugging.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
