### PR TITLE
feat(avoidance): implement yield maneuver in avoidance module

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -11,6 +11,7 @@
       enable_avoidance_over_opposite_direction: true
       enable_update_path_when_object_is_gone: false
       enable_safety_check: false
+      enable_yield_maneuver: false
 
       # For target object filtering
       threshold_speed_object_is_stopped: 1.0      # [m/s]
@@ -30,11 +31,13 @@
       safety_check_time_horizon: 10.0             # [s]
       safety_check_idling_time: 1.5               # [s]
       safety_check_accel_for_rss: 2.5             # [m/ss]
+      safety_check_hysteresis_factor: 2.0         # [-]
 
       # For lateral margin
       object_envelope_buffer: 0.3                 # [m]
       lateral_collision_margin: 1.0               # [m]
       lateral_collision_safety_buffer: 0.7        # [m]
+      lateral_passable_safety_buffer: 0.5         # [m]
 
       # For longitudinal margin
       longitudinal_collision_margin_buffer: 0.0   # [m]
@@ -71,6 +74,13 @@
       # not enabled yet
       longitudinal_collision_margin_min_distance: 0.0          # [m]
       longitudinal_collision_margin_time: 0.0
+
+      # For yield maneuver
+      yield_velocity: 2.78                        # [m/s]
+
+      # For stop maneuver
+      stop_min_distance: 10.0                     # [m]
+      stop_max_distance: 20.0                     # [m]
 
       # avoidance is performed for the object type with true
       target_object:

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -2,93 +2,25 @@
 /**:
   ros__parameters:
     avoidance:
-      resample_interval_for_planning: 0.3
-      resample_interval_for_output: 4.0
-      detection_area_right_expand_dist: 0.0
-      detection_area_left_expand_dist: 1.0
+      resample_interval_for_planning: 0.3               # [m]
+      resample_interval_for_output: 4.0                 # [m]
+      detection_area_right_expand_dist: 0.0             # [m]
+      detection_area_left_expand_dist: 1.0              # [m]
+      drivable_area_right_bound_offset: 0.0             # [m]
+      drivable_area_left_bound_offset: 0.0              # [m]
+      object_envelope_buffer: 0.3                       # [m]
 
+      # avoidance module common setting
+      enable_bound_clipping: false
       enable_avoidance_over_same_direction: true
       enable_avoidance_over_opposite_direction: true
       enable_update_path_when_object_is_gone: false
       enable_safety_check: false
       enable_yield_maneuver: false
 
-      # For target object filtering
-      threshold_speed_object_is_stopped: 1.0      # [m/s]
-      threshold_time_object_is_moving: 1.0        # [s]
-
-      object_check_forward_distance: 150.0        # [m]
-      object_check_backward_distance: 2.0         # [m]
-      object_check_goal_distance: 20.0            # [m]
-
-      threshold_distance_object_is_on_center: 1.0 # [m]
-
-      object_check_shiftable_ratio: 0.6           # [-]
-      object_check_min_road_shoulder_width: 0.5   # [m]
-
-      # For safety check
-      safety_check_backward_distance: 50.0        # [m]
-      safety_check_time_horizon: 10.0             # [s]
-      safety_check_idling_time: 1.5               # [s]
-      safety_check_accel_for_rss: 2.5             # [m/ss]
-      safety_check_hysteresis_factor: 2.0         # [-]
-
-      # For lateral margin
-      object_envelope_buffer: 0.3                 # [m]
-      lateral_collision_margin: 1.0               # [m]
-      lateral_collision_safety_buffer: 0.7        # [m]
-      lateral_passable_safety_buffer: 0.5         # [m]
-
-      # For longitudinal margin
-      longitudinal_collision_margin_buffer: 0.0   # [m]
-
-      prepare_time: 2.0                           # [s]
-      min_prepare_distance: 1.0                   # [m]
-      min_avoidance_distance: 10.0                # [m]
-
-      min_nominal_avoidance_speed: 7.0  # [m/s]
-      min_sharp_avoidance_speed: 1.0    # [m/s]
-
-      road_shoulder_safety_margin: 0.0 # [m]
-
-      max_right_shift_length: 5.0
-      max_left_shift_length: 5.0
-
-      # For longitudinal constraints
-      hard_constraints: false
-      nominal_deceleration: -1.0                  # [m/ss]
-      nominal_jerk: 1.0                           # [m/sss]
-      max_deceleration: -1.0                      # [m/ss]
-      max_jerk: 1.0                               # [m/sss]
-
-      # For lateral constraints
-      nominal_lateral_jerk: 0.2   # [m/s3]
-      max_lateral_jerk: 1.0       # [m/s3]
-
-      # For detection loss compensation
-      object_last_seen_threshold: 2.0   # [s]
-
-      # For prevention of large acceleration while avoidance
-      min_avoidance_speed_for_acc_prevention: 3.0  # [m/s]
-      max_avoidance_acceleration: 0.5  # [m/s2]
-
-      # bound clipping for objects
-      enable_bound_clipping: false
-
       # for debug
       publish_debug_marker: false
       print_debug_info: false
-
-      # not enabled yet
-      longitudinal_collision_margin_min_distance: 0.0          # [m]
-      longitudinal_collision_margin_time: 0.0
-
-      # For yield maneuver
-      yield_velocity: 2.78                        # [m/s]
-
-      # For stop maneuver
-      stop_min_distance: 10.0                     # [m]
-      stop_max_distance: 20.0                     # [m]
 
       # avoidance is performed for the object type with true
       target_object:
@@ -101,11 +33,80 @@
         motorcycle: false
         pedestrian: false
 
-      # ---------- advanced parameters ----------
-      avoidance_execution_lateral_threshold: 0.499
+      # For target object filtering
+      target_filtering:
+        # filtering moving objects
+        threshold_speed_object_is_stopped: 1.0          # [m/s]
+        threshold_time_object_is_moving: 1.0            # [s]
+        # detection range
+        object_check_forward_distance: 150.0            # [m]
+        object_check_backward_distance: 2.0             # [m]
+        object_check_goal_distance: 20.0                # [m]
+        # filtering parking objects
+        threshold_distance_object_is_on_center: 1.0     # [m]
+        object_check_shiftable_ratio: 0.6               # [-]
+        object_check_min_road_shoulder_width: 0.5       # [m]
+        # lost object compensation
+        object_last_seen_threshold: 2.0
+
+      # For safety check
+      safety_check:
+        safety_check_backward_distance: 50.0            # [m]
+        safety_check_time_horizon: 10.0                 # [s]
+        safety_check_idling_time: 1.5                   # [s]
+        safety_check_accel_for_rss: 2.5                 # [m/ss]
+        safety_check_hysteresis_factor: 2.0             # [-]
+
+      # For avoidance maneuver
+      avoidance:
+        # avoidance lateral parameters
+        lateral:
+          lateral_collision_margin: 1.0                 # [m]
+          lateral_collision_safety_buffer: 0.7          # [m]
+          lateral_passable_safety_buffer: 0.0           # [m]
+          road_shoulder_safety_margin: 0.0              # [m]
+          avoidance_execution_lateral_threshold: 0.499
+          max_right_shift_length: 5.0
+          max_left_shift_length: 5.0
+        # avoidance distance parameters
+        longitudinal:
+          prepare_time: 2.0                             # [s]
+          longitudinal_collision_safety_buffer: 0.0     # [m]
+          min_prepare_distance: 1.0                     # [m]
+          min_avoidance_distance: 10.0                  # [m]
+          min_nominal_avoidance_speed: 7.0              # [m/s]
+          min_sharp_avoidance_speed: 1.0                # [m/s]
+
+      # For yield maneuver
+      yield:
+        yield_velocity: 2.78                            # [m/s]
+
+      # For stop maneuver
+      stop:
+        min_distance: 10.0                              # [m]
+        max_distance: 20.0                              # [m]
+
+      constraints:
+        # constraints type
+        hard_constraints: false                         # [-]
+
+        # lateral constraints
+        lateral:
+          nominal_lateral_jerk: 0.2                     # [m/s3]
+          max_lateral_jerk: 1.0                         # [m/s3]
+
+        # longitudinal constraints
+        longitudinal:
+          nominal_deceleration: -1.0                    # [m/ss]
+          nominal_jerk: 0.5                             # [m/sss]
+          max_deceleration: -2.0                        # [m/ss]
+          max_jerk: 1.0
+          # For prevention of large acceleration while avoidance
+          min_avoidance_speed_for_acc_prevention: 3.0   # [m/s]
+          max_avoidance_acceleration: 0.5               # [m/ss]
 
       target_velocity_matrix:
-        col_size: 4
+        col_size: 2
         matrix:
-          [2.78, 5.56, 11.1, 13.9,   # velocity [m/s]
-           0.20, 0.90, 1.10, 1.20]   # margin [m]
+          [2.78, 13.9,                                  # velocity [m/s]
+           0.50, 1.00]                                  # margin [m]

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -87,8 +87,8 @@
         max_distance: 20.0                              # [m]
 
       constraints:
-        # constraints type
-        hard_constraints: false                         # [-]
+        # vehicle slows down under longitudinal constraints
+        use_constraints_for_decel: false                # [-]
 
         # lateral constraints
         lateral:

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -54,6 +54,14 @@
       max_right_shift_length: 5.0
       max_left_shift_length: 5.0
 
+      # For longitudinal constraints
+      hard_constraints: false
+      nominal_deceleration: -1.0                  # [m/ss]
+      nominal_jerk: 1.0                           # [m/sss]
+      max_deceleration: -1.0                      # [m/ss]
+      max_jerk: 1.0                               # [m/sss]
+
+      # For lateral constraints
       nominal_lateral_jerk: 0.2   # [m/s3]
       max_lateral_jerk: 1.0       # [m/s3]
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -289,9 +289,6 @@ private:
   std::shared_ptr<double> ego_velocity_starting_avoidance_ptr_;
   void modifyPathVelocityToPreventAccelerationOnAvoidance(ShiftedPath & shifted_path);
 
-  // clean up shifter
-  void postProcess(PathShifter & shifter) const;
-
   // turn signal
   TurnSignalInfo calcTurnSignalInfo(const ShiftedPath & path) const;
 
@@ -315,6 +312,25 @@ private:
     const double v_ego, const double v_obj, const bool is_front_object) const;
 
   ObjectDataArray getAdjacentLaneObjects(const lanelet::ConstLanelets & adjacent_lanes) const;
+
+  // ========= plan ======================
+
+  AvoidanceState updateEgoState(const AvoidancePlanningData & data) const;
+
+  void updateEgoBehavior(const AvoidancePlanningData & data, ShiftedPath & path);
+
+  void removeAllRegisteredShiftPoints(PathShifter & path_shifter)
+  {
+    current_raw_shift_lines_.clear();
+    registered_raw_shift_lines_.clear();
+    path_shifter.setShiftLines(ShiftLineArray{});
+  }
+
+  void postProcess(PathShifter & path_shifter) const
+  {
+    const size_t nearest_idx = findEgoIndex(path_shifter.getReferencePath().points);
+    path_shifter.removeBehindShiftLineAndSetBaseOffset(nearest_idx);
+  }
 
   // ========= safety check ==============
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -344,9 +344,9 @@ private:
     path_shifter.removeBehindShiftLineAndSetBaseOffset(nearest_idx);
   }
 
-  boost::optional<double> getFeasibleDecelDistance(const double target_velocity) const;
+  double getFeasibleDecelDistance(const double target_velocity) const;
 
-  boost::optional<double> getMildDecelDistance(const double target_velocity) const;
+  double getMildDecelDistance(const double target_velocity) const;
 
   // ========= safety check ==============
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -325,7 +325,7 @@ private:
 
   void updateEgoBehavior(const AvoidancePlanningData & data, ShiftedPath & path);
 
-  void insertWaitPoint(const bool hard_constraints, ShiftedPath & shifted_path) const;
+  void insertWaitPoint(const bool use_constraints_for_decel, ShiftedPath & shifted_path) const;
 
   void insertPrepareVelocity(const bool avoidable, ShiftedPath & shifted_path) const;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -202,11 +202,17 @@ private:
    * object pre-process
    */
   void fillAvoidanceTargetObjects(AvoidancePlanningData & data, DebugData & debug) const;
