### PR TITLE
fix(behavior_path_planner): lane change check default parameters

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -372,10 +372,10 @@ bool isLaneChangePathSafe(
     lane_change_parameters.enable_collision_check_at_prepare_phase;
   const auto & lane_changing_duration = lane_change_parameters.lane_changing_duration;
   const double check_end_time = lane_change_prepare_duration + lane_changing_duration;
-  constexpr double ego_predicted_path_min_speed{1.0};
+  const double min_lc_speed{lane_change_parameters.minimum_lane_change_velocity};
   const auto vehicle_predicted_path = util::convertToPredictedPath(
     path, current_twist, current_pose, static_cast<double>(current_seg_idx), check_end_time,
-    time_resolution, acceleration, ego_predicted_path_min_speed);
+    time_resolution, acceleration, min_lc_speed);
   const auto prepare_phase_ignore_target_speed_thresh =
     lane_change_parameters.prepare_phase_ignore_target_speed_thresh;
 
@@ -387,7 +387,7 @@ bool isLaneChangePathSafe(
     util::filterObjectIndicesByLanelets(*dynamic_objects, target_lanes);
 
   // find objects in current lane
-  constexpr double check_distance = 100.0;
+  const double check_distance = common_parameters.forward_path_length;
   const auto current_lane_object_indices_lanelet = util::filterObjectIndicesByLanelets(
     *dynamic_objects, current_lanes, arc.length, arc.length + check_distance);
 


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar <zulfaqar.azmi@tier4.jp>

## Description

Parameterize min speed value and check distance value for lane change collision assessment.

Before PR

Ego predicted path min speed was hardcoded to `1.0m/s`. Therefore, the collision assessment assumes ego will decelerate to 1 m/s, and it will cause the planner to assume lane changing is safe.

https://user-images.githubusercontent.com/93502286/209271472-7086fb16-4dc6-49ed-a407-83b54375e6ef.mp4

After PR 

Ego predicted path will follow min lane changing speed.

https://user-images.githubusercontent.com/93502286/209271498-f0f096b3-0f20-489e-8f82-3a89860996b5.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
