### PR TITLE
feat(detection_by_tracker, shape_estimation): add trailer filter to properly track trailer shape

### DIFF
--- a/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
+++ b/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
@@ -80,8 +80,11 @@ private:
   std::shared_ptr<euclidean_cluster::EuclideanClusterInterface> cluster_;
   std::shared_ptr<Debugger> debugger_;
   std::map<uint8_t, int> max_search_distance_for_merger_;
+  std::map<uint8_t, int> max_search_distance_for_divider_;
 
   bool ignore_unknown_tracker_;
+
+  void setMaxSearchRange();
 
   void onObjects(
     const tier4_perception_msgs::msg::DetectedObjectsWithFeature::ConstSharedPtr input_msg);

--- a/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
+++ b/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
@@ -44,6 +44,7 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <deque>
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -78,6 +79,7 @@ private:
   std::shared_ptr<ShapeEstimator> shape_estimator_;
   std::shared_ptr<euclidean_cluster::EuclideanClusterInterface> cluster_;
   std::shared_ptr<Debugger> debugger_;
+  std::map<uint8_t, int> max_search_distance_for_merger_;
 
   bool ignore_unknown_tracker_;
 

--- a/perception/detection_by_tracker/src/detection_by_tracker_core.cpp
+++ b/perception/detection_by_tracker/src/detection_by_tracker_core.cpp
@@ -159,21 +159,37 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
 
   ignore_unknown_tracker_ = declare_parameter<bool>("ignore_unknown_tracker", true);
 
-  // set max search distance for each object
-  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
-  max_search_distance_for_merger_[Label::UNKNOWN] = 5.0;
-  max_search_distance_for_merger_[Label::CAR] = 5.0;
-  max_search_distance_for_merger_[Label::TRUCK] = 8.0;
-  max_search_distance_for_merger_[Label::BUS] = 8.0;
-  max_search_distance_for_merger_[Label::TRAILER] = 8.0;
-  max_search_distance_for_merger_[Label::MOTORCYCLE] = 2.0;
-  max_search_distance_for_merger_[Label::BICYCLE] = 1.0;
-  max_search_distance_for_merger_[Label::PEDESTRIAN] = 1.0;
+  // set maximum search setting for merger/divider
+  setMaxSearchRange();
 
   shape_estimator_ = std::make_shared<ShapeEstimator>(true, true);
   cluster_ = std::make_shared<euclidean_cluster::VoxelGridBasedEuclideanCluster>(
     false, 10, 10000, 0.7, 0.3, 0);
   debugger_ = std::make_shared<Debugger>(this);
