### PR TITLE
feat(mission_planner): refine goal pose with parameter and add config file

### DIFF
--- a/launch/tier4_planning_launch/launch/planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/planning.launch.xml
@@ -16,6 +16,8 @@
   <arg name="nearest_search_param_path"/>
   <!-- rtc -->
   <arg name="rtc_auto_mode_manager_param_path"/>
+  <!-- mission planner -->
+  <arg name="mission_planner_param_path"/>
   <!-- behavior path planner -->
   <arg name="side_shift_param_path"/>
   <arg name="avoidance_param_path"/>
@@ -58,7 +60,9 @@
     <!-- mission planning module -->
     <group>
       <push-ros-namespace namespace="mission_planning"/>
-      <include file="$(find-pkg-share tier4_planning_launch)/launch/mission_planning/mission_planning.launch.xml"/>
+      <include file="$(find-pkg-share tier4_planning_launch)/launch/mission_planning/mission_planning.launch.xml">
+        <arg name="mission_planner_param_path" value="$(var mission_planner_param_path)"/>
+      </include>
     </group>
 
     <!-- scenario planning module -->

--- a/planning/mission_planner/CMakeLists.txt
+++ b/planning/mission_planner/CMakeLists.txt
@@ -29,4 +29,8 @@ ament_auto_add_library(${PROJECT_NAME}_lanelet2_plugins SHARED
 )
 pluginlib_export_plugin_description_file(mission_planner plugins/plugin_description.xml)
 
-ament_auto_package(INSTALL_TO_SHARE launch)
+ament_auto_package(
+        INSTALL_TO_SHARE
+        config
+        launch
+)

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -14,13 +14,14 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 
 ### Parameters
 
-| Name                      | Type   | Description                          |
-| ------------------------- | ------ | ------------------------------------ |
-| `map_frame`               | string | The frame name for map               |
-| `arrival_check_angle_deg` | double | Angle threshold for goal check       |
-| `arrival_check_distance`  | double | Distance threshold for goal check    |
-| `arrival_check_duration`  | double | Duration threshold for goal check    |
-| `goal_angle_threshold`    | double | Max goal pose angle for goal approve |
+| Name                       | Type   | Description                                                                   |
+| -------------------------- | ------ | ----------------------------------------------------------------------------- |
+| `map_frame`                | string | The frame name for map                                                        |
+| `arrival_check_angle_deg`  | double | Angle threshold for goal check                                                |
+| `arrival_check_distance`   | double | Distance threshold for goal check                                             |
+| `arrival_check_duration`   | double | Duration threshold for goal check                                             |
+| `goal_angle_threshold`     | double | Max goal pose angle for goal approve                                          |
+| `enable_correct_goal_pose` | bool   | Enabling correction of goal pose according to the closest lanelet orientation |
 
 ### Services
 

--- a/planning/mission_planner/config/mission_planner.param.yaml
+++ b/planning/mission_planner/config/mission_planner.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    map_frame: map
+    arrival_check_angle_deg: 45.0
+    arrival_check_distance: 1.0
+    arrival_check_duration: 1.0
+    goal_angle_threshold_deg: 45.0
+    enable_correct_goal_pose: false

--- a/planning/mission_planner/launch/mission_planner.launch.xml
+++ b/planning/mission_planner/launch/mission_planner.launch.xml
@@ -9,7 +9,7 @@
     <param name="arrival_check_distance" value="1.0"/>
     <param name="arrival_check_duration" value="1.0"/>
     <param name="goal_angle_threshold_deg" value="45.0"/>
-    <param name="correct_goal_pose" value="false"/>
+    <param name="correct_goal_pose" value="true"/>
     <remap from="input/modified_goal" to="$(var modified_goal_topic_name)"/>
     <remap from="input/vector_map" to="$(var map_topic_name)"/>
     <remap from="debug/route_marker" to="$(var visualization_topic_name)"/>

