### PR TITLE
fix(accel_brake_map_calibrator): set method to none as default in view plot py

### DIFF
--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/scripts/view_plot.py
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/scripts/view_plot.py
@@ -281,7 +281,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-m",
         "--method",
-        default="None",
+        default=None,
         type=str,
         help="calibration method : each_cell or four_cell",
     )


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Currently, the default value of args.method is not None but "None".

> parser.add_argument(
        "-m",
        "--method",
        default="None",
        type=str,
        help="calibration method : each_cell or four_cell",
    )
![image](https://user-images.githubusercontent.com/59680180/216543574-fdb67a5d-bfcd-47d5-9760-1a54f4663baa.png)

So, None-check for ```calibration_method``` is not properly performed, and unnecessary errors are occured. I fixed it.

![image](https://user-images.githubusercontent.com/59680180/216543624-fa30e804-ded7-4b4b-8fbc-6768a9982044.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
