### PR TITLE
fix(lane_change): use current lane for num to preferred lane input

### DIFF
--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -6,8 +6,8 @@
 
       minimum_lane_change_prepare_distance: 2.0 # [m]
       minimum_lane_change_length: 16.5          # [m]
-      backward_length_buffer_for_end_of_lane: 2.0 # [m]
-      lane_change_finish_judge_buffer: 3.0      # [m]
+      backward_length_buffer_for_end_of_lane: 3.0 # [m]
+      lane_change_finish_judge_buffer: 2.0      # [m]
 
       lane_changing_lateral_jerk: 0.5           # [m/s3]
       lane_changing_lateral_acc: 0.5            # [m/s2]

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
@@ -76,6 +76,13 @@ enum class LaneChangeStates {
   Stop,
 };
 
+struct LaneChangePhaseInfo
+{
+  double prepare{0.0};
+  double lane_changing{0.0};
+
+  [[nodiscard]] double sum() const { return prepare + lane_changing; }
+};
 }  // namespace behavior_path_planner
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__LANE_CHANGE_MODULE_DATA_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -113,9 +113,10 @@ ShiftLine getLaneChangeShiftLine(
 
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
-  const Pose & lane_changing_start_pose, const double prepare_distance,
-  const double lane_changing_distance, const double min_total_lane_changing_distance,
-  const double forward_path_length, const double lane_changing_speed, const bool is_goal_in_route);
+  const Pose & lane_changing_start_pose, const double target_lane_length,
+  const double dist_prepare_to_lc_end, const double lane_changing_distance,
+  const double min_total_lane_changing_distance, const double forward_path_length,
+  const double lane_changing_speed, const bool is_goal_in_route);
 
 PathWithLaneId getLaneChangePathPrepareSegment(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & original_lanelets,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -114,7 +114,7 @@ ShiftLine getLaneChangeShiftLine(
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & lane_changing_start_pose, const double target_lane_length,
-  const double dist_prepare_to_lc_end, const double min_total_lane_changing_distance,
+  const LaneChangePhaseInfo dist_prepare_to_lc_end, const double min_total_lane_changing_distance,
   const double forward_path_length, const double resample_interval, const bool is_goal_in_route);
 
 PathWithLaneId getLaneChangePathPrepareSegment(
@@ -125,7 +125,7 @@ PathWithLaneId getLaneChangePathPrepareSegment(
 PathWithLaneId getLaneChangePathLaneChangingSegment(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanelets,
   const double forward_path_length, const double arc_length_from_target,
-  const double target_lane_length, const double dist_prepare_to_lc_end,
+  const double target_lane_length, const LaneChangePhaseInfo dist_prepare_to_lc_end,
   const double lane_changing_speed, const double total_required_min_dist);
 
 bool isEgoWithinOriginalLane(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -114,22 +114,20 @@ ShiftLine getLaneChangeShiftLine(
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & lane_changing_start_pose, const double prepare_distance,
-  const double lane_changing_distance, const double forward_path_length,
-  const double lane_changing_speed);
-
-PathWithLaneId getReferencePathFromTargetLane(
-  const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
-  const Pose & in_target_front_pose, const Pose & in_target_end_pose);
+  const double lane_changing_distance, const double min_total_lane_changing_distance,
+  const double forward_path_length, const double lane_changing_speed, const bool is_goal_in_route);
 
 PathWithLaneId getLaneChangePathPrepareSegment(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & original_lanelets,
-  const Pose & current_pose, const double & backward_path_length, const double & prepare_distance,
-  const double & prepare_duration, const double & minimum_lane_change_velocity);
+  const double arc_length_from_current, const double backward_path_length,
+  const double prepare_distance, const double prepare_speed);
 
 PathWithLaneId getLaneChangePathLaneChangingSegment(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanelets,
-  const Pose & current_pose, const double prepare_distance, const double lane_change_distance,
-  const double lane_changing_speed, const BehaviorPathPlannerParameters & common_param);
+  const double forward_path_length, const double arc_length_from_target,
+  const double target_lane_length, const double dist_prepare_to_lc_end,
+  const double lane_changing_speed, const double total_required_min_dist);
+
 bool isEgoWithinOriginalLane(
   const lanelet::ConstLanelets & current_lanes, const Pose & current_pose,
   const BehaviorPathPlannerParameters & common_param);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -114,9 +114,8 @@ ShiftLine getLaneChangeShiftLine(
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & lane_changing_start_pose, const double target_lane_length,
-  const double dist_prepare_to_lc_end, const double lane_changing_distance,
-  const double min_total_lane_changing_distance, const double forward_path_length,
-  const double lane_changing_speed, const bool is_goal_in_route);
+  const double dist_prepare_to_lc_end, const double min_total_lane_changing_distance,
+  const double forward_path_length, const double resample_interval, const bool is_goal_in_route);
 
 PathWithLaneId getLaneChangePathPrepareSegment(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & original_lanelets,

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -250,6 +250,11 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
 
   p.rear_vehicle_reaction_time = declare_parameter("rear_vehicle_reaction_time", 2.0);
   p.rear_vehicle_safety_time_margin = declare_parameter("rear_vehicle_safety_time_margin", 2.0);
+
+  if (p.backward_length_buffer_for_end_of_lane < 1.0) {
+    RCLCPP_WARN_STREAM(
+      get_logger(), "Lane change buffer must be more than 1 meter. Modifying the buffer.");
+  }
   return p;
 }
 