--- a/planning/mission_planner/launch/mission_planner.launch.xml
+++ b/planning/mission_planner/launch/mission_planner.launch.xml
@@ -9,6 +9,7 @@
     <param name="arrival_check_distance" value="1.0"/>
     <param name="arrival_check_duration" value="1.0"/>
     <param name="goal_angle_threshold_deg" value="45.0"/>
+    <param name="correct_goal_pose" value="false"/>
     <remap from="input/modified_goal" to="$(var modified_goal_topic_name)"/>
     <remap from="input/vector_map" to="$(var map_topic_name)"/>
     <remap from="debug/route_marker" to="$(var visualization_topic_name)"/>

--- a/planning/mission_planner/launch/mission_planner.launch.xml
+++ b/planning/mission_planner/launch/mission_planner.launch.xml
@@ -2,14 +2,10 @@
   <arg name="modified_goal_topic_name" default="/planning/scenario_planning/modified_goal"/>
   <arg name="map_topic_name" default="/map/vector_map"/>
   <arg name="visualization_topic_name" default="/planning/mission_planning/route_marker"/>
+  <arg name="mission_planner_param_path" default="$(find-pkg-share mission_planner)/config/mission_planner.param.yaml"/>
 
   <node pkg="mission_planner" exec="mission_planner" name="mission_planner" output="screen">
-    <param name="map_frame" value="map"/>
-    <param name="arrival_check_angle_deg" value="45.0"/>
-    <param name="arrival_check_distance" value="1.0"/>
-    <param name="arrival_check_duration" value="1.0"/>
-    <param name="goal_angle_threshold_deg" value="45.0"/>
-    <param name="correct_goal_pose" value="true"/>
+    <param from="$(var mission_planner_param_path)"/>
     <remap from="input/modified_goal" to="$(var modified_goal_topic_name)"/>
     <remap from="input/vector_map" to="$(var map_topic_name)"/>
     <remap from="debug/route_marker" to="$(var visualization_topic_name)"/>

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -117,7 +117,8 @@ void DefaultPlanner::initialize_common(rclcpp::Node * node)
     node_->create_publisher<MarkerArray>("debug/goal_footprint", durable_qos);
 
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo();
-  param_.goal_angle_threshold_deg = node_->declare_parameter("goal_angle_threshold_deg", 45.0);
+    param_.goal_angle_threshold_deg = node_->declare_parameter("goal_angle_threshold_deg", 45.0);
+    param_.correct_goal_pose = node_->declare_parameter("correct_goal_pose", true);
 }
 
 void DefaultPlanner::initialize(rclcpp::Node * node)
@@ -240,12 +241,11 @@ geometry_msgs::msg::Pose DefaultPlanner::get_closest_centerline_pose(
     auto nearest_idx = findNearestIndex(closest_lanelet.centerline(), point.position);
 
     auto const nearest_point = closest_lanelet.centerline()[nearest_idx.get()];
-    auto const nearest_point_next = closest_lanelet.centerline()[nearest_idx.get() + 1];
 
     const auto lane_yaw =
             lanelet::utils::getLaneletAngle(closest_lanelet, point.position);
 
-    // calculate new orientation of gole
+    // calculate new orientation of goal
     tf2::Quaternion tf2_quaternion;
     tf2_quaternion.setRPY(0, 0, lane_yaw);
     geometry_msgs::msg::Quaternion quaternion;
@@ -411,18 +411,22 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
     const auto local_route_sections = route_handler_.createMapSegments(path_lanelets);
     route_sections = combine_consecutive_route_sections(route_sections, local_route_sections);
   }
