### PR TITLE
refactor(bpp-avoidance): remove redundant parameters

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -6,8 +6,6 @@
       resample_interval_for_output: 4.0                 # [m]
       detection_area_right_expand_dist: 0.0             # [m]
       detection_area_left_expand_dist: 1.0              # [m]
-      drivable_area_right_bound_offset: 0.0             # [m]
-      drivable_area_left_bound_offset: 0.0              # [m]
       object_envelope_buffer: 0.3                       # [m]
 
       # avoidance module common setting


### PR DESCRIPTION
Signed-off-by: Mehmet Dogru <42mehmetdogru42@gmail.com>

## Description

Remove redundant parameters from bpp-avoidance config file regarding:
https://github.com/orgs/autowarefoundation/discussions/3207#discussioncomment-4704021

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
