### PR TITLE
chore(tier4_map_launch): add lanelet2 config files to tier4_map_launch

### DIFF
--- a/launch/tier4_map_launch/launch/map.launch.xml
+++ b/launch/tier4_map_launch/launch/map.launch.xml
@@ -11,12 +11,12 @@
     <push-ros-namespace namespace="map"/>
     <include file="$(find-pkg-share map_loader)/launch/lanelet2_map_loader.launch.xml">
       <arg name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>
+      <arg name="lanelet2_map_loader_param_path" value="$(var lanelet2_map_loader_param_path)"/>
     </include>
 
     <include file="$(find-pkg-share map_loader)/launch/pointcloud_map_loader.launch.xml">
       <arg name="pointcloud_map_path" value="$(var pointcloud_map_path)"/>
       <arg name="pointcloud_map_loader_param_path" value="$(var pointcloud_map_loader_param_path)"/>
-      <arg name="lanelet2_map_loader_param_path" value="$(var lanelet2_map_loader_param_path)"/>
     </include>
 
     <include file="$(find-pkg-share map_tf_generator)/launch/map_tf_generator.launch.xml">

--- a/launch/tier4_map_launch/launch/map.launch.xml
+++ b/launch/tier4_map_launch/launch/map.launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <!-- Parameter files -->
   <arg name="pointcloud_map_loader_param_path"/>
+  <arg name="lanelet2_map_loader_param_path"/>
 
   <arg name="map_path" default=""/>
   <arg name="lanelet2_map_path" default="$(var map_path)/lanelet2_map.osm"/>
@@ -15,6 +16,7 @@
     <include file="$(find-pkg-share map_loader)/launch/pointcloud_map_loader.launch.xml">
       <arg name="pointcloud_map_path" value="$(var pointcloud_map_path)"/>
       <arg name="pointcloud_map_loader_param_path" value="$(var pointcloud_map_loader_param_path)"/>
+      <arg name="lanelet2_map_loader_param_path" value="$(var lanelet2_map_loader_param_path)"/>
     </include>
 
     <include file="$(find-pkg-share map_tf_generator)/launch/map_tf_generator.launch.xml">

--- a/map/map_loader/launch/lanelet2_map_loader.launch.xml
+++ b/map/map_loader/launch/lanelet2_map_loader.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="param_file" default="$(find-pkg-share map_loader)/config/lanelet2_map_loader.param.yaml"/>
+  <arg name="lanelet2_map_loader_param_path" default="$(find-pkg-share map_loader)/config/lanelet2_map_loader.param.yaml"/>
   <arg name="lanelet2_map_path"/>
   <arg name="lanelet2_map_topic" default="vector_map"/>
   <arg name="lanelet2_map_marker_topic" default="vector_map_marker"/>
@@ -11,7 +11,7 @@
   <node pkg="map_loader" exec="lanelet2_map_loader" name="lanelet2_map_loader">
     <remap from="output/lanelet2_map" to="$(var lanelet2_map_topic)"/>
     <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>
-    <param from="$(var param_file)"/>
+    <param from="$(var lanelet2_map_loader_param_path)"/>
   </node>
 
   <node pkg="map_loader" exec="lanelet2_map_visualization" name="lanelet2_map_visualization">


### PR DESCRIPTION
Signed-off-by: melike tanrikulu <melike@leodrive.ai>

## Description
This PR aims to provide the ability to change lanelet2 map configurations from within tier4_map_launch.
At the same time, the following PR has been created in order to make changes to the config file in autoware_launch.
Related PR: https://github.com/autowarefoundation/autoware_launch/pull/169

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
