### PR TITLE
fix(behavior_path_planner): support the goal behind ego in pull out

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/utils/geometric_parallel_parking.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/utils/geometric_parallel_parking.hpp
@@ -118,7 +118,8 @@ private:
     const lanelet::ConstLanelets & road_lanes, const lanelet::ConstLanelets & shoulder_lanes,
     const bool is_forward, const double end_pose_offset, const double velocity);
   PathWithLaneId generateStraightPath(const Pose & start_pose);
-  void setVelocityToArcPaths(std::vector<PathWithLaneId> & arc_paths, const double velocity);
+  void setVelocityToArcPaths(
+    std::vector<PathWithLaneId> & arc_paths, const double velocity, const bool set_stop_end);
 
   // debug
   Pose Cr_;

--- a/planning/behavior_path_planner/src/scene_module/pull_out/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/geometric_pull_out.cpp
@@ -62,12 +62,11 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
   if (parameters_.divide_pull_out_path) {
     output.partial_paths = planner_.getPaths();
   } else {
-    const auto partial_paths = planner_.getPaths();
-    auto combined_path = combineReferencePath(partial_paths.at(0), partial_paths.at(1));
-    // set same velocity to all points not to stop
-    for (auto & point : combined_path.points) {
-      point.point.longitudinal_velocity_mps = parameters_.geometric_pull_out_velocity;
-    }
+    auto partial_paths = planner_.getPaths();
+    // remove stop velocity of first arc path
+    partial_paths.front().points.back().point.longitudinal_velocity_mps =
+      parameters_.geometric_pull_out_velocity;
+    const auto combined_path = combineReferencePath(partial_paths.at(0), partial_paths.at(1));
     output.partial_paths.push_back(combined_path);
   }
   output.start_pose = planner_.getArcPaths().at(0).points.back().point.pose;

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -136,8 +136,7 @@ bool PullOutModule::isExecutionRequested() const
   // Check if any of the footprint points are in the shoulder lane
   lanelet::Lanelet closest_shoulder_lanelet;
   if (!lanelet::utils::query::getClosestLanelet(
-        planner_data_->route_handler->getShoulderLanelets(),
-        planner_data_->self_odometry->pose.pose, &closest_shoulder_lanelet)) {
+        pull_out_lanes, planner_data_->self_odometry->pose.pose, &closest_shoulder_lanelet)) {
     return false;
   }
   if (!isOverlappedWithLane(closest_shoulder_lanelet, vehicle_footprint)) {
@@ -495,7 +494,7 @@ PathWithLaneId PullOutModule::generateStopPath() const
     p.point.longitudinal_velocity_mps = 0.0;
     lanelet::Lanelet closest_shoulder_lanelet;
     lanelet::utils::query::getClosestLanelet(
-      planner_data_->route_handler->getShoulderLanelets(), pose, &closest_shoulder_lanelet);
+      status_.pull_out_lanes, pose, &closest_shoulder_lanelet);
     p.lane_ids.push_back(closest_shoulder_lanelet.id());
     return p;
   };

