### PR TITLE
fix(ground_segmentation): fix unuse_time_series_filter bug

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -463,7 +463,9 @@ def launch_setup(context, *args, **kwargs):
     components.extend(
         pipeline.create_single_frame_obstacle_segmentation_components(
             input_topic=LaunchConfiguration("input/pointcloud"),
-            output_topic=pipeline.single_frame_obstacle_seg_output,
+            output_topic=pipeline.single_frame_obstacle_seg_output
+            if pipeline.use_single_frame_filter or pipeline.use_time_series_filter
+            else pipeline.output_topic,
         )
     )
 


### PR DESCRIPTION
Signed-off-by: badai-nguyen <dai.nguyen@tier4.jp>

## Description

There is no any node publishes /perception/obstacle_segmentation output_topic when [both use_time_series_filter and use_single_frame_filter set to false](https://github.com/autowarefoundation/autoware_launch/blob/2f45d819777096eb41de51f9612df6ef6da933f8/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml#L6)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
