### PR TITLE
feat(vehicle_cmd_gate): enable filter with actual steer in manual mode

### DIFF
--- a/control/vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
+++ b/control/vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
@@ -14,10 +14,11 @@
       lon_acc_lim: 5.0
       lon_jerk_lim: 5.0
       lat_acc_lim: 5.0
-      lat_jerk_lim: 5.0
+      lat_jerk_lim: 7.0
     on_transition:
       vel_lim: 50.0
       lon_acc_lim: 1.0
       lon_jerk_lim: 0.5
-      lat_acc_lim: 1.2
-      lat_jerk_lim: 0.75
+      lat_acc_lim: 2.0
+      lat_jerk_lim: 7.0
+      actual_steer_diff_lim: 1.0

--- a/control/vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
+++ b/control/vehicle_cmd_gate/config/vehicle_cmd_gate.param.yaml
@@ -15,6 +15,7 @@
       lon_jerk_lim: 5.0
       lat_acc_lim: 5.0
       lat_jerk_lim: 7.0
+      actual_steer_diff_lim: 1.0
     on_transition:
       vel_lim: 50.0
       lon_acc_lim: 1.0

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -148,6 +148,8 @@ def launch_setup(context, *args, **kwargs):
             ("input/emergency/gear_cmd", "/system/emergency/gear_cmd"),
             ("input/mrm_state", "/system/fail_safe/mrm_state"),
             ("input/gear_status", "/vehicle/status/gear_status"),
+            ("input/kinematics", "/localization/kinematic_state"),
+            ("input/acceleration", "/localization/acceleration"),
             ("output/vehicle_cmd_emergency", "/control/command/emergency_cmd"),
             ("output/control_cmd", "/control/command/control_cmd"),
             ("output/gear_cmd", "/control/command/gear_cmd"),


### PR DESCRIPTION
## Description

In manual mode, the filter must consider the current status (e.g. current steering angle) to prevent sudden movement when switching from manual to autonomous.
The current implementation only checks for the previous commands, which makes a large difference between the actual status and command, then results in the sudden movement of the steering and acceleration.

This PR only focuses on the steering behavior because longitudinal information can not be changed easily for other modules.

## Related links

https://github.com/tier4/autoware_launch/pull/733
https://github.com/autowarefoundation/autoware_launch/pull/189

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
