### PR TITLE
fix(trajectory_follower): fix mpc trajectory z pos

### DIFF
--- a/control/trajectory_follower/src/mpc_utils.cpp
+++ b/control/trajectory_follower/src/mpc_utils.cpp
@@ -230,7 +230,7 @@ bool convertToMPCTrajectory(
   for (const autoware_auto_planning_msgs::msg::TrajectoryPoint & p : input.points) {
     const double x = p.pose.position.x;
     const double y = p.pose.position.y;
-    const double z = 0.0;
+    const double z = p.pose.position.z;
     const double yaw = tf2::getYaw(p.pose.orientation);
     const double vx = p.longitudinal_velocity_mps;
     const double k = 0.0;


### PR DESCRIPTION

## Description

Fix `z` position on mpc trajectory.

**Before**
![Screenshot from 2022-12-09 14-34-39](https://user-images.githubusercontent.com/21360593/206644228-bb99d188-65b6-4358-8af0-aa2c65eb9963.png)


**After**
![Screenshot from 2022-12-09 14-38-29](https://user-images.githubusercontent.com/21360593/206644257-77971b76-98b7-4da7-8de7-69a11a5947d9.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
