### PR TITLE
fix(trajectory_follower_node): remove unused include line

### DIFF
--- a/control/trajectory_follower_nodes/include/trajectory_follower_nodes/controller_node.hpp
+++ b/control/trajectory_follower_nodes/include/trajectory_follower_nodes/controller_node.hpp
@@ -33,7 +33,6 @@
 #include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
 #include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
 #include "geometry_msgs/msg/accel_stamped.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

Build Error

```
--- stderr: trajectory_follower_nodes                                                                                                                                                                          
In file included from /home/satoshi/pilot-auto/src/autoware/universe/control/trajectory_follower_nodes/src/controller_node.cpp:15:                                                                             
/home/satoshi/pilot-auto/src/autoware/universe/control/trajectory_follower_nodes/include/trajectory_follower_nodes/controller_node.hpp:36:10: fatal error: autoware_auto_system_msgs/msg/float32_multi_array_di
agnostic.hpp: No such file or directory
   36 | #include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

- https://github.com/tier4/autoware_auto_msgs/pull/34

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
