### PR TITLE
feat(avoidance): implement avoidance path safety check logic

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -10,6 +10,7 @@
       enable_avoidance_over_same_direction: true
       enable_avoidance_over_opposite_direction: true
       enable_update_path_when_object_is_gone: false
+      enable_safety_check: false
 
       # For target object filtering
       threshold_speed_object_is_stopped: 1.0      # [m/s]
@@ -23,10 +24,19 @@
       object_check_shiftable_ratio: 0.6           # [-]
       object_check_min_road_shoulder_width: 0.5   # [m]
 
+      # For safety check
+      safety_check_backward_distance: 50.0        # [m]
+      safety_check_time_horizon: 10.0             # [s]
+      safety_check_idling_time: 1.5               # [s]
+      safety_check_accel_for_rss: 2.5             # [m/ss]
+
       # For lateral margin
       object_envelope_buffer: 0.3                 # [m]
       lateral_collision_margin: 1.0               # [m]
       lateral_collision_safety_buffer: 0.7        # [m]
+
+      # For longitudinal margin
+      longitudinal_collision_margin_buffer: 0.0   # [m]
 
       prepare_time: 2.0                           # [s]
       min_prepare_distance: 1.0                   # [m]
@@ -74,3 +84,9 @@
 
       # ---------- advanced parameters ----------
       avoidance_execution_lateral_threshold: 0.499
+
+      target_velocity_matrix:
+        col_size: 4
+        matrix:
+          [2.78, 5.56, 11.1, 13.9,   # velocity [m/s]
+           0.20, 0.90, 1.10, 1.20]   # margin [m]

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -238,7 +238,9 @@ private:
   // shift point generation: generator
   double getShiftLength(
     const ObjectData & object, const bool & is_object_on_right, const double & avoid_margin) const;
-  AvoidLineArray calcRawShiftLinesFromObjects(const ObjectDataArray & objects) const;
+
+  AvoidLineArray calcRawShiftLinesFromObjects(
+    const AvoidancePlanningData & data, DebugData & debug) const;
 
   // shift point generation: combiner
   AvoidLineArray combineRawShiftLinesWithUniqueCheck(
@@ -306,6 +308,30 @@ private:
   void updateAvoidanceDebugData(std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const;
   mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_line_;
   mutable rclcpp::Time debug_avoidance_initializer_for_shift_line_time_;
+
+  double getLateralMarginFromVelocity(const double velocity) const;
+
+  double getRSSLongitudinalDistance(
+    const double v_ego, const double v_obj, const bool is_front_object) const;
+
+  ObjectDataArray getAdjacentLaneObjects(const lanelet::ConstLanelets & adjacent_lanes) const;
+
+  // ========= safety check ==============
+
+  lanelet::ConstLanelets getAdjacentLane(
+    const PathShifter & path_shifter, const double forward_distance,
+    const double backward_distance) const;
+
+  bool isSafePath(
+    const PathShifter & path_shifter, ShiftedPath & shifted_path, DebugData & debug) const;
+
+  bool isSafePath(
+    const PathWithLaneId & path, const lanelet::ConstLanelets & check_lanes,
+    DebugData & debug) const;
+
+  bool isEnoughMargin(
+    const PathPointWithLaneId & p_ego, const double t, const ObjectData & object,
+    MarginData & margin_data) const;
 
   // ========= helper functions ==========
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -26,6 +26,7 @@
 
 #include <lanelet2_core/geometry/Lanelet.h>
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -33,6 +34,7 @@
 namespace behavior_path_planner
 {
 using autoware_auto_perception_msgs::msg::PredictedObject;
+using autoware_auto_perception_msgs::msg::PredictedPath;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 
 using tier4_autoware_utils::Point2d;
@@ -68,6 +70,9 @@ struct AvoidanceParameters
   // enable update path when if detected objects on planner data is gone.
   bool enable_update_path_when_object_is_gone{false};
 
+  // enable safety check. if avoidance path is NOT safe, the ego will execute yield maneuver
+  bool enable_safety_check{false};
+
   // Vehicles whose distance to the center of the path is
   // less than this will not be considered for avoidance.
   double threshold_distance_object_is_on_center;
@@ -99,6 +104,9 @@ struct AvoidanceParameters
   // don't ever set this value to 0
   double lateral_collision_safety_buffer{0.5};
 
+  // margin between object back and end point of avoid shift point
+  double longitudinal_collision_safety_buffer{0.0};
+
   // when complete avoidance motion, there is a distance margin with the object
   // for longitudinal direction
   double longitudinal_collision_margin_min_distance;
@@ -106,6 +114,21 @@ struct AvoidanceParameters
   // when complete avoidance motion, there is a time margin with the object
   // for longitudinal direction
   double longitudinal_collision_margin_time;
+
+  // find adjacent lane vehicles
+  double safety_check_backward_distance;
+
+  // minimum longitudinal margin for vehicles in adjacent lane
+  double safety_check_min_longitudinal_margin;
+
+  // safety check time horizon
+  double safety_check_time_horizon;
+
+  // use in RSS calculation
+  double safety_check_idling_time;
+
+  // use in RSS calculation
+  double safety_check_accel_for_rss;
 
   // start avoidance after this time to avoid sudden path change
   double prepare_time;
@@ -162,6 +185,12 @@ struct AvoidanceParameters
   // In multiple targets case: if there are multiple vehicles in a row to be avoided, no new
   // avoidance path will be generated unless their lateral margin difference exceeds this value.
   double avoidance_execution_lateral_threshold;
+
+  // target velocity matrix
+  std::vector<double> target_velocity_matrix;
+
+  // matrix col size
+  size_t col_size;
 
   // true by default
   bool avoid_car{true};      // avoidance is performed for type object car
@@ -234,6 +263,9 @@ struct ObjectData  // avoidance target
 
   // lateral distance from overhang to the road shoulder
   double to_road_shoulder_distance{0.0};
+
+  // unavoidable reason
+  std::string reason{""};
 };
 using ObjectDataArray = std::vector<ObjectData>;
 
@@ -301,6 +333,8 @@ struct AvoidancePlanningData
   // new shift point
   AvoidLineArray unapproved_new_sl{};
 
+  bool safe{false};
+
   bool avoiding_now{false};
 };
 
@@ -329,6 +363,27 @@ struct ShiftLineData
 };
 
 /*
+ * Data struct for longitudinal margin
+ */
+struct MarginData
+{
+  Pose pose{};
+
+  bool enough_lateral_margin{true};
+
+  double longitudinal_distance{std::numeric_limits<double>::max()};
+
+  double longitudinal_margin{std::numeric_limits<double>::lowest()};
+
+  double vehicle_width;
+
+  double base_link2front;
+
+  double base_link2rear;
+};
+using MarginDataArray = std::vector<MarginData>;
+
+/*
  * Debug information for marker array
  */
 struct DebugData
@@ -355,6 +410,17 @@ struct DebugData
   std::vector<double> neg_shift;
   std::vector<double> total_shift;
   std::vector<double> output_shift;
