### PR TITLE
fix(motion_velocity_smoother): resample making empty path

### DIFF
--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -287,7 +287,7 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilt
   }
 
   // Interpolate with constant interval distance for lateral acceleration calculation.
-  const double points_interval = use_resampling ? input_points_interval : 0.1;  // [m]
+  const double points_interval = use_resampling ? 0.1 : input_points_interval;  // [m]
 
   TrajectoryPoints output;
   // since the resampling takes a long time, omit the resampling when it is not requested

--- a/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -299,7 +299,7 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilt
     }
     const auto output_traj =
       motion_utils::resampleTrajectory(motion_utils::convertToTrajectory(input), out_arclength);
-    auto output = motion_utils::convertToTrajectoryPointArray(output_traj);
+    output = motion_utils::convertToTrajectoryPointArray(output_traj);
     output.back() = input.back();  // keep the final speed.
   } else {
     output = input;


### PR DESCRIPTION
## Description

This is a fix for the issue of the process dying in the behavior_velocity_planner.

## Related links



## Tests performed

Checked in the planner won't die in the several map with an intersection, crosswalk traffic light scenes.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
