### PR TITLE
fix(obstacle_avoidance_planner): add guard for empty points array to prevent dying

### DIFF
--- a/planning/obstacle_avoidance_planner/src/eb_path_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/eb_path_optimizer.cpp
@@ -154,6 +154,9 @@ EBPathOptimizer::getOptimizedTrajectory(
       interpolated_points = std::vector<geometry_msgs::msg::Point>(
         interpolated_points.begin(),
         interpolated_points.begin() + interpolated_points_end_seg_idx.get());
+      if (interpolated_points.empty()) {
+        return boost::none;
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Add return in getOptimizedTrajectory. (There is a same process soon before it, but the clipping may cause interpolated_points to become empty again. )
```
      if (interpolated_points.empty()) {
        return boost::none;
      }
```


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Set a vehicle position and a goal, then move the vehicle position to another location.
![image](https://user-images.githubusercontent.com/59680180/208904487-f901621c-3932-4c6c-b184-5e4c6ac01756.png)
After merging the PR, motion_planning_container does not die.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
