### PR TITLE
fix(lane_change): ego predicted path's min speed

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -104,11 +104,6 @@ std::vector<Point> convertToGeometryPointArray(const PathWithLaneId & path);
 
 PoseArray convertToGeometryPoseArray(const PathWithLaneId & path);
 
-PredictedPath convertToPredictedPath(
-  const PathWithLaneId & path, const Twist & vehicle_twist, const Pose & pose,
-  const double nearest_seg_idx, const double duration, const double resolution,
-  const double acceleration, const double min_speed = 1.0);
-
 template <class T>
 FrenetCoordinate3d convertToFrenetCoordinate3d(
   const std::vector<T> & pose_array, const Point & search_point_geom, const size_t seg_idx)


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

![image](https://user-images.githubusercontent.com/93502286/216545158-0eb36a05-a2a2-4ddd-a656-7d7090b82daa.png)

Before performing collision assessment, lane change candidate path is converted into predicted path. Because each candidate path has it's own deceleration value, prepare and lane changing speed, when converted to candidate path, it should also depend on the prepare and lane changing speed which is encoded to the path.

However, current convertToPredictedPath caused ego speed to be equal to `min_speed` after decelerate. This is incorrect, as the min speed of the predicted path should vary based on the predicted and lane changing speed. Therefore, this PR aims to fix this issue.

Note:
Old function is removed.
New function is scoped in lane change util's file.

## Related links

This PR is to solve `LC-00004_001_case6_v2` scenario.

## Tests performed

### Before PR
Red box in ego path shows the last position of ego's predicted path. It is in the current lane.
![Screenshot from 2023-02-03 17-16-55](https://user-images.githubusercontent.com/93502286/216548485-f3e7da04-b313-4138-9a46-b09099e40ad5.png)

### After PR

Red box in ego path shows the last position of ego's predicted path. It is in the target lane.
![Screenshot from 2023-02-03 17-18-00](https://user-images.githubusercontent.com/93502286/216548603-cfc61e32-5b79-4d8d-b143-46277b54783a.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