--- a/planning/behavior_path_planner/src/scene_module/utils/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/src/scene_module/utils/geometric_parallel_parking.cpp
@@ -98,11 +98,11 @@ PathWithLaneId GeometricParallelParking::getArcPath() const
 bool GeometricParallelParking::isParking() const { return current_path_idx_ > 0; }
 
 void GeometricParallelParking::setVelocityToArcPaths(
-  std::vector<PathWithLaneId> & arc_paths, const double velocity)
+  std::vector<PathWithLaneId> & arc_paths, const double velocity, const bool set_stop_end)
 {
   for (auto & path : arc_paths) {
     for (size_t i = 0; i < path.points.size(); i++) {
-      if (i == path.points.size() - 1) {
+      if (i == path.points.size() - 1 && set_stop_end) {
         // stop point at the end of the path
         path.points.at(i).point.longitudinal_velocity_mps = 0.0;
       } else {
@@ -129,7 +129,8 @@ std::vector<PathWithLaneId> GeometricParallelParking::generatePullOverPaths(
   arc_paths_ = arc_paths;
 
   // set parking velocity and stop velocity at the end of the path
-  setVelocityToArcPaths(arc_paths, velocity);
+  constexpr bool set_stop_end = true;
+  setVelocityToArcPaths(arc_paths, velocity, set_stop_end);
 
   // straight path from current to parking start
   const auto straight_path = generateStraightPath(start_pose);
@@ -265,24 +266,36 @@ bool GeometricParallelParking::planPullOut(
       }
     }
 
-    arc_paths_ = arc_paths;
-
     // get road center line path from departing end to goal, and combine after the second arc path
-    PathWithLaneId road_center_line_path;
-    {
-      const double s_start = getArcCoordinates(road_lanes, *end_pose).length + 1.0;  // need buffer?
-      const double s_end = getArcCoordinates(road_lanes, goal_pose).length;
-      road_center_line_path =
-        planner_data_->route_handler->getCenterLinePath(road_lanes, s_start, s_end, true);
-    }
+    const double s_start = getArcCoordinates(road_lanes, *end_pose).length + 1.0;  // need buffer?
+    const double s_goal = getArcCoordinates(road_lanes, goal_pose).length;
+    const double road_lanes_length = std::accumulate(
+      road_lanes.begin(), road_lanes.end(), 0.0, [](const double sum, const auto & lane) {
+        return sum + lanelet::utils::getLaneletLength2d(lane);
+      });
+    const bool goal_is_behind = s_goal < s_start;
+    const double s_end = goal_is_behind ? road_lanes_length : s_goal;
+    PathWithLaneId road_center_line_path =
+      planner_data_->route_handler->getCenterLinePath(road_lanes, s_start, s_end, true);
+
+    // set departing velocity to arc paths and 0 velocity to end point
+    constexpr bool set_stop_end = false;
+    setVelocityToArcPaths(arc_paths, parameters_.departing_velocity, set_stop_end);
+    arc_paths.back().points.front().point.longitudinal_velocity_mps = 0.0;
+
+    // combine the road center line path with the second arc path
     auto paths = arc_paths;
     paths.back().points.insert(
       paths.back().points.end(), road_center_line_path.points.begin(),
       road_center_line_path.points.end());
     removeOverlappingPoints(paths.back());
 
-    // set departing velocity and stop velocity at the end of the path
-    setVelocityToArcPaths(paths, parameters_.departing_velocity);
+    // if the end point is the goal, set the velocity to 0
+    if (!goal_is_behind) {
+      paths.back().points.back().point.longitudinal_velocity_mps = 0.0;
+    }
+
+    arc_paths_ = arc_paths;
     paths_ = paths;
 
     return true;


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
Fixed the problem that pull_out can not generate a valid path when the goal is behind ego, 
![image](https://user-images.githubusercontent.com/39142679/215019548-07f93318-db8b-4d3a-b824-4b8d051c2e93.png)

And not set pull out velocity after end point in geometric pull out.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

[tier4 internal link](https://tier4.atlassian.net/browse/T4PB-25534)
## Tests performed

<!-- Describe how you have tested this PR. -->

psim

Set the goal behind the ego, and checked that pull_out -> pull_over works
- shift pull out
![Screenshot from 2023-01-27 13-47-45](https://user-images.githubusercontent.com/39142679/215019879-b7bd39e4-1f7e-464a-9cd3-3754d4e8853f.png)

- geometric pull out
![image](https://user-images.githubusercontent.com/39142679/215024346-a60dcec6-9f83-410b-8f8a-912dbcd8e9a5.png)



**limitation**

lane following can not generate a valid path when the goal is behind the ego in same the lane.
So in this situation after pull_out the vehicle will stop.
To solve this problem we need to deal with loop route https://github.com/autowarefoundation/autoware.universe/pull/2424

https://user-images.githubusercontent.com/39142679/215078125-a43d5476-ddeb-4a7d-96a9-373ec04128e0.mp4




## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
