### PR TITLE
fix(behavior_path_planner): candidate path header

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -788,6 +788,9 @@ Path BehaviorPathPlannerNode::convertToPath(
   }
 
   output = util::toPath(*path_candidate_ptr);
+  // header is replaced by the input one, so it is substituted again
+  output.header = planner_data_->route_handler->getRouteHeader();
+  output.header.stamp = this->now();
 
   if (!is_ready) {
     for (auto & point : output.points) {


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

If the header of `candidate_path_` is not set, it is not visualized, because the header of `output` is replaced with input by `util::toPath()`

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware.universe/pull/2486

## Tests performed

<!-- Describe how you have tested this PR. -->
psim

![Screenshot from 2022-12-20 17-23-09](https://user-images.githubusercontent.com/39142679/208620987-51774355-1847-4e81-b70b-ace14d0b4a78.png)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
