### PR TITLE
chore(simulator_compatibility_test): suppress setuptools warnings

### DIFF
--- a/tools/simulator_test/simulator_compatibility_test/setup.py
+++ b/tools/simulator_test/simulator_compatibility_test/setup.py
@@ -1,4 +1,11 @@
+from warnings import simplefilter
+
+from pkg_resources import PkgResourcesDeprecationWarning
+from setuptools import SetuptoolsDeprecationWarning
 from setuptools import setup
+
+simplefilter("ignore", category=SetuptoolsDeprecationWarning)
+simplefilter("ignore", category=PkgResourcesDeprecationWarning)
 
 package_name = "simulator_compatibility_test"
 clients = "simulator_compatibility_test/clients/"


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Suppress these warnings because I found a comment that the fix had many disadvantages in the discussion of ament or colcon,
* https://github.com/colcon/colcon-core/issues/454
* https://github.com/ament/ament_cmake/issues/382

```
EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
PkgResourcesDeprecationWarning: 1.16.0-unknown is an invalid version and will not be supported in a future release
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
