### PR TITLE
feat(autoware_auto_perception_rviz_plugin): add simple visualize mode

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -126,7 +126,7 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::Sha
 get_predicted_path_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
-  const std_msgs::msg::ColorRGBA & predicted_path_color);
+  const std_msgs::msg::ColorRGBA & predicted_path_color, const bool is_simple = false);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_path_confidence_marker_ptr(
@@ -163,7 +163,7 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_polygon_bottom_line_lis
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_path_line_list(
   const autoware_auto_perception_msgs::msg::PredictedPath & paths,
-  std::vector<geometry_msgs::msg::Point> & points);
+  std::vector<geometry_msgs::msg::Point> & points, const bool is_simple = false);
 
 /// \brief Convert Point32 to Point
 /// \param val Point32 to be converted

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -87,6 +87,11 @@ public:
     m_display_type_property->addOption("3d", 0);
     m_display_type_property->addOption("2d", 1);
     m_display_type_property->addOption("Disable", 2);
+    m_simple_visualize_mode_property = new rviz_common::properties::EnumProperty(
+      "Vislualization Type", "Normal", "Simplicity of the polygon to display object.", this,
+      SLOT(updatePalette()));
+    m_simple_visualize_mode_property->addOption("Normal", 0);
+    m_simple_visualize_mode_property->addOption("Simple", 1);
     // iterate over default values to create and initialize the properties.
     for (const auto & map_property_it : detail::kDefaultObjectPropertyValues) {
       const auto & class_property_values = map_property_it.second;
@@ -262,7 +267,9 @@ protected:
     if (m_display_predicted_paths_property.getBool()) {
       const std::string uuid_str = uuid_to_string(uuid);
       const std_msgs::msg::ColorRGBA predicted_path_color = get_color_from_uuid(uuid_str);
-      return detail::get_predicted_path_marker_ptr(shape, predicted_path, predicted_path_color);
+      return detail::get_predicted_path_marker_ptr(
+        shape, predicted_path, predicted_path_color,
+        m_simple_visualize_mode_property->getOptionInt() == 1);
     } else {
       return std::nullopt;
     }
@@ -384,6 +391,8 @@ private:
   PolygonPropertyMap m_polygon_properties;
   // Property to choose type of visualization polygon
   rviz_common::properties::EnumProperty * m_display_type_property;
+  // Property to choose simplicity of visualization polygon
+  rviz_common::properties::EnumProperty * m_simple_visualize_mode_property;
   // Property to enable/disable label visualization
   rviz_common::properties::BoolProperty m_display_label_property;
   // Property to enable/disable uuid visualization

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -88,7 +88,7 @@ public:
     m_display_type_property->addOption("2d", 1);
     m_display_type_property->addOption("Disable", 2);
     m_simple_visualize_mode_property = new rviz_common::properties::EnumProperty(
-      "Vislualization Type", "Normal", "Simplicity of the polygon to display object.", this,
+      "Visualization Type", "Normal", "Simplicity of the polygon to display object.", this,
       SLOT(updatePalette()));
     m_simple_visualize_mode_property->addOption("Normal", 0);
     m_simple_visualize_mode_property->addOption("Simple", 1);

--- a/common/autoware_auto_perception_rviz_plugin/package.xml
+++ b/common/autoware_auto_perception_rviz_plugin/package.xml
@@ -7,6 +7,8 @@
   <maintainer email="opensource@apex.ai">Apex.AI, Inc.</maintainer>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
+  <maintainer email="takeshi.miura@tier4.jp">Takeshi Miura</maintainer>
+
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Add simple visualization mode to autoware_auto_perception_rviz_plugin for reduction of visualization cost.
Compared to before the PR merge, there is no change when using default parameters.

Normal
![image](https://user-images.githubusercontent.com/59680180/216888431-57436d28-02a2-49c3-9f2f-4636e48f7930.png)

Simple
![image](https://user-images.githubusercontent.com/59680180/216888422-d0b7adbe-0de8-41df-b34d-6d6fe0762398.png)


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
