### PR TITLE
fix(motion_utils/path_shifter): modify the sampling method

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -438,6 +438,39 @@ double calcSignedArcLength(const T & points, const size_t src_idx, const size_t 
 }
 
 /**
+ *  @brief Computes the partial sums of the elements in the sub-ranges of
+ *         the range [src_idx, dst_idx) and return these sum as vector
+ */
+template <class T>
+std::vector<double> calcSignedArcLengthPartialSum(
+  const T & points, const size_t src_idx, const size_t dst_idx)
+{
+  try {
+    validateNonEmpty(points);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+    return {};
+  }
+
+  if (src_idx + 1 > dst_idx) {
+    auto copied = points;
+    std::reverse(copied.begin(), copied.end());
+    return calcSignedArcLengthPartialSum(points, dst_idx, src_idx);
+  }
+
+  std::vector<double> partial_dist;
+  partial_dist.reserve(dst_idx - src_idx);
+
+  double dist_sum = 0.0;
+  partial_dist.push_back(dist_sum);
+  for (size_t i = src_idx; i < dst_idx - 1; ++i) {
+    dist_sum += tier4_autoware_utils::calcDistance2d(points.at(i), points.at(i + 1));
+    partial_dist.push_back(dist_sum);
+  }
+  return partial_dist;
+}
+
+/**
  * @brief calcSignedArcLength from point to index
  */
 template <class T>

--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -78,8 +78,10 @@ PathWithLaneId resamplePathWithSpline(
   // Get lane ids that are not duplicated
   std::vector<double> s_in;
   std::vector<int64_t> unique_lane_ids;
+  const auto s_vec =
+    motion_utils::calcSignedArcLengthPartialSum(transformed_path, 0, transformed_path.size());
   for (size_t i = 0; i < path.points.size(); ++i) {
-    const double s = motion_utils::calcSignedArcLength(transformed_path, 0, i);
+    const double s = s_vec.at(i);
     for (const auto & lane_id : path.points.at(i).lane_ids) {
       if (keep_input_points && !has_almost_same_value(s_in, s)) {
         s_in.push_back(s);
@@ -98,7 +100,7 @@ PathWithLaneId resamplePathWithSpline(
   std::vector<double> s_out = s_in;
 
   const auto start_s = std::max(target_section.first, 0.0);
-  const auto end_s = std::min(target_section.second, motion_utils::calcArcLength(transformed_path));
+  const auto end_s = std::min(target_section.second, s_vec.back());
   for (double s = start_s; s < end_s; s += interval) {
     if (!has_almost_same_value(s_out, s)) {
       s_out.push_back(s);


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

The lane change candidate path performance is currently reduced, which might caused by the resampling of the candidate path.

Presently, the resamplingPathWithSpline method employs, `const double s = motion_utils::calcSignedArcLength(transformed_path, 0, i)` to compute the sum between path's `0`th and `i`th index. This causes additional interation to be made.

To simplify the computation, a new function is introduce to return a vector of the interval sum. Therefore, the sum between path's `0`th and `i`th index only computed once, reducing the need to compute them at each iteration.

Slight performance gain is observed (0.15 ~ 0.2 hz improvement observed)
Laptop specs
```
CPU: i7-11800H @ 2.30gHz x 16
RAM: 32 GB
Ubuntu: 22.04
```

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

1. Open planning_simulator and add `RTCManagerPanel`.
2. Set `lane_change_right` and `lane_change_left` to `manual mode`.
3. Test lane change scenario.
4. Publish constant twist as follow 
   ```
   ros2 topic pub /simulation/input/initialtwist geometry_msgs/msg/TwistStamped "{twist: 
   {linear: {x: 10.0}}}" -r 100`
   ```
5. Echo the following topic 
   ```
   ros2 topic hz /planning/path_candidate/lane_change
   ```

**Before PR**
Before approval, at `36km/h`

``` 
ros2 topic hz /planning/path_candidate/lane_change
average rate: 8.384
min: 0.113s max: 0.170s std dev: 0.00584s
```
``` 
ros2 topic hz /planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id
average rate: 8.457
min: 0.111s max: 0.140s std dev: 0.00420s
```

After approval, at `36km/h`
``` 
ros2 topic hz /planning/path_candidate/lane_change
average rate: 10.00
min: 0.090s max: 0.110s std dev: 0.00381s
```
``` 
ros2 topic hz /planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id
average rate: 10.00
min: 0.089s max: 0.113s std dev: 0.00427s
```


**After PR**
Before approval, at `36km/h`

``` 
ros2 topic hz /planning/path_candidate/lane_change
average rate: 8.654
min: 0.110s max: 0.208s std dev: 0.00499s
```
``` 
ros2 topic hz /planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id
average rate: 8.675
min: 0.105s max: 0.145s std dev: 0.00403s
```

After approval, at `36km/h`
``` 
ros2 topic hz /planning/path_candidate/lane_change
average rate: 10.00
min: 0.090s max: 0.110s std dev: 0.00392s
```
``` 
ros2 topic hz /planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id
average rate: 10.00
min: 0.086s max: 0.116s std dev: 0.00453s
```

## Notes for reviewers

I named the `motion_utils::calcSignedArcLengthPartialSum` following [stl](https://en.cppreference.com/w/cpp/algorithm/partial_sum)'s `partial_sum`. But if there is better naming, please let me know.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