+
   void fillObjectEnvelopePolygon(const Pose & closest_pose, ObjectData & object_data) const;
+
   void fillObjectMovingTime(ObjectData & object_data) const;
+
   void compensateDetectionLost(
     ObjectDataArray & target_objects, ObjectDataArray & other_objects) const;
+
   void fillShiftLine(AvoidancePlanningData & data, DebugData & debug) const;
+
+  void fillDebugData(const AvoidancePlanningData & data, DebugData & debug) const;
 
   // data used in previous planning
   ShiftedPath prev_output_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -76,6 +76,21 @@ struct AvoidanceParameters
   // enable yield maneuver.
   bool enable_yield_maneuver{false};
 
+  // constrains
+  bool hard_constraints{false};
+
+  // max deceleration for
+  double max_deceleration;
+
+  // max jerk
+  double max_jerk;
+
+  // comfortable deceleration
+  double nominal_deceleration;
+
+  // comfortable jerk
+  double nominal_jerk;
+
   // Vehicles whose distance to the center of the path is
   // less than this will not be considered for avoidance.
   double threshold_distance_object_is_on_center;
@@ -142,6 +157,15 @@ struct AvoidanceParameters
 
   // transit hysteresis (unsafe to safe)
   double safety_check_hysteresis_factor;
+
+  // keep target velocity in yield maneuver
+  double yield_velocity;
+
+  // minimum stop distance
+  double stop_min_distance;
+
+  // maximum stop distance
+  double stop_max_distance;
 
   // start avoidance after this time to avoid sudden path change
   double prepare_time;
@@ -449,6 +473,10 @@ struct DebugData
   std::vector<double> neg_shift;
   std::vector<double> total_shift;
   std::vector<double> output_shift;
+
+  boost::optional<Pose> stop_pose{boost::none};
+  boost::optional<Pose> slow_pose{boost::none};
+  boost::optional<Pose> feasible_bound{boost::none};
 
   bool exist_adjacent_objects{false};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -73,6 +73,9 @@ struct AvoidanceParameters
   // enable safety check. if avoidance path is NOT safe, the ego will execute yield maneuver
   bool enable_safety_check{false};
 
+  // enable yield maneuver.
+  bool enable_yield_maneuver{false};
+
   // Vehicles whose distance to the center of the path is
   // less than this will not be considered for avoidance.
   double threshold_distance_object_is_on_center;
@@ -108,6 +111,9 @@ struct AvoidanceParameters
   // don't ever set this value to 0
   double lateral_collision_safety_buffer{0.5};
 
+  // if object overhang is less than this value, the ego stops behind the object.
+  double lateral_passable_safety_buffer{0.5};
+
   // margin between object back and end point of avoid shift point
   double longitudinal_collision_safety_buffer{0.0};
 
@@ -133,6 +139,9 @@ struct AvoidanceParameters
 
   // use in RSS calculation
   double safety_check_accel_for_rss;
+
+  // transit hysteresis (unsafe to safe)
+  double safety_check_hysteresis_factor;
 
   // start avoidance after this time to avoid sudden path change
   double prepare_time;
@@ -268,6 +277,9 @@ struct ObjectData  // avoidance target
   // lateral distance from overhang to the road shoulder
   double to_road_shoulder_distance{0.0};
 
+  // if lateral margin is NOT enough, the ego must avoid the object.
+  bool avoid_required{false};
+
   // unavoidable reason
   std::string reason{""};
 };
