### PR TITLE
feat(longitudinal_controller): skip integral in manual mode

### DIFF
--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -30,6 +30,7 @@
 #include "trajectory_follower_base/longitudinal_controller_base.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
 
+#include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
 #include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
@@ -46,7 +47,7 @@
 
 namespace autoware::motion::control::pid_longitudinal_controller
 {
-using autoware_auto_vehicle_msgs::msg::ControlModeReport;
+using autoware_adapi_v1_msgs::msg::OperationModeState;
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 
 /// \class PidLongitudinalController
@@ -88,7 +89,7 @@ private:
   nav_msgs::msg::Odometry m_current_kinematic_state;
   geometry_msgs::msg::AccelWithCovarianceStamped m_current_accel;
   autoware_auto_planning_msgs::msg::Trajectory m_trajectory;
-  autoware_auto_vehicle_msgs::msg::ControlModeReport m_current_control_mode;
+  OperationModeState m_current_operation_mode;
 
   // vehicle info
   double m_wheel_base;
@@ -227,10 +228,10 @@ private:
   void setCurrentAcceleration(const geometry_msgs::msg::AccelWithCovarianceStamped & msg);
 
   /**
-   * @brief set current control mode with received message
-   * @param [in] msg control mode report message
+   * @brief set current operation mode with received message
+   * @param [in] msg operation mode report message
    */
-  void setCurrentControlMode(const autoware_auto_vehicle_msgs::msg::ControlModeReport & msg);
+  void setCurrentOperationMode(const OperationModeState & msg);
 
   /**
    * @brief set reference trajectory with received message

--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -46,7 +46,7 @@
 
 namespace autoware::motion::control::pid_longitudinal_controller
 {
-
+using autoware_auto_vehicle_msgs::msg::ControlModeReport;
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 
 /// \class PidLongitudinalController
@@ -88,6 +88,7 @@ private:
   nav_msgs::msg::Odometry m_current_kinematic_state;
   geometry_msgs::msg::AccelWithCovarianceStamped m_current_accel;
   autoware_auto_planning_msgs::msg::Trajectory m_trajectory;
+  autoware_auto_vehicle_msgs::msg::ControlModeReport m_current_control_mode;
 
   // vehicle info
   double m_wheel_base;
@@ -224,6 +225,12 @@ private:
    * @param [in] msg trajectory message
    */
   void setCurrentAcceleration(const geometry_msgs::msg::AccelWithCovarianceStamped & msg);
+
+  /**
+   * @brief set current control mode with received message
+   * @param [in] msg control mode report message
+   */
+  void setCurrentControlMode(const autoware_auto_vehicle_msgs::msg::ControlModeReport & msg);
 
   /**
    * @brief set reference trajectory with received message

--- a/control/pid_longitudinal_controller/package.xml
+++ b/control/pid_longitudinal_controller/package.xml
@@ -18,6 +18,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_geometry</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -203,10 +203,9 @@ void PidLongitudinalController::setCurrentAcceleration(
   m_current_accel = msg;
 }
 
-void PidLongitudinalController::setCurrentControlMode(
-  const autoware_auto_vehicle_msgs::msg::ControlModeReport & msg)
+void PidLongitudinalController::setCurrentOperationMode(const OperationModeState & msg)
 {
-  m_current_control_mode = msg;
+  m_current_operation_mode = msg;
 }
 
 void PidLongitudinalController::setTrajectory(
@@ -363,7 +362,7 @@ trajectory_follower::LongitudinalOutput PidLongitudinalController::run(
   setTrajectory(input_data.current_trajectory);
   setKinematicState(input_data.current_odometry);
   setCurrentAcceleration(input_data.current_accel);
-  setCurrentControlMode(input_data.current_control_mode);
+  setCurrentOperationMode(input_data.current_operation_mode);
 
   // calculate current pose and control data
   geometry_msgs::msg::Pose current_pose = m_current_kinematic_state.pose.pose;
@@ -915,9 +914,7 @@ double PidLongitudinalController::applyVelocityFeedback(
 {
   const double current_vel_abs = std::fabs(current_vel);
   const double target_vel_abs = std::fabs(target_motion.vel);
-  const bool is_under_control =
-    m_current_control_mode.mode == ControlModeReport::AUTONOMOUS ||
-    m_current_control_mode.mode == ControlModeReport::AUTONOMOUS_VELOCITY_ONLY;
+  const bool is_under_control = m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;
   const bool enable_integration =
     (current_vel_abs > m_current_vel_threshold_pid_integrate) && is_under_control;
   const double error_vel_filtered = m_lpf_vel_error->filter(target_vel_abs - current_vel_abs);

--- a/control/trajectory_follower_base/include/trajectory_follower_base/input_data.hpp
+++ b/control/trajectory_follower_base/include/trajectory_follower_base/input_data.hpp
@@ -15,8 +15,8 @@
 #ifndef TRAJECTORY_FOLLOWER_BASE__INPUT_DATA_HPP_
 #define TRAJECTORY_FOLLOWER_BASE__INPUT_DATA_HPP_
 
+#include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
-#include "autoware_auto_vehicle_msgs/msg/control_mode_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -29,7 +29,7 @@ struct InputData
   nav_msgs::msg::Odometry current_odometry;
   autoware_auto_vehicle_msgs::msg::SteeringReport current_steering;
   geometry_msgs::msg::AccelWithCovarianceStamped current_accel;
-  autoware_auto_vehicle_msgs::msg::ControlModeReport current_control_mode;
+  autoware_adapi_v1_msgs::msg::OperationModeState current_operation_mode;
 };
 }  // namespace autoware::motion::control::trajectory_follower
 

--- a/control/trajectory_follower_base/include/trajectory_follower_base/input_data.hpp
+++ b/control/trajectory_follower_base/include/trajectory_follower_base/input_data.hpp
@@ -16,6 +16,7 @@
 #define TRAJECTORY_FOLLOWER_BASE__INPUT_DATA_HPP_
 
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
+#include "autoware_auto_vehicle_msgs/msg/control_mode_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -28,6 +29,7 @@ struct InputData
   nav_msgs::msg::Odometry current_odometry;
   autoware_auto_vehicle_msgs::msg::SteeringReport current_steering;
   geometry_msgs::msg::AccelWithCovarianceStamped current_accel;
+  autoware_auto_vehicle_msgs::msg::ControlModeReport current_control_mode;
 };
 }  // namespace autoware::motion::control::trajectory_follower
 

--- a/control/trajectory_follower_base/package.xml
+++ b/control/trajectory_follower_base/package.xml
@@ -20,6 +20,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_geometry</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
+++ b/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
@@ -48,6 +48,8 @@ using trajectory_follower::LongitudinalOutput;
 namespace trajectory_follower_node
 {
 
+using autoware_auto_vehicle_msgs::msg::ControlModeReport;
+
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 
 /// \classController
@@ -70,6 +72,7 @@ private:
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odometry_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::SteeringReport>::SharedPtr sub_steering_;
   rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr sub_accel_;
+  rclcpp::Subscription<ControlModeReport>::SharedPtr sub_control_mode_;
   rclcpp::Publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
     control_cmd_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_marker_pub_;
@@ -78,6 +81,7 @@ private:
   nav_msgs::msg::Odometry::SharedPtr current_odometry_ptr_;
   autoware_auto_vehicle_msgs::msg::SteeringReport::SharedPtr current_steering_ptr_;
   geometry_msgs::msg::AccelWithCovarianceStamped::SharedPtr current_accel_ptr_;
+  ControlModeReport::SharedPtr current_control_mode_ptr_;
 
   enum class LateralControllerMode {
     INVALID = 0,

--- a/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
+++ b/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
@@ -48,7 +48,7 @@ using trajectory_follower::LongitudinalOutput;
 namespace trajectory_follower_node
 {
 
-using autoware_auto_vehicle_msgs::msg::ControlModeReport;
+using autoware_adapi_v1_msgs::msg::OperationModeState;
 
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 
@@ -72,7 +72,7 @@ private:
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odometry_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::SteeringReport>::SharedPtr sub_steering_;
   rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr sub_accel_;
-  rclcpp::Subscription<ControlModeReport>::SharedPtr sub_control_mode_;
+  rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_;
   rclcpp::Publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
     control_cmd_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_marker_pub_;
@@ -81,7 +81,7 @@ private:
   nav_msgs::msg::Odometry::SharedPtr current_odometry_ptr_;
   autoware_auto_vehicle_msgs::msg::SteeringReport::SharedPtr current_steering_ptr_;
   geometry_msgs::msg::AccelWithCovarianceStamped::SharedPtr current_accel_ptr_;
-  ControlModeReport::SharedPtr current_control_mode_ptr_;
+  OperationModeState::SharedPtr current_operation_mode_ptr_;
 
   enum class LateralControllerMode {
     INVALID = 0,

--- a/control/trajectory_follower_node/package.xml
+++ b/control/trajectory_follower_node/package.xml
@@ -20,6 +20,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/control/trajectory_follower_node/src/controller_node.cpp
+++ b/control/trajectory_follower_node/src/controller_node.cpp
@@ -69,9 +69,9 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
     "~/input/current_odometry", rclcpp::QoS{1}, std::bind(&Controller::onOdometry, this, _1));
   sub_accel_ = create_subscription<geometry_msgs::msg::AccelWithCovarianceStamped>(
     "~/input/current_accel", rclcpp::QoS{1}, std::bind(&Controller::onAccel, this, _1));
-  sub_control_mode_ = create_subscription<ControlModeReport>(
-    "~/input/current_control_mode", rclcpp::QoS{1},
-    [this](const ControlModeReport::SharedPtr msg) { current_control_mode_ptr_ = msg; });
+  sub_operation_mode_ = create_subscription<OperationModeState>(
+    "~/input/current_operation_mode", rclcpp::QoS{1},
+    [this](const OperationModeState::SharedPtr msg) { current_operation_mode_ptr_ = msg; });
   control_cmd_pub_ = create_publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>(
     "~/output/control_cmd", rclcpp::QoS{1}.transient_local());
   debug_marker_pub_ =
@@ -166,8 +166,8 @@ boost::optional<trajectory_follower::InputData> Controller::createInputData(
     return {};
   }
 
-  if (!current_control_mode_ptr_) {
-    RCLCPP_INFO_THROTTLE(get_logger(), clock, 5000, "Waiting for current control mode.");
+  if (!current_operation_mode_ptr_) {
+    RCLCPP_INFO_THROTTLE(get_logger(), clock, 5000, "Waiting for current operation mode.");
     return {};
   }
 
@@ -176,7 +176,7 @@ boost::optional<trajectory_follower::InputData> Controller::createInputData(
   input_data.current_odometry = *current_odometry_ptr_;
   input_data.current_steering = *current_steering_ptr_;
   input_data.current_accel = *current_accel_ptr_;
-  input_data.current_control_mode = *current_control_mode_ptr_;
+  input_data.current_operation_mode = *current_operation_mode_ptr_;
 
   return input_data;
 }

--- a/control/trajectory_follower_node/src/controller_node.cpp
+++ b/control/trajectory_follower_node/src/controller_node.cpp
@@ -69,6 +69,9 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
     "~/input/current_odometry", rclcpp::QoS{1}, std::bind(&Controller::onOdometry, this, _1));
   sub_accel_ = create_subscription<geometry_msgs::msg::AccelWithCovarianceStamped>(
     "~/input/current_accel", rclcpp::QoS{1}, std::bind(&Controller::onAccel, this, _1));
+  sub_control_mode_ = create_subscription<ControlModeReport>(
+    "~/input/current_control_mode", rclcpp::QoS{1},
+    [this](const ControlModeReport::SharedPtr msg) { current_control_mode_ptr_ = msg; });
   control_cmd_pub_ = create_publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>(
     "~/output/control_cmd", rclcpp::QoS{1}.transient_local());
   debug_marker_pub_ =
@@ -163,11 +166,17 @@ boost::optional<trajectory_follower::InputData> Controller::createInputData(
     return {};
   }
 
+  if (!current_control_mode_ptr_) {
+    RCLCPP_INFO_THROTTLE(get_logger(), clock, 5000, "Waiting for current control mode.");
+    return {};
+  }
+
   trajectory_follower::InputData input_data;
   input_data.current_trajectory = *current_trajectory_ptr_;
   input_data.current_odometry = *current_odometry_ptr_;
   input_data.current_steering = *current_steering_ptr_;
   input_data.current_accel = *current_accel_ptr_;
+  input_data.current_control_mode = *current_control_mode_ptr_;
 
   return input_data;
 }

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -70,7 +70,7 @@ def launch_setup(context, *args, **kwargs):
             ("~/input/current_odometry", "/localization/kinematic_state"),
             ("~/input/current_steering", "/vehicle/status/steering_status"),
             ("~/input/current_accel", "/localization/acceleration"),
-            ("~/input/current_control_mode", "/vehicle/status/control_mode"),
+            ("~/input/current_operation_mode", "/system/operation_mode/state"),
             ("~/output/predicted_trajectory", "lateral/predicted_trajectory"),
             ("~/output/lateral_diagnostic", "lateral/diagnostic"),
             ("~/output/slope_angle", "longitudinal/slope_angle"),

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -70,6 +70,7 @@ def launch_setup(context, *args, **kwargs):
             ("~/input/current_odometry", "/localization/kinematic_state"),
             ("~/input/current_steering", "/vehicle/status/steering_status"),
             ("~/input/current_accel", "/localization/acceleration"),
+            ("~/input/current_control_mode", "/vehicle/status/control_mode"),
             ("~/output/predicted_trajectory", "lateral/predicted_trajectory"),
             ("~/output/lateral_diagnostic", "lateral/diagnostic"),
             ("~/output/slope_angle", "longitudinal/slope_angle"),


### PR DESCRIPTION
## Description

In the current implementation, if the vehicle speed is almost zero, the control error integral is skipped. However, when the vehicle is moving under manual control, the integration is performed which is unexpected behavior. This causes an overshoot when the vehicle is engaged while driving.

This PR fixes the issue by disabling the integration when the control_mode is not in autonomous.


## Related links

must be merged with https://github.com/tier4/autoware_launch/pull/683

## Tests performed

- psim, run/stop

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
