### PR TITLE
refactor(lane_change): compute obj indices return if safe path found

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module_data.hpp
@@ -72,6 +72,13 @@ struct LaneChangePhaseInfo
 
   [[nodiscard]] double sum() const { return prepare + lane_changing; }
 };
+
+struct LaneChangeTargetObjectIndices
+{
+  std::vector<size_t> current_lane{};
+  std::vector<size_t> target_lane{};
+  std::vector<size_t> other_lane{};
+};
 }  // namespace behavior_path_planner
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__LANE_CHANGE_MODULE_DATA_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/util.hpp
@@ -69,33 +69,22 @@ std::optional<LaneChangePath> constructCandidatePath(
   const double prepare_speed, const double lane_change_distance, const double lane_changing_speed,
   const BehaviorPathPlannerParameters & params, const LaneChangeParameters & lane_change_param);
 
-LaneChangePaths getLaneChangePaths(
+std::pair<bool, bool> getLaneChangePaths(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & original_lanelets,
   const lanelet::ConstLanelets & target_lanelets, const Pose & pose, const Twist & twist,
-  const BehaviorPathPlannerParameters & common_parameter,
-  const behavior_path_planner::LaneChangeParameters & parameter);
-
-LaneChangePaths selectValidPaths(
-  const LaneChangePaths & paths, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & target_lanes, const RouteHandler & route_handler,
-  const Pose & current_pose, const Pose & goal_pose, const double minimum_lane_change_length);
-
-bool selectSafePath(
-  const LaneChangePaths & paths, const lanelet::ConstLanelets & backward_lanes,
-  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
-  const Twist & current_twist, const BehaviorPathPlannerParameters & common_parameters,
-  const behavior_path_planner::LaneChangeParameters & ros_parameters,
-  LaneChangePath * selected_path,
-  std::unordered_map<std::string, CollisionCheckDebug> & debug_data);
+  const PredictedObjects::ConstSharedPtr dynamic_objects,
+  const BehaviorPathPlannerParameters & common_parameter, const LaneChangeParameters & parameter,
+  const double check_distance, LaneChangePaths * candidate_paths,
+  std::unordered_map<std::string, CollisionCheckDebug> * debug_data);
 
 bool isLaneChangePathSafe(
-  const LaneChangePath & lane_change_path, const lanelet::ConstLanelets & backward_lanes,
-  const PredictedObjects::ConstSharedPtr dynamic_objects, const Pose & current_pose,
+  const LaneChangePath & lane_change_path, const PredictedObjects::ConstSharedPtr dynamic_objects,
+  const LaneChangeTargetObjectIndices & dynamic_object_indices, const Pose & current_pose,
   const size_t current_seg_idx, const Twist & current_twist,
   const BehaviorPathPlannerParameters & common_parameters,
   const behavior_path_planner::LaneChangeParameters & lane_change_parameters,
   const double front_decel, const double rear_decel, Pose & ego_pose_before_collision,
-  std::unordered_map<std::string, CollisionCheckDebug> & debug_data, const bool use_buffer = true,
+  std::unordered_map<std::string, CollisionCheckDebug> & debug_data,
   const double acceleration = 0.0);
 
 bool hasEnoughDistance(
@@ -150,5 +139,14 @@ bool hasEnoughDistanceToLaneChangeAfterAbort(
 lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
   const RouteHandler & route_handler, const lanelet::ConstLanelet & target_lanes,
   const Pose & current_pose, const double backward_length);
+
+LaneChangeTargetObjectIndices filterObjectIndices(
+  const LaneChangePaths & lane_change_paths, const PredictedObjects & objects,
+  const lanelet::ConstLanelets & target_backward_lanes, const Pose & current_pose,
+  const double forward_path_length, const double filter_width,
+  const bool ignore_unknown_obj = false);
+
+double calcLateralBufferForFiltering(const double vehicle_width, const double lateral_buffer = 0.0);
+
 }  // namespace behavior_path_planner::lane_change_utils
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -376,43 +376,12 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
   }
 
   // find candidate paths
