### PR TITLE
fix(lane_change): fix object predicted path getter logic

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2239,20 +2239,20 @@ bool getObjectExpectedPoseAndConvertToPolygon(
 std::vector<PredictedPath> getPredictedPathFromObj(
   const PredictedObject & obj, const bool & is_use_all_predicted_path)
 {
-  std::vector<PredictedPath> predicted_path_vec;
-  if (is_use_all_predicted_path) {
-    std::copy_if(
-      obj.kinematics.predicted_paths.cbegin(), obj.kinematics.predicted_paths.cend(),
-      std::back_inserter(predicted_path_vec),
-      [](const PredictedPath & path) { return !path.path.empty(); });
-  } else {
+  if (!is_use_all_predicted_path) {
     const auto max_confidence_path = std::max_element(
       obj.kinematics.predicted_paths.begin(), obj.kinematics.predicted_paths.end(),
-      [](const auto & path1, const auto & path2) { return path1.confidence > path2.confidence; });
+      [](const auto & path1, const auto & path2) { return path1.confidence < path2.confidence; });
     if (max_confidence_path != obj.kinematics.predicted_paths.end()) {
-      predicted_path_vec.push_back(*max_confidence_path);
+      return {*max_confidence_path};
     }
   }
+
+  std::vector<PredictedPath> predicted_path_vec;
+  std::copy_if(
+    obj.kinematics.predicted_paths.cbegin(), obj.kinematics.predicted_paths.cend(),
+    std::back_inserter(predicted_path_vec),
+    [](const PredictedPath & path) { return !path.path.empty(); });
   return predicted_path_vec;
 }
 


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

The logic to get the path with maximum confidence is incorrect, so the PR aims to fix this by changing the sign of the maximum check.

Also, the code is slightly refactored.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
