### PR TITLE
fix(behavior_path_planner): fix find nearest function from lateral distance

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -80,7 +80,8 @@ size_t findNearestSegmentIndexFromLateralDistance(
 {
   size_t closest_idx = motion_utils::findNearestSegmentIndex(points, pose.position);
   double min_lateral_dist =
-    motion_utils::calcLongitudinalOffsetToSegment(points, closest_idx, pose.position);
+    std::fabs(motion_utils::calcLateralOffset(points, pose.position, closest_idx));
+
   for (size_t seg_idx = 0; seg_idx < points.size() - 1; ++seg_idx) {
     const double lon_dist =
       motion_utils::calcLongitudinalOffsetToSegment(points, seg_idx, pose.position);
@@ -94,6 +95,7 @@ size_t findNearestSegmentIndexFromLateralDistance(
       std::fabs(motion_utils::calcLateralOffset(points, pose.position, seg_idx));
     if (lat_dist < min_lateral_dist) {
       closest_idx = seg_idx;
+      min_lateral_dist = lat_dist;
     }
   }
 


### PR DESCRIPTION
## Description
There is some bug in the find nearest function from the lateral distance function, so I fixed it in this PR.

- Before this PR
![image](https://user-images.githubusercontent.com/43805014/207507457-abc3f3b4-f8c1-442a-9495-11af0a70cc30.png)

- After this PR
![image](https://user-images.githubusercontent.com/43805014/207507468-2ae8d678-08b0-450b-a2b3-0d2d40b57969.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
