### PR TITLE
perf(lane_change): only compute interpolate ego once

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -17,6 +17,7 @@
 
 #include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/marker_util/debug_utilities.hpp"
+#include "behavior_path_planner/util/lane_change/lane_change_module_data.hpp"
 #include "behavior_path_planner/util/pull_out/pull_out_path.hpp"
 
 #include <opencv2/opencv.hpp>
@@ -496,7 +497,8 @@ bool isSafeInLaneletCollisionCheck(
   const std::vector<std::pair<Pose, tier4_autoware_utils::Polygon2d>> & interpolated_ego,
   const Twist & ego_current_twist, const std::vector<double> & check_duration,
   const PredictedObject & target_object, const PredictedPath & target_object_path,
-  const BehaviorPathPlannerParameters & common_parameters, const double front_decel,
+  const BehaviorPathPlannerParameters & common_parameters,
+  const LaneChangeParameters & lane_change_parameters, const double front_decel,
   const double rear_decel, Pose & ego_pose_before_collision, CollisionCheckDebug & debug);
 
 bool isSafeInFreeSpaceCollisionCheck(

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -496,17 +496,18 @@ bool isLateralDistanceEnough(
 bool isSafeInLaneletCollisionCheck(
   const std::vector<std::pair<Pose, tier4_autoware_utils::Polygon2d>> & interpolated_ego,
   const Twist & ego_current_twist, const std::vector<double> & check_duration,
-  const PredictedObject & target_object, const PredictedPath & target_object_path,
-  const BehaviorPathPlannerParameters & common_parameters,
-  const LaneChangeParameters & lane_change_parameters, const double front_decel,
+  const double prepare_duration, const PredictedObject & target_object,
+  const PredictedPath & target_object_path, const BehaviorPathPlannerParameters & common_parameters,
+  const double prepare_phase_ignore_target_speed_thresh, const double front_decel,
   const double rear_decel, Pose & ego_pose_before_collision, CollisionCheckDebug & debug);
 
 bool isSafeInFreeSpaceCollisionCheck(
-  const Pose & ego_current_pose, const Twist & ego_current_twist,
-  const PredictedPath & ego_predicted_path, const VehicleInfo & ego_info,
-  const double check_start_time, const double check_end_time, const double check_time_resolution,
-  const PredictedObject & target_object, const BehaviorPathPlannerParameters & common_parameters,
-  const double front_decel, const double rear_decel, CollisionCheckDebug & debug);
+  const std::vector<std::pair<Pose, tier4_autoware_utils::Polygon2d>> & interpolated_ego,
+  const Twist & ego_current_twist, const std::vector<double> & check_duration,
+  const double prepare_duration, const PredictedObject & target_object,
+  const BehaviorPathPlannerParameters & common_parameters,
+  const double prepare_phase_ignore_target_speed_thresh, const double front_decel,
+  const double rear_decel, CollisionCheckDebug & debug);
 
 bool checkPathRelativeAngle(const PathWithLaneId & path, const double angle_threshold);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -493,9 +493,8 @@ bool isLateralDistanceEnough(
   const double & relative_lateral_distance, const double & lateral_distance_threshold);
 
 bool isSafeInLaneletCollisionCheck(
-  const Pose & ego_current_pose, const Twist & ego_current_twist,
-  const PredictedPath & ego_predicted_path, const VehicleInfo & ego_info,
-  const double check_start_time, const double check_end_time, const double check_time_resolution,
+  const std::vector<std::pair<Pose, tier4_autoware_utils::Polygon2d>> & interpolated_ego,
+  const Twist & ego_current_twist, const std::vector<double> & check_duration,
   const PredictedObject & target_object, const PredictedPath & target_object_path,
   const BehaviorPathPlannerParameters & common_parameters, const double front_decel,
   const double rear_decel, Pose & ego_pose_before_collision, CollisionCheckDebug & debug);

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -506,19 +506,16 @@ bool isLaneChangePathSafe(
   }
 
   const double time_resolution = lane_change_parameters.prediction_time_resolution;
-  const auto & lane_change_prepare_duration = lane_change_path.duration.prepare;
-  const auto & enable_collision_check_at_prepare_phase =
+  const auto check_at_prepare_phase =
     lane_change_parameters.enable_collision_check_at_prepare_phase;
-  const auto & lane_changing_safety_check_duration = lane_change_path.duration.lane_changing;
-  const double check_end_time = lane_change_prepare_duration + lane_changing_safety_check_duration;
+
+  const double check_start_time = check_at_prepare_phase ? 0.0 : lane_change_path.duration.prepare;
+  const double check_end_time = lane_change_path.duration.sum();
   const double min_lc_speed{lane_change_parameters.minimum_lane_change_velocity};
 
   const auto vehicle_predicted_path = util::convertToPredictedPath(
     path, current_twist, current_pose, static_cast<double>(current_seg_idx), check_end_time,
     time_resolution, acceleration, min_lc_speed);
-  const auto prepare_phase_ignore_target_speed_thresh =
-    lane_change_parameters.prepare_phase_ignore_target_speed_thresh;
-
   const auto & vehicle_info = common_parameters.vehicle_info;
 
   auto in_lane_object_indices = dynamic_objects_indices.target_lane;
@@ -551,26 +548,40 @@ bool isLaneChangePathSafe(
       }
     };
 
