### PR TITLE
fix(costmap_generator): wait for lanelet map

### DIFF
--- a/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
+++ b/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
@@ -334,6 +334,10 @@ void CostmapGenerator::onTimer()
 
 bool CostmapGenerator::isActive()
 {
+  if (!lanelet_map_) {
+    return false;
+  }
+
   if (activate_by_scenario_) {
     if (scenario_) {
       const auto & s = scenario_->activating_scenarios;


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

Accessing `lanelet_map_`  before it is set causes that node dies.

ex) In the following situation I observed the problem
- set initial ego vehicle in parking_space
- activate_by_scenario: False

`const auto all_parking_lots = lanelet::utils::query::getAllParkingLots(lanelet_map_ptr);` (f 2)
![image](https://user-images.githubusercontent.com/39142679/215106919-307dcab2-9481-4715-89c4-5b4d898a569f.png)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.


