### PR TITLE
feat(behavior_path_planner): cog centered path shape planning

### DIFF
--- a/common/motion_utils/CMakeLists.txt
+++ b/common/motion_utils/CMakeLists.txt
@@ -12,6 +12,7 @@ ament_auto_add_library(motion_utils SHARED
   src/marker/marker_helper.cpp
   src/resample/resample.cpp
   src/trajectory/interpolation.cpp
+  src/trajectory/path_with_lane_id.cpp
   src/vehicle/vehicle_state_checker.cpp
 )
 

--- a/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
@@ -100,6 +100,9 @@ inline size_t findNearestSegmentIndexFromLaneId(
   return nearest_idx;
 }
 
+// @brief Calculates the path to be followed by the rear wheel center in order to make the vehicle center follow the input path
+// @param [in] path with position to be followed by the center of the vehicle
+// @param [out] PathWithLaneId to be followed by the rear wheel center follow to make the vehicle center follow the input path
 // NOTE: rear_to_cog is supposed to be positive
 autoware_auto_planning_msgs::msg::PathWithLaneId convertToRearWheelCenter(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double rear_to_cog,

--- a/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
@@ -99,6 +99,11 @@ inline size_t findNearestSegmentIndexFromLaneId(
 
   return nearest_idx;
 }
+
+// NOTE: rear_to_cog is supposed to be positive
+autoware_auto_planning_msgs::msg::PathWithLaneId convertToRearWheelCenter(
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double rear_to_cog,
+  const bool enable_last_point_compensation = true);
 }  // namespace motion_utils
 
 #endif  // MOTION_UTILS__TRAJECTORY__PATH_WITH_LANE_ID_HPP_

--- a/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/path_with_lane_id.hpp
@@ -100,10 +100,11 @@ inline size_t findNearestSegmentIndexFromLaneId(
   return nearest_idx;
 }
 
-// @brief Calculates the path to be followed by the rear wheel center in order to make the vehicle center follow the input path
+// @brief Calculates the path to be followed by the rear wheel center in order to make the vehicle
+// center follow the input path
 // @param [in] path with position to be followed by the center of the vehicle
-// @param [out] PathWithLaneId to be followed by the rear wheel center follow to make the vehicle center follow the input path
-// NOTE: rear_to_cog is supposed to be positive
+// @param [out] PathWithLaneId to be followed by the rear wheel center follow to make the vehicle
+// center follow the input path NOTE: rear_to_cog is supposed to be positive
 autoware_auto_planning_msgs::msg::PathWithLaneId convertToRearWheelCenter(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double rear_to_cog,
   const bool enable_last_point_compensation = true);

--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -1645,38 +1645,6 @@ T cropPoints(
 
   return cropped_points;
 }
-
-template <class T>
-std::vector<T> convertToRearWheelCenter(
-  const std::vector<T> & points, const double rear_to_cog,
-  [[maybe_unused]] const bool is_containing_last_point = false)
-{
-  const auto cog_points = points;
-
-  // calculate curvature from spline interpolation
-  const auto spline = SplineInterpolationPoints2d(points);
-  const auto curvatures = spline.getSplineInterpolatedCurvatures();
-  const auto yaws = spline.getSplineInterpolatedYaws();
-
-  for (size_t i = 0; i < points.size() - 1; ++i) {  // TODO(murooka) consider last pose
-    // calculate beta, which is CoG's velocity direction
-    const double beta = std::asin(rear_to_cog * curvatures.at(i));
-
-    // apply beta to CoG pose
-    geometry_msgs::msg::Pose cog_pose_with_beta;
-    cog_pose_with_beta.position = tier4_autoware_utils::getPoint(points.at(i));
-    const double yaw = tf2::getYaw(tier4_autoware_utils::getPose(points.at(i)).orientation);
-    cog_pose_with_beta.orientation = tier4_autoware_utils::createQuaternionFromYaw(yaw - beta);
-
-    const auto rear_pose =
-      tier4_autoware_utils::calcOffsetPose(cog_pose_with_beta, -rear_to_cog, 0.0, 0.0);
-
-    // update pose
-    tier4_autoware_utils::setPose(rear_pose, cog_points.at(i));
-  }
-
-  return cog_points;
-}
 }  // namespace motion_utils
 
 #endif  // MOTION_UTILS__TRAJECTORY__TRAJECTORY_HPP_

