### PR TITLE
fix(trajectory_follower_nodes): mpc_follower does not send proper converged data under low steering rate limit

### DIFF
--- a/control/mpc_lateral_controller/README.md
+++ b/control/mpc_lateral_controller/README.md
@@ -34,12 +34,15 @@ For the optimization, a Quadratic Programming (QP) solver is used and two option
 <!-- cspell: ignore ADMM -->
 
 - unconstraint_fast : use least square method to solve unconstraint QP with eigen.
-- [osqp](https://osqp.org/): run the [following ADMM](https://web.stanford.edu/~boyd/papers/admm_distr_stats.html) algorithm (for more details see the related papers at the [Citing OSQP](https://web.stanford.edu/~boyd/papers/admm_distr_stats.html) section):
+- [osqp](https://osqp.org/): run the [following ADMM](https://web.stanford.edu/~boyd/papers/admm_distr_stats.html)
+  algorithm (for more details see the related papers at
+  the [Citing OSQP](https://web.stanford.edu/~boyd/papers/admm_distr_stats.html) section):
 
 ### Filtering
 
 Filtering is required for good noise reduction.
-A [Butterworth filter](https://en.wikipedia.org/wiki/Butterworth_filter) is used for the yaw and lateral errors used as input of the MPC as well as for
+A [Butterworth filter](https://en.wikipedia.org/wiki/Butterworth_filter) is used for the yaw and lateral errors used as
+input of the MPC as well as for
 the output steering angle.
 Other filtering methods can be considered as long as the noise reduction performances are good
 enough.
@@ -105,6 +108,7 @@ AutonomouStuff Lexus RX 450h for under 40 km/h driving.
 | keep_steer_control_until_converged           | bool   | keep steer control until steer is converged                                                                                                       | true          |
 | new_traj_duration_time                       | double | threshold value of the time to be considered as new trajectory                                                                                    | 1.0           |
 | new_traj_end_dist                            | double | threshold value of the distance between trajectory ends to be considered as new trajectory                                                        | 0.3           |
+| mpc_converged_threshold_rps                  | double | threshold value to be sure output of the optimization is converged, it is used in stopped state                                                   | 0.3           |
 
 (\*1) To prevent unnecessary steering movement, the steering command is fixed to the previous value in the stop state.
 
@@ -143,11 +147,13 @@ AutonomouStuff Lexus RX 450h for under 40 km/h driving.
 ### How to tune MPC parameters
 
 1. Set appropriate vehicle kinematics parameters for distance to front and rear axle and max steer angle.
-   Also check that the input `VehicleKinematicState` has appropriate values (speed: vehicle rear-wheels-center velocity [km/h], angle: steering (tire) angle [rad]).
+   Also check that the input `VehicleKinematicState` has appropriate values (speed: vehicle rear-wheels-center
+   velocity [km/h], angle: steering (tire) angle [rad]).
    These values give a vehicle information to the controller for path following.
    Errors in these values cause fundamental tracking error.
 
-2. Set appropriate vehicle dynamics parameters of `steering_tau`, which is the approximated delay from steering angle command to actual steering angle.
+2. Set appropriate vehicle dynamics parameters of `steering_tau`, which is the approximated delay from steering angle
+   command to actual steering angle.
 
 3. Set `weight_steering_input` = 1.0, `weight_lat_error` = 0.1, and other weights to 0.
    If the vehicle oscillates when driving with low speed, set `weight_lat_error` smaller.
@@ -156,7 +162,8 @@ AutonomouStuff Lexus RX 450h for under 40 km/h driving.
    One of the simple way for tuning is to increase `weight_lat_error` until oscillation occurs.
    If the vehicle is unstable with very small `weight_lat_error`, increase terminal weight :
    `weight_terminal_lat_error` and `weight_terminal_heading_error` to improve tracking stability.
-   Larger `prediction_horizon` and smaller `prediction_sampling_time` is effective for tracking performance, but it is a trade-off between computational costs.
+   Larger `prediction_horizon` and smaller `prediction_sampling_time` is effective for tracking performance, but it is a
+   trade-off between computational costs.
    Other parameters can be adjusted like below.
 
 - `weight_lat_error`: Reduce lateral tracking error. This acts like P gain in PID.
@@ -165,8 +172,10 @@ AutonomouStuff Lexus RX 450h for under 40 km/h driving.
 - `weight_steering_input`: Reduce oscillation of tracking.
 - `weight_steering_input_squared_vel_coeff`: Reduce oscillation of tracking in high speed range.
 - `weight_lat_jerk`: Reduce lateral jerk.
-- `weight_terminal_lat_error`: Preferable to set a higher value than normal lateral weight `weight_lat_error` for stability.
-- `weight_terminal_heading_error`: Preferable to set a higher value than normal heading weight `weight_heading_error` for stability.
+- `weight_terminal_lat_error`: Preferable to set a higher value than normal lateral weight `weight_lat_error` for
+  stability.
+- `weight_terminal_heading_error`: Preferable to set a higher value than normal heading weight `weight_heading_error`
+  for stability.
 
 ## References / External links
 

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
@@ -99,15 +99,31 @@ private:
   double m_stop_state_entry_ego_speed;
   double m_stop_state_entry_target_speed;
   double m_converged_steer_rad;
-  double m_new_traj_duration_time;  // check trajectory shape change
-  double m_new_traj_end_dist;       // check trajectory shape change
+  double m_mpc_converged_threshold_rps;  // max mpc output change threshold for 1 sec
+  double m_new_traj_duration_time;       // check trajectory shape change
+  double m_new_traj_end_dist;            // check trajectory shape change
   bool m_keep_steer_control_until_converged;
+
+  /* parameter to store the actual steering rate limit */
+  double m_steer_rate_lim;
 
   // trajectory buffer for detecting new trajectory
   std::deque<autoware_auto_planning_msgs::msg::Trajectory> m_trajectory_buffer;
 
   // MPC object
   MPC m_mpc;
+
+  // Check is mpc output converged
+  bool m_is_mpc_history_filled{false};
+
+  //!< @brief store the last mpc outputs for 1 sec
+  std::vector<std::pair<autoware_auto_control_msgs::msg::AckermannLateralCommand, rclcpp::Time>>
+    m_mpc_steering_history{};
+  //!< @brief set the mpc steering output to history
+  void setSteeringToHistory(
+    const autoware_auto_control_msgs::msg::AckermannLateralCommand & steering);
+  //!< @brief check if the mpc steering output is converged
+  bool isMpcConverged();
 
   //!< @brief measured kinematic state
   nav_msgs::msg::Odometry m_current_kinematic_state;

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
@@ -47,6 +47,7 @@
 #include <deque>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::motion::control::mpc_lateral_controller

--- a/control/mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
+++ b/control/mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
@@ -62,6 +62,7 @@
     keep_steer_control_until_converged: true
     new_traj_duration_time: 1.0
     new_traj_end_dist: 0.3
+    mpc_converged_threshold_rps: 0.01 # threshold of mpc convergence check [rad/s]
 
     # steer offset
     steering_offset:


### PR DESCRIPTION
Signed-off-by: Berkay Karaman <brkay54@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
Closes: https://github.com/autowarefoundation/autoware.universe/issues/1543

In current Autoware.universe, mpc_follower sends is_steer_converged data "true" to longitudinal controller without reaching the desired steering angle value.

The problem is that when reinitialize the vehicle under low steering angle rate limit, solver can not solve the problem and sends the previous command to vehicle rather than the target value.
Like before reinitialize previous cmd = 30.0 degree,
After we reinitialize vehicle, previous_cmd still 30.0 degree but target_value is maybe 0.0 degree ideally but because steering_angle_rate_limit so small, mpc can not solve the problem and sends 30.0 degree again and vehicle starts moving (because before re initialization, current steering was near to 30.0 degree.)

To solve this, I set mpc's steering_rate_limit large as possible if the vehicle in stop state (otherwise it will be what we declared), so It send the (expected) target steering without steering_rate_limit constraint.

Also I changed the logic of the `isSteerConverged()`. Like @kosuke55 said [here](https://github.com/autowarefoundation/autoware.universe/issues/1543#issuecomment-1323623075), mpc_follower will wait for the (prev_cmd == current_cmd) to be sure output will be the desired angle. Because mpc sends prev_cmd if mpc can not solve the problem, we are also checking is_mpc_calculated. 

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
