### PR TITLE
Fix for freespace planner memleak issue.

### DIFF
--- a/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -118,7 +118,12 @@ void AbstractPlanningAlgorithm::setMap(const nav_msgs::msg::OccupancyGrid & cost
     }
   }
   is_obstacle_table_ = is_obstacle_table;
-
+  
+  // Clear the collision index table before constructing
+  // to avoid memleak issue
+  //BugFix : Memleak issue
+  coll_indexes_table_.clear();
+  
   // construct collision indexes table
   for (int i = 0; i < planner_common_param_.theta_size; i++) {
     std::vector<IndexXY> indexes_2d, vertex_indexes_2d;

--- a/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -118,12 +118,12 @@ void AbstractPlanningAlgorithm::setMap(const nav_msgs::msg::OccupancyGrid & cost
     }
   }
   is_obstacle_table_ = is_obstacle_table;
-  
+
   // Clear the collision index table before constructing
   // to avoid memleak issue
-  //BugFix : Memleak issue
+  // BugFix : Memleak issue
   coll_indexes_table_.clear();
-  
+
   // construct collision indexes table
   for (int i = 0; i < planner_common_param_.theta_size; i++) {
     std::vector<IndexXY> indexes_2d, vertex_indexes_2d;


### PR DESCRIPTION
Freespace planner application crashes when "replan_when_obstacle_found" is enabled. Issue being collision_indexes_table_ is populated contineously without resetting for every setMap which leads to contineous memory allocation for the above mentioned vector table. Its curcial while using the application on a low resource compute environment.

PFA for a video on memleak issue.
https://user-images.githubusercontent.com/48509412/210761182-7edfed4f-88aa-4d13-98ba-603e1ad10e16.mp4