### PR TITLE
refactor(motion_velocity_smoother): remove unneccesary optional

### DIFF
--- a/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/trajectory_utils.hpp
@@ -105,7 +105,7 @@ inline bool smoothPath(
 
   // Resample trajectory with ego-velocity based interval distances
   auto traj_resampled = smoother->resampleTrajectory(
-    *traj_lateral_acc_filtered, v0, current_pose, planner_data->ego_nearest_dist_threshold,
+    traj_lateral_acc_filtered, v0, current_pose, planner_data->ego_nearest_dist_threshold,
     planner_data->ego_nearest_yaw_threshold);
   const size_t traj_resampled_closest = motion_utils::findFirstNearestIndexWithSoftConstraints(
     traj_resampled, current_pose, planner_data->ego_nearest_dist_threshold,

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -77,7 +77,7 @@ public:
     [[maybe_unused]] const double nearest_dist_threshold,
     [[maybe_unused]] const double nearest_yaw_threshold) const override;
 
-  boost::optional<TrajectoryPoints> applyLateralAccelerationFilter(
+  TrajectoryPoints applyLateralAccelerationFilter(
     const TrajectoryPoints & input, [[maybe_unused]] const double v0,
     [[maybe_unused]] const double a0,
     [[maybe_unused]] const bool enable_smooth_limit) const override;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/smoother/smoother_base.hpp
@@ -71,12 +71,12 @@ public:
     const TrajectoryPoints & input, const double v0, const geometry_msgs::msg::Pose & current_pose,
     const double nearest_dist_threshold, const double nearest_yaw_threshold) const = 0;
 
-  virtual boost::optional<TrajectoryPoints> applyLateralAccelerationFilter(
+  virtual TrajectoryPoints applyLateralAccelerationFilter(
     const TrajectoryPoints & input, [[maybe_unused]] const double v0 = 0.0,
     [[maybe_unused]] const double a0 = 0.0,
     [[maybe_unused]] const bool enable_smooth_limit = false) const;
 
-  boost::optional<TrajectoryPoints> applySteeringRateLimit(const TrajectoryPoints & input) const;
+  TrajectoryPoints applySteeringRateLimit(const TrajectoryPoints & input) const;
 
   double getMaxAccel() const;
   double getMinDecel() const;

--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -277,16 +277,12 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::resampleTrajectory(
   return output;
 }
 
-boost::optional<TrajectoryPoints> AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilter(
+TrajectoryPoints AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilter(
   const TrajectoryPoints & input, [[maybe_unused]] const double v0,
   [[maybe_unused]] const double a0, [[maybe_unused]] const bool enable_smooth_limit) const
 {
-  if (input.empty()) {
-    return boost::none;
-  }
-
   if (input.size() < 3) {
-    return boost::optional<TrajectoryPoints>(input);  // cannot calculate lateral acc. do nothing.
+    return input;  // cannot calculate lateral acc. do nothing.
   }
 
   // Interpolate with constant interval distance for lateral acceleration calculation.

--- a/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/smoother_base.cpp
@@ -69,16 +69,12 @@ double SmootherBase::getMaxJerk() const { return base_param_.max_jerk; }
 
 double SmootherBase::getMinJerk() const { return base_param_.min_jerk; }
 
-boost::optional<TrajectoryPoints> SmootherBase::applyLateralAccelerationFilter(
+TrajectoryPoints SmootherBase::applyLateralAccelerationFilter(
   const TrajectoryPoints & input, [[maybe_unused]] const double v0,
   [[maybe_unused]] const double a0, [[maybe_unused]] const bool enable_smooth_limit) const
 {
-  if (input.empty()) {
-    return boost::none;
-  }
-
   if (input.size() < 3) {
-    return boost::optional<TrajectoryPoints>(input);  // cannot calculate lateral acc. do nothing.
+    return input;  // cannot calculate lateral acc. do nothing.
   }
 
   // Interpolate with constant interval distance for lateral acceleration calculation.
@@ -135,16 +131,10 @@ boost::optional<TrajectoryPoints> SmootherBase::applyLateralAccelerationFilter(
   return output;
 }
 
-boost::optional<TrajectoryPoints> SmootherBase::applySteeringRateLimit(
-  const TrajectoryPoints & input) const
+TrajectoryPoints SmootherBase::applySteeringRateLimit(const TrajectoryPoints & input) const
 {
-  if (input.empty()) {
-    return boost::none;
-  }
-
   if (input.size() < 3) {
-    return boost::optional<TrajectoryPoints>(
-      input);  // cannot calculate the desired velocity. do nothing.
+    return input;  // cannot calculate the desired velocity. do nothing.
   }
   // Interpolate with constant interval distance for lateral acceleration calculation.
   std::vector<double> out_arclength;


### PR DESCRIPTION
## Description

The boost::optional for filters used in the `motion_velocuty_smoother` gets none only when the path is empty.
 This PR moves the empty check out of the filters and changes the return value to the actual value.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