-  const auto lane_change_paths = lane_change_utils::getLaneChangePaths(
+  LaneChangePaths valid_paths;
+  const auto [found_valid_path, found_safe_path] = lane_change_utils::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
-    common_parameters, *parameters_);
-
-  if (lane_change_paths.empty()) {
-    return std::make_pair(false, false);
-  }
-
-  // get lanes used for detection
-  lanelet::ConstLanelets check_lanes;
-  const auto & longest_path = lane_change_paths.front();
-  // we want to see check_distance [m] behind vehicle so add lane changing length
-  const double check_distance_with_path = check_distance + longest_path.length.sum();
-  check_lanes = route_handler->getCheckTargetLanesFromPath(
-    longest_path.path, lane_change_lanes, check_distance_with_path);
-
-  // select valid path
-  const LaneChangePaths valid_paths = lane_change_utils::selectValidPaths(
-    lane_change_paths, current_lanes, check_lanes, *route_handler, current_pose,
-    route_handler->getGoalPose(),
-    common_parameters.minimum_lane_change_length +
-      common_parameters.backward_length_buffer_for_end_of_lane +
-      parameters_->lane_change_finish_judge_buffer);
-
-  if (valid_paths.empty()) {
-    return std::make_pair(false, false);
-  }
+    planner_data_->dynamic_object, common_parameters, *parameters_, check_distance, &valid_paths,
+    &object_debug_);
   debug_valid_path_ = valid_paths;
-
-  // get lanes used for detection
-  const auto backward_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, lane_change_lanes.front(), current_pose, check_distance);
-
-  // select safe path
-  const bool found_safe_path = lane_change_utils::selectSafePath(
-    valid_paths, backward_lanes, planner_data_->dynamic_object, current_pose, current_twist,
-    common_parameters, *parameters_, &safe_path, object_debug_);
 
   if (parameters_->publish_debug_marker) {
     setObjectDebugVisualization();
@@ -420,7 +389,18 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
     debug_marker_.markers.clear();
   }
 
-  return std::make_pair(true, found_safe_path);
+  if (!found_valid_path) {
+    return {false, false};
+  }
+
+  if (found_safe_path) {
+    safe_path = valid_paths.back();
+  } else {
+    // force candidate
+    safe_path = valid_paths.front();
+  }
+
+  return {found_valid_path, found_safe_path};
 }
 
 bool ExternalRequestLaneChangeModule::isSafe() const { return status_.is_safe; }
@@ -689,14 +669,21 @@ bool ExternalRequestLaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
 
+  constexpr auto ignore_unknown{true};
+  const auto lateral_buffer =
+    lane_change_utils::calcLateralBufferForFiltering(common_parameters.vehicle_width);
+  const auto dynamic_object_indices = lane_change_utils::filterObjectIndices(
+    {path}, *dynamic_objects, check_lanes, current_pose, common_parameters.forward_path_length,
+    lateral_buffer, ignore_unknown);
+
   const size_t current_seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
     path.path.points, current_pose, common_parameters.ego_nearest_dist_threshold,
     common_parameters.ego_nearest_yaw_threshold);
   return lane_change_utils::isLaneChangePathSafe(
-    path, check_lanes, dynamic_objects, current_pose, current_seg_idx, current_twist,
+    path, dynamic_objects, dynamic_object_indices, current_pose, current_seg_idx, current_twist,
     common_parameters, *parameters_, common_parameters.expected_front_deceleration_for_abort,
     common_parameters.expected_rear_deceleration_for_abort, ego_pose_before_collision, debug_data,
-    false, status_.lane_change_path.acceleration);
+    status_.lane_change_path.acceleration);
 }
 
 void ExternalRequestLaneChangeModule::updateOutputTurnSignal(BehaviorModuleOutput & output)


### PR DESCRIPTION
## Description

This PR is related to lane change performance improvement.
As the effort to reduce computation, the PR aims to fix two things
1. getting dynamic object indices for collision check. 
   Since we can expect that across all candidate path, the relation between the path and objects are fairly same, therefore, we only need to compute the path once.
2. return once both valid and safe path is found.
   Since we don't really need to compute all the candidate path at all time, this will safe time by a little.


## Related links

[TIER IV internal link](https://tier4.atlassian.net/browse/T4PB-25681)

## Tests performed

Use the rosbag in the [TIER IV internal link](https://tier4.atlassian.net/browse/T4PB-25681) and compare before and after. It is expected that the computation time is reduced.

Degradation test performed. No issues with the commits

## Notes for reviewers

#2776 is needed. So once #2776 is merged, I will rebase this PR.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
