### PR TITLE
fix(behavior_path_planner): fix planing when start and target in same lane

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -852,15 +852,26 @@ PathWithLaneId BehaviorPathPlannerNode::modifyPathForSmoothGoalConnection(
   const PathWithLaneId & path) const
 {
   const auto goal = planner_data_->route_handler->getGoalPose();
-  const auto goal_lane_id = planner_data_->route_handler->getGoalLaneId();
+  auto goal_lane_id = planner_data_->route_handler->getGoalLaneId();
 
-  Pose refined_goal{};
+  Pose refined_goal;
   {
     lanelet::ConstLanelet goal_lanelet;
+    lanelet::ConstLanelet start_lanelet;
+    
     if (planner_data_->route_handler->getGoalLanelet(&goal_lanelet)) {
       refined_goal = util::refineGoal(goal, goal_lanelet);
     } else {
       refined_goal = goal;
+    }
+
+    if(planner_data_->route_handler->getStartLanelet(&start_lanelet))
+    {
+      if(lanelet::utils::isInLanelet(goal, start_lanelet, 0.01))
+      {
+        refined_goal = util::refineGoal(goal, start_lanelet);
+        goal_lane_id = start_lanelet.id(); 
+      }
     }
   }
 

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1830,8 +1830,8 @@ bool checkLaneIsInIntersection(
       return false;
     }
 
-    auto backlanelet_length = lanelet::utils::getLaneletLength2d(lanelet_sequence.back());
-    if (backlanelet_length > min_lane_change_distance) 
+    auto back_lanelet_length = lanelet::utils::getLaneletLength2d(lanelet_sequence.back());
+    if (back_lanelet_length > min_lane_change_distance) 
     {
       return false;
     }

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1829,6 +1829,12 @@ bool checkLaneIsInIntersection(
     if (get_signed_distance > min_lane_change_distance) {
       return false;
     }
+
+    auto backlanelet_length = lanelet::utils::getLaneletLength2d(lanelet_sequence.back());
+    if (backlanelet_length > min_lane_change_distance) 
+    {
+      return false;
+    }
   }
   // if you come to here, basically either back lane is goal, or back lane to goal is not enough
   // distance

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1778,6 +1778,14 @@ PathWithLaneId getCenterLinePath(
   if (route_handler.isInGoalRouteSection(lanelet_sequence.back())) {
     const auto goal_arc_coordinates =
       lanelet::utils::getArcCoordinates(lanelet_sequence, route_handler.getGoalPose());
+    if(lanelet_sequence.size()>1 && (lanelet_sequence.back().id() == lanelet_sequence.front().id()))
+    {
+      lanelet::ConstLanelets lanelets;
+      lanelets = lanelet_sequence;
+      lanelets.pop_back();
+      auto length = lanelet::utils::getLaneletLength2d(lanelets);
+      goal_arc_coordinates.length += length;
+    }
     s_forward = std::min(s_forward, goal_arc_coordinates.length - lane_change_buffer);
   }
 

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -57,6 +57,8 @@ private:
   void map_callback(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
   bool is_goal_valid(const geometry_msgs::msg::Pose & goal) const;
   Pose refine_goal_height(const Pose & goal, const RouteSections & route_sections);
+  bool check_goal_position(Pose start_pose,Pose goal_pose,lanelet::ConstLanelets & prev_lanes);
+  lanelet::ConstLanelets plan_route_with_prevlanes(lanelet::ConstLanelets prev_lanes,Pose start_pose);
 };
 
 }  // namespace mission_planner::lanelet2

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -93,6 +93,8 @@ public:
   Pose getGoalPose() const;
   lanelet::Id getGoalLaneId() const;
   bool getGoalLanelet(lanelet::ConstLanelet * goal_lanelet) const;
+    lanelet::Id getStartLaneId() const;
+  bool getStartLanelet(lanelet::ConstLanelet * start_lanelet) const;
   std::vector<lanelet::ConstLanelet> getLanesBeforePose(
     const geometry_msgs::msg::Pose & pose, const double vehicle_length) const;
   std::vector<lanelet::ConstLanelet> getLanesAfterGoal(const double vehicle_length) const;
@@ -277,6 +279,7 @@ private:
   bool is_route_msg_ready_{false};
   bool is_map_msg_ready_{false};
   bool is_handler_ready_{false};
+  bool is_loop_plan_{false};
 
   // non-const methods
   void setLaneletsFromRouteMsg();


### PR DESCRIPTION
## Description
 The planning shall plan the right path when  start and target in same lane
<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/issues/2354
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed


![loop_plan_2](https://user-images.githubusercontent.com/102840938/205014851-1228e95a-d7ab-44b7-80c9-e03f1b5a4a23.png)



![loop_plan_avoid](https://user-images.githubusercontent.com/102840938/205014936-f009fafa-daa5-4b9e-ac8c-be29d67f3e8c.png)



<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
