### PR TITLE
feat(behavior_path_planner): change turn signal output timing

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -627,23 +627,6 @@ void BehaviorPathPlannerNode::run()
 
   // update planner data
   planner_data_->prev_output_path = path;
-  mutex_pd_.unlock();
-
-  // publish drivable bounds
-  publish_bounds(*path);
-
-  const size_t target_idx = findEgoIndex(path->points);
-  util::clipPathLength(*path, target_idx, planner_data_->parameters);
-
-  if (!path->points.empty()) {
-    path_publisher_->publish(*path);
-  } else {
-    RCLCPP_ERROR_THROTTLE(
-      get_logger(), *get_clock(), 5000, "behavior path output is empty! Stop publish.");
-  }
-
-  const auto path_candidate = getPathCandidate(output, planner_data);
-  path_candidate_publisher_->publish(util::toPath(*path_candidate));
 
   // for turn signal
   {
@@ -664,6 +647,25 @@ void BehaviorPathPlannerNode::run()
 
     publish_steering_factor(turn_signal);
   }
+
+  // unlock planner data
+  mutex_pd_.unlock();
+
+  // publish drivable bounds
+  publish_bounds(*path);
+
+  const size_t target_idx = findEgoIndex(path->points);
+  util::clipPathLength(*path, target_idx, planner_data_->parameters);
+
+  if (!path->points.empty()) {
+    path_publisher_->publish(*path);
+  } else {
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 5000, "behavior path output is empty! Stop publish.");
+  }
+
+  const auto path_candidate = getPathCandidate(output, planner_data);
+  path_candidate_publisher_->publish(util::toPath(*path_candidate));
 
   publishSceneModuleDebugMsg();
 


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
As mentioned in [this issue](https://github.com/autowarefoundation/autoware.universe/issues/2422), the turn signal decider uses planner data after mutex is unlocked. This sometimes causes serious problems when generating blinkers. In order to fix this problem, I moved the turn signal decider code before the behavior path planner unlocks the mutex_pd_. 
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
