### PR TITLE
fix(lane_change): extend target lane range in safety check

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -148,6 +148,9 @@ bool hasEnoughDistanceToLaneChangeAfterAbort(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const Pose & curent_pose, const double abort_return_dist,
   const BehaviorPathPlannerParameters & common_param);
-}  // namespace behavior_path_planner::lane_change_utils
 
+lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
+  const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
+  const double to_back_dist);
+}  // namespace behavior_path_planner::lane_change_utils
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -151,6 +151,6 @@ bool hasEnoughDistanceToLaneChangeAfterAbort(
 
 lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
   const RouteHandler & route_handler, const lanelet::ConstLanelet & target_lanes,
-  const double backward_length);
+  const Pose & current_pose, const double backward_length);
 }  // namespace behavior_path_planner::lane_change_utils
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -82,7 +82,7 @@ LaneChangePaths selectValidPaths(
 
 bool selectSafePath(
   const LaneChangePaths & paths, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & target_lanes,
+  const lanelet::ConstLanelets & backward_lanes,
   const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const BehaviorPathPlannerParameters & common_parameters,
   const behavior_path_planner::LaneChangeParameters & ros_parameters,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -150,7 +150,7 @@ bool hasEnoughDistanceToLaneChangeAfterAbort(
   const BehaviorPathPlannerParameters & common_param);
 
 lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
-  const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
-  const double to_back_dist);
+  const RouteHandler & route_handler, const lanelet::ConstLanelet & target_lanes,
+  const double backward_length);
 }  // namespace behavior_path_planner::lane_change_utils
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -81,8 +81,7 @@ LaneChangePaths selectValidPaths(
   const Pose & current_pose, const Pose & goal_pose, const double minimum_lane_change_length);
 
 bool selectSafePath(
-  const LaneChangePaths & paths, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & backward_lanes,
+  const LaneChangePaths & paths, const lanelet::ConstLanelets & backward_lanes,
   const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const BehaviorPathPlannerParameters & common_parameters,
   const behavior_path_planner::LaneChangeParameters & ros_parameters,
@@ -90,8 +89,7 @@ bool selectSafePath(
   std::unordered_map<std::string, CollisionCheckDebug> & debug_data);
 
 bool isLaneChangePathSafe(
-  const LaneChangePath & lane_change_path, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & backward_lanes,
+  const LaneChangePath & lane_change_path, const lanelet::ConstLanelets & backward_lanes,
   const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const size_t current_seg_idx, const Twist & current_twist,
   const BehaviorPathPlannerParameters & common_parameters,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -91,7 +91,7 @@ bool selectSafePath(
 
 bool isLaneChangePathSafe(
   const LaneChangePath & lane_change_path, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & target_lanes,
+  const lanelet::ConstLanelets & backward_lanes,
   const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const size_t current_seg_idx, const Twist & current_twist,
   const BehaviorPathPlannerParameters & common_parameters,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -384,10 +384,17 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
     return std::make_pair(false, false);
   }
 
+  // get lanes used for detection
+  lanelet::ConstLanelets check_lanes;
+  const auto & longest_path = lane_change_paths.front();
+  // we want to see check_distance [m] behind vehicle so add lane changing length
+  const double check_distance_with_path = check_distance + longest_path.length.sum();
+  check_lanes = route_handler->getCheckTargetLanesFromPath(
+    longest_path.path, lane_change_lanes, check_distance_with_path);
+
   // select valid path
-  const auto & target_lanes = lane_change_paths.front().target_lanelets;
   const LaneChangePaths valid_paths = lane_change_utils::selectValidPaths(
-    lane_change_paths, current_lanes, target_lanes, *route_handler, current_pose,
+    lane_change_paths, current_lanes, check_lanes, *route_handler, current_pose,
     route_handler->getGoalPose(),
     common_parameters.minimum_lane_change_length +
       common_parameters.backward_length_buffer_for_end_of_lane +
@@ -399,12 +406,12 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
   debug_valid_path_ = valid_paths;
 
   // get lanes used for detection
-  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+  const auto backward_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
     *route_handler, lane_change_lanes.front(), current_pose, check_distance);
 
   // select safe path
   const bool found_safe_path = lane_change_utils::selectSafePath(
-    valid_paths, current_lanes, check_lanes, planner_data_->dynamic_object, current_pose,
+    valid_paths, current_lanes, backward_lanes, planner_data_->dynamic_object, current_pose,
     current_twist, common_parameters, *parameters_, &safe_path, object_debug_);
 
   if (parameters_->publish_debug_marker) {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -371,50 +371,48 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
 
   const auto current_lanes = util::getCurrentLanes(planner_data_);
 
-  if (!lane_change_lanes.empty()) {
-    // find candidate paths
-    const auto lane_change_paths = lane_change_utils::getLaneChangePaths(
-      *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
-      common_parameters, *parameters_);
-
-    // get lanes used for detection
-    lanelet::ConstLanelets check_lanes;
-    if (!lane_change_paths.empty()) {
-      const auto & longest_path = lane_change_paths.front();
-      // we want to see check_distance [m] behind vehicle so add lane changing length
-      const double check_distance_with_path = check_distance + longest_path.length.sum();
-      check_lanes = route_handler->getCheckTargetLanesFromPath(
-        longest_path.path, lane_change_lanes, check_distance_with_path);
-    }
-
-    // select valid path
-    const LaneChangePaths valid_paths = lane_change_utils::selectValidPaths(
-      lane_change_paths, current_lanes, check_lanes, *route_handler, current_pose,
-      route_handler->getGoalPose(),
-      common_parameters.minimum_lane_change_length +
-        common_parameters.backward_length_buffer_for_end_of_lane +
-        parameters_->lane_change_finish_judge_buffer);
-
-    if (valid_paths.empty()) {
-      return std::make_pair(false, false);
-    }
-    debug_valid_path_ = valid_paths;
-
-    // select safe path
-    const bool found_safe_path = lane_change_utils::selectSafePath(
-      valid_paths, current_lanes, check_lanes, planner_data_->dynamic_object, current_pose,
-      current_twist, common_parameters, *parameters_, &safe_path, object_debug_);
-
-    if (parameters_->publish_debug_marker) {
-      setObjectDebugVisualization();
-    } else {
-      debug_marker_.markers.clear();
-    }
-
-    return std::make_pair(true, found_safe_path);
+  if (lane_change_lanes.empty()) {
+    return std::make_pair(false, false);
   }
 
-  return std::make_pair(false, false);
+  // find candidate paths
+  const auto lane_change_paths = lane_change_utils::getLaneChangePaths(
+    *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
+    common_parameters, *parameters_);
+
+  if (lane_change_paths.empty()) {
+    return std::make_pair(false, false);
+  }
+  // get lanes used for detection
+  // get lanes used for detection
+  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+    *route_handler, lane_change_lanes, check_distance);
+
+  // select valid path
+  const LaneChangePaths valid_paths = lane_change_utils::selectValidPaths(
+    lane_change_paths, current_lanes, check_lanes, *route_handler, current_pose,
+    route_handler->getGoalPose(),
+    common_parameters.minimum_lane_change_length +
+      common_parameters.backward_length_buffer_for_end_of_lane +
+      parameters_->lane_change_finish_judge_buffer);
+
+  if (valid_paths.empty()) {
+    return std::make_pair(false, false);
+  }
+  debug_valid_path_ = valid_paths;
+
+  // select safe path
+  const bool found_safe_path = lane_change_utils::selectSafePath(
+    valid_paths, current_lanes, check_lanes, planner_data_->dynamic_object, current_pose,
+    current_twist, common_parameters, *parameters_, &safe_path, object_debug_);
+
+  if (parameters_->publish_debug_marker) {
+    setObjectDebugVisualization();
+  } else {
+    debug_marker_.markers.clear();
+  }
+
+  return std::make_pair(true, found_safe_path);
 }
 
 bool ExternalRequestLaneChangeModule::isSafe() const { return status_.is_safe; }
@@ -679,9 +677,8 @@ bool ExternalRequestLaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_
 
   constexpr double check_distance = 100.0;
   // get lanes used for detection
-  const double check_distance_with_path = check_distance + path.length.sum();
-  const auto check_lanes = route_handler->getCheckTargetLanesFromPath(
-    path.path, status_.lane_change_lanes, check_distance_with_path);
+  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+    *route_handler, path.target_lanelets, check_distance);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -383,14 +383,11 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
   if (lane_change_paths.empty()) {
     return std::make_pair(false, false);
   }
-  // get lanes used for detection
-  // get lanes used for detection
-  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, lane_change_lanes, check_distance);
 
   // select valid path
+  const auto & target_lanes = lane_change_paths.front().target_lanelets;
   const LaneChangePaths valid_paths = lane_change_utils::selectValidPaths(
-    lane_change_paths, current_lanes, check_lanes, *route_handler, current_pose,
+    lane_change_paths, current_lanes, target_lanes, *route_handler, current_pose,
     route_handler->getGoalPose(),
     common_parameters.minimum_lane_change_length +
       common_parameters.backward_length_buffer_for_end_of_lane +
@@ -400,6 +397,10 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
     return std::make_pair(false, false);
   }
   debug_valid_path_ = valid_paths;
+
+  // get lanes used for detection
+  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+    *route_handler, lane_change_lanes.front(), check_distance);
 
   // select safe path
   const bool found_safe_path = lane_change_utils::selectSafePath(
@@ -678,7 +679,7 @@ bool ExternalRequestLaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_
   constexpr double check_distance = 100.0;
   // get lanes used for detection
   const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, path.target_lanelets, check_distance);
