### PR TITLE
fix(mpc_lateral_controller): fix inconsistent argument order

### DIFF
--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_dynamics.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_dynamics.hpp
@@ -89,7 +89,7 @@ public:
    * @param [in] dt Discretization time [s]
    */
   void calculateDiscreteMatrix(
-    Eigen::MatrixXd & a_d, Eigen::MatrixXd & b_d, Eigen::MatrixXd & w_d, Eigen::MatrixXd & c_d,
+    Eigen::MatrixXd & a_d, Eigen::MatrixXd & b_d, Eigen::MatrixXd & c_d, Eigen::MatrixXd & w_d,
     const double dt) override;
 
   /**


### PR DESCRIPTION
`DynamicsBicycleModel::calculateDiscreteMatrix` is declared with arguments `a_d, b_d, w_d, c_d, dt`, but implementation uses `a_d, b_d, c_d, w_d, dt` order. Usage in mpc.cpp follows implementation.

## Description

TLDR; just a typo fix

Declaration order: a_d, b_d, w_d, c_d, dt
https://github.com/autowarefoundation/autoware.universe/blob/b81fc590329534f5aca81fd71f114f03021dac05/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_dynamics.hpp#L91-L93

Implementation order: a_d, b_d, c_d, w_d, dt
https://github.com/autowarefoundation/autoware.universe/blob/b81fc590329534f5aca81fd71f114f03021dac05/control/mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_dynamics.cpp#L37-L39

Usage order: a_d, b_d, c_d, w_d, dt
https://github.com/autowarefoundation/autoware.universe/blob/b81fc590329534f5aca81fd71f114f03021dac05/control/mpc_lateral_controller/src/mpc.cpp#L478
https://github.com/autowarefoundation/autoware.universe/blob/b81fc590329534f5aca81fd71f114f03021dac05/control/mpc_lateral_controller/src/mpc.cpp#L569

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

N/A

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