+
+  bool exist_adjacent_objects{false};
+
+  // margin
+  MarginDataArray margin_data_array;
+
+  // avoidance require objects
+  ObjectDataArray unavoidable_objects;
+
+  // avoidance unsafe objects
+  ObjectDataArray unsafe_objects;
 
   // tmp for plot
   PathWithLaneId center_line;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -413,6 +413,9 @@ struct DebugData
 
   bool exist_adjacent_objects{false};
 
+  // future pose
+  PathWithLaneId path_with_planned_velocity;
+
   // margin
   MarginDataArray margin_data_array;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -101,6 +101,15 @@ void generateDrivableArea(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes, const double vehicle_length,
   const std::shared_ptr<const PlannerData> planner_data, const ObjectDataArray & objects,
   const bool enable_bound_clipping);
+
+double getLongitudinalVelocity(const Pose & p_ref, const Pose & p_target, const double v);
+
+bool isCentroidWithinLanelets(
+  const PredictedObject & object, const lanelet::ConstLanelets & target_lanelets);
+
+lanelet::ConstLanelets getTargetLanelets(
+  const std::shared_ptr<const PlannerData> & planner_data, lanelet::ConstLanelets & route_lanelets,
+  const double left_offset, const double right_offset);
 }  // namespace behavior_path_planner
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__AVOIDANCE_UTILS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -52,6 +52,8 @@ MarkerArray createAvoidLineMarkerArray(
   const AvoidLineArray & shift_points, std::string && ns, const float & r, const float & g,
   const float & b, const double & w);
 
+MarkerArray createPredictedVehiclePositions(const PathWithLaneId & path, std::string && ns);
+
 MarkerArray createTargetObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);
 
 MarkerArray createOtherObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/debug.hpp
@@ -36,6 +36,7 @@ namespace marker_utils::avoidance_marker
 {
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
+using behavior_path_planner::AvoidancePlanningData;
 using behavior_path_planner::AvoidLineArray;
 using behavior_path_planner::ObjectDataArray;
 using behavior_path_planner::ShiftLineArray;
@@ -44,15 +45,20 @@ using geometry_msgs::msg::Polygon;
 using geometry_msgs::msg::Pose;
 using visualization_msgs::msg::MarkerArray;
 
+MarkerArray createEgoStatusMarkerArray(
+  const AvoidancePlanningData & data, const Pose & p_ego, std::string && ns);
+
 MarkerArray createAvoidLineMarkerArray(
   const AvoidLineArray & shift_points, std::string && ns, const float & r, const float & g,
   const float & b, const double & w);
 
-MarkerArray createTargetObjectsMarkerArray(
-  const behavior_path_planner::ObjectDataArray & objects, std::string && ns);
+MarkerArray createTargetObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);
 
-MarkerArray createOtherObjectsMarkerArray(
-  const behavior_path_planner::ObjectDataArray & objects, std::string && ns);
+MarkerArray createOtherObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);
+
+MarkerArray createUnsafeObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);
+
+MarkerArray createUnavoidableObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);
 
 MarkerArray makeOverhangToRoadShoulderMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects, std::string && ns);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -47,6 +47,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace behavior_path_planner::util
@@ -88,7 +89,7 @@ struct ProjectedDistancePoint
   double distance{0.0};
 };
 
-template <typename Pythagoras = bg::strategy::distance::pythagoras<> >
+template <typename Pythagoras = bg::strategy::distance::pythagoras<>>
 ProjectedDistancePoint pointToSegment(
   const Point2d & reference_point, const Point2d & point_from_ego,
   const Point2d & point_from_object);
