### PR TITLE
feat(simple_planning_sim): publish sensing interface imu data

### DIFF
--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -44,6 +44,7 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "sensor_msgs/msg/imu.hpp"
 #include "tier4_external_api_msgs/srv/initialize_pose.hpp"
 
 #include <tf2_ros/buffer.h>
@@ -82,6 +83,7 @@ using geometry_msgs::msg::TransformStamped;
 using geometry_msgs::msg::Twist;
 using geometry_msgs::msg::TwistStamped;
 using nav_msgs::msg::Odometry;
+using sensor_msgs::msg::Imu;
 using tier4_external_api_msgs::srv::InitializePose;
 
 class DeltaTime
@@ -126,6 +128,7 @@ private:
   rclcpp::Publisher<Odometry>::SharedPtr pub_odom_;
   rclcpp::Publisher<SteeringReport>::SharedPtr pub_steer_;
   rclcpp::Publisher<AccelWithCovarianceStamped>::SharedPtr pub_acc_;
+  rclcpp::Publisher<Imu>::SharedPtr pub_imu_;
   rclcpp::Publisher<ControlModeReport>::SharedPtr pub_control_mode_report_;
   rclcpp::Publisher<GearReport>::SharedPtr pub_gear_report_;
   rclcpp::Publisher<TurnIndicatorsReport>::SharedPtr pub_turn_indicators_report_;
@@ -327,6 +330,11 @@ private:
    * @brief publish acceleration
    */
   void publish_acceleration();
+
+  /**
+   * @brief publish imu
+   */
+  void publish_imu();
 
   /**
    * @brief publish control_mode report

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -66,6 +66,7 @@ def launch_setup(context, *args, **kwargs):
             ("output/twist", "/vehicle/status/velocity_status"),
             ("output/odometry", "/localization/kinematic_state"),
             ("output/acceleration", "/localization/acceleration"),
+            ("output/imu", "/sensing/imu/imu_data"),
             ("output/steering", "/vehicle/status/steering_status"),
             ("output/gear_report", "/vehicle/status/gear_status"),
             ("output/turn_indicators_report", "/vehicle/status/turn_indicators_status"),

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -20,6 +20,7 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -567,22 +567,24 @@ void SimplePlanningSimulator::publish_acceleration()
 
 void SimplePlanningSimulator::publish_imu()
 {
+  using COV_IDX = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+
   sensor_msgs::msg::Imu imu;
-  imu.header.frame_id = "/base_link";
+  imu.header.frame_id = "base_link";
   imu.header.stamp = now();
   imu.linear_acceleration.x = vehicle_model_ptr_->getAx();
   constexpr auto COV = 0.001;
-  imu.linear_acceleration_covariance.at(0) = COV;
-  imu.linear_acceleration_covariance.at(3) = COV;
-  imu.linear_acceleration_covariance.at(6) = COV;
+  imu.linear_acceleration_covariance.at(COV_IDX::X_X) = COV;
+  imu.linear_acceleration_covariance.at(COV_IDX::Y_Y) = COV;
+  imu.linear_acceleration_covariance.at(COV_IDX::Z_Z) = COV;
   imu.angular_velocity = current_odometry_.twist.twist.angular;
-  imu.angular_velocity_covariance.at(0) = COV;
-  imu.angular_velocity_covariance.at(3) = COV;
-  imu.angular_velocity_covariance.at(6) = COV;
+  imu.angular_velocity_covariance.at(COV_IDX::X_X) = COV;
+  imu.angular_velocity_covariance.at(COV_IDX::Y_Y) = COV;
+  imu.angular_velocity_covariance.at(COV_IDX::Z_Z) = COV;
   imu.orientation = current_odometry_.pose.pose.orientation;
-  imu.orientation_covariance.at(0) = COV;
-  imu.orientation_covariance.at(3) = COV;
-  imu.orientation_covariance.at(6) = COV;
+  imu.orientation_covariance.at(COV_IDX::X_X) = COV;
+  imu.orientation_covariance.at(COV_IDX::Y_Y) = COV;
+  imu.orientation_covariance.at(COV_IDX::Z_Z) = COV;
   pub_imu_->publish(imu);
 }
 

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -130,6 +130,7 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
   pub_odom_ = create_publisher<Odometry>("output/odometry", QoS{1});
   pub_steer_ = create_publisher<SteeringReport>("output/steering", QoS{1});
   pub_acc_ = create_publisher<AccelWithCovarianceStamped>("output/acceleration", QoS{1});
+  pub_imu_ = create_publisher<Imu>("output/imu", QoS{1});
   pub_tf_ = create_publisher<tf2_msgs::msg::TFMessage>("/tf", QoS{1});
 
   /* set param callback */
@@ -298,6 +299,7 @@ void SimplePlanningSimulator::on_timer()
   publish_velocity(current_velocity_);
   publish_steering(current_steer_);
   publish_acceleration();
+  publish_imu();
 
   publish_control_mode_report();
   publish_gear_report();
@@ -561,6 +563,27 @@ void SimplePlanningSimulator::publish_acceleration()
   msg.accel.covariance.at(COV_IDX::PITCH_PITCH) = COV;  // angular y
   msg.accel.covariance.at(COV_IDX::YAW_YAW) = COV;      // angular z
   pub_acc_->publish(msg);
+}
+
+void SimplePlanningSimulator::publish_imu()
+{
+  sensor_msgs::msg::Imu imu;
+  imu.header.frame_id = "/base_link";
+  imu.header.stamp = now();
+  imu.linear_acceleration.x = vehicle_model_ptr_->getAx();
+  constexpr auto COV = 0.001;
+  imu.linear_acceleration_covariance.at(0) = COV;
+  imu.linear_acceleration_covariance.at(3) = COV;
+  imu.linear_acceleration_covariance.at(6) = COV;
+  imu.angular_velocity = current_odometry_.twist.twist.angular;
+  imu.angular_velocity_covariance.at(0) = COV;
+  imu.angular_velocity_covariance.at(3) = COV;
+  imu.angular_velocity_covariance.at(6) = COV;
+  imu.orientation = current_odometry_.pose.pose.orientation;
+  imu.orientation_covariance.at(0) = COV;
+  imu.orientation_covariance.at(3) = COV;
+  imu.orientation_covariance.at(6) = COV;
+  pub_imu_->publish(imu);
 }
 
 void SimplePlanningSimulator::publish_control_mode_report()


### PR DESCRIPTION


## Description

Add imu publisher in the `simple_planning_simulator` so that the planning modules using imu info can run.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Run psim and check if the imu topic is published:
```
ros2 topic echo /sensing/imu/imu_data
```

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
