### PR TITLE
fix(costmap_generator): fix invalid argument order

### DIFF
--- a/planning/costmap_generator/nodes/costmap_generator/object_map_utils.cpp
+++ b/planning/costmap_generator/nodes/costmap_generator/object_map_utils.cpp
@@ -61,7 +61,7 @@ void FillPolygonAreas(
   grid_map::GridMap & out_grid_map,
   const std::vector<std::vector<geometry_msgs::msg::Point>> & in_points,
   const std::string & in_grid_layer_name, const int in_layer_background_value,
-  const int in_layer_min_value, const int in_fill_color, const int in_layer_max_value,
+  const int in_fill_color, const int in_layer_min_value, const int in_layer_max_value,
   const std::string & in_tf_target_frame, const std::string & in_tf_source_frame,
   const tf2_ros::Buffer & in_tf_buffer)
 {


### PR DESCRIPTION
function `object_map::FillPolygonAreas` is declared with arguments `..., in_layer_background_value, in_fill_color, in_layer_min_value, in_layer_max_value,...`, but implementation has different order: `..., in_layer_background_value, in_layer_min_value, in_fill_color, in_layer_max_value,...` The function is only used once in `costmap_generator_node.cpp`, for which `in_layer_min_value == in_fill_color`, so fixing the argument order has no impact on the code behavior.

## Description

Declaration:
https://github.com/autowarefoundation/autoware.universe/blob/b81fc590329534f5aca81fd71f114f03021dac05/planning/costmap_generator/include/costmap_generator/object_map_utils.hpp#L91-L97

Definition: `in_fill_color` and `in_layer_min_value` are swaped
https://github.com/autowarefoundation/autoware.universe/blob/b81fc590329534f5aca81fd71f114f03021dac05/planning/costmap_generator/nodes/costmap_generator/object_map_utils.cpp#L60-L66

Usage: `in_fill_color` and `in_layer_min_value` have same value
https://github.com/autowarefoundation/autoware.universe/blob/b81fc590329534f5aca81fd71f114f03021dac05/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp#L429-L431

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
