### PR TITLE
fix(emergency_handler): fix mrm handling when mrm behavior is none

### DIFF
--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -224,6 +224,10 @@ void EmergencyHandler::callMrmBehavior(
   auto request = std::make_shared<tier4_system_msgs::srv::OperateMrm::Request>();
   request->operate = true;
 
+  if (mrm_behavior == MrmState::NONE) {
+    RCLCPP_WARN(this->get_logger(), "MRM behavior is None. Do nothing.");
+    return;
+  }
   if (mrm_behavior == MrmState::COMFORTABLE_STOP) {
     auto result = client_mrm_comfortable_stop_->async_send_request(request).get();
     if (result->response.success == true) {
@@ -253,6 +257,10 @@ void EmergencyHandler::cancelMrmBehavior(
   auto request = std::make_shared<tier4_system_msgs::srv::OperateMrm::Request>();
   request->operate = false;
 
+  if (mrm_behavior == MrmState::NONE) {
+    // Do nothing
+    return;
+  }
   if (mrm_behavior == MrmState::COMFORTABLE_STOP) {
     auto result = client_mrm_comfortable_stop_->async_send_request(request).get();
     if (result->response.success == true) {


### PR DESCRIPTION
Signed-off-by: Makoto Kurihara <mkuri8m@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
![mrm-behavior-state-machine](https://user-images.githubusercontent.com/876355/206394273-f113e9a8-530a-4c34-815d-547e93d68822.png)
When each MRM behavior is called from the MRM None behavior, a process to cancel the None behavior is called.
But there was no corresponding process to cancel the None behavior, so a warning was displayed.

Add a handler for MRM None behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
