### PR TITLE
fix(lane_change): chattering issue when performing check

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -510,20 +510,8 @@ bool isLaneChangePathSafe(
   const double check_end_time = lane_change_prepare_duration + lane_changing_safety_check_duration;
   const double min_lc_speed{lane_change_parameters.minimum_lane_change_velocity};
 
-  const auto get_pose = std::invoke([&]() {
-    Pose p;
-    double dist{0.0};
-    for (size_t i = 1; i < path.points.size(); ++i) {
-      dist += motion_utils::calcSignedArcLength(path.points, i - 1, i);
-      if (dist >= common_parameters.backward_path_length) {
-        return path.points.at(i).point.pose;
-      }
-    }
-    return path.points.front().point.pose;
-  });
-
   const auto vehicle_predicted_path = util::convertToPredictedPath(
-    path, current_twist, get_pose, static_cast<double>(current_seg_idx), check_end_time,
+    path, current_twist, current_pose, static_cast<double>(current_seg_idx), check_end_time,
     time_resolution, acceleration, min_lc_speed);
   const auto prepare_phase_ignore_target_speed_thresh =
     lane_change_parameters.prepare_phase_ignore_target_speed_thresh;


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

Revert to using ego's current pose as the metric for generating candidate path.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
