### PR TITLE
fix(avoidance): ignore unavoidable objects around the goal

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -18,6 +18,7 @@
 
       object_check_forward_distance: 150.0        # [m]
       object_check_backward_distance: 2.0         # [m]
+      object_check_goal_distance: 0.0             # [m]
 
       threshold_distance_object_is_on_center: 1.0 # [m]
 

--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -18,7 +18,7 @@
 
       object_check_forward_distance: 150.0        # [m]
       object_check_backward_distance: 2.0         # [m]
-      object_check_goal_distance: 0.0             # [m]
+      object_check_goal_distance: 20.0            # [m]
 
       threshold_distance_object_is_on_center: 1.0 # [m]
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -86,6 +86,10 @@ struct AvoidanceParameters
   // continue to detect backward vehicles as avoidance targets until they are this distance away
   double object_check_backward_distance;
 
+  // if the distance between object and goal position is less than this parameter, the module ignore
+  // the object.
+  double object_check_goal_distance;
+
   // use in judge whether the vehicle is parking object on road shoulder
   double object_check_shiftable_ratio;
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -295,6 +295,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.threshold_time_object_is_moving = dp("threshold_time_object_is_moving", 1.0);
   p.object_check_forward_distance = dp("object_check_forward_distance", 150.0);
   p.object_check_backward_distance = dp("object_check_backward_distance", 2.0);
+  p.object_check_goal_distance = dp("object_check_goal_distance", 0.0);
   p.object_check_shiftable_ratio = dp("object_check_shiftable_ratio", 1.0);
   p.object_check_min_road_shoulder_width = dp("object_check_min_road_shoulder_width", 0.5);
   p.object_envelope_buffer = dp("object_envelope_buffer", 0.1);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -295,7 +295,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   p.threshold_time_object_is_moving = dp("threshold_time_object_is_moving", 1.0);
   p.object_check_forward_distance = dp("object_check_forward_distance", 150.0);
   p.object_check_backward_distance = dp("object_check_backward_distance", 2.0);
-  p.object_check_goal_distance = dp("object_check_goal_distance", 0.0);
+  p.object_check_goal_distance = dp("object_check_goal_distance", 20.0);
   p.object_check_shiftable_ratio = dp("object_check_shiftable_ratio", 1.0);
   p.object_check_min_road_shoulder_width = dp("object_check_min_road_shoulder_width", 0.5);
   p.object_envelope_buffer = dp("object_envelope_buffer", 0.1);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -320,6 +320,13 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
       continue;
     }
 
+    if (object_data.longitudinal + parameters_->object_check_goal_distance > dist_to_goal) {
+      avoidance_debug_array_false_and_push_back("TooNearToGoal");
+      object_data.reason = "TooNearToGoal";
+      data.other_objects.push_back(object_data);
+      continue;
+    }
+
     // Calc lateral deviation from path to target object.
     object_data.lateral = calcLateralDeviation(object_closest_pose, object_pose.position);
     avoidance_debug_msg.lateral_distance_from_centerline = object_data.lateral;


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

This PR contains small modification about the avoidance module.
The module will ignore not only the object that is behind the goal but also those around (near) the goal, because those object are almost unavoidable.

[[TIER IV INTERNAL LINK]](https://star4.slack.com/archives/C03QW0GU6P7/p1672883485409599)

- https://github.com/tier4/autoware_launch/pull/676
- https://github.com/autowarefoundation/autoware_launch/pull/152

![image](https://user-images.githubusercontent.com/44889564/210714895-4162e721-7f1e-436e-aade-7b8d343254ae.png)


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
