### PR TITLE
feat(transition_manager): add param to ignore autonomous transition condition

### DIFF
--- a/control/operation_mode_transition_manager/config/operation_mode_transition_manager.param.yaml
+++ b/control/operation_mode_transition_manager/config/operation_mode_transition_manager.param.yaml
@@ -2,6 +2,7 @@
   ros__parameters:
     transition_timeout: 10.0
     frequency_hz: 10.0
+    check_engage_condition: false # set false if you do not want to care about the engage condition.
     engage_acceptable_limits:
       allow_autonomous_in_stopped: true  # no check if the velocity is zero, always allowed.
       dist_threshold: 1.5

--- a/control/operation_mode_transition_manager/src/data.hpp
+++ b/control/operation_mode_transition_manager/src/data.hpp
@@ -58,7 +58,6 @@ struct Transition
 
 struct EngageAcceptableParam
 {
-  bool check_engage_condition = true;  // if false, the vehicle is engaged without any checks.
   bool allow_autonomous_in_stopped = true;
   double dist_threshold = 2.0;
   double speed_upper_threshold = 10.0;

--- a/control/operation_mode_transition_manager/src/data.hpp
+++ b/control/operation_mode_transition_manager/src/data.hpp
@@ -58,6 +58,7 @@ struct Transition
 
 struct EngageAcceptableParam
 {
+  bool check_engage_condition = true;  // if false, the vehicle is engaged without any checks.
   bool allow_autonomous_in_stopped = true;
   double dist_threshold = 2.0;
   double speed_upper_threshold = 10.0;

--- a/control/operation_mode_transition_manager/src/state.cpp
+++ b/control/operation_mode_transition_manager/src/state.cpp
@@ -83,8 +83,6 @@ void AutonomousMode::update(bool transition)
 bool AutonomousMode::isModeChangeCompleted()
 {
   if (!check_engage_condition_) {
-    RCLCPP_INFO(
-      logger_, "check_engage_condition is false. Mode change completion check is ignored.");
     return true;
   }
 
@@ -189,7 +187,6 @@ std::pair<bool, bool> AutonomousMode::hasDangerLateralAcceleration()
 bool AutonomousMode::isModeChangeAvailable()
 {
   if (!check_engage_condition_) {
-    RCLCPP_INFO(logger_, "check_engage_condition is false. Engage is accepted.");
     debug_info_.is_all_ok = true;
     return true;
   }

--- a/control/operation_mode_transition_manager/src/state.cpp
+++ b/control/operation_mode_transition_manager/src/state.cpp
@@ -42,10 +42,11 @@ AutonomousMode::AutonomousMode(rclcpp::Node * node)
   sub_trajectory_ = node->create_subscription<Trajectory>(
     "trajectory", 1, [this](const Trajectory::SharedPtr msg) { trajectory_ = *msg; });
 
+  check_engage_condition_ = node->declare_parameter<bool>("check_engage_condition");
+
   // params for mode change available
   {
     auto & p = engage_acceptable_param_;
-    p.check_engage_condition = node->declare_parameter<bool>("check_engage_condition");
     p.allow_autonomous_in_stopped =
       node->declare_parameter<bool>("engage_acceptable_limits.allow_autonomous_in_stopped");
     p.dist_threshold = node->declare_parameter<double>("engage_acceptable_limits.dist_threshold");
@@ -81,6 +82,12 @@ void AutonomousMode::update(bool transition)
 
 bool AutonomousMode::isModeChangeCompleted()
 {
+  if (!check_engage_condition_) {
+    RCLCPP_INFO(
+      logger_, "check_engage_condition is false. Mode change completion check is ignored.");
+    return true;
+  }
+
   constexpr auto dist_max = 5.0;
   constexpr auto yaw_max = M_PI_4;
 
@@ -181,8 +188,7 @@ std::pair<bool, bool> AutonomousMode::hasDangerLateralAcceleration()
 
 bool AutonomousMode::isModeChangeAvailable()
 {
-  const auto & param = engage_acceptable_param_;
-  if (!param.check_engage_condition) {
+  if (!check_engage_condition_) {
     RCLCPP_INFO(logger_, "check_engage_condition is false. Engage is accepted.");
     debug_info_.is_all_ok = true;
     return true;
@@ -193,6 +199,7 @@ bool AutonomousMode::isModeChangeAvailable()
 
   const auto current_speed = kinematics_.twist.twist.linear.x;
   const auto target_control_speed = control_cmd_.longitudinal.speed;
+  const auto & param = engage_acceptable_param_;
 
   if (trajectory_.points.size() < 2) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(

--- a/control/operation_mode_transition_manager/src/state.hpp
+++ b/control/operation_mode_transition_manager/src/state.hpp
@@ -72,6 +72,7 @@ private:
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
 
+  bool check_engage_condition_ = true;  // if false, the vehicle is engaged without any checks.
   EngageAcceptableParam engage_acceptable_param_;
   StableCheckParam stable_check_param_;
   AckermannControlCommand control_cmd_;

--- a/launch/tier4_control_launch/config/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
+++ b/launch/tier4_control_launch/config/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
@@ -2,6 +2,7 @@
   ros__parameters:
     transition_timeout: 10.0
     frequency_hz: 10.0
+    check_engage_condition: false # set false if you do not want to care about the engage condition.
     engage_acceptable_limits:
       allow_autonomous_in_stopped: true  # no check if the velocity is zero, always allowed.
       dist_threshold: 1.5


### PR DESCRIPTION
## Description

Add a parameter to ignore conditions of autonomous transition.
The aim is for a simple simulator or debug purpose. Now because the scenario simulator does not support the engage system appropriately, the simulation will not start moving when it has an initial velocity. 


To test, please check `is_all_ok` field in `/control/operation_mode_transition_manager/debug_info` is always true even the vehicle has an initial speed or pose deviation from path is very large.

## Related links

https://github.com/tier4/autoware_launch/pull/591

## Tests performed

Checked the vehicle can transit to automonous mode with an initial speed in the simple_planning_simulator 

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