+    *route_handler, path.target_lanelets.front(), check_distance);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -400,7 +400,7 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
 
   // get lanes used for detection
   const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, lane_change_lanes.front(), check_distance);
+    *route_handler, lane_change_lanes.front(), current_pose, check_distance);
 
   // select safe path
   const bool found_safe_path = lane_change_utils::selectSafePath(
@@ -679,7 +679,7 @@ bool ExternalRequestLaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_
   constexpr double check_distance = 100.0;
   // get lanes used for detection
   const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, path.target_lanelets.front(), check_distance);
+    *route_handler, path.target_lanelets.front(), current_pose, check_distance);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -411,8 +411,8 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
 
   // select safe path
   const bool found_safe_path = lane_change_utils::selectSafePath(
-    valid_paths, current_lanes, backward_lanes, planner_data_->dynamic_object, current_pose,
-    current_twist, common_parameters, *parameters_, &safe_path, object_debug_);
+    valid_paths, backward_lanes, planner_data_->dynamic_object, current_pose, current_twist,
+    common_parameters, *parameters_, &safe_path, object_debug_);
 
   if (parameters_->publish_debug_marker) {
     setObjectDebugVisualization();
@@ -678,7 +678,6 @@ bool ExternalRequestLaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_
   const auto current_pose = getEgoPose();
   const auto current_twist = getEgoTwist();
   const auto & dynamic_objects = planner_data_->dynamic_object;
-  const auto & current_lanes = status_.current_lanes;
   const auto & common_parameters = planner_data_->parameters;
   const auto & route_handler = planner_data_->route_handler;
   const auto path = status_.lane_change_path;
@@ -694,7 +693,7 @@ bool ExternalRequestLaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_
     path.path.points, current_pose, common_parameters.ego_nearest_dist_threshold,
     common_parameters.ego_nearest_yaw_threshold);
   return lane_change_utils::isLaneChangePathSafe(
-    path, current_lanes, check_lanes, dynamic_objects, current_pose, current_seg_idx, current_twist,
+    path, check_lanes, dynamic_objects, current_pose, current_seg_idx, current_twist,
     common_parameters, *parameters_, common_parameters.expected_front_deceleration_for_abort,
     common_parameters.expected_rear_deceleration_for_abort, ego_pose_before_collision, debug_data,
     false, status_.lane_change_path.acceleration);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -385,17 +385,8 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
   }
 
   // get lanes used for detection