@@ -302,10 +314,24 @@ struct AvoidLine : public ShiftLine
 using AvoidLineArray = std::vector<AvoidLine>;
 
 /*
+ * avoidance state
+ */
+enum class AvoidanceState {
+  NOT_AVOID = 0,
+  AVOID_EXECUTE,
+  YIELD,
+  AVOID_PATH_READY,
+  AVOID_PATH_NOT_READY,
+};
+
+/*
  * Common data for avoidance planning
  */
 struct AvoidancePlanningData
 {
+  // ego final state
+  AvoidanceState state{AvoidanceState::NOT_AVOID};
+
   // un-shifted pose (for current lane detection)
   Pose reference_pose;
 
@@ -337,9 +363,18 @@ struct AvoidancePlanningData
   // new shift point
   AvoidLineArray unapproved_new_sl{};
 
+  // safe shift point
+  AvoidLineArray safe_new_sl{};
+
   bool safe{false};
 
   bool avoiding_now{false};
+
+  bool avoid_required{false};
+
+  bool yield_required{false};
+
+  bool found_avoidance_path{false};
 };
 
 /*

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -77,7 +77,7 @@ struct AvoidanceParameters
   bool enable_yield_maneuver{false};
 
   // constrains
-  bool hard_constraints{false};
+  bool use_constraints_for_decel{false};
 
   // max deceleration for
   double max_deceleration;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -110,6 +110,14 @@ bool isCentroidWithinLanelets(
 lanelet::ConstLanelets getTargetLanelets(
   const std::shared_ptr<const PlannerData> & planner_data, lanelet::ConstLanelets & route_lanelets,
   const double left_offset, const double right_offset);
+
+boost::optional<double> calcDecelDistWithJerkAndAccConstraints(
+  const double current_vel, const double target_vel, const double current_acc, const double acc_min,
+  const double jerk_acc, const double jerk_dec);
+
+void insertDecelPoint(
+  const Point & p_src, const double offset, const double velocity, PathWithLaneId & path,
+  boost::optional<Pose> & p_out);
 }  // namespace behavior_path_planner
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__AVOIDANCE_UTILS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -111,7 +111,7 @@ lanelet::ConstLanelets getTargetLanelets(
   const std::shared_ptr<const PlannerData> & planner_data, lanelet::ConstLanelets & route_lanelets,
   const double left_offset, const double right_offset);
 
-boost::optional<double> calcDecelDistWithJerkAndAccConstraints(
+double calcDecelDistWithJerkAndAccConstraints(
   const double current_vel, const double target_vel, const double current_acc, const double acc_min,
   const double jerk_acc, const double jerk_dec);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -37,7 +37,9 @@ namespace marker_utils::avoidance_marker
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using behavior_path_planner::AvoidancePlanningData;
+using behavior_path_planner::AvoidanceState;
 using behavior_path_planner::AvoidLineArray;
+using behavior_path_planner::DebugData;
 using behavior_path_planner::ObjectDataArray;
 using behavior_path_planner::ShiftLineArray;
 using geometry_msgs::msg::Point;
@@ -47,6 +49,9 @@ using visualization_msgs::msg::MarkerArray;
 
 MarkerArray createEgoStatusMarkerArray(
   const AvoidancePlanningData & data, const Pose & p_ego, std::string && ns);
+
+MarkerArray createSafetyCheckMarkerArray(
+  const AvoidanceState & state, const Pose & pose, const DebugData & data);
 
 MarkerArray createAvoidLineMarkerArray(
   const AvoidLineArray & shift_points, std::string && ns, const float & r, const float & g,

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -291,6 +291,12 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.enable_safety_check = dp("enable_safety_check", false);
   p.enable_yield_maneuver = dp("enable_yield_maneuver", false);
 
+  p.hard_constraints = dp("hard_constraints", false);
+  p.nominal_deceleration = dp("nominal_deceleration", -1.0);
+  p.nominal_jerk = dp("nominal_jerk", 0.5);
+  p.max_deceleration = dp("max_deceleration", -2.0);
+  p.max_jerk = dp("max_jerk", 1.0);
+
   p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 1.0);
   p.threshold_speed_object_is_stopped = dp("threshold_speed_object_is_stopped", 1.0);
   p.threshold_time_object_is_moving = dp("threshold_time_object_is_moving", 1.0);
@@ -313,6 +319,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
 
   p.yield_clear_hysteresis_time_horizon = dp("yield_clear_hysteresis_time_horizon", 10.0);
   p.yield_clear_hysteresis_longitudinal = dp("yield_clear_hysteresis_longitudinal", 10.0);
+  p.yield_velocity = dp("yield_velocity", 2.78);
 
   p.prepare_time = dp("prepare_time", 3.0);
   p.min_prepare_distance = dp("min_prepare_distance", 10.0);
@@ -337,6 +344,9 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
 
   p.min_avoidance_speed_for_acc_prevention = dp("min_avoidance_speed_for_acc_prevention", 3.0);
   p.max_avoidance_acceleration = dp("max_avoidance_acceleration", 0.5);
+
+  p.stop_min_distance = dp("stop_min_distance", 10.0);
+  p.stop_max_distance = dp("stop_max_distance", 20.0);
 
   p.publish_debug_marker = dp("publish_debug_marker", false);
   p.print_debug_info = dp("print_debug_info", false);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -289,6 +289,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.enable_avoidance_over_opposite_direction = dp("enable_avoidance_over_opposite_direction", true);
   p.enable_update_path_when_object_is_gone = dp("enable_update_path_when_object_is_gone", false);
   p.enable_safety_check = dp("enable_safety_check", false);
+  p.enable_yield_maneuver = dp("enable_yield_maneuver", false);
 
   p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 1.0);
   p.threshold_speed_object_is_stopped = dp("threshold_speed_object_is_stopped", 1.0);
@@ -301,6 +302,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.object_envelope_buffer = dp("object_envelope_buffer", 0.1);
   p.lateral_collision_margin = dp("lateral_collision_margin", 2.0);
   p.lateral_collision_safety_buffer = dp("lateral_collision_safety_buffer", 0.5);
+  p.lateral_passable_safety_buffer = dp("lateral_passable_safety_buffer", 0.5);
   p.longitudinal_collision_safety_buffer = dp("longitudinal_collision_safety_buffer", 0.0);
 
   p.safety_check_min_longitudinal_margin = dp("safety_check_min_longitudinal_margin", 0.0);
@@ -308,6 +310,9 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.safety_check_time_horizon = dp("safety_check_time_horizon", 10.0);
   p.safety_check_idling_time = dp("safety_check_idling_time", 1.5);
   p.safety_check_accel_for_rss = dp("safety_check_accel_for_rss", 2.5);
+
+  p.yield_clear_hysteresis_time_horizon = dp("yield_clear_hysteresis_time_horizon", 10.0);
+  p.yield_clear_hysteresis_longitudinal = dp("yield_clear_hysteresis_longitudinal", 10.0);
 
   p.prepare_time = dp("prepare_time", 3.0);
   p.min_prepare_distance = dp("min_prepare_distance", 10.0);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -275,81 +275,144 @@ SideShiftParameters BehaviorPathPlannerNode::getSideShiftParam()
 
 AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
 {
-  const auto dp = [this](const std::string & str, auto def_val) {
-    std::string name = "avoidance." + str;
-    return this->declare_parameter(name, def_val);
-  };
-
   AvoidanceParameters p{};
-  p.resample_interval_for_planning = dp("resample_interval_for_planning", 0.3);
-  p.resample_interval_for_output = dp("resample_interval_for_output", 3.0);
-  p.detection_area_right_expand_dist = dp("detection_area_right_expand_dist", 0.0);
-  p.detection_area_left_expand_dist = dp("detection_area_left_expand_dist", 1.0);
-  p.enable_avoidance_over_same_direction = dp("enable_avoidance_over_same_direction", true);
-  p.enable_avoidance_over_opposite_direction = dp("enable_avoidance_over_opposite_direction", true);
-  p.enable_update_path_when_object_is_gone = dp("enable_update_path_when_object_is_gone", false);
-  p.enable_safety_check = dp("enable_safety_check", false);
-  p.enable_yield_maneuver = dp("enable_yield_maneuver", false);
+  // general params
+  {
+    std::string ns = "avoidance.";
+    p.resample_interval_for_planning =
+      declare_parameter<double>(ns + "resample_interval_for_planning");
+    p.resample_interval_for_output = declare_parameter<double>(ns + "resample_interval_for_output");
+    p.detection_area_right_expand_dist =
+      declare_parameter<double>(ns + "detection_area_right_expand_dist");
+    p.detection_area_left_expand_dist =
+      declare_parameter<double>(ns + "detection_area_left_expand_dist");
+    p.drivable_area_right_bound_offset =
+      declare_parameter<double>(ns + "drivable_area_right_bound_offset");
+    p.drivable_area_left_bound_offset =
+      declare_parameter<double>(ns + "drivable_area_left_bound_offset");
+    p.object_envelope_buffer = declare_parameter<double>(ns + "object_envelope_buffer");
+    p.enable_bound_clipping = declare_parameter<bool>(ns + "enable_bound_clipping");
+    p.enable_avoidance_over_same_direction =
+      declare_parameter<bool>(ns + "enable_avoidance_over_same_direction");
+    p.enable_avoidance_over_opposite_direction =
+      declare_parameter<bool>(ns + "enable_avoidance_over_opposite_direction");
+    p.enable_update_path_when_object_is_gone =
+      declare_parameter<bool>(ns + "enable_update_path_when_object_is_gone");
+    p.enable_safety_check = declare_parameter<bool>(ns + "enable_safety_check");
+    p.enable_yield_maneuver = declare_parameter<bool>(ns + "enable_yield_maneuver");
+    p.publish_debug_marker = declare_parameter<bool>(ns + "publish_debug_marker");
+    p.print_debug_info = declare_parameter<bool>(ns + "print_debug_info");
+  }
 
-  p.hard_constraints = dp("hard_constraints", false);
-  p.nominal_deceleration = dp("nominal_deceleration", -1.0);
-  p.nominal_jerk = dp("nominal_jerk", 0.5);
-  p.max_deceleration = dp("max_deceleration", -2.0);
-  p.max_jerk = dp("max_jerk", 1.0);
+  // target object
+  {
+    std::string ns = "avoidance.target_object.";
+    p.avoid_car = declare_parameter<bool>(ns + "car");
+    p.avoid_truck = declare_parameter<bool>(ns + "truck");
+    p.avoid_bus = declare_parameter<bool>(ns + "bus");
+    p.avoid_trailer = declare_parameter<bool>(ns + "trailer");
+    p.avoid_unknown = declare_parameter<bool>(ns + "unknown");
+    p.avoid_bicycle = declare_parameter<bool>(ns + "bicycle");
+    p.avoid_motorcycle = declare_parameter<bool>(ns + "motorcycle");
+    p.avoid_pedestrian = declare_parameter<bool>(ns + "pedestrian");
+  }
 
-  p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 1.0);
-  p.threshold_speed_object_is_stopped = dp("threshold_speed_object_is_stopped", 1.0);
-  p.threshold_time_object_is_moving = dp("threshold_time_object_is_moving", 1.0);
-  p.object_check_forward_distance = dp("object_check_forward_distance", 150.0);
-  p.object_check_backward_distance = dp("object_check_backward_distance", 2.0);
-  p.object_check_goal_distance = dp("object_check_goal_distance", 20.0);
-  p.object_check_shiftable_ratio = dp("object_check_shiftable_ratio", 1.0);
-  p.object_check_min_road_shoulder_width = dp("object_check_min_road_shoulder_width", 0.5);
-  p.object_envelope_buffer = dp("object_envelope_buffer", 0.1);
-  p.lateral_collision_margin = dp("lateral_collision_margin", 2.0);
-  p.lateral_collision_safety_buffer = dp("lateral_collision_safety_buffer", 0.5);
-  p.lateral_passable_safety_buffer = dp("lateral_passable_safety_buffer", 0.5);
-  p.longitudinal_collision_safety_buffer = dp("longitudinal_collision_safety_buffer", 0.0);
+  // target filtering
+  {
+    std::string ns = "avoidance.target_filtering.";
+    p.threshold_speed_object_is_stopped =
+      declare_parameter<double>(ns + "threshold_speed_object_is_stopped");
+    p.threshold_time_object_is_moving =
+      declare_parameter<double>(ns + "threshold_time_object_is_moving");
+    p.object_check_forward_distance =
+      declare_parameter<double>(ns + "object_check_forward_distance");
+    p.object_check_backward_distance =
+      declare_parameter<double>(ns + "object_check_backward_distance");
+    p.object_check_goal_distance = declare_parameter<double>(ns + "object_check_goal_distance");
+    p.threshold_distance_object_is_on_center =
+      declare_parameter<double>(ns + "threshold_distance_object_is_on_center");
+    p.object_check_shiftable_ratio = declare_parameter<double>(ns + "object_check_shiftable_ratio");
+    p.object_check_min_road_shoulder_width =
+      declare_parameter<double>(ns + "object_check_min_road_shoulder_width");
+    p.object_last_seen_threshold = declare_parameter<double>(ns + "object_last_seen_threshold");
+  }
 
-  p.safety_check_min_longitudinal_margin = dp("safety_check_min_longitudinal_margin", 0.0);
-  p.safety_check_backward_distance = dp("safety_check_backward_distance", 0.0);
-  p.safety_check_time_horizon = dp("safety_check_time_horizon", 10.0);
-  p.safety_check_idling_time = dp("safety_check_idling_time", 1.5);
-  p.safety_check_accel_for_rss = dp("safety_check_accel_for_rss", 2.5);
+  // safety check
+  {
+    std::string ns = "avoidance.safety_check.";
+    p.safety_check_backward_distance =
+      declare_parameter<double>(ns + "safety_check_backward_distance");
+    p.safety_check_time_horizon = declare_parameter<double>(ns + "safety_check_time_horizon");
+    p.safety_check_idling_time = declare_parameter<double>(ns + "safety_check_idling_time");
+    p.safety_check_accel_for_rss = declare_parameter<double>(ns + "safety_check_accel_for_rss");
+    p.safety_check_hysteresis_factor =
+      declare_parameter<double>(ns + "safety_check_hysteresis_factor");
+  }
 
-  p.yield_clear_hysteresis_time_horizon = dp("yield_clear_hysteresis_time_horizon", 10.0);
-  p.yield_clear_hysteresis_longitudinal = dp("yield_clear_hysteresis_longitudinal", 10.0);
-  p.yield_velocity = dp("yield_velocity", 2.78);
+  // avoidance maneuver (lateral)
+  {
+    std::string ns = "avoidance.avoidance.lateral.";
+    p.lateral_collision_margin = declare_parameter<double>(ns + "lateral_collision_margin");
+    p.lateral_collision_safety_buffer =
+      declare_parameter<double>(ns + "lateral_collision_safety_buffer");
+    p.lateral_passable_safety_buffer =
+      declare_parameter<double>(ns + "lateral_passable_safety_buffer");
+    p.road_shoulder_safety_margin = declare_parameter<double>(ns + "road_shoulder_safety_margin");
+    p.avoidance_execution_lateral_threshold =
+      declare_parameter<double>(ns + "avoidance_execution_lateral_threshold");
+    p.max_right_shift_length = declare_parameter<double>(ns + "max_right_shift_length");
+    p.max_left_shift_length = declare_parameter<double>(ns + "max_left_shift_length");
+  }
 
-  p.prepare_time = dp("prepare_time", 3.0);
-  p.min_prepare_distance = dp("min_prepare_distance", 10.0);
-  p.min_avoidance_distance = dp("min_avoidance_distance", 10.0);
+  // avoidance maneuver (longitudinal)
+  {
+    std::string ns = "avoidance.avoidance.longitudinal.";
+    p.prepare_time = declare_parameter<double>(ns + "prepare_time");
+    p.longitudinal_collision_safety_buffer =
+      declare_parameter<double>(ns + "longitudinal_collision_safety_buffer");
+    p.min_prepare_distance = declare_parameter<double>(ns + "min_prepare_distance");
+    p.min_avoidance_distance = declare_parameter<double>(ns + "min_avoidance_distance");
+    p.min_nominal_avoidance_speed = declare_parameter<double>(ns + "min_nominal_avoidance_speed");
+    p.min_sharp_avoidance_speed = declare_parameter<double>(ns + "min_sharp_avoidance_speed");
+  }
 
-  p.min_nominal_avoidance_speed = dp("min_nominal_avoidance_speed", 5.0);
-  p.min_sharp_avoidance_speed = dp("min_sharp_avoidance_speed", 1.0);
+  // yield
+  {
+    std::string ns = "avoidance.yield.";
+    p.yield_velocity = declare_parameter<double>(ns + "yield_velocity");
+  }
 
-  p.road_shoulder_safety_margin = dp("road_shoulder_safety_margin", 0.0);
+  // stop
+  {
+    std::string ns = "avoidance.stop.";
+    p.stop_min_distance = declare_parameter<double>(ns + "min_distance");
+    p.stop_max_distance = declare_parameter<double>(ns + "max_distance");
+  }
 
-  p.max_right_shift_length = dp("max_right_shift_length", 1.5);
-  p.max_left_shift_length = dp("max_left_shift_length", 1.5);
+  // constraints
+  {
+    std::string ns = "avoidance.constraints.";
+    p.hard_constraints = declare_parameter<bool>(ns + "hard_constraints");
+  }
 
-  p.nominal_lateral_jerk = dp("nominal_lateral_jerk", 0.3);
-  p.max_lateral_jerk = dp("max_lateral_jerk", 2.0);
+  // constraints (longitudinal)
+  {
+    std::string ns = "avoidance.constraints.longitudinal.";
+    p.nominal_deceleration = declare_parameter<double>(ns + "nominal_deceleration");
+    p.nominal_jerk = declare_parameter<double>(ns + "nominal_jerk");
+    p.max_deceleration = declare_parameter<double>(ns + "max_deceleration");
+    p.max_jerk = declare_parameter<double>(ns + "max_jerk");
+    p.min_avoidance_speed_for_acc_prevention =
+      declare_parameter<double>(ns + "min_avoidance_speed_for_acc_prevention");
+    p.max_avoidance_acceleration = declare_parameter<double>(ns + "max_avoidance_acceleration");
+  }
 
-  p.longitudinal_collision_margin_min_distance =
-    dp("longitudinal_collision_margin_min_distance", 0.0);
-  p.longitudinal_collision_margin_time = dp("longitudinal_collision_margin_time", 0.0);
-
-  p.object_last_seen_threshold = dp("object_last_seen_threshold", 2.0);
-
-  p.min_avoidance_speed_for_acc_prevention = dp("min_avoidance_speed_for_acc_prevention", 3.0);
-  p.max_avoidance_acceleration = dp("max_avoidance_acceleration", 0.5);
-
-  p.stop_min_distance = dp("stop_min_distance", 10.0);
-  p.stop_max_distance = dp("stop_max_distance", 20.0);
-
-  p.publish_debug_marker = dp("publish_debug_marker", false);
-  p.print_debug_info = dp("print_debug_info", false);
+  // constraints (lateral)
+  {
+    std::string ns = "avoidance.constraints.lateral.";
+    p.nominal_lateral_jerk = declare_parameter<double>(ns + "nominal_lateral_jerk");
+    p.max_lateral_jerk = declare_parameter<double>(ns + "max_lateral_jerk");
+  }
 
   // velocity matrix
   {
@@ -357,22 +420,6 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
     p.col_size = declare_parameter<int>(ns + "col_size");
     p.target_velocity_matrix = declare_parameter<std::vector<double>>(ns + "matrix");
   }
-
-  p.avoid_car = dp("target_object.car", true);
-  p.avoid_truck = dp("target_object.truck", true);
-  p.avoid_bus = dp("target_object.bus", true);
-  p.avoid_trailer = dp("target_object.trailer", true);
-  p.avoid_unknown = dp("target_object.unknown", false);
-  p.avoid_bicycle = dp("target_object.bicycle", false);
-  p.avoid_motorcycle = dp("target_object.motorcycle", false);
-  p.avoid_pedestrian = dp("target_object.pedestrian", false);
-
-  p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
-  p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);
-
-  p.enable_bound_clipping = dp("enable_bound_clipping", false);
-
-  p.avoidance_execution_lateral_threshold = dp("avoidance_execution_lateral_threshold", 0.499);
 
   return p;
 }

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -392,7 +392,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   // constraints
   {
     std::string ns = "avoidance.constraints.";
-    p.hard_constraints = declare_parameter<bool>(ns + "hard_constraints");
+    p.use_constraints_for_decel = declare_parameter<bool>(ns + "use_constraints_for_decel");
   }
 
   // constraints (longitudinal)

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3159,6 +3159,10 @@ void AvoidanceModule::updateData()
   updateRegisteredObject(avoidance_data_.target_objects);
   compensateDetectionLost(avoidance_data_.target_objects, avoidance_data_.other_objects);
 
+  std::sort(
+    avoidance_data_.target_objects.begin(), avoidance_data_.target_objects.end(),
+    [](auto a, auto b) { return a.longitudinal < b.longitudinal; });
+
   path_shifter_.setPath(avoidance_data_.reference_path);
 
   // update registered shift point for new reference path & remove past objects

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -721,18 +721,18 @@ void AvoidanceModule::updateEgoBehavior(const AvoidancePlanningData & data, Shif
     }
     case AvoidanceState::YIELD: {
       insertYieldVelocity(path);
-      insertWaitPoint(parameters_->hard_constraints, path);
+      insertWaitPoint(parameters_->use_constraints_for_decel, path);
       removeAllRegisteredShiftPoints(path_shifter_);
       break;
     }
     case AvoidanceState::AVOID_PATH_NOT_READY: {
       insertPrepareVelocity(false, path);
-      insertWaitPoint(parameters_->hard_constraints, path);
+      insertWaitPoint(parameters_->use_constraints_for_decel, path);
       break;
     }
     case AvoidanceState::AVOID_PATH_READY: {
       insertPrepareVelocity(true, path);
-      insertWaitPoint(parameters_->hard_constraints, path);
+      insertWaitPoint(parameters_->use_constraints_for_decel, path);
       break;
     }
     case AvoidanceState::AVOID_EXECUTE: {
@@ -3566,7 +3566,8 @@ double AvoidanceModule::getMildDecelDistance(const double target_velocity) const
     getEgoSpeed(), target_velocity, a_now, a_lim, j_lim, -1.0 * j_lim);
 }
 
-void AvoidanceModule::insertWaitPoint(const bool hard_constraints, ShiftedPath & shifted_path) const
+void AvoidanceModule::insertWaitPoint(
+  const bool use_constraints_for_decel, ShiftedPath & shifted_path) const
 {
   const auto & p = parameters_;
   const auto & data = avoidance_data_;
@@ -3608,7 +3609,7 @@ void AvoidanceModule::insertWaitPoint(const bool hard_constraints, ShiftedPath &
     o_front.longitudinal -
     std::clamp(variable + constant, p->stop_min_distance, p->stop_max_distance);
 
-  if (!hard_constraints) {
+  if (!use_constraints_for_decel) {
     insertDecelPoint(
       getEgoPosition(), start_longitudinal, 0.0, shifted_path.path, debug_data_.stop_pose);
     return;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3548,8 +3548,7 @@ void AvoidanceModule::updateAvoidanceDebugData(
   }
 }
 
-boost::optional<double> AvoidanceModule::getFeasibleDecelDistance(
-  const double target_velocity) const
+double AvoidanceModule::getFeasibleDecelDistance(const double target_velocity) const
 {
   const auto & a_now = planner_data_->self_acceleration->accel.accel.linear.x;
   const auto & a_lim = parameters_->max_deceleration;
@@ -3558,7 +3557,7 @@ boost::optional<double> AvoidanceModule::getFeasibleDecelDistance(
     getEgoSpeed(), target_velocity, a_now, a_lim, j_lim, -1.0 * j_lim);
 }
 
-boost::optional<double> AvoidanceModule::getMildDecelDistance(const double target_velocity) const
+double AvoidanceModule::getMildDecelDistance(const double target_velocity) const
 {
   const auto & a_now = planner_data_->self_acceleration->accel.accel.linear.x;
   const auto & a_lim = parameters_->nominal_deceleration;
@@ -3617,11 +3616,7 @@ void AvoidanceModule::insertWaitPoint(const bool hard_constraints, ShiftedPath &
 
   const auto stop_distance = getMildDecelDistance(0.0);
 
-  if (!stop_distance) {
-    return;
-  }
-
-  const auto insert_distance = std::max(start_longitudinal, stop_distance.get());
+  const auto insert_distance = std::max(start_longitudinal, stop_distance);
 
   insertDecelPoint(
     getEgoPosition(), insert_distance, 0.0, shifted_path.path, debug_data_.stop_pose);
@@ -3642,13 +3637,8 @@ void AvoidanceModule::insertYieldVelocity(ShiftedPath & shifted_path) const
 
   const auto decel_distance = getMildDecelDistance(p->yield_velocity);
 
-  if (!decel_distance) {
-    return;
-  }
-
   insertDecelPoint(
-    getEgoPosition(), decel_distance.get(), p->yield_velocity, shifted_path.path,
-    debug_data_.slow_pose);
+    getEgoPosition(), decel_distance, p->yield_velocity, shifted_path.path, debug_data_.slow_pose);
 }
 
 void AvoidanceModule::insertPrepareVelocity(const bool avoidable, ShiftedPath & shifted_path) const
@@ -3673,12 +3663,7 @@ void AvoidanceModule::insertPrepareVelocity(const bool avoidable, ShiftedPath & 
 
   const auto decel_distance = getFeasibleDecelDistance(0.0);
 
-  if (!decel_distance) {
-    return;
-  }
-
-  insertDecelPoint(
-    getEgoPosition(), decel_distance.get(), 0.0, shifted_path.path, debug_data_.slow_pose);
+  insertDecelPoint(getEgoPosition(), decel_distance, 0.0, shifted_path.path, debug_data_.slow_pose);
 }
 
 std::shared_ptr<AvoidanceDebugMsgArray> AvoidanceModule::get_debug_msg_array() const

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -33,10 +33,14 @@
 namespace behavior_path_planner
 {
 
+using motion_utils::calcLongitudinalOffsetPoint;
+using motion_utils::findNearestSegmentIndex;
+using motion_utils::insertTargetPoint;
 using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::calcYawDeviation;
 using tier4_autoware_utils::createQuaternionFromRPY;
+using tier4_autoware_utils::getPose;
 using tier4_autoware_utils::pose2transform;
 
 namespace
@@ -58,6 +62,147 @@ geometry_msgs::msg::Polygon toMsg(const tier4_autoware_utils::Polygon2d & polygo
     ret.points.push_back(createPoint32(p.x(), p.y(), z));
   }
   return ret;
+}
+
+bool validCheckDecelPlan(
+  const double v_end, const double a_end, const double v_target, const double a_target,
+  const double v_margin, const double a_margin)
+{
+  const double v_min = v_target - std::abs(v_margin);
+  const double v_max = v_target + std::abs(v_margin);
+  const double a_min = a_target - std::abs(a_margin);
+  const double a_max = a_target + std::abs(a_margin);
+
+  if (v_end < v_min || v_max < v_end) {
+    RCLCPP_DEBUG_STREAM(
+      rclcpp::get_logger("validCheckDecelPlan"),
+      "[validCheckDecelPlan] valid check error! v_target = " << v_target << ", v_end = " << v_end);
+    return false;
+  }
+  if (a_end < a_min || a_max < a_end) {
+    RCLCPP_DEBUG_STREAM(
+      rclcpp::get_logger("validCheckDecelPlan"),
+      "[validCheckDecelPlan] valid check error! a_target = " << a_target << ", a_end = " << a_end);
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * @brief calculate distance until velocity is reached target velocity (TYPE1)
+ * @param (v0) current velocity [m/s]
+ * @param (vt) target velocity [m/s]
+ * @param (a0) current acceleration [m/ss]
+ * @param (am) minimum deceleration [m/ss]
+ * @param (ja) maximum jerk [m/sss]
+ * @param (jd) minimum jerk [m/sss]
+ * @param (t_min) duration of constant deceleration [s]
+ * @return moving distance until velocity is reached vt [m]
+ * @detail TODO(Satoshi Ota)
+ */
+boost::optional<double> calcDecelDistPlanType1(
+  const double v0, const double vt, const double a0, const double am, const double ja,
+  const double jd, const double t_min)
+{
+  constexpr double epsilon = 1e-3;
+
+  const double j1 = am < a0 ? jd : ja;
+  const double t1 = epsilon < (am - a0) / j1 ? (am - a0) / j1 : 0.0;
+  const double a1 = a0 + j1 * t1;
+  const double v1 = v0 + a0 * t1 + 0.5 * j1 * t1 * t1;
+  const double x1 = v0 * t1 + 0.5 * a0 * t1 * t1 + (1.0 / 6.0) * j1 * t1 * t1 * t1;
+
+  const double t2 = epsilon < t_min ? t_min : 0.0;
+  const double a2 = a1;
+  const double v2 = v1 + a1 * t2;
+  const double x2 = x1 + v1 * t2 + 0.5 * a1 * t2 * t2;
+
+  const double t3 = epsilon < (0.0 - am) / ja ? (0.0 - am) / ja : 0.0;
+  const double a3 = a2 + ja * t3;
+  const double v3 = v2 + a2 * t3 + 0.5 * ja * t3 * t3;
+  const double x3 = x2 + v2 * t3 + 0.5 * a2 * t3 * t3 + (1.0 / 6.0) * ja * t3 * t3 * t3;
+
+  const double a_target = 0.0;
+  const double v_margin = 0.3;  // [m/s]
+  const double a_margin = 0.1;  // [m/s^2]
+
+  if (!validCheckDecelPlan(v3, a3, vt, a_target, v_margin, a_margin)) {
+    return {};
+  }
+
+  return x3;
+}
+
+/**
+ * @brief calculate distance until velocity is reached target velocity (TYPE2)
+ * @param (v0) current velocity [m/s]
+ * @param (vt) target velocity [m/s]
+ * @param (a0) current acceleration [m/ss]
+ * @param (am) minimum deceleration [m/ss]
+ * @param (ja) maximum jerk [m/sss]
+ * @param (jd) minimum jerk [m/sss]
+ * @return moving distance until velocity is reached vt [m]
+ * @detail TODO(Satoshi Ota)
+ */
+boost::optional<double> calcDecelDistPlanType2(
+  const double v0, const double vt, const double a0, const double ja, const double jd)
+{
+  constexpr double epsilon = 1e-3;
+
+  const double a1_square = (vt - v0 - 0.5 * (0.0 - a0) / jd * a0) * (2.0 * ja * jd / (ja - jd));
+  const double a1 = -std::sqrt(a1_square);
+
+  const double t1 = epsilon < (a1 - a0) / jd ? (a1 - a0) / jd : 0.0;
+  const double v1 = v0 + a0 * t1 + 0.5 * jd * t1 * t1;
+  const double x1 = v0 * t1 + 0.5 * a0 * t1 * t1 + (1.0 / 6.0) * jd * t1 * t1 * t1;
+
+  const double t2 = epsilon < (0.0 - a1) / ja ? (0.0 - a1) / ja : 0.0;
+  const double a2 = a1 + ja * t2;
+  const double v2 = v1 + a1 * t2 + 0.5 * ja * t2 * t2;
+  const double x2 = x1 + v1 * t2 + 0.5 * a1 * t2 * t2 + (1.0 / 6.0) * ja * t2 * t2 * t2;
+
+  const double a_target = 0.0;
+  const double v_margin = 0.3;
+  const double a_margin = 0.1;
+
+  if (!validCheckDecelPlan(v2, a2, vt, a_target, v_margin, a_margin)) {
+    return {};
+  }
+
+  return x2;
+}
+
+/**
+ * @brief calculate distance until velocity is reached target velocity (TYPE3)
+ * @param (v0) current velocity [m/s]
+ * @param (vt) target velocity [m/s]
+ * @param (a0) current acceleration [m/ss]
+ * @param (ja) maximum jerk [m/sss]
+ * @return moving distance until velocity is reached vt [m]
+ * @detail TODO(Satoshi Ota)
+ */
+boost::optional<double> calcDecelDistPlanType3(
+  const double v0, const double vt, const double a0, const double ja)
+{
+  constexpr double epsilon = 1e-3;
+
+  const double t_acc = (0.0 - a0) / ja;
+
+  const double t1 = epsilon < t_acc ? t_acc : 0.0;
+  const double a1 = a0 + ja * t1;
+  const double v1 = v0 + a0 * t1 + 0.5 * ja * t1 * t1;
+  const double x1 = v0 * t1 + 0.5 * a0 * t1 * t1 + (1.0 / 6.0) * ja * t1 * t1 * t1;
+
+  const double a_target = 0.0;
+  const double v_margin = 0.3;
+  const double a_margin = 0.1;
+
+  if (!validCheckDecelPlan(v1, a1, vt, a_target, v_margin, a_margin)) {
+    return {};
+  }
+
+  return x1;
 }
 
 }  // namespace
