### PR TITLE
refactor(pure_pursuit): minor refactoring for trajectory_follower_node

### DIFF
--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -106,7 +106,7 @@ public:
 private:
   rclcpp::Node::SharedPtr node_;
   tier4_autoware_utils::SelfPoseListener self_pose_listener_;
-  boost::optional<std::vector<TrajectoryPoint>> output_tp_array_;
+  std::vector<TrajectoryPoint> output_tp_array_;
   autoware_auto_planning_msgs::msg::Trajectory::SharedPtr trajectory_resampled_;
   autoware_auto_planning_msgs::msg::Trajectory trajectory_;
   nav_msgs::msg::Odometry current_odometry_;
@@ -119,8 +119,6 @@ private:
   // Predicted Trajectory publish
   rclcpp::Publisher<autoware_auto_planning_msgs::msg::Trajectory>::SharedPtr
     pub_predicted_trajectory_;
-
-  bool isDataReady();
 
   void onTrajectory(const autoware_auto_planning_msgs::msg::Trajectory::ConstSharedPtr msg);
 
@@ -162,7 +160,7 @@ private:
 
   boost::optional<Trajectory> generatePredictedTrajectory();
 
-  boost::optional<AckermannLateralCommand> generateOutputControlCmd();
+  AckermannLateralCommand generateOutputControlCmd();
 
   bool calcIsSteerConverged(const AckermannLateralCommand & cmd);
 

--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -35,7 +35,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
-#include "tier4_autoware_utils/ros/self_pose_listener.hpp"
 #include "trajectory_follower_base/lateral_controller_base.hpp"
 
 #include <motion_utils/resample/resample.hpp>
@@ -105,7 +104,6 @@ public:
 
 private:
   rclcpp::Node::SharedPtr node_;
-  tier4_autoware_utils::SelfPoseListener self_pose_listener_;
   std::vector<TrajectoryPoint> output_tp_array_;
   autoware_auto_planning_msgs::msg::Trajectory::SharedPtr trajectory_resampled_;
   autoware_auto_planning_msgs::msg::Trajectory trajectory_;
@@ -129,7 +127,7 @@ private:
   // TF
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
-  geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
+  geometry_msgs::msg::Pose current_pose_;
 
   void publishDebugMarker() const;
 

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -101,17 +101,6 @@ PurePursuitLateralController::PurePursuitLateralController(rclcpp::Node & node)
   tf_utils::waitForTransform(tf_buffer_, "map", "base_link");
 }
 
-bool PurePursuitLateralController::isDataReady()
-{
-  if (!current_pose_) {
-    RCLCPP_WARN_THROTTLE(
-      node_->get_logger(), *node_->get_clock(), 5000, "waiting for current_pose...");
-    return false;
-  }
-
-  return true;
-}
-
 double PurePursuitLateralController::calcLookaheadDistance(
   const double lateral_error, const double curvature, const double velocity, const double min_ld,
   const bool is_control_cmd)
@@ -181,8 +170,7 @@ void PurePursuitLateralController::setResampledTrajectory()
       motion_utils::convertToTrajectory(input_tp_array), out_arclength));
   trajectory_resampled_->points.back() = trajectory_.points.back();
   trajectory_resampled_->header = trajectory_.header;
-  output_tp_array_ = boost::optional<std::vector<TrajectoryPoint>>(
-    motion_utils::convertToTrajectoryPointArray(*trajectory_resampled_));
+  output_tp_array_ = motion_utils::convertToTrajectoryPointArray(*trajectory_resampled_);
 }
 
 double PurePursuitLateralController::calcCurvature(const size_t closest_idx)
