### PR TITLE
fix(lane_change): fix bug when target reference path is empty

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -375,7 +375,7 @@ LaneChangePaths getLaneChangePaths(
       route_handler, target_lanelets, lane_changing_start_pose, target_lane_length, lc_dist,
       required_total_min_distance, forward_path_length, resample_interval, is_goal_in_route);
     if (target_lane_reference_path.points.empty()) {
-      return candidate_paths;
+      continue;
     }
 
     const ShiftLine shift_line = getLaneChangeShiftLine(

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -374,6 +374,9 @@ LaneChangePaths getLaneChangePaths(
     const auto target_lane_reference_path = getReferencePathFromTargetLane(
       route_handler, target_lanelets, lane_changing_start_pose, target_lane_length, lc_dist,
       required_total_min_distance, forward_path_length, resample_interval, is_goal_in_route);
+    if (target_lane_reference_path.points.empty()) {
+      return candidate_paths;
+    }
 
     const ShiftLine shift_line = getLaneChangeShiftLine(
       prepare_segment_reference, lane_changing_segment_reference, target_lanelets,


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
When target_lane_reference_path is empty, behavior_path_planner dies with the following error.
![image](https://user-images.githubusercontent.com/59680180/214756502-8bfd948b-b29f-490b-b8bf-72f8a1c7790c.png)
( Note: In the external lane change module, the reference path is often empty )
![image](https://user-images.githubusercontent.com/59680180/214756618-fd5427eb-64dd-4a9d-8f87-4a713c321f17.png)

<!-- Write a brief description of this PR. -->

## Related links
(TIER IV Internal Link) evaluator https://evaluation.tier4.jp/evaluation/reports/4ec045cd-5fea-550e-a4a9-9315ccfc19a0/tests/4874d7ea-2934-5bba-863b-812de0c2bcac/ca5874a9-7b72-5568-88cb-af3c42bc4371/ea2a9252-30df-548e-99f9-6bed698ded47?project_id=prd_jt
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
I confirmed that the behavior module does not die with merging this PR using the planning simulator.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
