### PR TITLE
fix(intersection): additional fix for #2463

### DIFF
--- a/planning/behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/package.xml
@@ -7,6 +7,7 @@
 
   <!-- intersection module -->
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <!-- crosswalk module -->
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <!-- detection area module -->

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -150,6 +150,33 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   }
   const size_t closest_idx = closest_idx_opt.get();
 
+  if (stop_lines_idx_opt.has_value()) {
+    const auto stop_line_idx = stop_lines_idx_opt.value().stop_line;
+    const auto pass_judge_line_idx = stop_lines_idx_opt.value().pass_judge_line;
+    const auto keep_detection_line_idx = stop_lines_idx_opt.value().keep_detection_line;
+
+    const bool is_over_pass_judge_line =
+      util::isOverTargetIndex(*path, closest_idx, current_pose.pose, pass_judge_line_idx);
+    const bool is_before_keep_detection_line =
+      stop_lines_idx_opt.has_value()
+        ? util::isBeforeTargetIndex(*path, closest_idx, current_pose.pose, keep_detection_line_idx)
+        : false;
+    const bool keep_detection = is_before_keep_detection_line &&
+                                std::fabs(current_vel) < planner_param_.keep_detection_vel_thr;
+
+    if (is_over_pass_judge_line && keep_detection) {
+      // in case ego could not stop exactly before the stop line, but with some overshoot,
+      // keep detection within some margin under low velocity threshold
+    } else if (is_over_pass_judge_line && is_go_out_ && !external_stop) {
+      RCLCPP_INFO(logger_, "over the keep_detection line and not low speed. no plan needed.");
+      RCLCPP_DEBUG(logger_, "===== plan end =====");
+      setSafe(true);
+      setDistance(motion_utils::calcSignedArcLength(
+        path->points, planner_data_->current_pose.pose.position,
+        path->points.at(stop_line_idx).point.pose.position));
+      return true;
+    }
+  }
   /* collision checking */
   bool is_entry_prohibited = false;
 
@@ -202,29 +229,6 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     setSafe(true);
     setDistance(std::numeric_limits<double>::lowest());
     return false;
-  }
-
-  const bool is_over_pass_judge_line =
-    util::isOverTargetIndex(*path, closest_idx, current_pose.pose, pass_judge_line_idx_final);
-  const bool is_before_keep_detection_line =
-    stop_lines_idx_opt.has_value()
-      ? util::isBeforeTargetIndex(
-          *path, closest_idx, current_pose.pose, stop_lines_idx_opt.value().keep_detection_line)
-      : false;
-  const bool keep_detection =
-    is_before_keep_detection_line && std::fabs(current_vel) < planner_param_.keep_detection_vel_thr;
-
-  if (is_over_pass_judge_line && keep_detection) {
-    // in case ego could not stop exactly before the stop line, but with some overshoot,
-    // keep detection within some margin under low velocity threshold
-  } else if (is_over_pass_judge_line && is_go_out_ && !external_stop) {
-    RCLCPP_DEBUG(logger_, "over the keep_detection line and not low speed. no plan needed.");
-    RCLCPP_DEBUG(logger_, "===== plan end =====");
-    setSafe(true);
-    setDistance(motion_utils::calcSignedArcLength(
-      path->points, planner_data_->current_pose.pose.position,
-      path->points.at(stop_line_idx_final).point.pose.position));
-    return true;
   }
 
   state_machine_.setStateWithMarginTime(

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -198,8 +198,10 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     closest_idx, stuck_vehicle_detect_area);
 
   /* calculate final stop lines */
-  int stop_line_idx_final = -1;
-  int pass_judge_line_idx_final = -1;
+  int stop_line_idx_final =
+    stop_lines_idx_opt.has_value() ? stop_lines_idx_opt.value().stop_line : -1;
+  int pass_judge_line_idx_final =
+    stop_lines_idx_opt.has_value() ? stop_lines_idx_opt.value().pass_judge_line : -1;
   if (external_go) {
     is_entry_prohibited = false;
   } else if (external_stop) {


### PR DESCRIPTION
## Description

This PR is an additional fix for the PR https://github.com/autowarefoundation/autoware.universe/pull/2463.

(1) handle if ego is before/over the `pass_judge_line` as before. In #2463 the order of checking this and collision checking was changed inadvertently
(2) RTC distance was not set in #2463 for default stop position.

## Related links

Jira link: https://tier4.atlassian.net/browse/T4PB-23602

## Tests performed

All scenarios green: https://evaluation.tier4.jp/evaluation/reports/f8f886bc-b47f-5567-bab1-1efa67c9f47c?project_id=prd_jt

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
