### PR TITLE
fix(pointcloud_preprocessor): remove unused library

### DIFF
--- a/sensing/pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/pointcloud_preprocessor/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(OpenCV REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
 find_package(PCL REQUIRED)
-find_package(OpenMP)
 find_package(CGAL REQUIRED COMPONENTS Core)
 
 include_directories(
@@ -21,7 +20,6 @@ include_directories(
   ${PCL_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
-  ${GRID_MAP_INCLUDE_DIR}
 )
 
 add_library(pointcloud_preprocessor_filter_base SHARED
@@ -71,13 +69,6 @@ target_link_libraries(pointcloud_preprocessor_filter
   ${OpenCV_LIBRARIES}
   ${PCL_LIBRARIES}
 )
-
-if(OPENMP_FOUND)
-  set_target_properties(pointcloud_preprocessor_filter PROPERTIES
-    COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
-    LINK_FLAGS ${OpenMP_CXX_FLAGS}
-  )
-endif()
 
 # ========== Concatenate data ==========
 rclcpp_components_register_node(pointcloud_preprocessor_filter


### PR DESCRIPTION
Signed-off-by: Kaan Çolak <kaancolak95@gmail.com>

OpenMP and grid_map not used anywhere of the poincloud_preprocessor module. 

## Description

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
