### PR TITLE
feat(intersection): consider state transit margin time in collision detection

### DIFF
--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -1,10 +1,8 @@
 /**:
   ros__parameters:
     intersection:
-      state_transit_margin_time: 1.0
+      state_transit_margin_time: 0.8
       stop_line_margin: 3.0
-      keep_detection_line_margin: 1.0 # distance (toward path end) from generated stop line. keep detection if ego is before this line and ego.vel < keep_detection_vel_thr
-      keep_detection_vel_thr: 0.833 # == 3.0km/h
       stuck_vehicle_detect_dist: 3.0 # this should be the length between cars when they are stopped. The actual stuck vehicle detection length will be this value + vehicle_length.
       stuck_vehicle_ignore_dist: 10.0 # obstacle stop max distance(5.0m) + stuck vehicle size / 2 (0.0m-)
       stuck_vehicle_vel_thr: 0.833 # 0.833m/s = 3.0km/h
@@ -17,8 +15,8 @@
       detection_area_angle_threshold: 0.785 # [rad]
       min_predicted_path_confidence: 0.05
       minimum_ego_predicted_velocity: 1.388 # [m/s]
-      collision_start_margin_time: 4.0 # [s]
-      collision_end_margin_time: 2.0 # [s]
+      collision_start_margin_time: 4.2 # [s] this + state_transit_margin_time = 5.0
+      collision_end_margin_time: 2.2 # [s] this + state_transit_margin_time = 3.0
       use_stuck_stopline: false # stopline generate before the intersection lanelet when is_stuck
       assumed_front_car_decel: 1.0 # [m/ss] the expected deceleration of front car when front car as well as ego are turning
       enable_front_car_decel_prediction: false # By default this feature is disabled

--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -17,8 +17,8 @@
       detection_area_angle_threshold: 0.785 # [rad]
       min_predicted_path_confidence: 0.05
       minimum_ego_predicted_velocity: 1.388 # [m/s]
-      collision_start_margin_time: 6.0 # [s]
-      collision_end_margin_time: 7.0 # [s]
+      collision_start_margin_time: 4.0 # [s]
+      collision_end_margin_time: 2.0 # [s]
       use_stuck_stopline: false # stopline generate before the intersection lanelet when is_stuck
       assumed_front_car_decel: 1.0 # [m/ss] the expected deceleration of front car when front car as well as ego are turning
       enable_front_car_decel_prediction: false # By default this feature is disabled

--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     intersection:
-      state_transit_margin_time: 0.5
+      state_transit_margin_time: 1.0
       stop_line_margin: 3.0
       keep_detection_line_margin: 1.0 # distance (toward path end) from generated stop line. keep detection if ego is before this line and ego.vel < keep_detection_vel_thr
       keep_detection_vel_thr: 0.833 # == 3.0km/h
@@ -16,8 +16,9 @@
       detection_area_length: 200.0 # [m]
       detection_area_angle_threshold: 0.785 # [rad]
       min_predicted_path_confidence: 0.05
-      collision_start_margin_time: 5.0 # [s]
-      collision_end_margin_time: 2.0 # [s]
+      minimum_ego_predicted_velocity: 1.388 # [m/s]
+      collision_start_margin_time: 6.0 # [s]
+      collision_end_margin_time: 7.0 # [s]
       use_stuck_stopline: false # stopline generate before the intersection lanelet when is_stuck
       assumed_front_car_decel: 1.0 # [m/ss] the expected deceleration of front car when front car as well as ego are turning
       enable_front_car_decel_prediction: false # By default this feature is disabled

--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     intersection:
-      state_transit_margin_time: 0.8
+      state_transit_margin_time: 1.0
       stop_line_margin: 3.0
       stuck_vehicle_detect_dist: 3.0 # this should be the length between cars when they are stopped. The actual stuck vehicle detection length will be this value + vehicle_length.
       stuck_vehicle_ignore_dist: 10.0 # obstacle stop max distance(5.0m) + stuck vehicle size / 2 (0.0m-)
@@ -15,8 +15,8 @@
       detection_area_angle_threshold: 0.785 # [rad]
       min_predicted_path_confidence: 0.05
       minimum_ego_predicted_velocity: 1.388 # [m/s]
-      collision_start_margin_time: 4.2 # [s] this + state_transit_margin_time = 5.0
-      collision_end_margin_time: 2.2 # [s] this + state_transit_margin_time = 3.0
+      collision_start_margin_time: 4.0 # [s] this + state_transit_margin_time should be higher to account for collision with fast/accelerating object
+      collision_end_margin_time: 6.0 # [s] this + state_transit_margin_time should be higher to account for collision with slow/decelerating object
       use_stuck_stopline: false # stopline generate before the intersection lanelet when is_stuck
       assumed_front_car_decel: 1.0 # [m/ss] the expected deceleration of front car when front car as well as ego are turning
       enable_front_car_decel_prediction: false # By default this feature is disabled

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -69,10 +69,6 @@ public:
   {
     double state_transit_margin_time;
     double stop_line_margin;  //! distance from auto-generated stopline to detection_area boundary
-    double keep_detection_line_margin;  //! distance (toward path end) from generated stop line.
-                                        //! keep detection if ego is before this line and ego.vel <
-                                        //! keep_detection_vel_thr
-    double keep_detection_vel_thr;
     double stuck_vehicle_detect_dist;  //! distance from end point to finish stuck vehicle check
     double
       stuck_vehicle_ignore_dist;   //! distance from intersection start to start stuck vehicle check

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -139,7 +139,7 @@ private:
     const lanelet::ConstLanelets & adjacent_lanelets,
     const std::optional<Polygon2d> & intersection_area,
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr,
-    const int closest_idx, const Polygon2d & stuck_vehicle_detect_area);
+    const int closest_idx, const Polygon2d & stuck_vehicle_detect_area, const double time_delay);
 
   /**
    * @brief Check if there is a stopped vehicle on the ego-lane.
@@ -186,7 +186,7 @@ private:
    */
   TimeDistanceArray calcIntersectionPassingTime(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
-    const int objective_lane_id) const;
+    const int objective_lane_id, const double time_delay) const;
 
   /**
    * @brief check if the object has a target type for collision check

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -88,9 +88,10 @@ public:
     double detection_area_angle_thr;     //! threshold in checking the angle of detecting objects
     double min_predicted_path_confidence;
     //! minimum confidence value of predicted path to use for collision detection
-    double external_input_timeout;       //! used to disable external input
-    double collision_start_margin_time;  //! start margin time to check collision
-    double collision_end_margin_time;    //! end margin time to check collision
+    double external_input_timeout;          //! used to disable external input
+    double minimum_ego_predicted_velocity;  //! used to calclate ego's future velocity profile
+    double collision_start_margin_time;     //! start margin time to check collision
+    double collision_end_margin_time;       //! end margin time to check collision
     bool use_stuck_stopline;  //! stopline generate before the intersection lanelet when is_stuck.
     double
       assumed_front_car_decel;  //! the expected deceleration of front car when front car as well

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -116,7 +116,7 @@ private:
   std::string turn_direction_;
   bool has_traffic_light_;
   bool is_go_out_;
-
+  std::shared_ptr<std::ofstream> predicted_velocity_;
   // Parameter
   PlannerParam planner_param_;
 

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -113,7 +113,6 @@ private:
   std::string turn_direction_;
   bool has_traffic_light_;
   bool is_go_out_;
-  std::shared_ptr<std::ofstream> predicted_velocity_;
   // Parameter
   PlannerParam planner_param_;
 

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -61,7 +61,6 @@ struct StopLineIdx
   size_t first_inside_lane = 0;
   size_t pass_judge_line = 0;
   size_t stop_line = 0;
-  size_t keep_detection_line = 0;
 };
 
 /**
@@ -78,8 +77,7 @@ std::pair<std::optional<size_t>, std::optional<StopLineIdx>> generateStopLine(
   const int lane_id, const std::vector<lanelet::CompoundPolygon3d> & detection_areas,
   const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
   const std::shared_ptr<const PlannerData> & planner_data, const double stop_line_margin,
-  const double keep_detection_line_margin, const bool use_stuck_stopline,
-  autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
+  const bool use_stuck_stopline, autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & target_path, const rclcpp::Logger logger,
   const rclcpp::Clock::SharedPtr clock);
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -46,8 +46,6 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
   ip.state_transit_margin_time = node.declare_parameter(ns + ".state_transit_margin_time", 2.0);
   ip.stop_line_margin = node.declare_parameter(ns + ".stop_line_margin", 1.0);
-  ip.keep_detection_line_margin = node.declare_parameter(ns + ".keep_detection_line_margin", 1.0);
-  ip.keep_detection_vel_thr = node.declare_parameter(ns + ".keep_detection_vel_thr", 0.833);
   ip.stuck_vehicle_detect_dist = node.declare_parameter(ns + ".stuck_vehicle_detect_dist", 3.0);
   ip.stuck_vehicle_ignore_dist = node.declare_parameter(ns + ".stuck_vehicle_ignore_dist", 5.0) +
                                  vehicle_info.max_longitudinal_offset_m;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -63,6 +63,8 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   ip.min_predicted_path_confidence =
     node.declare_parameter(ns + ".min_predicted_path_confidence", 0.05);
   ip.external_input_timeout = node.declare_parameter(ns + ".walkway.external_input_timeout", 1.0);
+  ip.minimum_ego_predicted_velocity =
+    node.declare_parameter(ns + ".minimum_ego_predicted_velocity", 1.388);
   ip.collision_start_margin_time = node.declare_parameter(ns + ".collision_start_margin_time", 5.0);
   ip.collision_end_margin_time = node.declare_parameter(ns + ".collision_end_margin_time", 2.0);
   ip.use_stuck_stopline = node.declare_parameter(ns + ".use_stuck_stopline", true);

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -198,7 +198,8 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   const bool is_stuck = checkStuckVehicleInIntersection(objects_ptr, stuck_vehicle_detect_area);
 
   /* calculate dynamic collision around detection area */