-
-    const auto test_pose = get_closest_centerline_pose(road_lanelets_, points.back());
-    if (!is_goal_valid(test_pose, all_route_lanelets)) {
-    RCLCPP_WARN(logger, "Goal is not valid! Please check position and angle of goal_pose");
-    return route_msg;
+  geometry_msgs::msg::Pose goal_pose;
+  goal_pose = points.back();
+  if (param_.correct_goal_pose){
+      goal_pose = get_closest_centerline_pose(road_lanelets_, goal_pose);
+  } else {
+      if (!is_goal_valid(goal_pose, all_route_lanelets)) {
+          RCLCPP_WARN(logger, "Goal is not valid! Please check position and angle of goal_pose");
+          return route_msg;
+      }
   }
   if (route_handler_.isRouteLooped(route_sections)) {
     RCLCPP_WARN(logger, "Loop detected within route!");
     return route_msg;
   }
 
-  const auto refined_goal = refine_goal_height(test_pose, route_sections);
+  const auto refined_goal = refine_goal_height(goal_pose, route_sections);
   RCLCPP_DEBUG(logger, "Goal Pose Z : %lf", refined_goal.position.z);
 
   // The header is assigned by mission planner.

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -102,26 +102,6 @@ double project_goal_to_map(
   return project.z();
 }
 
-geometry_msgs::msg::Pose get_closest_centerline_pose(
-        const lanelet::ConstLanelets road_lanelets, const geometry_msgs::msg::Pose & point)
-{
-    lanelet::Lanelet closest_lanelet;
-    lanelet::utils::query::getClosestLanelet(road_lanelets, point, &closest_lanelet);
-
-    const auto refined_center_line =
-            lanelet::utils::generateFineCenterline(closest_lanelet, 1.0);
-    closest_lanelet.setCenterline(refined_center_line);
-    auto nearest_idx = findNearestIndex(closest_lanelet.centerline(), point.position);
-
-    auto const nearest_point = closest_lanelet.centerline()[nearest_idx.get()];
-    auto const nearest_point_next = closest_lanelet.centerline()[nearest_idx.get() + 1];
-
-    auto const pose_orientation = getOrientation(nearest_point, nearest_point_next);
-    auto closest_pose = convertBasicPoint3dToPose(nearest_point, pose_orientation);
-    return closest_pose;
-
-}
-
 }  // anonymous namespace
 
 namespace mission_planner::lanelet2
@@ -245,6 +225,37 @@ visualization_msgs::msg::MarkerArray DefaultPlanner::visualize_debug_footprint(
   msg.markers.push_back(marker);
 
   return msg;
+}
+geometry_msgs::msg::Pose DefaultPlanner::get_closest_centerline_pose(
+        const lanelet::ConstLanelets road_lanelets, const geometry_msgs::msg::Pose & point)
+{
+    const auto logger = node_->get_logger();
+
+    lanelet::Lanelet closest_lanelet;
+    lanelet::utils::query::getClosestLanelet(road_lanelets, point, &closest_lanelet);
+
+    const auto refined_center_line =
+            lanelet::utils::generateFineCenterline(closest_lanelet, 1.0);
+    closest_lanelet.setCenterline(refined_center_line);
+    auto nearest_idx = findNearestIndex(closest_lanelet.centerline(), point.position);
+
+    auto const nearest_point = closest_lanelet.centerline()[nearest_idx.get()];
+    auto const nearest_point_next = closest_lanelet.centerline()[nearest_idx.get() + 1];
+
+    const auto lane_yaw =
+            lanelet::utils::getLaneletAngle(closest_lanelet, point.position);
+
+    // calculate new orientation of gole
+    tf2::Quaternion tf2_quaternion;
+    tf2_quaternion.setRPY(0, 0, lane_yaw);
+    geometry_msgs::msg::Quaternion quaternion;
+    quaternion.w = tf2_quaternion.getW();
+    quaternion.x = tf2_quaternion.getX();
+    quaternion.y = tf2_quaternion.getY();
+    quaternion.z = tf2_quaternion.getZ();
+    auto closest_pose = convertBasicPoint3dToPose(nearest_point, quaternion);
+
+    return closest_pose;
 }
 
 bool DefaultPlanner::check_goal_footprint(
@@ -400,6 +411,7 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
     const auto local_route_sections = route_handler_.createMapSegments(path_lanelets);
     route_sections = combine_consecutive_route_sections(route_sections, local_route_sections);
   }