-  const auto check_lanes = std::invoke([&]() {
-    const auto & target_lanes = lane_change_paths.front().target_lanelets;
-    const auto & target_lane = target_lanes.front();
-    const auto & basic_pt = target_lane.centerline().front();
-    Pose pose;
-    pose.position = lanelet::utils::conversion::toGeomMsgPt(basic_pt);
-
-    auto backward_lanes = route_handler->getLaneletSequence(target_lane, pose, check_distance, 0.0);
-    backward_lanes.insert(backward_lanes.end(), target_lanes.begin(), target_lanes.end());
-    return backward_lanes;
-  });
+  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+    *route_handler, lane_change_lanes, check_distance);
 
   // select valid path
   const LaneChangePaths valid_paths = lane_change_utils::selectValidPaths(
@@ -684,17 +675,8 @@ bool LaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
   constexpr double check_distance = 100.0;
   // get lanes used for detection
   // const double check_distance_with_path = check_distance + path.length.sum();
-  const auto check_lanes = std::invoke([&]() {
-    const auto & target_lanes = path.target_lanelets;
-    const auto & target_lane = target_lanes.front();
-    const auto & basic_pt = target_lane.centerline().front();
-    Pose pose;
-    pose.position = lanelet::utils::conversion::toGeomMsgPt(basic_pt);
-
-    auto backward_lanes = route_handler->getLaneletSequence(target_lane, pose, check_distance, 0.0);
-    backward_lanes.insert(backward_lanes.end(), target_lanes.begin(), target_lanes.end());
-    return backward_lanes;
-  });
+  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+    *route_handler, path.target_lanelets, check_distance);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -384,13 +384,10 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
     return std::make_pair(false, false);
   }
 
