### PR TITLE
fix: rename `use_external_emergency_stop` to  `check_external_emergency_heartbeat` (#2455)

### DIFF
--- a/control/vehicle_cmd_gate/README.md
+++ b/control/vehicle_cmd_gate/README.md
@@ -48,7 +48,7 @@
 | ------------------------------------------- | ------ | --------------------------------------------------------------------------- |
 | `update_period`                             | double | update period                                                               |
 | `use_emergency_handling`                    | bool   | true when emergency handler is used                                         |
-| `use_external_emergency_stop`               | bool   | true when external emergency stop information is used                       |
+| `check_external_emergency_heartbeat`        | bool   | true when checking heartbeat for emergency stop                             |
 | `system_emergency_heartbeat_timeout`        | double | timeout for system emergency                                                |
 | `external_emergency_stop_heartbeat_timeout` | double | timeout for external emergency                                              |
 | `stop_hold_acceleration`                    | double | longitudinal acceleration cmd when vehicle should stop                      |
@@ -66,6 +66,6 @@
 
 ## Assumptions / Known limits
 
-The parameter `use_external_emergency_stop` (true by default) enables an emergency stop request from external modules.
+The parameter `check_external_emergency_heartbeat` (true by default) enables an emergency stop request from external modules.
 This feature requires a `~/input/external_emergency_stop_heartbeat` topic for health monitoring of the external module, and the vehicle_cmd_gate module will not start without the topic.
-The `use_external_emergency_stop` parameter must be false when the "external emergency stop" function is not used.
+The `check_external_emergency_heartbeat` parameter must be false when the "external emergency stop" function is not used.

--- a/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
+++ b/control/vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <arg name="config_file" default="$(find-pkg-share vehicle_cmd_gate)/config/vehicle_cmd_gate.param.yaml"/>
   <arg name="use_emergency_handling" default="false"/>
-  <arg name="use_external_emergency_stop" default="true"/>
+  <arg name="check_external_emergency_heartbeat" default="true"/>
   <arg name="use_start_request" default="false"/>
 
   <!-- vehicle info -->
@@ -48,7 +48,7 @@
     <param from="$(var config_file)"/>
     <param from="$(var vehicle_info_param_file)"/>
     <param name="use_emergency_handling" value="$(var use_emergency_handling)"/>
-    <param name="use_external_emergency_stop" value="$(var use_external_emergency_stop)"/>
+    <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
     <param name="use_start_request" value="$(var use_start_request)"/>
   </node>
 </launch>

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -128,7 +128,8 @@ VehicleCmdGate::VehicleCmdGate(const rclcpp::NodeOptions & node_options)
   // Parameter
   update_period_ = 1.0 / declare_parameter("update_rate", 10.0);
   use_emergency_handling_ = declare_parameter("use_emergency_handling", false);
-  use_external_emergency_stop_ = declare_parameter("use_external_emergency_stop", false);
+  check_external_emergency_heartbeat_ =
+    declare_parameter("check_external_emergency_heartbeat", false);
   system_emergency_heartbeat_timeout_ =
     declare_parameter("system_emergency_heartbeat_timeout", 0.5);
   external_emergency_stop_heartbeat_timeout_ =
@@ -224,7 +225,7 @@ bool VehicleCmdGate::isDataReady()
     }
   }
 
-  if (use_external_emergency_stop_) {
+  if (check_external_emergency_heartbeat_) {
     if (!external_emergency_stop_heartbeat_received_time_) {
       RCLCPP_WARN(get_logger(), "external_emergency_stop_heartbeat_received_time_ is false");
       return false;
@@ -322,7 +323,7 @@ void VehicleCmdGate::onTimer()
   }
 
   // Check external emergency stop heartbeat
-  if (use_external_emergency_stop_) {
+  if (check_external_emergency_heartbeat_) {
     is_external_emergency_stop_heartbeat_timeout_ = isHeartbeatTimeout(
       external_emergency_stop_heartbeat_received_time_, external_emergency_stop_heartbeat_timeout_);
 

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
@@ -160,7 +160,7 @@ private:
   // Parameter
   double update_period_;
   bool use_emergency_handling_;
-  bool use_external_emergency_stop_;
+  bool check_external_emergency_heartbeat_;
   double system_emergency_heartbeat_timeout_;
   double external_emergency_stop_heartbeat_timeout_;
   double stop_hold_acceleration_;

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -209,7 +209,9 @@ def launch_setup(context, *args, **kwargs):
             vehicle_info_param,
             {
                 "use_emergency_handling": LaunchConfiguration("use_emergency_handling"),
-                "use_external_emergency_stop": LaunchConfiguration("use_external_emergency_stop"),
+                "check_external_emergency_heartbeat": LaunchConfiguration(
+                    "check_external_emergency_heartbeat"
+                ),
                 "use_start_request": LaunchConfiguration("use_start_request"),
             },
         ],
@@ -374,7 +376,7 @@ def generate_launch_description():
 
     # vehicle cmd gate
     add_launch_arg("use_emergency_handling", "false", "use emergency handling")
-    add_launch_arg("use_external_emergency_stop", "true", "use external emergency stop")
+    add_launch_arg("check_external_emergency_heartbeat", "true", "use external emergency stop")
     add_launch_arg("use_start_request", "false", "use start request service")
 
     # external cmd selector


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR cherry picked https://github.com/autowarefoundation/autoware.universe/pull/2455 to upgrade the galactic branch.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
