### PR TITLE
fix(behavior_velocity_planner): clean up expired intersection/merge_from_private/traffic_light

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/manager.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/manager.hpp
@@ -43,7 +43,9 @@ private:
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 
-  bool hasSameParentLanelet(const lanelet::ConstLanelet & lane) const;
+  bool hasSameParentLaneletWith(const lanelet::ConstLanelet & lane, const size_t module_id) const;
+
+  bool hasSameParentLaneletWithRegistered(const lanelet::ConstLanelet & lane) const;
 };
 
 class MergeFromPrivateModuleManager : public SceneModuleManagerInterface

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/manager.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/manager.hpp
@@ -63,7 +63,7 @@ private:
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 
-  bool hasSameParentLanelet(const lanelet::ConstLanelet & lane) const;
+  bool hasSameParentLaneletWith(const lanelet::ConstLanelet & lane, const size_t module_id) const;
 };
 }  // namespace behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/include/scene_module/traffic_light/manager.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/traffic_light/manager.hpp
@@ -43,7 +43,9 @@ private:
 
   void modifyPathVelocity(autoware_auto_planning_msgs::msg::PathWithLaneId * path) override;
 
-  bool isModuleRegisteredFromRegElement(const lanelet::Id & id) const;
+  bool isModuleRegisteredFromRegElement(const lanelet::Id & id, const size_t module_id) const;
+
+  bool isModuleRegisteredFromExistingAssociatedModule(const lanelet::Id & id) const;
 
   bool hasSameTrafficLight(
     const lanelet::TrafficLightConstPtr element,

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -97,7 +97,7 @@ void IntersectionModuleManager::launchNewModules(
     const auto lane_id = ll.id();
     const auto module_id = lane_id;
 
-    if (hasSameParentLanelet(ll)) {
+    if (hasSameParentLaneletWithRegistered(ll)) {
       continue;
     }
 
@@ -177,21 +177,20 @@ IntersectionModuleManager::getModuleExpiredFunction(
   const auto lane_set = planning_utils::getLaneletsOnPath(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  return
-    [this, lane_set]([[maybe_unused]] const std::shared_ptr<SceneModuleInterface> & scene_module) {
-      for (const auto & lane : lane_set) {
-        const std::string turn_direction = lane.attributeOr("turn_direction", "else");
-        const auto is_intersection =
-          turn_direction == "right" || turn_direction == "left" || turn_direction == "straight";
-        if (!is_intersection) {
-          continue;
-        }
-        if (hasSameParentLanelet(lane)) {
-          return false;
-        }
+  return [this, lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
+    for (const auto & lane : lane_set) {
+      const std::string turn_direction = lane.attributeOr("turn_direction", "else");
+      const auto is_intersection =
+        turn_direction == "right" || turn_direction == "left" || turn_direction == "straight";
+      if (!is_intersection) {
+        continue;
       }
-      return true;
-    };
+      if (hasSameParentLaneletWith(lane, scene_module->getModuleId())) {
+        return false;
+      }
+    }
+    return true;
+  };
 }
 
 std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
@@ -218,7 +217,26 @@ MergeFromPrivateModuleManager::getModuleExpiredFunction(
     };
 }
 
-bool IntersectionModuleManager::hasSameParentLanelet(const lanelet::ConstLanelet & lane) const
+bool IntersectionModuleManager::hasSameParentLaneletWith(
+  const lanelet::ConstLanelet & lane, const size_t module_id) const
+{
+  lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
+
+  const auto registered_lane = planner_data_->route_handler_->getLaneletsFromId(module_id);
+  lanelet::ConstLanelets registered_parents =
+    planner_data_->route_handler_->getPreviousLanelets(registered_lane);
+  for (const auto & ll : registered_parents) {
+    auto neighbor_lanes = planner_data_->route_handler_->getLaneChangeableNeighbors(ll);
+    neighbor_lanes.push_back(ll);
+    if (hasSameLanelet(parents, neighbor_lanes)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool IntersectionModuleManager::hasSameParentLaneletWithRegistered(
+  const lanelet::ConstLanelet & lane) const
 {
   lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -200,21 +200,20 @@ MergeFromPrivateModuleManager::getModuleExpiredFunction(
   const auto lane_set = planning_utils::getLaneletsOnPath(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  return
-    [this, lane_set]([[maybe_unused]] const std::shared_ptr<SceneModuleInterface> & scene_module) {
-      for (const auto & lane : lane_set) {
-        const std::string turn_direction = lane.attributeOr("turn_direction", "else");
-        const auto is_intersection =
-          turn_direction == "right" || turn_direction == "left" || turn_direction == "straight";
-        if (!is_intersection) {
-          continue;
-        }
-        if (hasSameParentLanelet(lane)) {
-          return false;
-        }
+  return [this, lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
+    for (const auto & lane : lane_set) {
+      const std::string turn_direction = lane.attributeOr("turn_direction", "else");
+      const auto is_intersection =
+        turn_direction == "right" || turn_direction == "left" || turn_direction == "straight";
+      if (!is_intersection) {
+        continue;
       }
-      return true;
-    };
+      if (hasSameParentLaneletWith(lane, scene_module->getModuleId())) {
+        return false;
+      }
+    }
+    return true;
+  };
 }
 
 bool IntersectionModuleManager::hasSameParentLaneletWith(
@@ -255,20 +254,19 @@ bool IntersectionModuleManager::hasSameParentLaneletWithRegistered(
   return false;
 }
 
-bool MergeFromPrivateModuleManager::hasSameParentLanelet(const lanelet::ConstLanelet & lane) const
+bool MergeFromPrivateModuleManager::hasSameParentLaneletWith(
+  const lanelet::ConstLanelet & lane, const size_t module_id) const
 {
   lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
 
-  for (const auto & id : registered_module_id_set_) {
-    const auto registered_lane = planner_data_->route_handler_->getLaneletsFromId(id);
-    lanelet::ConstLanelets registered_parents =
-      planner_data_->route_handler_->getPreviousLanelets(registered_lane);
-    for (const auto & ll : registered_parents) {
-      auto neighbor_lanes = planner_data_->route_handler_->getLaneChangeableNeighbors(ll);
-      neighbor_lanes.push_back(ll);
-      if (hasSameLanelet(parents, neighbor_lanes)) {
-        return true;
-      }
+  const auto registered_lane = planner_data_->route_handler_->getLaneletsFromId(module_id);
+  lanelet::ConstLanelets registered_parents =
+    planner_data_->route_handler_->getPreviousLanelets(registered_lane);
+  for (const auto & ll : registered_parents) {
+    auto neighbor_lanes = planner_data_->route_handler_->getLaneChangeableNeighbors(ll);
+    neighbor_lanes.push_back(ll);
+    if (hasSameLanelet(parents, neighbor_lanes)) {
+      return true;
     }
   }
   return false;

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
@@ -125,7 +125,7 @@ void TrafficLightModuleManager::launchNewModules(
     // Use lanelet_id to unregister module when the route is changed
     const auto lane_id = traffic_light_reg_elem.second.id();
     const auto module_id = lane_id;
-    if (!isModuleRegisteredFromRegElement(module_id)) {
+    if (!isModuleRegisteredFromExistingAssociatedModule(module_id)) {
       registerModule(std::make_shared<TrafficLightModule>(
         module_id, lane_id, *(traffic_light_reg_elem.first), traffic_light_reg_elem.second,
         planner_param_, logger_.get_child("traffic_light_module"), clock_));
@@ -143,10 +143,9 @@ TrafficLightModuleManager::getModuleExpiredFunction(
   const auto lanelet_id_set = planning_utils::getLaneletIdSetOnPath<TrafficLight>(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  return [this, lanelet_id_set](
-           [[maybe_unused]] const std::shared_ptr<SceneModuleInterface> & scene_module) {
+  return [this, lanelet_id_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
     for (const auto & id : lanelet_id_set) {
-      if (isModuleRegisteredFromRegElement(id)) {
+      if (isModuleRegisteredFromRegElement(id, scene_module->getModuleId())) {
         return false;
       }
     }
@@ -154,7 +153,25 @@ TrafficLightModuleManager::getModuleExpiredFunction(
   };
 }
 
-bool TrafficLightModuleManager::isModuleRegisteredFromRegElement(const lanelet::Id & id) const
+bool TrafficLightModuleManager::isModuleRegisteredFromRegElement(
+  const lanelet::Id & id, const size_t module_id) const
+{
+  const auto lane = planner_data_->route_handler_->getLaneletMapPtr()->laneletLayer.get(id);
+
+  const auto registered_lane =
+    planner_data_->route_handler_->getLaneletMapPtr()->laneletLayer.get(module_id);
+  for (const auto & registered_element : registered_lane.regulatoryElementsAs<TrafficLight>()) {
+    for (const auto & element : lane.regulatoryElementsAs<TrafficLight>()) {
+      if (hasSameTrafficLight(element, registered_element)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool TrafficLightModuleManager::isModuleRegisteredFromExistingAssociatedModule(
+  const lanelet::Id & id) const
 {
   const auto lane = planner_data_->route_handler_->getLaneletMapPtr()->laneletLayer.get(id);
 


### PR DESCRIPTION
## Description

I fixed the way to get expired module in intersection/merge_from_private/traffic_light modules to consider each scene_modules's id respectively.

## Related links

Prior Lane change feature in intersection: https://github.com/autowarefoundation/autoware.universe/pull/2720

## Tests performed

### Intersection

Before this PR the marker of intersection module remained even after ego passed through it. After this PR this does not remain. In the below image orange polygon marker is coming from outdated intersection module which does not appear with this PR.

![image](https://user-images.githubusercontent.com/28677420/216005148-ba42e625-fe45-474a-9558-9fff71fc858a.png)

### Traffic light
### Before
The nearest traffic light module with uuid `[32, 238, 103, ...]` still remains when ego passed the lane.

![image](https://user-images.githubusercontent.com/28677420/216009386-1ff7627f-c18e-4f06-acfe-287e8e6a1b84.png)

![image](https://user-images.githubusercontent.com/28677420/216009967-178c9e93-dfb9-4f62-9144-290d8b4502cf.png)

#### After
The nearest traffic light module with uuid `[114, 113, 40, ...]` disappears ego passed the lane.

![image](https://user-images.githubusercontent.com/28677420/216010205-9f704430-6b94-40f2-8e6c-ee173168f0c6.png)

![image](https://user-images.githubusercontent.com/28677420/216010311-33669807-b1a9-4941-9ef2-d1ee58096746.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
