### PR TITLE
feat(behavior_path_planner): ignore pull out start near lane end

### DIFF
--- a/planning/behavior_path_planner/README.md
+++ b/planning/behavior_path_planner/README.md
@@ -453,6 +453,7 @@ If a safe path cannot be generated from the current position, search backwards f
 | max_back_distance                                                          | [m]            | double | maximum back distance                                                                                                 | 15.0          |
 | backward_search_resolution                                                 | [m]            | double | distance interval for searching backward pull out start point                                                         | 2.0           |
 | backward_path_update_duration                                              | [s]            | double | time interval for searching backward pull out start point. this prevents chattering between back driving and pull_out | 3.0           |
+| ignore_distance_from_lane_end                                              | [m]            | double | distance from end of pull out lanes for ignoring start candidates                                                     | 15.0          |
 
 #### Unimplemented parts / limitations for pull put
 

--- a/planning/behavior_path_planner/config/pull_out/pull_out.param.yaml
+++ b/planning/behavior_path_planner/config/pull_out/pull_out.param.yaml
@@ -28,3 +28,4 @@
       max_back_distance: 15.0
       backward_search_resolution: 2.0
       backward_path_update_duration: 3.0
+      ignore_distance_from_lane_end: 15.0

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_parameters.hpp
@@ -50,6 +50,7 @@ struct PullOutParameters
   double max_back_distance;
   double backward_search_resolution;
   double backward_path_update_duration;
+  double ignore_distance_from_lane_end;
   // drivable area expansion
   double drivable_area_right_bound_offset;
   double drivable_area_left_bound_offset;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -657,6 +657,7 @@ PullOutParameters BehaviorPathPlannerNode::getPullOutParam()
   p.max_back_distance = dp("max_back_distance", 15.0);
   p.backward_search_resolution = dp("backward_search_resolution", 2.0);
   p.backward_path_update_duration = dp("backward_path_update_duration", 3.0);
+  p.ignore_distance_from_lane_end = dp("ignore_distance_from_lane_end", 15.0);
   // drivable area
   p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
   p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -174,7 +174,8 @@ BehaviorModuleOutput PullOutModule::plan()
 
   BehaviorModuleOutput output;
   if (!status_.is_safe) {
-    RCLCPP_INFO(getLogger(), "not found safe path");
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 5000, "Not found safe pull out path, publish stop path");
     return output;
   }
 