@@ -266,7 +267,23 @@ std::vector<size_t> filterObjectIndicesByLanelets(
 std::vector<size_t> filterObjectIndicesByLanelets(
   const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets);
 
+/**
+ * @brief Separate index of the obstacles into two part based on whether the object is within
+ * lanelet.
+ * @return Indices of objects pair. first objects are in the lanelet, and second others are out of
+ * lanelet.
+ */
+std::pair<std::vector<size_t>, std::vector<size_t>> separateObjectIndicesByLanelets(
+  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets);
+
 PredictedObjects filterObjectsByLanelets(
+  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets);
+
+/**
+ * @brief Separate the objects into two part based on whether the object is within lanelet.
+ * @return Objects pair. first objects are in the lanelet, and second others are out of lanelet.
+ */
+std::pair<PredictedObjects, PredictedObjects> separateObjectsByLanelets(
   const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets);
 
 std::vector<size_t> filterObjectsIndicesByPath(

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -261,22 +261,12 @@ std::vector<size_t> filterObjectIndicesByLanelets(
   const double start_arc_length, const double end_arc_length);
 
 /**
- * @brief Get index of the obstacles inside the lanelets
- * @return Indices corresponding to the obstacle inside the lanelets
- */
-std::vector<size_t> filterObjectIndicesByLanelets(
-  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets);
-
-/**
  * @brief Separate index of the obstacles into two part based on whether the object is within
  * lanelet.
  * @return Indices of objects pair. first objects are in the lanelet, and second others are out of
  * lanelet.
  */
 std::pair<std::vector<size_t>, std::vector<size_t>> separateObjectIndicesByLanelets(
-  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets);
-
-PredictedObjects filterObjectsByLanelets(
   const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets);
 
 /**

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -288,6 +288,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.enable_avoidance_over_same_direction = dp("enable_avoidance_over_same_direction", true);
   p.enable_avoidance_over_opposite_direction = dp("enable_avoidance_over_opposite_direction", true);
   p.enable_update_path_when_object_is_gone = dp("enable_update_path_when_object_is_gone", false);
+  p.enable_safety_check = dp("enable_safety_check", false);
 
   p.threshold_distance_object_is_on_center = dp("threshold_distance_object_is_on_center", 1.0);
   p.threshold_speed_object_is_stopped = dp("threshold_speed_object_is_stopped", 1.0);
@@ -299,6 +300,13 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.object_envelope_buffer = dp("object_envelope_buffer", 0.1);
   p.lateral_collision_margin = dp("lateral_collision_margin", 2.0);
   p.lateral_collision_safety_buffer = dp("lateral_collision_safety_buffer", 0.5);
+  p.longitudinal_collision_safety_buffer = dp("longitudinal_collision_safety_buffer", 0.0);
+
+  p.safety_check_min_longitudinal_margin = dp("safety_check_min_longitudinal_margin", 0.0);
+  p.safety_check_backward_distance = dp("safety_check_backward_distance", 0.0);
+  p.safety_check_time_horizon = dp("safety_check_time_horizon", 10.0);
+  p.safety_check_idling_time = dp("safety_check_idling_time", 1.5);
+  p.safety_check_accel_for_rss = dp("safety_check_accel_for_rss", 2.5);
 
   p.prepare_time = dp("prepare_time", 3.0);
   p.min_prepare_distance = dp("min_prepare_distance", 10.0);
@@ -326,6 +334,13 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
 
   p.publish_debug_marker = dp("publish_debug_marker", false);
   p.print_debug_info = dp("print_debug_info", false);
+
+  // velocity matrix
+  {
+    std::string ns = "avoidance.target_velocity_matrix.";
+    p.col_size = declare_parameter<int>(ns + "col_size");
+    p.target_velocity_matrix = declare_parameter<std::vector<double>>(ns + "matrix");
+  }
 
   p.avoid_car = dp("target_object.car", true);
   p.avoid_truck = dp("target_object.truck", true);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -47,7 +47,12 @@ using motion_utils::calcSignedArcLength;
 using motion_utils::findNearestIndex;
 using motion_utils::findNearestSegmentIndex;
 using tier4_autoware_utils::calcDistance2d;
+using tier4_autoware_utils::calcInterpolatedPose;
 using tier4_autoware_utils::calcLateralDeviation;
+using tier4_autoware_utils::calcLongitudinalDeviation;
+using tier4_autoware_utils::calcYawDeviation;
+using tier4_autoware_utils::getPoint;
+using tier4_autoware_utils::getPose;
 using tier4_planning_msgs::msg::AvoidanceDebugFactor;
 
 namespace
@@ -220,14 +225,23 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
   // detection area filter
   // when expanding lanelets, right_offset must be minus.
   // This is because y axis is positive on the left.
-  const auto expanded_lanelets = lanelet::utils::getExpandedLanelets(
-    data.current_lanelets, parameters_->detection_area_left_expand_dist,
+  const auto expanded_lanelets = getTargetLanelets(
+    planner_data_, data.current_lanelets, parameters_->detection_area_left_expand_dist,
     parameters_->detection_area_right_expand_dist * (-1.0));
-  const auto lane_filtered_objects_index =
-    util::filterObjectIndicesByLanelets(*planner_data_->dynamic_object, expanded_lanelets);
+
+  PredictedObjects far_objects;
+  const auto lane_filtered_objects =
+    filterObjectsByLanelets(*planner_data_->dynamic_object, expanded_lanelets, far_objects);
+
+  for (const auto & object : far_objects.objects) {
+    ObjectData other_object;
+    other_object.object = object;
+    other_object.reason = "OutOfTargetArea";
+    data.other_objects.push_back(other_object);
+  }
 
   DEBUG_PRINT("dynamic_objects size = %lu", planner_data_->dynamic_object->objects.size());
-  DEBUG_PRINT("lane_filtered_objects size = %lu", lane_filtered_objects_index.size());
+  DEBUG_PRINT("lane_filtered_objects size = %lu", lane_filtered_objects.objects.size());
 
   // for goal
   const auto & rh = planner_data_->route_handler;
@@ -241,8 +255,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
   // for filtered objects
   ObjectDataArray target_objects;
   std::vector<AvoidanceDebugMsg> avoidance_debug_msg_array;
-  for (const auto & i : lane_filtered_objects_index) {
-    const auto & object = planner_data_->dynamic_object->objects.at(i);
+  for (const auto & object : lane_filtered_objects.objects) {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     AvoidanceDebugMsg avoidance_debug_msg;
     const auto avoidance_debug_array_false_and_push_back =
@@ -252,14 +265,16 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
         avoidance_debug_msg_array.push_back(avoidance_debug_msg);
       };
 
-    if (!isTargetObjectType(object)) {
-      avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_IS_NOT_TYPE);
-      continue;
-    }
-
     ObjectData object_data;
     object_data.object = object;
     avoidance_debug_msg.object_id = getUuidStr(object_data);
+
+    if (!isTargetObjectType(object)) {
+      avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_IS_NOT_TYPE);
+      object_data.reason = AvoidanceDebugFactor::OBJECT_IS_NOT_TYPE;
+      data.other_objects.push_back(object_data);
+      continue;
+    }
 
     const auto object_closest_index = findNearestIndex(path_points, object_pose.position);
     const auto object_closest_pose = path_points.at(object_closest_index).point.pose;
@@ -279,6 +294,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
 
     if (object_data.move_time > parameters_->threshold_time_object_is_moving) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::MOVING_OBJECT);
+      object_data.reason = AvoidanceDebugFactor::MOVING_OBJECT;
       data.other_objects.push_back(object_data);
       continue;
     }
@@ -286,11 +302,13 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
     // object is behind ego or too far.
     if (object_data.longitudinal < -parameters_->object_check_backward_distance) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_IS_BEHIND_THRESHOLD);
+      object_data.reason = AvoidanceDebugFactor::OBJECT_BEHIND_PATH_GOAL;
       data.other_objects.push_back(object_data);
       continue;
     }
     if (object_data.longitudinal > parameters_->object_check_forward_distance) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_IS_IN_FRONT_THRESHOLD);
+      object_data.reason = AvoidanceDebugFactor::OBJECT_IS_IN_FRONT_THRESHOLD;
       data.other_objects.push_back(object_data);
       continue;
     }
@@ -298,6 +316,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
     // Target object is behind the path goal -> ignore.
     if (object_data.longitudinal > dist_to_goal) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_BEHIND_PATH_GOAL);
+      object_data.reason = AvoidanceDebugFactor::OBJECT_BEHIND_PATH_GOAL;
       data.other_objects.push_back(object_data);
       continue;
     }
@@ -350,6 +369,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
     avoidance_debug_msg.lateral_distance_from_centerline = object_data.lateral;
     if (std::abs(object_data.lateral) < parameters_->threshold_distance_object_is_on_center) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE);
+      object_data.reason = AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE;
       data.other_objects.push_back(object_data);
       continue;
     }
@@ -381,6 +401,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
       std::string turn_direction = overhang_lanelet.attributeOr("turn_direction", "else");
       if (turn_direction == "right" || turn_direction == "left" || turn_direction == "straight") {
         avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::NOT_PARKING_OBJECT);
+        object_data.reason = AvoidanceDebugFactor::NOT_PARKING_OBJECT;
         data.other_objects.push_back(object_data);
         continue;
       }
@@ -432,6 +453,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
 
       if (!is_parking_object) {
         avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::NOT_PARKING_OBJECT);
+        object_data.reason = AvoidanceDebugFactor::NOT_PARKING_OBJECT;
         data.other_objects.push_back(object_data);
         continue;
       }
@@ -531,7 +553,7 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
    * Create raw shift points from target object. The lateral margin between the ego and the target
    * object varies depending on the relative speed between the ego and the target object.
    */
-  data.unapproved_raw_sl = calcRawShiftLinesFromObjects(data.target_objects);
+  data.unapproved_raw_sl = calcRawShiftLinesFromObjects(data, debug);
 
   /**
    * STEP 2
@@ -557,10 +579,20 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
    * STEP 5
    * Generate avoidance path.
    */
-  data.candidate_path = generateAvoidancePath(path_shifter);
+  auto candidate_path = generateAvoidancePath(path_shifter);
+
+  /**
+   * STEP 6
+   * Check avoidance path safety. For each target objects and the objects in adjacent lanes,
+   * check that there is a certain amount of margin in the lateral and longitudinal direction.
+   */
+  data.safe = isSafePath(path_shifter, candidate_path, debug);
+  data.candidate_path = candidate_path;
 
   {
+    debug.output_shift = data.candidate_path.shift_length;
     debug.current_raw_shift = data.unapproved_raw_sl;
+    debug.new_shift_lines = data.unapproved_new_sl;
   }
 }
 
@@ -707,9 +739,14 @@ double AvoidanceModule::getShiftLength(
  * Calculate the shift points (start/end point, shift length) from the object lateral
  * and longitudinal positions in the Frenet coordinate. The jerk limit is also considered here.
  */
-AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(const ObjectDataArray & objects) const
+AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
+  const AvoidancePlanningData & data, DebugData & debug) const
 {
-  debug_avoidance_initializer_for_shift_line_.clear();
+  {
+    debug_avoidance_initializer_for_shift_line_.clear();
+    debug.unavoidable_objects.clear();
+  }
+
   const auto prepare_distance = getNominalPrepareDistance();
 
   // To be consistent with changes in the ego position, the current shift length is considered.
@@ -724,8 +761,8 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(const ObjectDataArr
 
   AvoidLineArray avoid_lines;
   std::vector<AvoidanceDebugMsg> avoidance_debug_msg_array;
-  avoidance_debug_msg_array.reserve(objects.size());
-  for (auto & o : objects) {
+  avoidance_debug_msg_array.reserve(data.target_objects.size());
+  for (auto o : data.target_objects) {
     AvoidanceDebugMsg avoidance_debug_msg;
     const auto avoidance_debug_array_false_and_push_back =
       [&avoidance_debug_msg, &avoidance_debug_msg_array](const std::string & failed_reason) {
@@ -751,6 +788,8 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(const ObjectDataArr
       } else {
         avoidance_debug_array_false_and_push_back(
           AvoidanceDebugFactor::INSUFFICIENT_LATERAL_MARGIN);
+        o.reason = AvoidanceDebugFactor::INSUFFICIENT_LATERAL_MARGIN;
+        debug.unavoidable_objects.push_back(o);
         continue;
       }
     }
@@ -759,6 +798,8 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(const ObjectDataArr
     const auto shift_length = getShiftLength(o, is_object_on_right, avoid_margin);
     if (isSameDirectionShift(is_object_on_right, shift_length)) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::SAME_DIRECTION_SHIFT);
+      o.reason = AvoidanceDebugFactor::SAME_DIRECTION_SHIFT;
+      debug.unavoidable_objects.push_back(o);
       continue;
     }
 
@@ -786,6 +827,10 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(const ObjectDataArr
         // is not zero.
         avoidance_debug_array_false_and_push_back(
           AvoidanceDebugFactor::REMAINING_DISTANCE_LESS_THAN_ZERO);
+        if (!data.avoiding_now) {
+          o.reason = AvoidanceDebugFactor::REMAINING_DISTANCE_LESS_THAN_ZERO;
+          debug.unavoidable_objects.push_back(o);
+        }
         continue;
       }
 
@@ -796,6 +841,10 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(const ObjectDataArr
       avoidance_debug_msg.maximum_jerk = parameters_->max_lateral_jerk;
       if (required_jerk > parameters_->max_lateral_jerk) {
         avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::TOO_LARGE_JERK);
+        if (!data.avoiding_now) {
+          o.reason = AvoidanceDebugFactor::TOO_LARGE_JERK;
+          debug.unavoidable_objects.push_back(o);
+        }
         continue;
       }
     }
@@ -1939,6 +1988,367 @@ void AvoidanceModule::addReturnShiftLineFromEgo(
   DEBUG_PRINT("Return Shift is added.");
 }
 
+bool AvoidanceModule::isSafePath(
+  const PathShifter & path_shifter, ShiftedPath & shifted_path, DebugData & debug) const
+{
+  const auto & p = parameters_;
+
+  if (!p->enable_safety_check) {
+    return true;  // if safety check is disabled, it always return safe.
+  }
+
+  const auto & forward_check_distance = p->object_check_forward_distance;
+  const auto & backward_check_distance = p->safety_check_backward_distance;
+  const auto check_lanes =
+    getAdjacentLane(path_shifter, forward_check_distance, backward_check_distance);
+
+  PathWithLaneId smoothed_path;
+  if (!util::applyVelocitySmoothing(
+        planner_data_, shifted_path.path, forward_check_distance, smoothed_path)) {
+    // TODO(Satoshi OTA)  Think later the process in the case of failed to velocity smoothing.
+    RCLCPP_WARN(
+      rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
+      "failed velocity smoothing.");
+    return true;
+  }
+
+  smoothed_path = util::resamplePathWithSpline(smoothed_path, 0.5);
+
+  return isSafePath(smoothed_path, check_lanes, debug);
+}
+
+bool AvoidanceModule::isSafePath(
+  const PathWithLaneId & path, const lanelet::ConstLanelets & check_lanes, DebugData & debug) const
+{
+  if (path.points.empty()) {
+    return true;
+  }
+
+  const auto path_with_time = [&path]() {
+    std::vector<std::pair<PathPointWithLaneId, double>> ret{};
+
+    float travel_time = 0.0;
+    ret.push_back(std::make_pair(path.points.front(), travel_time));
+
+    for (size_t i = 1; i < path.points.size(); ++i) {
+      const auto & p1 = path.points.at(i - 1);
+      const auto & p2 = path.points.at(i);
+
+      const auto v = std::max(p1.point.longitudinal_velocity_mps, float{1.0});
+      const auto ds = calcDistance2d(p1, p2);
+
+      travel_time += ds / v;
+
+      ret.push_back(std::make_pair(p2, travel_time));
+    }
+
+    return ret;
+  }();
+
+  const auto move_objects = getAdjacentLaneObjects(check_lanes);
+
+  {
+    debug.unsafe_objects.clear();
+    debug.margin_data_array.clear();
+    debug.exist_adjacent_objects = !move_objects.empty();
+  }
+
+  bool is_safe = true;
+  for (const auto & p : path_with_time) {
+    MarginData margin_data{};
+    margin_data.pose = getPose(p.first);
+
+    if (p.second > parameters_->safety_check_time_horizon) {
+      break;
+    }
+
+    for (const auto & o : move_objects) {
+      const auto is_enough_margin = isEnoughMargin(p.first, p.second, o, margin_data);
+
+      if (!is_enough_margin) {
+        debug.unsafe_objects.push_back(o);
+      }
+
+      is_safe = is_safe && is_enough_margin;
+    }
+
+    debug.margin_data_array.push_back(margin_data);
+  }
+
+  return is_safe;
+}
+
+bool AvoidanceModule::isEnoughMargin(
+  const PathPointWithLaneId & p_ego, const double t, const ObjectData & object,
+  MarginData & margin_data) const
+{
+  const auto & common_param = planner_data_->parameters;
+  const auto & vehicle_width = common_param.vehicle_width;
+  const auto & base_link2front = common_param.base_link2front;
+  const auto & base_link2rear = common_param.base_link2rear;
+
+  const auto p_ref = [this, &p_ego]() {
+    const auto idx = findNearestIndex(avoidance_data_.reference_path.points, getPoint(p_ego));
+    return getPose(avoidance_data_.reference_path.points.at(idx));
+  }();
+
+  const auto & v_ego = p_ego.point.longitudinal_velocity_mps;
+  const auto & v_ego_lon = getLongitudinalVelocity(p_ref, getPose(p_ego), v_ego);
+  const auto & v_obj = object.object.kinematics.initial_twist_with_covariance.twist.linear.x;
+
+  if (!isTargetObjectType(object.object)) {
+    return true;
+  }
+
+  // |           centerline
+  // |               ^ x
+  // |  +-------+    |
+  // |  |       |    |
+  // |  |       | D1 |     D2      D4
+  // |  |  obj  |<-->|<---------->|<->|
+  // |  |       | D3 |        +-------+
+  // |  |       |<----------->|       |
+  // |  +-------+    |        |       |
+  // |               |        |  ego  |
+  // |               |        |       |
+  // |               |        |       |
+  // |               |        +-------+
+  // |        y <----+
+  // D1: overhang_dist (signed value)
+  // D2: shift_length (signed value)
+  // D3: lateral_distance (should be larger than margin that's calculated from relative velocity.)
+  // D4: vehicle_width (unsigned value)
+
+  const auto reliable_path = std::max_element(
+    object.object.kinematics.predicted_paths.begin(),
+    object.object.kinematics.predicted_paths.end(),
+    [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
+
+  if (reliable_path == object.object.kinematics.predicted_paths.end()) {
+    return true;
+  }
+
+  const auto p_obj = [&t, &reliable_path]() {
+    boost::optional<Pose> ret{boost::none};
+
+    const auto dt = rclcpp::Duration(reliable_path->time_step).seconds();
+    const auto idx = static_cast<size_t>(std::floor(t / dt));
+    const auto res = t - dt * idx;
+
+    if (idx > reliable_path->path.size() - 2) {
+      return ret;
+    }
+
+    const auto & p_src = reliable_path->path.at(idx);
+    const auto & p_dst = reliable_path->path.at(idx + 1);
+    ret = calcInterpolatedPose(p_src, p_dst, res / dt);
+    return ret;
+  }();
+
+  if (!p_obj) {
+    return true;
+  }
+
+  const auto v_obj_lon = getLongitudinalVelocity(p_ref, p_obj.get(), v_obj);
+
+  const auto shift_length = calcLateralDeviation(p_ref, getPoint(p_ego));
+  const auto lateral_distance = std::abs(object.overhang_dist - shift_length) - 0.5 * vehicle_width;
+  const auto lateral_margin = getLateralMarginFromVelocity(std::abs(v_ego_lon - v_obj_lon));
+
+  if (lateral_distance > lateral_margin) {
+    return true;
+  }
+
+  const auto lon_deviation = calcLongitudinalDeviation(getPose(p_ego), p_obj.get().position);
+  const auto is_front_object = lon_deviation > 0.0;
+  const auto longitudinal_margin =
+    getRSSLongitudinalDistance(v_ego_lon, v_obj_lon, is_front_object);
+  const auto vehicle_offset = is_front_object ? base_link2front : base_link2rear;
+  const auto longitudinal_distance =
+    std::abs(lon_deviation) - vehicle_offset - 0.5 * object.object.shape.dimensions.x;
+
+  {
+    margin_data.pose.orientation = p_ref.orientation;
+    margin_data.enough_lateral_margin = false;
+    margin_data.longitudinal_distance =
+      std::min(margin_data.longitudinal_distance, longitudinal_distance);
+    margin_data.longitudinal_margin =
+      std::max(margin_data.longitudinal_margin, longitudinal_margin);
+    margin_data.vehicle_width = vehicle_width;
+    margin_data.base_link2front = base_link2front;
+    margin_data.base_link2rear = base_link2rear;
+  }
+
+  if (longitudinal_distance > longitudinal_margin) {
+    return true;
+  }
+
+  return false;
+}
+
+double AvoidanceModule::getLateralMarginFromVelocity(const double velocity) const
+{
+  const auto & p = parameters_;
+
+  if (p->col_size < 2 || p->col_size * 2 != p->target_velocity_matrix.size()) {
+    throw std::logic_error("invalid matrix col size.");
+  }
+
+  if (velocity < p->target_velocity_matrix.front()) {
+    return p->target_velocity_matrix.at(p->col_size);
+  }
+
+  if (velocity > p->target_velocity_matrix.at(p->col_size - 1)) {
+    return p->target_velocity_matrix.back();
+  }
+
+  for (size_t i = 1; i < p->col_size; ++i) {
+    if (velocity < p->target_velocity_matrix.at(i)) {
+      const auto v1 = p->target_velocity_matrix.at(i - 1);
+      const auto v2 = p->target_velocity_matrix.at(i);
+      const auto m1 = p->target_velocity_matrix.at(i - 1 + p->col_size);
+      const auto m2 = p->target_velocity_matrix.at(i + p->col_size);
+
+      const auto v_clamp = std::clamp(velocity, v1, v2);
+      return m1 + (m2 - m1) * (v_clamp - v1) / (v2 - v1);
+    }
+  }
+
+  return p->target_velocity_matrix.back();
+}
+
+double AvoidanceModule::getRSSLongitudinalDistance(
+  const double v_ego, const double v_obj, const bool is_front_object) const
+{
+  const auto & accel_for_rss = parameters_->safety_check_accel_for_rss;
+  const auto & idling_time = parameters_->safety_check_idling_time;
+
+  const auto opposite_lane_vehicle = v_obj < 0.0;
+
+  /**
+   * object and ego already pass each other.
+   * =======================================
+   *                          Ego-->
+   * ---------------------------------------
+   *       <--Obj
+   * =======================================
+   */
+  if (!is_front_object && opposite_lane_vehicle) {
+    return 0.0;
+  }
+
+  /**
+   * object drive opposite direction.
+   * =======================================
+   *       Ego-->
+   * ---------------------------------------
+   *                          <--Obj
+   * =======================================
+   */
+  if (is_front_object && opposite_lane_vehicle) {
+    return v_ego * idling_time + 0.5 * accel_for_rss * std::pow(idling_time, 2.0) +
+           std::pow(v_ego + accel_for_rss * idling_time, 2.0) / (2.0 * accel_for_rss) +
+           std::abs(v_obj) * idling_time + 0.5 * accel_for_rss * std::pow(idling_time, 2.0) +
+           std::pow(v_obj + accel_for_rss * idling_time, 2.0) / (2.0 * accel_for_rss);
+  }
+
+  /**
+   * object is in front of ego, and drive same direction.
+   * =======================================
+   *       Ego-->
+   * ---------------------------------------
+   *                          Obj-->
+   * =======================================
+   */
+  if (is_front_object && !opposite_lane_vehicle) {
+    return v_ego * idling_time + 0.5 * accel_for_rss * std::pow(idling_time, 2.0) +
+           std::pow(v_ego + accel_for_rss * idling_time, 2.0) / (2.0 * accel_for_rss) -
+           std::pow(v_obj, 2.0) / (2.0 * accel_for_rss);
+  }
+
+  /**
+   * object is behind ego, and drive same direction.
+   * =======================================
+   *                          Ego-->
+   * ---------------------------------------
+   *       Obj-->
+   * =======================================
+   */
+  if (!is_front_object && !opposite_lane_vehicle) {
+    return v_obj * idling_time + 0.5 * accel_for_rss * std::pow(v_obj, 2.0) +
+           std::pow(v_obj + accel_for_rss * idling_time, 2.0) / (2.0 * accel_for_rss) -
+           std::pow(v_ego, 2.0) / (2.0 * accel_for_rss);
+  }
+
+  return 0.0;
+}
+
+lanelet::ConstLanelets AvoidanceModule::getAdjacentLane(
+  const PathShifter & path_shifter, const double forward_distance,
+  const double backward_distance) const
+{
+  const auto & rh = planner_data_->route_handler;
+
+  bool has_left_shift = false;
+  bool has_right_shift = false;
+
+  for (const auto & sp : path_shifter.getShiftLines()) {
+    if (sp.end_shift_length > 0.01) {
+      has_left_shift = true;
+      continue;
+    }
+
+    if (sp.end_shift_length < -0.01) {
+      has_right_shift = true;
+      continue;
+    }
+  }
+
+  lanelet::ConstLanelet current_lane;
+  if (!rh->getClosestLaneletWithinRoute(getEgoPose(), &current_lane)) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
+      "failed to find closest lanelet within route!!!");
+    return {};  // TODO(Satoshi Ota)
+  }
+
+  const auto ego_succeeding_lanes =
+    rh->getLaneletSequence(current_lane, getEgoPose(), backward_distance, forward_distance);
+
+  lanelet::ConstLanelets check_lanes{};
+  for (const auto & lane : ego_succeeding_lanes) {
+    const auto opt_left_lane = rh->getLeftLanelet(lane);
+    if (has_left_shift && opt_left_lane) {
+      check_lanes.push_back(opt_left_lane.get());
+    }
+
+    const auto opt_right_lane = rh->getRightLanelet(lane);
+    if (has_right_shift && opt_right_lane) {
+      check_lanes.push_back(opt_right_lane.get());
+    }
+
+    const auto right_opposite_lanes = rh->getRightOppositeLanelets(lane);
+    if (has_right_shift && !right_opposite_lanes.empty()) {
+      check_lanes.push_back(right_opposite_lanes.front());
+    }
+  }
+
+  return check_lanes;
+}
+
+ObjectDataArray AvoidanceModule::getAdjacentLaneObjects(
+  const lanelet::ConstLanelets & adjacent_lanes) const
+{
+  ObjectDataArray objects;
+  for (const auto & o : avoidance_data_.other_objects) {
+    if (isCentroidWithinLanelets(o.object, adjacent_lanes)) {
+      objects.push_back(o);
+    }
+  }
+
+  return objects;
+}
+
 // TODO(murooka) judge when and which way to extend drivable area. current implementation is keep
 // extending during avoidance module
 // TODO(murooka) freespace during turning in intersection where there is no neighbour lanes
@@ -2865,9 +3275,12 @@ void AvoidanceModule::setDebugData(
   using marker_utils::createShiftLengthMarkerArray;
   using marker_utils::createShiftLineMarkerArray;
   using marker_utils::avoidance_marker::createAvoidLineMarkerArray;
+  using marker_utils::avoidance_marker::createEgoStatusMarkerArray;
   using marker_utils::avoidance_marker::createOtherObjectsMarkerArray;
   using marker_utils::avoidance_marker::createOverhangFurthestLineStringMarkerArray;
   using marker_utils::avoidance_marker::createTargetObjectsMarkerArray;
+  using marker_utils::avoidance_marker::createUnavoidableObjectsMarkerArray;
+  using marker_utils::avoidance_marker::createUnsafeObjectsMarkerArray;
   using marker_utils::avoidance_marker::makeOverhangToRoadShoulderMarkerArray;
 
   debug_marker_.markers.clear();
@@ -2886,6 +3299,8 @@ void AvoidanceModule::setDebugData(
       add(createShiftLineMarkerArray(sl_arr, shifter.getBaseOffset(), ns, r, g, b, w));
     };
 
+  add(createEgoStatusMarkerArray(data, getEgoPose(), "ego_status"));
+
   const auto & path = data.reference_path;
   add(createPathMarkerArray(debug.center_line, "centerline", 0, 0.0, 0.5, 0.9));
   add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
@@ -2899,6 +3314,9 @@ void AvoidanceModule::setDebugData(
   add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
   add(createOverhangFurthestLineStringMarkerArray(
     *debug.farthest_linestring_from_overhang, "farthest_linestring_from_overhang", 1.0, 0.0, 1.0));
+
+  add(createUnavoidableObjectsMarkerArray(debug.unavoidable_objects, "unavoidable_objects"));
+  add(createUnsafeObjectsMarkerArray(debug.unsafe_objects, "unsafe_objects"));
 
   // parent object info
   addAvoidLine(debug.registered_raw_shift, "p_registered_shift", 0.8, 0.8, 0.0);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2030,7 +2030,7 @@ bool AvoidanceModule::isSafePath(
     std::vector<std::pair<PathPointWithLaneId, double>> ret{};
 
     float travel_time = 0.0;
-    ret.push_back(std::make_pair(path.points.front(), travel_time));
+    ret.emplace_back(std::make_pair(path.points.front(), travel_time));
 
     for (size_t i = 1; i < path.points.size(); ++i) {
       const auto & p1 = path.points.at(i - 1);
@@ -2041,7 +2041,7 @@ bool AvoidanceModule::isSafePath(
 
       travel_time += ds / v;
 
-      ret.push_back(std::make_pair(p2, travel_time));
+      ret.emplace_back(std::make_pair(p2, travel_time));
     }
 
     return ret;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -229,11 +229,10 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
     planner_data_, data.current_lanelets, parameters_->detection_area_left_expand_dist,
     parameters_->detection_area_right_expand_dist * (-1.0));
 
-  PredictedObjects far_objects;
-  const auto lane_filtered_objects =
-    filterObjectsByLanelets(*planner_data_->dynamic_object, expanded_lanelets, far_objects);
+  const auto [object_within_target_lane, object_outside_target_lane] =
+    util::separateObjectsByLanelets(*planner_data_->dynamic_object, expanded_lanelets);
 
-  for (const auto & object : far_objects.objects) {
+  for (const auto & object : object_outside_target_lane.objects) {
     ObjectData other_object;
     other_object.object = object;
     other_object.reason = "OutOfTargetArea";
@@ -241,7 +240,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
   }
 
   DEBUG_PRINT("dynamic_objects size = %lu", planner_data_->dynamic_object->objects.size());
-  DEBUG_PRINT("lane_filtered_objects size = %lu", lane_filtered_objects.objects.size());
+  DEBUG_PRINT("lane_filtered_objects size = %lu", object_within_target_lane.objects.size());
 
   // for goal
   const auto & rh = planner_data_->route_handler;
@@ -255,7 +254,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
   // for filtered objects
   ObjectDataArray target_objects;
   std::vector<AvoidanceDebugMsg> avoidance_debug_msg_array;
-  for (const auto & object : lane_filtered_objects.objects) {
+  for (const auto & object : object_within_target_lane.objects) {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     AvoidanceDebugMsg avoidance_debug_msg;
     const auto avoidance_debug_array_false_and_push_back =

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2030,7 +2030,7 @@ bool AvoidanceModule::isSafePath(
     std::vector<std::pair<PathPointWithLaneId, double>> ret{};
 
     float travel_time = 0.0;
-    ret.emplace_back(std::make_pair(path.points.front(), travel_time));
+    ret.emplace_back(path.points.front(), travel_time);
 
     for (size_t i = 1; i < path.points.size(); ++i) {
       const auto & p1 = path.points.at(i - 1);
@@ -2041,7 +2041,7 @@ bool AvoidanceModule::isSafePath(
 
       travel_time += ds / v;
 
-      ret.emplace_back(std::make_pair(p2, travel_time));
+      ret.emplace_back(p2, travel_time);
     }
 
     return ret;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/debug.cpp
@@ -28,10 +28,12 @@ namespace marker_utils::avoidance_marker
 using behavior_path_planner::AvoidLine;
 using behavior_path_planner::util::shiftPose;
 using tier4_autoware_utils::appendMarkerArray;
+using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerScale;
 using tier4_autoware_utils::createPoint;
+using tier4_autoware_utils::getPose;
 using visualization_msgs::msg::Marker;
 
 namespace
@@ -173,6 +175,68 @@ MarkerArray createAvoidLineMarkerArray(
     }
     // current_shift = sp.length;
   }
+
+  return msg;
+}
+
+MarkerArray createPredictedVehiclePositions(const PathWithLaneId & path, std::string && ns)
+{
+  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+  MarkerArray msg;
+
+  auto p_marker = createDefaultMarker(
+    "map", current_time, ns, 0L, Marker::POINTS, createMarkerScale(0.4, 0.4, 0.0),
+    createMarkerColor(1.0, 0.0, 0.0, 0.999));
+
+  const auto pushPointMarker = [&](const Pose & p, const double t) {
+    const auto r = t > 10.0 ? 1.0 : t / 10.0;
+    p_marker.points.push_back(p.position);
+    p_marker.colors.push_back(createMarkerColor(r, 1.0 - r, 0.0, 0.999));
+  };
+
+  auto t_marker = createDefaultMarker(
+    "map", current_time, ns + "_text", 0L, Marker::TEXT_VIEW_FACING,
+    createMarkerScale(0.3, 0.3, 0.3), createMarkerColor(1.0, 1.0, 0.0, 1.0));
+
+  const auto pushTextMarker = [&](const Pose & p, const double t, const double d, const double v) {
+    t_marker.id++;
+    t_marker.pose = p;
+    std::ostringstream string_stream;
+    string_stream << std::fixed << std::setprecision(2);
+    string_stream << "t[s]: " << t << "\n"
+                  << "d[m]: " << d << "\n"
+                  << "v[m/s]: " << v;
+    t_marker.text = string_stream.str();
+    msg.markers.push_back(t_marker);
+  };
+
+  constexpr double dt_save = 1.0;
+  double t_save = 0.0;
+  double t_sum = 0.0;
+  double d_sum = 0.0;
+
+  if (path.points.empty()) {
+    return msg;
+  }
+
+  for (size_t i = 1; i < path.points.size(); ++i) {
+    const auto & p1 = path.points.at(i - 1);
+    const auto & p2 = path.points.at(i);
+    const auto ds = calcDistance2d(p1, p2);
+
+    if (t_save < t_sum + 1e-3) {
+      pushPointMarker(getPose(p1), t_sum);
+      pushTextMarker(getPose(p1), t_sum, d_sum, p1.point.longitudinal_velocity_mps);
+      t_save += dt_save;
+    }
+
+    const auto v = std::max(p1.point.longitudinal_velocity_mps, float{1.0});
+
+    t_sum += ds / v;
+    d_sum += ds;
+  }
+
+  msg.markers.push_back(p_marker);
 
   return msg;
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -383,8 +383,8 @@ bool isLaneChangePathSafe(
 
   // find obstacle in lane change target lanes
   // retrieve lanes that are merging target lanes as well
-  const auto target_lane_object_indices =
-    util::filterObjectIndicesByLanelets(*dynamic_objects, target_lanes);
+  const auto [target_lane_object_indices, others] =
+    util::separateObjectIndicesByLanelets(*dynamic_objects, target_lanes);
 
   // find objects in current lane
   constexpr double check_distance = 100.0;

--- a/planning/behavior_path_planner/src/scene_module/pull_out/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/geometric_pull_out.cpp
@@ -52,8 +52,8 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
 
   // collision check with objects in shoulder lanes
   const auto arc_path = planner_.getArcPath();
-  const auto shoulder_lane_objects =
-    util::filterObjectsByLanelets(*(planner_data_->dynamic_object), shoulder_lanes);
+  const auto [shoulder_lane_objects, others] =
+    util::separateObjectsByLanelets(*(planner_data_->dynamic_object), shoulder_lanes);
   if (util::checkCollisionBetweenPathFootprintsAndObjects(
         vehicle_footprint_, arc_path, shoulder_lane_objects, parameters_.collision_check_margin)) {
     return {};

--- a/planning/behavior_path_planner/src/scene_module/pull_out/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/shift_pull_out.cpp
@@ -56,8 +56,8 @@ boost::optional<PullOutPath> ShiftPullOut::plan(Pose start_pose, Pose goal_pose)
   }
 
   // extract objects in shoulder lane for collision check
-  const auto shoulder_lane_objects =
-    util::filterObjectsByLanelets(*dynamic_objects, shoulder_lanes);
+  const auto [shoulder_lane_objects, others] =
+    util::separateObjectsByLanelets(*dynamic_objects, shoulder_lanes);
 
   // get safe path
   for (auto & pull_out_path : pull_out_paths) {

--- a/planning/behavior_path_planner/src/scene_module/pull_over/goal_searcher.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/goal_searcher.cpp
@@ -63,8 +63,8 @@ GoalCandidates GoalSearcher::search(const Pose & original_goal_pose)
     route_handler->getCenterLinePath(pull_over_lanes, s_start, s_end),
     parameters_.goal_search_interval);
 
-  const auto shoulder_lane_objects =
-    util::filterObjectsByLanelets(*(planner_data_->dynamic_object), pull_over_lanes);
+  const auto [shoulder_lane_objects, others] =
+    util::separateObjectsByLanelets(*(planner_data_->dynamic_object), pull_over_lanes);
 
   std::vector<Pose> original_search_poses{};
   for (size_t goal_id = 0; goal_id < center_line_path.points.size(); ++goal_id) {

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -598,6 +598,58 @@ std::vector<size_t> filterObjectIndicesByLanelets(
   return indices;
 }
 
+std::pair<std::vector<size_t>, std::vector<size_t>> separateObjectIndicesByLanelets(
+  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets)
+{
+  if (target_lanelets.empty()) {
+    return {};
+  }
+
+  std::vector<size_t> target_indices;
+  std::vector<size_t> other_indices;
+
+  for (size_t i = 0; i < objects.objects.size(); i++) {
+    // create object polygon
+    const auto & obj = objects.objects.at(i);
+    // create object polygon
+    Polygon2d obj_polygon;
+    if (!util::calcObjectPolygon(obj, &obj_polygon)) {
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("behavior_path_planner").get_child("utilities"),
+        "Failed to calcObjectPolygon...!!!");
+      continue;
+    }
+
+    bool is_filtered_object = false;
+
+    for (const auto & llt : target_lanelets) {
+      // create lanelet polygon
+      const auto polygon2d = llt.polygon2d().basicPolygon();
+      if (polygon2d.empty()) {
+        // no lanelet polygon
+        continue;
+      }
+      Polygon2d lanelet_polygon;
+      for (const auto & lanelet_point : polygon2d) {
+        lanelet_polygon.outer().emplace_back(lanelet_point.x(), lanelet_point.y());
+      }
+      lanelet_polygon.outer().push_back(lanelet_polygon.outer().front());
+      // check the object does not intersect the lanelet
+      if (!boost::geometry::disjoint(lanelet_polygon, obj_polygon)) {
+        target_indices.push_back(i);
+        is_filtered_object = true;
+        break;
+      }
+    }
+
+    if (!is_filtered_object) {
+      other_indices.push_back(i);
+    }
+  }
+
+  return std::make_pair(target_indices, other_indices);
+}
+
 PredictedObjects filterObjectsByLanelets(
   const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets)
 {
@@ -608,6 +660,29 @@ PredictedObjects filterObjectsByLanelets(
     filtered_objects.objects.push_back(objects.objects.at(i));
   }
   return filtered_objects;
+}
+
+std::pair<PredictedObjects, PredictedObjects> separateObjectsByLanelets(
+  const PredictedObjects & objects, const lanelet::ConstLanelets & target_lanelets)
+{
+  PredictedObjects target_objects;
+  PredictedObjects other_objects;
+
+  const auto [target_indices, other_indices] =
+    separateObjectIndicesByLanelets(objects, target_lanelets);
+
+  target_objects.objects.reserve(target_indices.size());
+  other_objects.objects.reserve(other_indices.size());
+
+  for (const size_t i : target_indices) {
+    target_objects.objects.push_back(objects.objects.at(i));
+  }
+
+  for (const size_t i : other_indices) {
+    other_objects.objects.push_back(objects.objects.at(i));
+  }
+
+  return std::make_pair(target_objects, other_objects);
 }
 
 bool calcObjectPolygon(const PredictedObject & object, Polygon2d * object_polygon)


### PR DESCRIPTION
## Description

### BackGround

The previous avoidance module did not have a safety check mechanism, and the operator had no choice but to OR (over ride) and interrupt the avoidance maneuver as manualy if a vehicle in the adjacent or opposite lane approached after the module had switched output paths for avoidance. This problems has a significant impact on miles per disengagement, so we would like to implement safety check mechanism and yield behavior in the module.

As a first step, I implement safetye check mechanism in this PR. The latter (yield maneuver) will be implement in another PR.

### Logic

Add following new parameters for safety check mechanism.

```yaml
enable_safety_check: false

# For safety check
safety_check_backward_distance: 50.0  # [m]
safety_check_time_horizon: 10.0 # [s]
safety_check_idling_time: 1.5 # [s]
safety_check_accel_for_rss: 2.5  # [m/ss]
```
#### Step1

`safety_check_backward_distance` is the parameter related to the safety check area. The module checks a collision risk for all vehicle that is within shift side lane and between object _check_forward_distance ahead and safety_check_backward_distance behind.

**NOTE**: Even if a part of an object polygon overlaps the detection area, if the center of gravity of the object does not exist on the lane, the vehicle is excluded from the safety check target.

![image](https://user-images.githubusercontent.com/44889564/208624805-446bdfca-e274-4a1e-848a-e7754694ac0e.png)

#### Step2

Judge the risk of collision based on ego future position and object prediction path. The module calculates Ego's future position in the time horizon (`safety_check_time_horizon`), and use object's prediction path as object future position.

![image](https://user-images.githubusercontent.com/44889564/208629468-813c4aa9-b495-47fd-850d-600f81d3d354.png)

After calculating the future position of Ego and object, the module calculates the lateral/longitudinal deviation of Ego and the object. The module also calculates the lateral/longitudinal margin necessary to determine that it is safe to execute avoidance maneuver, and if both the lateral and longitudinal distances are less than the margins, it determines that there is a risk of a collision at that time.

![image](https://user-images.githubusercontent.com/44889564/208631748-7f8066ba-208d-4eb7-8380-ddf05646cbe5.png)

The value of the longitudinal margin is calculated based on Responsibility-Sensitive Safety theory ([RSS](https://newsroom.intel.com/articles/rss-explained-five-rules-autonomous-vehicle-safety/#gs.ljzofv)). The `safety_check_idling_time` represents $T_{idle}$, and `safety_check_accel_for_rss` represents $a_{max}$.

```math
D_{lon} = V_{ego}T_{idle} + \frac{1}{2}a_{max}T_{idle}^2 + \frac{(V_{ego} + a_{max}T_{idle})^2}{2a_{max}} - \frac{V_{obj}^2}{2a_{max}}
```

The lateral margin is changeable based on ego longitudinal velocity. If the vehicle is driving at a high speed, the lateral margin should be larger, and if the vehicle is driving at a low speed, the value of the lateral margin should be set to a smaller value. Thus, the lateral margin for each vehicle speed is set as a parameter, and the module determines the lateral margin from the current vehicle speed as shown in the following figure.

```yaml
target_velocity_matrix:
  col_size: 4
  matrix:
    [2.78, 5.56, 11.1, 13.9,   # target velocity [m/s]
     0.20, 0.90, 1.10, 1.20]   # margin [m]
```

![image](https://user-images.githubusercontent.com/44889564/208785711-6a47ed75-1315-426b-ba32-f24f7f499d95.png)

### Assumption

<!-- Write a brief description of this PR. -->

## Related links

- https://github.com/tier4/autoware_launch/pull/637

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

### Evaluator Result

[[TIER IV INTERNAL]](https://evaluation.tier4.jp/evaluation/reports/056ebb1d-3d8a-52ad-9a36-12400596f07d?project_id=prd_jt) This PR#1 (817/825)
[[TIER IV INTERNAL]](https://evaluation.tier4.jp/evaluation/reports/431498f3-9e2e-5533-89a2-d2b00b83467d?project_id=prd_jt) This PR#2 (818/825)
[[TIER IV INTERNAL]](https://evaluation.tier4.jp/evaluation/reports/981ab539-bd85-5a45-9fe2-781255a71554?project_id=prd_jt) Baseline (812/825)

### Test in local

Befor the tests, please use [this](https://github.com/tier4/autoware_launch/pull/637) autoware_launch branch and set following params in config to `true`.

```yaml
enable_safety_check: true
publish_debug_marker: true # optional
```

Since this PR only implements a function that returns the safety of the avoidance path as a boolean, it does not change the behavior of the vehicle (Even if the module judges the avoidance path is NOT safe, do nothing. The vehicle will go on avoidance maneuver.). On the other hand, we can see the status via debug marker and check whether the module has determined that the avoidance path is safe or not.

![rviz_screenshot_2022_12_20-19_26_01](https://user-images.githubusercontent.com/44889564/208645051-7aea5746-9f1f-491a-9237-45c7854e09f5.png)

![rviz_screenshot_2022_12_20-19_26_20](https://user-images.githubusercontent.com/44889564/208646147-cd6076c8-4ba8-4ce2-9b80-6d882eed85ce.png)

- debug marker topic: `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance`
- The vehicles that has collision risk are shown as BLUE CUBE in rviz (namespace `unsafe_objects`).
- The safety judge is shown as WHITE TEXT in rviz (namespace `ego_status`)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
