### PR TITLE
refactor(avoidance): generate shift line before the plan() function

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -200,6 +200,7 @@ private:
   void fillObjectMovingTime(ObjectData & object_data) const;
   void compensateDetectionLost(
     ObjectDataArray & target_objects, ObjectDataArray & other_objects) const;
+  void fillAvoidancePath(AvoidancePlanningData & data, DebugData & debug) const;
 
   // data used in previous planning
   ShiftedPath prev_output_;
@@ -225,7 +226,8 @@ private:
   void updateRegisteredObject(const ObjectDataArray & objects);
 
   // -- for shift point generation --
-  AvoidLineArray calcShiftLines(AvoidLineArray & current_raw_shift_lines, DebugData & debug) const;
+  AvoidLineArray applyPreProcessToRawShiftLines(
+    AvoidLineArray & current_raw_shift_points, DebugData & debug) const;
 
   // shift point generation: generator
   double getShiftLength(
@@ -268,7 +270,7 @@ private:
   void fillAdditionalInfoFromLongitudinal(AvoidLineArray & shift_lines) const;
 
   // -- for new shift point approval --
-  boost::optional<AvoidLineArray> findNewShiftLine(
+  AvoidLineArray findNewShiftLine(
     const AvoidLineArray & shift_lines, const PathShifter & shifter) const;
   void addShiftLineIfApproved(const AvoidLineArray & point);
   void addNewShiftLines(PathShifter & path_shifter, const AvoidLineArray & shift_lines) const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -28,6 +28,7 @@
 #include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
 #include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
@@ -35,7 +36,12 @@
 
 namespace behavior_path_planner
 {
+
+using motion_utils::calcSignedArcLength;
+using motion_utils::findNearestIndex;
+
 using tier4_planning_msgs::msg::AvoidanceDebugMsg;
+
 class AvoidanceModule : public SceneModuleInterface
 {
 public:
@@ -134,10 +140,10 @@ private:
     const Point ego_position = planner_data_->self_pose->pose.position;
 
     for (const auto & left_shift : left_shift_array_) {
-      const double start_distance = motion_utils::calcSignedArcLength(
-        path.points, ego_position, left_shift.start_pose.position);
-      const double finish_distance = motion_utils::calcSignedArcLength(
-        path.points, ego_position, left_shift.finish_pose.position);
+      const double start_distance =
+        calcSignedArcLength(path.points, ego_position, left_shift.start_pose.position);
+      const double finish_distance =
+        calcSignedArcLength(path.points, ego_position, left_shift.finish_pose.position);
       rtc_interface_left_.updateCooperateStatus(
         left_shift.uuid, true, start_distance, finish_distance, clock_->now());
       if (finish_distance > -1.0e-03) {
@@ -148,10 +154,10 @@ private:
     }
 
     for (const auto & right_shift : right_shift_array_) {
-      const double start_distance = motion_utils::calcSignedArcLength(
-        path.points, ego_position, right_shift.start_pose.position);
-      const double finish_distance = motion_utils::calcSignedArcLength(
-        path.points, ego_position, right_shift.finish_pose.position);
+      const double start_distance =
+        calcSignedArcLength(path.points, ego_position, right_shift.start_pose.position);
+      const double finish_distance =
+        calcSignedArcLength(path.points, ego_position, right_shift.finish_pose.position);
       rtc_interface_right_.updateCooperateStatus(
         right_shift.uuid, true, start_distance, finish_distance, clock_->now());
       if (finish_distance > -1.0e-03) {
@@ -233,8 +239,6 @@ private:
   double getShiftLength(
     const ObjectData & object, const bool & is_object_on_right, const double & avoid_margin) const;
   AvoidLineArray calcRawShiftLinesFromObjects(const ObjectDataArray & objects) const;
-  double getRightShiftBound() const;
-  double getLeftShiftBound() const;
 
   // shift point generation: combiner
   AvoidLineArray combineRawShiftLinesWithUniqueCheck(
@@ -302,32 +306,90 @@ private:
   void updateAvoidanceDebugData(std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const;
   mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_line_;
   mutable rclcpp::Time debug_avoidance_initializer_for_shift_line_time_;
-  // =====================================
+
   // ========= helper functions ==========
-  // =====================================
+
+  double getEgoSpeed() const
+  {
+    return std::abs(planner_data_->self_odometry->twist.twist.linear.x);
+  }
+
+  double getNominalAvoidanceEgoSpeed() const
+  {
+    return std::max(getEgoSpeed(), parameters_->min_nominal_avoidance_speed);
+  }
+
+  double getSharpAvoidanceEgoSpeed() const
+  {
+    return std::max(getEgoSpeed(), parameters_->min_sharp_avoidance_speed);
+  }
+
+  double getNominalPrepareDistance() const
+  {
+    const auto & p = parameters_;
+    const auto epsilon_m = 0.01;  // for floating error to pass "has_enough_distance" check.
+    const auto nominal_distance =
+      std::max(getEgoSpeed() * p->prepare_time, p->min_prepare_distance);
+    return nominal_distance + epsilon_m;
+  }
+
+  double getNominalAvoidanceDistance(const double shift_length) const
+  {
+    const auto & p = parameters_;
+    const auto distance_by_jerk = PathShifter::calcLongitudinalDistFromJerk(
+      shift_length, parameters_->nominal_lateral_jerk, getNominalAvoidanceEgoSpeed());
+
+    return std::max(p->min_avoidance_distance, distance_by_jerk);
+  }
+
+  double getSharpAvoidanceDistance(const double shift_length) const
+  {
+    const auto & p = parameters_;
+    const auto distance_by_jerk = PathShifter::calcLongitudinalDistFromJerk(
+      shift_length, parameters_->max_lateral_jerk, getSharpAvoidanceEgoSpeed());
+
+    return std::max(p->min_avoidance_distance, distance_by_jerk);
+  }
+
+  double getRightShiftBound() const
+  {
+    // TODO(Horibe) write me. Real lane boundary must be considered here.
+    return -parameters_->max_right_shift_length;
+  }
+
+  double getLeftShiftBound() const
+  {
+    // TODO(Horibe) write me. Real lane boundary must be considered here.
+    return parameters_->max_left_shift_length;
+  }
+
+  double getCurrentShift() const
+  {
+    return prev_output_.shift_length.at(
+      findNearestIndex(prev_output_.path.points, getEgoPosition()));
+  }
+
+  double getCurrentLinearShift() const
+  {
+    return prev_linear_shift_path_.shift_length.at(
+      findNearestIndex(prev_linear_shift_path_.path.points, getEgoPosition()));
+  }
+
+  double getCurrentBaseShift() const { return path_shifter_.getBaseOffset(); }
+
+  Point getEgoPosition() const { return planner_data_->self_pose->pose.position; }
+
+  Pose getEgoPose() const { return planner_data_->self_pose->pose; }
+
+  Pose getUnshiftedEgoPose(const ShiftedPath & prev_path) const;
 
   PathWithLaneId calcCenterLinePath(
-    const std::shared_ptr<const PlannerData> & planner_data, const PoseStamped & pose) const;
+    const std::shared_ptr<const PlannerData> & planner_data, const Pose & pose) const;
 
   // TODO(Horibe): think later.
   // for unique ID
   mutable uint64_t original_unique_id = 0;  // TODO(Horibe) remove mutable
   uint64_t getOriginalShiftLineUniqueId() const { return original_unique_id++; }
-
-  double getNominalAvoidanceDistance(const double shift_length) const;
-  double getNominalPrepareDistance() const;
-  double getNominalAvoidanceEgoSpeed() const;
-
-  double getSharpAvoidanceDistance(const double shift_length) const;
-  double getSharpAvoidanceEgoSpeed() const;
-
-  double getEgoSpeed() const;
-  Point getEgoPosition() const;
-  PoseStamped getEgoPose() const;
-  PoseStamped getUnshiftedEgoPose(const ShiftedPath & prev_path) const;
-  double getCurrentBaseShift() const { return path_shifter_.getBaseOffset(); }
-  double getCurrentShift() const;
-  double getCurrentLinearShift() const;
 
   /**
    * avoidance module misc data

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -206,7 +206,7 @@ private:
   void fillObjectMovingTime(ObjectData & object_data) const;
   void compensateDetectionLost(
     ObjectDataArray & target_objects, ObjectDataArray & other_objects) const;
-  void fillAvoidancePath(AvoidancePlanningData & data, DebugData & debug) const;
+  void fillShiftLine(AvoidancePlanningData & data, DebugData & debug) const;
 
   // data used in previous planning
   ShiftedPath prev_output_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -286,11 +286,22 @@ struct AvoidancePlanningData
   // current driving lanelet
   lanelet::ConstLanelets current_lanelets;
 
+  // output path
+  ShiftedPath candidate_path;
+
   // avoidance target objects
   ObjectDataArray target_objects;
 
   // the others
   ObjectDataArray other_objects;
+
+  // raw shift point
+  AvoidLineArray unapproved_raw_sl{};
+
+  // new shift point
+  AvoidLineArray unapproved_new_sl{};
+
+  bool avoiding_now{false};
 };
 
 /*

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -53,7 +53,7 @@ using tier4_planning_msgs::msg::AvoidanceDebugFactor;
 namespace
 {
 
-AvoidLine getNotStraightShiftLine(const AvoidLineArray & shift_lines)
+AvoidLine getNonStraightShiftLine(const AvoidLineArray & shift_lines)
 {
   for (const auto & sl : shift_lines) {
     if (fabs(sl.getRelativeLength()) > 0.01) {
@@ -2277,7 +2277,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
     DEBUG_PRINT("new_shift_lines size = %lu", data.unapproved_new_sl.size());
     printShiftLines(data.unapproved_new_sl, "new_shift_lines");
 
-    const auto sl = getNotStraightShiftLine(data.unapproved_new_sl);
+    const auto sl = getNonStraightShiftLine(data.unapproved_new_sl);
     if (sl.getRelativeLength() > 0.0) {
       removePreviousRTCStatusRight();
     } else if (sl.getRelativeLength() < 0.0) {
@@ -2345,7 +2345,7 @@ CandidateOutput AvoidanceModule::planCandidate() const
   if (!data.unapproved_new_sl.empty()) {  // clip from shift start index for visualize
     clipByMinStartIdx(data.unapproved_new_sl, shifted_path.path);
 
-    const auto sl = getNotStraightShiftLine(data.unapproved_new_sl);
+    const auto sl = getNonStraightShiftLine(data.unapproved_new_sl);
     const auto sl_front = data.unapproved_new_sl.front();
     const auto sl_back = data.unapproved_new_sl.back();
 
@@ -2403,7 +2403,7 @@ void AvoidanceModule::addShiftLineIfApproved(const AvoidLineArray & shift_lines)
     // register original points for consistency
     registerRawShiftLines(shift_lines);
 
-    const auto sl = getNotStraightShiftLine(shift_lines);
+    const auto sl = getNonStraightShiftLine(shift_lines);
     const auto sl_front = shift_lines.front();
     const auto sl_back = shift_lines.back();
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -519,7 +519,7 @@ void AvoidanceModule::fillObjectMovingTime(ObjectData & object_data) const
   }
 }
 
-void AvoidanceModule::fillAvoidancePath(AvoidancePlanningData & data, DebugData & debug) const
+void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & debug) const
 {
   constexpr double AVOIDING_SHIFT_THR = 0.1;
   data.avoiding_now = std::abs(getCurrentShift()) > AVOIDING_SHIFT_THR;
@@ -2613,7 +2613,7 @@ void AvoidanceModule::updateData()
     prev_reference_ = avoidance_data_.reference_path;
   }
 
-  fillAvoidancePath(avoidance_data_, debug_data_);
+  fillShiftLine(avoidance_data_, debug_data_);
 }
 
 /*


### PR DESCRIPTION
## Description

- this PR contains small process flow update.
  - previously, shift lines are generated in plan().
  - in this PR, shift lines are generated in updateData() (before the plan() function)
- this PR also contains code cleaning.
  - define helper functions in header file.

<!-- Write a brief description of this PR. -->

## Test Perform

Evaluator Result

- [[TIER IV INTERNAL]](https://evaluation.tier4.jp/evaluation/reports/8253c599-6048-519d-b643-1f571653b14f?project_id=prd_jt) This PR (817/825)
- [[TIER IV INTERNAL]](https://evaluation.tier4.jp/evaluation/reports/981ab539-bd85-5a45-9fe2-781255a71554?project_id=prd_jt) Baseline (812/825)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
