### PR TITLE
fix(crosswalk): fix base path for stop point caluculation

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -446,7 +446,7 @@ boost::optional<geometry_msgs::msg::Point> CrosswalkModule::findNearestStopPoint
   const auto stop_line_distance = exist_stopline_in_map ? 0.0 : planner_param_.stop_line_distance;
   const auto margin = stop_at_stop_line ? stop_line_distance + base_link2front
                                         : planner_param_.stop_margin + base_link2front;
-  const auto stop_pose = calcLongitudinalOffsetPose(sparse_resample_path.points, p_stop, -margin);
+  const auto stop_pose = calcLongitudinalOffsetPose(ego_path.points, p_stop, -margin);
 
   if (!stop_pose) {
     return {};


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

> Plot of the original path, the resampled path, and the calculated stop position for the kashiwanoha crossing.
> - The stop point is calculated from the resampled path.
> - The stop point is inserted in the original path.
> - In this specific case, the stop point is very close to its previous point in the path and after being inserted in the path, the calculated yaw will be very wrong.

![image](https://user-images.githubusercontent.com/44889564/209500024-81758a69-3d64-47ce-9994-0638716c5f38.png)

To fix the above problem, the path used as a reference for calculating the stopping point is changed from sparse resampled path to original path.

Special thanks :smile: :  @maxime-clem 

## Test

[[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/dd126cf6-9562-570f-84c8-14b64f4389dc?project_id=prd_jt) This PR(822/825)
[[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/2d34596c-85c8-5ddf-97ab-00f6de48bd85?project_id=prd_jt) Baseline(821/825)

- Suite 1 (90/90) All PASS
- Suite 2 (224/224) All PASS
- Suite 3 (234/234) All PASS

## Link

[[TIER IV INTERNAL LINK]](https://tier4.atlassian.net/browse/T4PB-24274)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
