### PR TITLE
fix(external_velocity_limit_selector): increase history depth external velocity limit selector

### DIFF
--- a/planning/external_velocity_limit_selector/include/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
+++ b/planning/external_velocity_limit_selector/include/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
@@ -17,6 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <tier4_debug_msgs/msg/string_stamped.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
 
@@ -25,9 +26,12 @@
 #include <string>
 #include <unordered_map>
 
+using tier4_debug_msgs::msg::StringStamped;
 using tier4_planning_msgs::msg::VelocityLimit;
 using tier4_planning_msgs::msg::VelocityLimitClearCommand;
 using tier4_planning_msgs::msg::VelocityLimitConstraints;
+
+using VelocityLimitTable = std::unordered_map<std::string, VelocityLimit>;
 
 class ExternalVelocityLimitSelectorNode : public rclcpp::Node
 {
@@ -58,18 +62,20 @@ private:
   rclcpp::Subscription<VelocityLimit>::SharedPtr sub_external_velocity_limit_from_internal_;
   rclcpp::Subscription<VelocityLimitClearCommand>::SharedPtr sub_velocity_limit_clear_command_;
   rclcpp::Publisher<VelocityLimit>::SharedPtr pub_external_velocity_limit_;
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_string_;
 
   void publishVelocityLimit(const VelocityLimit & velocity_limit);
   void setVelocityLimitFromAPI(const VelocityLimit & velocity_limit);
   void setVelocityLimitFromInternal(const VelocityLimit & velocity_limit);
   void clearVelocityLimit(const std::string & sender);
   void updateVelocityLimit();
+  void publishDebugString();
   VelocityLimit getCurrentVelocityLimit() { return hardest_limit_; }
 
   // Parameters
   NodeParam node_param_{};
   VelocityLimit hardest_limit_{};
-  std::unordered_map<std::string, VelocityLimit> velocity_limit_table_;
+  VelocityLimitTable velocity_limit_table_;
 };
 
 #endif  // EXTERNAL_VELOCITY_LIMIT_SELECTOR__EXTERNAL_VELOCITY_LIMIT_SELECTOR_NODE_HPP_

--- a/planning/external_velocity_limit_selector/launch/external_velocity_limit_selector.launch.xml
+++ b/planning/external_velocity_limit_selector/launch/external_velocity_limit_selector.launch.xml
@@ -8,6 +8,7 @@
   <arg name="input_velocity_limit_from_internal" default="/planning/scenario_planning/max_velocity_candidates"/>
   <arg name="input_velocity_limit_clear_command_from_internal" default="/planning/scenario_planning/clear_velocity_limit"/>
   <arg name="output_velocity_limit_from_selector" default="/planning/scenario_planning/max_velocity"/>
+  <arg name="output_debug_string" default="/planning/scenario_planning/external_velocity_limit_selector/debug"/>
 
   <node pkg="external_velocity_limit_selector" exec="external_velocity_limit_selector" name="external_velocity_limit_selector" output="screen">
     <param from="$(var common_param_path)"/>
@@ -16,5 +17,6 @@
     <remap from="input/velocity_limit_from_internal" to="$(var input_velocity_limit_from_internal)"/>
     <remap from="input/velocity_limit_clear_command_from_internal" to="$(var input_velocity_limit_clear_command_from_internal)"/>
     <remap from="output/external_velocity_limit" to="$(var output_velocity_limit_from_selector)"/>
+    <remap from="output/debug" to="$(var output_debug_string)"/>
   </node>
 </launch>

--- a/planning/external_velocity_limit_selector/package.xml
+++ b/planning/external_velocity_limit_selector/package.xml
@@ -15,6 +15,7 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tier4_debug_msgs</depend>
   <depend>tier4_planning_msgs</depend>
 
   <exec_depend>ros2cli</exec_depend>

