### PR TITLE
fix(simple_planning_simulator): sim model with gear acc

### DIFF
--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
@@ -124,6 +124,7 @@ void SimModelDelaySteerAccGeared::updateStateWithGear(
       state(IDX::X) = prev_state(IDX::X);
       state(IDX::Y) = prev_state(IDX::Y);
       state(IDX::YAW) = prev_state(IDX::YAW);
+      state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
     }
   } else if (gear == GearCommand::REVERSE || gear == GearCommand::REVERSE_2) {
     if (state(IDX::VX) > 0.0) {
@@ -131,18 +132,19 @@ void SimModelDelaySteerAccGeared::updateStateWithGear(
       state(IDX::X) = prev_state(IDX::X);
       state(IDX::Y) = prev_state(IDX::Y);
       state(IDX::YAW) = prev_state(IDX::YAW);
+      state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
     }
   } else if (gear == GearCommand::PARK) {
     state(IDX::VX) = 0.0;
     state(IDX::X) = prev_state(IDX::X);
     state(IDX::Y) = prev_state(IDX::Y);
     state(IDX::YAW) = prev_state(IDX::YAW);
+    state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
   } else {
     state(IDX::VX) = 0.0;
     state(IDX::X) = prev_state(IDX::X);
     state(IDX::Y) = prev_state(IDX::Y);
     state(IDX::YAW) = prev_state(IDX::YAW);
+    state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
   }
-
-  state(IDX::ACCX) = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
 }

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
@@ -79,6 +79,7 @@ void SimModelIdealSteerAccGeared::updateStateWithGear(
       state(IDX::X) = prev_state(IDX::X);
       state(IDX::Y) = prev_state(IDX::Y);
       state(IDX::YAW) = prev_state(IDX::YAW);
+      current_acc_ = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
     }
   } else if (gear == GearCommand::REVERSE || gear == GearCommand::REVERSE_2) {
     if (state(IDX::VX) > 0.0) {
@@ -86,18 +87,19 @@ void SimModelIdealSteerAccGeared::updateStateWithGear(
       state(IDX::X) = prev_state(IDX::X);
       state(IDX::Y) = prev_state(IDX::Y);
       state(IDX::YAW) = prev_state(IDX::YAW);
+      current_acc_ = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
     }
   } else if (gear == GearCommand::PARK) {
     state(IDX::VX) = 0.0;
     state(IDX::X) = prev_state(IDX::X);
     state(IDX::Y) = prev_state(IDX::Y);
     state(IDX::YAW) = prev_state(IDX::YAW);
+    current_acc_ = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
   } else {
     state(IDX::VX) = 0.0;
     state(IDX::X) = prev_state(IDX::X);
     state(IDX::Y) = prev_state(IDX::Y);
     state(IDX::YAW) = prev_state(IDX::YAW);
+    current_acc_ = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
   }
-
-  current_acc_ = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
 }


### PR DESCRIPTION
## Description

previously calculated acc is updated with (v_current-v_previous)/dt 
which is [not precise value](https://star4.slack.com/archives/C03QW0GU6P7/p1669972528102939?thread_ts=1669968931.755209&cid=C03QW0GU6P7).

So I fix acceleration calculation of psim

- noise is due to recording timing velocity is nominal

I test 
- time constant 0.4
- time delay 0.33

 -before this PR
 time constant is almost 0.8 and delay is much more than expected 
![image](https://user-images.githubusercontent.com/65527974/205417256-c57d46e7-f61b-49a9-8e6d-f5eea884bbc6.png)

- after this PR
![image](https://user-images.githubusercontent.com/65527974/205275968-3a9195d6-e8b3-4c80-a885-4372e4c1bdde.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
