### PR TITLE
fix(behavior_path_planner): lane change candidate resolution

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -111,8 +111,7 @@ ShiftLine getLaneChangeShiftLine(
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & lane_changing_start_pose, const double prepare_distance,
-  const double lane_changing_distance, const double forward_path_length,
-  const double current_speed);
+  const double lane_changing_distance, const double forward_path_length);
 
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -111,7 +111,8 @@ ShiftLine getLaneChangeShiftLine(
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & lane_changing_start_pose, const double prepare_distance,
-  const double lane_changing_distance, const double forward_path_length);
+  const double lane_changing_distance, const double forward_path_length,
+  const double lane_changing_speed);
 
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -110,8 +110,9 @@ ShiftLine getLaneChangeShiftLine(
 
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
-  const Pose & lane_changing_start_pose, const double & prepare_distance,
-  const double & lane_changing_distance, const double & forward_path_length);
+  const Pose & lane_changing_start_pose, const double prepare_distance,
+  const double lane_changing_distance, const double forward_path_length,
+  const double current_speed);
 
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -143,8 +143,7 @@ BT::NodeStatus LaneChangeModule::updateState()
 
 BehaviorModuleOutput LaneChangeModule::plan()
 {
-  constexpr double resample_interval{1.0};
-  auto path = util::resamplePathWithSpline(status_.lane_change_path.path, resample_interval);
+  auto path = status_.lane_change_path.path;
 
   if (!isValidPath(path)) {
     status_.is_safe = false;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -238,8 +238,7 @@ LaneChangePaths getLaneChangePaths(
 
     const PathWithLaneId target_lane_reference_path = getReferencePathFromTargetLane(
       route_handler, target_lanelets, lane_changing_start_pose, prepare_distance,
-      lane_changing_distance, forward_path_length,
-      std::max(lane_changing_speed, minimum_lane_change_velocity));
+      lane_changing_distance, forward_path_length, lane_changing_speed);
 
     const ShiftLine shift_line = getLaneChangeShiftLine(
       prepare_segment_reference, lane_changing_segment_reference, target_lanelets,
@@ -511,7 +510,7 @@ PathWithLaneId getReferencePathFromTargetLane(
   constexpr auto min_resampling_points{30.0};
   constexpr auto resampling_dt{0.2};
   const auto resample_interval =
-    std::min(lane_changing_distance / min_resampling_points, lane_changing_speed * resampling_dt);
+    std::max(lane_changing_distance / min_resampling_points, lane_changing_speed * resampling_dt);
   return util::resamplePathWithSpline(lane_changing_reference_path, resample_interval);
 }
 


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

As a preparation for the new shift point computation, we have to increase the resolution of the candidate path.


Before PR
Resolution of candidate path at lane changing section is sparse.

![Screenshot from 2022-12-01 19-12-19](https://user-images.githubusercontent.com/93502286/205026340-b2c37fe3-4114-4866-a06f-d590c6d8d3ec.png)

After PR
Resolution of candidate path at lane changing section is dense.

![Screenshot from 2022-12-01 19-08-34](https://user-images.githubusercontent.com/93502286/205025532-43f30552-c2fc-4e29-bda4-0e61915f1504.png)

https://user-images.githubusercontent.com/93502286/205051043-4e59c58a-4bf7-48c7-86da-d6f096cffd46.mp4

## Tests performed

On the display, add `PathFootprint` and input `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/output/path_candidate` as the topic.

Then perform lane change maneuver.

## Notes for reviewers

Average time taken to run the resampler = `16us`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