+}
+
+void DetectionByTracker::setMaxSearchRange()
+{
+  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+  // set max search distance for merger
+  max_search_distance_for_merger_[Label::UNKNOWN] = 5.0;
+  max_search_distance_for_merger_[Label::CAR] = 5.0;
+  max_search_distance_for_merger_[Label::TRUCK] = 8.0;
+  max_search_distance_for_merger_[Label::BUS] = 8.0;
+  max_search_distance_for_merger_[Label::TRAILER] = 10.0;
+  max_search_distance_for_merger_[Label::MOTORCYCLE] = 2.0;
+  max_search_distance_for_merger_[Label::BICYCLE] = 1.0;
+  max_search_distance_for_merger_[Label::PEDESTRIAN] = 1.0;
+
+  // set max search distance for divider
+  max_search_distance_for_divider_[Label::UNKNOWN] = 6.0;
+  max_search_distance_for_divider_[Label::CAR] = 6.0;
+  max_search_distance_for_divider_[Label::TRUCK] = 9.0;
+  max_search_distance_for_divider_[Label::BUS] = 9.0;
+  max_search_distance_for_divider_[Label::TRAILER] = 11.0;
+  max_search_distance_for_divider_[Label::MOTORCYCLE] = 3.0;
+  max_search_distance_for_divider_[Label::BICYCLE] = 2.0;
+  max_search_distance_for_divider_[Label::PEDESTRIAN] = 2.0;
 }
 
 void DetectionByTracker::onObjects(
@@ -233,7 +249,6 @@ void DetectionByTracker::divideUnderSegmentedObjects(
 {
   constexpr float recall_min_threshold = 0.4;
   constexpr float precision_max_threshold = 0.5;
-  constexpr float max_search_range = 6.0;
   constexpr float min_score_threshold = 0.4;
 
   out_objects.header = in_cluster_objects.header;
@@ -242,6 +257,9 @@ void DetectionByTracker::divideUnderSegmentedObjects(
   for (const auto & tracked_object : tracked_objects.objects) {
     const auto & label = tracked_object.classification.front().label;
     if (ignore_unknown_tracker_ && (label == Label::UNKNOWN)) continue;
+
+    // change search range according to label type
+    const float max_search_range = max_search_distance_for_divider_[label];
 
     std::optional<tier4_perception_msgs::msg::DetectedObjectWithFeature>
       highest_score_divided_object = std::nullopt;

--- a/perception/shape_estimation/CMakeLists.txt
+++ b/perception/shape_estimation/CMakeLists.txt
@@ -24,6 +24,7 @@ ament_auto_add_library(shape_estimation_lib SHARED
   lib/filter/car_filter.cpp
   lib/filter/bus_filter.cpp
   lib/filter/truck_filter.cpp
+  lib/filter/trailer_filter.cpp
   lib/filter/no_filter.cpp
   lib/filter/utils.cpp
   lib/corrector/no_corrector.cpp

--- a/perception/shape_estimation/include/shape_estimation/corrector/corrector.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/corrector.hpp
@@ -20,6 +20,7 @@
 #include "shape_estimation/corrector/corrector_interface.hpp"
 #include "shape_estimation/corrector/no_corrector.hpp"
 #include "shape_estimation/corrector/reference_shape_size_corrector.hpp"
+#include "shape_estimation/corrector/trailer_corrector.hpp"
 #include "shape_estimation/corrector/truck_corrector.hpp"
 
 #endif  // SHAPE_ESTIMATION__CORRECTOR__CORRECTOR_HPP_

--- a/perception/shape_estimation/include/shape_estimation/corrector/trailer_corrector.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/trailer_corrector.hpp
@@ -1,0 +1,43 @@
+// Copyright 2018 Autoware Foundation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SHAPE_ESTIMATION__CORRECTOR__TRAILER_CORRECTOR_HPP_
+#define SHAPE_ESTIMATION__CORRECTOR__TRAILER_CORRECTOR_HPP_
+
+#include "shape_estimation/corrector/vehicle_corrector.hpp"
+#include "utils.hpp"
+
+// Generally speaking, trailer would be much larger than bus and truck.
+// But currently we do not make large differences among bus/truck/trailer
+// because current our vehicle classification is not reliable enough.
+class TrailerCorrector : public VehicleCorrector
+{
+public:
+  explicit TrailerCorrector(const bool use_reference_yaw = false)
+  : VehicleCorrector(use_reference_yaw)
+  {
+    corrector_utils::CorrectionBBParameters params;
+    params.min_width = 2.0;
+    params.max_width = 3.2;
+    params.default_width = (params.min_width + params.max_width) * 0.5;
+    params.min_length = 5.0;
+    params.max_length = 24.0;
+    params.default_length = 8.0;  // Ideally, it should be 12m from average Japanese trailer size.
+    setParams(params);
+  }
+
+  ~TrailerCorrector() = default;
+};
+
+#endif  // SHAPE_ESTIMATION__CORRECTOR__TRAILER_CORRECTOR_HPP_

--- a/perception/shape_estimation/include/shape_estimation/filter/filter.hpp
+++ b/perception/shape_estimation/include/shape_estimation/filter/filter.hpp
@@ -19,6 +19,7 @@
 #include "shape_estimation/filter/car_filter.hpp"
 #include "shape_estimation/filter/filter_interface.hpp"
 #include "shape_estimation/filter/no_filter.hpp"
+#include "shape_estimation/filter/trailer_filter.hpp"
 #include "shape_estimation/filter/truck_filter.hpp"
 
 #endif  // SHAPE_ESTIMATION__FILTER__FILTER_HPP_

--- a/perception/shape_estimation/include/shape_estimation/filter/trailer_filter.hpp
+++ b/perception/shape_estimation/include/shape_estimation/filter/trailer_filter.hpp
@@ -12,14 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "shape_estimation/filter/truck_filter.hpp"
+#ifndef SHAPE_ESTIMATION__FILTER__TRAILER_FILTER_HPP_
+#define SHAPE_ESTIMATION__FILTER__TRAILER_FILTER_HPP_
 
-bool TruckFilter::filter(
-  const autoware_auto_perception_msgs::msg::Shape & shape,
-  [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
+#include "shape_estimation/filter/filter_interface.hpp"
+#include "utils.hpp"
+
+class TrailerFilter : public ShapeEstimationFilterInterface
 {
-  constexpr float min_width = 1.5;
-  constexpr float max_width = 3.2;
-  constexpr float max_length = 7.9;  // upto 12m in japanese law
-  return utils::filterVehicleBoundingBox(shape, min_width, max_width, max_length);
-}
+public:
+  TrailerFilter() = default;
+
+  ~TrailerFilter() = default;
+
+  bool filter(
+    const autoware_auto_perception_msgs::msg::Shape & shape,
+    const geometry_msgs::msg::Pose & pose) override;
+};
+
+#endif  // SHAPE_ESTIMATION__FILTER__TRAILER_FILTER_HPP_

--- a/perception/shape_estimation/lib/filter/trailer_filter.cpp
+++ b/perception/shape_estimation/lib/filter/trailer_filter.cpp
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "shape_estimation/filter/truck_filter.hpp"
+#include "shape_estimation/filter/trailer_filter.hpp"
 
-bool TruckFilter::filter(
+bool TrailerFilter::filter(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
 {
   constexpr float min_width = 1.5;
   constexpr float max_width = 3.2;
-  constexpr float max_length = 7.9;  // upto 12m in japanese law
+  constexpr float max_length = 25.0;  // maximum Full-TRAILER size in JAPAN(normally upto 18m)
   return utils::filterVehicleBoundingBox(shape, min_width, max_width, max_length);
 }

--- a/perception/shape_estimation/lib/shape_estimator.cpp
+++ b/perception/shape_estimation/lib/shape_estimator.cpp
@@ -92,8 +92,10 @@ bool ShapeEstimator::applyFilter(
     filter_ptr.reset(new CarFilter);
   } else if (label == Label::BUS) {
     filter_ptr.reset(new BusFilter);
-  } else if (label == Label::TRUCK || label == Label::TRAILER) {
+  } else if (label == Label::TRUCK) {
     filter_ptr.reset(new TruckFilter);
+  } else if (label == Label::TRAILER) {
+    filter_ptr.reset(new TrailerFilter);
   } else {
     filter_ptr.reset(new NoFilter);
   }

--- a/perception/shape_estimation/lib/shape_estimator.cpp
+++ b/perception/shape_estimation/lib/shape_estimator.cpp
@@ -116,8 +116,10 @@ bool ShapeEstimator::applyCorrector(
     corrector_ptr.reset(new CarCorrector(use_reference_yaw));
   } else if (label == Label::BUS) {
     corrector_ptr.reset(new BusCorrector(use_reference_yaw));
-  } else if (label == Label::TRUCK || label == Label::TRAILER) {
+  } else if (label == Label::TRUCK) {
     corrector_ptr.reset(new TruckCorrector(use_reference_yaw));
+  } else if (label == Label::TRAILER) {
+    corrector_ptr.reset(new TrailerCorrector(use_reference_yaw));
   } else {
     corrector_ptr.reset(new NoCorrector);
   }


### PR DESCRIPTION
Signed-off-by: yoshiri <yoshiyoshidetteiu@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

### Outline

Fixed problem that trailer in the sample rosbag tutorial not merging.


|before|after|
|--|--|
|![image](https://user-images.githubusercontent.com/20086766/211997517-eab8b521-da0c-42d1-b7e4-61acbc984488.png)|![image](https://user-images.githubusercontent.com/20086766/211997577-543ce8ad-38d5-4b3d-807c-6e7f060c1091.png)|

### Problem

Trailer object tends to split due to relatively narrow search/merge range.

###  Updated packages

- **detection_by_tracker**: use adaptive range in merging objects
  - use adaptive max_distance threshold in merging objects 
- **shape estimation** : add filter/corrector for trailer 
  - trailer used max size threshold of truck (7.9m), but actual trailer is up to 18-25m
  - so add trailer threshold config and use it in shape_estimation function   


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