--- a/common/motion_utils/src/trajectory/path_with_lane_id.cpp
+++ b/common/motion_utils/src/trajectory/path_with_lane_id.cpp
@@ -1,0 +1,57 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "motion_utils/trajectory/path_with_lane_id.hpp"
+
+namespace motion_utils
+{
+// NOTE: rear_to_cog is supposed to be positive
+autoware_auto_planning_msgs::msg::PathWithLaneId convertToRearWheelCenter(
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double rear_to_cog,
+  const bool enable_last_point_compensation)
+{
+  auto cog_path = path;
+
+  // calculate curvature and yaw from spline interpolation
+  const auto spline = SplineInterpolationPoints2d(path.points);
+  const auto curvature_vec = spline.getSplineInterpolatedCurvatures();
+  const auto yaw_vec = spline.getSplineInterpolatedYaws();
+
+  for (size_t i = 0; i < path.points.size(); ++i) {
+    // calculate beta, which is CoG's velocity direction
+    const double beta = std::atan(rear_to_cog * curvature_vec.at(i));
+
+    // apply beta to CoG pose
+    geometry_msgs::msg::Pose cog_pose_with_beta;
+    cog_pose_with_beta.position = tier4_autoware_utils::getPoint(path.points.at(i));
+    cog_pose_with_beta.orientation =
+      tier4_autoware_utils::createQuaternionFromYaw(yaw_vec.at(i) - beta);
+
+    const auto rear_pose =
+      tier4_autoware_utils::calcOffsetPose(cog_pose_with_beta, -rear_to_cog, 0.0, 0.0);
+
+    // update pose
+    tier4_autoware_utils::setPose(rear_pose, cog_path.points.at(i));
+  }
+
+  // compensate for the last pose
+  if (enable_last_point_compensation) {
+    cog_path.points.back() = path.points.back();
+  }
+
+  insertOrientation(cog_path.points, true);
+
+  return cog_path;
+}
+}  // namespace motion_utils

--- a/common/motion_utils/test/src/trajectory/test_path_with_lane_id.cpp
+++ b/common/motion_utils/test/src/trajectory/test_path_with_lane_id.cpp
@@ -161,3 +161,31 @@ TEST(path_with_lane_id, findNearestIndexFromLaneId)
     findNearestSegmentIndexFromLaneId(PathWithLaneId{}, createPoint(2.4, 1.3, 0.0), 100),
     std::invalid_argument);
 }
