### PR TITLE
feat(behavior_velocity_planner): change planner data update

### DIFF
--- a/planning/behavior_velocity_planner/include/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/include/behavior_velocity_planner/node.hpp
@@ -40,6 +40,7 @@
 
 namespace behavior_velocity_planner
 {
+using autoware_auto_mapping_msgs::msg::HADMapBin;
 using tier4_planning_msgs::msg::VelocityLimit;
 class BehaviorVelocityPlannerNode : public rclcpp::Node
 {
@@ -109,6 +110,8 @@ private:
   PlannerData planner_data_;
   BehaviorVelocityPlannerManager planner_manager_;
   bool is_driving_forward_{true};
+  HADMapBin::ConstSharedPtr map_ptr_{nullptr};
+  bool has_received_map_;
 
   // mutex for planner_data_
   std::mutex mutex_;

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -238,12 +238,7 @@ bool BehaviorVelocityPlannerNode::isDataReady(
     RCLCPP_INFO_THROTTLE(get_logger(), clock, 3000, "Waiting for pointcloud");
     return false;
   }
-  if (!d.route_handler_) {
-    RCLCPP_INFO_THROTTLE(
-      get_logger(), clock, 3000, "Waiting for the initialization of route_handler");
-    return false;
-  }
-  if (!d.route_handler_->isMapMsgReady()) {
+  if (!map_ptr_) {
     RCLCPP_INFO_THROTTLE(get_logger(), clock, 3000, "Waiting for the initialization of map");
     return false;
   }
@@ -344,8 +339,8 @@ void BehaviorVelocityPlannerNode::onLaneletMap(
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  // Load map
-  planner_data_.route_handler_ = std::make_shared<route_handler::RouteHandler>(*msg);
+  map_ptr_ = msg;
+  has_received_map_ = true;
 }
 
 void BehaviorVelocityPlannerNode::onTrafficSignals(
@@ -415,6 +410,18 @@ void BehaviorVelocityPlannerNode::onTrigger(
   }
 
   if (!isDataReady(planner_data_, *get_clock())) {
+    mutex_.unlock();
+    return;
+  }
+
+  // Load map and check route handler
+  if (has_received_map_) {
+    planner_data_.route_handler_ = std::make_shared<route_handler::RouteHandler>(*map_ptr_);
+    has_received_map_ = false;
+  }
+  if (!planner_data_.route_handler_) {
+    RCLCPP_INFO_THROTTLE(
+      get_logger(), *get_clock(), 3000, "Waiting for the initialization of route_handler");
     mutex_.unlock();
     return;
   }


### PR DESCRIPTION
Signed-off-by: yutaka <purewater0901@gmail.com>

## Description
Current planner data handlers in the behavior velocity planner can cause serious problems for data access. In this PR, I changed the timing of updating the route_handler in planner_data.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