+
     const auto test_pose = get_closest_centerline_pose(road_lanelets_, points.back());
     if (!is_goal_valid(test_pose, all_route_lanelets)) {
     RCLCPP_WARN(logger, "Goal is not valid! Please check position and angle of goal_pose");

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -118,7 +118,8 @@ geometry_msgs::msg::Pose get_closest_centerline_pose(
     motion_utils::findNearestIndex(convertCenterlineToPoints(closest_lanelet), point.position);
   const auto nearest_point = closest_lanelet.centerline()[nearest_idx];
 
-  // update y coordinate according to the asymmetric vehicle margin
+  // shift nearest point on its local y axis so that vehicle's right and left edges
+  // would have approx the same clearance from road border
   const auto shift_length = (vehicle_info.right_overhang_m - vehicle_info.left_overhang_m) / 2.0;
   const auto delta_x = -1 * shift_length * sin(lane_yaw);
   const auto delta_y = shift_length * cos(lane_yaw);
@@ -147,7 +148,7 @@ void DefaultPlanner::initialize_common(rclcpp::Node * node)
 
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo();
   param_.goal_angle_threshold_deg = node_->declare_parameter("goal_angle_threshold_deg", 45.0);
-  param_.correct_goal_pose = node_->declare_parameter("correct_goal_pose", false);
+  param_.enable_correct_goal_pose = node_->declare_parameter("enable_correct_goal_pose", false);
 }
 
 void DefaultPlanner::initialize(rclcpp::Node * node)
@@ -412,7 +413,7 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
   }
   geometry_msgs::msg::Pose goal_pose;
   goal_pose = points.back();
-  if (param_.correct_goal_pose) {
+  if (param_.enable_correct_goal_pose) {
     goal_pose = get_closest_centerline_pose(road_lanelets_, goal_pose, vehicle_info_);
   }
 

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -36,7 +36,7 @@ namespace mission_planner::lanelet2
 struct DefaultPlannerParameters
 {
   double goal_angle_threshold_deg;
-  bool correct_goal_pose;
+  bool enable_correct_goal_pose;
 };
 
 class DefaultPlanner : public mission_planner::PlannerPlugin

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -36,6 +36,7 @@ namespace mission_planner::lanelet2
 struct DefaultPlannerParameters
 {
   double goal_angle_threshold_deg;
+  bool correct_goal_pose;
 };
 
 class DefaultPlanner : public mission_planner::PlannerPlugin

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -74,8 +74,6 @@ private:
     const lanelet::ConstLanelet & combined_prev_lanelet,
     const tier4_autoware_utils::Polygon2d & goal_footprint, double & next_lane_length,
     const double search_margin = 2.0);
-  geometry_msgs::msg::Pose get_closest_centerline_pose(
-    const lanelet::ConstLanelets road_lanelets, const geometry_msgs::msg::Pose & point);
   bool is_goal_valid(const geometry_msgs::msg::Pose & goal, lanelet::ConstLanelets path_lanelets);
   Pose refine_goal_height(const Pose & goal, const RouteSections & route_sections);
 };

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -73,6 +73,8 @@ private:
     const lanelet::ConstLanelet & combined_prev_lanelet,
     const tier4_autoware_utils::Polygon2d & goal_footprint, double & next_lane_length,
     const double search_margin = 2.0);
+  geometry_msgs::msg::Pose get_closest_centerline_pose(
+    const lanelet::ConstLanelets road_lanelets, const geometry_msgs::msg::Pose & point);
   bool is_goal_valid(const geometry_msgs::msg::Pose & goal, lanelet::ConstLanelets path_lanelets);
   Pose refine_goal_height(const Pose & goal, const RouteSections & route_sections);
 };

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -86,3 +86,61 @@ lanelet::ConstLanelet combine_lanelets(const lanelet::ConstLanelets & lanelets)
   auto combined_lanelet = lanelet::Lanelet(lanelet::InvalId, left_bound, right_bound);
   return std::move(combined_lanelet);
 }
