### PR TITLE
feat(accel_map_calibrator): publish estimated covariance

### DIFF
--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
@@ -79,6 +79,7 @@ private:
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr update_map_occ_pub_;
   rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr original_map_raw_pub_;
   rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr update_map_raw_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr offset_covariance_pub_;
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr debug_pub_;
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr data_count_pub_;
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr data_count_with_self_pose_pub_;
@@ -184,6 +185,8 @@ private:
   std::vector<std::vector<double>> brake_map_value_;
   std::vector<std::vector<double>> update_accel_map_value_;
   std::vector<std::vector<double>> update_brake_map_value_;
+  std::vector<std::vector<double>> accel_offset_covariance_value_;
+  std::vector<std::vector<double>> brake_offset_covariance_value_;
   std::vector<std::vector<std::vector<double>>> map_value_data_;
   std::vector<double> accel_vel_index_;
   std::vector<double> brake_vel_index_;
@@ -296,6 +299,9 @@ private:
   void publishMap(
     const std::vector<std::vector<double>> accel_map_value,
     const std::vector<std::vector<double>> brake_map_value, const std::string publish_type);
+  void publishOffsetCovMap(
+    const std::vector<std::vector<double>> accel_map_value,
+    const std::vector<std::vector<double>> brake_map_value);
   void publishCountMap();
   void publishIndex();
   bool writeMapToCSV(

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
@@ -288,6 +288,17 @@ private:
   bool isTimeout(const builtin_interfaces::msg::Time & stamp, const double timeout_sec);
   bool isTimeout(const DataStampedPtr & data_stamped, const double timeout_sec);
 
+  /* for covariance calculation */
+  // mean value on each cell (counting methoud depends on the update algorithm)
+  Eigen::MatrixXd accel_data_mean_mat_;
+  Eigen::MatrixXd brake_data_mean_mat_;
+  // calculated vairiance on each cell
+  Eigen::MatrixXd accel_data_covariance_mat_;
+  Eigen::MatrixXd brake_data_covariance_mat_;
+  // number of data on each cell (counting methoud depends on the update algorithm)
+  Eigen::MatrixXd accel_data_num_;
+  Eigen::MatrixXd brake_data_num_;
+
   nav_msgs::msg::OccupancyGrid getOccMsg(
     const std::string frame_id, const double height, const double width, const double resolution,
     const std::vector<int8_t> & map_value);

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -147,10 +147,10 @@ AccelBrakeMapCalibrator::AccelBrakeMapCalibrator(const rclcpp::NodeOptions & nod
   accel_offset_covariance_value_.resize((accel_map_value_.size()));
   brake_offset_covariance_value_.resize((brake_map_value_.size()));
   for (auto & m : accel_offset_covariance_value_) {
-    m.resize(accel_map_value_.at(0).size());
+    m.resize(accel_map_value_.at(0).size(),covariance_);
   }
   for (auto & m : brake_offset_covariance_value_) {
-    m.resize(brake_map_value_.at(0).size());
+    m.resize(brake_map_value_.at(0).size(),covariance_);
   }
   map_value_data_.resize(accel_map_value_.size() + brake_map_value_.size() - 1);
   for (auto & m : map_value_data_) {
@@ -984,6 +984,7 @@ bool AccelBrakeMapCalibrator::updateFourCellAroundOffset(
   offset_covariance_value.at(pedal_index + 1).at(vel_index + 1)=sigma(1);
   offset_covariance_value.at(pedal_index + 0).at(vel_index + 0)=sigma(2);
   offset_covariance_value.at(pedal_index + 1).at(vel_index + 1)=sigma(3);
+
   return true;
 }
 
@@ -1438,7 +1439,7 @@ void AccelBrakeMapCalibrator::publishOffsetCovMap(
   for (int i = 0; i < h; i++) {
     for (int j = 0; j < w; j++) {
       vec[i * w + j] = static_cast<float>(
-        getMapColumnFromUnifiedIndex(accel_map_value_, brake_map_value_, i).at(j));
+        getMapColumnFromUnifiedIndex(accel_map_value, brake_map_value, i).at(j));
     }
   }
   float_map.data = vec;

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -162,7 +162,7 @@ AccelBrakeMapCalibrator::AccelBrakeMapCalibrator(const rclcpp::NodeOptions & nod
 
   // inialize matrix for covariance calculation
   {
-    const auto genConstMat = [](const Map & map, const auto val) {
+    const auto genConstMat = [](const raw_vehicle_cmd_converter::Map & map, const auto val) {
       return Eigen::MatrixXd::Constant(map.size(), map.at(0).size(), val);
     };
     accel_data_mean_mat_ = genConstMat(accel_map_value_, map_offset_);

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -991,10 +991,10 @@ bool AccelBrakeMapCalibrator::updateFourCellAroundOffset(
   update_map_value.at(pedal_index + 1).at(vel_index + 1) =
     map_value.at(pedal_index + 1).at(vel_index + 1) + map_offset(3);
 
-  offset_covariance_value.at(pedal_index + 0).at(vel_index + 0) = sigma(0);
-  offset_covariance_value.at(pedal_index + 1).at(vel_index + 1) = sigma(1);
-  offset_covariance_value.at(pedal_index + 0).at(vel_index + 0) = sigma(2);
-  offset_covariance_value.at(pedal_index + 1).at(vel_index + 1) = sigma(3);
+  offset_covariance_value.at(pedal_index + 0).at(vel_index + 0) = std::sqrt(sigma(0));
+  offset_covariance_value.at(pedal_index + 1).at(vel_index + 1) = std::sqrt(sigma(1));
+  offset_covariance_value.at(pedal_index + 0).at(vel_index + 0) = std::sqrt(sigma(2));
+  offset_covariance_value.at(pedal_index + 1).at(vel_index + 1) = std::sqrt(sigma(3));
 
   return true;
 }


### PR DESCRIPTION
## Description

In order to see the quality of the calibration data, the variance (standard deviation) on each cell is calculated and published.
Note that the calculation of the standard deviation depends on the update algorithm (with a four-cell method, one data point effects on four cells stddev.).


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
