### PR TITLE
fix(lane_change): checks only shifted path for isInLanelet check

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -322,13 +322,13 @@ std::optional<LaneChangePath> constructCandidatePath(
     point.lane_ids = lane_changing_segment.points.at(*nearest_idx).lane_ids;
   }
 
-  candidate_path.path = combineReferencePath(prepare_segment, shifted_path.path);
-  candidate_path.shifted_path = shifted_path;
-
-  // check candidate path is in lanelet
-  if (!isPathInLanelets(candidate_path.path, original_lanelets, target_lanelets)) {
+  if (!isPathInLanelets(shifted_path.path, original_lanelets, target_lanelets)) {
     return std::nullopt;
   }
+
+  // check candidate path is in lanelet
+  candidate_path.path = combineReferencePath(prepare_segment, shifted_path.path);
+  candidate_path.shifted_path = shifted_path;
 
   return std::optional<LaneChangePath>{candidate_path};
 }


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

Up until now, we confirm the whole lane change path via is in lanelet, which include prepare phase and lane changing phase. But because prepare phase originally doesn't divert from the current lane, and it is guarantee to be feasible, therefore we can actually ignore them from the check. 

This PR aims to fix the check by only check the shifted path.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
