### PR TITLE
fix: sort lane_ids of lange change path

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -239,15 +239,11 @@ std::optional<LaneChangePath> constructCandidatePath(
   const auto insertLaneIDsToBegin = [](auto & target, const auto src) {
     target.lane_ids.insert(target.lane_ids.begin(), src.lane_ids.begin(), src.lane_ids.end());
   };
-  const auto insertLaneIDsToEnd = [](auto & target, const auto src) {
-    target.lane_ids.insert(target.lane_ids.end(), src.lane_ids.begin(), src.lane_ids.end());
-  };
   if (lanechange_end_idx) {
     for (size_t i = 0; i < shifted_path.path.points.size(); ++i) {
       auto & point = shifted_path.path.points.at(i);
       if (i < *lanechange_end_idx) {
         insertLaneIDsToBegin(point, lane_changing_start_point);
-        insertLaneIDsToEnd(point, lane_changing_end_point);
         point.point.longitudinal_velocity_mps = std::min(
           point.point.longitudinal_velocity_mps,
           lane_changing_start_point.point.longitudinal_velocity_mps);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -236,15 +236,18 @@ std::optional<LaneChangePath> constructCandidatePath(
   const Pose & lane_changing_end_pose = lane_changing_end_point.point.pose;
   const auto lanechange_end_idx =
     motion_utils::findNearestIndex(shifted_path.path.points, lane_changing_end_pose);
-  const auto insertLaneIDs = [](auto & target, const auto src) {
+  const auto insertLaneIDsToBegin = [](auto & target, const auto src) {
+    target.lane_ids.insert(target.lane_ids.begin(), src.lane_ids.begin(), src.lane_ids.end());
+  };
+  const auto insertLaneIDsToEnd = [](auto & target, const auto src) {
     target.lane_ids.insert(target.lane_ids.end(), src.lane_ids.begin(), src.lane_ids.end());
   };
   if (lanechange_end_idx) {
     for (size_t i = 0; i < shifted_path.path.points.size(); ++i) {
       auto & point = shifted_path.path.points.at(i);
       if (i < *lanechange_end_idx) {
-        insertLaneIDs(point, lane_changing_start_point);
-        insertLaneIDs(point, lane_changing_end_point);
+        insertLaneIDsToBegin(point, lane_changing_start_point);
+        insertLaneIDsToEnd(point, lane_changing_end_point);
         point.point.longitudinal_velocity_mps = std::min(
           point.point.longitudinal_velocity_mps,
           lane_changing_start_point.point.longitudinal_velocity_mps);


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
In current implementation of behavior_velocity module, It is assumed that lane_ids in ```/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id``` are sorted as following figure.
![image](https://user-images.githubusercontent.com/59680180/217321297-4a3c5760-3466-44ee-9623-8a05b8ddff86.png)

But now, lane_ids in ```/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id``` is not sorted in lane change sequence and it causes unnecessary register/unregister of behavior module and sudden deceleration.
I fixed it by sorting the lane_ids.

https://user-images.githubusercontent.com/59680180/217321910-cfdd83b4-66d7-45ca-9fc6-54b33406211a.mp4
(about 18s)



<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Not executed. (The above bug rarely occurs, so we cannot test it. )

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
