### PR TITLE
perf(motion_utils): improve performance of zero_order_hold

### DIFF
--- a/common/interpolation/include/interpolation/zero_order_hold.hpp
+++ b/common/interpolation/include/interpolation/zero_order_hold.hpp
@@ -21,36 +21,57 @@
 
 namespace interpolation
 {
+inline std::vector<size_t> calc_closest_segment_indices(
+  const std::vector<double> & base_keys, const std::vector<double> & query_keys,
+  const double overlap_threshold = 1e-3)
+{
+  // throw exception for invalid arguments
+  const auto validated_query_keys = interpolation_utils::validateKeys(base_keys, query_keys);
+
+  std::vector<size_t> closest_segment_indices(validated_query_keys.size(), 0);
+  for (size_t i = 0; i < validated_query_keys.size(); ++i) {
+    // Check if query_key is closes to the terminal point of the base keys
+    if (base_keys.back() - overlap_threshold < validated_query_keys.at(i)) {
+      closest_segment_indices.at(i) = base_keys.size() - 1;
+    } else {
+      for (size_t j = base_keys.size() - 1; j > closest_segment_indices.at(i); --j) { 
+        if (
+          base_keys.at(j - 1) - overlap_threshold < validated_query_keys.at(i) &&
+          validated_query_keys.at(i) < base_keys.at(j)) {
+          // find closest segment in base keys
+          closest_segment_indices.at(i) = j - 1;
+          break;
+        }
+      }
+    }
+  }
+
+  return closest_segment_indices;
+}
+
+template <class T>
+std::vector<T> zero_order_hold(
+  const std::vector<double> & base_keys, const std::vector<T> & base_values,
+  const std::vector<size_t> & closest_segment_indices)
+{
+  // throw exception for invalid arguments
+  interpolation_utils::validateKeysAndValues(base_keys, base_values);
+
+  std::vector<T> query_values(base_keys.size());
+  for (size_t i = 0; i < base_keys.size(); ++i) {
+    query_values.at(i) = base_values.at(closest_segment_indices.at(i));
+  }
+
+  return query_values;
+}
+
 template <class T>
 std::vector<T> zero_order_hold(
   const std::vector<double> & base_keys, const std::vector<T> & base_values,
   const std::vector<double> & query_keys, const double overlap_threshold = 1e-3)
 {
-  // throw exception for invalid arguments
-  const auto validated_query_keys = interpolation_utils::validateKeys(base_keys, query_keys);
-  interpolation_utils::validateKeysAndValues(base_keys, base_values);
-
-  std::vector<T> query_values;
-  size_t closest_segment_idx = 0;
-  for (size_t i = 0; i < validated_query_keys.size(); ++i) {
-    // Check if query_key is closes to the terminal point of the base keys
-    if (base_keys.back() - overlap_threshold < validated_query_keys.at(i)) {
-      closest_segment_idx = base_keys.size() - 1;
-    } else {
-      for (size_t j = closest_segment_idx; j < base_keys.size() - 1; ++j) {
-        if (
-          base_keys.at(j) - overlap_threshold < validated_query_keys.at(i) &&
-          validated_query_keys.at(i) < base_keys.at(j + 1)) {
-          // find closest segment in base keys
-          closest_segment_idx = j;
-        }
-      }
-    }
-
-    query_values.push_back(base_values.at(closest_segment_idx));
-  }
-
-  return query_values;
+  return zero_order_hold(
+    base_keys, base_values, calc_closest_segment_indices(base_keys, query_keys, overlap_threshold));
 }
 }  // namespace interpolation
 