--- a/planning/external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
+++ b/planning/external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
@@ -24,7 +24,7 @@
 namespace
 {
 VelocityLimit getHardestLimit(
-  const std::unordered_map<std::string, VelocityLimit> & velocity_limits,
+  const VelocityLimitTable & velocity_limits,
   const ExternalVelocityLimitSelectorNode::NodeParam & node_param)
 {
   VelocityLimit hardest_limit{};
@@ -65,6 +65,23 @@ VelocityLimit getHardestLimit(
 
   return hardest_limit;
 }
+
+std::string getDebugString(const VelocityLimitTable & velocity_limits)
+{
+  std::ostringstream string_stream;
+  string_stream << std::boolalpha << std::fixed << std::setprecision(2);
+  for (const auto & limit : velocity_limits) {
+    string_stream << "[" << limit.first << "]";
+    string_stream << "(";
+    string_stream << limit.second.use_constraints << ",";
+    string_stream << limit.second.max_velocity << ",";
+    string_stream << limit.second.constraints.min_acceleration << ",";
+    string_stream << limit.second.constraints.min_jerk << ",";
+    string_stream << limit.second.constraints.max_jerk << ")";
+  }
+
+  return string_stream.str();
+}
 }  // namespace
 
 ExternalVelocityLimitSelectorNode::ExternalVelocityLimitSelectorNode(
@@ -89,6 +106,8 @@ ExternalVelocityLimitSelectorNode::ExternalVelocityLimitSelectorNode(
   pub_external_velocity_limit_ =
     this->create_publisher<VelocityLimit>("output/external_velocity_limit", 1);
 
+  pub_debug_string_ = this->create_publisher<StringStamped>("output/debug", 1);
+
   // Params
   {
     auto & p = node_param_;
@@ -112,6 +131,8 @@ void ExternalVelocityLimitSelectorNode::onVelocityLimitFromAPI(
 
   const auto velocity_limit = getCurrentVelocityLimit();
   publishVelocityLimit(velocity_limit);
+
+  publishDebugString();
 }
 
 void ExternalVelocityLimitSelectorNode::onVelocityLimitFromInternal(
@@ -122,6 +143,8 @@ void ExternalVelocityLimitSelectorNode::onVelocityLimitFromInternal(
 
   const auto velocity_limit = getCurrentVelocityLimit();
   publishVelocityLimit(velocity_limit);
+
+  publishDebugString();
 }
 
 void ExternalVelocityLimitSelectorNode::onVelocityLimitClearCommand(
@@ -135,11 +158,21 @@ void ExternalVelocityLimitSelectorNode::onVelocityLimitClearCommand(
 
   const auto velocity_limit = getCurrentVelocityLimit();
   publishVelocityLimit(velocity_limit);
+
+  publishDebugString();
 }
 
 void ExternalVelocityLimitSelectorNode::publishVelocityLimit(const VelocityLimit & velocity_limit)
 {
   pub_external_velocity_limit_->publish(velocity_limit);
+}
+
+void ExternalVelocityLimitSelectorNode::publishDebugString()
+{
+  StringStamped debug_string{};
+  debug_string.stamp = this->now();
+  debug_string.data = getDebugString(velocity_limit_table_);
+  pub_debug_string_->publish(debug_string);
 }
 
 void ExternalVelocityLimitSelectorNode::setVelocityLimitFromAPI(

--- a/planning/external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
+++ b/planning/external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
@@ -78,11 +78,11 @@ ExternalVelocityLimitSelectorNode::ExternalVelocityLimitSelectorNode(
     std::bind(&ExternalVelocityLimitSelectorNode::onVelocityLimitFromAPI, this, _1));
 
   sub_external_velocity_limit_from_internal_ = this->create_subscription<VelocityLimit>(
-    "input/velocity_limit_from_internal", rclcpp::QoS{1}.transient_local(),
+    "input/velocity_limit_from_internal", rclcpp::QoS{10}.transient_local(),
     std::bind(&ExternalVelocityLimitSelectorNode::onVelocityLimitFromInternal, this, _1));
 
   sub_velocity_limit_clear_command_ = this->create_subscription<VelocityLimitClearCommand>(
-    "input/velocity_limit_clear_command_from_internal", rclcpp::QoS{1}.transient_local(),
+    "input/velocity_limit_clear_command_from_internal", rclcpp::QoS{10}.transient_local(),
     std::bind(&ExternalVelocityLimitSelectorNode::onVelocityLimitClearCommand, this, _1));
 
   // Output


### PR DESCRIPTION
## Description

Previously, the history_depth of subscriber is set to 1. Thus, there was a possibility that a topic will be missed when a topic is simultaneously published by multiple nodes. So, I update QoS setting and increase history depth 1 to 10.

In addition, I add a publisher that outputs the velocity limit table for debug as `tier4_debug_msgs/StringStamped`.

```
stamp:
  sec: 1672024401
  nanosec: 540246185
data: '[obstacle_stop_planner](true,1.38,-2.50,-0.60,0.60)'
```

true,1.38,-2.50,-0.60,0.60 -> use_constraints,max_velocity,min_acceleration,min_jerk,max_jerk

The debug topic name is `/planning/scenario_planning/external_velocity_limit_selector/debug`.

## Link

[[TIER IV INTERNAL LINK]](https://tier4.atlassian.net/browse/T4PB-21444)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
