### PR TITLE
feat(behavior_path_planner): remove unnecessary parameters

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -7,11 +7,6 @@
     backward_length_buffer_for_end_of_pull_out: 5.0
     minimum_lane_change_length: 12.0
     minimum_pull_over_length: 16.0
-    drivable_area_resolution: 0.1
-    drivable_lane_forward_length: 50.0
-    drivable_lane_backward_length:  5.0
-    drivable_lane_margin: 3.0
-    drivable_area_margin: 6.0
     refine_goal_search_radius_range: 7.5
     turn_signal_intersection_search_distance: 30.0
     turn_signal_intersection_angle_threshold_deg: 15.0

--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -9,12 +9,6 @@
     minimum_lane_change_prepare_distance: 2.0 # [m]
     minimum_pull_over_length: 16.0
 
-    drivable_area_resolution: 0.1
-    drivable_lane_forward_length: 50.0
-    drivable_lane_backward_length:  5.0
-    drivable_lane_margin: 3.0
-    drivable_area_margin: 6.0
-
     refine_goal_search_radius_range: 7.5
 
     # parameters for turn signal decider

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -31,11 +31,6 @@ struct BehaviorPathPlannerParameters
   double minimum_pull_out_length;
   double drivable_area_resolution;
 
-  double drivable_lane_forward_length;
-  double drivable_lane_backward_length;
-  double drivable_lane_margin;
-  double drivable_area_margin;
-
   double refine_goal_search_radius_range;
 
   double turn_signal_intersection_search_distance;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -211,11 +211,6 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
     declare_parameter("minimum_lane_change_prepare_distance", 2.0);
 
   p.minimum_pull_over_length = declare_parameter("minimum_pull_over_length", 15.0);
-  p.drivable_area_resolution = declare_parameter<double>("drivable_area_resolution");
-  p.drivable_lane_forward_length = declare_parameter<double>("drivable_lane_forward_length");
-  p.drivable_lane_backward_length = declare_parameter<double>("drivable_lane_backward_length");
-  p.drivable_lane_margin = declare_parameter<double>("drivable_lane_margin");
-  p.drivable_area_margin = declare_parameter<double>("drivable_area_margin");
   p.refine_goal_search_radius_range = declare_parameter("refine_goal_search_radius_range", 7.5);
   p.turn_signal_intersection_search_distance =
     declare_parameter("turn_signal_intersection_search_distance", 30.0);

--- a/planning/static_centerline_optimizer/src/utils.cpp
+++ b/planning/static_centerline_optimizer/src/utils.cpp
@@ -85,9 +85,6 @@ PathWithLaneId get_path_with_lane_id(
   auto planner_data = std::make_shared<behavior_path_planner::PlannerData>();
   planner_data->route_handler = std::make_shared<RouteHandler>(route_handler);
   planner_data->self_pose = convert_to_pose_stamped(start_pose);
-  planner_data->parameters.drivable_lane_forward_length = std::numeric_limits<double>::max();
-  planner_data->parameters.drivable_lane_backward_length = std::numeric_limits<double>::min();
-  planner_data->parameters.drivable_lane_margin = 5.0;
   planner_data->parameters.ego_nearest_dist_threshold = ego_nearest_dist_threshold;
   planner_data->parameters.ego_nearest_yaw_threshold = ego_nearest_yaw_threshold;
 


### PR DESCRIPTION
## Description
Remove unnecessary drivable area parameters. These parameters are no longer used due to the recent change of the drivable area format.

[Related PR](https://github.com/tier4/autoware_launch/pull/618)

[Drivable Area Change](https://github.com/autowarefoundation/autoware.universe/pull/2472)
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
