### PR TITLE
fix(obstacle_avoidance_planner): fix drivable area polygon point order direction

### DIFF
--- a/planning/obstacle_avoidance_planner/src/utils/utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/utils.cpp
@@ -661,16 +661,16 @@ bg_polygon createDrivablePolygon(
 {
   bg_polygon drivable_area_poly;
 
-  // right bound
-  for (const auto rp : right_bound) {
-    drivable_area_poly.outer().push_back(bg_point(rp.x, rp.y));
+  // left bound
+  for (const auto lp : left_bound) {
+    drivable_area_poly.outer().push_back(bg_point(lp.x, lp.y));
   }
 
-  // left bound
-  auto reversed_left_bound = left_bound;
-  std::reverse(reversed_left_bound.begin(), reversed_left_bound.end());
-  for (const auto lp : reversed_left_bound) {
-    drivable_area_poly.outer().push_back(bg_point(lp.x, lp.y));
+  // right bound
+  auto reversed_right_bound = right_bound;
+  std::reverse(reversed_right_bound.begin(), reversed_right_bound.end());
+  for (const auto rp : reversed_right_bound) {
+    drivable_area_poly.outer().push_back(bg_point(rp.x, rp.y));
   }
 
   drivable_area_poly.outer().push_back(drivable_area_poly.outer().front());


### PR DESCRIPTION
Signed-off-by: Mehmet Dogru <42mehmetdogru42@gmail.com>

## Description

closes #2690 

This PR fixes the direction of drivable area polygon points since it can yield wrong results to use the polygon in other boost functions. ([please refer](https://www.boost.org/doc/libs/1_63_0/libs/geometry/doc/html/geometry/reference/models/model_polygon.html#:~:text=point%20type-,bool%20ClockWise,true%20for%20clockwise%20direction%2C%20false%20for%20CounterClockWise%20direction,-bool%20Closed))

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
