### PR TITLE
fix(behavior_path_planner): fix drivable area for long backawrd avoidance path

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -636,7 +636,6 @@ std::vector<Point> updateBoundary(
     motion_utils::findNearestSegmentIndex(original_bound, start_edge_point);
   const double front_offset = motion_utils::calcLongitudinalOffsetToSegment(
     original_bound, start_segment_idx, start_edge_point);
-  std::cerr << start_segment_idx << " " << front_offset << std::endl;
   const auto closest_front_point =
     motion_utils::calcLongitudinalOffsetPoint(original_bound, start_segment_idx, front_offset);
   const size_t end_segment_idx =

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -636,6 +636,7 @@ std::vector<Point> updateBoundary(
     motion_utils::findNearestSegmentIndex(original_bound, start_edge_point);
   const double front_offset = motion_utils::calcLongitudinalOffsetToSegment(
     original_bound, start_segment_idx, start_edge_point);
+  std::cerr << start_segment_idx << " " << front_offset << std::endl;
   const auto closest_front_point =
     motion_utils::calcLongitudinalOffsetPoint(original_bound, start_segment_idx, front_offset);
   const size_t end_segment_idx =
@@ -645,24 +646,28 @@ std::vector<Point> updateBoundary(
   const auto closest_end_point =
     motion_utils::calcLongitudinalOffsetPoint(original_bound, end_segment_idx, end_offset);
 
-  std::vector<Point> updated_bound;
-
   const double min_dist = 1e-3;
-  // copy original points until front point
-  std::copy(
-    original_bound.begin(), original_bound.begin() + start_segment_idx + 1,
-    std::back_inserter(updated_bound));
 
-  // insert closest front point
-  if (
-    closest_front_point &&
-    tier4_autoware_utils::calcDistance2d(*closest_front_point, updated_bound.back()) > min_dist) {
-    updated_bound.push_back(*closest_front_point);
+  std::vector<Point> updated_bound;
+  if (0 < front_offset) {
+    // copy original points until front point
+    std::copy(
+      original_bound.begin(), original_bound.begin() + start_segment_idx + 1,
+      std::back_inserter(updated_bound));
+
+    // insert closest front point
+    if (
+      closest_front_point &&
+      tier4_autoware_utils::calcDistance2d(*closest_front_point, updated_bound.back()) > min_dist) {
+      updated_bound.push_back(*closest_front_point);
+    }
   }
 
   // insert sorted points
   for (const auto & sorted_point : sorted_points) {
-    if (tier4_autoware_utils::calcDistance2d(sorted_point.point, updated_bound.back()) > min_dist) {
+    if (
+      updated_bound.empty() ||
+      tier4_autoware_utils::calcDistance2d(sorted_point.point, updated_bound.back()) > min_dist) {
       updated_bound.push_back(sorted_point.point);
     }
   }
@@ -670,13 +675,15 @@ std::vector<Point> updateBoundary(
   // insert closest end point
   if (
     closest_end_point &&
-    tier4_autoware_utils::calcDistance2d(*closest_end_point, updated_bound.back()) > min_dist) {
+    (updated_bound.empty() ||
+     tier4_autoware_utils::calcDistance2d(*closest_end_point, updated_bound.back()) > min_dist)) {
     updated_bound.push_back(*closest_end_point);
   }
 
   // copy original points until the end of the original bound
   for (size_t i = end_segment_idx + 1; i < original_bound.size(); ++i) {
     if (
+      updated_bound.empty() ||
       tier4_autoware_utils::calcDistance2d(original_bound.at(i), updated_bound.back()) > min_dist) {
       updated_bound.push_back(original_bound.at(i));
     }


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description
When backward path is long enough for avoidance, the front point of the drivable area line string is weird.
Fixed the bug in this PR.

Please check the behavior when the front point of drivable area line string is close to the object.
**before**
[Screencast from 2023年02月08日 00時19分12秒.webm](https://user-images.githubusercontent.com/20228327/217285899-39dc2a6d-a333-4a13-be71-78c5d29f41bb.webm)

**after**
[Screencast from 2023年02月08日 00時14分03秒.webm](https://user-images.githubusercontent.com/20228327/217285149-a99298df-8994-4c83-b928-4fe7567e59d7.webm)

FYI: The parameter diff I changed to check if PR works well.
![image](https://user-images.githubusercontent.com/20228327/217285624-72f024be-cffe-4b35-99d0-ec351318d39c.png)


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
