### PR TITLE
feat(behavior_path_planner): fix overlap checker

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -288,7 +288,7 @@ std::vector<DrivableLanes> generateDrivableLanes(const lanelet::ConstLanelets & 
 std::vector<DrivableLanes> generateDrivableLanesWithShoulderLanes(
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & shoulder_lanes);
 
-size_t getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes);
+boost::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes);
 std::vector<DrivableLanes> cutOverlappedLanes(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes);
 

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -73,6 +73,32 @@ size_t findNearestSegmentIndex(
 
   return motion_utils::findNearestSegmentIndex(points, pose.position);
 }
+
+template <class T>
+size_t findNearestSegmentIndexFromLateralDistance(
+  const std::vector<T> & points, const geometry_msgs::msg::Pose & pose)
+{
+  size_t closest_idx = motion_utils::findNearestSegmentIndex(points, pose.position);
+  double min_lateral_dist =
+    motion_utils::calcLongitudinalOffsetToSegment(points, closest_idx, pose.position);
+  for (size_t seg_idx = 0; seg_idx < points.size() - 1; ++seg_idx) {
+    const double lon_dist =
+      motion_utils::calcLongitudinalOffsetToSegment(points, seg_idx, pose.position);
+    const double segment_length =
+      tier4_autoware_utils::calcDistance2d(points.at(seg_idx), points.at(seg_idx + 1));
+    if (lon_dist < 0.0 || segment_length < lon_dist) {
+      continue;
+    }
+
+    const double lat_dist =
+      std::fabs(motion_utils::calcLateralOffset(points, pose.position, seg_idx));
+    if (lat_dist < min_lateral_dist) {
+      closest_idx = seg_idx;
+    }
+  }
+
+  return closest_idx;
+}
 }  // namespace
 
 namespace behavior_path_planner::util
@@ -991,7 +1017,7 @@ std::vector<DrivableLanes> generateDrivableLanesWithShoulderLanes(
   return drivable_lanes;
 }
 
