### PR TITLE
fix(intersection): always set RTC distance to default stop line

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -236,13 +236,9 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     logger_.get_child("state_machine"), *clock_);
 
   setSafe(state_machine_.getState() == StateMachine::State::GO);
-  if (is_entry_prohibited) {
-    setDistance(motion_utils::calcSignedArcLength(
-      path->points, planner_data_->current_pose.pose.position,
-      path->points.at(stop_line_idx_final).point.pose.position));
-  } else {
-    setDistance(std::numeric_limits<double>::lowest());
-  }
+  setDistance(motion_utils::calcSignedArcLength(
+    path->points, planner_data_->current_pose.pose.position,
+    path->points.at(stop_line_idx_final).point.pose.position));
 
   if (!isActivated()) {
     // if RTC says intersection entry is 'dangerous', insert stop_line(v == 0.0) in this block


### PR DESCRIPTION
Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

Always set RTC distance to default stop line position

## Tests performed

### RTC distance value:

before this change:
```
  module:
    type: 8
  safe: true
  command_status:
    type: 1
  auto_mode: false
  start_distance: -100000.0
  finish_distance: -100000.0
```

after this change:
```
  module:
    type: 8
  safe: true
  command_status:
    type: 0
  auto_mode: false
  start_distance: 32.69912338256836
  finish_distance: 32.69912338256836
```

### stop line visibility

pressed R2 button on foa.

before this change (intersection stop line does not appear):
 
![Screenshot from 2022-12-20 11-05-22](https://user-images.githubusercontent.com/28677420/208564595-51a7785e-e7b0-43c3-973e-0e6f8b2096ee.png)

after this change (intersection stop line appears):

![Screenshot from 2022-12-20 11-07-52](https://user-images.githubusercontent.com/28677420/208564664-df6ba700-2ea4-4728-8d1e-39284528fba5.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