+
+// NOTE: This test is temporary for the current implementation.
+TEST(path_with_lane_id, convertToRearWheelCenter)
+{
+  using motion_utils::convertToRearWheelCenter;
+
+  PathWithLaneId path;
+
+  PathPointWithLaneId p1;
+  p1.point.pose = createPose(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  path.points.push_back(p1);
+  PathPointWithLaneId p2;
+  p2.point.pose = createPose(1.0, 2.0, 0.0, 0.0, 0.0, 0.0);
+  path.points.push_back(p2);
+  PathPointWithLaneId p3;
+  p3.point.pose = createPose(2.0, 4.0, 0.0, 0.0, 0.0, 0.0);
+  path.points.push_back(p3);
+
+  const auto cog_path = convertToRearWheelCenter(path, 1.0);
+
+  constexpr double epsilon = 1e-6;
+  EXPECT_NEAR(cog_path.points.at(0).point.pose.position.x, -0.4472136, epsilon);
+  EXPECT_NEAR(cog_path.points.at(0).point.pose.position.y, -0.8944272, epsilon);
+  EXPECT_NEAR(cog_path.points.at(1).point.pose.position.x, 0.5527864, epsilon);
+  EXPECT_NEAR(cog_path.points.at(1).point.pose.position.y, 1.1055728, epsilon);
+  EXPECT_NEAR(cog_path.points.at(2).point.pose.position.x, 2.0, epsilon);
+  EXPECT_NEAR(cog_path.points.at(2).point.pose.position.y, 4.0, epsilon);
+}

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -60,6 +60,7 @@ struct BehaviorPathPlannerParameters
   bool turn_signal_on_swerving;
 
   double enable_akima_spline_first;
+  double enable_cog_on_centerline;
   double input_path_interval;
   double output_path_interval;
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -441,6 +441,7 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.turn_signal_on_swerving = declare_parameter("turn_signal_on_swerving", true);
 
   p.enable_akima_spline_first = declare_parameter<bool>("enable_akima_spline_first");
+  p.enable_cog_on_centerline = declare_parameter<bool>("enable_cog_on_centerline");
   p.input_path_interval = declare_parameter<double>("input_path_interval");
   p.output_path_interval = declare_parameter<double>("output_path_interval");
   p.visualize_maximum_drivable_area = declare_parameter("visualize_maximum_drivable_area", true);

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -15,7 +15,7 @@
 #include "behavior_path_planner/utilities.hpp"
 
 #include "behavior_path_planner/util/drivable_area_expansion/drivable_area_expansion.hpp"
-#include "interpolation/spline_interpolation_points_2d.hpp"
+#include "motion_utils/trajectory/path_with_lane_id.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/query.hpp>
@@ -1830,123 +1830,11 @@ PathWithLaneId getCenterLinePath(
 
   // convert centerline, which we consider as CoG center,  to rear wheel center
   if (parameter.enable_cog_on_centerline) {
-    const double rear_to_cog = (parameter.vehicle_length / 2 - parameter.rear_overhang) * 1.2;
-    return motion_utils::convertToRearWheelCenter(resampled_path_with_lane_id.points, rear_to_cog);
+    const double rear_to_cog = parameter.vehicle_length / 2 - parameter.rear_overhang;
+    return motion_utils::convertToRearWheelCenter(resampled_path_with_lane_id, rear_to_cog);
   }
 
-  resampled_path_with_lane_id.points;
-}
-
-bool checkLaneIsInIntersection(
-  const RouteHandler & route_handler, const PathWithLaneId & reference_path,
-  const lanelet::ConstLanelets & lanelet_sequence, const BehaviorPathPlannerParameters & parameter,
-  const int num_lane_change, double & additional_length_to_add)
-{
-  if (num_lane_change == 0) {
-    return false;
-  }
-
-  if (lanelet_sequence.size() < 2 || reference_path.points.empty()) {
-    return false;
-  }
-
-  const auto goal_pose = route_handler.getGoalPose();
-  lanelet::ConstLanelet goal_lanelet;
-  if (!route_handler.getGoalLanelet(&goal_lanelet)) {
-    std::cerr << "fail to get goal lanelet for intersection check.\n";
-    return false;
-  }
-  const auto goal_lanelet_point = lanelet::utils::conversion::toLaneletPoint(goal_pose.position);
-
-  const auto min_lane_change_distance =
-    num_lane_change *
-    (parameter.minimum_lane_change_length + parameter.backward_length_buffer_for_end_of_lane);
-  const double goal_distance_in_goal_lanelet = std::invoke([&goal_lanelet_point, &goal_lanelet]() {
-    const auto goal_centerline = goal_lanelet.centerline2d();
-    const auto arc_coordinate =
-      lanelet::geometry::toArcCoordinates(goal_centerline, goal_lanelet_point.basicPoint2d());
-    return arc_coordinate.length;
-  });
-
-  if (goal_distance_in_goal_lanelet > min_lane_change_distance) {
-    return false;
-  }
-
-  const auto & path_points = reference_path.points;
-  const auto & end_of_route_pose = path_points.back().point.pose;
-
-  if (lanelet_sequence.back().id() != goal_lanelet.id()) {
-    const auto get_signed_distance =
-      getSignedDistance(end_of_route_pose, goal_pose, lanelet_sequence);
-
-    if (get_signed_distance > min_lane_change_distance) {
-      return false;
-    }
-  }
-  // if you come to here, basically either back lane is goal, or back lane to goal is not enough
-  // distance
-  auto prev_lane = lanelet_sequence.crbegin();
-  auto find_intersection_iter = lanelet_sequence.crbegin();
-  for (; find_intersection_iter != lanelet_sequence.crend(); ++find_intersection_iter) {
-    prev_lane = std::next(find_intersection_iter);
-    if (prev_lane == lanelet_sequence.crend()) {
-      return false;
-    }
-    const auto lanes = route_handler.getNextLanelets(*prev_lane);
-    const auto is_neighbor_with_turn_direction = std::any_of(
-      lanes.cbegin(), lanes.cend(),
-      [](const lanelet::ConstLanelet & lane) { return lane.hasAttribute("turn_direction"); });
-
-    if (is_neighbor_with_turn_direction) {
-      const auto & intersection_back = find_intersection_iter->centerline2d().back();
-      geometry_msgs::msg::Pose intersection_back_pose;
-      intersection_back_pose.position.x = intersection_back.x();
-      intersection_back_pose.position.y = intersection_back.y();
-      intersection_back_pose.position.z = 0.0;
-      const auto get_signed_distance =
-        getSignedDistance(intersection_back_pose, goal_pose, lanelet_sequence);
-
-      if (get_signed_distance > min_lane_change_distance) {
-        return false;
-      }
-      break;
-    }
-  }
-
-  const auto checkAttribute = [](const lanelet::ConstLineString3d & linestring) noexcept {
-    const auto & attribute_name = lanelet::AttributeNamesString::LaneChange;
-    if (linestring.hasAttribute(attribute_name)) {
-      const auto attr = linestring.attribute(attribute_name);
-      if (attr.value() == std::string("yes")) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  const auto isLaneChangeAttributeYes =
-    [checkAttribute](const lanelet::ConstLanelet & lanelet) noexcept {
-      return (checkAttribute(lanelet.rightBound()) || checkAttribute(lanelet.leftBound()));
-    };
-
-  lanelet::ConstLanelets lane_change_prohibited_lanes{*find_intersection_iter};
-  for (auto prev_ll_itr = prev_lane; prev_ll_itr != lanelet_sequence.crend(); ++prev_ll_itr) {
-    if (isLaneChangeAttributeYes(*prev_ll_itr)) {
-      break;
-    }
-    lane_change_prohibited_lanes.push_back(*prev_ll_itr);
-  }
-
-  std::reverse(lane_change_prohibited_lanes.begin(), lane_change_prohibited_lanes.end());
-  const auto prohibited_arc_coordinate =
-    lanelet::utils::getArcCoordinates(lane_change_prohibited_lanes, goal_pose);
-
-  additional_length_to_add =
-    (num_lane_change > 0 ? 1 : -1) *
-    (parameter.backward_length_buffer_for_end_of_lane + prohibited_arc_coordinate.length);
-
-  return true;
->>>>>>> 1d862c3efc (feat(behavior_path_planner): cog centered planning)
+  return resampled_path_with_lane_id;
 }
 
 // for lane following

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -15,6 +15,7 @@
 #include "behavior_path_planner/utilities.hpp"
 
 #include "behavior_path_planner/util/drivable_area_expansion/drivable_area_expansion.hpp"
+#include "interpolation/spline_interpolation_points_2d.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/query.hpp>
@@ -1826,7 +1827,126 @@ PathWithLaneId getCenterLinePath(
     route_handler.getCenterLinePath(lanelet_sequence, s_backward, s_forward, true);
   const auto resampled_path_with_lane_id = motion_utils::resamplePath(
     raw_path_with_lane_id, parameter.input_path_interval, parameter.enable_akima_spline_first);
-  return resampled_path_with_lane_id;
+
+  // convert centerline, which we consider as CoG center,  to rear wheel center
+  if (true) {
+    const double rear_to_cog = (parameter.vehicle_length / 2 - parameter.rear_overhang) * 1.2;
+    return motion_utils::convertToRearWheelCenter(resampled_path_with_lane_id.points, rear_to_cog);
+  }
+
+  resampled_path_with_lane_id.points;
+}
+
+bool checkLaneIsInIntersection(
+  const RouteHandler & route_handler, const PathWithLaneId & reference_path,
+  const lanelet::ConstLanelets & lanelet_sequence, const BehaviorPathPlannerParameters & parameter,
+  const int num_lane_change, double & additional_length_to_add)
+{
+  if (num_lane_change == 0) {
+    return false;
+  }
+
+  if (lanelet_sequence.size() < 2 || reference_path.points.empty()) {
+    return false;
+  }
+
+  const auto goal_pose = route_handler.getGoalPose();
+  lanelet::ConstLanelet goal_lanelet;
+  if (!route_handler.getGoalLanelet(&goal_lanelet)) {
+    std::cerr << "fail to get goal lanelet for intersection check.\n";
+    return false;
+  }
+  const auto goal_lanelet_point = lanelet::utils::conversion::toLaneletPoint(goal_pose.position);
+
+  const auto min_lane_change_distance =
+    num_lane_change *
+    (parameter.minimum_lane_change_length + parameter.backward_length_buffer_for_end_of_lane);
+  const double goal_distance_in_goal_lanelet = std::invoke([&goal_lanelet_point, &goal_lanelet]() {
+    const auto goal_centerline = goal_lanelet.centerline2d();
+    const auto arc_coordinate =
+      lanelet::geometry::toArcCoordinates(goal_centerline, goal_lanelet_point.basicPoint2d());
+    return arc_coordinate.length;
+  });
+
+  if (goal_distance_in_goal_lanelet > min_lane_change_distance) {
+    return false;
+  }
+
+  const auto & path_points = reference_path.points;
+  const auto & end_of_route_pose = path_points.back().point.pose;
+
+  if (lanelet_sequence.back().id() != goal_lanelet.id()) {
+    const auto get_signed_distance =
+      getSignedDistance(end_of_route_pose, goal_pose, lanelet_sequence);
+
+    if (get_signed_distance > min_lane_change_distance) {
+      return false;
+    }
+  }
+  // if you come to here, basically either back lane is goal, or back lane to goal is not enough
+  // distance
+  auto prev_lane = lanelet_sequence.crbegin();
+  auto find_intersection_iter = lanelet_sequence.crbegin();
+  for (; find_intersection_iter != lanelet_sequence.crend(); ++find_intersection_iter) {
+    prev_lane = std::next(find_intersection_iter);
+    if (prev_lane == lanelet_sequence.crend()) {
+      return false;
+    }
+    const auto lanes = route_handler.getNextLanelets(*prev_lane);
+    const auto is_neighbor_with_turn_direction = std::any_of(
+      lanes.cbegin(), lanes.cend(),
+      [](const lanelet::ConstLanelet & lane) { return lane.hasAttribute("turn_direction"); });
+
+    if (is_neighbor_with_turn_direction) {
+      const auto & intersection_back = find_intersection_iter->centerline2d().back();
+      geometry_msgs::msg::Pose intersection_back_pose;
+      intersection_back_pose.position.x = intersection_back.x();
+      intersection_back_pose.position.y = intersection_back.y();
+      intersection_back_pose.position.z = 0.0;
+      const auto get_signed_distance =
+        getSignedDistance(intersection_back_pose, goal_pose, lanelet_sequence);
+
+      if (get_signed_distance > min_lane_change_distance) {
+        return false;
+      }
+      break;
+    }
+  }
+
+  const auto checkAttribute = [](const lanelet::ConstLineString3d & linestring) noexcept {
+    const auto & attribute_name = lanelet::AttributeNamesString::LaneChange;
+    if (linestring.hasAttribute(attribute_name)) {
+      const auto attr = linestring.attribute(attribute_name);
+      if (attr.value() == std::string("yes")) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const auto isLaneChangeAttributeYes =
+    [checkAttribute](const lanelet::ConstLanelet & lanelet) noexcept {
+      return (checkAttribute(lanelet.rightBound()) || checkAttribute(lanelet.leftBound()));
+    };
+
+  lanelet::ConstLanelets lane_change_prohibited_lanes{*find_intersection_iter};
+  for (auto prev_ll_itr = prev_lane; prev_ll_itr != lanelet_sequence.crend(); ++prev_ll_itr) {
+    if (isLaneChangeAttributeYes(*prev_ll_itr)) {
+      break;
+    }
+    lane_change_prohibited_lanes.push_back(*prev_ll_itr);
+  }
+
+  std::reverse(lane_change_prohibited_lanes.begin(), lane_change_prohibited_lanes.end());
+  const auto prohibited_arc_coordinate =
+    lanelet::utils::getArcCoordinates(lane_change_prohibited_lanes, goal_pose);
+
+  additional_length_to_add =
+    (num_lane_change > 0 ? 1 : -1) *
+    (parameter.backward_length_buffer_for_end_of_lane + prohibited_arc_coordinate.length);
+
+  return true;
+>>>>>>> 1d862c3efc (feat(behavior_path_planner): cog centered planning)
 }
 
 // for lane following

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1829,7 +1829,7 @@ PathWithLaneId getCenterLinePath(
     raw_path_with_lane_id, parameter.input_path_interval, parameter.enable_akima_spline_first);
 
   // convert centerline, which we consider as CoG center,  to rear wheel center
-  if (true) {
+  if (parameter.enable_cog_on_centerline) {
     const double rear_to_cog = (parameter.vehicle_length / 2 - parameter.rear_overhang) * 1.2;
     return motion_utils::convertToRearWheelCenter(resampled_path_with_lane_id.points, rear_to_cog);
   }


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description
No behavior change with default parameters
Added a option where the CoG instead of back wheel center will follow the centerline, which is false by default.

**Logic**
![image](https://user-images.githubusercontent.com/20228327/229879587-e7c10a19-056f-4ee7-a114-76d54619b52a.png)

**Result**
before
![image](https://user-images.githubusercontent.com/20228327/229880670-579e738b-617f-4738-b961-4c88250d4d67.png)

after
![image](https://user-images.githubusercontent.com/20228327/229883614-11f5b93e-128e-4768-8134-0079c131e3c4.png)

## Test performed
Nothing due to no behavior change.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
