### PR TITLE
feat(tier4_state_rviz_plugin): use ADAPI v1 instead of old API

### DIFF
--- a/common/tier4_state_rviz_plugin/package.xml
+++ b/common/tier4_state_rviz_plugin/package.xml
@@ -11,6 +11,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware_state_panel.hpp"
 
+#include <QGridLayout>
 #include <QHBoxLayout>
 #include <QString>
 #include <QVBoxLayout>
@@ -32,33 +33,6 @@ namespace rviz_plugins
 {
 AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(parent)
 {
-  // Gate Mode
-  auto * gate_prefix_label_ptr = new QLabel("GATE: ");
-  gate_prefix_label_ptr->setAlignment(Qt::AlignRight);
-  gate_mode_label_ptr_ = new QLabel("INIT");
-  gate_mode_label_ptr_->setAlignment(Qt::AlignCenter);
-  auto * gate_layout = new QHBoxLayout;
-  gate_layout->addWidget(gate_prefix_label_ptr);
-  gate_layout->addWidget(gate_mode_label_ptr_);
-
-  // Selector Mode
-  auto * selector_prefix_label_ptr = new QLabel("SELECT: ");
-  selector_prefix_label_ptr->setAlignment(Qt::AlignRight);
-  selector_mode_label_ptr_ = new QLabel("INIT");
-  selector_mode_label_ptr_->setAlignment(Qt::AlignCenter);
-  auto * selector_layout = new QHBoxLayout;
-  selector_layout->addWidget(selector_prefix_label_ptr);
-  selector_layout->addWidget(selector_mode_label_ptr_);
-
-  // State
-  auto * state_prefix_label_ptr = new QLabel("STATE: ");
-  state_prefix_label_ptr->setAlignment(Qt::AlignRight);
-  autoware_state_label_ptr_ = new QLabel("INIT");
-  autoware_state_label_ptr_->setAlignment(Qt::AlignCenter);
-  auto * state_layout = new QHBoxLayout;
-  state_layout->addWidget(state_prefix_label_ptr);
-  state_layout->addWidget(autoware_state_label_ptr_);
-
   // Gear
   auto * gear_prefix_label_ptr = new QLabel("GEAR: ");
   gear_prefix_label_ptr->setAlignment(Qt::AlignRight);
@@ -67,23 +41,6 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   auto * gear_layout = new QHBoxLayout;
   gear_layout->addWidget(gear_prefix_label_ptr);
   gear_layout->addWidget(gear_label_ptr_);
-
-  // Engage Status
-  auto * engage_prefix_label_ptr = new QLabel("Engage: ");
-  engage_prefix_label_ptr->setAlignment(Qt::AlignRight);
-  engage_status_label_ptr_ = new QLabel("INIT");
-  engage_status_label_ptr_->setAlignment(Qt::AlignCenter);
-  auto * engage_status_layout = new QHBoxLayout;
-  engage_status_layout->addWidget(engage_prefix_label_ptr);
-  engage_status_layout->addWidget(engage_status_label_ptr_);
-
-  // Autoware Engage Button
-  engage_button_ptr_ = new QPushButton("Engage");
-  connect(engage_button_ptr_, SIGNAL(clicked()), SLOT(onClickAutowareEngage()));
-
-  // Gate Mode Button
-  gate_mode_button_ptr_ = new QPushButton("Gate Mode");
-  connect(gate_mode_button_ptr_, SIGNAL(clicked()), SLOT(onClickGateMode()));
 
   // Velocity Limit
   velocity_limit_button_ptr_ = new QPushButton("Send Velocity Limit");
@@ -99,16 +56,10 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
 
   // Layout
   auto * v_layout = new QVBoxLayout;
-  auto * gate_mode_path_change_approval_layout = new QHBoxLayout;
   auto * velocity_limit_layout = new QHBoxLayout();
-  v_layout->addLayout(gate_layout);
-  v_layout->addLayout(selector_layout);
-  v_layout->addLayout(state_layout);
+  v_layout->addWidget(makeOperationModeGroup());
+  v_layout->addWidget(makeControlModeGroup());
   v_layout->addLayout(gear_layout);
-  v_layout->addLayout(engage_status_layout);
-  v_layout->addWidget(engage_button_ptr_);
-  v_layout->addLayout(engage_status_layout);
-  gate_mode_path_change_approval_layout->addWidget(gate_mode_button_ptr_);
   velocity_limit_layout->addWidget(velocity_limit_button_ptr_);
   velocity_limit_layout->addWidget(pub_velocity_limit_input_);
   velocity_limit_layout->addWidget(new QLabel("  [km/h]"));
@@ -117,115 +68,169 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   setLayout(v_layout);
 }
 
+QGroupBox * AutowareStatePanel::makeOperationModeGroup()
+{
+  auto * group = new QGroupBox("OperationMode");
+  auto * grid = new QGridLayout;
+
+  operation_mode_label_ptr_ = new QLabel("INIT");
+  operation_mode_label_ptr_->setAlignment(Qt::AlignCenter);
+  operation_mode_label_ptr_->setStyleSheet("border:1px solid black;");
+  grid->addWidget(operation_mode_label_ptr_, 0, 0, 0, 1);
+
+  auto_button_ptr_ = new QPushButton("AUTO");
+  auto_button_ptr_->setCheckable(true);
+  connect(auto_button_ptr_, SIGNAL(clicked()), SLOT(onClickAutonomous()));
+  grid->addWidget(auto_button_ptr_, 0, 1);
+
+  stop_button_ptr_ = new QPushButton("STOP");
+  stop_button_ptr_->setCheckable(true);
+  connect(stop_button_ptr_, SIGNAL(clicked()), SLOT(onClickStop()));
+  grid->addWidget(stop_button_ptr_, 0, 2);
+
+  local_button_ptr_ = new QPushButton("LOCAL");
+  local_button_ptr_->setCheckable(true);
+  connect(local_button_ptr_, SIGNAL(clicked()), SLOT(onClickLocal()));
+  grid->addWidget(local_button_ptr_, 1, 1);
+
+  remote_button_ptr_ = new QPushButton("REMOTE");
+  remote_button_ptr_->setCheckable(true);
+  connect(remote_button_ptr_, SIGNAL(clicked()), SLOT(onClickRemote()));
+  grid->addWidget(remote_button_ptr_, 1, 2);
+
+  group->setLayout(grid);
+  return group;
+
+}
+
+QGroupBox * AutowareStatePanel::makeControlModeGroup()
+{
+  auto * group = new QGroupBox("ControlMode");
+  auto * grid = new QGridLayout;
+
+  control_mode_label_ptr_ = new QLabel("INIT");
+  control_mode_label_ptr_->setAlignment(Qt::AlignCenter);
+  control_mode_label_ptr_->setStyleSheet("border:1px solid black;");
+  grid->addWidget(control_mode_label_ptr_, 0, 0);
+
+  autoware_control_button_ptr_ = new QPushButton("Autoware");
+  autoware_control_button_ptr_->setCheckable(true);
+  connect(autoware_control_button_ptr_, SIGNAL(clicked()), SLOT(onClickAutowareControl()));
+  grid->addWidget(autoware_control_button_ptr_, 0, 1);
+
+  direct_control_button_ptr_ = new QPushButton("Direct");
+  direct_control_button_ptr_->setCheckable(true);
+  connect(direct_control_button_ptr_, SIGNAL(clicked()), SLOT(onClickDirectControl()));
+  grid->addWidget(direct_control_button_ptr_, 0, 2);
+
+  group->setLayout(grid);
+  return group;
+}
+
 void AutowareStatePanel::onInitialize()
 {
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
 
-  sub_gate_mode_ = raw_node_->create_subscription<tier4_control_msgs::msg::GateMode>(
-    "/control/current_gate_mode", 10, std::bind(&AutowareStatePanel::onGateMode, this, _1));
+  // Operation Mode
+  sub_operation_mode_ = raw_node_->create_subscription<OperationModeState>(
+    "/api/operation_mode/state", rclcpp::QoS{1}.transient_local(),
+    std::bind(&AutowareStatePanel::onOperationMode, this, _1));
 
-  sub_selector_mode_ =
-    raw_node_->create_subscription<tier4_control_msgs::msg::ExternalCommandSelectorMode>(
-      "/control/external_cmd_selector/current_selector_mode", 10,
-      std::bind(&AutowareStatePanel::onSelectorMode, this, _1));
+  client_change_to_autonomous_ = raw_node_->create_client<ChangeOperationMode>(
+    "/api/operation_mode/change_to_autonomous", rmw_qos_profile_services_default);
 
-  sub_autoware_state_ =
-    raw_node_->create_subscription<autoware_auto_system_msgs::msg::AutowareState>(
-      "/autoware/state", 10, std::bind(&AutowareStatePanel::onAutowareState, this, _1));
+  client_change_to_stop_ = raw_node_->create_client<ChangeOperationMode>(
+    "/api/operation_mode/change_to_stop", rmw_qos_profile_services_default);
+
+  client_change_to_local_ = raw_node_->create_client<ChangeOperationMode>(
+    "/api/operation_mode/change_to_local", rmw_qos_profile_services_default);
+
+  client_change_to_remote_ = raw_node_->create_client<ChangeOperationMode>(
+    "/api/operation_mode/change_to_remote", rmw_qos_profile_services_default);
+
+  client_enable_autoware_control_ = raw_node_->create_client<ChangeOperationMode>(
+    "/api/operation_mode/enable_autoware_control", rmw_qos_profile_services_default);
+
+  client_enable_direct_control_ = raw_node_->create_client<ChangeOperationMode>(
+    "/api/operation_mode/disable_autoware_control", rmw_qos_profile_services_default);
 
   sub_gear_ = raw_node_->create_subscription<autoware_auto_vehicle_msgs::msg::GearReport>(
     "/vehicle/status/gear_status", 10, std::bind(&AutowareStatePanel::onShift, this, _1));
 
-  sub_engage_ = raw_node_->create_subscription<tier4_external_api_msgs::msg::EngageStatus>(
-    "/api/external/get/engage", 10, std::bind(&AutowareStatePanel::onEngageStatus, this, _1));
-
   sub_emergency_ = raw_node_->create_subscription<tier4_external_api_msgs::msg::Emergency>(
     "/api/autoware/get/emergency", 10, std::bind(&AutowareStatePanel::onEmergencyStatus, this, _1));
-
-  client_engage_ = raw_node_->create_client<tier4_external_api_msgs::srv::Engage>(
-    "/api/external/set/engage", rmw_qos_profile_services_default);
 
   client_emergency_stop_ = raw_node_->create_client<tier4_external_api_msgs::srv::SetEmergency>(
     "/api/autoware/set/emergency", rmw_qos_profile_services_default);
 
   pub_velocity_limit_ = raw_node_->create_publisher<tier4_planning_msgs::msg::VelocityLimit>(
     "/planning/scenario_planning/max_velocity_default", rclcpp::QoS{1}.transient_local());
-
-  pub_gate_mode_ = raw_node_->create_publisher<tier4_control_msgs::msg::GateMode>(
-    "/control/gate_mode_cmd", rclcpp::QoS{1}.transient_local());
 }
 
-void AutowareStatePanel::onGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg)
+void AutowareStatePanel::onOperationMode(const OperationModeState::ConstSharedPtr msg)
 {
-  switch (msg->data) {
-    case tier4_control_msgs::msg::GateMode::AUTO:
-      gate_mode_label_ptr_->setText("AUTO");
-      gate_mode_label_ptr_->setStyleSheet("background-color: #00FF00;");
+  auto changeButtonState = [](
+                             QPushButton * button, const bool is_desired_mode_available,
+                             const uint8_t current_mode = OperationModeState::UNKNOWN,
+                             const uint8_t desired_mode = OperationModeState::STOP) {
+    if (is_desired_mode_available && current_mode != desired_mode) {
+      button->setChecked(false);
+      button->setEnabled(true);
+    } else {
+      button->setChecked(true);
+      button->setEnabled(false);
+    }
+  };
+
+  // Gate Mode
+  switch (msg->mode) {
+    case OperationModeState::AUTONOMOUS:
+      operation_mode_label_ptr_->setText("AUTONOMOUS");
+      operation_mode_label_ptr_->setStyleSheet("background-color: #00FF00;");
       break;
 
-    case tier4_control_msgs::msg::GateMode::EXTERNAL:
-      gate_mode_label_ptr_->setText("EXTERNAL");
-      gate_mode_label_ptr_->setStyleSheet("background-color: #FFFF00;");
+    case OperationModeState::LOCAL:
+      operation_mode_label_ptr_->setText("LOCAL");
+      operation_mode_label_ptr_->setStyleSheet("background-color: #FFFF00;");
+      break;
+
+    case OperationModeState::REMOTE:
+      operation_mode_label_ptr_->setText("REMOTE");
+      operation_mode_label_ptr_->setStyleSheet("background-color: #FFFF00;");
+      break;
+
+    case OperationModeState::STOP:
+      operation_mode_label_ptr_->setText("STOP");
+      operation_mode_label_ptr_->setStyleSheet("background-color: #FFA500;");
       break;
 
     default:
-      gate_mode_label_ptr_->setText("UNKNOWN");
-      gate_mode_label_ptr_->setStyleSheet("background-color: #FF0000;");
+      operation_mode_label_ptr_->setText("UNKNOWN");
+      operation_mode_label_ptr_->setStyleSheet("background-color: #FF0000;");
       break;
   }
-}
 
-void AutowareStatePanel::onSelectorMode(
-  const tier4_control_msgs::msg::ExternalCommandSelectorMode::ConstSharedPtr msg)
-{
-  switch (msg->data) {
-    case tier4_control_msgs::msg::ExternalCommandSelectorMode::REMOTE:
-      selector_mode_label_ptr_->setText("REMOTE");
-      selector_mode_label_ptr_->setStyleSheet("background-color: #00FF00;");
-      break;
-
-    case tier4_control_msgs::msg::ExternalCommandSelectorMode::LOCAL:
-      selector_mode_label_ptr_->setText("LOCAL");
-      selector_mode_label_ptr_->setStyleSheet("background-color: #FFFF00;");
-      break;
-
-    case tier4_control_msgs::msg::ExternalCommandSelectorMode::NONE:
-      selector_mode_label_ptr_->setText("NONE");
-      selector_mode_label_ptr_->setStyleSheet("background-color: #FF0000;");
-      break;
-
-    default:
-      selector_mode_label_ptr_->setText("UNKNOWN");
-      selector_mode_label_ptr_->setStyleSheet("background-color: #FF0000;");
-      break;
+  // Control Mode
+  if (msg->is_autoware_control_enabled) {
+    control_mode_label_ptr_->setText("Autoware");
+    control_mode_label_ptr_->setStyleSheet("background-color: #00FF00;");
+  } else {
+    control_mode_label_ptr_->setText("Direct");
+    control_mode_label_ptr_->setStyleSheet("background-color: #FFFF00;");
   }
-}
 
-void AutowareStatePanel::onAutowareState(
-  const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr msg)
-{
-  if (msg->state == autoware_auto_system_msgs::msg::AutowareState::INITIALIZING) {
-    autoware_state_label_ptr_->setText("INITIALIZING");
-    autoware_state_label_ptr_->setStyleSheet("background-color: #FFFF00;");
-  } else if (msg->state == autoware_auto_system_msgs::msg::AutowareState::WAITING_FOR_ROUTE) {
-    autoware_state_label_ptr_->setText("WAITING_FOR_ROUTE");
-    autoware_state_label_ptr_->setStyleSheet("background-color: #FFFF00;");
-  } else if (msg->state == autoware_auto_system_msgs::msg::AutowareState::PLANNING) {
-    autoware_state_label_ptr_->setText("PLANNING");
-    autoware_state_label_ptr_->setStyleSheet("background-color: #FFFF00;");
-  } else if (msg->state == autoware_auto_system_msgs::msg::AutowareState::WAITING_FOR_ENGAGE) {
-    autoware_state_label_ptr_->setText("WAITING_FOR_ENGAGE");
-    autoware_state_label_ptr_->setStyleSheet("background-color: #00FFFF;");
-  } else if (msg->state == autoware_auto_system_msgs::msg::AutowareState::DRIVING) {
-    autoware_state_label_ptr_->setText("DRIVING");
-    autoware_state_label_ptr_->setStyleSheet("background-color: #00FF00;");
-  } else if (msg->state == autoware_auto_system_msgs::msg::AutowareState::ARRIVED_GOAL) {
-    autoware_state_label_ptr_->setText("ARRIVED_GOAL");
-    autoware_state_label_ptr_->setStyleSheet("background-color: #FF00FF;");
-  } else if (msg->state == autoware_auto_system_msgs::msg::AutowareState::FINALIZING) {
-    autoware_state_label_ptr_->setText("FINALIZING");
-    autoware_state_label_ptr_->setStyleSheet("background-color: #FFFF00;");
-  }
+  // Button
+  changeButtonState(
+    auto_button_ptr_, msg->is_autonomous_mode_available, msg->mode, OperationModeState::AUTONOMOUS);
+  changeButtonState(
+    stop_button_ptr_, msg->is_stop_mode_available, msg->mode, OperationModeState::STOP);
+  changeButtonState(
+    local_button_ptr_, msg->is_local_mode_available, msg->mode, OperationModeState::LOCAL);
+  changeButtonState(
+    remote_button_ptr_, msg->is_remote_mode_available, msg->mode, OperationModeState::REMOTE);
+
+  changeButtonState(autoware_control_button_ptr_, !msg->is_autoware_control_enabled);
+  changeButtonState(direct_control_button_ptr_, msg->is_autoware_control_enabled);
 }
 
 void AutowareStatePanel::onShift(
@@ -245,13 +250,6 @@ void AutowareStatePanel::onShift(
       gear_label_ptr_->setText("LOW");
       break;
   }
-}
-
-void AutowareStatePanel::onEngageStatus(
-  const tier4_external_api_msgs::msg::EngageStatus::ConstSharedPtr msg)
-{
-  current_engage_ = msg->engage;
-  engage_status_label_ptr_->setText(QString::fromStdString(Bool2String(current_engage_)));
 }
 
 void AutowareStatePanel::onEmergencyStatus(
@@ -274,21 +272,32 @@ void AutowareStatePanel::onClickVelocityLimit()
   pub_velocity_limit_->publish(*velocity_limit);
 }
 
-void AutowareStatePanel::onClickAutowareEngage()
+void AutowareStatePanel::onClickAutonomous() { changeOperationMode(client_change_to_autonomous_); }
+void AutowareStatePanel::onClickStop() { changeOperationMode(client_change_to_stop_); }
+void AutowareStatePanel::onClickLocal() { changeOperationMode(client_change_to_local_); }
+void AutowareStatePanel::onClickRemote() { changeOperationMode(client_change_to_remote_); }
+void AutowareStatePanel::onClickAutowareControl()
 {
-  using tier4_external_api_msgs::srv::Engage;
+  changeOperationMode(client_enable_autoware_control_);
+}
+void AutowareStatePanel::onClickDirectControl()
+{
+  changeOperationMode(client_enable_direct_control_);
+}
 
-  auto req = std::make_shared<Engage::Request>();
-  req->engage = !current_engage_;
+void AutowareStatePanel::changeOperationMode(
+  const rclcpp::Client<ChangeOperationMode>::SharedPtr client)
+{
+  auto req = std::make_shared<ChangeOperationMode::Request>();
 
   RCLCPP_INFO(raw_node_->get_logger(), "client request");
 
-  if (!client_engage_->service_is_ready()) {
+  if (!client->service_is_ready()) {
     RCLCPP_INFO(raw_node_->get_logger(), "client is unavailable");
     return;
   }
 
-  client_engage_->async_send_request(req, [this](rclcpp::Client<Engage>::SharedFuture result) {
+  client->async_send_request(req, [this](rclcpp::Client<ChangeOperationMode>::SharedFuture result) {
     RCLCPP_INFO(
       raw_node_->get_logger(), "Status: %d, %s", result.get()->status.code,
       result.get()->status.message.c_str());
@@ -316,15 +325,7 @@ void AutowareStatePanel::onClickEmergencyButton()
       }
     });
 }
-void AutowareStatePanel::onClickGateMode()
-{
-  const auto data = gate_mode_label_ptr_->text().toStdString() == "AUTO"
-                      ? tier4_control_msgs::msg::GateMode::EXTERNAL
-                      : tier4_control_msgs::msg::GateMode::AUTO;
-  RCLCPP_INFO(raw_node_->get_logger(), "data : %d", data);
-  pub_gate_mode_->publish(
-    tier4_control_msgs::build<tier4_control_msgs::msg::GateMode>().data(data));
-}
+
 }  // namespace rviz_plugins
 
 #include <pluginlib/class_list_macros.hpp>

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -100,7 +100,6 @@ QGroupBox * AutowareStatePanel::makeOperationModeGroup()
 
   group->setLayout(grid);
   return group;
-
 }
 
 QGroupBox * AutowareStatePanel::makeControlModeGroup()

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -209,6 +209,10 @@ void AutowareStatePanel::onOperationMode(const OperationModeState::ConstSharedPt
       break;
   }
 
+  if (msg->is_in_transition) {
+    operation_mode_label_ptr_->setText(operation_mode_label_ptr_->text() + "\n(TRANSITION)");
+  }
+
   // Control Mode
   if (msg->is_autoware_control_enabled) {
     control_mode_label_ptr_->setText("Enable");

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -181,7 +181,7 @@ void AutowareStatePanel::onOperationMode(const OperationModeState::ConstSharedPt
     }
   };
 
-  // Gate Mode
+  // Operation Mode
   switch (msg->mode) {
     case OperationModeState::AUTONOMOUS:
       operation_mode_label_ptr_->setText("AUTONOMOUS");

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -104,7 +104,7 @@ QGroupBox * AutowareStatePanel::makeOperationModeGroup()
 
 QGroupBox * AutowareStatePanel::makeControlModeGroup()
 {
-  auto * group = new QGroupBox("ControlMode");
+  auto * group = new QGroupBox("AutowareControl");
   auto * grid = new QGridLayout;
 
   control_mode_label_ptr_ = new QLabel("INIT");
@@ -112,15 +112,15 @@ QGroupBox * AutowareStatePanel::makeControlModeGroup()
   control_mode_label_ptr_->setStyleSheet("border:1px solid black;");
   grid->addWidget(control_mode_label_ptr_, 0, 0);
 
-  autoware_control_button_ptr_ = new QPushButton("Autoware");
-  autoware_control_button_ptr_->setCheckable(true);
-  connect(autoware_control_button_ptr_, SIGNAL(clicked()), SLOT(onClickAutowareControl()));
-  grid->addWidget(autoware_control_button_ptr_, 0, 1);
+  enable_button_ptr_ = new QPushButton("Enable");
+  enable_button_ptr_->setCheckable(true);
+  connect(enable_button_ptr_, SIGNAL(clicked()), SLOT(onClickAutowareControl()));
+  grid->addWidget(enable_button_ptr_, 0, 1);
 
-  direct_control_button_ptr_ = new QPushButton("Direct");
-  direct_control_button_ptr_->setCheckable(true);
-  connect(direct_control_button_ptr_, SIGNAL(clicked()), SLOT(onClickDirectControl()));
-  grid->addWidget(direct_control_button_ptr_, 0, 2);
+  disable_button_ptr_ = new QPushButton("Disable");
+  disable_button_ptr_->setCheckable(true);
+  connect(disable_button_ptr_, SIGNAL(clicked()), SLOT(onClickDirectControl()));
+  grid->addWidget(disable_button_ptr_, 0, 2);
 
   group->setLayout(grid);
   return group;
@@ -211,10 +211,10 @@ void AutowareStatePanel::onOperationMode(const OperationModeState::ConstSharedPt
 
   // Control Mode
   if (msg->is_autoware_control_enabled) {
-    control_mode_label_ptr_->setText("Autoware");
+    control_mode_label_ptr_->setText("Enable");
     control_mode_label_ptr_->setStyleSheet("background-color: #00FF00;");
   } else {
-    control_mode_label_ptr_->setText("Direct");
+    control_mode_label_ptr_->setText("Disable");
     control_mode_label_ptr_->setStyleSheet("background-color: #FFFF00;");
   }
 
@@ -228,8 +228,8 @@ void AutowareStatePanel::onOperationMode(const OperationModeState::ConstSharedPt
   changeButtonState(
     remote_button_ptr_, msg->is_remote_mode_available, msg->mode, OperationModeState::REMOTE);
 
-  changeButtonState(autoware_control_button_ptr_, !msg->is_autoware_control_enabled);
-  changeButtonState(direct_control_button_ptr_, msg->is_autoware_control_enabled);
+  changeButtonState(enable_button_ptr_, !msg->is_autoware_control_enabled);
+  changeButtonState(disable_button_ptr_, msg->is_autoware_control_enabled);
 }
 
 void AutowareStatePanel::onShift(

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -85,10 +85,6 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   gate_mode_button_ptr_ = new QPushButton("Gate Mode");
   connect(gate_mode_button_ptr_, SIGNAL(clicked()), SLOT(onClickGateMode()));
 
-  // Path Change Approval Button
-  path_change_approval_button_ptr_ = new QPushButton("Path Change Approval");
-  connect(path_change_approval_button_ptr_, SIGNAL(clicked()), SLOT(onClickPathChangeApproval()));
-
   // Velocity Limit
   velocity_limit_button_ptr_ = new QPushButton("Send Velocity Limit");
   pub_velocity_limit_input_ = new QSpinBox();
@@ -113,8 +109,6 @@ AutowareStatePanel::AutowareStatePanel(QWidget * parent) : rviz_common::Panel(pa
   v_layout->addWidget(engage_button_ptr_);
   v_layout->addLayout(engage_status_layout);
   gate_mode_path_change_approval_layout->addWidget(gate_mode_button_ptr_);
-  gate_mode_path_change_approval_layout->addWidget(path_change_approval_button_ptr_);
-  v_layout->addLayout(gate_mode_path_change_approval_layout);
   velocity_limit_layout->addWidget(velocity_limit_button_ptr_);
   velocity_limit_layout->addWidget(pub_velocity_limit_input_);
   velocity_limit_layout->addWidget(new QLabel("  [km/h]"));
@@ -159,11 +153,6 @@ void AutowareStatePanel::onInitialize()
 
   pub_gate_mode_ = raw_node_->create_publisher<tier4_control_msgs::msg::GateMode>(
     "/control/gate_mode_cmd", rclcpp::QoS{1}.transient_local());
-
-  pub_path_change_approval_ = raw_node_->create_publisher<tier4_planning_msgs::msg::Approval>(
-    "/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/"
-    "path_change_approval",
-    rclcpp::QoS{1}.transient_local());
 }
 
 void AutowareStatePanel::onGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg)
@@ -335,14 +324,6 @@ void AutowareStatePanel::onClickGateMode()
   RCLCPP_INFO(raw_node_->get_logger(), "data : %d", data);
   pub_gate_mode_->publish(
     tier4_control_msgs::build<tier4_control_msgs::msg::GateMode>().data(data));
-}
-
-void AutowareStatePanel::onClickPathChangeApproval()
-{
-  pub_path_change_approval_->publish(
-    tier4_planning_msgs::build<tier4_planning_msgs::msg::Approval>()
-      .stamp(raw_node_->now())
-      .approval(true));
 }
 }  // namespace rviz_plugins
 

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -88,8 +88,8 @@ protected:
 
   //// Control Mode
   QLabel * control_mode_label_ptr_{nullptr};
-  QPushButton * autoware_control_button_ptr_{nullptr};
-  QPushButton * direct_control_button_ptr_{nullptr};
+  QPushButton * enable_button_ptr_{nullptr};
+  QPushButton * disable_button_ptr_{nullptr};
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_autoware_control_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_direct_control_;
 

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -48,7 +48,6 @@ public Q_SLOTS:  // NOLINT for Qt
   void onClickAutowareEngage();
   void onClickVelocityLimit();
   void onClickGateMode();
-  void onClickPathChangeApproval();
   void onClickEmergencyButton();
 
 protected:
@@ -75,7 +74,6 @@ protected:
 
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
   rclcpp::Publisher<tier4_control_msgs::msg::GateMode>::SharedPtr pub_gate_mode_;
-  rclcpp::Publisher<tier4_planning_msgs::msg::Approval>::SharedPtr pub_path_change_approval_;
 
   QLabel * gate_mode_label_ptr_;
   QLabel * selector_mode_label_ptr_;
@@ -85,7 +83,6 @@ protected:
   QPushButton * engage_button_ptr_;
   QPushButton * velocity_limit_button_ptr_;
   QPushButton * gate_mode_button_ptr_;
-  QPushButton * path_change_approval_button_ptr_;
   QSpinBox * pub_velocity_limit_input_;
   QPushButton * emergency_button_ptr_;
 

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -17,27 +17,28 @@
 #ifndef AUTOWARE_STATE_PANEL_HPP_
 #define AUTOWARE_STATE_PANEL_HPP_
 
+#include <QGroupBox>
 #include <QLabel>
+#include <QLayout>
 #include <QPushButton>
 #include <QSpinBox>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
 
-#include <autoware_auto_system_msgs/msg/autoware_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
-#include <tier4_control_msgs/msg/external_command_selector_mode.hpp>
-#include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_external_api_msgs/msg/emergency.hpp>
-#include <tier4_external_api_msgs/msg/engage_status.hpp>
-#include <tier4_external_api_msgs/srv/engage.hpp>
 #include <tier4_external_api_msgs/srv/set_emergency.hpp>
-#include <tier4_planning_msgs/msg/approval.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 
 namespace rviz_plugins
 {
 class AutowareStatePanel : public rviz_common::Panel
 {
+  using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
+  using ChangeOperationMode = autoware_adapi_v1_msgs::srv::ChangeOperationMode;
+
   Q_OBJECT
 
 public:
@@ -45,44 +46,60 @@ public:
   void onInitialize() override;
 
 public Q_SLOTS:  // NOLINT for Qt
-  void onClickAutowareEngage();
+  void onClickAutonomous();
+  void onClickStop();
+  void onClickLocal();
+  void onClickRemote();
+  void onClickAutowareControl();
+  void onClickDirectControl();
   void onClickVelocityLimit();
-  void onClickGateMode();
   void onClickEmergencyButton();
 
 protected:
-  void onGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg);
-  void onSelectorMode(
-    const tier4_control_msgs::msg::ExternalCommandSelectorMode::ConstSharedPtr msg);
-  void onAutowareState(const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr msg);
+  // Layout
+  QGroupBox * makeOperationModeGroup();
+  QGroupBox * makeControlModeGroup();
+
   void onShift(const autoware_auto_vehicle_msgs::msg::GearReport::ConstSharedPtr msg);
   void onEmergencyStatus(const tier4_external_api_msgs::msg::Emergency::ConstSharedPtr msg);
-  void onEngageStatus(const tier4_external_api_msgs::msg::EngageStatus::ConstSharedPtr msg);
 
   rclcpp::Node::SharedPtr raw_node_;
-  rclcpp::Subscription<tier4_control_msgs::msg::GateMode>::SharedPtr sub_gate_mode_;
-  rclcpp::Subscription<tier4_control_msgs::msg::ExternalCommandSelectorMode>::SharedPtr
-    sub_selector_mode_;
-  rclcpp::Subscription<autoware_auto_system_msgs::msg::AutowareState>::SharedPtr
-    sub_autoware_state_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::GearReport>::SharedPtr sub_gear_;
-  rclcpp::Subscription<tier4_external_api_msgs::msg::EngageStatus>::SharedPtr sub_engage_;
 
-  rclcpp::Client<tier4_external_api_msgs::srv::Engage>::SharedPtr client_engage_;
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::GearReport>::SharedPtr sub_gear_;
+
   rclcpp::Client<tier4_external_api_msgs::srv::SetEmergency>::SharedPtr client_emergency_stop_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::Emergency>::SharedPtr sub_emergency_;
 
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
-  rclcpp::Publisher<tier4_control_msgs::msg::GateMode>::SharedPtr pub_gate_mode_;
 
-  QLabel * gate_mode_label_ptr_;
-  QLabel * selector_mode_label_ptr_;
-  QLabel * autoware_state_label_ptr_;
-  QLabel * gear_label_ptr_;
-  QLabel * engage_status_label_ptr_;
-  QPushButton * engage_button_ptr_;
+  // Operation Mode
+  //// Gate Mode
+  QLabel * operation_mode_label_ptr_;
+  QPushButton * stop_button_ptr_;
+  QPushButton * auto_button_ptr_;
+  QPushButton * local_button_ptr_;
+  QPushButton * remote_button_ptr_;
+
+  rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr client_change_to_autonomous_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr client_change_to_stop_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr client_change_to_local_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr client_change_to_remote_;
+
+  //// Control Mode
+  QLabel * control_mode_label_ptr_;
+  QPushButton * autoware_control_button_ptr_;
+  QPushButton * direct_control_button_ptr_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_autoware_control_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_direct_control_;
+
+  // Functions
+  void onOperationMode(const OperationModeState::ConstSharedPtr msg);
+  void changeOperationMode(const rclcpp::Client<ChangeOperationMode>::SharedPtr client);
+
   QPushButton * velocity_limit_button_ptr_;
-  QPushButton * gate_mode_button_ptr_;
+  QLabel * gear_label_ptr_;
+
   QSpinBox * pub_velocity_limit_input_;
   QPushButton * emergency_button_ptr_;
 

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -74,11 +74,11 @@ protected:
 
   // Operation Mode
   //// Gate Mode
-  QLabel * operation_mode_label_ptr_;
-  QPushButton * stop_button_ptr_;
-  QPushButton * auto_button_ptr_;
-  QPushButton * local_button_ptr_;
-  QPushButton * remote_button_ptr_;
+  QLabel * operation_mode_label_ptr_{nullptr};
+  QPushButton * stop_button_ptr_{nullptr};
+  QPushButton * auto_button_ptr_{nullptr};
+  QPushButton * local_button_ptr_{nullptr};
+  QPushButton * remote_button_ptr_{nullptr};
 
   rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_change_to_autonomous_;
@@ -87,9 +87,9 @@ protected:
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_change_to_remote_;
 
   //// Control Mode
-  QLabel * control_mode_label_ptr_;
-  QPushButton * autoware_control_button_ptr_;
-  QPushButton * direct_control_button_ptr_;
+  QLabel * control_mode_label_ptr_{nullptr};
+  QPushButton * autoware_control_button_ptr_{nullptr};
+  QPushButton * direct_control_button_ptr_{nullptr};
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_autoware_control_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_direct_control_;
 

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -93,7 +93,7 @@ protected:
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_autoware_control_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr client_enable_direct_control_;
 
-  // Functions
+  //// Functions
   void onOperationMode(const OperationModeState::ConstSharedPtr msg);
   void changeOperationMode(const rclcpp::Client<ChangeOperationMode>::SharedPtr client);
 

--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.hpp
@@ -103,7 +103,6 @@ protected:
   QSpinBox * pub_velocity_limit_input_;
   QPushButton * emergency_button_ptr_;
 
-  bool current_engage_{false};
   bool current_emergency_{false};
 };
 


### PR DESCRIPTION
## Description

- use ADAPI v1 instead of old API
- delete path change approval because RTC is now providing same function.

![image](https://user-images.githubusercontent.com/9547070/205225999-60acea5d-e2fd-41c4-9704-24379fbef0f3.png)



## Related links

TIERIV_INTERNAL_LINK: https://tier4.atlassian.net/browse/T4PB-24038

## Tests performed

In planning_simulator
- set ego and goal position
- click auto button and ego is driving.
- click stop and ego is stopping

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
