### PR TITLE
fix(behavior_path_planner): consider length for unavoidable objects around the goal

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -320,7 +320,9 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
       continue;
     }
 
-    if (object_data.longitudinal + parameters_->object_check_goal_distance > dist_to_goal) {
+    if (
+      object_data.longitudinal + object_data.length / 2 + parameters_->object_check_goal_distance >
+      dist_to_goal) {
       avoidance_debug_array_false_and_push_back("TooNearToGoal");
       object_data.reason = "TooNearToGoal";
       data.other_objects.push_back(object_data);


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

Consider target vehicle length for ignoring avoidable objects around the goal.
This is for a large vehicle like a bus.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware.universe/pull/2612

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