-  // get lanes used for detection
-  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, lane_change_lanes, check_distance);
-
   // select valid path
+  const auto & target_lanes = lane_change_paths.front().target_lanelets;
   const LaneChangePaths valid_paths = lane_change_utils::selectValidPaths(
-    lane_change_paths, current_lanes, check_lanes, *route_handler, current_pose,
+    lane_change_paths, current_lanes, target_lanes, *route_handler, current_pose,
     route_handler->getGoalPose(),
     common_parameters.minimum_lane_change_length +
       common_parameters.backward_length_buffer_for_end_of_lane +
@@ -400,6 +397,10 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
     return std::make_pair(false, false);
   }
   debug_valid_path_ = valid_paths;
+
+  // get lanes used for detection
+  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+    *route_handler, lane_change_paths.front().target_lanelets.front(), check_distance);
 
   // select safe path
   const bool found_safe_path = lane_change_utils::selectSafePath(
@@ -672,11 +673,9 @@ bool LaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
   const auto & route_handler = planner_data_->route_handler;
   const auto & path = status_.lane_change_path;
 
-  constexpr double check_distance = 100.0;
   // get lanes used for detection
-  // const double check_distance_with_path = check_distance + path.length.sum();
   const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, path.target_lanelets, check_distance);
+    *route_handler, path.target_lanelets.front(), check_distance_);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -400,7 +400,8 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
 
   // get lanes used for detection
   const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, lane_change_paths.front().target_lanelets.front(), check_distance);
+    *route_handler, lane_change_paths.front().target_lanelets.front(), current_pose,
+    check_distance);
 
   // select safe path
   const bool found_safe_path = lane_change_utils::selectSafePath(
@@ -675,7 +676,7 @@ bool LaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
 
   // get lanes used for detection
   const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, path.target_lanelets.front(), check_distance_);
