### PR TITLE
fix(freespace_planning_algorithms): set goal z to path

### DIFF
--- a/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/astar_search.hpp
+++ b/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/astar_search.hpp
@@ -144,6 +144,7 @@ private:
   bool setGoalNode();
   double estimateCost(const geometry_msgs::msg::Pose & pose) const;
   bool isGoal(const AstarNode & node) const;
+  geometry_msgs::msg::Pose node2pose(const AstarNode & node) const;
 
   AstarNode * getNodeRef(const IndexXYT & index)
   {

--- a/planning/freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/freespace_planning_algorithms/src/astar_search.cpp
@@ -61,18 +61,6 @@ geometry_msgs::msg::Pose calcRelativePose(
   return transformed.pose;
 }
 
-geometry_msgs::msg::Pose node2pose(const AstarNode & node)
-{
-  geometry_msgs::msg::Pose pose_local;
-
-  pose_local.position.x = node.x;
-  pose_local.position.y = node.y;
-  pose_local.position.z = 0;
-  pose_local.orientation = tier4_autoware_utils::createQuaternionFromYaw(node.theta);
-
-  return pose_local;
-}
-
 AstarSearch::TransitionTable createTransitionTable(
   const double minimum_turning_radius, const double maximum_turning_radius,
   const int turning_radius_size, const double theta_size, const bool use_back)
@@ -354,6 +342,18 @@ bool AstarSearch::isGoal(const AstarNode & node) const
   }
 
   return true;
+}
+
+geometry_msgs::msg::Pose AstarSearch::node2pose(const AstarNode & node) const
+{
+  geometry_msgs::msg::Pose pose_local;
+
+  pose_local.position.x = node.x;
+  pose_local.position.y = node.y;
+  pose_local.position.z = goal_pose_.position.z;
+  pose_local.orientation = tier4_autoware_utils::createQuaternionFromYaw(node.theta);
+
+  return pose_local;
 }
 
 }  // namespace freespace_planning_algorithms

--- a/planning/freespace_planning_algorithms/src/rrtstar.cpp
+++ b/planning/freespace_planning_algorithms/src/rrtstar.cpp
@@ -141,7 +141,7 @@ void RRTStar::setRRTPath(const std::vector<rrtstar_core::Pose> & waypoints)
     geometry_msgs::msg::Pose pose_local;
     pose_local.position.x = pt.x;
     pose_local.position.y = pt.y;
-    pose_local.position.z = 0.0;
+    pose_local.position.z = goal_pose_.position.z;
     tf2::Quaternion quat;
     quat.setRPY(0, 0, pt.yaw);
     tf2::convert(quat, pose_local.orientation);


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

 set goal z to path

before

![Screenshot from 2023-02-02 16-04-50](https://user-images.githubusercontent.com/39142679/216258871-14ef4447-5fcc-4ee5-8916-f2b90a3fe50c.png)


after

![Screenshot from 2023-02-02 16-16-25](https://user-images.githubusercontent.com/39142679/216258894-25f24a83-b982-4388-b6ff-5a9d08067c44.png)



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
