### PR TITLE
fix(simple_planning_simulator): fix ideal steer acc calc

### DIFF
--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp
@@ -69,7 +69,6 @@ void SimModelIdealSteerAccGeared::updateStateWithGear(
     state(IDX::X) = prev_state(IDX::X);
     state(IDX::Y) = prev_state(IDX::Y);
     state(IDX::YAW) = prev_state(IDX::YAW);
-    current_acc_ = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
   };
 
   using autoware_auto_vehicle_msgs::msg::GearCommand;
@@ -94,4 +93,6 @@ void SimModelIdealSteerAccGeared::updateStateWithGear(
   } else {
     setStopState();
   }
+  // calculate acc from velocity diff
+  current_acc_ = (state(IDX::VX) - prev_state(IDX::VX)) / std::max(dt, 1.0e-5);
 }


### PR DESCRIPTION
## Description

effect 
- x2 type IDEAL_STEER_ACC_GEARED's published accleration
![image](https://user-images.githubusercontent.com/65527974/209736082-3d303bb2-1e14-408f-a0f2-b97c195b682b.png)

since ideal steer acc geared doesn't have current acceleration IDX::ACCX like xx1 tyoe [here](https://github.com/autowarefoundation/autoware.universe/blob/3cd453b06aba6a14e146dc1817647132f34bf0c4/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp#L104)
https://github.com/autowarefoundation/autoware.universe/blob/3cd453b06aba6a14e146dc1817647132f34bf0c4/simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.cpp#L59
it needs acceleration calculate from velocity_{t} - velocity_{t-1} / dt

before this PR left after this PR right
![image](https://user-images.githubusercontent.com/65527974/209738842-c73f8e80-5739-472d-8f39-39c5b02d9c83.png)


https://github.com/autowarefoundation/autoware.universe/pull/2437

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
