### PR TITLE
feat(obstacle_stop_planner): add configurable lateral_distance for different target objects

### DIFF
--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -7,6 +7,7 @@
     voxel_grid_y: 0.05                       # voxel grid y parameter for filtering pointcloud [m]
     voxel_grid_z: 100000.0                   # voxel grid z parameter for filtering pointcloud [m]
     use_predicted_objects : False            # whether to use predicted objects [-]
+    publish_obstacle_polygon: False          # whether to publish obstacle polygon [-]
 
     stop_planner:
       # params for stop position

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -6,6 +6,7 @@
     voxel_grid_x: 0.05                       # voxel grid x parameter for filtering pointcloud [m]
     voxel_grid_y: 0.05                       # voxel grid y parameter for filtering pointcloud [m]
     voxel_grid_z: 100000.0                   # voxel grid z parameter for filtering pointcloud [m]
+    use_predicted_objects : False            # whether to use predicted objects [-]
 
     stop_planner:
       # params for stop position
@@ -16,7 +17,10 @@
 
       # params for detection area
       detection_area:
-        lateral_margin: 0.0                  # margin of vehicle footprint [m]
+        lateral_margin: 0.0                  # margin [m]
+        vehicle_lateral_margin: 0.0          # margin of vehicle footprint [m]
+        pedestrian_lateral_margin: 0.0       # margin of pedestrian footprint [m]
+        unknown_lateral_margin: 0.0          # margin of unknown footprint [m]
         step_length: 1.0                     # step length for pointcloud search range [m]
         extend_distance: 0.0                 # extend trajectory to consider after goal obstacle in the extend_distance [m]
 
@@ -32,6 +36,9 @@
       # params for detection area
       detection_area:
         lateral_margin: 1.0                  # offset from vehicle side edge for expanding the search area of the surrounding point cloud [m]
+        vehicle_lateral_margin: 1.0          # offset from vehicle side edge for expanding the search area of the surrounding point cloud [m]
+        pedestrian_lateral_margin: 1.0       # offset from pedestrian side edge for expanding the search area of the surrounding point cloud [m]
+        unknown_lateral_margin: 1.0          # offset from unknown side edge for expanding the search area of the surrounding point cloud [m]
 
       # params for velocity
       target_velocity:

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/debug_marker.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/debug_marker.hpp
@@ -51,7 +51,7 @@ using tier4_planning_msgs::msg::StopFactor;
 using tier4_planning_msgs::msg::StopReason;
 using tier4_planning_msgs::msg::StopReasonArray;
 
-enum class PolygonType : int8_t { Vehicle = 0, Collision, SlowDownRange, SlowDown };
+enum class PolygonType : int8_t { Vehicle = 0, Collision, SlowDownRange, SlowDown, Obstacle };
 
 enum class PointType : int8_t { Stop = 0, SlowDown };
 
@@ -143,6 +143,7 @@ private:
   std::vector<std::vector<Eigen::Vector3d>> slow_down_range_polygons_;
   std::vector<std::vector<Eigen::Vector3d>> collision_polygons_;
   std::vector<std::vector<Eigen::Vector3d>> slow_down_polygons_;
+  std::vector<std::vector<Eigen::Vector3d>> obstacle_polygons_;
 
   DebugValues debug_values_;
 };

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -239,6 +239,20 @@ private:
     }
   }
 
+  void updatePredictedObstacleHistory(const rclcpp::Time & now)
+  {
+    for (auto itr = predicted_object_history_.begin(); itr != predicted_object_history_.end();) {
+      const auto expired = (now - itr->detection_time).seconds() > node_param_.chattering_threshold;
+
+      if (expired) {
+        itr = predicted_object_history_.erase(itr);
+        continue;
+      }
+
+      itr++;
+    }
+  }
+
   PointCloud::Ptr getOldPointCloudPtr() const
   {
     PointCloud::Ptr ret(new PointCloud);

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -173,6 +173,10 @@ private:
     PlannerData & planner_data, const Header & trajectory_header, const VehicleInfo & vehicle_info,
     const StopParam & stop_param, const PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr);
 
+  void searchPredictedObject(
+    const TrajectoryPoints & decimate_trajectory, PlannerData & planner_data,
+    const VehicleInfo & vehicle_info, const StopParam & stop_param);
+
   void insertVelocity(
     TrajectoryPoints & trajectory, PlannerData & planner_data, const Header & trajectory_header,
     const VehicleInfo & vehicle_info, const double current_acc, const double current_vel,

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -103,6 +103,17 @@ struct ObstacleWithDetectionTime
   pcl::PointXYZ point;
 };
 
+struct PredictedObjectWithDetectionTime
+{
+  explicit PredictedObjectWithDetectionTime(const rclcpp::Time & t, Pose & p)
+  : detection_time(t), point(p)
+  {
+  }
+
+  rclcpp::Time detection_time;
+  Pose point;
+};
+
 class ObstacleStopPlannerNode : public rclcpp::Node
 {
 public:
@@ -135,6 +146,7 @@ private:
   std::shared_ptr<ObstacleStopPlannerDebugNode> debug_ptr_;
   boost::optional<SlowDownSection> latest_slow_down_section_{boost::none};
   std::vector<ObstacleWithDetectionTime> obstacle_history_{};
+        std::vector<PredictedObjectWithDetectionTime> predicted_object_history_{};
   tf2_ros::Buffer tf_buffer_{get_clock()};
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -146,7 +146,7 @@ private:
   std::shared_ptr<ObstacleStopPlannerDebugNode> debug_ptr_;
   boost::optional<SlowDownSection> latest_slow_down_section_{boost::none};
   std::vector<ObstacleWithDetectionTime> obstacle_history_{};
-        std::vector<PredictedObjectWithDetectionTime> predicted_object_history_{};
+  std::vector<PredictedObjectWithDetectionTime> predicted_object_history_{};
   tf2_ros::Buffer tf_buffer_{get_clock()};
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
@@ -79,6 +79,8 @@ struct NodeParam
 
   // voxel grid z parameter for filtering pointcloud [m]
   double voxel_grid_z;
+
+  bool use_predicted_objects;
 };
 
 struct StopParam
@@ -103,6 +105,9 @@ struct StopParam
   // if any obstacles exist within the detection area, this module plans to stop
   // before the obstacle.
   double lateral_margin;
+  double vehicle_lateral_margin;
+  double pedestrian_lateral_margin;
+  double unknown_lateral_margin;
 
   // =================================
   // params for trajectory pre-process
@@ -152,6 +157,9 @@ struct SlowDownParam
   // lateral margin between the ego's footprint and the boundary of the detection area for slow down
   // obstacles [m]
   double lateral_margin;
+  double vehicle_lateral_margin;
+  double pedestrian_lateral_margin;
+  double unknown_lateral_margin;
 
   // ===================
   // params for velocity

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
@@ -240,6 +240,12 @@ struct PlannerData
 
   pcl::PointXYZ lateral_nearest_slow_down_point;
 
+  Pose nearest_collision_point_pose{};
+
+  Pose nearest_slow_down_point_pose{};
+
+  Pose lateral_nearest_slow_down_point_pose{};
+
   rclcpp::Time nearest_collision_point_time{};
 
   double lateral_deviation{0.0};

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
@@ -81,6 +81,8 @@ struct NodeParam
   double voxel_grid_z;
 
   bool use_predicted_objects;
+
+  bool publish_obstacle_polygon;
 };
 
 struct StopParam

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_utils.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_utils.hpp
@@ -28,6 +28,7 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_array.hpp>
 
 #include <boost/optional.hpp>
 
@@ -45,6 +46,7 @@ using diagnostic_msgs::msg::DiagnosticStatus;
 using diagnostic_msgs::msg::KeyValue;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
+using geometry_msgs::msg::PoseArray;
 using geometry_msgs::msg::TransformStamped;
 using std_msgs::msg::Header;
 
@@ -148,7 +150,25 @@ void getLateralNearestPoint(
   const PointCloud & pointcloud, const Pose & base_pose, pcl::PointXYZ * lateral_nearest_point,
   double * deviation);
 
+void getNearestPointForPredictedObject(
+  const PoseArray & object, const Pose & base_pose, Pose * nearest_collision_point,
+  rclcpp::Time * nearest_collision_point_time);
+
+void getLateralNearestPointForPredictedObject(
+  const PoseArray & object, const Pose & base_pose, Pose * lateral_nearest_point,
+  double * deviation);
+
 Pose getVehicleCenterFromBase(const Pose & base_pose, const VehicleInfo & vehicle_info);
+
+Polygon2d convertPolygonObjectToGeometryPolygon(
+  const Pose & current_pose, const autoware_auto_perception_msgs::msg::Shape & obj_shape);
+
+Polygon2d convertCylindricalObjectToGeometryPolygon(
+  const Pose & current_pose, const autoware_auto_perception_msgs::msg::Shape & obj_shape);
+
+Polygon2d convertBoundingBoxObjectToGeometryPolygon(
+  const Pose & current_pose, const double & base_to_front, const double & base_to_rear,
+  const double & base_to_width);
 
 std::string jsonDumpsPose(const Pose & pose);
 

--- a/planning/obstacle_stop_planner/src/debug_marker.cpp
+++ b/planning/obstacle_stop_planner/src/debug_marker.cpp
@@ -88,6 +88,11 @@ bool ObstacleStopPlannerDebugNode::pushPolygon(
         slow_down_polygons_.push_back(polygon);
       }
       return true;
+    case PolygonType::Obstacle:
+      if (!polygon.empty()) {
+        obstacle_polygons_.push_back(polygon);
+      }
+      return true;
     default:
       return false;
   }
@@ -167,6 +172,7 @@ void ObstacleStopPlannerDebugNode::publish()
   collision_polygons_.clear();
   slow_down_range_polygons_.clear();
   slow_down_polygons_.clear();
+  obstacle_polygons_.clear();
   stop_pose_ptr_ = nullptr;
   target_stop_pose_ptr_ = nullptr;
   slow_down_start_pose_ptr_ = nullptr;