@@ -273,7 +261,7 @@ void PurePursuitLateralController::averageFilterTrajectory(
 boost::optional<Trajectory> PurePursuitLateralController::generatePredictedTrajectory()
 {
   const auto closest_idx_result =
-    motion_utils::findNearestIndex(*output_tp_array_, current_pose_->pose, 3.0, M_PI_4);
+    motion_utils::findNearestIndex(output_tp_array_, current_pose_->pose, 3.0, M_PI_4);
 
   if (!closest_idx_result) {
     return boost::none;
@@ -340,29 +328,8 @@ boost::optional<Trajectory> PurePursuitLateralController::generatePredictedTraje
   return predicted_trajectory;
 }
 
-bool PurePursuitLateralController::isReady(const InputData & input_data)
+bool PurePursuitLateralController::isReady([[maybe_unused]] const InputData & input_data)
 {
-  current_pose_ = self_pose_listener_.getCurrentPose();
-  trajectory_ = input_data.current_trajectory;
-  current_odometry_ = input_data.current_odometry;
-  current_steering_ = input_data.current_steering;
-
-  if (!isDataReady()) {
-    return false;
-  }
-  setResampledTrajectory();
-  if (!output_tp_array_ || !trajectory_resampled_) {
-    return false;
-  }
-  if (param_.enable_path_smoothing) {
-    averageFilterTrajectory(*trajectory_resampled_);
-  }
-  const auto cmd_msg = generateOutputControlCmd();
-  if (!cmd_msg) {
-    RCLCPP_ERROR(node_->get_logger(), "Failed to generate control command.");
-    return false;
-  }
-
   return true;
 }
 
@@ -381,8 +348,8 @@ LateralOutput PurePursuitLateralController::run(const InputData & input_data)
   const auto cmd_msg = generateOutputControlCmd();
 
   LateralOutput output;
-  output.control_cmd = *cmd_msg;
-  output.sync_data.is_steer_converged = calcIsSteerConverged(*cmd_msg);
+  output.control_cmd = cmd_msg;
+  output.sync_data.is_steer_converged = calcIsSteerConverged(cmd_msg);
 
   // calculate predicted trajectory with iterative calculation
   const auto predicted_trajectory = generatePredictedTrajectory();
@@ -401,7 +368,7 @@ bool PurePursuitLateralController::calcIsSteerConverged(const AckermannLateralCo
          static_cast<float>(param_.converged_steer_rad_);
 }
 
-boost::optional<AckermannLateralCommand> PurePursuitLateralController::generateOutputControlCmd()
+AckermannLateralCommand PurePursuitLateralController::generateOutputControlCmd()
 {
   // Generate the control command
   const auto pp_output = calcTargetCurvature(true, current_pose_->pose);
@@ -462,7 +429,7 @@ boost::optional<PpOutput> PurePursuitLateralController::calcTargetCurvature(
   // Calculate target point for velocity/acceleration
 
   const auto closest_idx_result =
-    motion_utils::findNearestIndex(*output_tp_array_, pose, 3.0, M_PI_4);
+    motion_utils::findNearestIndex(output_tp_array_, pose, 3.0, M_PI_4);
   if (!closest_idx_result) {
     RCLCPP_ERROR(node_->get_logger(), "cannot find closest waypoint");
     return {};

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -57,7 +57,7 @@ enum TYPE {
 namespace pure_pursuit
 {
 PurePursuitLateralController::PurePursuitLateralController(rclcpp::Node & node)
-: node_{&node}, self_pose_listener_(&node), tf_buffer_(node_->get_clock()), tf_listener_(tf_buffer_)
+: node_{&node}, tf_buffer_(node_->get_clock()), tf_listener_(tf_buffer_)
 {
   pure_pursuit_ = std::make_unique<PurePursuit>();
 
@@ -261,7 +261,7 @@ void PurePursuitLateralController::averageFilterTrajectory(
 boost::optional<Trajectory> PurePursuitLateralController::generatePredictedTrajectory()
 {
   const auto closest_idx_result =
-    motion_utils::findNearestIndex(output_tp_array_, current_pose_->pose, 3.0, M_PI_4);
+    motion_utils::findNearestIndex(output_tp_array_, current_pose_, 3.0, M_PI_4);
 
   if (!closest_idx_result) {
     return boost::none;
@@ -282,7 +282,7 @@ boost::optional<Trajectory> PurePursuitLateralController::generatePredictedTraje
       // For first point, use the odometry for velocity, and use the current_pose for prediction.
 
       TrajectoryPoint p;
-      p.pose = current_pose_->pose;
+      p.pose = current_pose_;
       p.longitudinal_velocity_mps = current_odometry_.twist.twist.linear.x;
       predicted_trajectory.points.push_back(p);
 
@@ -335,8 +335,7 @@ bool PurePursuitLateralController::isReady([[maybe_unused]] const InputData & in
 
 LateralOutput PurePursuitLateralController::run(const InputData & input_data)
 {
-  // TODO(murooka) needs to be refactored to seperate isReady and run clearly
-  current_pose_ = self_pose_listener_.getCurrentPose();
+  current_pose_ = input_data.current_odometry.pose.pose;
   trajectory_ = input_data.current_trajectory;
   current_odometry_ = input_data.current_odometry;
   current_steering_ = input_data.current_steering;
@@ -371,7 +370,7 @@ bool PurePursuitLateralController::calcIsSteerConverged(const AckermannLateralCo
 AckermannLateralCommand PurePursuitLateralController::generateOutputControlCmd()
 {
   // Generate the control command
-  const auto pp_output = calcTargetCurvature(true, current_pose_->pose);
+  const auto pp_output = calcTargetCurvature(true, current_pose_);
   AckermannLateralCommand output_cmd;
 
   if (pp_output) {
@@ -411,7 +410,7 @@ void PurePursuitLateralController::publishDebugMarker() const
 
   marker_array.markers.push_back(createNextTargetMarker(debug_data_.next_target));
   marker_array.markers.push_back(
-    createTrajectoryCircleMarker(debug_data_.next_target, current_pose_->pose));
+    createTrajectoryCircleMarker(debug_data_.next_target, current_pose_));
 
   pub_debug_marker_->publish(marker_array);
 }


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

applied minor refactoring to pure_pursuit so that trajectory_follower_node/base can be refactored more.

FYI: In the near future, isReady function can be removed from the trajectory_follower_node/base since no need to exist.
https://github.com/tier4/autoware.universe/blob/3f246b039e04146b7f628e61c2ce08c96cbcd62d/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp#L331-L334

![image](https://user-images.githubusercontent.com/20228327/209499959-ade365f0-4302-4c93-af4b-fddc4c6b026a.png)

TODO
- [x] confirm psim works well
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