-  const double time_delay = is_go_out_ ? 0.0 : planner_param_.state_transit_margin_time;
+  const double time_delay =
+    is_go_out_ ? 0.0 : (planner_param_.state_transit_margin_time - state_machine_.duration);
   const bool has_collision = checkCollision(
     lanelet_map_ptr, *path, detection_lanelets, adjacent_lanelets, intersection_area, objects_ptr,
     closest_idx, stuck_vehicle_detect_area, time_delay);

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -531,8 +531,6 @@ TimeDistanceArray IntersectionModule::calcIntersectionPassingTime(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
   const int objective_lane_id, const double time_delay) const
 {
-  static constexpr double k_minimum_velocity = 1e-01;
-
   double dist_sum = 0.0;
   int assigned_lane_found = false;
 
@@ -581,7 +579,9 @@ TimeDistanceArray IntersectionModule::calcIntersectionPassingTime(
     const double average_velocity =
       (p1.point.longitudinal_velocity_mps + p2.point.longitudinal_velocity_mps) / 2.0;
     passing_time +=
-      (dist / std::max<double>(k_minimum_velocity, average_velocity));  // to avoid zero-division
+      (dist / std::max<double>(
+                planner_param_.minimum_ego_predicted_velocity,
+                average_velocity));  // to avoid zero-division
 
     time_distance_array.emplace_back(passing_time, dist_sum);
   }

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -27,7 +27,6 @@
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
 #include <algorithm>
-#include <fstream>
 #include <memory>
 #include <vector>
 
@@ -56,10 +55,7 @@ IntersectionModule::IntersectionModule(
   const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
   const PlannerParam & planner_param, const rclcpp::Logger logger,
   const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock),
-  lane_id_(lane_id),
-  is_go_out_(false),
-  predicted_velocity_(nullptr)
+: SceneModuleInterface(module_id, logger, clock), lane_id_(lane_id), is_go_out_(false)
 {
   velocity_factor_.init(VelocityFactor::INTERSECTION);
   planner_param_ = planner_param;
@@ -70,7 +66,6 @@ IntersectionModule::IntersectionModule(
   has_traffic_light_ =
     !(assigned_lanelet.regulatoryElementsAs<const lanelet::TrafficLight>().empty());
   state_machine_.setMarginTime(planner_param_.state_transit_margin_time);
-  predicted_velocity_ = std::make_shared<std::ofstream>("predicted_velocity.csv");
 }
 
 bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
@@ -548,13 +543,6 @@ TimeDistanceArray IntersectionModule::calcIntersectionPassingTime(
     RCLCPP_WARN(logger_, "smoothPath failed");
   }
 
-  std::ofstream & ofs = *predicted_velocity_;
-  std::string delim = "";
-  ofs << clock_->now().nanoseconds() << ",";
-  for (const auto & point : smoothed_reference_path.points) {
-    ofs << std::exchange(delim, ",") << point.point.longitudinal_velocity_mps;
-  }
-  ofs << "\n";
   // calculate when ego is going to reach each (interpolated) points on the path
   TimeDistanceArray time_distance_array{};
   dist_sum = 0.0;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -86,7 +86,6 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 
   /* get current pose */
   const geometry_msgs::msg::Pose current_pose = planner_data_->current_odometry->pose;
-  const double current_vel = planner_data_->current_velocity->twist.linear.x;
 
   /* get lanelet map */
   const auto lanelet_map_ptr = planner_data_->route_handler_->getLaneletMapPtr();
@@ -154,7 +153,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     const auto pass_judge_line_idx = stop_lines_idx_opt.value().pass_judge_line;
 
     const bool is_over_pass_judge_line =
-      util::isOverTargetIndex(*path, closest_idx, current_pose.pose, pass_judge_line_idx);
+      util::isOverTargetIndex(*path, closest_idx, current_pose, pass_judge_line_idx);
 
     /* if ego is over the pass judge line before collision is detected, keep going */
     if (is_over_pass_judge_line && is_go_out_ && !external_stop) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -82,8 +82,7 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopR
     extractPathNearExitOfPrivateRoad(*path, planner_data_->vehicle_info_.vehicle_length_m);
   const auto [stuck_line_idx_opt, stop_lines_idx_opt] = util::generateStopLine(
     lane_id_, detection_area, conflicting_area, planner_data_, planner_param_.stop_line_margin,
-    0.0 /* unnecessary in merge_from_private */, false /* same */, path, *path,
-    logger_.get_child("util"), clock_);
+    false /* same */, path, *path, logger_.get_child("util"), clock_);
   if (!stop_lines_idx_opt.has_value()) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000 /* ms */, "setStopLineIdx fail");
     return false;


### PR DESCRIPTION
## Description

I fixed the collision detection algorithm to consider the ego vehicle's time delay in making the decision to go out when collision detection judgement turned safe.

## Related links

https://tier4.atlassian.net/browse/T4PB-24144

parameter PR to awf: https://github.com/autowarefoundation/autoware_launch/pull/181
parameter PR to tier4: https://github.com/tier4/autoware_launch/pull/728

## Tests performed

All scenarios passed without any retrial.

https://evaluation.tier4.jp/evaluation/reports/20c3d884-d33d-5361-a88a-953038dd13dc?project_id=prd_jt

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