@@ -266,8 +271,8 @@ SideShiftParameters BehaviorPathPlannerNode::getSideShiftParam()
   p.shifting_lateral_jerk = dp("shifting_lateral_jerk", 0.2);
   p.min_shifting_distance = dp("min_shifting_distance", 5.0);
   p.min_shifting_speed = dp("min_shifting_speed", 5.56);
-  p.shift_request_time_limit = dp("shift_request_time_limit", 1.0);
   p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
+  p.shift_request_time_limit = dp("shift_request_time_limit", 1.0);
   p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);
 
   return p;
@@ -440,10 +445,10 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   const auto lc_buffer =
     this->get_parameter("lane_change.backward_length_buffer_for_end_of_lane").get_value<double>();
   if (lc_buffer < p.lane_change_finish_judge_buffer + 1.0) {
-    RCLCPP_FATAL_STREAM(
-      get_logger(),
-      "finish judge buffer should not be more than lane change buffer. Terminating the program...");
-    exit(EXIT_FAILURE);
+    p.lane_change_finish_judge_buffer = lc_buffer - 1;
+    RCLCPP_WARN_STREAM(
+      get_logger(), "lane change buffer is less than finish buffer. Modifying the value to "
+                      << p.lane_change_finish_judge_buffer << "....");
   }
 
   return p;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -437,6 +437,15 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
     exit(EXIT_FAILURE);
   }
 
+  const auto lc_buffer =
+    this->get_parameter("lane_change.backward_length_buffer_for_end_of_lane").get_value<double>();
+  if (lc_buffer < p.lane_change_finish_judge_buffer + 1.0) {
+    RCLCPP_FATAL_STREAM(
+      get_logger(),
+      "finish judge buffer should not be more than lane change buffer. Terminating the program...");
+    exit(EXIT_FAILURE);
+  }
+
   return p;
 }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -693,7 +693,7 @@ PathWithLaneId getReferencePathFromTargetLane(
     route_handler.getCenterLinePath(target_lanes, s_start, s_end);
 
   return util::resamplePathWithSpline(
-    lane_changing_reference_path, resample_interval, true, {0.0, lane_changing_distance});
+    lane_changing_reference_path, resample_interval, true, {0.0, dist_prepare_to_lc_end.lane_changing});
 }
 
 bool isEgoWithinOriginalLane(

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -693,7 +693,8 @@ PathWithLaneId getReferencePathFromTargetLane(
     route_handler.getCenterLinePath(target_lanes, s_start, s_end);
 
   return util::resamplePathWithSpline(
-    lane_changing_reference_path, resample_interval, true, {0.0, dist_prepare_to_lc_end.lane_changing});
+    lane_changing_reference_path, resample_interval, true,
+    {0.0, dist_prepare_to_lc_end.lane_changing});
 }
 
 bool isEgoWithinOriginalLane(


### PR DESCRIPTION
## Description

This PR aims to fix triple lane change issue. To standardize some computations, the current available functions are also refactored.

Before PR

https://user-images.githubusercontent.com/93502286/210927728-c4e4d502-3a5b-4b52-8b72-7b0362e2ee7c.mp4

After PR

https://user-images.githubusercontent.com/93502286/210927774-379107af-9c6d-49a6-9f1c-ee22678b8147.mp4

## Related links

## Tests performed

Perform triple lane changes scenario .

## Notes for reviewers

The following parameters in `lane_change.param.yaml` need to be modified as follows
```
backward_length_buffer_for_end_of_lane > lane_change_finish_judge_buffer + 1
```

```
backward_length_buffer_for_end_of_lane: 3.0
lane_change_finish_judge_buffer: 2.0      # [m]
```

### Rationale

For lane change change more than 1, because lane changing module have to be complete in order for the second lane change to start. And lane change completion depends on finish judge buffer. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
