### PR TITLE
feat(traffic_light_ssd_fine_detector): visualize bounding boxes optionally

### DIFF
--- a/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
@@ -4,6 +4,8 @@ project(traffic_light_ssd_fine_detector)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+add_compile_options(-Wno-deprecated-declarations)
+
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
 find_package(OpenCV REQUIRED)

--- a/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
+++ b/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
@@ -72,13 +72,13 @@ private:
   bool getTlrIdFromLabel(const std::vector<std::string> & labels, int & tlr_id);
 
   // variables
-  std::shared_ptr<image_transport::ImageTransport> image_transport_;
   image_transport::SubscriberFilter image_sub_;
   message_filters::Subscriber<autoware_auto_perception_msgs::msg::TrafficLightRoiArray> roi_sub_;
   std::mutex connect_mutex_;
   rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrafficLightRoiArray>::SharedPtr
     output_roi_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr exe_time_pub_;
+  std::shared_ptr<image_transport::Publisher> debug_image_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   typedef message_filters::sync_policies::ExactTime<
@@ -93,6 +93,7 @@ private:
   typedef message_filters::Synchronizer<ApproximateSyncPolicy> ApproximateSync;
   std::shared_ptr<ApproximateSync> approximate_sync_;
 
+  bool will_debug_visualize_;
   bool is_approximate_sync_;
   double score_thresh_;
 

--- a/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
+++ b/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
@@ -12,7 +12,7 @@
   <arg name="std" default="[0.5, 0.5, 0.5]"/>
   <arg name="save_rough_roi_image" default="false"/>
   <arg name="manager" default="traffic_light_recognition_nodelet_manager"/>
-  <arg name="will_debug_visualize" default="true"/>
+  <arg name="will_debug_visualize" default="false"/>
 
   <node pkg="traffic_light_ssd_fine_detector" exec="traffic_light_ssd_fine_detector_node" name="traffic_light_ssd_fine_detector">
     <remap from="~/input/image" to="$(var input/image)"/>

--- a/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
+++ b/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
@@ -12,6 +12,7 @@
   <arg name="std" default="[0.5, 0.5, 0.5]"/>
   <arg name="save_rough_roi_image" default="false"/>
   <arg name="manager" default="traffic_light_recognition_nodelet_manager"/>
+  <arg name="will_debug_visualize" default="true"/>
 
   <node pkg="traffic_light_ssd_fine_detector" exec="traffic_light_ssd_fine_detector_node" name="traffic_light_ssd_fine_detector">
     <remap from="~/input/image" to="$(var input/image)"/>
@@ -25,6 +26,7 @@
     <param name="approximate_sync" value="$(var approximate_sync)"/>
     <param name="mean" value="$(var mean)"/>
     <param name="std" value="$(var std)"/>
+    <param name="will_debug_visualize" value="$(var will_debug_visualize)"/>
   </node>
 
   <node if="$(var save_rough_roi_image)" pkg="roi_image_saver" exec="traffic_light_roi_image_saver_node" name="$(anon traffic_light_roi_image_saver)" output="screen">


### PR DESCRIPTION
## Description

As I was creating this PR, I've realized that this already existed in https://github.com/autowarefoundation/autoware.universe/tree/main/perception/traffic_light_visualization (╥ᆺ╥；)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
