### PR TITLE
fix(system_error_monitor): hold emergency when timeout happens

### DIFF
--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -141,6 +141,7 @@ private:
     autoware_auto_system_msgs::msg::HazardStatus * hazard_status) const;
   autoware_auto_system_msgs::msg::HazardStatus judgeHazardStatus() const;
   void updateHazardStatus();
+  void updateTimeoutHazardStatus();
   bool canAutoRecovery() const;
   bool isEmergencyHoldingRequired() const;
 };

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -182,20 +182,6 @@ std::set<std::string> getErrorModules(
   return error_modules;
 }
 
-autoware_auto_system_msgs::msg::HazardStatus createTimeoutHazardStatus()
-{
-  autoware_auto_system_msgs::msg::HazardStatus hazard_status;
-  hazard_status.level = autoware_auto_system_msgs::msg::HazardStatus::SINGLE_POINT_FAULT;
-  hazard_status.emergency = true;
-  hazard_status.emergency_holding = false;
-  diagnostic_msgs::msg::DiagnosticStatus diag;
-  diag.name = "system_error_monitor/input_data_timeout";
-  diag.hardware_id = "system_error_monitor";
-  diag.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-  hazard_status.diag_single_point_fault.push_back(diag);
-  return hazard_status;
-}
-
 int isInNoFaultCondition(
   const autoware_auto_system_msgs::msg::AutowareState & autoware_state,
   const tier4_control_msgs::msg::GateMode & current_gate_mode)
@@ -459,13 +445,15 @@ void AutowareErrorMonitor::onTimer()
       RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
         "input data is timeout");
-      publishHazardStatus(createTimeoutHazardStatus());
+      updateTimeoutHazardStatus();
+      publishHazardStatus(hazard_status_);
     }
     return;
   }
 
   if (isDataHeartbeatTimeout()) {
-    publishHazardStatus(createTimeoutHazardStatus());
+    updateTimeoutHazardStatus();
+    publishHazardStatus(hazard_status_);
     return;
   }
 
@@ -607,6 +595,31 @@ void AutowareErrorMonitor::updateHazardStatus()
   // Update emergency_holding condition
   if (params_.use_emergency_hold) {
     hazard_status_.emergency_holding = isEmergencyHoldingRequired();
+  }
+}
+
+void AutowareErrorMonitor::updateTimeoutHazardStatus()
+{
+  const bool prev_emergency_status = hazard_status_.emergency;
+
+  hazard_status_.level = autoware_auto_system_msgs::msg::HazardStatus::SINGLE_POINT_FAULT;
+  hazard_status_.emergency = true;
+
+  if (hazard_status_.emergency != prev_emergency_status) {
+    emergency_state_switch_time_ = this->now();
+  }
+
+  diagnostic_msgs::msg::DiagnosticStatus diag;
+  diag.name = "system_error_monitor/input_data_timeout";
+  diag.hardware_id = "system_error_monitor";
+  diag.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+  hazard_status_.diag_single_point_fault =
+    std::vector<diagnostic_msgs::msg::DiagnosticStatus>{diag};
+
+  // Update emergency_holding condition
+  if (params_.use_emergency_hold) {
+    const auto emergency_duration = (this->now() - emergency_state_switch_time_).seconds();
+    hazard_status_.emergency_holding = emergency_duration > params_.hazard_recovery_timeout;
   }
 }
 

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -609,6 +609,10 @@ void AutowareErrorMonitor::updateTimeoutHazardStatus()
     emergency_state_switch_time_ = this->now();
   }
 
+  hazard_status_.diag_no_fault = std::vector<diagnostic_msgs::msg::DiagnosticStatus>();
+  hazard_status_.diag_safe_fault = std::vector<diagnostic_msgs::msg::DiagnosticStatus>();
+  hazard_status_.diag_latent_fault = std::vector<diagnostic_msgs::msg::DiagnosticStatus>();
+
   diagnostic_msgs::msg::DiagnosticStatus diag;
   diag.name = "system_error_monitor/input_data_timeout";
   diag.hardware_id = "system_error_monitor";


### PR DESCRIPTION
## Description

When timeout happens,  emergency becomes true, but emergency_holding does not become true.
I'll fix it.

## Related links

TIERIV_INTERNAL_LINK: https://tier4.atlassian.net/browse/T4PB-25040

## Tests performed

- change `use_emergency_hold` to true in `system.launch.xml`
https://github.com/autowarefoundation/autoware.universe/blob/main/launch/tier4_system_launch/launch/system.launch.xml#L65
- launch psim
- echo `/system/emergency/hazard_status`
- kill default_ad_api to occur timeout
  `ps -aux | grep default_ad_api | awk '{print $2}' | xargs kill`
- confirm status transition of emergency_holding to true after 5 seconds

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