-size_t getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes)
+boost::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes)
 {
   auto overlaps = [](const DrivableLanes & lanes, const DrivableLanes & target_lanes) {
     const auto lanelets = transformToLanelets(lanes);
@@ -999,7 +1025,7 @@ size_t getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes)
 
     for (const auto & lanelet : lanelets) {
       for (const auto & target_lanelet : target_lanelets) {
-        if (boost::geometry::overlaps(
+        if (boost::geometry::intersects(
               lanelet.polygon2d().basicPolygon(), target_lanelet.polygon2d().basicPolygon())) {
           return true;
         }
@@ -1011,7 +1037,7 @@ size_t getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes)
   };
 
   if (lanes.size() <= 2) {
-    return lanes.size();
+    return {};
   }
 
   size_t overlapped_idx = lanes.size();
@@ -1029,15 +1055,15 @@ size_t getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes)
 std::vector<DrivableLanes> cutOverlappedLanes(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes)
 {
-  const size_t overlapped_lanelet_id = getOverlappedLaneletId(lanes);
-  if (overlapped_lanelet_id == lanes.size()) {
+  const auto overlapped_lanelet_id = getOverlappedLaneletId(lanes);
+  if (!overlapped_lanelet_id) {
     return lanes;
   }
 
   const std::vector<DrivableLanes> shorten_lanes{
-    lanes.begin(), lanes.begin() + overlapped_lanelet_id};
+    lanes.begin(), lanes.begin() + *overlapped_lanelet_id};
   const std::vector<DrivableLanes> removed_lanes{
-    lanes.begin() + overlapped_lanelet_id, lanes.end()};
+    lanes.begin() + *overlapped_lanelet_id, lanes.end()};
 
   const auto transformed_lanes = util::transformToLanelets(removed_lanes);
 
@@ -1064,16 +1090,6 @@ std::vector<DrivableLanes> cutOverlappedLanes(
   }
 
   return shorten_lanes;
-}
-
-size_t findNearestSegmentIndex(
-  const std::vector<geometry_msgs::msg::Pose> & points, const geometry_msgs::msg::Pose & pose,
-  const double dist_threshold, const double yaw_threshold)
-{
-  const auto nearest_idx =
-    motion_utils::findNearestSegmentIndex(points, pose, dist_threshold, yaw_threshold);
-  return nearest_idx ? nearest_idx.get()
-                     : motion_utils::findNearestSegmentIndex(points, pose.position);
 }
 
 geometry_msgs::msg::Pose calcLongitudinalOffsetStartPose(
@@ -1111,9 +1127,6 @@ void generateDrivableArea(
   const auto transformed_lanes = util::transformToLanelets(lanes);
   const auto current_pose = planner_data->self_pose;
   const auto route_handler = planner_data->route_handler;
-  const auto & param = planner_data->parameters;
-  const double dist_threshold = std::numeric_limits<double>::max();
-  const double yaw_threshold = param.ego_nearest_yaw_threshold;
   constexpr double overlap_threshold = 0.01;
 
   auto addLeftBoundPoints = [&left_bound](const lanelet::ConstLanelet & lane) {
@@ -1149,10 +1162,31 @@ void generateDrivableArea(
     addRightBoundPoints(lane.right_lane);
   }
 
+  const auto has_same_lane = [&](const auto & lane) {
+    if (lanes.empty()) return false;
+    const auto has_same = [&](const auto & ll) { return ll.id() == lane.id(); };
+    return std::find_if(transformed_lanes.begin(), transformed_lanes.end(), has_same) !=
+           transformed_lanes.end();
+  };
+
+  const auto has_overlap = [&](const auto & lane) {
+    for (const auto & transformed_lane : transformed_lanes) {
+      if (boost::geometry::intersects(
+            lane.polygon2d().basicPolygon(), transformed_lane.polygon2d().basicPolygon())) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   // Insert points after goal
   if (containsGoal(transformed_lanes, route_handler->getGoalLaneId())) {
     const auto lanes_after_goal = route_handler->getLanesAfterGoal(vehicle_length);
     for (const auto & lane : lanes_after_goal) {
+      if (has_same_lane(lane) || has_overlap(lane)) {
+        continue;
+      }
+      std::cerr << "after goal id: " << lane.id() << std::endl;
       addLeftBoundPoints(lane);
       addRightBoundPoints(lane);
     }
@@ -1166,32 +1200,46 @@ void generateDrivableArea(
   constexpr double front_length = 0.5;
   const auto front_pose = path.points.empty() ? current_pose->pose : path.points.front().point.pose;
   const size_t front_left_start_idx =
-    findNearestSegmentIndex(left_bound, front_pose, dist_threshold, yaw_threshold);
+    findNearestSegmentIndexFromLateralDistance(left_bound, front_pose);
   const size_t front_right_start_idx =
-    findNearestSegmentIndex(right_bound, front_pose, dist_threshold, yaw_threshold);
+    findNearestSegmentIndexFromLateralDistance(right_bound, front_pose);
   const auto left_start_pose =
     calcLongitudinalOffsetStartPose(left_bound, front_pose, front_left_start_idx, -front_length);
   const auto right_start_pose =
     calcLongitudinalOffsetStartPose(right_bound, front_pose, front_right_start_idx, -front_length);
   const size_t left_start_idx =
-    findNearestSegmentIndex(left_bound, left_start_pose, dist_threshold, yaw_threshold);
+    findNearestSegmentIndexFromLateralDistance(left_bound, left_start_pose);
   const size_t right_start_idx =
-    findNearestSegmentIndex(right_bound, right_start_pose, dist_threshold, yaw_threshold);
+    findNearestSegmentIndexFromLateralDistance(right_bound, right_start_pose);
+
+  std::cerr << "front_left_start_idx: " << front_left_start_idx << std::endl;
+  std::cerr << "front_right_start_idx: " << front_right_start_idx << std::endl;
+  std::cerr << "left_start_idx: " << left_start_idx << std::endl;
+  std::cerr << "right_start_idx: " << right_start_idx << std::endl;
 
   // Get Closest segment for the goal point
   const auto goal_pose = path.points.empty() ? current_pose->pose : path.points.back().point.pose;
   const size_t goal_left_start_idx =
-    findNearestSegmentIndex(left_bound, goal_pose, dist_threshold, yaw_threshold);
+    findNearestSegmentIndexFromLateralDistance(left_bound, goal_pose);
   const size_t goal_right_start_idx =
-    findNearestSegmentIndex(right_bound, goal_pose, dist_threshold, yaw_threshold);
+    findNearestSegmentIndexFromLateralDistance(right_bound, goal_pose);
   const auto left_goal_pose =
     calcLongitudinalOffsetGoalPose(left_bound, goal_pose, goal_left_start_idx, vehicle_length);
   const auto right_goal_pose =
     calcLongitudinalOffsetGoalPose(right_bound, goal_pose, goal_right_start_idx, vehicle_length);
   const size_t left_goal_idx =
-    findNearestSegmentIndex(left_bound, left_goal_pose, dist_threshold, yaw_threshold);
+    findNearestSegmentIndexFromLateralDistance(left_bound, left_goal_pose);
   const size_t right_goal_idx =
-    findNearestSegmentIndex(right_bound, right_goal_pose, dist_threshold, yaw_threshold);
+    findNearestSegmentIndexFromLateralDistance(right_bound, right_goal_pose);
+
+  std::cerr << "goal_left_start_idx: " << goal_left_start_idx << std::endl;
+  std::cerr << "goal_right_start_idx: " << goal_right_start_idx << std::endl;
+  std::cerr << "left_goal_idx: " << left_goal_idx << std::endl;
+  std::cerr << "right_goal_idx: " << right_goal_idx << std::endl;
+
+  for (const auto & transformed_lane : transformed_lanes) {
+    std::cerr << "id: " << transformed_lane.id() << std::endl;
+  }
 
   // Store Data
   path.left_bound.clear();

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1186,7 +1186,6 @@ void generateDrivableArea(
       if (has_same_lane(lane) || has_overlap(lane)) {
         continue;
       }
-      std::cerr << "after goal id: " << lane.id() << std::endl;
       addLeftBoundPoints(lane);
       addRightBoundPoints(lane);
     }
@@ -1212,11 +1211,6 @@ void generateDrivableArea(
   const size_t right_start_idx =
     findNearestSegmentIndexFromLateralDistance(right_bound, right_start_pose);
 
-  std::cerr << "front_left_start_idx: " << front_left_start_idx << std::endl;
-  std::cerr << "front_right_start_idx: " << front_right_start_idx << std::endl;
-  std::cerr << "left_start_idx: " << left_start_idx << std::endl;
-  std::cerr << "right_start_idx: " << right_start_idx << std::endl;
-
   // Get Closest segment for the goal point
   const auto goal_pose = path.points.empty() ? current_pose->pose : path.points.back().point.pose;
   const size_t goal_left_start_idx =
@@ -1232,20 +1226,9 @@ void generateDrivableArea(
   const size_t right_goal_idx =
     findNearestSegmentIndexFromLateralDistance(right_bound, right_goal_pose);
 
-  std::cerr << "goal_left_start_idx: " << goal_left_start_idx << std::endl;
-  std::cerr << "goal_right_start_idx: " << goal_right_start_idx << std::endl;
-  std::cerr << "left_goal_idx: " << left_goal_idx << std::endl;
-  std::cerr << "right_goal_idx: " << right_goal_idx << std::endl;
-
-  for (const auto & transformed_lane : transformed_lanes) {
-    std::cerr << "id: " << transformed_lane.id() << std::endl;
-  }
-
   // Store Data
   path.left_bound.clear();
   path.right_bound.clear();
-  path.left_bound.reserve(left_goal_idx - left_start_idx);
-  path.right_bound.reserve(right_goal_idx - right_start_idx);
 
   // Insert a start point
   path.left_bound.push_back(left_start_pose.position);


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
In the current code, the behavior path planner cannot check the overlapped lanes correctly. In this PR, I used different function from boost geometry so that it can compute overlapped lanes correclty.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