+  const auto reserve_size =
+    static_cast<size_t>((check_end_time - check_start_time) / time_resolution);
+  std::vector<double> check_durations{};
+  std::vector<std::pair<Pose, tier4_autoware_utils::Polygon2d>> interpolated_ego{};
+  check_durations.reserve(reserve_size);
+  interpolated_ego.reserve(reserve_size);
+
+  {
+    Pose expected_ego_pose = current_pose;
+    for (double t = check_start_time; t < check_end_time; t += time_resolution) {
+      std::string failed_reason;
+      tier4_autoware_utils::Polygon2d ego_polygon;
+      [[maybe_unused]] const auto get_ego_info = util::getEgoExpectedPoseAndConvertToPolygon(
+        current_pose, vehicle_predicted_path, ego_polygon, t, vehicle_info, expected_ego_pose,
+        failed_reason);
+      check_durations.push_back(t);
+      interpolated_ego.emplace_back(expected_ego_pose, ego_polygon);
+    }
+  }
+
   for (const auto & i : in_lane_object_indices) {
     const auto & obj = dynamic_objects->objects.at(i);
-    const auto object_speed =
-      util::l2Norm(obj.kinematics.initial_twist_with_covariance.twist.linear);
-    const double check_start_time = (enable_collision_check_at_prepare_phase &&
-                                     (object_speed > prepare_phase_ignore_target_speed_thresh))
-                                      ? 0.0
-                                      : lane_change_prepare_duration;
     auto current_debug_data = assignDebugData(obj);
     const auto predicted_paths =
       util::getPredictedPathFromObj(obj, lane_change_parameters.use_all_predicted_path);
     for (const auto & obj_path : predicted_paths) {
       if (!util::isSafeInLaneletCollisionCheck(
-            current_pose, current_twist, vehicle_predicted_path, vehicle_info, check_start_time,
-            check_end_time, time_resolution, obj, obj_path, common_parameters, front_decel,
-            rear_decel, ego_pose_before_collision, current_debug_data.second)) {
+            interpolated_ego, current_twist, check_durations, obj, obj_path, common_parameters,
+            front_decel, rear_decel, ego_pose_before_collision, current_debug_data.second)) {
         appendDebugInfo(current_debug_data, false);
         return false;
       }
     }
+    appendDebugInfo(current_debug_data, true);
   }
 
   if (!lane_change_parameters.use_predicted_path_outside_lanelet) {
@@ -585,12 +596,6 @@ bool isLaneChangePathSafe(
     const auto predicted_paths =
       util::getPredictedPathFromObj(obj, lane_change_parameters.use_all_predicted_path);
 
-    const auto object_speed =
-      util::l2Norm(obj.kinematics.initial_twist_with_covariance.twist.linear);
-    const double check_start_time = (enable_collision_check_at_prepare_phase &&
-                                     (object_speed > prepare_phase_ignore_target_speed_thresh))
-                                      ? 0.0
-                                      : lane_change_prepare_duration;
     if (!util::isSafeInFreeSpaceCollisionCheck(
           current_pose, current_twist, vehicle_predicted_path, vehicle_info, check_start_time,
           check_end_time, time_resolution, obj, common_parameters, front_decel, rear_decel,

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -576,7 +576,8 @@ bool isLaneChangePathSafe(
     for (const auto & obj_path : predicted_paths) {
       if (!util::isSafeInLaneletCollisionCheck(
             interpolated_ego, current_twist, check_durations, obj, obj_path, common_parameters,
-            front_decel, rear_decel, ego_pose_before_collision, current_debug_data.second)) {
+            lane_change_parameters, front_decel, rear_decel, ego_pose_before_collision,
+            current_debug_data.second)) {
         appendDebugInfo(current_debug_data, false);
         return false;
       }

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -575,9 +575,10 @@ bool isLaneChangePathSafe(
       util::getPredictedPathFromObj(obj, lane_change_parameters.use_all_predicted_path);
     for (const auto & obj_path : predicted_paths) {
       if (!util::isSafeInLaneletCollisionCheck(
-            interpolated_ego, current_twist, check_durations, obj, obj_path, common_parameters,
-            lane_change_parameters, front_decel, rear_decel, ego_pose_before_collision,
-            current_debug_data.second)) {
+            interpolated_ego, current_twist, check_durations, lane_change_path.duration.prepare,
+            obj, obj_path, common_parameters,
+            lane_change_parameters.prepare_phase_ignore_target_speed_thresh, front_decel,
+            rear_decel, ego_pose_before_collision, current_debug_data.second)) {
         appendDebugInfo(current_debug_data, false);
         return false;
       }
@@ -598,9 +599,9 @@ bool isLaneChangePathSafe(
       util::getPredictedPathFromObj(obj, lane_change_parameters.use_all_predicted_path);
 
     if (!util::isSafeInFreeSpaceCollisionCheck(
-          current_pose, current_twist, vehicle_predicted_path, vehicle_info, check_start_time,
-          check_end_time, time_resolution, obj, common_parameters, front_decel, rear_decel,
-          current_debug_data.second)) {
+          interpolated_ego, current_twist, check_durations, lane_change_path.duration.prepare, obj,
+          common_parameters, lane_change_parameters.prepare_phase_ignore_target_speed_thresh,
+          front_decel, rear_decel, current_debug_data.second)) {
       appendDebugInfo(current_debug_data, false);
       return false;
     }


### PR DESCRIPTION
## Description

Related to increasing performance of lane change module.

At the moment, ego pose and polyon is interpolated against its predicted path during safety check, together with target object. but this is unnecessary, as ego path can be interpolated only once.

To solve this, I have extracted ego pose and polygon computation so that it only computed once.

## Related links

#2825 

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
