### PR TITLE
feat(motion_utils): add points resample function

### DIFF
--- a/common/motion_utils/include/motion_utils/resample/resample.hpp
+++ b/common/motion_utils/include/motion_utils/resample/resample.hpp
@@ -38,6 +38,42 @@
 namespace motion_utils
 {
 /**
+ * @brief A resampling function for a path(points). Note that in a default setting, position xy are
+ *        resampled by spline interpolation, position z are resampled by linear interpolation, and
+ *        orientation of the resampled path are calculated by a forward difference method
+ *        based on the interpolated position x and y.
+ * @param input_path input path(point) to resample
+ * @param resampled_arclength arclength that contains length of each resampling points from initial
+ *        point
+ * @param use_lerp_for_xy If true, it uses linear interpolation to resample position x and
+ *        y. Otherwise, it uses spline interpolation
+ * @param use_lerp_for_z If true, it uses linear interpolation to resample position z.
+ *        Otherwise, it uses spline interpolation
+ * @return resampled path(poses)
+ */
+std::vector<geometry_msgs::msg::Point> resamplePointVector(
+  const std::vector<geometry_msgs::msg::Point> & points,
+  const std::vector<double> & resampled_arclength, const bool use_lerp_for_xy = false,
+  const bool use_lerp_for_z = true);
+
+/**
+ * @brief A resampling function for a path(position). Note that in a default setting, position xy
+ * are resampled by spline interpolation, position z are resampled by linear interpolation, and
+ *        orientation of the resampled path are calculated by a forward difference method
+ *        based on the interpolated position x and y.
+ * @param input_path input path(position) to resample
+ * @param resample_interval resampling interval
+ * @param use_lerp_for_xy If true, it uses linear interpolation to resample position x and
+ *        y. Otherwise, it uses spline interpolation
+ * @param use_lerp_for_z If true, it uses linear interpolation to resample position z.
+ *        Otherwise, it uses spline interpolation
+ * @return resampled path(poses)
+ */
+std::vector<geometry_msgs::msg::Point> resamplePositionVector(
+  const std::vector<geometry_msgs::msg::Point> & points, const double resample_interval,
+  const bool use_lerp_for_xy = false, const bool use_lerp_for_z = true);
+
+/**
  * @brief A resampling function for a path(poses). Note that in a default setting, position xy are
  *        resampled by spline interpolation, position z are resampled by linear interpolation, and
  *        orientation of the resampled path are calculated by a forward difference method
@@ -70,7 +106,7 @@ std::vector<geometry_msgs::msg::Pose> resamplePoseVector(
  * @return resampled path(poses)
  */
 std::vector<geometry_msgs::msg::Pose> resamplePoseVector(
-  const std::vector<geometry_msgs::msg::Pose> & points, const double resampled_interval,
+  const std::vector<geometry_msgs::msg::Pose> & points, const double resample_interval,
   const bool use_lerp_for_xy = false, const bool use_lerp_for_z = true);
 
 /**


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
Add resampling functions for geometry_msgs::msg::Point. This enables users to use resampling functions for points vector.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Unit Test
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
