### PR TITLE
fix(bag_time_manager_rviz_plugin): update create_client API to use rc…

### DIFF
--- a/common/bag_time_manager_rviz_plugin/src/bag_time_manager_panel.cpp
+++ b/common/bag_time_manager_rviz_plugin/src/bag_time_manager_panel.cpp
@@ -66,10 +66,8 @@ BagTimeManagerPanel::BagTimeManagerPanel(QWidget * parent) : rviz_common::Panel(
 void BagTimeManagerPanel::onInitialize()
 {
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
-  client_pause_ =
-    raw_node_->create_client<Pause>("/rosbag2_player/pause", rclcpp::ServicesQoS);
-  client_resume_ =
-    raw_node_->create_client<Resume>("/rosbag2_player/resume", rclcpp::ServicesQoS);
+  client_pause_ = raw_node_->create_client<Pause>("/rosbag2_player/pause", rclcpp::ServicesQoS);
+  client_resume_ = raw_node_->create_client<Resume>("/rosbag2_player/resume", rclcpp::ServicesQoS);
   client_set_rate_ =
     raw_node_->create_client<SetRate>("/rosbag2_player/set_rate", rclcpp::ServicesQoS);
 }

--- a/common/bag_time_manager_rviz_plugin/src/bag_time_manager_panel.cpp
+++ b/common/bag_time_manager_rviz_plugin/src/bag_time_manager_panel.cpp
@@ -67,11 +67,11 @@ void BagTimeManagerPanel::onInitialize()
 {
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
   client_pause_ =
-    raw_node_->create_client<Pause>("/rosbag2_player/pause", rmw_qos_profile_services_default);
+    raw_node_->create_client<Pause>("/rosbag2_player/pause", rclcpp::ServicesQoS);
   client_resume_ =
-    raw_node_->create_client<Resume>("/rosbag2_player/resume", rmw_qos_profile_services_default);
+    raw_node_->create_client<Resume>("/rosbag2_player/resume", rclcpp::ServicesQoS);
   client_set_rate_ =
-    raw_node_->create_client<SetRate>("/rosbag2_player/set_rate", rmw_qos_profile_services_default);
+    raw_node_->create_client<SetRate>("/rosbag2_player/set_rate", rclcpp::ServicesQoS);
 }
 
 void BagTimeManagerPanel::onPauseClicked()

--- a/common/bag_time_manager_rviz_plugin/src/bag_time_manager_panel.cpp
+++ b/common/bag_time_manager_rviz_plugin/src/bag_time_manager_panel.cpp
@@ -19,8 +19,9 @@
 #include <qt5/QtWidgets/QHBoxLayout>
 #include <qt5/QtWidgets/QLabel>
 #include <qt5/QtWidgets/QWidget>
-#include <rclcpp/version.h>
 #include <rviz_common/display_context.hpp>
+
+#include <rclcpp/version.h>
 
 namespace rviz_plugins
 {

--- a/common/bag_time_manager_rviz_plugin/src/bag_time_manager_panel.cpp
+++ b/common/bag_time_manager_rviz_plugin/src/bag_time_manager_panel.cpp
@@ -68,21 +68,17 @@ BagTimeManagerPanel::BagTimeManagerPanel(QWidget * parent) : rviz_common::Panel(
 void BagTimeManagerPanel::onInitialize()
 {
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
+
 // APIs taking rclcpp::QoS objects are only available in ROS 2 Iron and higher
 #if RCLCPP_VERSION_MAJOR >= 18
-  client_pause_ = raw_node_->create_client<Pause>("/rosbag2_player/pause", rclcpp::ServicesQoS());
-  client_resume_ =
-    raw_node_->create_client<Resume>("/rosbag2_player/resume", rclcpp::ServicesQoS());
-  client_set_rate_ =
-    raw_node_->create_client<SetRate>("/rosbag2_player/set_rate", rclcpp::ServicesQoS());
+  const auto qos_default = rclcpp::ServicesQoS();
 #else
-  client_pause_ =
-    raw_node_->create_client<Pause>("/rosbag2_player/pause", rmw_qos_profile_services_default);
-  client_resume_ =
-    raw_node_->create_client<Resume>("/rosbag2_player/resume", rmw_qos_profile_services_default);
-  client_set_rate_ =
-    raw_node_->create_client<SetRate>("/rosbag2_player/set_rate", rmw_qos_profile_services_default);
+  const auto qos_default = rmw_qos_profile_services_default;
 #endif
+
+  client_pause_ = raw_node_->create_client<Pause>("/rosbag2_player/pause", qos_default);
+  client_resume_ = raw_node_->create_client<Resume>("/rosbag2_player/resume", qos_default);
+  client_set_rate_ = raw_node_->create_client<SetRate>("/rosbag2_player/set_rate", qos_default);
 }
 
 void BagTimeManagerPanel::onPauseClicked()


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`rclcpp::create_client` in `rolling` deprecated `rmw_qos_profile_t` in favor of the `rclcpp::QoS` API

Fixes https://github.com/autowarefoundation/autoware.universe/issues/2782

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