+    *route_handler, path.target_lanelets.front(), current_pose, check_distance_);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -409,8 +409,8 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
     *route_handler, lane_change_paths.front().target_lanelets.front(), current_pose,
     check_distance);
   const bool found_safe_path = lane_change_utils::selectSafePath(
-    valid_paths, current_lanes, backward_lanes, planner_data_->dynamic_object, current_pose,
-    current_twist, common_parameters, *parameters_, &safe_path, object_debug_);
+    valid_paths, backward_lanes, planner_data_->dynamic_object, current_pose, current_twist,
+    common_parameters, *parameters_, &safe_path, object_debug_);
 
   if (parameters_->publish_debug_marker) {
     setObjectDebugVisualization();
@@ -674,7 +674,6 @@ bool LaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
   const auto current_pose = getEgoPose();
   const auto current_twist = getEgoTwist();
   const auto & dynamic_objects = planner_data_->dynamic_object;
-  const auto & current_lanes = status_.current_lanes;
   const auto & common_parameters = planner_data_->parameters;
   const auto & route_handler = planner_data_->route_handler;
   const auto & path = status_.lane_change_path;
@@ -689,7 +688,7 @@ bool LaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
     path.path.points, current_pose, common_parameters.ego_nearest_dist_threshold,
     common_parameters.ego_nearest_yaw_threshold);
   return lane_change_utils::isLaneChangePathSafe(
-    path, current_lanes, check_lanes, dynamic_objects, current_pose, current_seg_idx, current_twist,
+    path, check_lanes, dynamic_objects, current_pose, current_seg_idx, current_twist,
     common_parameters, *parameters_, common_parameters.expected_front_deceleration_for_abort,
     common_parameters.expected_rear_deceleration_for_abort, ego_pose_before_collision, debug_data,
     false, status_.lane_change_path.acceleration);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -380,7 +380,7 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     common_parameters, *parameters_);
 
