### PR TITLE
fix(lanelet2_map_loader): delete unused parameters

### DIFF
--- a/map/map_loader/launch/lanelet2_map_loader.launch.xml
+++ b/map/map_loader/launch/lanelet2_map_loader.launch.xml
@@ -3,7 +3,6 @@
   <arg name="lanelet2_map_path"/>
   <arg name="lanelet2_map_topic" default="vector_map"/>
   <arg name="lanelet2_map_marker_topic" default="vector_map_marker"/>
-  <arg name="center_line_resolution" default="5.0"/>
 
   <node pkg="map_loader" exec="map_hash_generator" name="map_hash_generator">
     <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>

--- a/map/map_loader/launch/lanelet2_map_loader.launch.xml
+++ b/map/map_loader/launch/lanelet2_map_loader.launch.xml
@@ -11,10 +11,7 @@
 
   <node pkg="map_loader" exec="lanelet2_map_loader" name="lanelet2_map_loader">
     <remap from="output/lanelet2_map" to="$(var lanelet2_map_topic)"/>
-    <param name="center_line_resolution" value="$(var center_line_resolution)"/>
     <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>
-    <param name="lanelet2_map_projector_type" value="MGRS"/>
-    <!-- UTM or MGRS -->
     <param from="$(var param_file)"/>
   </node>
 


### PR DESCRIPTION
## Description

In #954, I added following parameters in `lanelet2_map_loader.param.yaml`.
- lanelet2_map_projector_type
- center_line_resolution

However, I forget to delete from lanelet2_map_loader.launch.xml.
I fix it.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
