### PR TITLE
fix(behavior_path_planner): lane change interpolated obj orientation

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -155,8 +155,21 @@ double getArcLengthToTargetLanelet(
   const Pose & pose);
 
 // object collision check
+inline Pose lerpByPose(const Pose & p1, const Pose & p2, const double t)
+{
+  tf2::Transform tf_transform1;
+  tf2::Transform tf_transform2;
+  tf2::fromMsg(p1, tf_transform1);
+  tf2::fromMsg(p2, tf_transform2);
+  const auto & tf_point = tf2::lerp(tf_transform1.getOrigin(), tf_transform2.getOrigin(), t);
+  const auto & tf_quaternion =
+    tf2::slerp(tf_transform1.getRotation(), tf_transform2.getRotation(), t);
 
-Pose lerpByPose(const Pose & p1, const Pose & p2, const double t);
+  Pose pose{};
+  pose.position = tf2::toMsg(tf_point, pose.position);
+  pose.orientation = tf2::toMsg(tf_quaternion);
+  return pose;
+}
 
 inline Point lerpByPoint(const Point & p1, const Point & p2, const double t)
 {
@@ -193,6 +206,28 @@ Point lerpByLength(const std::vector<T> & point_array, const double length)
   }
 
   return tier4_autoware_utils::getPoint(point_array.back());
+}
+
+template <class T>
+Pose lerpPoseByLength(const std::vector<T> & point_array, const double length)
+{
+  Pose lerped_pose;
+  if (point_array.empty()) {
+    return lerped_pose;
+  }
+  Pose prev_geom_pose = tier4_autoware_utils::getPose(point_array.front());
+  double accumulated_length = 0;
+  for (const auto & pt : point_array) {
+    const auto & geom_pose = tier4_autoware_utils::getPose(pt);
+    const double distance = tier4_autoware_utils::calcDistance3d(prev_geom_pose, geom_pose);
+    if (accumulated_length + distance > length) {
+      return lerpByPose(prev_geom_pose, geom_pose, (length - accumulated_length) / distance);
+    }
+    accumulated_length += distance;
+    prev_geom_pose = geom_pose;
+  }
+
+  return tier4_autoware_utils::getPose(point_array.back());
 }
 
 bool lerpByTimeStamp(const PredictedPath & path, const double t, Pose * lerped_pt);


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

When getting ego's predicted path, lane change path uses position-based interpolation method. This cause the orientation information to be incorrect. This PR aims to fix this.

Before PR, the orientation of ego predicted path follows ego's current orientation

![Screenshot from 2023-01-24 19-04-53](https://user-images.githubusercontent.com/93502286/214263784-823faaa9-8a24-4e99-a034-2c0d60e7b4ca.png)

After PR, ego's orientation is based on path's orientation

![Screenshot from 2023-01-24 19-11-49](https://user-images.githubusercontent.com/93502286/214265346-5b04d779-95f8-4e17-85d1-bfc73e22e2a4.png)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Enable debug marker

```
ros2 param set /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner lane_change.publish_debug_marker true 
```

Then add the marker from RVIZ's panel, and test lane change scenario.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