-  if (!lane_change_paths.empty()) {
+  if (lane_change_paths.empty()) {
     return std::make_pair(false, false);
   }
   // get lanes used for detection

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -371,53 +371,54 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
 
   const auto current_lanes = util::getCurrentLanes(planner_data_);
 
-  if (!lane_change_lanes.empty()) {
-    // find candidate paths
-    const auto lane_change_paths = lane_change_utils::getLaneChangePaths(
-      *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
-      common_parameters, *parameters_);
-
-    // get lanes used for detection
-    lanelet::ConstLanelets check_lanes;
-    if (!lane_change_paths.empty()) {
-      const auto & longest_path = lane_change_paths.front();
-      // we want to see check_distance [m] behind vehicle so add lane changing length
-      const double check_distance_with_path = check_distance + longest_path.length.sum();
-      check_lanes = route_handler->getCheckTargetLanesFromPath(
-        longest_path.path, lane_change_lanes, check_distance_with_path);
-    }
-
-    // select valid path
-    const LaneChangePaths valid_paths = lane_change_utils::selectValidPaths(
-      lane_change_paths, current_lanes, check_lanes, *route_handler, current_pose,
-      route_handler->getGoalPose(),
-      common_parameters.minimum_lane_change_length +
-        common_parameters.backward_length_buffer_for_end_of_lane +
-        parameters_->lane_change_finish_judge_buffer);
-
-    if (valid_paths.empty()) {
-      return std::make_pair(false, false);
-    }
-    debug_valid_path_ = valid_paths;
-
-    // select safe path
-    const auto backward_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-      *route_handler, lane_change_paths.front().target_lanelets.front(), current_pose,
-      check_distance);
-    const bool found_safe_path = lane_change_utils::selectSafePath(
-      valid_paths, current_lanes, backward_lanes, planner_data_->dynamic_object, current_pose,
-      current_twist, common_parameters, *parameters_, &safe_path, object_debug_);
-
-    if (parameters_->publish_debug_marker) {
-      setObjectDebugVisualization();
-    } else {
-      debug_marker_.markers.clear();
-    }
-
-    return std::make_pair(true, found_safe_path);
+  if (lane_change_lanes.empty()) {
+    return std::make_pair(false, false);
   }
 
-  return std::make_pair(false, false);
+  // find candidate paths
+  const auto lane_change_paths = lane_change_utils::getLaneChangePaths(
+    *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
+    common_parameters, *parameters_);
+
+  if (!lane_change_paths.empty()) {
+    return std::make_pair(false, false);
+  }
+  // get lanes used for detection
+  lanelet::ConstLanelets check_lanes;
+  const auto & longest_path = lane_change_paths.front();
+  // we want to see check_distance [m] behind vehicle so add lane changing length
+  const double check_distance_with_path = check_distance + longest_path.length.sum();
+  check_lanes = route_handler->getCheckTargetLanesFromPath(
+    longest_path.path, lane_change_lanes, check_distance_with_path);
+
+  // select valid path
+  const LaneChangePaths valid_paths = lane_change_utils::selectValidPaths(
+    lane_change_paths, current_lanes, check_lanes, *route_handler, current_pose,
+    route_handler->getGoalPose(),
+    common_parameters.minimum_lane_change_length +
+      common_parameters.backward_length_buffer_for_end_of_lane +
+      parameters_->lane_change_finish_judge_buffer);
+
+  if (valid_paths.empty()) {
+    return std::make_pair(false, false);
+  }
+  debug_valid_path_ = valid_paths;
+
+  // select safe path
+  const auto backward_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+    *route_handler, lane_change_paths.front().target_lanelets.front(), current_pose,
+    check_distance);
+  const bool found_safe_path = lane_change_utils::selectSafePath(
+    valid_paths, current_lanes, backward_lanes, planner_data_->dynamic_object, current_pose,
+    current_twist, common_parameters, *parameters_, &safe_path, object_debug_);
+
+  if (parameters_->publish_debug_marker) {
+    setObjectDebugVisualization();
+  } else {
+    debug_marker_.markers.clear();
+  }
+
+  return std::make_pair(true, found_safe_path);
   // get lanes used for detection
 }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -683,9 +683,18 @@ bool LaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
 
   constexpr double check_distance = 100.0;
   // get lanes used for detection
