### PR TITLE
feat(behavior_path_planner): check if object is avoidable for drivable area generation

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -240,7 +240,7 @@ private:
   // ========= shift line generator ======
 
   AvoidLineArray calcRawShiftLinesFromObjects(
-    const AvoidancePlanningData & data, DebugData & debug) const;
+    AvoidancePlanningData & data, DebugData & debug) const;
 
   AvoidLineArray applyPreProcessToRawShiftLines(
     AvoidLineArray & current_raw_shift_points, DebugData & debug) const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -310,6 +310,9 @@ struct ObjectData  // avoidance target
 
   // unavoidable reason
   std::string reason{""};
+
+  // is avoidable by behavior module
+  bool is_avoidable{false};
 };
 using ObjectDataArray = std::vector<ObjectData>;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -99,7 +99,7 @@ std::vector<Point> updateBoundary(
 void generateDrivableArea(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes, const double vehicle_length,
   const std::shared_ptr<const PlannerData> planner_data, const ObjectDataArray & objects,
-  const bool enable_bound_clipping);
+  const bool enable_bound_clipping, const bool disable_path_update);
 
 double getLongitudinalVelocity(const Pose & p_ref, const Pose & p_target, const double v);
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -900,7 +900,7 @@ double AvoidanceModule::getShiftLength(
  * and longitudinal positions in the Frenet coordinate. The jerk limit is also considered here.
  */
 AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
-  const AvoidancePlanningData & data, DebugData & debug) const
+  AvoidancePlanningData & data, DebugData & debug) const
 {
   {
     debug_avoidance_initializer_for_shift_line_.clear();
@@ -922,7 +922,7 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
   AvoidLineArray avoid_lines;
   std::vector<AvoidanceDebugMsg> avoidance_debug_msg_array;
   avoidance_debug_msg_array.reserve(data.target_objects.size());
-  for (auto o : data.target_objects) {
+  for (auto & o : data.target_objects) {
     AvoidanceDebugMsg avoidance_debug_msg;
     const auto avoidance_debug_array_false_and_push_back =
       [&avoidance_debug_msg, &avoidance_debug_msg_array](const std::string & failed_reason) {
@@ -1051,6 +1051,8 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
       nominal_return_distance);
     avoidance_debug_msg.allow_avoidance = true;
     avoidance_debug_msg_array.push_back(avoidance_debug_msg);
+
+    o.is_avoidable = true;
   }
 
   debug_avoidance_initializer_for_shift_line_ = std::move(avoidance_debug_msg_array);
@@ -2637,7 +2639,7 @@ void AvoidanceModule::generateExtendedDrivableArea(PathWithLaneId & path) const
     const auto & p = planner_data_->parameters;
     generateDrivableArea(
       path, drivable_lanes, p.vehicle_length, planner_data_, avoidance_data_.target_objects,
-      parameters_->enable_bound_clipping);
+      parameters_->enable_bound_clipping, parameters_->disable_path_update);
   }
 }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -692,7 +692,7 @@ std::vector<Point> updateBoundary(
 void generateDrivableArea(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes, const double vehicle_length,
   const std::shared_ptr<const PlannerData> planner_data, const ObjectDataArray & objects,
-  const bool enable_bound_clipping)
+  const bool enable_bound_clipping, const bool disable_path_update)
 {
   util::generateDrivableArea(path, lanes, vehicle_length, planner_data);
   if (objects.empty() || !enable_bound_clipping) {
@@ -700,6 +700,16 @@ void generateDrivableArea(
   }
 
   for (const auto & object : objects) {
+    if (!disable_path_update) {
+      // If avoidance is executed by both behavior and motion, only non-avoidable object will be
+      // extracted from the drivable area.
+      if (object.is_avoidable) {
+        continue;
+      }
+    }
+
+    // TODO(murooka) check if there is lateral margin to run in the drivable area
+
     const auto & obj_pose = object.object.kinematics.initial_pose_with_covariance.pose;
     const auto & obj_poly = object.envelope_poly;
 


### PR DESCRIPTION
## Description

**when disable_path_update  is true**
All the target_objects are removed from the drivable area
![image](https://user-images.githubusercontent.com/20228327/217697448-97e3cd0f-c126-4737-8b51-71404c1ea52c.png)

**when disable_path_update is false**
A part of the target_objects, whose `is_avoidable` is false, are removed from the drivable area
![image](https://user-images.githubusercontent.com/20228327/217699049-bc98db7a-98a3-44a0-9f99-5f9282404b96.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
