### PR TITLE
feat(lane_departure_checker): add braking distance offset to avoid unwanted move after stop

### DIFF
--- a/control/lane_departure_checker/config/lane_departure_checker.param.yaml
+++ b/control/lane_departure_checker/config/lane_departure_checker.param.yaml
@@ -13,3 +13,5 @@
     max_longitudinal_deviation: 2.0
     max_yaw_deviation_deg: 60.0
     delta_yaw_threshold_for_closest_point: 1.570 #M_PI/2.0, delta yaw thres for closest point
+    braking_distance_offset: 0.0
+    

--- a/control/lane_departure_checker/config/lane_departure_checker.param.yaml
+++ b/control/lane_departure_checker/config/lane_departure_checker.param.yaml
@@ -14,4 +14,4 @@
     max_yaw_deviation_deg: 60.0
     delta_yaw_threshold_for_closest_point: 1.570 #M_PI/2.0, delta yaw thres for closest point
     braking_distance_offset: 0.0
-    
+

--- a/control/lane_departure_checker/config/lane_departure_checker.param.yaml
+++ b/control/lane_departure_checker/config/lane_departure_checker.param.yaml
@@ -13,5 +13,4 @@
     max_longitudinal_deviation: 2.0
     max_yaw_deviation_deg: 60.0
     delta_yaw_threshold_for_closest_point: 1.570 #M_PI/2.0, delta yaw thres for closest point
-    braking_distance_offset: 0.0
-
+    min_braking_distance: 0.0

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
@@ -58,7 +58,7 @@ struct Param
   double max_lateral_deviation;
   double max_longitudinal_deviation;
   double max_yaw_deviation_deg;
-  double braking_distance_offset;
+  double min_braking_distance;
   // nearest search to ego
   double ego_nearest_dist_threshold;
   double ego_nearest_yaw_threshold;

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
@@ -58,6 +58,7 @@ struct Param
   double max_lateral_deviation;
   double max_longitudinal_deviation;
   double max_yaw_deviation_deg;
+  double braking_distance_offset;
   // nearest search to ego
   double ego_nearest_dist_threshold;
   double ego_nearest_yaw_threshold;

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -109,8 +109,9 @@ Output LaneDepartureChecker::update(const Input & input)
     const auto & raw_abs_velocity = std::abs(input.current_odom->twist.twist.linear.x);
     const auto abs_velocity = raw_abs_velocity < min_velocity ? 0.0 : raw_abs_velocity;
 
-    const auto braking_distance =
-      calcBrakingDistance(abs_velocity, param_.max_deceleration, param_.delay_time);
+    const auto braking_distance = std::max(
+      param_.braking_distance_offset,
+      calcBrakingDistance(abs_velocity, param_.max_deceleration, param_.delay_time));
 
     output.resampled_trajectory = cutTrajectory(
       resampleTrajectory(*input.predicted_trajectory, param_.resample_interval), braking_distance);

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -110,7 +110,7 @@ Output LaneDepartureChecker::update(const Input & input)
     const auto abs_velocity = raw_abs_velocity < min_velocity ? 0.0 : raw_abs_velocity;
 
     const auto braking_distance = std::max(
-      param_.braking_distance_offset,
+      param_.min_braking_distance,
       calcBrakingDistance(abs_velocity, param_.max_deceleration, param_.delay_time));
 
     output.resampled_trajectory = cutTrajectory(

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -144,6 +144,7 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   param_.max_yaw_deviation_deg = declare_parameter("max_yaw_deviation_deg", 30.0);
   param_.ego_nearest_dist_threshold = declare_parameter<double>("ego_nearest_dist_threshold");
   param_.ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
+  param_.braking_distance_offset = declare_parameter<double>("braking_distance_offset");
 
   // Parameter Callback
   set_param_res_ =
@@ -367,6 +368,7 @@ rcl_interfaces::msg::SetParametersResult LaneDepartureCheckerNode::onParameter(
     update_param(parameters, "resample_interval", param_.resample_interval);
     update_param(parameters, "max_deceleration", param_.max_deceleration);
     update_param(parameters, "delay_time", param_.delay_time);
+    update_param(parameters, "braking_distance_offset", param_.braking_distance_offset);
 
     if (lane_departure_checker_) {
       lane_departure_checker_->setParam(param_);

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -144,7 +144,7 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   param_.max_yaw_deviation_deg = declare_parameter("max_yaw_deviation_deg", 30.0);
   param_.ego_nearest_dist_threshold = declare_parameter<double>("ego_nearest_dist_threshold");
   param_.ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
-  param_.braking_distance_offset = declare_parameter<double>("braking_distance_offset");
+  param_.min_braking_distance = declare_parameter<double>("min_braking_distance");
 
   // Parameter Callback
   set_param_res_ =
@@ -368,7 +368,7 @@ rcl_interfaces::msg::SetParametersResult LaneDepartureCheckerNode::onParameter(
     update_param(parameters, "resample_interval", param_.resample_interval);
     update_param(parameters, "max_deceleration", param_.max_deceleration);
     update_param(parameters, "delay_time", param_.delay_time);
-    update_param(parameters, "braking_distance_offset", param_.braking_distance_offset);
+    update_param(parameters, "min_braking_distance", param_.min_braking_distance);
 
     if (lane_departure_checker_) {
       lane_departure_checker_->setParam(param_);


### PR DESCRIPTION
Signed-off-by: Berkay Karaman <brkay54@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
In current implementation, braking distance is 0.0 if the velocity is 0.0. It causes unwanted motion, for example, if vehicle's footprint will be out of the lane, lane_departure_checker make the vehicle stop. After vehicle slow down, braking distance is getting smaller and footprint won't be out of the lane and vehicle starts to moving. It continues like stop, move, stop, move and so on.

To avoid this problem, I want to suggest that adding offset to braking distance as optional.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
