### PR TITLE
fix(traffic_light_ssd_fine_detector): improve ssd bbox selection when multiple traffic lights are within one rough roi

### DIFF
--- a/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
+++ b/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
@@ -62,7 +62,8 @@ private:
     const std::vector<cv::Mat> & in_imgs, const int num_rois, std::vector<float> & data);
   bool cnnOutput2BoxDetection(
     const float * scores, const float * boxes, const int tlr_id,
-    const std::vector<cv::Mat> & in_imgs, const int num_rois, std::vector<Detection> & detections);
+    const std::vector<cv::Mat> & in_imgs, const int num_rois, std::vector<Detection> & detections,
+    const autoware_auto_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr rough_roi_msg);
   bool rosMsg2CvMat(const sensor_msgs::msg::Image::ConstSharedPtr image_msg, cv::Mat & image);
   bool fitInFrame(cv::Point & lt, cv::Point & rb, const cv::Size & size);
   void cvRect2TlRoiMsg(


### PR DESCRIPTION
# Issue
https://tier4.atlassian.net/browse/T4PB-25095

# Description

* Sometimes when two crosses are close, two different traffic lights might appear within the same rough roi generated by traffic_light_map_based_detector. This PR aims at solving the problem by improving the bbox selection in traffic_light_ssd_fine_detector.
* The detailed method is described in code and
https://docs.google.com/presentation/d/1FJljvDGJ_I0Q1g_t2Y_yKf0BBjQHClWtuJUazr2KlbE/edit#slide=id.g1b5661847ad_0_25