### PR TITLE
fix(tier4_autoware_api_launch): add rosbridge_server dependency

### DIFF
--- a/launch/tier4_autoware_api_launch/package.xml
+++ b/launch/tier4_autoware_api_launch/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>awapi_awiv_adapter</exec_depend>
   <exec_depend>default_ad_api</exec_depend>
   <exec_depend>path_distance_calculator</exec_depend>
+  <exec_depend>rosbridge_server</exec_depend>
   <exec_depend>topic_tools</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

Due to https://github.com/autowarefoundation/autoware.universe/pull/2405 removing rosbridge_server dependency, currently the build failed.
![image](https://user-images.githubusercontent.com/20228327/206217069-627c32f4-76df-469d-a0a8-84346bdb1c1c.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