+
+boost::optional<size_t> findNearestIndex(
+        const lanelet::ConstLineString3d & line, const geometry_msgs::msg::Point & point)
+{
+    if (line.empty()) {
+        return {};
+    }
+
+    double min_dist = std::numeric_limits<double>::max();
+    size_t min_idx = 0;
+
+    for (size_t i = 0; i < line.size(); ++i) {
+        geometry_msgs::msg::Point p1;
+        p1.x = line[i].basicPoint().x();
+        p1.y = line[i].basicPoint().y();
+
+        const auto dx = p1.x - point.x;
+        const auto dy = p1.y - point.y;
+        const auto squared_distance = dx * dx + dy * dy;
+
+        if (squared_distance < min_dist) {
+            min_dist = squared_distance;
+            min_idx = i;
+        }
+    }
+    return min_idx;
+}
+
+geometry_msgs::msg::Quaternion getOrientation(
+        const lanelet::BasicPoint3d & point, const lanelet::BasicPoint3d & next_point)
+{
+    auto angle = std::atan2(next_point.y() - point.y(), next_point.x() - point.x());
+
+    tf2::Quaternion tf2_q;
+    tf2_q.setRPY(0, 0, angle);
+
+    geometry_msgs::msg::Quaternion q;
+    q.w = tf2_q.getW();
+    q.x = tf2_q.getX();
+    q.y = tf2_q.getY();
+    q.z = tf2_q.getZ();
+
+    return q;
+}
+
+geometry_msgs::msg::Pose convertBasicPoint3dToPose(
+        const lanelet::BasicPoint3d & point, const geometry_msgs::msg::Quaternion & quaternion)
+{
+    geometry_msgs::msg::Pose pose;
+
+    pose.position.x = point.x();
+    pose.position.y = point.y();
+    pose.position.z = point.z();
+
+    pose.orientation = quaternion;
+
+    return pose;
+}

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -114,23 +114,6 @@ boost::optional<size_t> findNearestIndex(
     return min_idx;
 }
 
