### PR TITLE
fix(mission_planner): combined lanelet calculation

### DIFF
--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -59,22 +59,23 @@ lanelet::ConstLanelet combine_lanelets(const lanelet::ConstLanelets & lanelets)
   lanelet::Points3d lefts;
   lanelet::Points3d rights;
   lanelet::Points3d centers;
-  std::vector<uint64_t> bound_ids;
+  std::vector<uint64_t> left_bound_ids;
+  std::vector<uint64_t> right_bound_ids;
 
   for (const auto & llt : lanelets) {
     if (llt.id() != 0) {
-      bound_ids.push_back(llt.leftBound().id());
-      bound_ids.push_back(llt.rightBound().id());
+      left_bound_ids.push_back(llt.leftBound().id());
+      right_bound_ids.push_back(llt.rightBound().id());
     }
   }
 
   for (const auto & llt : lanelets) {
-    if (std::count(bound_ids.begin(), bound_ids.end(), llt.leftBound().id()) < 2) {
+    if (std::count(right_bound_ids.begin(), right_bound_ids.end(), llt.leftBound().id()) < 1) {
       for (const auto & pt : llt.leftBound()) {
         lefts.push_back(lanelet::Point3d(pt));
       }
     }
-    if (std::count(bound_ids.begin(), bound_ids.end(), llt.rightBound().id()) < 2) {
+    if (std::count(left_bound_ids.begin(), left_bound_ids.end(), llt.rightBound().id()) < 1) {
       for (const auto & pt : llt.rightBound()) {
         rights.push_back(lanelet::Point3d(pt));
       }


### PR DESCRIPTION
Signed-off-by: ismet atabay <ismet@leodrive.ai>

## Description
If start lane and goal lane are opposite lane with a same bound , the ```combine_lanelet``` function creates the lanelet like the region on the left in the image below. This PR fix this issue like right side of the image below.

<p align="center">
<img src="https://user-images.githubusercontent.com/56237550/208728225-12d4f091-612e-49d6-a1ad-a4e8d17c5b8a.png" width="80%"/>
</p>

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
