### PR TITLE
feat(behavior_path_planner): use akima spline for xy only first

### DIFF
--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -434,8 +434,8 @@ autoware_auto_planning_msgs::msg::Path resamplePath(
 
 autoware_auto_planning_msgs::msg::Path resamplePath(
   const autoware_auto_planning_msgs::msg::Path & input_path, const double resample_interval,
-  const bool use_akima_spline_for_xy, const bool use_lerp_for_z, const bool use_zero_order_hold_for_twist,
-  const bool resample_input_path_stop_point)
+  const bool use_akima_spline_for_xy, const bool use_lerp_for_z,
+  const bool use_zero_order_hold_for_twist, const bool resample_input_path_stop_point)
 {
   // validate arguments
   if (!resample_utils::validate_arguments(input_path.points, resample_interval)) {

--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -434,8 +434,8 @@ autoware_auto_planning_msgs::msg::Path resamplePath(
 
 autoware_auto_planning_msgs::msg::Path resamplePath(
   const autoware_auto_planning_msgs::msg::Path & input_path, const double resample_interval,
-  const bool use_akima_spline_for_xy, const bool use_lerp_for_z,
-  const bool use_zero_order_hold_for_twist, const bool resample_input_path_stop_point)
+  const bool use_akima_spline_for_xy, const bool use_lerp_for_z, const bool use_zero_order_hold_for_twist,
+  const bool resample_input_path_stop_point)
 {
   // validate arguments
   if (!resample_utils::validate_arguments(input_path.points, resample_interval)) {

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -56,7 +56,9 @@ struct BehaviorPathPlannerParameters
   double turn_signal_shift_length_threshold;
   bool turn_signal_on_swerving;
 
-  double path_interval;
+  double enable_akima_spline_first;
+  double input_path_interval;
+  double output_path_interval;
 
   double ego_nearest_dist_threshold;
   double ego_nearest_yaw_threshold;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -383,7 +383,9 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
     declare_parameter("turn_signal_shift_length_threshold", 0.3);
   p.turn_signal_on_swerving = declare_parameter("turn_signal_on_swerving", true);
 
-  p.path_interval = declare_parameter<double>("path_interval");
+  p.enable_akima_spline_first = declare_parameter<bool>("enable_akima_spline_first");
+  p.input_path_interval = declare_parameter<double>("input_path_interval");
+  p.output_path_interval = declare_parameter<double>("output_path_interval");
   p.visualize_maximum_drivable_area = declare_parameter("visualize_maximum_drivable_area", true);
   p.ego_nearest_dist_threshold = declare_parameter<double>("ego_nearest_dist_threshold");
   p.ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
@@ -1211,7 +1213,7 @@ PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPath(
   }
 
   const auto resampled_path = util::resamplePathWithSpline(
-    connected_path, planner_data_->parameters.path_interval,
+    connected_path, planner_data_->parameters.output_path_interval,
     keepInputPoints(module_status_ptr_vec));
   return std::make_shared<PathWithLaneId>(resampled_path);
 }

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1959,7 +1959,14 @@ PathWithLaneId getCenterLinePath(
     s_forward = std::min(s_forward, goal_arc_coordinates.length - lane_change_buffer);
   }
 
-  return route_handler.getCenterLinePath(lanelet_sequence, s_backward, s_forward, true);
+  const bool use_akima_spline = true;
+  const auto raw_path_with_lane_id = route_handler.getCenterLinePath(lanelet_sequence, s_backward, s_forward, true);
+  if (use_akima_spline) {
+    const auto resampled_path_with_lane_id = motion_utils::resamplePath(raw_path_with_lane_id, 1.0, true);
+    return resampled_path_with_lane_id;
+  }
+
+  return raw_path_with_lane_id;
 }
 
 // for lane following

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1959,13 +1959,10 @@ PathWithLaneId getCenterLinePath(
     s_forward = std::min(s_forward, goal_arc_coordinates.length - lane_change_buffer);
   }
 
-  const bool use_akima_spline = true;
-  const auto raw_path_with_lane_id = route_handler.getCenterLinePath(lanelet_sequence, s_backward, s_forward, true);
-  if (use_akima_spline) {
-    const auto resampled_path_with_lane_id = motion_utils::resamplePath(raw_path_with_lane_id, 1.0, true);
-    return resampled_path_with_lane_id;
-  }
-
+  const auto raw_path_with_lane_id =
+    route_handler.getCenterLinePath(lanelet_sequence, s_backward, s_forward, true);
+  const auto resampled_path_with_lane_id = motion_utils::resamplePath(
+    raw_path_with_lane_id, parameter.input_path_interval, parameter.enable_akima_spline_first);
   return raw_path_with_lane_id;
 }
 


### PR DESCRIPTION
## Description

Applied akima spline for xy only first when getting centerline from lanelet.

**TODO**
- [x] add a figure to compare when enabling and disabling akima spline.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
