### PR TITLE
fix(behavior_path_planner): pull over emergency stop velocity 

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -635,6 +635,7 @@ PathWithLaneId PullOverModule::generateEmergencyStopPath()
   const auto & current_pose = planner_data_->self_pose->pose;
   const auto & common_parameters = planner_data_->parameters;
   const double current_vel = planner_data_->self_odometry->twist.twist.linear.x;
+  constexpr double eps_vel = 0.01;
 
   // generate stop reference path
   const auto s_current =
@@ -662,7 +663,7 @@ PathWithLaneId PullOverModule::generateEmergencyStopPath()
       common_parameters.ego_nearest_yaw_threshold);
     const double distance_to_target = calcSignedArcLength(
       stop_path.points, current_pose.position, ego_idx, p.pose.position, target_idx);
-    if (0.0 < distance_to_target && 0.01 < current_vel) {
+    if (0.0 < distance_to_target && eps_vel < current_vel) {
       p.longitudinal_velocity_mps = std::clamp(
         static_cast<float>(
           current_vel * (min_stop_distance - distance_to_target) / min_stop_distance),

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -662,7 +662,7 @@ PathWithLaneId PullOverModule::generateEmergencyStopPath()
       common_parameters.ego_nearest_yaw_threshold);
     const double distance_to_target = calcSignedArcLength(
       stop_path.points, current_pose.position, ego_idx, p.pose.position, target_idx);
-    if (0.0 < distance_to_target) {
+    if (0.0 < distance_to_target && 0.01 < current_vel) {
       p.longitudinal_velocity_mps = std::clamp(
         static_cast<float>(
           current_vel * (min_stop_distance - distance_to_target) / min_stop_distance),


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

when current_vel is 0, min_stop_distance is also 0, this causes 0 divide here.

```
      p.longitudinal_velocity_mps = std::clamp(
        static_cast<float>(
          current_vel * (min_stop_distance - distance_to_target) / min_stop_distance),
        0.0f, p.longitudinal_velocity_mps);
```


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