@@ -559,4 +704,63 @@ lanelet::ConstLanelets getTargetLanelets(
   return target_lanelets;
 }
 
+boost::optional<double> calcDecelDistWithJerkAndAccConstraints(
+  const double current_vel, const double target_vel, const double current_acc, const double acc_min,
+  const double jerk_acc, const double jerk_dec)
+{
+  constexpr double epsilon = 1e-3;
+  const double t_dec =
+    acc_min < current_acc ? (acc_min - current_acc) / jerk_dec : (acc_min - current_acc) / jerk_acc;
+  const double t_acc = (0.0 - acc_min) / jerk_acc;
+  const double t_min = (target_vel - current_vel - current_acc * t_dec -
+                        0.5 * jerk_dec * t_dec * t_dec - 0.5 * acc_min * t_acc) /
+                       acc_min;
+
+  // check if it is possible to decelerate to the target velocity
+  // by simply bringing the current acceleration to zero.
+  const auto is_decel_needed =
+    0.5 * (0.0 - current_acc) / jerk_acc * current_acc > target_vel - current_vel;
+
+  if (t_min > epsilon) {
+    return calcDecelDistPlanType1(
+      current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec, t_min);
+  } else if (is_decel_needed || current_acc > epsilon) {
+    return calcDecelDistPlanType2(current_vel, target_vel, current_acc, jerk_acc, jerk_dec);
+  } else {
+    return calcDecelDistPlanType3(current_vel, target_vel, current_acc, jerk_acc);
+  }
+
+  return {};
+}
+
+void insertDecelPoint(
+  const Point & p_src, const double offset, const double velocity, PathWithLaneId & path,
+  boost::optional<Pose> & p_out)
+{
+  const auto decel_point = calcLongitudinalOffsetPoint(path.points, p_src, offset);
+
+  if (!decel_point) {
+    // TODO(Satoshi OTA)  Think later the process in the case of no decel point found.
+    return;
+  }
+
+  const auto seg_idx = findNearestSegmentIndex(path.points, decel_point.get());
+  const auto insert_idx = insertTargetPoint(seg_idx, decel_point.get(), path.points);
+
+  if (!insert_idx) {
+    // TODO(Satoshi OTA)  Think later the process in the case of no decel point found.
+    return;
+  }
+
+  const auto insertVelocity = [&insert_idx](PathWithLaneId & path, const float v) {
+    for (size_t i = insert_idx.get(); i < path.points.size(); ++i) {
+      const auto & original_velocity = path.points.at(i).point.longitudinal_velocity_mps;
+      path.points.at(i).point.longitudinal_velocity_mps = std::min(original_velocity, v);
+    }
+  };
+
+  insertVelocity(path, velocity);
+
+  p_out = getPose(path.points.at(insert_idx.get()));
+}
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -29,6 +29,7 @@ using behavior_path_planner::AvoidLine;
 using behavior_path_planner::util::shiftPose;
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcDistance2d;
+using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerScale;
@@ -120,10 +121,101 @@ MarkerArray createEgoStatusMarkerArray(
     std::ostringstream string_stream;
     string_stream << std::fixed << std::setprecision(2) << std::boolalpha;
     string_stream << "avoid_now:" << data.avoiding_now << ","
+                  << "avoid_req:" << data.avoid_required << ","
+                  << "yield_req:" << data.yield_required << ","
                   << "safe:" << data.safe;
     marker.text = string_stream.str();
 
     msg.markers.push_back(marker);
+  }
+
+  {
+    std::ostringstream string_stream;
+    string_stream << "ego_state:";
+    switch (data.state) {
+      case AvoidanceState::NOT_AVOID:
+        string_stream << "NOT_AVOID";
+        break;
+      case AvoidanceState::AVOID_PATH_NOT_READY:
+        string_stream << "AVOID_PATH_NOT_READY";
+        marker.color = createMarkerColor(1.0, 0.0, 0.0, 0.999);
+        break;
+      case AvoidanceState::YIELD:
+        string_stream << "YIELD";
+        marker.color = createMarkerColor(1.0, 1.0, 0.0, 0.999);
+        break;
+      case AvoidanceState::AVOID_PATH_READY:
+        string_stream << "AVOID_PATH_READY";
+        marker.color = createMarkerColor(0.0, 1.0, 0.0, 0.999);
+        break;
+      case AvoidanceState::AVOID_EXECUTE:
+        string_stream << "AVOID_EXECUTE";
+        marker.color = createMarkerColor(0.0, 1.0, 0.0, 0.999);
+        break;
+      default:
+        throw std::domain_error("invalid behaivor");
+    }
+    marker.text = string_stream.str();
+    marker.pose.position.z += 2.0;
+    marker.id++;
+
+    msg.markers.push_back(marker);
+  }
+
+  return msg;
+}
+
+MarkerArray createSafetyCheckMarkerArray(
+  const AvoidanceState & state, const Pose & pose, const DebugData & data)
+{
+  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+  MarkerArray msg;
+
+  if (data.exist_adjacent_objects) {
+    auto marker = createDefaultMarker(
+      "map", current_time, "safety_alert", 0L, Marker::CYLINDER, createMarkerScale(0.2, 0.2, 2.0),
+      createMarkerColor(1.0, 1.0, 0.0, 0.8));
+
+    marker.color = state == AvoidanceState::YIELD ? createMarkerColor(1.0, 0.0, 0.0, 0.8)
+                                                  : createMarkerColor(1.0, 1.0, 0.0, 0.8);
+
+    marker.pose = calcOffsetPose(pose, 0.0, 1.5, 1.0);
+    msg.markers.push_back(marker);
+
+    marker.pose = calcOffsetPose(pose, 0.0, -1.5, 1.0);
+    marker.id++;
+    msg.markers.push_back(marker);
+  }
+
+  if (state == AvoidanceState::YIELD) {
+    return msg;
+  }
+
+  {
+    auto marker = createDefaultMarker(
+      "map", current_time, "safety_longitudinal_margin", 0L, Marker::CUBE,
+      createMarkerScale(3.0, 1.5, 1.5), createMarkerColor(1.0, 1.0, 1.0, 0.1));
+
+    for (const auto & m : data.margin_data_array) {
+      if (m.enough_lateral_margin) {
+        continue;
+      }
+
+      constexpr double max_x = 10.0;
+
+      const auto offset = 0.5 * (m.base_link2front + m.base_link2rear) - m.base_link2rear;
+      const auto diff = m.longitudinal_distance - m.longitudinal_margin;
+      const auto scale_x = std::min(max_x, 2.0 * (m.base_link2front + m.base_link2rear + diff));
+
+      const auto ratio = std::clamp(diff / max_x, 0.0, 1.0);
+
+      marker.pose = calcOffsetPose(m.pose, offset, 0.0, 0.0);
+      marker.pose.position.z += 1.0;
+      marker.scale = createMarkerScale(scale_x, 2.0 * m.vehicle_width, 2.0);
+      marker.color = createMarkerColor(1.0 - ratio, ratio, 0.0, 0.1);
+      marker.id++;
+      msg.markers.push_back(marker);
+    }
   }
 
   return msg;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -153,7 +153,7 @@ MarkerArray createEgoStatusMarkerArray(
         marker.color = createMarkerColor(0.0, 1.0, 0.0, 0.999);
         break;
       default:
-        throw std::domain_error("invalid behaivor");
+        throw std::domain_error("invalid behavior");
     }
     marker.text = string_stream.str();
     marker.pose.position.z += 2.0;


### PR DESCRIPTION
## Description

### BackGround

The previous avoidance module did not have a safety check mechanism, and the operator had no choice but to OR (over ride) and interrupt the avoidance maneuver as manualy if a vehicle in the adjacent or opposite lane approached after the module had switched output paths for avoidance. This problems has a significant impact on miles per disengagement, so we would like to implement safety check mechanism and yield behavior in the module.

I implement YIELD maneuver based on the safety check (https://github.com/autowarefoundation/autoware.universe/pull/2534) result in this PR, and define the vehicle behavior for each staus.

---

### Logic

The Safety Chack Mechanism is [here](https://github.com/autowarefoundation/autoware.universe/pull/2534). The module determines the behavior of the vehicle according to the following flow chart.

![image](https://user-images.githubusercontent.com/44889564/208805023-f7d2a173-3e7e-45f5-a53d-f253e45996b4.png)

---

#### YIELD maneuver

If an avoidance path can be generated and it is determined that avoidance maneuver should not be executed due to surrounding traffic conditions, the module executes YIELD maneuver. There are new params about yield maneuver as follow:

```yaml
# For yield maneuver
yield_velocity: 2.78                        # [m/s]
```

In yield maneuver, the vehicle slows down to the target vehicle velocity (`yield_velocity`) and keep that speed until the module judge that avoidance path is safe.  If the YIELD condition goes on and the vehicle approaches the avoidance target, it stops at the avoidable position and waits until the safety is confirmed.

![image](https://user-images.githubusercontent.com/44889564/208806620-4d90c3a2-755d-4fdf-9c5d-a4cfd6a3ddc2.png)

In addition, I add hysterisis to safety check mechanism to prevent chattering the safe/unsafe judgement. When transitioning from unsafe to safe, the lateral/longitudinal margins are multiplied by a constant (`safety_check_hysteresis_factor`).

```yaml
# For yield maneuver
safety_check_hysteresis_factor: 1.5                       # [-]
```

![image](https://user-images.githubusercontent.com/44889564/208809938-f6a284ab-8db7-4c18-889f-928a296a30c2.png)

**NOTE**: In yield maneuver, the vehicle decelerates target velocity within following constraints.

```yaml
nominal_deceleration: -1.0                  # [m/ss]
nominal_jerk: 0.5                           # [m/sss]
```
---

#### STOP maneuver

If the vehicle cannot pass without avoidance and any one of following condition is satisfied, it will stop in front of the avoidance target with an avoidable interval.

- Safety operator don't approve path modification via RTC.
- In yield maneuver.
- Not found the avoidance path.

The module determines that it is NOT passable without avoidance if the object overhang is less than the threshold. 

```yaml
lateral_passable_collision_margin: 0.5                  # [-]
```

```math
L_{overhang} < \frac{W}{2} + L_{margin} (not passable)
```

The $W$ represents vehicle width, and $L_{margin}$ represents `lateral_passable_collision_margin`.

---

### Limitation1

The current behavior in unsafe condition is just slow down and it is so conservative. It is difficult to achieve aggresive behavior in the current architecture because of modulatiry. There are many modules in autoware that change the vehicle speed, and the avoidance module cannot know what speed planning they will output, so it is forced to choose a behavior that is as independent of other modules' processing as possible.

### Limitation2

The YIELD maneuver is executed **ONLY** when the vehicle has **NOT** initiated avoidance maneuver. The module has a threshold parameter (`avoidance_initiate_threshold`) for the amount of shifting and determines that the vehicle is initiating avoidance if the vehicle current shift exceeds the threshold.

```math
SHIFT_{current} > L_{threshold}
```

![image](https://user-images.githubusercontent.com/44889564/208804147-f67cc631-83f7-4fa0-ac76-06e925367c67.png)

![image](https://user-images.githubusercontent.com/44889564/208805316-0c9a65c5-3732-4aa2-ab73-b2b9bee7e7bf.png)

Even in situations where avoidance behavior has already been initiated, there may be cases where avoidance should be interrupted due to the surrounding vehicle traffic, but the ego's behavior in such cases should be carefully discussed. This is because even if the module reverts the avoidance path and returns to the original lane, there are target object that the vehicle must avoid, and stopping on the spot may impede the traffic of surrounding vehicles. We will continue to discuss solution of this scenario.

<!-- Write a brief description of this PR. -->

## Related links

- https://github.com/autowarefoundation/autoware.universe/pull/2534
- https://github.com/autowarefoundation/autoware_launch/pull/146
- https://github.com/tier4/autoware_launch/pull/657

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

### Evaluator

[[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/9a0b80b6-f1f1-5097-8c52-4045172daa13?project_id=prd_jt) This PR (Disable YIELD) (820/825)
[[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/f074dd0d-590c-5e2c-9be7-c2a1f1b2cb10?project_id=prd_jt) This PR (Enable YIELD) (820/825)
[[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/2d34596c-85c8-5ddf-97ab-00f6de48bd85?project_id=prd_jt) Baseline (821/825)

**Note**: [This](https://evaluation.tier4.jp/evaluation/reports/9a0b80b6-f1f1-5097-8c52-4045172daa13/tests/34410b18-c892-5613-8347-8a99fb367891/422bcbc5-47b5-56c6-82df-52055d152a47/0e21ad23-26b5-5081-8651-b191edc341f0?project_id=prd_jt) failure may be caused by smoother undershoot.

### Test in local

Befor the tests, please use [this](https://github.com/tier4/autoware_launch/pull/657) autoware_launch branch and set following params in config to true.

```yaml
enable_safety_check: true
enable_yield_maneuver: true
publish_debug_marker: true # optional
```

https://user-images.githubusercontent.com/44889564/208866306-c268d94e-0f2c-4f1d-9000-50c07244fcd9.mp4

- debug marker topic: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance
- The vehicles that has collision risk are shown as BLUE CUBE in rviz (namespace unsafe_objects).
- The safety judge is shown as WHITE TEXT in rviz (namespace ego_status)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