-geometry_msgs::msg::Quaternion getOrientation(
-        const lanelet::BasicPoint3d & point, const lanelet::BasicPoint3d & next_point)
-{
-    auto angle = std::atan2(next_point.y() - point.y(), next_point.x() - point.x());
-
-    tf2::Quaternion tf2_q;
-    tf2_q.setRPY(0, 0, angle);
-
-    geometry_msgs::msg::Quaternion q;
-    q.w = tf2_q.getW();
-    q.x = tf2_q.getX();
-    q.y = tf2_q.getY();
-    q.z = tf2_q.getZ();
-
-    return q;
-}
-
 geometry_msgs::msg::Pose convertBasicPoint3dToPose(
         const lanelet::BasicPoint3d & point, const geometry_msgs::msg::Quaternion & quaternion)
 {

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -90,18 +90,18 @@ lanelet::ConstLanelet combine_lanelets(const lanelet::ConstLanelets & lanelets)
 std::vector<geometry_msgs::msg::Point> convertCenterlineToPoints(const lanelet::Lanelet & lanelet)
 {
   std::vector<geometry_msgs::msg::Point> centerline_points;
-  geometry_msgs::msg::Point center_point;
   for (const auto & point : lanelet.centerline()) {
+    geometry_msgs::msg::Point center_point;
     center_point.x = point.basicPoint().x();
     center_point.y = point.basicPoint().y();
     center_point.z = point.basicPoint().z();
-    centerline_points.push_back(tier4_autoware_utils::getPoint(center_point));
+    centerline_points.push_back(center_point);
   }
   return centerline_points;
 }
 
 geometry_msgs::msg::Pose convertBasicPoint3dToPose(
-  const lanelet::BasicPoint3d & point, const double & lane_yaw)
+  const lanelet::BasicPoint3d & point, const double lane_yaw)
 {
   // calculate new orientation of goal
   geometry_msgs::msg::Pose pose;
@@ -109,7 +109,7 @@ geometry_msgs::msg::Pose convertBasicPoint3dToPose(
   pose.position.y = point.y();
   pose.position.z = point.z();
 
-  pose.orientation = tier4_autoware_utils::createQuaternionFromRPY(0.0, 0.0, lane_yaw);
+  pose.orientation = tier4_autoware_utils::createQuaternionFromYaw(lane_yaw);
 
   return pose;
 }

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
@@ -52,4 +52,10 @@ void insert_marker_array(
   visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2);
 
 lanelet::ConstLanelet combine_lanelets(const lanelet::ConstLanelets & lanelets);
+boost::optional<size_t> findNearestIndex(
+        const lanelet::ConstLineString3d & line, const geometry_msgs::msg::Point & point);
+geometry_msgs::msg::Quaternion getOrientation(
+        const lanelet::BasicPoint3d & point, const lanelet::BasicPoint3d & next_point);
+geometry_msgs::msg::Pose convertBasicPoint3dToPose(
+        const lanelet::BasicPoint3d & point, const geometry_msgs::msg::Quaternion & quaternion);
 #endif  // LANELET2_PLUGINS__UTILITY_FUNCTIONS_HPP_

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
@@ -54,8 +54,6 @@ void insert_marker_array(
 lanelet::ConstLanelet combine_lanelets(const lanelet::ConstLanelets & lanelets);
 boost::optional<size_t> findNearestIndex(
         const lanelet::ConstLineString3d & line, const geometry_msgs::msg::Point & point);
-geometry_msgs::msg::Quaternion getOrientation(
-        const lanelet::BasicPoint3d & point, const lanelet::BasicPoint3d & next_point);
 geometry_msgs::msg::Pose convertBasicPoint3dToPose(
         const lanelet::BasicPoint3d & point, const geometry_msgs::msg::Quaternion & quaternion);
 #endif  // LANELET2_PLUGINS__UTILITY_FUNCTIONS_HPP_

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
@@ -54,5 +54,5 @@ void insert_marker_array(
 lanelet::ConstLanelet combine_lanelets(const lanelet::ConstLanelets & lanelets);
 std::vector<geometry_msgs::msg::Point> convertCenterlineToPoints(const lanelet::Lanelet & lanelet);
 geometry_msgs::msg::Pose convertBasicPoint3dToPose(
-  const lanelet::BasicPoint3d & point, const double & lane_yaw);
+  const lanelet::BasicPoint3d & point, const double lane_yaw);
 #endif  // LANELET2_PLUGINS__UTILITY_FUNCTIONS_HPP_

--- a/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/utility_functions.hpp
@@ -52,8 +52,7 @@ void insert_marker_array(
   visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2);
 
 lanelet::ConstLanelet combine_lanelets(const lanelet::ConstLanelets & lanelets);
-boost::optional<size_t> findNearestIndex(
-        const lanelet::ConstLineString3d & line, const geometry_msgs::msg::Point & point);
+std::vector<geometry_msgs::msg::Point> convertCenterlineToPoints(const lanelet::Lanelet & lanelet);
 geometry_msgs::msg::Pose convertBasicPoint3dToPose(
-        const lanelet::BasicPoint3d & point, const geometry_msgs::msg::Quaternion & quaternion);
+  const lanelet::BasicPoint3d & point, const double & lane_yaw);
 #endif  // LANELET2_PLUGINS__UTILITY_FUNCTIONS_HPP_


### PR DESCRIPTION
## Description


This PR adds config file to mission_planner and  parameter for refining goal pose in order to skip goal validation step. If added parameter is set to true, then given goal is refined according to the closest lane orientation.

autoware_launch PR (must be merged with this PR): https://github.com/autowarefoundation/autoware_launch/pull/225

## Tests performed

https://user-images.githubusercontent.com/56237550/212691970-35c7803d-7609-4d29-886b-e0a08274dc06.mp4



## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