@@ -311,6 +317,29 @@ MarkerArray ObstacleStopPlannerDebugNode::makeVisualizationMarker()
           marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
         } else {
           const auto & p = slow_down_polygons_.at(i).at(j + 1);
+          marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
+        }
+      }
+    }
+    msg.markers.push_back(marker);
+  }
+
+  if (!obstacle_polygons_.empty()) {
+    auto marker = createDefaultMarker(
+      "map", current_time, "obstacle_polygons", 0, Marker::LINE_LIST,
+      createMarkerScale(0.05, 0.0, 0.0), createMarkerColor(1.0, 1.0, 0.0, 0.999));
+
+    for (size_t i = 0; i < obstacle_polygons_.size(); ++i) {
+      for (size_t j = 0; j < obstacle_polygons_.at(i).size(); ++j) {
+        {
+          const auto & p = obstacle_polygons_.at(i).at(j);
+          marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
+        }
+        if (j + 1 == obstacle_polygons_.at(i).size()) {
+          const auto & p = obstacle_polygons_.at(i).at(0);
+          marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
+        } else {
+          const auto & p = obstacle_polygons_.at(i).at(j + 1);
           marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
         }
       }

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -699,13 +699,12 @@ void ObstacleStopPlannerNode::searchObstacle(
             debug_ptr_->pushPolygon(
               one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
             one_step_move_vehicle_polygon.clear();
-            if (node_param_.publish_obstacle_polygon){
+            if (node_param_.publish_obstacle_polygon) {
               std::vector<cv::Point2d> obstacle_polygon;
               for (const auto & point : object_polygon.outer()) {
                 obstacle_polygon.emplace_back(point.x(), point.y());
               }
-              debug_ptr_->pushPolygon(
-                obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
+              debug_ptr_->pushPolygon(obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
             }
             planner_data.stop_require = planner_data.found_collision_points;
             mutex_.lock();
@@ -761,13 +760,12 @@ void ObstacleStopPlannerNode::searchObstacle(
             debug_ptr_->pushPolygon(
               one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
             one_step_move_vehicle_polygon.clear();
-            if (node_param_.publish_obstacle_polygon){
+            if (node_param_.publish_obstacle_polygon) {
               std::vector<cv::Point2d> obstacle_polygon;
               for (const auto & point : object_polygon.outer()) {
                 obstacle_polygon.emplace_back(point.x(), point.y());
               }
-              debug_ptr_->pushPolygon(
-                obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
+              debug_ptr_->pushPolygon(obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
             }
 
             planner_data.stop_require = planner_data.found_collision_points;

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -328,8 +328,499 @@ void ObstacleStopPlannerNode::searchObstacle(
   PlannerData & planner_data, const Header & trajectory_header, const VehicleInfo & vehicle_info,
   const StopParam & stop_param, const PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr)
 {
+  const auto object_ptr = object_ptr_;
   if (node_param_.use_predicted_objects){
-    std::cout << "use_predicted_objects" << std::endl;
+    if (object_ptr->objects.empty()) {
+      return;
+    }
+    const auto now = this->now();
+
+    updateObstacleHistory(now);
+    for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
+      // create one step circle center for vehicle
+      const auto & p_front = decimate_trajectory.at(i).pose;
+      const auto & p_back = decimate_trajectory.at(i + 1).pose;
+      const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
+      const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
+      const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
+      const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
+
+      if (node_param_.enable_slow_down) {
+        for (const auto & obj : object_ptr->objects) {
+          if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+            Polygon2d object_polygon{};
+            object_polygon = convertCylindricalObjectToGeometryPolygon(
+              obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+
+            std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
+            Polygon2d one_step_move_vehicle_polygon2d;
+            // create one step polygon for slow_down range
+            createOneStepPolygon(
+              p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
+              slow_down_param_.pedestrian_lateral_margin);
+            debug_ptr_->pushPolygon(
+              one_step_move_slow_down_range_polygon, p_front.position.z,
+              PolygonType::SlowDownRange);
+            for (const auto & point : one_step_move_slow_down_range_polygon) {
+              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+            }
+            planner_data.found_slow_down_points =
+              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+            const auto found_first_slow_down_points =
+              planner_data.found_slow_down_points && !planner_data.slow_down_require;
+
+            if (found_first_slow_down_points) {
+              // found nearest slow down obstacle
+              planner_data.decimate_trajectory_slow_down_index = i;
+              planner_data.slow_down_require = true;
+              std::vector<Point2d> slow_down_point;
+              geometry_msgs::msg::PoseArray slow_down_points;
+              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, slow_down_point);
+              for (const auto & point : slow_down_point) {
+                geometry_msgs::msg::Pose pose;
+                pose.position.x = point.x();
+                pose.position.y = point.y();
+                slow_down_points.poses.push_back(pose);
+              }
+
+              getNearestPointForPredictedObject(
+                slow_down_points, p_front, &planner_data.nearest_slow_down_point_pose,
+                &planner_data.nearest_collision_point_time);
+
+              getLateralNearestPointForPredictedObject(
+                slow_down_points, p_front, &planner_data.lateral_nearest_slow_down_point_pose,
+                &planner_data.lateral_deviation);
+
+              debug_ptr_->pushObstaclePoint(
+                planner_data.nearest_slow_down_point_pose.position, PointType::SlowDown);
+              debug_ptr_->pushPolygon(
+                one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
+            }
+
+          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+            const double & length_m = obj.shape.dimensions.x / 2;
+            const double & width_m = obj.shape.dimensions.y / 2;
+            Polygon2d object_polygon{};
+            object_polygon = convertBoundingBoxObjectToGeometryPolygon(
+              obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
+
+            std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
+            Polygon2d one_step_move_vehicle_polygon2d;
+            // create one step polygon for slow_down range
+            createOneStepPolygon(
+              p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
+              slow_down_param_.vehicle_lateral_margin);
+            debug_ptr_->pushPolygon(
+              one_step_move_slow_down_range_polygon, p_front.position.z,
+              PolygonType::SlowDownRange);
+            for (const auto & point : one_step_move_slow_down_range_polygon) {
+              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+            }
+            planner_data.found_slow_down_points =
+              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+            const auto found_first_slow_down_points =
+              planner_data.found_slow_down_points && !planner_data.slow_down_require;
+
+            if (found_first_slow_down_points) {
+              // found nearest slow down obstacle
+              planner_data.decimate_trajectory_slow_down_index = i;
+              planner_data.slow_down_require = true;
+              std::vector<Point2d> slow_down_point;
+              geometry_msgs::msg::PoseArray slow_down_points;
+              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, slow_down_point);
+              for (const auto & point : slow_down_point) {
+                geometry_msgs::msg::Pose pose;
+                pose.position.x = point.x();
+                pose.position.y = point.y();
+                slow_down_points.poses.push_back(pose);
+              }
+
+              getNearestPointForPredictedObject(
+                slow_down_points, p_front, &planner_data.nearest_slow_down_point_pose,
+                &planner_data.nearest_collision_point_time);
+
+              getLateralNearestPointForPredictedObject(
+                slow_down_points, p_front, &planner_data.lateral_nearest_slow_down_point_pose,
+                &planner_data.lateral_deviation);
+
+              debug_ptr_->pushObstaclePoint(
+                planner_data.nearest_slow_down_point_pose.position, PointType::SlowDown);
+              debug_ptr_->pushPolygon(
+                one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
+            }
+          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+            Polygon2d object_polygon{};
+            object_polygon = convertPolygonObjectToGeometryPolygon(
+              obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+
+            std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
+            Polygon2d one_step_move_slow_down_range_polygon2d;
+            // create one step polygon for slow_down range
+            createOneStepPolygon(
+              p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
+              slow_down_param_.unknown_lateral_margin);
+            debug_ptr_->pushPolygon(
+              one_step_move_slow_down_range_polygon, p_front.position.z,
+              PolygonType::SlowDownRange);
+
+
+            const auto found_first_slow_down_points =
+              planner_data.found_slow_down_points && !planner_data.slow_down_require;
+
+            if (found_first_slow_down_points) {
+              // found nearest slow down obstacle
+              planner_data.decimate_trajectory_slow_down_index = i;
+              planner_data.slow_down_require = true;
+              std::vector<Point2d> slow_down_point;
+              geometry_msgs::msg::PoseArray slow_down_points;
+              bg::intersection(one_step_move_slow_down_range_polygon2d, object_polygon, slow_down_point);
+              for (const auto & point : slow_down_point) {
+                geometry_msgs::msg::Pose pose;
+                pose.position.x = point.x();
+                pose.position.y = point.y();
+                slow_down_points.poses.push_back(pose);
+              }
+
+              getNearestPointForPredictedObject(
+                slow_down_points, p_front, &planner_data.nearest_slow_down_point_pose,
+                &planner_data.nearest_collision_point_time);
+
+              getLateralNearestPointForPredictedObject(
+                slow_down_points, p_front, &planner_data.lateral_nearest_slow_down_point_pose,
+                &planner_data.lateral_deviation);
+
+              debug_ptr_->pushObstaclePoint(
+                planner_data.nearest_slow_down_point_pose.position, PointType::SlowDown);
+              debug_ptr_->pushPolygon(
+                one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
+            }
+          } else {
+            RCLCPP_WARN_THROTTLE(
+              get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
+              obj.shape.type);
+          }
+        }
+
+      }
+
+      {
+        for (const auto & obj : object_ptr->objects) {
+          if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER){
+            Polygon2d object_polygon{};
+            object_polygon = convertCylindricalObjectToGeometryPolygon(
+              obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+
+            std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+            Polygon2d one_step_move_vehicle_polygon2d;
+            // create one step polygon for vehicle
+            createOneStepPolygon(
+              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.pedestrian_lateral_margin);
+            debug_ptr_->pushPolygon(
+              one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+              PolygonType::Vehicle);
+
+            for (const auto & point : one_step_move_vehicle_polygon) {
+              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+            }
+            const auto found_collision_points =
+              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+            if (found_collision_points) {
+              Pose nearest_collision_point_pose;
+              rclcpp::Time nearest_collision_point_time;
+
+              std::vector<Point2d> collision_point;
+              geometry_msgs::msg::PoseArray collision_points;
+              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+              for (const auto & point : collision_point) {
+                geometry_msgs::msg::Pose pose;
+                pose.position.x = point.x();
+                pose.position.y = point.y();
+                collision_points.poses.push_back(pose);
+              }
+              getNearestPointForPredictedObject(
+                collision_points, p_front, &nearest_collision_point_pose,
+                &nearest_collision_point_time);
+
+              predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
+              break;
+            }
+
+          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX){
+            const double & length_m = obj.shape.dimensions.x / 2;
+            const double & width_m = obj.shape.dimensions.y / 2;
+            Polygon2d object_polygon{};
+            object_polygon = convertBoundingBoxObjectToGeometryPolygon(
+              obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
+
+            std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+            Polygon2d one_step_move_vehicle_polygon2d;
+            // create one step polygon for vehicle
+            createOneStepPolygon(
+              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.pedestrian_lateral_margin);
+            debug_ptr_->pushPolygon(
+              one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+              PolygonType::Vehicle);
+
+            for (const auto & point : one_step_move_vehicle_polygon) {
+              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+            }
+            const auto found_collision_points =
+              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+            if (found_collision_points) {
+              Pose nearest_collision_point_pose;
+              rclcpp::Time nearest_collision_point_time;
+
+              std::vector<Point2d> collision_point;
+              geometry_msgs::msg::PoseArray collision_points;
+              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+              for (const auto & point : collision_point) {
+                geometry_msgs::msg::Pose pose;
+                pose.position.x = point.x();
+                pose.position.y = point.y();
+                collision_points.poses.push_back(pose);
+              }
+              getNearestPointForPredictedObject(
+                collision_points, p_front, &nearest_collision_point_pose,
+                &nearest_collision_point_time);
+
+              predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
+              break;
+            }
+          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON){
+            Polygon2d object_polygon{};
+            object_polygon = convertPolygonObjectToGeometryPolygon(
+              obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+
+            std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+            Polygon2d one_step_move_vehicle_polygon2d;
+            // create one step polygon for vehicle
+            createOneStepPolygon(
+              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.pedestrian_lateral_margin);
+            debug_ptr_->pushPolygon(
+              one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+              PolygonType::Vehicle);
+
+            for (const auto & point : one_step_move_vehicle_polygon) {
+              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+            }
+            const auto found_collision_points =
+              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+            if (found_collision_points) {
+              Pose nearest_collision_point_pose;
+              rclcpp::Time nearest_collision_point_time;
+
+              std::vector<Point2d> collision_point;
+              geometry_msgs::msg::PoseArray collision_points;
+              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+              for (const auto & point : collision_point) {
+                geometry_msgs::msg::Pose pose;
+                pose.position.x = point.x();
+                pose.position.y = point.y();
+                collision_points.poses.push_back(pose);
+              }
+              getNearestPointForPredictedObject(
+                collision_points, p_front, &nearest_collision_point_pose,
+                &nearest_collision_point_time);
+
+              predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
+              break;
+            }
+          } else {
+            RCLCPP_WARN_THROTTLE(
+              get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
+              obj.shape.type);
+          }
+        }
+      }
+    }
+    for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
+      // create one step circle center for vehicle
+      const auto & p_front = decimate_trajectory.at(i).pose;
+      const auto & p_back = decimate_trajectory.at(i + 1).pose;
+      const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
+      const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
+      const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
+      const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
+      for (const auto & obj : object_ptr->objects) {
+        if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+          Polygon2d object_polygon{};
+          object_polygon = convertCylindricalObjectToGeometryPolygon(
+            obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+
+          std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+          Polygon2d one_step_move_vehicle_polygon2d;
+          // create one step polygon for vehicle
+          createOneStepPolygon(
+            p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+            stop_param.pedestrian_lateral_margin);
+          debug_ptr_->pushPolygon(
+            one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+            PolygonType::Vehicle);
+
+          for (const auto & point : one_step_move_vehicle_polygon) {
+            one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+          }
+          // check new collision points
+          planner_data.found_collision_points =
+            bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+          if (planner_data.found_collision_points) {
+            planner_data.decimate_trajectory_collision_index = i;
+            rclcpp::Time nearest_collision_point_time;
+
+            std::vector<Point2d> collision_point;
+            geometry_msgs::msg::PoseArray collision_points;
+            bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+
+            for (const auto & point : collision_point) {
+              geometry_msgs::msg::Pose pose;
+              pose.position.x = point.x();
+              pose.position.y = point.y();
+              collision_points.poses.push_back(pose);
+              std::cout << "collision point x: " << point.x() << " y: " << point.y() << std::endl;
+            }
+            getNearestPointForPredictedObject(
+              collision_points, p_front, &planner_data.nearest_collision_point_pose,
+              &nearest_collision_point_time);
+
+
+            std::cout << "nearest point x: " << planner_data.nearest_collision_point_pose.position.x << " y: " << planner_data.nearest_collision_point_pose.position.y << std::endl;
+
+
+            debug_ptr_->pushObstaclePoint(
+              planner_data.nearest_collision_point_pose.position, PointType::Stop);
+            debug_ptr_->pushPolygon(
+              one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
+            planner_data.stop_require = planner_data.found_collision_points;
+            mutex_.lock();
+            const auto current_odometry_ptr = current_odometry_ptr_;
+            mutex_.unlock();
+            if (!planner_data.stop_require) {
+              predicted_object_history_.clear();
+            }
+
+            break;
+          }
+        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX){
+          const double & length_m = obj.shape.dimensions.x / 2;
+          const double & width_m = obj.shape.dimensions.y / 2;
+          Polygon2d object_polygon{};
+          object_polygon = convertBoundingBoxObjectToGeometryPolygon(
+            obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
+
+          std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+          Polygon2d one_step_move_vehicle_polygon2d;
+          // create one step polygon for vehicle
+          createOneStepPolygon(
+            p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+            stop_param.vehicle_lateral_margin);
+          debug_ptr_->pushPolygon(
+            one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+            PolygonType::Vehicle);
+
+          for (const auto & point : one_step_move_vehicle_polygon) {
+            one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+          }
+          // check new collision points
+          planner_data.found_collision_points =
+            bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+          if (planner_data.found_collision_points) {
+            planner_data.decimate_trajectory_collision_index = i;
+            rclcpp::Time nearest_collision_point_time;
+
+            std::vector<Point2d> collision_point;
+            geometry_msgs::msg::PoseArray collision_points;
+            bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+            for (const auto & point : collision_point) {
+              geometry_msgs::msg::Pose pose;
+              pose.position.x = point.x();
+              pose.position.y = point.y();
+              collision_points.poses.push_back(pose);
+            }
+            getNearestPointForPredictedObject(
+              collision_points, p_front, &planner_data.nearest_collision_point_pose,
+              &nearest_collision_point_time);
+
+            debug_ptr_->pushObstaclePoint(
+              planner_data.nearest_collision_point_pose.position, PointType::Stop);
+            debug_ptr_->pushPolygon(
+              one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
+            planner_data.stop_require = planner_data.found_collision_points;
+            mutex_.lock();
+            const auto current_odometry_ptr = current_odometry_ptr_;
+            mutex_.unlock();
+            if (!planner_data.stop_require) {
+              predicted_object_history_.clear();
+            }
+
+            break;
+          }
+        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON){
+          Polygon2d object_polygon{};
+          object_polygon = convertPolygonObjectToGeometryPolygon(
+            obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+
+          std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+          Polygon2d one_step_move_vehicle_polygon2d;
+          // create one step polygon for vehicle
+          createOneStepPolygon(
+            p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+            stop_param.unknown_lateral_margin);
+          debug_ptr_->pushPolygon(
+            one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+            PolygonType::Vehicle);
+
+          for (const auto & point : one_step_move_vehicle_polygon) {
+            one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+          }
+          // check new collision points
+          planner_data.found_collision_points =
+            bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+          if (planner_data.found_collision_points) {
+            planner_data.decimate_trajectory_collision_index = i;
+            rclcpp::Time nearest_collision_point_time;
+
+            std::vector<Point2d> collision_point;
+            geometry_msgs::msg::PoseArray collision_points;
+            bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+            for (const auto & point : collision_point) {
+              geometry_msgs::msg::Pose pose;
+              pose.position.x = point.x();
+              pose.position.y = point.y();
+              collision_points.poses.push_back(pose);
+            }
+            getNearestPointForPredictedObject(
+              collision_points, p_front, &planner_data.nearest_collision_point_pose,
+              &nearest_collision_point_time);
+
+            debug_ptr_->pushObstaclePoint(
+              planner_data.nearest_collision_point_pose.position, PointType::Stop);
+            debug_ptr_->pushPolygon(
+              one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
+            planner_data.stop_require = planner_data.found_collision_points;
+            mutex_.lock();
+            const auto current_odometry_ptr = current_odometry_ptr_;
+            mutex_.unlock();
+            if (!planner_data.stop_require) {
+              predicted_object_history_.clear();
+            }
+
+            break;
+          }
+        } else {
+          RCLCPP_WARN_THROTTLE(
+            get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
+            obj.shape.type);
+        }
+      }
+    }
   } else {
     // search candidate obstacle pointcloud
     PointCloud::Ptr slow_down_pointcloud_ptr(new PointCloud);
@@ -459,7 +950,6 @@ void ObstacleStopPlannerNode::searchObstacle(
         planner_data.stop_require = planner_data.found_collision_points;
 
         mutex_.lock();
-        const auto object_ptr = object_ptr_;
         const auto current_odometry_ptr = current_odometry_ptr_;
         mutex_.unlock();
 
@@ -492,10 +982,18 @@ void ObstacleStopPlannerNode::insertVelocity(
     const auto idx = planner_data.decimate_trajectory_index_map.at(
                        planner_data.decimate_trajectory_collision_index) +
                      planner_data.trajectory_trim_index;
-    const auto index_with_dist_remain = findNearestFrontIndex(
-      std::min(idx, traj_end_idx), output,
-      createPoint(
-        planner_data.nearest_collision_point.x, planner_data.nearest_collision_point.y, 0));
+    boost::optional<std::pair<size_t, double>> index_with_dist_remain;
+    if (node_param_.use_predicted_objects) {
+      index_with_dist_remain = findNearestFrontIndex(
+        std::min(idx, traj_end_idx), output,
+        createPoint(
+          planner_data.nearest_collision_point_pose.position.x, planner_data.nearest_collision_point_pose.position.y, 0));
+    } else {
+      index_with_dist_remain = findNearestFrontIndex(
+        std::min(idx, traj_end_idx), output,
+        createPoint(
+          planner_data.nearest_collision_point.x, planner_data.nearest_collision_point.y, 0));
+    }
 
     if (index_with_dist_remain) {
       const auto vehicle_idx = std::min(planner_data.trajectory_trim_index, traj_end_idx);
@@ -608,11 +1106,37 @@ void ObstacleStopPlannerNode::insertVelocity(
       const auto end_insert_point_with_idx = getBackwardInsertPointFromBasePoint(
         index_with_dist_remain.get().first, output, -index_with_dist_remain.get().second);
 
-      const auto slow_down_velocity =
-        slow_down_param_.min_slow_down_velocity +
-        (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-          std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-          slow_down_param_.lateral_margin;
+      double slow_down_velocity;
+      if (node_param_.use_predicted_objects){
+        for (const auto & obj : object_ptr_->objects) {
+          if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER){
+            slow_down_velocity = slow_down_param_.min_slow_down_velocity +
+                                 (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
+                                   std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+                                   slow_down_param_.pedestrian_lateral_margin;
+          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+            slow_down_velocity = slow_down_param_.min_slow_down_velocity +
+                                 (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
+                                   std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+                                   slow_down_param_.vehicle_lateral_margin;
+          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+            slow_down_velocity = slow_down_param_.min_slow_down_velocity +
+                                 (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
+                                   std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+                                   slow_down_param_.unknown_lateral_margin;
+          } else {
+            RCLCPP_WARN_THROTTLE(
+              get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
+              obj.shape.type);
+          }
+        }
+      } else {
+        slow_down_velocity =
+          slow_down_param_.min_slow_down_velocity +
+          (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
+            std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+            slow_down_param_.lateral_margin;
+      }
 
       const auto target_velocity = slow_down_param_.consider_constraints
                                      ? slow_down_param_.slow_down_velocity

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -248,10 +248,10 @@ void ObstacleStopPlannerNode::onTrigger(const Trajectory::ConstSharedPtr input_m
 
   {
     const auto waiting = [this](const auto & str) {
-        RCLCPP_WARN_THROTTLE(
-          get_logger(), *get_clock(), std::chrono::milliseconds(5000).count(), "waiting for %s ...",
-          str);
-      };
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), std::chrono::milliseconds(5000).count(), "waiting for %s ...",
+        str);
+    };
 
     if (!object_ptr) {
       waiting("perception object");
@@ -309,9 +309,8 @@ void ObstacleStopPlannerNode::onTrigger(const Trajectory::ConstSharedPtr input_m
   const auto decimate_trajectory = decimateTrajectory(
     extend_trajectory, stop_param.step_length, planner_data.decimate_trajectory_index_map);
 
-  if(node_param_.use_predicted_objects){
-    searchPredictedObject(decimate_trajectory, planner_data,
-                          vehicle_info, stop_param);
+  if (node_param_.use_predicted_objects) {
+    searchPredictedObject(decimate_trajectory, planner_data, vehicle_info, stop_param);
   } else {
     // search obstacles within slow-down/collision area
     searchObstacle(
@@ -346,9 +345,8 @@ void ObstacleStopPlannerNode::searchObstacle(
   PointCloud::Ptr slow_down_pointcloud_ptr(new PointCloud);
   PointCloud::Ptr obstacle_candidate_pointcloud_ptr(new PointCloud);
   if (!searchPointcloudNearTrajectory(
-      decimate_trajectory, obstacle_ros_pointcloud_ptr, obstacle_candidate_pointcloud_ptr,
-      trajectory_header, vehicle_info, stop_param))
-  {
+        decimate_trajectory, obstacle_ros_pointcloud_ptr, obstacle_candidate_pointcloud_ptr,
+        trajectory_header, vehicle_info, stop_param)) {
     return;
   }
 
@@ -523,8 +521,7 @@ void ObstacleStopPlannerNode::searchPredictedObject(
             p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
             slow_down_param_.pedestrian_lateral_margin);
           debug_ptr_->pushPolygon(
-            one_step_move_slow_down_range_polygon, p_front.position.z,
-            PolygonType::SlowDownRange);
+            one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDownRange);
           for (const auto & point : one_step_move_slow_down_range_polygon) {
             one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
           }
@@ -576,8 +573,7 @@ void ObstacleStopPlannerNode::searchPredictedObject(
             p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
             slow_down_param_.vehicle_lateral_margin);
           debug_ptr_->pushPolygon(
-            one_step_move_slow_down_range_polygon, p_front.position.z,
-            PolygonType::SlowDownRange);
+            one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDownRange);
           for (const auto & point : one_step_move_slow_down_range_polygon) {
             one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
           }
@@ -626,8 +622,7 @@ void ObstacleStopPlannerNode::searchPredictedObject(
             p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
             slow_down_param_.unknown_lateral_margin);
           debug_ptr_->pushPolygon(
-            one_step_move_slow_down_range_polygon, p_front.position.z,
-            PolygonType::SlowDownRange);
+            one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDownRange);
 
           const auto found_first_slow_down_points =
             planner_data.found_slow_down_points && !planner_data.slow_down_require;
@@ -1015,8 +1010,8 @@ void ObstacleStopPlannerNode::insertVelocity(
     // insert stop point
     const auto traj_end_idx = output.size() - 1;
     const auto idx = planner_data.decimate_trajectory_index_map.at(
-      planner_data.decimate_trajectory_collision_index) +
-      planner_data.trajectory_trim_index;
+                       planner_data.decimate_trajectory_collision_index) +
+                     planner_data.trajectory_trim_index;
     boost::optional<std::pair<size_t, double>> index_with_dist_remain;
     if (node_param_.use_predicted_objects) {
       index_with_dist_remain = findNearestFrontIndex(
@@ -1050,22 +1045,22 @@ void ObstacleStopPlannerNode::insertVelocity(
         node_param_.ego_nearest_yaw_threshold);
 
       const double stop_point_distance = [&]() {
-          if (output.size() < 2) {
-            return 0.0;
-          }
+        if (output.size() < 2) {
+          return 0.0;
+        }
 
-          size_t stop_seg_idx = 0;
-          const double lon_offset =
-            calcLongitudinalOffsetToSegment(output, stop_point.index, getPoint(stop_point.point));
-          if (lon_offset < 0) {
-            stop_seg_idx = std::max(static_cast<size_t>(0), stop_point.index - 1);
-          } else {
-            stop_seg_idx = std::min(output.size() - 2, stop_point.index);
-          }
+        size_t stop_seg_idx = 0;
+        const double lon_offset =
+          calcLongitudinalOffsetToSegment(output, stop_point.index, getPoint(stop_point.point));
+        if (lon_offset < 0) {
+          stop_seg_idx = std::max(static_cast<size_t>(0), stop_point.index - 1);
+        } else {
+          stop_seg_idx = std::min(output.size() - 2, stop_point.index);
+        }
 
-          return calcSignedArcLength(
-            output, ego_pose.position, ego_seg_idx, getPoint(stop_point.point), stop_seg_idx);
-        }();
+        return calcSignedArcLength(
+          output, ego_pose.position, ego_seg_idx, getPoint(stop_point.point), stop_seg_idx);
+      }();
       const auto is_stopped = current_vel < 0.01;
 
       const auto & ego_pos = planner_data.current_pose.position;
@@ -1120,8 +1115,7 @@ void ObstacleStopPlannerNode::insertVelocity(
       if (
         !latest_slow_down_section_ &&
         dist_baselink_to_obstacle + index_with_dist_remain.get().second <
-        vehicle_info.max_longitudinal_offset_m)
-      {
+          vehicle_info.max_longitudinal_offset_m) {
         latest_slow_down_section_ = slow_down_section;
       }
 
@@ -1150,20 +1144,20 @@ void ObstacleStopPlannerNode::insertVelocity(
             slow_down_velocity =
               slow_down_param_.min_slow_down_velocity +
               (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-              std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-              slow_down_param_.pedestrian_lateral_margin;
+                std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+                slow_down_param_.pedestrian_lateral_margin;
           } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
             slow_down_velocity =
               slow_down_param_.min_slow_down_velocity +
               (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-              std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-              slow_down_param_.vehicle_lateral_margin;
+                std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+                slow_down_param_.vehicle_lateral_margin;
           } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
             slow_down_velocity =
               slow_down_param_.min_slow_down_velocity +
               (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-              std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-              slow_down_param_.unknown_lateral_margin;
+                std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+                slow_down_param_.unknown_lateral_margin;
           } else {
             RCLCPP_WARN_THROTTLE(
               get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
@@ -1174,13 +1168,13 @@ void ObstacleStopPlannerNode::insertVelocity(
         slow_down_velocity =
           slow_down_param_.min_slow_down_velocity +
           (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-          std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-          slow_down_param_.lateral_margin;
+            std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+            slow_down_param_.lateral_margin;
       }
 
-      const auto target_velocity = slow_down_param_.consider_constraints ?
-        slow_down_param_.slow_down_velocity :
-        slow_down_velocity;
+      const auto target_velocity = slow_down_param_.consider_constraints
+                                     ? slow_down_param_.slow_down_velocity
+                                     : slow_down_velocity;
 
       SlowDownSection slow_down_section{};
       slow_down_section.slow_down_start_idx = 0;
@@ -1292,8 +1286,8 @@ SlowDownSection ObstacleStopPlannerNode::createSlowDownSection(
     const auto use_velocity_limit = relax_target_vel || set_velocity_limit_;
 
     const auto update_forward_margin_from_vehicle =
-      use_velocity_limit ? slow_down_param_.min_longitudinal_forward_margin - dist_remain :
-      margin_with_vel.get().first - dist_remain;
+      use_velocity_limit ? slow_down_param_.min_longitudinal_forward_margin - dist_remain
+                         : margin_with_vel.get().first - dist_remain;
     const auto update_backward_margin_from_vehicle =
       slow_down_param_.longitudinal_backward_margin + dist_remain;
 
@@ -1312,8 +1306,8 @@ SlowDownSection ObstacleStopPlannerNode::createSlowDownSection(
     const auto velocity =
       slow_down_param_.min_slow_down_velocity +
       (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-      std::max(lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-      slow_down_param_.lateral_margin;
+        std::max(lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+        slow_down_param_.lateral_margin;
 
     return createSlowDownSectionFromMargin(
       idx, base_trajectory, update_forward_margin_from_vehicle, update_backward_margin_from_vehicle,
@@ -1378,8 +1372,7 @@ void ObstacleStopPlannerNode::insertSlowDownSection(
 
   if (
     !is_start_p_base_and_p_insert_overlap && !is_start_p_next_and_p_insert_overlap &&
-    is_valid_index_start)
-  {
+    is_valid_index_start) {
     // insert: start_idx and end_idx are shifted by one
     output.insert(output.begin() + start_idx + 1, p_insert_start);
     update_start_idx = std::min(update_start_idx + 1, traj_end_idx);
@@ -1398,8 +1391,7 @@ void ObstacleStopPlannerNode::insertSlowDownSection(
 
   if (
     !is_end_p_base_and_p_insert_overlap && !is_end_p_next_and_p_insert_overlap &&
-    is_valid_index_end)
-  {
+    is_valid_index_end) {
     // insert: end_idx is shifted by one
     output.insert(output.begin() + update_end_idx + 1, p_insert_end);
     update_end_idx = std::min(update_end_idx + 1, traj_end_idx);
@@ -1483,9 +1475,9 @@ bool ObstacleStopPlannerNode::searchPointcloudNearTrajectory(
   output_points_ptr->header = transformed_points_ptr->header;
 
   // search obstacle candidate pointcloud to reduce calculation cost
-  const double search_radius = node_param_.enable_slow_down ?
-    slow_down_param_.slow_down_search_radius :
-    stop_param.stop_search_radius;
+  const double search_radius = node_param_.enable_slow_down
+                                 ? slow_down_param_.slow_down_search_radius
+                                 : stop_param.stop_search_radius;
   const double squared_radius = search_radius * search_radius;
   std::vector<geometry_msgs::msg::Point> center_points;
   center_points.reserve(trajectory.size());
@@ -1531,7 +1523,7 @@ void ObstacleStopPlannerNode::resetExternalVelocityLimit(
   const double current_acc, const double current_vel)
 {
   const auto reach_target_vel = current_vel < slow_down_param_.slow_down_velocity +
-    slow_down_param_.velocity_threshold_decel_complete;
+                                                slow_down_param_.velocity_threshold_decel_complete;
   const auto constant_vel =
     std::abs(current_acc) < slow_down_param_.acceleration_threshold_decel_complete;
   const auto no_undershoot = reach_target_vel && constant_vel;

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -88,9 +88,12 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
 
     // params for detection area
     p.lateral_margin = declare_parameter<double>(ns + "detection_area.lateral_margin");
-    p.vehicle_lateral_margin = declare_parameter<double>(ns + "detection_area.vehicle_lateral_margin");
-    p.pedestrian_lateral_margin = declare_parameter<double>(ns + "detection_area.pedestrian_lateral_margin");
-    p.unknown_lateral_margin = declare_parameter<double>(ns + "detection_area.unknown_lateral_margin");
+    p.vehicle_lateral_margin =
+      declare_parameter<double>(ns + "detection_area.vehicle_lateral_margin");
+    p.pedestrian_lateral_margin =
+      declare_parameter<double>(ns + "detection_area.pedestrian_lateral_margin");
+    p.unknown_lateral_margin =
+      declare_parameter<double>(ns + "detection_area.unknown_lateral_margin");
     p.extend_distance = declare_parameter<double>(ns + "detection_area.extend_distance");
     p.step_length = declare_parameter<double>(ns + "detection_area.step_length");
 
@@ -124,9 +127,12 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
 
     // params for detection area
     p.lateral_margin = declare_parameter<double>(ns + "detection_area.lateral_margin");
-    p.vehicle_lateral_margin = declare_parameter<double>(ns + "detection_area.vehicle_lateral_margin");
-    p.pedestrian_lateral_margin = declare_parameter<double>(ns + "detection_area.pedestrian_lateral_margin");
-    p.unknown_lateral_margin = declare_parameter<double>(ns + "detection_area.unknown_lateral_margin");
+    p.vehicle_lateral_margin =
+      declare_parameter<double>(ns + "detection_area.vehicle_lateral_margin");
+    p.pedestrian_lateral_margin =
+      declare_parameter<double>(ns + "detection_area.pedestrian_lateral_margin");
+    p.unknown_lateral_margin =
+      declare_parameter<double>(ns + "detection_area.unknown_lateral_margin");
 
     // params for target velocity
     p.max_slow_down_velocity =
@@ -329,7 +335,7 @@ void ObstacleStopPlannerNode::searchObstacle(
   const StopParam & stop_param, const PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr)
 {
   const auto object_ptr = object_ptr_;
-  if (node_param_.use_predicted_objects){
+  if (node_param_.use_predicted_objects) {
     if (object_ptr->objects.empty()) {
       return;
     }
@@ -465,7 +471,6 @@ void ObstacleStopPlannerNode::searchObstacle(
               one_step_move_slow_down_range_polygon, p_front.position.z,
               PolygonType::SlowDownRange);
 
-
             const auto found_first_slow_down_points =
               planner_data.found_slow_down_points && !planner_data.slow_down_require;
 
@@ -475,7 +480,8 @@ void ObstacleStopPlannerNode::searchObstacle(
               planner_data.slow_down_require = true;
               std::vector<Point2d> slow_down_point;
               geometry_msgs::msg::PoseArray slow_down_points;
-              bg::intersection(one_step_move_slow_down_range_polygon2d, object_polygon, slow_down_point);
+              bg::intersection(
+                one_step_move_slow_down_range_polygon2d, object_polygon, slow_down_point);
               for (const auto & point : slow_down_point) {
                 geometry_msgs::msg::Pose pose;
                 pose.position.x = point.x();
@@ -502,12 +508,11 @@ void ObstacleStopPlannerNode::searchObstacle(
               obj.shape.type);
           }
         }
-
       }
 
       {
         for (const auto & obj : object_ptr->objects) {
-          if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER){
+          if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
             Polygon2d object_polygon{};
             object_polygon = convertCylindricalObjectToGeometryPolygon(
               obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
@@ -516,7 +521,8 @@ void ObstacleStopPlannerNode::searchObstacle(
             Polygon2d one_step_move_vehicle_polygon2d;
             // create one step polygon for vehicle
             createOneStepPolygon(
-              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.pedestrian_lateral_margin);
+              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+              stop_param.pedestrian_lateral_margin);
             debug_ptr_->pushPolygon(
               one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
               PolygonType::Vehicle);
@@ -548,7 +554,7 @@ void ObstacleStopPlannerNode::searchObstacle(
               break;
             }
 
-          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX){
+          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
             const double & length_m = obj.shape.dimensions.x / 2;
             const double & width_m = obj.shape.dimensions.y / 2;
             Polygon2d object_polygon{};
@@ -559,7 +565,8 @@ void ObstacleStopPlannerNode::searchObstacle(
             Polygon2d one_step_move_vehicle_polygon2d;
             // create one step polygon for vehicle
             createOneStepPolygon(
-              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.pedestrian_lateral_margin);
+              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+              stop_param.pedestrian_lateral_margin);
             debug_ptr_->pushPolygon(
               one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
               PolygonType::Vehicle);
@@ -590,7 +597,7 @@ void ObstacleStopPlannerNode::searchObstacle(
               predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
               break;
             }
-          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON){
+          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
             Polygon2d object_polygon{};
             object_polygon = convertPolygonObjectToGeometryPolygon(
               obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
@@ -599,7 +606,8 @@ void ObstacleStopPlannerNode::searchObstacle(
             Polygon2d one_step_move_vehicle_polygon2d;
             // create one step polygon for vehicle
             createOneStepPolygon(
-              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.pedestrian_lateral_margin);
+              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+              stop_param.pedestrian_lateral_margin);
             debug_ptr_->pushPolygon(
               one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
               PolygonType::Vehicle);
@@ -688,9 +696,9 @@ void ObstacleStopPlannerNode::searchObstacle(
               collision_points, p_front, &planner_data.nearest_collision_point_pose,
               &nearest_collision_point_time);
 
-
-            std::cout << "nearest point x: " << planner_data.nearest_collision_point_pose.position.x << " y: " << planner_data.nearest_collision_point_pose.position.y << std::endl;
-
+            std::cout << "nearest point x: " << planner_data.nearest_collision_point_pose.position.x
+                      << " y: " << planner_data.nearest_collision_point_pose.position.y
+                      << std::endl;
 
             debug_ptr_->pushObstaclePoint(
               planner_data.nearest_collision_point_pose.position, PointType::Stop);
@@ -706,7 +714,7 @@ void ObstacleStopPlannerNode::searchObstacle(
 
             break;
           }
-        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX){
+        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
           const double & length_m = obj.shape.dimensions.x / 2;
           const double & width_m = obj.shape.dimensions.y / 2;
           Polygon2d object_polygon{};
@@ -761,7 +769,7 @@ void ObstacleStopPlannerNode::searchObstacle(
 
             break;
           }
-        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON){
+        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
           Polygon2d object_polygon{};
           object_polygon = convertPolygonObjectToGeometryPolygon(
             obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
@@ -987,7 +995,8 @@ void ObstacleStopPlannerNode::insertVelocity(
       index_with_dist_remain = findNearestFrontIndex(
         std::min(idx, traj_end_idx), output,
         createPoint(
-          planner_data.nearest_collision_point_pose.position.x, planner_data.nearest_collision_point_pose.position.y, 0));
+          planner_data.nearest_collision_point_pose.position.x,
+          planner_data.nearest_collision_point_pose.position.y, 0));
     } else {
       index_with_dist_remain = findNearestFrontIndex(
         std::min(idx, traj_end_idx), output,
@@ -1107,23 +1116,26 @@ void ObstacleStopPlannerNode::insertVelocity(
         index_with_dist_remain.get().first, output, -index_with_dist_remain.get().second);
 
       double slow_down_velocity;
-      if (node_param_.use_predicted_objects){
+      if (node_param_.use_predicted_objects) {
         for (const auto & obj : object_ptr_->objects) {
-          if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER){
-            slow_down_velocity = slow_down_param_.min_slow_down_velocity +
-                                 (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-                                   std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-                                   slow_down_param_.pedestrian_lateral_margin;
+          if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+            slow_down_velocity =
+              slow_down_param_.min_slow_down_velocity +
+              (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
+                std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+                slow_down_param_.pedestrian_lateral_margin;
           } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-            slow_down_velocity = slow_down_param_.min_slow_down_velocity +
-                                 (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-                                   std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-                                   slow_down_param_.vehicle_lateral_margin;
+            slow_down_velocity =
+              slow_down_param_.min_slow_down_velocity +
+              (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
+                std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+                slow_down_param_.vehicle_lateral_margin;
           } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
-            slow_down_velocity = slow_down_param_.min_slow_down_velocity +
-                                 (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-                                   std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-                                   slow_down_param_.unknown_lateral_margin;
+            slow_down_velocity =
+              slow_down_param_.min_slow_down_velocity +
+              (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
+                std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+                slow_down_param_.unknown_lateral_margin;
           } else {
             RCLCPP_WARN_THROTTLE(
               get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -72,6 +72,7 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
     p.voxel_grid_y = declare_parameter("voxel_grid_y", 0.05);
     p.voxel_grid_z = declare_parameter("voxel_grid_z", 100000.0);
     p.use_predicted_objects = declare_parameter<bool>("use_predicted_objects");
+    p.publish_obstacle_polygon = declare_parameter<bool>("publish_obstacle_polygon");
   }
 
   {
@@ -704,6 +705,15 @@ void ObstacleStopPlannerNode::searchObstacle(
               planner_data.nearest_collision_point_pose.position, PointType::Stop);
             debug_ptr_->pushPolygon(
               one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
+            one_step_move_vehicle_polygon.clear();
+            if (node_param_.publish_obstacle_polygon){
+              std::vector<cv::Point2d> obstacle_polygon;
+              for (const auto & point : object_polygon.outer()) {
+                obstacle_polygon.emplace_back(point.x(), point.y());
+              }
+              debug_ptr_->pushPolygon(
+                obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
+            }
             planner_data.stop_require = planner_data.found_collision_points;
             mutex_.lock();
             const auto current_odometry_ptr = current_odometry_ptr_;
@@ -759,6 +769,16 @@ void ObstacleStopPlannerNode::searchObstacle(
               planner_data.nearest_collision_point_pose.position, PointType::Stop);
             debug_ptr_->pushPolygon(
               one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
+            one_step_move_vehicle_polygon.clear();
+            if (node_param_.publish_obstacle_polygon){
+              std::vector<cv::Point2d> obstacle_polygon;
+              for (const auto & point : object_polygon.outer()) {
+                obstacle_polygon.emplace_back(point.x(), point.y());
+              }
+              debug_ptr_->pushPolygon(
+                obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
+            }
+
             planner_data.stop_require = planner_data.found_collision_points;
             mutex_.lock();
             const auto current_odometry_ptr = current_odometry_ptr_;
@@ -812,6 +832,14 @@ void ObstacleStopPlannerNode::searchObstacle(
               planner_data.nearest_collision_point_pose.position, PointType::Stop);
             debug_ptr_->pushPolygon(
               one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
+            one_step_move_vehicle_polygon.clear();
+            if (node_param_.publish_obstacle_polygon) {
+              std::vector<cv::Point2d> obstacle_polygon;
+              for (const auto & point : object_polygon.outer()) {
+                obstacle_polygon.emplace_back(point.x(), point.y());
+              }
+              debug_ptr_->pushPolygon(obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
+            }
             planner_data.stop_require = planner_data.found_collision_points;
             mutex_.lock();
             const auto current_odometry_ptr = current_odometry_ptr_;

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -248,10 +248,10 @@ void ObstacleStopPlannerNode::onTrigger(const Trajectory::ConstSharedPtr input_m
 
   {
     const auto waiting = [this](const auto & str) {
-      RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), std::chrono::milliseconds(5000).count(), "waiting for %s ...",
-        str);
-    };
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), std::chrono::milliseconds(5000).count(), "waiting for %s ...",
+          str);
+      };
 
     if (!object_ptr) {
       waiting("perception object");
@@ -309,10 +309,16 @@ void ObstacleStopPlannerNode::onTrigger(const Trajectory::ConstSharedPtr input_m
   const auto decimate_trajectory = decimateTrajectory(
     extend_trajectory, stop_param.step_length, planner_data.decimate_trajectory_index_map);
 
-  // search obstacles within slow-down/collision area
-  searchObstacle(
-    decimate_trajectory, output_trajectory_points, planner_data, input_msg->header, vehicle_info,
-    stop_param, obstacle_ros_pointcloud_ptr);
+  if(node_param_.use_predicted_objects){
+    searchPredictedObject(decimate_trajectory, planner_data,
+                          vehicle_info, stop_param);
+  } else {
+    // search obstacles within slow-down/collision area
+    searchObstacle(
+      decimate_trajectory, output_trajectory_points, planner_data, input_msg->header, vehicle_info,
+      stop_param, obstacle_ros_pointcloud_ptr);
+  }
+
   // insert slow-down-section/stop-point
   insertVelocity(
     output_trajectory_points, planner_data, input_msg->header, vehicle_info, current_acc,
@@ -336,324 +342,333 @@ void ObstacleStopPlannerNode::searchObstacle(
   const StopParam & stop_param, const PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr)
 {
   const auto object_ptr = object_ptr_;
-  if (node_param_.use_predicted_objects) {
-    if (object_ptr->objects.empty()) {
-      return;
-    }
-    const auto now = this->now();
+  // search candidate obstacle pointcloud
+  PointCloud::Ptr slow_down_pointcloud_ptr(new PointCloud);
+  PointCloud::Ptr obstacle_candidate_pointcloud_ptr(new PointCloud);
+  if (!searchPointcloudNearTrajectory(
+      decimate_trajectory, obstacle_ros_pointcloud_ptr, obstacle_candidate_pointcloud_ptr,
+      trajectory_header, vehicle_info, stop_param))
+  {
+    return;
+  }
 
-    updatePredictedObstacleHistory(now);
-    for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
-      // create one step circle center for vehicle
-      const auto & p_front = decimate_trajectory.at(i).pose;
-      const auto & p_back = decimate_trajectory.at(i + 1).pose;
-      const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
-      const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
-      const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
-      const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
+  const auto now = this->now();
 
-      if (node_param_.enable_slow_down) {
-        for (const auto & obj : object_ptr->objects) {
-          if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
-            Polygon2d object_polygon{};
-            object_polygon = convertCylindricalObjectToGeometryPolygon(
-              obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+  updateObstacleHistory(now);
 
-            std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
-            Polygon2d one_step_move_vehicle_polygon2d;
-            // create one step polygon for slow_down range
-            createOneStepPolygon(
-              p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
-              slow_down_param_.pedestrian_lateral_margin);
-            debug_ptr_->pushPolygon(
-              one_step_move_slow_down_range_polygon, p_front.position.z,
-              PolygonType::SlowDownRange);
-            for (const auto & point : one_step_move_slow_down_range_polygon) {
-              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
-            }
-            planner_data.found_slow_down_points =
-              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+  for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
+    // create one step circle center for vehicle
+    const auto & p_front = decimate_trajectory.at(i).pose;
+    const auto & p_back = decimate_trajectory.at(i + 1).pose;
+    const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
+    const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
+    const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
+    const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
 
-            const auto found_first_slow_down_points =
-              planner_data.found_slow_down_points && !planner_data.slow_down_require;
+    if (node_param_.enable_slow_down) {
+      std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
+      // create one step polygon for slow_down range
+      createOneStepPolygon(
+        p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
+        slow_down_param_.lateral_margin);
+      debug_ptr_->pushPolygon(
+        one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDownRange);
 
-            if (found_first_slow_down_points) {
-              // found nearest slow down obstacle
-              planner_data.decimate_trajectory_slow_down_index = i;
-              planner_data.slow_down_require = true;
-              std::vector<Point2d> slow_down_point;
-              geometry_msgs::msg::PoseArray slow_down_points;
-              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, slow_down_point);
-              for (const auto & point : slow_down_point) {
-                geometry_msgs::msg::Pose pose;
-                pose.position.x = point.x();
-                pose.position.y = point.y();
-                slow_down_points.poses.push_back(pose);
-              }
+      planner_data.found_slow_down_points = withinPolygon(
+        one_step_move_slow_down_range_polygon, slow_down_param_.slow_down_search_radius,
+        prev_center_point, next_center_point, obstacle_candidate_pointcloud_ptr,
+        slow_down_pointcloud_ptr);
 
-              getNearestPointForPredictedObject(
-                slow_down_points, p_front, &planner_data.nearest_slow_down_point_pose,
-                &planner_data.nearest_collision_point_time);
+      const auto found_first_slow_down_points =
+        planner_data.found_slow_down_points && !planner_data.slow_down_require;
 
-              getLateralNearestPointForPredictedObject(
-                slow_down_points, p_front, &planner_data.lateral_nearest_slow_down_point_pose,
-                &planner_data.lateral_deviation);
+      if (found_first_slow_down_points) {
+        // found nearest slow down obstacle
+        planner_data.decimate_trajectory_slow_down_index = i;
+        planner_data.slow_down_require = true;
+        getNearestPoint(
+          *slow_down_pointcloud_ptr, p_front, &planner_data.nearest_slow_down_point,
+          &planner_data.nearest_collision_point_time);
+        getLateralNearestPoint(
+          *slow_down_pointcloud_ptr, p_front, &planner_data.lateral_nearest_slow_down_point,
+          &planner_data.lateral_deviation);
 
-              debug_ptr_->pushObstaclePoint(
-                planner_data.nearest_slow_down_point_pose.position, PointType::SlowDown);
-              debug_ptr_->pushPolygon(
-                one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
-            }
-
-          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-            const double & length_m = obj.shape.dimensions.x / 2;
-            const double & width_m = obj.shape.dimensions.y / 2;
-            Polygon2d object_polygon{};
-            object_polygon = convertBoundingBoxObjectToGeometryPolygon(
-              obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
-
-            std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
-            Polygon2d one_step_move_vehicle_polygon2d;
-            // create one step polygon for slow_down range
-            createOneStepPolygon(
-              p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
-              slow_down_param_.vehicle_lateral_margin);
-            debug_ptr_->pushPolygon(
-              one_step_move_slow_down_range_polygon, p_front.position.z,
-              PolygonType::SlowDownRange);
-            for (const auto & point : one_step_move_slow_down_range_polygon) {
-              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
-            }
-            planner_data.found_slow_down_points =
-              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
-
-            const auto found_first_slow_down_points =
-              planner_data.found_slow_down_points && !planner_data.slow_down_require;
-
-            if (found_first_slow_down_points) {
-              // found nearest slow down obstacle
-              planner_data.decimate_trajectory_slow_down_index = i;
-              planner_data.slow_down_require = true;
-              std::vector<Point2d> slow_down_point;
-              geometry_msgs::msg::PoseArray slow_down_points;
-              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, slow_down_point);
-              for (const auto & point : slow_down_point) {
-                geometry_msgs::msg::Pose pose;
-                pose.position.x = point.x();
-                pose.position.y = point.y();
-                slow_down_points.poses.push_back(pose);
-              }
-
-              getNearestPointForPredictedObject(
-                slow_down_points, p_front, &planner_data.nearest_slow_down_point_pose,
-                &planner_data.nearest_collision_point_time);
-
-              getLateralNearestPointForPredictedObject(
-                slow_down_points, p_front, &planner_data.lateral_nearest_slow_down_point_pose,
-                &planner_data.lateral_deviation);
-
-              debug_ptr_->pushObstaclePoint(
-                planner_data.nearest_slow_down_point_pose.position, PointType::SlowDown);
-              debug_ptr_->pushPolygon(
-                one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
-            }
-          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
-            Polygon2d object_polygon{};
-            object_polygon = convertPolygonObjectToGeometryPolygon(
-              obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
-
-            std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
-            Polygon2d one_step_move_slow_down_range_polygon2d;
-            // create one step polygon for slow_down range
-            createOneStepPolygon(
-              p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
-              slow_down_param_.unknown_lateral_margin);
-            debug_ptr_->pushPolygon(
-              one_step_move_slow_down_range_polygon, p_front.position.z,
-              PolygonType::SlowDownRange);
-
-            const auto found_first_slow_down_points =
-              planner_data.found_slow_down_points && !planner_data.slow_down_require;
-
-            if (found_first_slow_down_points) {
-              // found nearest slow down obstacle
-              planner_data.decimate_trajectory_slow_down_index = i;
-              planner_data.slow_down_require = true;
-              std::vector<Point2d> slow_down_point;
-              geometry_msgs::msg::PoseArray slow_down_points;
-              bg::intersection(
-                one_step_move_slow_down_range_polygon2d, object_polygon, slow_down_point);
-              for (const auto & point : slow_down_point) {
-                geometry_msgs::msg::Pose pose;
-                pose.position.x = point.x();
-                pose.position.y = point.y();
-                slow_down_points.poses.push_back(pose);
-              }
-
-              getNearestPointForPredictedObject(
-                slow_down_points, p_front, &planner_data.nearest_slow_down_point_pose,
-                &planner_data.nearest_collision_point_time);
-
-              getLateralNearestPointForPredictedObject(
-                slow_down_points, p_front, &planner_data.lateral_nearest_slow_down_point_pose,
-                &planner_data.lateral_deviation);
-
-              debug_ptr_->pushObstaclePoint(
-                planner_data.nearest_slow_down_point_pose.position, PointType::SlowDown);
-              debug_ptr_->pushPolygon(
-                one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
-            }
-          } else {
-            RCLCPP_WARN_THROTTLE(
-              get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
-              obj.shape.type);
-          }
-        }
+        debug_ptr_->pushObstaclePoint(planner_data.nearest_slow_down_point, PointType::SlowDown);
+        debug_ptr_->pushPolygon(
+          one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
       }
 
-      {
-        for (const auto & obj : object_ptr->objects) {
-          if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
-            Polygon2d object_polygon{};
-            object_polygon = convertCylindricalObjectToGeometryPolygon(
-              obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+    } else {
+      slow_down_pointcloud_ptr = obstacle_candidate_pointcloud_ptr;
+    }
 
-            std::vector<cv::Point2d> one_step_move_vehicle_polygon;
-            Polygon2d one_step_move_vehicle_polygon2d;
-            // create one step polygon for vehicle
-            createOneStepPolygon(
-              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
-              stop_param.pedestrian_lateral_margin);
-            debug_ptr_->pushPolygon(
-              one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
-              PolygonType::Vehicle);
+    {
+      std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+      // create one step polygon for vehicle
+      createOneStepPolygon(
+        p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.lateral_margin);
+      debug_ptr_->pushPolygon(
+        one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+        PolygonType::Vehicle);
 
-            for (const auto & point : one_step_move_vehicle_polygon) {
-              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
-            }
-            const auto found_collision_points =
-              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+      PointCloud::Ptr collision_pointcloud_ptr(new PointCloud);
+      collision_pointcloud_ptr->header = obstacle_candidate_pointcloud_ptr->header;
 
-            if (found_collision_points) {
-              Pose nearest_collision_point_pose;
-              rclcpp::Time nearest_collision_point_time;
+      const auto found_collision_points = withinPolygon(
+        one_step_move_vehicle_polygon, stop_param.stop_search_radius, prev_center_point,
+        next_center_point, slow_down_pointcloud_ptr, collision_pointcloud_ptr);
 
-              std::vector<Point2d> collision_point;
-              geometry_msgs::msg::PoseArray collision_points;
-              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
-              for (const auto & point : collision_point) {
-                geometry_msgs::msg::Pose pose;
-                pose.position.x = point.x();
-                pose.position.y = point.y();
-                collision_points.poses.push_back(pose);
-              }
-              getNearestPointForPredictedObject(
-                collision_points, p_front, &nearest_collision_point_pose,
-                &nearest_collision_point_time);
+      if (found_collision_points) {
+        pcl::PointXYZ nearest_collision_point;
+        rclcpp::Time nearest_collision_point_time;
 
-              predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
-              break;
-            }
-          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
-            const double & length_m = obj.shape.dimensions.x / 2;
-            const double & width_m = obj.shape.dimensions.y / 2;
-            Polygon2d object_polygon{};
-            object_polygon = convertBoundingBoxObjectToGeometryPolygon(
-              obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
+        getNearestPoint(
+          *collision_pointcloud_ptr, p_front, &nearest_collision_point,
+          &nearest_collision_point_time);
 
-            std::vector<cv::Point2d> one_step_move_vehicle_polygon;
-            Polygon2d one_step_move_vehicle_polygon2d;
-            // create one step polygon for vehicle
-            createOneStepPolygon(
-              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
-              stop_param.vehicle_lateral_margin);
-            debug_ptr_->pushPolygon(
-              one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
-              PolygonType::Vehicle);
+        obstacle_history_.emplace_back(now, nearest_collision_point);
 
-            for (const auto & point : one_step_move_vehicle_polygon) {
-              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
-            }
-            const auto found_collision_points =
-              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+        break;
+      }
+    }
+  }
 
-            if (found_collision_points) {
-              Pose nearest_collision_point_pose;
-              rclcpp::Time nearest_collision_point_time;
+  for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
+    // create one step circle center for vehicle
+    const auto & p_front = decimate_trajectory.at(i).pose;
+    const auto & p_back = decimate_trajectory.at(i + 1).pose;
+    const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
+    const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
+    const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
+    const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
 
-              std::vector<Point2d> collision_point;
-              geometry_msgs::msg::PoseArray collision_points;
-              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
-              for (const auto & point : collision_point) {
-                geometry_msgs::msg::Pose pose;
-                pose.position.x = point.x();
-                pose.position.y = point.y();
-                collision_points.poses.push_back(pose);
-              }
-              getNearestPointForPredictedObject(
-                collision_points, p_front, &nearest_collision_point_pose,
-                &nearest_collision_point_time);
+    std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+    // create one step polygon for vehicle
+    createOneStepPolygon(
+      p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.lateral_margin);
+    debug_ptr_->pushPolygon(
+      one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+      PolygonType::Vehicle);
 
-              predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
-              break;
-            }
-          } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
-            Polygon2d object_polygon{};
-            object_polygon = convertPolygonObjectToGeometryPolygon(
-              obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+    PointCloud::Ptr collision_pointcloud_ptr(new PointCloud);
+    collision_pointcloud_ptr->header = obstacle_candidate_pointcloud_ptr->header;
 
-            std::vector<cv::Point2d> one_step_move_vehicle_polygon;
-            Polygon2d one_step_move_vehicle_polygon2d;
-            // create one step polygon for vehicle
-            createOneStepPolygon(
-              p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
-              stop_param.unknown_lateral_margin);
-            debug_ptr_->pushPolygon(
-              one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
-              PolygonType::Vehicle);
+    // check new collision points
+    planner_data.found_collision_points = withinPolygon(
+      one_step_move_vehicle_polygon, stop_param.stop_search_radius, prev_center_point,
+      next_center_point, getOldPointCloudPtr(), collision_pointcloud_ptr);
 
-            for (const auto & point : one_step_move_vehicle_polygon) {
-              one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
-            }
-            const auto found_collision_points =
-              bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+    if (planner_data.found_collision_points) {
+      planner_data.decimate_trajectory_collision_index = i;
+      getNearestPoint(
+        *collision_pointcloud_ptr, p_front, &planner_data.nearest_collision_point,
+        &planner_data.nearest_collision_point_time);
 
-            if (found_collision_points) {
-              Pose nearest_collision_point_pose;
-              rclcpp::Time nearest_collision_point_time;
+      debug_ptr_->pushObstaclePoint(planner_data.nearest_collision_point, PointType::Stop);
+      debug_ptr_->pushPolygon(
+        one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
 
-              std::vector<Point2d> collision_point;
-              geometry_msgs::msg::PoseArray collision_points;
-              bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
-              for (const auto & point : collision_point) {
-                geometry_msgs::msg::Pose pose;
-                pose.position.x = point.x();
-                pose.position.y = point.y();
-                collision_points.poses.push_back(pose);
-              }
-              getNearestPointForPredictedObject(
-                collision_points, p_front, &nearest_collision_point_pose,
-                &nearest_collision_point_time);
+      planner_data.stop_require = planner_data.found_collision_points;
 
-              predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
-              break;
-            }
-          } else {
-            RCLCPP_WARN_THROTTLE(
-              get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
-              obj.shape.type);
+      mutex_.lock();
+      const auto current_odometry_ptr = current_odometry_ptr_;
+      mutex_.unlock();
+
+      acc_controller_->insertAdaptiveCruiseVelocity(
+        decimate_trajectory, planner_data.decimate_trajectory_collision_index,
+        planner_data.current_pose, planner_data.nearest_collision_point,
+        planner_data.nearest_collision_point_time, object_ptr, current_odometry_ptr,
+        &planner_data.stop_require, &output, trajectory_header);
+
+      if (!planner_data.stop_require) {
+        obstacle_history_.clear();
+      }
+
+      break;
+    }
+  }
+}
+
+void ObstacleStopPlannerNode::searchPredictedObject(
+  const TrajectoryPoints & decimate_trajectory, PlannerData & planner_data,
+  const VehicleInfo & vehicle_info, const StopParam & stop_param)
+{
+  const auto object_ptr = object_ptr_;
+  if (object_ptr->objects.empty()) {
+    return;
+  }
+  const auto now = this->now();
+
+  updatePredictedObstacleHistory(now);
+  for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
+    // create one step circle center for vehicle
+    const auto & p_front = decimate_trajectory.at(i).pose;
+    const auto & p_back = decimate_trajectory.at(i + 1).pose;
+    const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
+    const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
+    const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
+    const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
+
+    if (node_param_.enable_slow_down) {
+      for (const auto & obj : object_ptr->objects) {
+        if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+          Polygon2d object_polygon{};
+          object_polygon = convertCylindricalObjectToGeometryPolygon(
+            obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+
+          std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
+          Polygon2d one_step_move_vehicle_polygon2d;
+          // create one step polygon for slow_down range
+          createOneStepPolygon(
+            p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
+            slow_down_param_.pedestrian_lateral_margin);
+          debug_ptr_->pushPolygon(
+            one_step_move_slow_down_range_polygon, p_front.position.z,
+            PolygonType::SlowDownRange);
+          for (const auto & point : one_step_move_slow_down_range_polygon) {
+            one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
           }
+          planner_data.found_slow_down_points =
+            bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+          const auto found_first_slow_down_points =
+            planner_data.found_slow_down_points && !planner_data.slow_down_require;
+
+          if (found_first_slow_down_points) {
+            // found nearest slow down obstacle
+            planner_data.decimate_trajectory_slow_down_index = i;
+            planner_data.slow_down_require = true;
+            std::vector<Point2d> slow_down_point;
+            geometry_msgs::msg::PoseArray slow_down_points;
+            bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, slow_down_point);
+            for (const auto & point : slow_down_point) {
+              geometry_msgs::msg::Pose pose;
+              pose.position.x = point.x();
+              pose.position.y = point.y();
+              slow_down_points.poses.push_back(pose);
+            }
+
+            getNearestPointForPredictedObject(
+              slow_down_points, p_front, &planner_data.nearest_slow_down_point_pose,
+              &planner_data.nearest_collision_point_time);
+
+            getLateralNearestPointForPredictedObject(
+              slow_down_points, p_front, &planner_data.lateral_nearest_slow_down_point_pose,
+              &planner_data.lateral_deviation);
+
+            debug_ptr_->pushObstaclePoint(
+              planner_data.nearest_slow_down_point_pose.position, PointType::SlowDown);
+            debug_ptr_->pushPolygon(
+              one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
+          }
+
+        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+          const double & length_m = obj.shape.dimensions.x / 2;
+          const double & width_m = obj.shape.dimensions.y / 2;
+          Polygon2d object_polygon{};
+          object_polygon = convertBoundingBoxObjectToGeometryPolygon(
+            obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
+
+          std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
+          Polygon2d one_step_move_vehicle_polygon2d;
+          // create one step polygon for slow_down range
+          createOneStepPolygon(
+            p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
+            slow_down_param_.vehicle_lateral_margin);
+          debug_ptr_->pushPolygon(
+            one_step_move_slow_down_range_polygon, p_front.position.z,
+            PolygonType::SlowDownRange);
+          for (const auto & point : one_step_move_slow_down_range_polygon) {
+            one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+          }
+          planner_data.found_slow_down_points =
+            bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+          const auto found_first_slow_down_points =
+            planner_data.found_slow_down_points && !planner_data.slow_down_require;
+
+          if (found_first_slow_down_points) {
+            // found nearest slow down obstacle
+            planner_data.decimate_trajectory_slow_down_index = i;
+            planner_data.slow_down_require = true;
+            std::vector<Point2d> slow_down_point;
+            geometry_msgs::msg::PoseArray slow_down_points;
+            bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, slow_down_point);
+            for (const auto & point : slow_down_point) {
+              geometry_msgs::msg::Pose pose;
+              pose.position.x = point.x();
+              pose.position.y = point.y();
+              slow_down_points.poses.push_back(pose);
+            }
+
+            getNearestPointForPredictedObject(
+              slow_down_points, p_front, &planner_data.nearest_slow_down_point_pose,
+              &planner_data.nearest_collision_point_time);
+
+            getLateralNearestPointForPredictedObject(
+              slow_down_points, p_front, &planner_data.lateral_nearest_slow_down_point_pose,
+              &planner_data.lateral_deviation);
+
+            debug_ptr_->pushObstaclePoint(
+              planner_data.nearest_slow_down_point_pose.position, PointType::SlowDown);
+            debug_ptr_->pushPolygon(
+              one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
+          }
+        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+          Polygon2d object_polygon{};
+          object_polygon = convertPolygonObjectToGeometryPolygon(
+            obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+
+          std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
+          Polygon2d one_step_move_slow_down_range_polygon2d;
+          // create one step polygon for slow_down range
+          createOneStepPolygon(
+            p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
+            slow_down_param_.unknown_lateral_margin);
+          debug_ptr_->pushPolygon(
+            one_step_move_slow_down_range_polygon, p_front.position.z,
+            PolygonType::SlowDownRange);
+
+          const auto found_first_slow_down_points =
+            planner_data.found_slow_down_points && !planner_data.slow_down_require;
+
+          if (found_first_slow_down_points) {
+            // found nearest slow down obstacle
+            planner_data.decimate_trajectory_slow_down_index = i;
+            planner_data.slow_down_require = true;
+            std::vector<Point2d> slow_down_point;
+            geometry_msgs::msg::PoseArray slow_down_points;
+            bg::intersection(
+              one_step_move_slow_down_range_polygon2d, object_polygon, slow_down_point);
+            for (const auto & point : slow_down_point) {
+              geometry_msgs::msg::Pose pose;
+              pose.position.x = point.x();
+              pose.position.y = point.y();
+              slow_down_points.poses.push_back(pose);
+            }
+
+            getNearestPointForPredictedObject(
+              slow_down_points, p_front, &planner_data.nearest_slow_down_point_pose,
+              &planner_data.nearest_collision_point_time);
+
+            getLateralNearestPointForPredictedObject(
+              slow_down_points, p_front, &planner_data.lateral_nearest_slow_down_point_pose,
+              &planner_data.lateral_deviation);
+
+            debug_ptr_->pushObstaclePoint(
+              planner_data.nearest_slow_down_point_pose.position, PointType::SlowDown);
+            debug_ptr_->pushPolygon(
+              one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
+          }
+        } else {
+          RCLCPP_WARN_THROTTLE(
+            get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
+            obj.shape.type);
         }
       }
     }
-    for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
-      // create one step circle center for vehicle
-      const auto & p_front = decimate_trajectory.at(i).pose;
-      const auto & p_back = decimate_trajectory.at(i + 1).pose;
-      const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
-      const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
-      const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
-      const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
+
+    {
       for (const auto & obj : object_ptr->objects) {
         if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
           Polygon2d object_polygon{};
@@ -673,12 +688,11 @@ void ObstacleStopPlannerNode::searchObstacle(
           for (const auto & point : one_step_move_vehicle_polygon) {
             one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
           }
-          // check new collision points
-          planner_data.found_collision_points =
+          const auto found_collision_points =
             bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
 
-          if (planner_data.found_collision_points) {
-            planner_data.decimate_trajectory_collision_index = i;
+          if (found_collision_points) {
+            Pose nearest_collision_point_pose;
             rclcpp::Time nearest_collision_point_time;
 
             std::vector<Point2d> collision_point;
@@ -691,28 +705,10 @@ void ObstacleStopPlannerNode::searchObstacle(
               collision_points.poses.push_back(pose);
             }
             getNearestPointForPredictedObject(
-              collision_points, p_front, &planner_data.nearest_collision_point_pose,
+              collision_points, p_front, &nearest_collision_point_pose,
               &nearest_collision_point_time);
 
-            debug_ptr_->pushObstaclePoint(
-              planner_data.nearest_collision_point_pose.position, PointType::Stop);
-            debug_ptr_->pushPolygon(
-              one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
-            one_step_move_vehicle_polygon.clear();
-            if (node_param_.publish_obstacle_polygon) {
-              std::vector<cv::Point2d> obstacle_polygon;
-              for (const auto & point : object_polygon.outer()) {
-                obstacle_polygon.emplace_back(point.x(), point.y());
-              }
-              debug_ptr_->pushPolygon(obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
-            }
-            planner_data.stop_require = planner_data.found_collision_points;
-            mutex_.lock();
-            const auto current_odometry_ptr = current_odometry_ptr_;
-            mutex_.unlock();
-            if (!planner_data.stop_require) {
-              predicted_object_history_.clear();
-            }
+            predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
             break;
           }
         } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
@@ -721,66 +717,6 @@ void ObstacleStopPlannerNode::searchObstacle(
           Polygon2d object_polygon{};
           object_polygon = convertBoundingBoxObjectToGeometryPolygon(
             obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
-          std::vector<cv::Point2d> one_step_move_vehicle_polygon;
-          Polygon2d one_step_move_vehicle_polygon2d;
-          // create one step polygon for vehicle
-          createOneStepPolygon(
-            p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
-            stop_param.unknown_lateral_margin);
-          debug_ptr_->pushPolygon(
-            one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
-            PolygonType::Vehicle);
-
-          for (const auto & point : one_step_move_vehicle_polygon) {
-            one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
-          }
-          // check new collision points
-          planner_data.found_collision_points =
-            bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
-
-          if (planner_data.found_collision_points) {
-            planner_data.decimate_trajectory_collision_index = i;
-            rclcpp::Time nearest_collision_point_time;
-
-            std::vector<Point2d> collision_point;
-            geometry_msgs::msg::PoseArray collision_points;
-            bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
-            for (const auto & point : collision_point) {
-              geometry_msgs::msg::Pose pose;
-              pose.position.x = point.x();
-              pose.position.y = point.y();
-              collision_points.poses.push_back(pose);
-            }
-            getNearestPointForPredictedObject(
-              collision_points, p_front, &planner_data.nearest_collision_point_pose,
-              &nearest_collision_point_time);
-
-            debug_ptr_->pushObstaclePoint(
-              planner_data.nearest_collision_point_pose.position, PointType::Stop);
-            debug_ptr_->pushPolygon(
-              one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
-            one_step_move_vehicle_polygon.clear();
-            if (node_param_.publish_obstacle_polygon) {
-              std::vector<cv::Point2d> obstacle_polygon;
-              for (const auto & point : object_polygon.outer()) {
-                obstacle_polygon.emplace_back(point.x(), point.y());
-              }
-              debug_ptr_->pushPolygon(obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
-            }
-
-            planner_data.stop_require = planner_data.found_collision_points;
-            mutex_.lock();
-            const auto current_odometry_ptr = current_odometry_ptr_;
-            mutex_.unlock();
-            if (!planner_data.stop_require) {
-              predicted_object_history_.clear();
-            }
-            break;
-          }
-        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
-          Polygon2d object_polygon{};
-          object_polygon = convertPolygonObjectToGeometryPolygon(
-            obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
 
           std::vector<cv::Point2d> one_step_move_vehicle_polygon;
           Polygon2d one_step_move_vehicle_polygon2d;
@@ -795,12 +731,11 @@ void ObstacleStopPlannerNode::searchObstacle(
           for (const auto & point : one_step_move_vehicle_polygon) {
             one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
           }
-          // check new collision points
-          planner_data.found_collision_points =
+          const auto found_collision_points =
             bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
 
-          if (planner_data.found_collision_points) {
-            planner_data.decimate_trajectory_collision_index = i;
+          if (found_collision_points) {
+            Pose nearest_collision_point_pose;
             rclcpp::Time nearest_collision_point_time;
 
             std::vector<Point2d> collision_point;
@@ -813,29 +748,51 @@ void ObstacleStopPlannerNode::searchObstacle(
               collision_points.poses.push_back(pose);
             }
             getNearestPointForPredictedObject(
-              collision_points, p_front, &planner_data.nearest_collision_point_pose,
+              collision_points, p_front, &nearest_collision_point_pose,
               &nearest_collision_point_time);
 
-            debug_ptr_->pushObstaclePoint(
-              planner_data.nearest_collision_point_pose.position, PointType::Stop);
-            debug_ptr_->pushPolygon(
-              one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
-            one_step_move_vehicle_polygon.clear();
-            if (node_param_.publish_obstacle_polygon) {
-              std::vector<cv::Point2d> obstacle_polygon;
-              for (const auto & point : object_polygon.outer()) {
-                obstacle_polygon.emplace_back(point.x(), point.y());
-              }
-              debug_ptr_->pushPolygon(obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
-            }
-            planner_data.stop_require = planner_data.found_collision_points;
-            mutex_.lock();
-            const auto current_odometry_ptr = current_odometry_ptr_;
-            mutex_.unlock();
-            if (!planner_data.stop_require) {
-              predicted_object_history_.clear();
-            }
+            predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
+            break;
+          }
+        } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+          Polygon2d object_polygon{};
+          object_polygon = convertPolygonObjectToGeometryPolygon(
+            obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
 
+          std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+          Polygon2d one_step_move_vehicle_polygon2d;
+          // create one step polygon for vehicle
+          createOneStepPolygon(
+            p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+            stop_param.unknown_lateral_margin);
+          debug_ptr_->pushPolygon(
+            one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+            PolygonType::Vehicle);
+
+          for (const auto & point : one_step_move_vehicle_polygon) {
+            one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+          }
+          const auto found_collision_points =
+            bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+          if (found_collision_points) {
+            Pose nearest_collision_point_pose;
+            rclcpp::Time nearest_collision_point_time;
+
+            std::vector<Point2d> collision_point;
+            geometry_msgs::msg::PoseArray collision_points;
+            bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+            for (const auto & point : collision_point) {
+              geometry_msgs::msg::Pose pose;
+              pose.position.x = point.x();
+              pose.position.y = point.y();
+              collision_points.poses.push_back(pose);
+            }
+            getNearestPointForPredictedObject(
+              collision_points, p_front, &nearest_collision_point_pose,
+              &nearest_collision_point_time);
+
+            predicted_object_history_.emplace_back(now, nearest_collision_point_pose);
             break;
           }
         } else {
@@ -845,149 +802,203 @@ void ObstacleStopPlannerNode::searchObstacle(
         }
       }
     }
-  } else {
-    // search candidate obstacle pointcloud
-    PointCloud::Ptr slow_down_pointcloud_ptr(new PointCloud);
-    PointCloud::Ptr obstacle_candidate_pointcloud_ptr(new PointCloud);
-    if (!searchPointcloudNearTrajectory(
-          decimate_trajectory, obstacle_ros_pointcloud_ptr, obstacle_candidate_pointcloud_ptr,
-          trajectory_header, vehicle_info, stop_param)) {
-      return;
-    }
+  }
+  for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
+    // create one step circle center for vehicle
+    const auto & p_front = decimate_trajectory.at(i).pose;
+    const auto & p_back = decimate_trajectory.at(i + 1).pose;
+    const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
+    const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
+    const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
+    const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
+    for (const auto & obj : object_ptr->objects) {
+      if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::CYLINDER) {
+        Polygon2d object_polygon{};
+        object_polygon = convertCylindricalObjectToGeometryPolygon(
+          obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
 
-    const auto now = this->now();
-
-    updateObstacleHistory(now);
-
-    for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
-      // create one step circle center for vehicle
-      const auto & p_front = decimate_trajectory.at(i).pose;
-      const auto & p_back = decimate_trajectory.at(i + 1).pose;
-      const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
-      const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
-      const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
-      const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
-
-      if (node_param_.enable_slow_down) {
-        std::vector<cv::Point2d> one_step_move_slow_down_range_polygon;
-        // create one step polygon for slow_down range
-        createOneStepPolygon(
-          p_front, p_back, one_step_move_slow_down_range_polygon, vehicle_info,
-          slow_down_param_.lateral_margin);
-        debug_ptr_->pushPolygon(
-          one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDownRange);
-
-        planner_data.found_slow_down_points = withinPolygon(
-          one_step_move_slow_down_range_polygon, slow_down_param_.slow_down_search_radius,
-          prev_center_point, next_center_point, obstacle_candidate_pointcloud_ptr,
-          slow_down_pointcloud_ptr);
-
-        const auto found_first_slow_down_points =
-          planner_data.found_slow_down_points && !planner_data.slow_down_require;
-
-        if (found_first_slow_down_points) {
-          // found nearest slow down obstacle
-          planner_data.decimate_trajectory_slow_down_index = i;
-          planner_data.slow_down_require = true;
-          getNearestPoint(
-            *slow_down_pointcloud_ptr, p_front, &planner_data.nearest_slow_down_point,
-            &planner_data.nearest_collision_point_time);
-          getLateralNearestPoint(
-            *slow_down_pointcloud_ptr, p_front, &planner_data.lateral_nearest_slow_down_point,
-            &planner_data.lateral_deviation);
-
-          debug_ptr_->pushObstaclePoint(planner_data.nearest_slow_down_point, PointType::SlowDown);
-          debug_ptr_->pushPolygon(
-            one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
-        }
-
-      } else {
-        slow_down_pointcloud_ptr = obstacle_candidate_pointcloud_ptr;
-      }
-
-      {
         std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+        Polygon2d one_step_move_vehicle_polygon2d;
         // create one step polygon for vehicle
         createOneStepPolygon(
-          p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.lateral_margin);
+          p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+          stop_param.pedestrian_lateral_margin);
         debug_ptr_->pushPolygon(
           one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
           PolygonType::Vehicle);
 
-        PointCloud::Ptr collision_pointcloud_ptr(new PointCloud);
-        collision_pointcloud_ptr->header = obstacle_candidate_pointcloud_ptr->header;
+        for (const auto & point : one_step_move_vehicle_polygon) {
+          one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+        }
+        // check new collision points
+        planner_data.found_collision_points =
+          bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
 
-        const auto found_collision_points = withinPolygon(
-          one_step_move_vehicle_polygon, stop_param.stop_search_radius, prev_center_point,
-          next_center_point, slow_down_pointcloud_ptr, collision_pointcloud_ptr);
-
-        if (found_collision_points) {
-          pcl::PointXYZ nearest_collision_point;
+        if (planner_data.found_collision_points) {
+          planner_data.decimate_trajectory_collision_index = i;
           rclcpp::Time nearest_collision_point_time;
 
-          getNearestPoint(
-            *collision_pointcloud_ptr, p_front, &nearest_collision_point,
+          std::vector<Point2d> collision_point;
+          geometry_msgs::msg::PoseArray collision_points;
+          bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+          for (const auto & point : collision_point) {
+            geometry_msgs::msg::Pose pose;
+            pose.position.x = point.x();
+            pose.position.y = point.y();
+            collision_points.poses.push_back(pose);
+          }
+          getNearestPointForPredictedObject(
+            collision_points, p_front, &planner_data.nearest_collision_point_pose,
             &nearest_collision_point_time);
 
-          obstacle_history_.emplace_back(now, nearest_collision_point);
+          debug_ptr_->pushObstaclePoint(
+            planner_data.nearest_collision_point_pose.position, PointType::Stop);
+          debug_ptr_->pushPolygon(
+            one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
+          one_step_move_vehicle_polygon.clear();
+          if (node_param_.publish_obstacle_polygon) {
+            std::vector<cv::Point2d> obstacle_polygon;
+            for (const auto & point : object_polygon.outer()) {
+              obstacle_polygon.emplace_back(point.x(), point.y());
+            }
+            debug_ptr_->pushPolygon(obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
+          }
+          planner_data.stop_require = planner_data.found_collision_points;
+          mutex_.lock();
+          const auto current_odometry_ptr = current_odometry_ptr_;
+          mutex_.unlock();
+          if (!planner_data.stop_require) {
+            predicted_object_history_.clear();
+          }
+          break;
+        }
+      } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+        const double & length_m = obj.shape.dimensions.x / 2;
+        const double & width_m = obj.shape.dimensions.y / 2;
+        Polygon2d object_polygon{};
+        object_polygon = convertBoundingBoxObjectToGeometryPolygon(
+          obj.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
+        std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+        Polygon2d one_step_move_vehicle_polygon2d;
+        // create one step polygon for vehicle
+        createOneStepPolygon(
+          p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+          stop_param.unknown_lateral_margin);
+        debug_ptr_->pushPolygon(
+          one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+          PolygonType::Vehicle);
+
+        for (const auto & point : one_step_move_vehicle_polygon) {
+          one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+        }
+        // check new collision points
+        planner_data.found_collision_points =
+          bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+        if (planner_data.found_collision_points) {
+          planner_data.decimate_trajectory_collision_index = i;
+          rclcpp::Time nearest_collision_point_time;
+
+          std::vector<Point2d> collision_point;
+          geometry_msgs::msg::PoseArray collision_points;
+          bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+          for (const auto & point : collision_point) {
+            geometry_msgs::msg::Pose pose;
+            pose.position.x = point.x();
+            pose.position.y = point.y();
+            collision_points.poses.push_back(pose);
+          }
+          getNearestPointForPredictedObject(
+            collision_points, p_front, &planner_data.nearest_collision_point_pose,
+            &nearest_collision_point_time);
+
+          debug_ptr_->pushObstaclePoint(
+            planner_data.nearest_collision_point_pose.position, PointType::Stop);
+          debug_ptr_->pushPolygon(
+            one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
+          one_step_move_vehicle_polygon.clear();
+          if (node_param_.publish_obstacle_polygon) {
+            std::vector<cv::Point2d> obstacle_polygon;
+            for (const auto & point : object_polygon.outer()) {
+              obstacle_polygon.emplace_back(point.x(), point.y());
+            }
+            debug_ptr_->pushPolygon(obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
+          }
+
+          planner_data.stop_require = planner_data.found_collision_points;
+          mutex_.lock();
+          const auto current_odometry_ptr = current_odometry_ptr_;
+          mutex_.unlock();
+          if (!planner_data.stop_require) {
+            predicted_object_history_.clear();
+          }
+          break;
+        }
+      } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
+        Polygon2d object_polygon{};
+        object_polygon = convertPolygonObjectToGeometryPolygon(
+          obj.kinematics.initial_pose_with_covariance.pose, obj.shape);
+
+        std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+        Polygon2d one_step_move_vehicle_polygon2d;
+        // create one step polygon for vehicle
+        createOneStepPolygon(
+          p_front, p_back, one_step_move_vehicle_polygon, vehicle_info,
+          stop_param.vehicle_lateral_margin);
+        debug_ptr_->pushPolygon(
+          one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
+          PolygonType::Vehicle);
+
+        for (const auto & point : one_step_move_vehicle_polygon) {
+          one_step_move_vehicle_polygon2d.outer().push_back(Point2d(point.x, point.y));
+        }
+        // check new collision points
+        planner_data.found_collision_points =
+          bg::intersects(one_step_move_vehicle_polygon2d, object_polygon);
+
+        if (planner_data.found_collision_points) {
+          planner_data.decimate_trajectory_collision_index = i;
+          rclcpp::Time nearest_collision_point_time;
+
+          std::vector<Point2d> collision_point;
+          geometry_msgs::msg::PoseArray collision_points;
+          bg::intersection(one_step_move_vehicle_polygon2d, object_polygon, collision_point);
+          for (const auto & point : collision_point) {
+            geometry_msgs::msg::Pose pose;
+            pose.position.x = point.x();
+            pose.position.y = point.y();
+            collision_points.poses.push_back(pose);
+          }
+          getNearestPointForPredictedObject(
+            collision_points, p_front, &planner_data.nearest_collision_point_pose,
+            &nearest_collision_point_time);
+
+          debug_ptr_->pushObstaclePoint(
+            planner_data.nearest_collision_point_pose.position, PointType::Stop);
+          debug_ptr_->pushPolygon(
+            one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
+          one_step_move_vehicle_polygon.clear();
+          if (node_param_.publish_obstacle_polygon) {
+            std::vector<cv::Point2d> obstacle_polygon;
+            for (const auto & point : object_polygon.outer()) {
+              obstacle_polygon.emplace_back(point.x(), point.y());
+            }
+            debug_ptr_->pushPolygon(obstacle_polygon, p_front.position.z, PolygonType::Obstacle);
+          }
+          planner_data.stop_require = planner_data.found_collision_points;
+          mutex_.lock();
+          const auto current_odometry_ptr = current_odometry_ptr_;
+          mutex_.unlock();
+          if (!planner_data.stop_require) {
+            predicted_object_history_.clear();
+          }
 
           break;
         }
-      }
-    }
-
-    for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
-      // create one step circle center for vehicle
-      const auto & p_front = decimate_trajectory.at(i).pose;
-      const auto & p_back = decimate_trajectory.at(i + 1).pose;
-      const auto prev_center_pose = getVehicleCenterFromBase(p_front, vehicle_info);
-      const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
-      const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
-      const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
-
-      std::vector<cv::Point2d> one_step_move_vehicle_polygon;
-      // create one step polygon for vehicle
-      createOneStepPolygon(
-        p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.lateral_margin);
-      debug_ptr_->pushPolygon(
-        one_step_move_vehicle_polygon, decimate_trajectory.at(i).pose.position.z,
-        PolygonType::Vehicle);
-
-      PointCloud::Ptr collision_pointcloud_ptr(new PointCloud);
-      collision_pointcloud_ptr->header = obstacle_candidate_pointcloud_ptr->header;
-
-      // check new collision points
-      planner_data.found_collision_points = withinPolygon(
-        one_step_move_vehicle_polygon, stop_param.stop_search_radius, prev_center_point,
-        next_center_point, getOldPointCloudPtr(), collision_pointcloud_ptr);
-
-      if (planner_data.found_collision_points) {
-        planner_data.decimate_trajectory_collision_index = i;
-        getNearestPoint(
-          *collision_pointcloud_ptr, p_front, &planner_data.nearest_collision_point,
-          &planner_data.nearest_collision_point_time);
-
-        debug_ptr_->pushObstaclePoint(planner_data.nearest_collision_point, PointType::Stop);
-        debug_ptr_->pushPolygon(
-          one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
-
-        planner_data.stop_require = planner_data.found_collision_points;
-
-        mutex_.lock();
-        const auto current_odometry_ptr = current_odometry_ptr_;
-        mutex_.unlock();
-
-        acc_controller_->insertAdaptiveCruiseVelocity(
-          decimate_trajectory, planner_data.decimate_trajectory_collision_index,
-          planner_data.current_pose, planner_data.nearest_collision_point,
-          planner_data.nearest_collision_point_time, object_ptr, current_odometry_ptr,
-          &planner_data.stop_require, &output, trajectory_header);
-
-        if (!planner_data.stop_require) {
-          obstacle_history_.clear();
-        }
-
-        break;
+      } else {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
+          obj.shape.type);
       }
     }
   }
@@ -1004,8 +1015,8 @@ void ObstacleStopPlannerNode::insertVelocity(
     // insert stop point
     const auto traj_end_idx = output.size() - 1;
     const auto idx = planner_data.decimate_trajectory_index_map.at(
-                       planner_data.decimate_trajectory_collision_index) +
-                     planner_data.trajectory_trim_index;
+      planner_data.decimate_trajectory_collision_index) +
+      planner_data.trajectory_trim_index;
     boost::optional<std::pair<size_t, double>> index_with_dist_remain;
     if (node_param_.use_predicted_objects) {
       index_with_dist_remain = findNearestFrontIndex(
@@ -1039,22 +1050,22 @@ void ObstacleStopPlannerNode::insertVelocity(
         node_param_.ego_nearest_yaw_threshold);
 
       const double stop_point_distance = [&]() {
-        if (output.size() < 2) {
-          return 0.0;
-        }
+          if (output.size() < 2) {
+            return 0.0;
+          }
 
-        size_t stop_seg_idx = 0;
-        const double lon_offset =
-          calcLongitudinalOffsetToSegment(output, stop_point.index, getPoint(stop_point.point));
-        if (lon_offset < 0) {
-          stop_seg_idx = std::max(static_cast<size_t>(0), stop_point.index - 1);
-        } else {
-          stop_seg_idx = std::min(output.size() - 2, stop_point.index);
-        }
+          size_t stop_seg_idx = 0;
+          const double lon_offset =
+            calcLongitudinalOffsetToSegment(output, stop_point.index, getPoint(stop_point.point));
+          if (lon_offset < 0) {
+            stop_seg_idx = std::max(static_cast<size_t>(0), stop_point.index - 1);
+          } else {
+            stop_seg_idx = std::min(output.size() - 2, stop_point.index);
+          }
 
-        return calcSignedArcLength(
-          output, ego_pose.position, ego_seg_idx, getPoint(stop_point.point), stop_seg_idx);
-      }();
+          return calcSignedArcLength(
+            output, ego_pose.position, ego_seg_idx, getPoint(stop_point.point), stop_seg_idx);
+        }();
       const auto is_stopped = current_vel < 0.01;
 
       const auto & ego_pos = planner_data.current_pose.position;
@@ -1109,7 +1120,8 @@ void ObstacleStopPlannerNode::insertVelocity(
       if (
         !latest_slow_down_section_ &&
         dist_baselink_to_obstacle + index_with_dist_remain.get().second <
-          vehicle_info.max_longitudinal_offset_m) {
+        vehicle_info.max_longitudinal_offset_m)
+      {
         latest_slow_down_section_ = slow_down_section;
       }
 
@@ -1138,20 +1150,20 @@ void ObstacleStopPlannerNode::insertVelocity(
             slow_down_velocity =
               slow_down_param_.min_slow_down_velocity +
               (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-                std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-                slow_down_param_.pedestrian_lateral_margin;
+              std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+              slow_down_param_.pedestrian_lateral_margin;
           } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
             slow_down_velocity =
               slow_down_param_.min_slow_down_velocity +
               (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-                std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-                slow_down_param_.vehicle_lateral_margin;
+              std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+              slow_down_param_.vehicle_lateral_margin;
           } else if (obj.shape.type == autoware_auto_perception_msgs::msg::Shape::POLYGON) {
             slow_down_velocity =
               slow_down_param_.min_slow_down_velocity +
               (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-                std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-                slow_down_param_.unknown_lateral_margin;
+              std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+              slow_down_param_.unknown_lateral_margin;
           } else {
             RCLCPP_WARN_THROTTLE(
               get_logger(), *get_clock(), 3000, "Object type is not supported. type: %d",
@@ -1162,13 +1174,13 @@ void ObstacleStopPlannerNode::insertVelocity(
         slow_down_velocity =
           slow_down_param_.min_slow_down_velocity +
           (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-            std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-            slow_down_param_.lateral_margin;
+          std::max(planner_data.lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+          slow_down_param_.lateral_margin;
       }
 
-      const auto target_velocity = slow_down_param_.consider_constraints
-                                     ? slow_down_param_.slow_down_velocity
-                                     : slow_down_velocity;
+      const auto target_velocity = slow_down_param_.consider_constraints ?
+        slow_down_param_.slow_down_velocity :
+        slow_down_velocity;
 
       SlowDownSection slow_down_section{};
       slow_down_section.slow_down_start_idx = 0;
@@ -1280,8 +1292,8 @@ SlowDownSection ObstacleStopPlannerNode::createSlowDownSection(
     const auto use_velocity_limit = relax_target_vel || set_velocity_limit_;
 
     const auto update_forward_margin_from_vehicle =
-      use_velocity_limit ? slow_down_param_.min_longitudinal_forward_margin - dist_remain
-                         : margin_with_vel.get().first - dist_remain;
+      use_velocity_limit ? slow_down_param_.min_longitudinal_forward_margin - dist_remain :
+      margin_with_vel.get().first - dist_remain;
     const auto update_backward_margin_from_vehicle =
       slow_down_param_.longitudinal_backward_margin + dist_remain;
 
@@ -1300,8 +1312,8 @@ SlowDownSection ObstacleStopPlannerNode::createSlowDownSection(
     const auto velocity =
       slow_down_param_.min_slow_down_velocity +
       (slow_down_param_.max_slow_down_velocity - slow_down_param_.min_slow_down_velocity) *
-        std::max(lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
-        slow_down_param_.lateral_margin;
+      std::max(lateral_deviation - vehicle_info.vehicle_width_m / 2, 0.0) /
+      slow_down_param_.lateral_margin;
 
     return createSlowDownSectionFromMargin(
       idx, base_trajectory, update_forward_margin_from_vehicle, update_backward_margin_from_vehicle,
@@ -1366,7 +1378,8 @@ void ObstacleStopPlannerNode::insertSlowDownSection(
 
   if (
     !is_start_p_base_and_p_insert_overlap && !is_start_p_next_and_p_insert_overlap &&
-    is_valid_index_start) {
+    is_valid_index_start)
+  {
     // insert: start_idx and end_idx are shifted by one
     output.insert(output.begin() + start_idx + 1, p_insert_start);
     update_start_idx = std::min(update_start_idx + 1, traj_end_idx);
@@ -1385,7 +1398,8 @@ void ObstacleStopPlannerNode::insertSlowDownSection(
 
   if (
     !is_end_p_base_and_p_insert_overlap && !is_end_p_next_and_p_insert_overlap &&
-    is_valid_index_end) {
+    is_valid_index_end)
+  {
     // insert: end_idx is shifted by one
     output.insert(output.begin() + update_end_idx + 1, p_insert_end);
     update_end_idx = std::min(update_end_idx + 1, traj_end_idx);
@@ -1469,14 +1483,15 @@ bool ObstacleStopPlannerNode::searchPointcloudNearTrajectory(
   output_points_ptr->header = transformed_points_ptr->header;
 
   // search obstacle candidate pointcloud to reduce calculation cost
-  const double search_radius = node_param_.enable_slow_down
-                                 ? slow_down_param_.slow_down_search_radius
-                                 : stop_param.stop_search_radius;
+  const double search_radius = node_param_.enable_slow_down ?
+    slow_down_param_.slow_down_search_radius :
+    stop_param.stop_search_radius;
   const double squared_radius = search_radius * search_radius;
   std::vector<geometry_msgs::msg::Point> center_points;
   center_points.reserve(trajectory.size());
-  for (const auto & trajectory_point : trajectory)
+  for (const auto & trajectory_point : trajectory) {
     center_points.push_back(getVehicleCenterFromBase(trajectory_point.pose, vehicle_info).position);
+  }
   for (const auto & point : transformed_points_ptr->points) {
     for (const auto & center_point : center_points) {
       const double x = center_point.x - point.x;
@@ -1516,7 +1531,7 @@ void ObstacleStopPlannerNode::resetExternalVelocityLimit(
   const double current_acc, const double current_vel)
 {
   const auto reach_target_vel = current_vel < slow_down_param_.slow_down_velocity +
-                                                slow_down_param_.velocity_threshold_decel_complete;
+    slow_down_param_.velocity_threshold_decel_complete;
   const auto constant_vel =
     std::abs(current_acc) < slow_down_param_.acceleration_threshold_decel_complete;
   const auto no_undershoot = reach_target_vel && constant_vel;

--- a/planning/obstacle_stop_planner/src/planner_utils.cpp
+++ b/planning/obstacle_stop_planner/src/planner_utils.cpp
@@ -696,6 +696,38 @@ void getLateralNearestPoint(
   *deviation = min_norm;
 }
 
+void getNearestPointForPredictedObject(
+  const PoseArray & object, const Pose & base_pose, Pose * nearest_collision_point,
+  rclcpp::Time * nearest_collision_point_time){
+  double min_norm = 0.0;
+  bool is_init = false;
+
+  for (const auto & p : object.poses) {
+    double norm = calcDistance2d(p, base_pose);
+    if (norm < min_norm || !is_init) {
+      min_norm = norm;
+      *nearest_collision_point = p;
+      *nearest_collision_point_time = (object.header).stamp;
+      is_init = true;
+    }
+  }
+}
+
+void getLateralNearestPointForPredictedObject(
+  const PoseArray & object, const Pose & base_pose, Pose * lateral_nearest_point,
+  double * deviation){
+
+  double min_norm = std::numeric_limits<double>::max();
+  for (size_t i = 0; i < object.poses.size(); ++i) {
+    double norm = calcDistance2d(object.poses.at(i), base_pose);
+    if (norm < min_norm) {
+      min_norm = norm;
+      *lateral_nearest_point = object.poses.at(i);
+    }
+  }
+  *deviation = min_norm;
+}
+
 Pose getVehicleCenterFromBase(const Pose & base_pose, const VehicleInfo & vehicle_info)
 {
   const auto & i = vehicle_info;
@@ -709,5 +741,83 @@ Pose getVehicleCenterFromBase(const Pose & base_pose, const VehicleInfo & vehicl
   center_pose.position.z = base_pose.position.z;
   center_pose.orientation = base_pose.orientation;
   return center_pose;
+}
+
+Polygon2d convertBoundingBoxObjectToGeometryPolygon(
+  const Pose & current_pose, const double & base_to_front, const double & base_to_rear,
+  const double & base_to_width)
+{
+  const auto mapped_point = [](const double & length_scalar, const double & width_scalar) {
+    tf2::Vector3 map;
+    map.setX(length_scalar);
+    map.setY(width_scalar);
+    map.setZ(0.0);
+    map.setW(1.0);
+    return map;
+  };
+
+  // set vertices at map coordinate
+  const tf2::Vector3 p1_map = std::invoke(mapped_point, base_to_front, -base_to_width);
+  const tf2::Vector3 p2_map = std::invoke(mapped_point, base_to_front, base_to_width);
+  const tf2::Vector3 p3_map = std::invoke(mapped_point, -base_to_rear, base_to_width);
+  const tf2::Vector3 p4_map = std::invoke(mapped_point, -base_to_rear, -base_to_width);
+
+  // transform vertices from map coordinate to object coordinate
+  tf2::Transform tf_map2obj;
+  tf2::fromMsg(current_pose, tf_map2obj);
+  const tf2::Vector3 p1_obj = tf_map2obj * p1_map;
+  const tf2::Vector3 p2_obj = tf_map2obj * p2_map;
+  const tf2::Vector3 p3_obj = tf_map2obj * p3_map;
+  const tf2::Vector3 p4_obj = tf_map2obj * p4_map;
+
+  Polygon2d object_polygon;
+  object_polygon.outer().reserve(5);
+  object_polygon.outer().emplace_back(p1_obj.x(), p1_obj.y());
+  object_polygon.outer().emplace_back(p2_obj.x(), p2_obj.y());
+  object_polygon.outer().emplace_back(p3_obj.x(), p3_obj.y());
+  object_polygon.outer().emplace_back(p4_obj.x(), p4_obj.y());
+
+  object_polygon.outer().push_back(object_polygon.outer().front());
+
+  return object_polygon;
+}
+
+Polygon2d convertCylindricalObjectToGeometryPolygon(
+  const Pose & current_pose, const autoware_auto_perception_msgs::msg::Shape & obj_shape)
+{
+  Polygon2d object_polygon;
+
+  const double obj_x = current_pose.position.x;
+  const double obj_y = current_pose.position.y;
+
+  constexpr int N = 20;
+  const double r = obj_shape.dimensions.x / 2;
+  object_polygon.outer().reserve(N + 1);
+  for (int i = 0; i < N; ++i) {
+    object_polygon.outer().emplace_back(
+      obj_x + r * std::cos(2.0 * M_PI / N * i), obj_y + r * std::sin(2.0 * M_PI / N * i));
+  }
+
+  object_polygon.outer().push_back(object_polygon.outer().front());
+
+  return object_polygon;
+}
+
+Polygon2d convertPolygonObjectToGeometryPolygon(
+  const Pose & current_pose, const autoware_auto_perception_msgs::msg::Shape & obj_shape)
+{
+  Polygon2d object_polygon;
+  tf2::Transform tf_map2obj;
+  fromMsg(current_pose, tf_map2obj);
+  const auto obj_points = obj_shape.footprint.points;
+  object_polygon.outer().reserve(obj_points.size() + 1);
+  for (const auto & obj_point : obj_points) {
+    tf2::Vector3 obj(obj_point.x, obj_point.y, obj_point.z);
+    tf2::Vector3 tf_obj = tf_map2obj * obj;
+    object_polygon.outer().emplace_back(tf_obj.x(), tf_obj.y());
+  }
+  object_polygon.outer().push_back(object_polygon.outer().front());
+
+  return object_polygon;
 }
 }  // namespace motion_planning

--- a/planning/obstacle_stop_planner/src/planner_utils.cpp
+++ b/planning/obstacle_stop_planner/src/planner_utils.cpp
@@ -698,7 +698,8 @@ void getLateralNearestPoint(
 
 void getNearestPointForPredictedObject(
   const PoseArray & object, const Pose & base_pose, Pose * nearest_collision_point,
-  rclcpp::Time * nearest_collision_point_time){
+  rclcpp::Time * nearest_collision_point_time)
+{
   double min_norm = 0.0;
   bool is_init = false;
 
@@ -715,8 +716,8 @@ void getNearestPointForPredictedObject(
 
 void getLateralNearestPointForPredictedObject(
   const PoseArray & object, const Pose & base_pose, Pose * lateral_nearest_point,
-  double * deviation){
-
+  double * deviation)
+{
   double min_norm = std::numeric_limits<double>::max();
   for (size_t i = 0; i < object.poses.size(); ++i) {
     double norm = calcDistance2d(object.poses.at(i), base_pose);


### PR DESCRIPTION
## Description

Fixes: #2222

Before this PR, [#140](https://github.com/autowarefoundation/autoware_launch/pull/140) needs to merge

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.