@@ -549,6 +550,9 @@ std::vector<Pose> PullOutModule::searchBackedPoses()
       lanelet::utils::getLaneletLength2d(status_.pull_out_lanes.back());
     const double distance_from_lane_end = length_to_lane_end - length_to_backed_pose;
     if (distance_from_lane_end < parameters_.ignore_distance_from_lane_end) {
+      RCLCPP_WARN_THROTTLE(
+        getLogger(), *clock_, 5000,
+        "the ego is too close to the lane end, so needs backward driving");
       continue;
     }
 

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -376,12 +376,13 @@ void PullOutModule::planWithPriorityOnEfficientPath(
 
   // plan with each planner
   for (const auto & planner : pull_out_planners_) {
-    for (size_t i = 0; i < start_pose_candidates.size(); ++i) {
-      // pull out start pose is current_pose
-      if (i == 0) {
-        status_.back_finished = true;
-      }
-      const auto & pull_out_start_pose = start_pose_candidates.at(i);
+    for (const Pose & pull_out_start_pose : start_pose_candidates) {
+      // check pull_out_start_pose is current_pose
+      const double distance_from_current_pose = tier4_autoware_utils::calcDistance2d(
+        pull_out_start_pose.position, planner_data_->self_pose->pose.position);
+      constexpr double epsilon = 0.1;
+      status_.back_finished = distance_from_current_pose < epsilon;
+
       planner->setPlannerData(planner_data_);
       const auto pull_out_path = planner->plan(pull_out_start_pose, goal_pose);
       if (pull_out_path) {  // found safe path
@@ -391,8 +392,6 @@ void PullOutModule::planWithPriorityOnEfficientPath(
         status_.planner_type = planner->getPlannerType();
         break;
       }
-      // pull out start pose is not current_pose(index > 0), so need back.
-      status_.back_finished = false;
     }
     if (status_.is_safe) {
       break;
@@ -406,12 +405,12 @@ void PullOutModule::planWithPriorityOnShortBackDistance(
   status_.is_safe = false;
   status_.planner_type = PlannerType::NONE;
 
-  for (size_t i = 0; i < start_pose_candidates.size(); ++i) {
-    // pull out start pose is current_pose
-    if (i == 0) {
-      status_.back_finished = true;
-    }
-    const auto & pull_out_start_pose = start_pose_candidates.at(i);
+  for (const Pose & pull_out_start_pose : start_pose_candidates) {
+    // check pull_out_start_pose is current_pose
+    const double distance_from_current_pose = tier4_autoware_utils::calcDistance2d(
+      pull_out_start_pose.position, planner_data_->self_pose->pose.position);
+    constexpr double epsilon = 0.1;
+    status_.back_finished = distance_from_current_pose < epsilon;
     // plan with each planner
     for (const auto & planner : pull_out_planners_) {
       planner->setPlannerData(planner_data_);
@@ -427,8 +426,6 @@ void PullOutModule::planWithPriorityOnShortBackDistance(
     if (status_.is_safe) {
       break;
     }
-    // pull out start pose is not current_pose(index > 0), so need back.
-    status_.back_finished = false;
   }
 }
 
@@ -518,7 +515,7 @@ void PullOutModule::updatePullOutStatus()
 // make this class?
 std::vector<Pose> PullOutModule::searchBackedPoses()
 {
-  const auto current_pose = planner_data_->self_pose->pose;
+  const Pose & current_pose = planner_data_->self_pose->pose;
 
   // get backward shoulder path
   const auto arc_position_pose =
@@ -542,6 +539,16 @@ std::vector<Pose> PullOutModule::searchBackedPoses()
     const auto backed_pose = calcLongitudinalOffsetPose(
       backward_shoulder_path.points, current_pose.position, -back_distance);
     if (!backed_pose) {
+      continue;
+    }
+
+    // check the back pose is near the lane end
+    const double length_to_backed_pose =
+      lanelet::utils::getArcCoordinates(status_.pull_out_lanes, *backed_pose).length;
+    const double length_to_lane_end =
+      lanelet::utils::getLaneletLength2d(status_.pull_out_lanes.back());
+    const double distance_from_lane_end = length_to_lane_end - length_to_backed_pose;
+    if (distance_from_lane_end < parameters_.ignore_distance_from_lane_end) {
       continue;
     }
 


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

Same to pull_over https://github.com/autowarefoundation/autoware.universe/pull/2667, 
ignore pull_out start candidate near the lane end to prevent distortion with the path generated close to the drivable area.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

launcher
- https://github.com/autowarefoundation/autoware_launch/pull/171
- https://github.com/tier4/autoware_launch/pull/702

tier4 internal link
  - https://star4.slack.com/archives/CEV8XMJBV/p1673943045631719?thread_ts=1673861071.218589&cid=CEV8XMJBV 

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

`ignore_distance_from_lane_end: 0.0`

https://user-images.githubusercontent.com/39142679/212949312-b9f0967a-ecab-46a4-90c0-9cea8414dc60.mp4

![Screenshot from 2023-01-18 00-52-13](https://user-images.githubusercontent.com/39142679/212949832-c9d22a53-2680-42ce-a113-622364699234.png)


`ignore_distance_from_lane_end: 15.0`

https://user-images.githubusercontent.com/39142679/212949498-9670792f-3a28-4f7e-a04d-c86c51c99e9f.mp4

![Screenshot from 2023-01-18 00-53-41](https://user-images.githubusercontent.com/39142679/212949956-748ac311-ee71-4146-894a-5d45f2176317.png)



`ignore_distance_from_lane_end: 20.0`

https://user-images.githubusercontent.com/39142679/212949441-539ae80c-7c9f-4c00-bb2e-5fd73e233ef0.mp4

![image](https://user-images.githubusercontent.com/39142679/212949631-c4f5bc30-1bac-42b3-a756-da9aa457643e.png)



## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