-  const double check_distance_with_path = check_distance + path.length.sum();
-  const auto check_lanes = route_handler->getCheckTargetLanesFromPath(
-    path.path, status_.lane_change_lanes, check_distance_with_path);
+  // const double check_distance_with_path = check_distance + path.length.sum();
+  const auto check_lanes = std::invoke([&]() {
+    const auto & target_lanes = path.target_lanelets;
+    const auto & target_lane = target_lanes.front();
+    const auto & basic_pt = target_lane.centerline().front();
+    Pose pose;
+    pose.position = lanelet::utils::conversion::toGeomMsgPt(basic_pt);
+
+    auto backward_lanes = route_handler->getLaneletSequence(target_lane, pose, check_distance, 0.0);
+    backward_lanes.insert(backward_lanes.end(), target_lanes.begin(), target_lanes.end());
+    return backward_lanes;
+  });
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -497,7 +497,7 @@ LaneChangePaths selectValidPaths(
 
 bool selectSafePath(
   const LaneChangePaths & paths, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & target_lanes,
+  const lanelet::ConstLanelets & backward_lanes,
   const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
   const Twist & current_twist, const BehaviorPathPlannerParameters & common_parameters,
   const LaneChangeParameters & ros_parameters, LaneChangePath * selected_path,
@@ -510,7 +510,7 @@ bool selectSafePath(
       common_parameters.ego_nearest_yaw_threshold);
     Pose ego_pose_before_collision;
     if (isLaneChangePathSafe(
-          path, current_lanes, target_lanes, dynamic_objects, current_pose, current_seg_idx,
+          path, current_lanes, backward_lanes, dynamic_objects, current_pose, current_seg_idx,
           current_twist, common_parameters, ros_parameters,
           common_parameters.expected_front_deceleration,
           common_parameters.expected_rear_deceleration, ego_pose_before_collision, debug_data, true,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -581,7 +581,7 @@ bool isLaneChangePathSafe(
   }
 
   const auto & path = lane_change_path.path;
-  if (path.points.empty() || target_lanes.empty() || current_lanes.empty()) {
+  if (path.points.empty() || current_lanes.empty()) {
     return false;
   }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -615,10 +615,11 @@ bool isLaneChangePathSafe(
       other_lane_object_indices, true);
   }
 
-  RCLCPP_INFO(
-    rclcpp::get_logger("lane_change"), "number of object in current: %lu, target: %lu, others: %lu",
-    current_lane_object_indices.size(), target_lane_object_indices.size(),
-    other_lane_object_indices.size());
+  RCLCPP_DEBUG(
+    rclcpp::get_logger("lane_change"),
+    "number of object -> total: %lu, in current: %lu, target: %lu, others: %lu",
+    dynamic_objects->objects.size(), current_lane_object_indices.size(),
+    target_lane_object_indices.size(), other_lane_object_indices.size());
 
   const auto assignDebugData = [](const PredictedObject & obj) {
     CollisionCheckDebug debug;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -1105,10 +1105,16 @@ bool hasEnoughDistanceToLaneChangeAfterAbort(
 // TODO(Azu): In the future, get back lanelet within `to_back_dist` [m] from queried lane
 lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
   const RouteHandler & route_handler, const lanelet::ConstLanelet & target_lane,
-  const double backward_length)
+  const Pose & current_pose, const double backward_length)
 {
-  const auto preceeding_lanes =
-    route_handler.getPrecedingLaneletSequence(target_lane, backward_length, {target_lane});
+  const auto arc_length = lanelet::utils::getArcCoordinates({target_lane}, current_pose);
+
+  if (arc_length.length >= backward_length) {
+    return {};
+  }
+
+  const auto preceeding_lanes = route_handler.getPrecedingLaneletSequence(
+    target_lane, std::abs(backward_length - arc_length.length), {target_lane});
 
   lanelet::ConstLanelets backward_lanes{};
   const auto num_of_lanes = std::invoke([&preceeding_lanes]() {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -21,6 +21,7 @@
 #include "behavior_path_planner/scene_module/utils/path_shifter.hpp"
 #include "behavior_path_planner/utilities.hpp"
 
+#include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -1081,5 +1082,19 @@ bool hasEnoughDistanceToLaneChangeAfterAbort(
   }
 
   return true;
+}
+
+lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
+  const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
+  const double to_back_dist)
+{
+  const auto & target_lane = target_lanes.front();
+  const auto & basic_pt = target_lane.centerline().front();
+  Pose pose;
+  pose.position = lanelet::utils::conversion::toGeomMsgPt(basic_pt);
+
+  auto backward_lanes = route_handler.getLaneletSequence(target_lane, pose, to_back_dist, 0.0);
+  backward_lanes.insert(backward_lanes.end(), target_lanes.begin(), target_lanes.end());
+  return backward_lanes;
 }
 }  // namespace behavior_path_planner::lane_change_utils

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -610,8 +610,7 @@ bool isLaneChangePathSafe(
   }
 
   RCLCPP_DEBUG(
-    rclcpp::get_logger("lane_change"),
-    "number of object -> total: %lu, in lane: %lu, others: %lu",
+    rclcpp::get_logger("lane_change"), "number of object -> total: %lu, in lane: %lu, others: %lu",
     dynamic_objects->objects.size(), in_lane_object_indices.size(),
     other_lane_object_indices.size());
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -592,10 +592,15 @@ bool isLaneChangePathSafe(
     const auto current_obj_filtering_buffer = lateral_buffer + common_parameters.vehicle_width / 2;
 
     filterObjectIndices(
-      *dynamic_objects, lane_change_path.reference_lanelets, lane_change_path.target_lanelets, path,
-      current_pose, common_parameters.forward_path_length, current_obj_filtering_buffer,
+      *dynamic_objects, lane_change_path.reference_lanelets, target_lanes, path, current_pose,
+      common_parameters.forward_path_length, current_obj_filtering_buffer,
       current_lane_object_indices, target_lane_object_indices, other_lane_object_indices, true);
   }
+
+  RCLCPP_DEBUG(
+    rclcpp::get_logger("lane_change"), "number of object in current: %lu, target: %lu, others: %lu",
+    current_lane_object_indices.size(), target_lane_object_indices.size(),
+    other_lane_object_indices.size());
 
   const auto assignDebugData = [](const PredictedObject & obj) {
     CollisionCheckDebug debug;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -1121,13 +1121,13 @@ lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
     return {};
   }
 
-  const auto preceeding_lanes = route_handler.getPrecedingLaneletSequence(
+  const auto preceding_lanes = route_handler.getPrecedingLaneletSequence(
     target_lane, std::abs(backward_length - arc_length.length), {target_lane});
 
   lanelet::ConstLanelets backward_lanes{};
-  const auto num_of_lanes = std::invoke([&preceeding_lanes]() {
+  const auto num_of_lanes = std::invoke([&preceding_lanes]() {
     size_t sum{0};
-    for (const auto & lanes : preceeding_lanes) {
+    for (const auto & lanes : preceding_lanes) {
       sum += lanes.size();
     }
     return sum;
@@ -1135,7 +1135,7 @@ lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
 
   backward_lanes.reserve(num_of_lanes);
 
-  for (const auto & lanes : preceeding_lanes) {
+  for (const auto & lanes : preceding_lanes) {
     backward_lanes.insert(backward_lanes.end(), lanes.begin(), lanes.end());
   }
 

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -237,6 +237,19 @@ public:
     const lanelet::ConstLanelet & lanelet, bool is_right = true, bool is_left = true,
     bool is_opposite = true) const noexcept;
 
+  /**
+   * Retrieves a sequence of lanelets before the given lanelet.
+   * The total length of retrieved lanelet sequence at least given length. Returned lanelet sequence
+   * does not include input lanelet.]
+   * @param graph [input lanelet routing graph]
+   * @param lanelet [input lanelet]
+   * @param length [minimum length of retrieved lanelet sequence]
+   * @return   [lanelet sequence that leads to given lanelet]
+   */
+  std::vector<lanelet::ConstLanelets> getPrecedingLaneletSequence(
+    const lanelet::ConstLanelet & lanelet, const double length,
+    const lanelet::ConstLanelets & exclude_lanelets = {}) const;
+
   int getNumLaneToPreferredLane(const lanelet::ConstLanelet & lanelet) const;
   bool getClosestLaneletWithinRoute(
     const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1086,6 +1086,14 @@ lanelet::ConstLineStrings3d RouteHandler::getFurthestLinestring(
   return linestrings;
 }
 
+std::vector<lanelet::ConstLanelets> RouteHandler::getPrecedingLaneletSequence(
+  const lanelet::ConstLanelet & lanelet, const double length,
+  const lanelet::ConstLanelets & exclude_lanelets) const
+{
+  return lanelet::utils::query::getPrecedingLaneletSequences(
+    routing_graph_ptr_, lanelet, length, exclude_lanelets);
+}
+
 bool RouteHandler::getLaneChangeTarget(
   const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const
 {


### PR DESCRIPTION
## Description

The range for safety check for target lane is currently depends on the registered target lane.
When an object is out of the registered lane, safety check will not be performed on the object.

In the following video, because the target lane is short, when ego move past the short lane, the last target lane is removed, therefore, even if there is an object in that lane, it will be totally ignored.

https://user-images.githubusercontent.com/93502286/215367019-fdbc342a-8f68-4165-82b1-84408aae1277.mp4

This PR aims fix this by extending the target lane during collision checking.


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
