### PR TITLE
revert(tier4_map_launch): move config back to autoware.universe

### DIFF
--- a/launch/tier4_map_launch/CMakeLists.txt
+++ b/launch/tier4_map_launch/CMakeLists.txt
@@ -7,4 +7,5 @@ autoware_package()
 ament_auto_package(
   INSTALL_TO_SHARE
   launch
+  config
 )

--- a/launch/tier4_map_launch/config/pointcloud_map_loader.param.yaml
+++ b/launch/tier4_map_launch/config/pointcloud_map_loader.param.yaml
@@ -1,0 +1,9 @@
+/**:
+  ros__parameters:
+    enable_whole_load: true
+    enable_downsampled_whole_load: false
+    enable_partial_load: false
+    enable_differential_load: false
+
+    # only used when downsample_whole_load enabled
+    leaf_size: 3.0 # downsample leaf size [m]

--- a/launch/tier4_map_launch/launch/map.launch.py
+++ b/launch/tier4_map_launch/launch/map.launch.py
@@ -161,7 +161,11 @@ def generate_launch_description():
     ),
     add_launch_arg(
         "pointcloud_map_loader_param_path",
-        "",
+        [
+            FindPackageShare("tier4_map_launch"),
+            "/config/pointcloud_map_loader.param.yaml",
+            # ToDo(kminoda): This file should eventually be removed as well as the other components
+        ],
         "path to pointcloud_map_loader param file",
     ),
     add_launch_arg("use_intra_process", "false", "use ROS2 component container communication"),

--- a/launch/tier4_map_launch/launch/map.launch.xml
+++ b/launch/tier4_map_launch/launch/map.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- Parameter files -->
-  <arg name="pointcloud_map_loader_param_path"/>
+  <arg name="pointcloud_map_loader_param_path" default="$(find-pkg-share tier4_map_launch)/config/pointcloud_map_loader.param.yaml"/>
 
   <arg name="map_path" default=""/>
   <arg name="lanelet2_map_path" default="$(var map_path)/lanelet2_map.osm"/>


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
Partially reverting https://github.com/autowarefoundation/autoware.universe/pull/2538.
Since some of the products in TIER IV were still referring to tier4_map_launch directly, we temporarily need a default parameter located in tier4_map_launch.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
