### PR TITLE
refactor(ekf_localizer): add a class to manage queue elements with their ages

### DIFF
--- a/localization/ekf_localizer/CMakeLists.txt
+++ b/localization/ekf_localizer/CMakeLists.txt
@@ -43,6 +43,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   set(TEST_FILES
+    test/test_aged_object_queue.cpp
     test/test_mahalanobis.cpp
     test/test_measurement.cpp
     test/test_numeric.cpp

--- a/localization/ekf_localizer/include/ekf_localizer/aged_object_queue.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/aged_object_queue.hpp
@@ -18,24 +18,15 @@
 #include <cstddef>
 #include <queue>
 
-template<typename Object>
+template <typename Object>
 class AgedObjectQueue
 {
 public:
-  explicit AgedObjectQueue(const int max_age)
-  : max_age_(max_age)
-  {
-  }
+  explicit AgedObjectQueue(const int max_age) : max_age_(max_age) {}
 
-  bool empty() const
-  {
-    return this->size() == 0;
-  }
+  bool empty() const { return this->size() == 0; }
 
-  size_t size() const
-  {
-    return objects_.size();
-  }
+  size_t size() const { return objects_.size(); }
 
   void push(const Object & object)
   {

--- a/localization/ekf_localizer/include/ekf_localizer/aged_object_queue.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/aged_object_queue.hpp
@@ -1,0 +1,73 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EKF_LOCALIZER__AGED_OBJECT_QUEUE_HPP_
+#define EKF_LOCALIZER__AGED_OBJECT_QUEUE_HPP_
+
+#include <cstddef>
+#include <queue>
+
+template<typename Object>
+class AgedObjectQueue
+{
+public:
+  explicit AgedObjectQueue(const int max_age)
+  : max_age_(max_age)
+  {
+  }
+
+  bool empty() const
+  {
+    return this->size() == 0;
+  }
+
+  size_t size() const
+  {
+    return objects_.size();
+  }
+
+  void push(const Object & object)
+  {
+    objects_.push(object);
+    ages_.push(0);
+  }
+
+  Object pop_increment_age()
+  {
+    const Object object = objects_.front();
+    const int age = ages_.front() + 1;
+    objects_.pop();
+    ages_.pop();
+
+    if (age < max_age_) {
+      objects_.push(object);
+      ages_.push(age);
+    }
+
+    return object;
+  }
+
+  void clear()
+  {
+    objects_ = std::queue<Object>();
+    ages_ = std::queue<int>();
+  }
+
+private:
+  const int max_age_;
+  std::queue<Object> objects_;
+  std::queue<int> ages_;
+};
+
+#endif  // EKF_LOCALIZER__AGED_OBJECT_QUEUE_HPP_

--- a/localization/ekf_localizer/include/ekf_localizer/aged_object_queue.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/aged_object_queue.hpp
@@ -28,6 +28,8 @@ public:
 
   size_t size() const { return objects_.size(); }
 
+  Object back() const { return objects_.back(); }
+
   void push(const Object & object)
   {
     objects_.push(object);

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -15,6 +15,7 @@
 #ifndef EKF_LOCALIZER__EKF_LOCALIZER_HPP_
 #define EKF_LOCALIZER__EKF_LOCALIZER_HPP_
 
+#include "ekf_localizer/aged_object_queue.hpp"
 #include "ekf_localizer/hyper_parameters.hpp"
 #include "ekf_localizer/warning.hpp"
 
@@ -166,14 +167,8 @@ private:
 
   bool is_activated_;
 
-  /* for model prediction */
-  std::queue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr>
-    current_twist_queue_;  //!< @brief current measured twist
-  std::queue<int> current_twist_count_queue_;
-
-  std::queue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr>
-    current_pose_queue_;  //!< @brief current measured pose
-  std::queue<int> current_pose_count_queue_;
+  AgedObjectQueue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr> pose_queue_;
+  AgedObjectQueue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr> twist_queue_;
 
   geometry_msgs::msg::PoseStamped current_ekf_pose_;  //!< @brief current estimated pose
   geometry_msgs::msg::PoseStamped

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -118,8 +118,6 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr pub_twist_cov_;
   //!< @brief debug info publisher
   rclcpp::Publisher<tier4_debug_msgs::msg::Float64MultiArrayStamped>::SharedPtr pub_debug_;
-  //!< @brief debug measurement pose publisher
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_measured_pose_;
   //!< @brief ekf estimated yaw bias publisher
   rclcpp::Publisher<tier4_debug_msgs::msg::Float64Stamped>::SharedPtr pub_yaw_bias_;
   //!< @brief ekf estimated yaw bias publisher

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -118,6 +118,8 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr pub_twist_cov_;
   //!< @brief debug info publisher
   rclcpp::Publisher<tier4_debug_msgs::msg::Float64MultiArrayStamped>::SharedPtr pub_debug_;
+  //!< @brief debug measurement pose publisher
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_measured_pose_;
   //!< @brief ekf estimated yaw bias publisher
   rclcpp::Publisher<tier4_debug_msgs::msg::Float64Stamped>::SharedPtr pub_yaw_bias_;
   //!< @brief ekf estimated yaw bias publisher

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -107,6 +107,7 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
 
   /* debug */
   pub_debug_ = create_publisher<tier4_debug_msgs::msg::Float64MultiArrayStamped>("debug", 1);
+  pub_measured_pose_ = create_publisher<geometry_msgs::msg::PoseStamped>("debug/measured_pose", 1);
 }
 
 /*
@@ -606,7 +607,19 @@ void EKFLocalizer::publishEstimateResult()
   odometry.twist = twist_cov.twist;
   pub_odom_->publish(odometry);
 
+  /* debug measured pose */
+  if (!pose_queue_.empty()) {
+    geometry_msgs::msg::PoseStamped p;
+    p.pose = pose_queue_.back()->pose.pose;
+    p.header.stamp = current_time;
+    pub_measured_pose_->publish(p);
+  }
+
+  /* debug publish */
   double pose_yaw = 0.0;
+  if (!pose_queue_.empty()) {
+    pose_yaw = tf2::getYaw(pose_queue_.back()->pose.pose.orientation);
+  }
 
   tier4_debug_msgs::msg::Float64MultiArrayStamped msg;
   msg.stamp = current_time;

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -53,7 +53,9 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
   params_(this),
   ekf_rate_(params_.ekf_rate),
   ekf_dt_(params_.ekf_dt),
-  dim_x_(6 /* x, y, yaw, yaw_bias, vx, wz */)
+  dim_x_(6 /* x, y, yaw, yaw_bias, vx, wz */),
+  pose_queue_(params_.pose_smoothing_steps),
+  twist_queue_(params_.twist_smoothing_steps)
 {
   /* convert to continuous to discrete */
   proc_cov_vx_d_ = std::pow(params_.proc_stddev_vx_c * ekf_dt_, 2.0);
@@ -105,7 +107,6 @@ EKFLocalizer::EKFLocalizer(const std::string & node_name, const rclcpp::NodeOpti
 
   /* debug */
   pub_debug_ = create_publisher<tier4_debug_msgs::msg::Float64MultiArrayStamped>("debug", 1);
-  pub_measured_pose_ = create_publisher<geometry_msgs::msg::PoseStamped>("debug/measured_pose", 1);
 }
 
 /*
@@ -171,46 +172,30 @@ void EKFLocalizer::timerCallback()
   DEBUG_INFO(get_logger(), "------------------------- end prediction -------------------------\n");
 
   /* pose measurement update */
-  if (!current_pose_queue_.empty()) {
+  if (!pose_queue_.empty()) {
     DEBUG_INFO(get_logger(), "------------------------- start Pose -------------------------");
     stop_watch_.tic();
 
-    for (size_t i = 0; i < current_pose_queue_.size(); ++i) {
-      const auto pose = current_pose_queue_.front();
-      current_pose_queue_.pop();
-
-      const int count = current_pose_count_queue_.front();
-      current_pose_count_queue_.pop();
-
+    // save the initial size because the queue size can change in the loop
+    const size_t n = pose_queue_.size();
+    for (size_t i = 0; i < n; ++i) {
+      const auto pose = pose_queue_.pop_increment_age();
       measurementUpdatePose(*pose);
-
-      if (count + 1 < params_.pose_smoothing_steps) {
-        current_pose_queue_.push(pose);
-        current_pose_count_queue_.push(count + 1);
-      }
     }
     DEBUG_INFO(get_logger(), "[EKF] measurementUpdatePose calc time = %f [ms]", stop_watch_.toc());
     DEBUG_INFO(get_logger(), "------------------------- end Pose -------------------------\n");
   }
 
   /* twist measurement update */
-  if (!current_twist_queue_.empty()) {
+  if (!twist_queue_.empty()) {
     DEBUG_INFO(get_logger(), "------------------------- start Twist -------------------------");
     stop_watch_.tic();
 
-    for (size_t i = 0; i < current_twist_queue_.size(); ++i) {
-      const auto twist = current_twist_queue_.front();
-      current_twist_queue_.pop();
-
-      const int count = current_twist_count_queue_.front();
-      current_twist_count_queue_.pop();
-
+    // save the initial size because the queue size can change in the loop
+    const size_t n = twist_queue_.size();
+    for (size_t i = 0; i < n; ++i) {
+      const auto twist = twist_queue_.pop_increment_age();
       measurementUpdateTwist(*twist);
-
-      if (count + 1 < params_.twist_smoothing_steps) {
-        current_twist_queue_.push(twist);
-        current_twist_count_queue_.push(count + 1);
-      }
     }
     DEBUG_INFO(get_logger(), "[EKF] measurementUpdateTwist calc time = %f [ms]", stop_watch_.toc());
     DEBUG_INFO(get_logger(), "------------------------- end Twist -------------------------\n");
@@ -370,8 +355,7 @@ void EKFLocalizer::callbackPoseWithCovariance(
     return;
   }
 
-  current_pose_queue_.push(msg);
-  current_pose_count_queue_.push(0);
+  pose_queue_.push(msg);
 
   updateSimple1DFilters(*msg);
 }
@@ -382,8 +366,7 @@ void EKFLocalizer::callbackPoseWithCovariance(
 void EKFLocalizer::callbackTwistWithCovariance(
   geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
 {
-  current_twist_queue_.push(msg);
-  current_twist_count_queue_.push(0);
+  twist_queue_.push(msg);
 }
 
 /*
@@ -623,19 +606,7 @@ void EKFLocalizer::publishEstimateResult()
   odometry.twist = twist_cov.twist;
   pub_odom_->publish(odometry);
 
-  /* debug measured pose */
-  if (!current_pose_queue_.empty()) {
-    geometry_msgs::msg::PoseStamped p;
-    p.pose = current_pose_queue_.back()->pose.pose;
-    p.header.stamp = current_time;
-    pub_measured_pose_->publish(p);
-  }
-
-  /* debug publish */
   double pose_yaw = 0.0;
-  if (!current_pose_queue_.empty()) {
-    pose_yaw = tf2::getYaw(current_pose_queue_.back()->pose.pose.orientation);
-  }
 
   tier4_debug_msgs::msg::Float64MultiArrayStamped msg;
   msg.stamp = current_time;
@@ -691,11 +662,8 @@ void EKFLocalizer::serviceTriggerNode(
   std_srvs::srv::SetBool::Response::SharedPtr res)
 {
   if (req->data) {
-    while (!current_pose_queue_.empty()) current_pose_queue_.pop();
-    while (!current_pose_count_queue_.empty()) current_pose_count_queue_.pop();
-
-    while (!current_twist_queue_.empty()) current_twist_queue_.pop();
-    while (!current_twist_count_queue_.empty()) current_twist_count_queue_.pop();
+    pose_queue_.clear();
+    twist_queue_.clear();
     is_activated_ = true;
   } else {
     is_activated_ = false;

--- a/localization/ekf_localizer/test/test_aged_object_queue.cpp
+++ b/localization/ekf_localizer/test/test_aged_object_queue.cpp
@@ -87,3 +87,15 @@ TEST(AgedObjectQueue, Clear)
 
   EXPECT_EQ(queue.size(), 0U);
 }
+
+TEST(AgedObjectQueue, Back)
+{
+  AgedObjectQueue<std::string> queue(3);
+
+  queue.push("a");
+
+  EXPECT_EQ(queue.back(), std::string{"a"});
+  queue.push("b");
+
+  EXPECT_EQ(queue.back(), std::string{"b"});
+}

--- a/localization/ekf_localizer/test/test_aged_object_queue.cpp
+++ b/localization/ekf_localizer/test/test_aged_object_queue.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-
 #include "ekf_localizer/aged_object_queue.hpp"
+
+#include <gtest/gtest.h>
 
 TEST(AgedObjectQueue, DisardsObjectWhenAgeReachesMaximum)
 {

--- a/localization/ekf_localizer/test/test_aged_object_queue.cpp
+++ b/localization/ekf_localizer/test/test_aged_object_queue.cpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-TEST(AgedObjectQueue, DisardsObjectWhenAgeReachesMaximum)
+TEST(AgedObjectQueue, DiscardsObjectWhenAgeReachesMaximum)
 {
   AgedObjectQueue<std::string> queue(3);
 

--- a/localization/ekf_localizer/test/test_aged_object_queue.cpp
+++ b/localization/ekf_localizer/test/test_aged_object_queue.cpp
@@ -1,0 +1,75 @@
+// Copyright 2023 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "ekf_localizer/aged_object_queue.hpp"
+
+TEST(AgedObjectQueue, DisardsObjectWhenAgeReachesMaximum)
+{
+  AgedObjectQueue<std::string> queue(3);
+
+  queue.push("a");
+  EXPECT_EQ(queue.size(), 1U);
+
+  queue.pop_increment_age();  // age = 1
+  EXPECT_EQ(queue.size(), 1U);
+
+  queue.pop_increment_age();  // age = 2
+  EXPECT_EQ(queue.size(), 1U);
+
+  queue.pop_increment_age();  // age = 3
+  EXPECT_EQ(queue.size(), 0U);
+}
+
+TEST(AgedObjectQueue, MultipleObjects)
+{
+  AgedObjectQueue<std::string> queue(3);
+
+  queue.push("a");
+  EXPECT_EQ(queue.size(), 1U);
+  EXPECT_EQ(queue.pop_increment_age(), std::string{"a"});  // age of a = 1
+  EXPECT_EQ(queue.size(), 1U);
+  EXPECT_EQ(queue.pop_increment_age(), std::string{"a"});  // age of a = 2
+
+  queue.push("b");
+
+  EXPECT_EQ(queue.pop_increment_age(), std::string{"a"});  // age of a = 3
+  EXPECT_EQ(queue.size(), 1U);
+
+  EXPECT_EQ(queue.pop_increment_age(), std::string{"b"});  // age of b = 1
+  EXPECT_EQ(queue.size(), 1U);
+
+  EXPECT_EQ(queue.pop_increment_age(), std::string{"b"});  // age of b = 2
+  EXPECT_EQ(queue.size(), 1U);
+
+  EXPECT_EQ(queue.pop_increment_age(), std::string{"b"});  // age of b = 3
+  EXPECT_EQ(queue.size(), 0U);
+}
+
+TEST(AgedObjectQueue, Empty)
+{
+  AgedObjectQueue<std::string> queue(2);
+
+  EXPECT_TRUE(queue.empty());
+
+  queue.push("a");
+
+  EXPECT_FALSE(queue.empty());
+
+  queue.pop_increment_age();
+  queue.pop_increment_age();
+
+  EXPECT_TRUE(queue.empty());
+}

--- a/localization/ekf_localizer/test/test_aged_object_queue.cpp
+++ b/localization/ekf_localizer/test/test_aged_object_queue.cpp
@@ -73,3 +73,17 @@ TEST(AgedObjectQueue, Empty)
 
   EXPECT_TRUE(queue.empty());
 }
+
+TEST(AgedObjectQueue, Clear)
+{
+  AgedObjectQueue<std::string> queue(3);
+
+  queue.push("a");
+  queue.push("b");
+
+  EXPECT_EQ(queue.size(), 2U);
+
+  queue.clear();
+
+  EXPECT_EQ(queue.size(), 0U);
+}


### PR DESCRIPTION
## Description

Add a class to manage message objects and their ages
Note that a debug publisher is also removed

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Check if the aged queue works as expected

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
