### PR TITLE
fix(behavior_path_planner): fix planner data copy

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -618,7 +618,11 @@ void BehaviorPathPlannerNode::run()
   // update planner data
   planner_data_->self_pose = self_pose_listener_.getCurrentPose();
 
-  const auto planner_data = planner_data_;
+  const auto planner_data = std::make_shared<PlannerData>(*planner_data_);
+
+  // unlock planner data
+  mutex_pd_.unlock();
+
   // run behavior planner
   const auto output = bt_manager_->run(planner_data);
 
@@ -630,9 +634,6 @@ void BehaviorPathPlannerNode::run()
 
   // compute turn signal
   computeTurnSignal(planner_data, *path, output);
-
-  // unlock planner data
-  mutex_pd_.unlock();
 
   // publish drivable bounds
   publish_bounds(*path);


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
Since it uses `shared_ptr` for `planner_data_`, it is not appropriate to copy it while using tmux. In this PR, I created a new shared_ptr to copy `planner_data_` to `planner_data`. 
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
