### PR TITLE
feat(behavior_path_planner): fix steering factor not publishing during turning

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -433,9 +433,9 @@ void TurnSignalDecider::set_intersection_info(
     }
     intersection_distance_ = dist_to_intersection_required_start;
     intersection_pose_point_ = inter_required_start_point;
+  } else {
+    initialize_intersection_info();
   }
-
-  initialize_intersection_info();
 }
 
 void TurnSignalDecider::initialize_intersection_info()


### PR DESCRIPTION
Signed-off-by: tkhmy <tkh.my.p@gmail.com>

## Description
- fix the steering factor not able to publish during turning since this https://github.com/autowarefoundation/autoware.universe/pull/1964

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers
- During turning at intersect, the following topic should able to publish the steering factor
```bash
ros2 topic echo /planning/steering_factor/intersection
```
The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
