### PR TITLE
fix(tier4_datetime_rviz_plugin): fix datetime plugin

### DIFF
--- a/common/tier4_datetime_rviz_plugin/src/autoware_datetime_panel.cpp
+++ b/common/tier4_datetime_rviz_plugin/src/autoware_datetime_panel.cpp
@@ -44,22 +44,24 @@ AutowareDateTimePanel::AutowareDateTimePanel(QWidget * parent) : rviz_common::Pa
   layout->addWidget(new QLabel("Wall Time:"));
   layout->addWidget(wall_time_label_);
   setLayout(layout);
+}
+
+void AutowareDateTimePanel::onInitialize()
+{
+  rviz_ros_node_ = getDisplayContext()->getRosNodeAbstraction();
 
   auto * timer = new QTimer(this);
   connect(timer, &QTimer::timeout, this, &AutowareDateTimePanel::update);
   timer->start(60);
 }
 
-void AutowareDateTimePanel::onInitialize()
-{
-  rviz_ros_node_ = getDisplayContext()->getRosNodeAbstraction();
-}
-
 void AutowareDateTimePanel::update()
 {
-  set_format_time(
-    ros_time_label_, rviz_ros_node_.lock()->get_raw_node()->get_clock()->now().seconds());
-  set_format_time(wall_time_label_, rclcpp::Clock().now().seconds());
+  const auto node = rviz_ros_node_.lock();
+  if (node) {
+    set_format_time(ros_time_label_, node->get_raw_node()->get_clock()->now().seconds());
+    set_format_time(wall_time_label_, rclcpp::Clock().now().seconds());
+  }
 }
 
 #include <pluginlib/class_list_macros.hpp>


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Fix https://github.com/autowarefoundation/autoware/issues/3173.
If the timer callback is executed before `onInitialize` function, `rviz_ros_node_` will be used without initialization.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
