### PR TITLE
fix(obstacle_avoidance_planner): check if bounds_candidates is empty for debug marker

### DIFF
--- a/planning/obstacle_avoidance_planner/src/utils/debug_utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/debug_utils.cpp
@@ -445,7 +445,7 @@ visualization_msgs::msg::MarkerArray getBoundsCandidatesLineMarkerArray(
   visualization_msgs::msg::MarkerArray msg;
   const std::string ns = "bounds_candidates";
 
-  if (ref_points.empty()) return msg;
+  if (ref_points.empty() || bounds_candidates.empty()) return msg;
 
   auto marker = createDefaultMarker(
     "map", rclcpp::Clock().now(), ns, 0, visualization_msgs::msg::Marker::LINE_LIST,


### PR DESCRIPTION


Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

the node will die when bonds is empty by accessing `bounds_candidates.at(i)`

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
