### PR TITLE
feat(vehicle_velocity_converter): add `speed_scale_factor`

### DIFF
--- a/sensing/vehicle_velocity_converter/README.md
+++ b/sensing/vehicle_velocity_converter/README.md
@@ -22,6 +22,7 @@ This package converts autoware_auto_vehicle_msgs::msg::VehicleReport message to 
 
 | Name                         | Type   | Description                     |
 | ---------------------------- | ------ | ------------------------------- |
+| `speed_scale_factor`         | double | speed scale factor (ideal value is 1.0)  |
 | `frame_id`                   | string | frame id for output message     |
 | `velocity_stddev_xx`         | double | standard deviation for vx       |
 | `angular_velocity_stddev_zz` | double | standard deviation for yaw rate |

--- a/sensing/vehicle_velocity_converter/README.md
+++ b/sensing/vehicle_velocity_converter/README.md
@@ -20,9 +20,9 @@ This package converts autoware_auto_vehicle_msgs::msg::VehicleReport message to 
 
 ## Parameters
 
-| Name                         | Type   | Description                     |
-| ---------------------------- | ------ | ------------------------------- |
-| `speed_scale_factor`         | double | speed scale factor (ideal value is 1.0)  |
-| `frame_id`                   | string | frame id for output message     |
-| `velocity_stddev_xx`         | double | standard deviation for vx       |
-| `angular_velocity_stddev_zz` | double | standard deviation for yaw rate |
+| Name                         | Type   | Description                             |
+| ---------------------------- | ------ | --------------------------------------- |
+| `speed_scale_factor`         | double | speed scale factor (ideal value is 1.0) |
+| `frame_id`                   | string | frame id for output message             |
+| `velocity_stddev_xx`         | double | standard deviation for vx               |
+| `angular_velocity_stddev_zz` | double | standard deviation for yaw rate         |

--- a/sensing/vehicle_velocity_converter/config/vehicle_velocity_converter.param.yaml
+++ b/sensing/vehicle_velocity_converter/config/vehicle_velocity_converter.param.yaml
@@ -1,5 +1,6 @@
 /**:
   ros__parameters:
+    speed_scale_factor: 1.0  # [.]
     velocity_stddev_xx: 0.2  # [m/s]
     angular_velocity_stddev_zz: 0.1  # [rad/s]
     frame_id: base_link

--- a/sensing/vehicle_velocity_converter/include/vehicle_velocity_converter/vehicle_velocity_converter.hpp
+++ b/sensing/vehicle_velocity_converter/include/vehicle_velocity_converter/vehicle_velocity_converter.hpp
@@ -43,6 +43,7 @@ private:
   std::string frame_id_;
   double stddev_vx_;
   double stddev_wz_;
+  double speed_scale_factor_;
   std::array<double, 36> twist_covariance_;
 };
 

--- a/sensing/vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
+++ b/sensing/vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
@@ -20,6 +20,7 @@ VehicleVelocityConverter::VehicleVelocityConverter() : Node("vehicle_velocity_co
   stddev_vx_ = declare_parameter("velocity_stddev_xx", 0.2);
   stddev_wz_ = declare_parameter("angular_velocity_stddev_zz", 0.1);
   frame_id_ = declare_parameter("frame_id", "base_link");
+  speed_scale_factor_ = declare_parameter("speed_scale_factor", 1.0);
 
   vehicle_report_sub_ = create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
     "velocity_status", rclcpp::QoS{100},
@@ -39,7 +40,7 @@ void VehicleVelocityConverter::callbackVelocityReport(
   // set twist with covariance msg from vehicle report msg
   geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance_msg;
   twist_with_covariance_msg.header = msg->header;
-  twist_with_covariance_msg.twist.twist.linear.x = msg->longitudinal_velocity;
+  twist_with_covariance_msg.twist.twist.linear.x = msg->longitudinal_velocity * speed_scale_factor_;
   twist_with_covariance_msg.twist.twist.linear.y = msg->lateral_velocity;
   twist_with_covariance_msg.twist.twist.angular.z = msg->heading_rate;
   twist_with_covariance_msg.twist.covariance[0 + 0 * 6] = stddev_vx_ * stddev_vx_;


### PR DESCRIPTION
## Description
Add `speed_scale_factor` parameter in `vehicle_velocity_converter`.
The parameter is intended to address several factors that induces velocity error, which include:
- tire slip 
- tire radius calibration error
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
I tested on logging_simulator.launch.xml and verified that the speed_scale_factor is properly applied to the output topic.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
