### PR TITLE
feat(tier4_autoware_utils): add toHexString

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/uuid_helper.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/uuid_helper.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2022 Tier IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 namespace tier4_autoware_utils
 {
-std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
+inline std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
 {
   std::stringstream ss;
   for (auto i = 0; i < 16; ++i) {

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/uuid_helper.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/uuid_helper.hpp
@@ -1,0 +1,34 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TIER4_AUTOWARE_UTILS__ROS__UUID_HELPER_HPP_
+#define TIER4_AUTOWARE_UTILS__ROS__UUID_HELPER_HPP_
+
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <string>
+
+namespace tier4_autoware_utils
+{
+std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
+{
+  std::stringstream ss;
+  for (auto i = 0; i < 16; ++i) {
+    ss << std::hex << std::setfill('0') << std::setw(2) << +id.uuid[i];
+  }
+  return ss.str();
+}
+}  // namespace tier4_autoware_utils
+
+#endif  // TIER4_AUTOWARE_UTILS__ROS__UUID_HELPER_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
@@ -33,6 +33,7 @@
 #include "tier4_autoware_utils/ros/self_pose_listener.hpp"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
 #include "tier4_autoware_utils/ros/update_param.hpp"
+#include "tier4_autoware_utils/ros/uuid_helper.hpp"
 #include "tier4_autoware_utils/ros/wait_for_param.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 

--- a/common/tier4_autoware_utils/package.xml
+++ b/common/tier4_autoware_utils/package.xml
@@ -23,6 +23,7 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tier4_debug_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -37,17 +37,6 @@
 
 namespace map_based_prediction
 {
-namespace
-{
-std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
-{
-  std::stringstream ss;
-  for (auto i = 0; i < 16; ++i) {
-    ss << std::hex << std::setfill('0') << std::setw(2) << +id.uuid[i];
-  }
-  return ss.str();
-}
-
 lanelet::ConstLanelets getLanelets(const map_based_prediction::LaneletsData & data)
 {
   lanelet::ConstLanelets lanelets;
@@ -246,7 +235,6 @@ bool hasPotentialToReach(
 
   return false;
 }
-}  // namespace
 
 MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_options)
 : Node("map_based_prediction", node_options), debug_accumulated_time_(0.0)
@@ -364,7 +352,7 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
   visualization_msgs::msg::MarkerArray debug_markers;
 
   for (const auto & object : in_objects->objects) {
-    std::string object_id = toHexString(object.object_id);
+    std::string object_id = tier4_autoware_utils::toHexString(object.object_id);
     TrackedObject transformed_object = object;
 
     // transform object frame if it's based on map frame
@@ -744,7 +732,7 @@ bool MapBasedPredictionNode::checkCloseLaneletCondition(
 
   // If the object is in the objects history, we check if the target lanelet is
   // inside the current lanelets id or following lanelets
-  const std::string object_id = toHexString(object.object_id);
+  const std::string object_id = tier4_autoware_utils::toHexString(object.object_id);
   if (objects_history_.count(object_id) != 0) {
     const std::vector<lanelet::ConstLanelet> & possible_lanelet =
       objects_history_.at(object_id).back().future_possible_lanelets;
@@ -817,7 +805,7 @@ void MapBasedPredictionNode::updateObjectsHistory(
   const std_msgs::msg::Header & header, const TrackedObject & object,
   const LaneletsData & current_lanelets_data)
 {
-  std::string object_id = toHexString(object.object_id);
+  std::string object_id = tier4_autoware_utils::toHexString(object.object_id);
   const auto current_lanelets = getLanelets(current_lanelets_data);
 
   ObjectData single_object_data;
@@ -904,7 +892,7 @@ Maneuver MapBasedPredictionNode::predictObjectManeuver(
   const double object_detected_time)
 {
   // Step1. Check if we have the object in the buffer
-  const std::string object_id = toHexString(object.object_id);
+  const std::string object_id = tier4_autoware_utils::toHexString(object.object_id);
   if (objects_history_.count(object_id) == 0) {
     return Maneuver::LANE_FOLLOW;
   }
@@ -1063,7 +1051,7 @@ double MapBasedPredictionNode::calcLeftLateralOffset(
 void MapBasedPredictionNode::updateFuturePossibleLanelets(
   const TrackedObject & object, const lanelet::routing::LaneletPaths & paths)
 {
-  std::string object_id = toHexString(object.object_id);
+  std::string object_id = tier4_autoware_utils::toHexString(object.object_id);
   if (objects_history_.count(object_id) == 0) {
     return;
   }

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -39,17 +39,10 @@ using tier4_autoware_utils::createPoint;
 using tier4_autoware_utils::getPoint;
 using tier4_autoware_utils::getPose;
 using tier4_autoware_utils::pose2transform;
+using tier4_autoware_utils::toHexString;
 
 namespace
 {
-std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
-{
-  std::stringstream ss;
-  for (auto i = 0; i < 16; ++i) {
-    ss << std::hex << std::setfill('0') << std::setw(2) << +id.uuid[i];
-  }
-  return ss.str();
-}
 geometry_msgs::msg::Point32 createPoint32(const double x, const double y, const double z)
 {
   geometry_msgs::msg::Point32 p;


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

add toHexString function, which is used in some packages, to tier4_autoware_utils

FYI: This function will be used in obstacle_cruise_planner as well in another PR.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
