### PR TITLE
fix(behavior_path_planner): pull_over checks lane departure only for parking part

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_over/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/shift_pull_over.cpp
@@ -167,17 +167,6 @@ boost::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
     p.point.pose.position.z = goal_pose.position.z;
   }
 
-  // check lane departure with road and shoulder lanes
-  const auto drivable_lanes =
-    util::generateDrivableLanesWithShoulderLanes(road_lanes, shoulder_lanes);
-  const auto expanded_lanes = util::expandLanelets(
-    drivable_lanes, parameters_.drivable_area_left_bound_offset,
-    parameters_.drivable_area_right_bound_offset);
-  if (lane_departure_checker_.checkPathWillLeaveLane(
-        util::transformToLanelets(expanded_lanes), shifted_path.path)) {
-    return {};
-  }
-
   // set lane_id and velocity to shifted_path
   for (size_t i = path_shifter.getShiftLines().front().start_idx;
        i < shifted_path.path.points.size() - 1; ++i) {
@@ -211,6 +200,17 @@ boost::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
   pull_over_path.end_pose = path_shifter.getShiftLines().front().end;
   pull_over_path.debug_poses.push_back(shift_end_pose_road_lane);
   pull_over_path.debug_poses.push_back(actual_shift_end_pose);
+
+  // check if the parking path will leave lanes
+  const auto drivable_lanes =
+    util::generateDrivableLanesWithShoulderLanes(road_lanes, shoulder_lanes);
+  const auto expanded_lanes = util::expandLanelets(
+    drivable_lanes, parameters_.drivable_area_left_bound_offset,
+    parameters_.drivable_area_right_bound_offset);
+  if (lane_departure_checker_.checkPathWillLeaveLane(
+        util::transformToLanelets(expanded_lanes), pull_over_path.getParkingPath())) {
+    return {};
+  }
 
   return pull_over_path;
 }


### PR DESCRIPTION

Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

The lane departure checker in shift_pull_over uses shifted_path, which causes a departure at the beginning of the lane
In this PR, only the parking part (start-end) is checked.


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim 

![Screenshot from 2023-01-17 20-59-41](https://user-images.githubusercontent.com/39142679/212897211-22f04dc6-d483-4942-936d-0f6ec20b2cce.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