--- a/common/interpolation/include/interpolation/zero_order_hold.hpp
+++ b/common/interpolation/include/interpolation/zero_order_hold.hpp
@@ -28,22 +28,25 @@ inline std::vector<size_t> calc_closest_segment_indices(
   // throw exception for invalid arguments
   const auto validated_query_keys = interpolation_utils::validateKeys(base_keys, query_keys);
 
-  std::vector<size_t> closest_segment_indices(validated_query_keys.size(), 0);
+  std::vector<size_t> closest_segment_indices(validated_query_keys.size());
+  size_t closest_segment_idx = 0;
   for (size_t i = 0; i < validated_query_keys.size(); ++i) {
     // Check if query_key is closes to the terminal point of the base keys
     if (base_keys.back() - overlap_threshold < validated_query_keys.at(i)) {
-      closest_segment_indices.at(i) = base_keys.size() - 1;
+      closest_segment_idx = base_keys.size() - 1;
     } else {
-      for (size_t j = base_keys.size() - 1; j > closest_segment_indices.at(i); --j) { 
+      for (size_t j = base_keys.size() - 1; j > closest_segment_idx; --j) { 
         if (
           base_keys.at(j - 1) - overlap_threshold < validated_query_keys.at(i) &&
           validated_query_keys.at(i) < base_keys.at(j)) {
           // find closest segment in base keys
-          closest_segment_indices.at(i) = j - 1;
+          closest_segment_idx = j - 1;
           break;
         }
       }
     }
+
+    closest_segment_indices.at(i) = closest_segment_idx;
   }
 
   return closest_segment_indices;
@@ -57,8 +60,8 @@ std::vector<T> zero_order_hold(
   // throw exception for invalid arguments
   interpolation_utils::validateKeysAndValues(base_keys, base_values);
 
-  std::vector<T> query_values(base_keys.size());
-  for (size_t i = 0; i < base_keys.size(); ++i) {
+  std::vector<T> query_values(closest_segment_indices.size());
+  for (size_t i = 0; i < closest_segment_indices.size(); ++i) {
     query_values.at(i) = base_values.at(closest_segment_indices.at(i));
   }
 

--- a/common/interpolation/include/interpolation/zero_order_hold.hpp
+++ b/common/interpolation/include/interpolation/zero_order_hold.hpp
@@ -35,7 +35,7 @@ inline std::vector<size_t> calc_closest_segment_indices(
     if (base_keys.back() - overlap_threshold < validated_query_keys.at(i)) {
       closest_segment_idx = base_keys.size() - 1;
     } else {
-      for (size_t j = base_keys.size() - 1; j > closest_segment_idx; --j) { 
+      for (size_t j = base_keys.size() - 1; j > closest_segment_idx; --j) {
         if (
           base_keys.at(j - 1) - overlap_threshold < validated_query_keys.at(i) &&
           validated_query_keys.at(i) < base_keys.at(j)) {

--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -241,7 +241,7 @@ autoware_auto_planning_msgs::msg::PathWithLaneId resamplePath(
     return interpolation::lerp(input_arclength, input, resampled_arclength);
   };
   
- auto closest_segment_indices = interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+  auto closest_segment_indices = interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
   
   const auto zoh = [&](const auto & input) {
     return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);

--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -240,9 +240,10 @@ autoware_auto_planning_msgs::msg::PathWithLaneId resamplePath(
   const auto lerp = [&](const auto & input) {
     return interpolation::lerp(input_arclength, input, resampled_arclength);
   };
-  
-  auto closest_segment_indices = interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
-  
+
+  auto closest_segment_indices =
+    interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+
   const auto zoh = [&](const auto & input) {
     return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);
   };
@@ -391,7 +392,8 @@ autoware_auto_planning_msgs::msg::Path resamplePath(
 
   std::vector<size_t> closest_segment_indices;
   if (use_zero_order_hold_for_v) {
-    closest_segment_indices = interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+    closest_segment_indices =
+      interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
   }
   const auto zoh = [&](const auto & input) {
     return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);
@@ -545,10 +547,11 @@ autoware_auto_planning_msgs::msg::Trajectory resampleTrajectory(
   const auto lerp = [&](const auto & input) {
     return interpolation::lerp(input_arclength, input, resampled_arclength);
   };
-  
+
   std::vector<size_t> closest_segment_indices;
   if (use_zero_order_hold_for_twist) {
-    closest_segment_indices = interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+    closest_segment_indices =
+      interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
   }
   const auto zoh = [&](const auto & input) {
     return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);

--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -240,8 +240,11 @@ autoware_auto_planning_msgs::msg::PathWithLaneId resamplePath(
   const auto lerp = [&](const auto & input) {
     return interpolation::lerp(input_arclength, input, resampled_arclength);
   };
+  
+ auto closest_segment_indices = interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+  
   const auto zoh = [&](const auto & input) {
-    return interpolation::zero_order_hold(input_arclength, input, resampled_arclength);
+    return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);
   };
 
   const auto interpolated_pose =
@@ -385,8 +388,13 @@ autoware_auto_planning_msgs::msg::Path resamplePath(
   const auto lerp = [&](const auto & input) {
     return interpolation::lerp(input_arclength, input, resampled_arclength);
   };
+
+  std::vector<size_t> closest_segment_indices;
+  if (use_zero_order_hold_for_v) {
+    closest_segment_indices = interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+  }
   const auto zoh = [&](const auto & input) {
-    return interpolation::zero_order_hold(input_arclength, input, resampled_arclength);
+    return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);
   };
 
   const auto interpolated_pose =
@@ -537,8 +545,13 @@ autoware_auto_planning_msgs::msg::Trajectory resampleTrajectory(
   const auto lerp = [&](const auto & input) {
     return interpolation::lerp(input_arclength, input, resampled_arclength);
   };
+  
+  std::vector<size_t> closest_segment_indices;
+  if (use_zero_order_hold_for_twist) {
+    closest_segment_indices = interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+  }
   const auto zoh = [&](const auto & input) {
-    return interpolation::zero_order_hold(input_arclength, input, resampled_arclength);
+    return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);
   };
 
   const auto interpolated_pose =


### PR DESCRIPTION
Signed-off-by: Ryuta Kambe [ryuta.kambe@tier4.jp](mailto:ryuta.kambe@tier4.jp)

# Description
There are two changes in this Pull Request:
 - when `closest_segment_idx` is found in backward loop in `zero_order_hold` function, immediatly break the loop. The previous implementation was forward and continue updating the idx value, which is unnecessary.
 - pre-calculate the `closest_segment_idx` with base and query keys. In the several calls of  `zero_order_hold` from `resample.cpp` in the form of `zoh`, the two parameters `base_keys` and `query_keys` are the same. Thus the calculation of `closest_segment_idx` is also the same, which includes double for loops and has a heavy computational cost. 

The following figure is the latency of [applyLateralAccelerationFilter](https://github.com/autowarefoundation/autoware.universe/blob/11ce12b63c9067b1c8843a3a05cc8c902e438faa/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp#L539)  ~ [resampleTrajectory](https://github.com/autowarefoundation/autoware.universe/blob/11ce12b63c9067b1c8843a3a05cc8c902e438faa/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp#L558), which calls `resampleTrajectory` in `resample.cpp` three times.
![image](https://user-images.githubusercontent.com/26951562/214481938-4bbc5bd0-6768-4d46-8fae-0c8c7957c18f.png)

# Related links
https://github.com/autowarefoundation/autoware.universe/issues/2728