### PR TITLE
fix(behavior_path_planner): avoid node death when points of path are empty in some cases

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1858,7 +1858,7 @@ PathWithLaneId getCenterLinePath(
       lanelet::utils::getArcCoordinates(lanelet_sequence, route_handler.getGoalPose());
     s_forward = std::min(s_forward, goal_arc_coordinates.length - lane_change_buffer);
   }
-  
+
   s_forward = std::max(s_forward, s_backward);
 
   return route_handler.getCenterLinePath(lanelet_sequence, s_backward, s_forward, true);

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1858,7 +1858,7 @@ PathWithLaneId getCenterLinePath(
       lanelet::utils::getArcCoordinates(lanelet_sequence, route_handler.getGoalPose());
     s_forward = std::min(s_forward, goal_arc_coordinates.length - lane_change_buffer);
   }
-  if(s_forward<0.0)
+  if(s_forward<s_backward)
   {
     RCLCPP_WARN(rclcpp::get_logger("behavior_path_planner"), "The forward distance is to small and the goal placement for lane change is invalid.");
   }

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1858,7 +1858,7 @@ PathWithLaneId getCenterLinePath(
       lanelet::utils::getArcCoordinates(lanelet_sequence, route_handler.getGoalPose());
     s_forward = std::min(s_forward, goal_arc_coordinates.length - lane_change_buffer);
   }
-  if(s_forward<s_backward)
+  if(s_forward < s_backward)
   {
     RCLCPP_WARN(rclcpp::get_logger("behavior_path_planner"), "The forward distance is to small and the goal placement for lane change is invalid.");
   }

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1858,7 +1858,10 @@ PathWithLaneId getCenterLinePath(
       lanelet::utils::getArcCoordinates(lanelet_sequence, route_handler.getGoalPose());
     s_forward = std::min(s_forward, goal_arc_coordinates.length - lane_change_buffer);
   }
-
+  if(s_forward<0.0)
+  {
+    RCLCPP_WARN(rclcpp::get_logger("behavior_path_planner"), "The forward distance is to small and the goal placement for lane change is invalid.");
+  }
   s_forward = std::max(s_forward, s_backward);
 
   return route_handler.getCenterLinePath(lanelet_sequence, s_backward, s_forward, true);

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1858,9 +1858,10 @@ PathWithLaneId getCenterLinePath(
       lanelet::utils::getArcCoordinates(lanelet_sequence, route_handler.getGoalPose());
     s_forward = std::min(s_forward, goal_arc_coordinates.length - lane_change_buffer);
   }
-  if(s_forward < s_backward)
-  {
-    RCLCPP_WARN(rclcpp::get_logger("behavior_path_planner"), "The forward distance is to small and the goal placement for lane change is invalid.");
+  if (s_forward < s_backward) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("behavior_path_planner"),
+      "The forward distance is to small and the goal placement for lane change is invalid.");
   }
   s_forward = std::max(s_forward, s_backward);
 

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1858,6 +1858,8 @@ PathWithLaneId getCenterLinePath(
       lanelet::utils::getArcCoordinates(lanelet_sequence, route_handler.getGoalPose());
     s_forward = std::min(s_forward, goal_arc_coordinates.length - lane_change_buffer);
   }
+  
+  s_forward = std::max(s_forward, s_backward);
 
   return route_handler.getCenterLinePath(lanelet_sequence, s_backward, s_forward, true);
 }


### PR DESCRIPTION
Signed-off-by: jack.song <jack.song@autocore.ai>

## Description
When  points of path are empty in some cases,the behavior_path_planner will die because of some functions like findEgoSegmentIndex(),findEgoIndex().
The points of path are empty in some cases in the function of getCenterLinePath() in the behavior_path_planner.
The function shall ensure that the forward length is not less than the backward length.
![Screenshot from 2023-01-05 12-46-15](https://user-images.githubusercontent.com/102840938/210703644-0dbf324e-f982-4c75-ae55-94a3604dff17.png)


<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/issues/2607
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Before the pr:
![Screenshot from 2023-01-03 15-30-06](https://user-images.githubusercontent.com/102840938/210693207-a025c7d1-50f3-4d3f-9741-99e4abdf7eb0.png)



After the pr:
![Screenshot from 2023-01-05 10-44-41](https://user-images.githubusercontent.com/102840938/210690960-7a7a0066-73a6-469b-b118-de6c931d00df.png)


No matter whether the lane change distance is enough, the node of behavior_path_planner will not die

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
