### PR TITLE
fix(tensor-rt): allow deprecated declarations for some tensorrt packages

### DIFF
--- a/common/tensorrt_common/CMakeLists.txt
+++ b/common/tensorrt_common/CMakeLists.txt
@@ -4,6 +4,9 @@ project(tensorrt_common)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+# TODO(tensorrt_common): Remove once upgrading to TensorRT 8.5 is complete
+add_compile_options(-Wno-deprecated-declarations)
+
 find_package(CUDA)
 find_package(CUDNN)
 find_package(TENSORRT)

--- a/perception/lidar_centerpoint/CMakeLists.txt
+++ b/perception/lidar_centerpoint/CMakeLists.txt
@@ -4,6 +4,9 @@ project(lidar_centerpoint)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+# TODO(lidar_centerpoint): Remove once upgrading to TensorRT 8.5 is complete
+add_compile_options(-Wno-deprecated-declarations)
+
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
 # set flags for CUDA availability

--- a/perception/tensorrt_yolo/CMakeLists.txt
+++ b/perception/tensorrt_yolo/CMakeLists.txt
@@ -4,6 +4,9 @@ project(tensorrt_yolo)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+# TODO(tensorrt_yolo): Remove once upgrading to TensorRT 8.5 is complete
+add_compile_options(-Wno-deprecated-declarations)
+
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
 find_package(OpenCV REQUIRED)

--- a/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
@@ -4,6 +4,9 @@ project(traffic_light_ssd_fine_detector)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+# TODO(traffic_light_ssd_fine_detector): Remove once upgrading to TensorRT 8.5 is complete
+add_compile_options(-Wno-deprecated-declarations)
+
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
 find_package(OpenCV REQUIRED)


### PR DESCRIPTION
Signed-off-by: M. Fatih Cırıt <mfc@leodrive.ai>

## Description

Part of: https://github.com/autowarefoundation/autoware.universe/issues/2330

Until we upgrade the packages, we can allow deprecated declarations in `CMakeLists.txt` files of the respective packages.

```cmake
# TODO(package_name): Remove once upgrading to TensorRT 8.5 is complete
add_compile_options(-Wno-deprecated-declarations)
```

I've compiled all with latest TensorRT 8.5 and it compiles fine. I've also checked the `traffic_light_ssd_fine_detector` and it seems to be working just fine in latest version.

![Screenshot from 2022-12-21 20-22-21](https://user-images.githubusercontent.com/10751153/208966201-1337d82b-e51c-48d5-820f-d026aa1b7fb6.png)

I went for this quick fix because updating enqueueV2 to [enqueueV3](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#runtime-phase) was complicated for me, I didn't want to spend more time on it.

I was going to add updated and deprecated codes together like I did in https://github.com/autowarefoundation/autoware.universe/pull/2325 but `enqueueV3` part didn't work as I expected and I didn't want to spend more time on it.

This simple fix should be ok until someone with better experience can take on the rest of issues.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
