### PR TITLE
fix(tier4_planning_launch): make use_experimental_lane_change_function available

### DIFF
--- a/launch/tier4_planning_launch/launch/planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/planning.launch.xml
@@ -9,6 +9,7 @@
   <arg name="use_pointcloud_container"/>
   <arg name="pointcloud_container_name"/>
   <arg name="use_surround_obstacle_check"/>
+  <arg name="use_experimental_lane_change_function"/>
 
   <!-- common -->
   <arg name="common_param_path"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
@@ -11,6 +11,7 @@
           <arg name="use_multithread" value="true"/>
           <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
           <arg name="container_name" value="$(var pointcloud_container_name)"/>
+          <arg name="use_experimental_lane_change_function" value="$(var use_experimental_lane_change_function)"/>
         </include>
       </group>
       <group>
@@ -28,7 +29,6 @@
         <arg name="use_multithread" value="true"/>
         <arg name="use_surround_obstacle_check" value="$(var use_surround_obstacle_check)"/>
         <arg name="cruise_planner_type" value="$(var cruise_planner_type)"/>
-        <arg name="use_experimental_lane_change_function" value="$(var use_experimental_lane_change_function)"/>
       </include>
     </group>
   </group>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -297,6 +297,9 @@ def generate_launch_description():
     )
     add_launch_arg("map_topic_name", "/map/vector_map", "input topic of map")
 
+    # package parameter
+    add_launch_arg("use_experimental_lane_change_function")
+
     # component
     add_launch_arg("use_intra_process", "false", "use ROS2 component container communication")
     add_launch_arg("use_multithread", "false", "use multithread")


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

fix for https://github.com/autowarefoundation/autoware.universe/pull/2666
use_experimental_lane_change_function is not available without this PR.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
