### PR TITLE
fix(system_monitor): change default param path

### DIFF
--- a/system/system_monitor/launch/system_monitor.launch.xml
+++ b/system/system_monitor/launch/system_monitor.launch.xml
@@ -1,12 +1,12 @@
 <launch>
-  <arg name="cpu_monitor_config_file" default="$(find-pkg-share tier4_system_launch)/config/system_monitor/cpu_monitor.param.yaml"/>
-  <arg name="hdd_monitor_config_file" default="$(find-pkg-share tier4_system_launch)/config/system_monitor/hdd_monitor.param.yaml"/>
-  <arg name="mem_monitor_config_file" default="$(find-pkg-share tier4_system_launch)/config/system_monitor/mem_monitor.param.yaml"/>
-  <arg name="net_monitor_config_file" default="$(find-pkg-share tier4_system_launch)/config/system_monitor/net_monitor.param.yaml"/>
-  <arg name="ntp_monitor_config_file" default="$(find-pkg-share tier4_system_launch)/config/system_monitor/ntp_monitor.param.yaml"/>
-  <arg name="process_monitor_config_file" default="$(find-pkg-share tier4_system_launch)/config/system_monitor/process_monitor.param.yaml"/>
-  <arg name="gpu_monitor_config_file" default="$(find-pkg-share tier4_system_launch)/config/system_monitor/gpu_monitor.param.yaml"/>
-  <arg name="voltage_monitor_config_file" default="$(find-pkg-share tier4_system_launch)/config/system_monitor/voltage_monitor.param.yaml"/>
+  <arg name="cpu_monitor_config_file" default="$(find-pkg-share system_monitor)/config/cpu_monitor.param.yaml"/>
+  <arg name="hdd_monitor_config_file" default="$(find-pkg-share system_monitor)/config/hdd_monitor.param.yaml"/>
+  <arg name="mem_monitor_config_file" default="$(find-pkg-share system_monitor)/config/mem_monitor.param.yaml"/>
+  <arg name="net_monitor_config_file" default="$(find-pkg-share system_monitor)/config/net_monitor.param.yaml"/>
+  <arg name="ntp_monitor_config_file" default="$(find-pkg-share system_monitor)/config/ntp_monitor.param.yaml"/>
+  <arg name="process_monitor_config_file" default="$(find-pkg-share system_monitor)/config/process_monitor.param.yaml"/>
+  <arg name="gpu_monitor_config_file" default="$(find-pkg-share system_monitor)/config/gpu_monitor.param.yaml"/>
+  <arg name="voltage_monitor_config_file" default="$(find-pkg-share system_monitor)/config/voltage_monitor.param.yaml"/>
 
   <group>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="system_monitor_container" namespace="system_monitor" output="screen">


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
Since [tier4_system_launch/config has been migrated to autoware_launch](https://github.com/autowarefoundation/autoware.universe/pull/2540), the parameter path that the node launch file refers to should be the one within the node.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
