### PR TITLE
revert(default_ad_api): fix autoware state to add wait time (#2407)

### DIFF
--- a/system/default_ad_api/src/compatibility/autoware_state.hpp
+++ b/system/default_ad_api/src/compatibility/autoware_state.hpp
@@ -23,7 +23,6 @@
 #include <std_srvs/srv/trigger.hpp>
 #include <tier4_system_msgs/msg/mode_change_available.hpp>
 
-#include <optional>
 #include <vector>
 
 // This file should be included after messages.
@@ -60,9 +59,6 @@ private:
   LocalizationState localization_state_;
   RoutingState routing_state_;
   OperationModeState operation_mode_state_;
-
-  rclcpp::Time previous_stamp_;
-  std::optional<AutowareState::_state_type> previous_state_;
 
   void on_timer();
   void on_localization(const LocalizationState::ConstSharedPtr msg);


### PR DESCRIPTION
## Description

The simulator supports new state transition. Revert #2407.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
