### PR TITLE
fix(behavior_path_planner): fix overlapping checker

### DIFF
--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1088,7 +1088,7 @@ void generateDrivableArea(
     };
 
   const auto has_overlap =
-    [&](const lanelet::ConstLanelet & lane, const lanelet::ConstLanelets& ignore_lanelets = {}) {
+    [&](const lanelet::ConstLanelet & lane, const lanelet::ConstLanelets & ignore_lanelets = {}) {
       for (const auto & transformed_lane : transformed_lanes) {
         if (checkHasSameLane(ignore_lanelets, transformed_lane)) {
           continue;
@@ -1117,10 +1117,10 @@ void generateDrivableArea(
     const auto goal_left_lanelet = route_handler->getLeftLanelet(goal_lanelet);
     const auto goal_right_lanelet = route_handler->getRightLanelet(goal_lanelet);
     lanelet::ConstLanelets goal_lanelets = {goal_lanelet};
-    if(goal_left_lanelet) {
+    if (goal_left_lanelet) {
       goal_lanelets.push_back(*goal_left_lanelet);
     }
-    if(goal_right_lanelet) {
+    if (goal_right_lanelet) {
       goal_lanelets.push_back(*goal_right_lanelet);
     }
 
@@ -1131,9 +1131,8 @@ void generateDrivableArea(
       }
       // Check if overlapped
       const bool is_overlapped =
-        (checkHasSameLane(next_lanes_after_goal, lane)
-          ? has_overlap(lane, goal_lanelets)
-          : has_overlap(lane));
+        (checkHasSameLane(next_lanes_after_goal, lane) ? has_overlap(lane, goal_lanelets)
+                                                       : has_overlap(lane));
       if (is_overlapped) {
         continue;
       }

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1088,9 +1088,9 @@ void generateDrivableArea(
     };
 
   const auto has_overlap =
-    [&](const lanelet::ConstLanelet & lane, const lanelet::Id & ignore_lane_id = lanelet::InvalId) {
+    [&](const lanelet::ConstLanelet & lane, const lanelet::ConstLanelets& ignore_lanelets = {}) {
       for (const auto & transformed_lane : transformed_lanes) {
-        if (transformed_lane.id() == ignore_lane_id) {
+        if (checkHasSameLane(ignore_lanelets, transformed_lane)) {
           continue;
         }
         if (boost::geometry::intersects(
@@ -1114,6 +1114,16 @@ void generateDrivableArea(
     checkHasSameLane(transformed_lanes, goal_lanelet)) {
     const auto lanes_after_goal = route_handler->getLanesAfterGoal(vehicle_length);
     const auto next_lanes_after_goal = route_handler->getNextLanelets(goal_lanelet);
+    const auto goal_left_lanelet = route_handler->getLeftLanelet(goal_lanelet);
+    const auto goal_right_lanelet = route_handler->getRightLanelet(goal_lanelet);
+    lanelet::ConstLanelets goal_lanelets = {goal_lanelet};
+    if(goal_left_lanelet) {
+      goal_lanelets.push_back(*goal_left_lanelet);
+    }
+    if(goal_right_lanelet) {
+      goal_lanelets.push_back(*goal_right_lanelet);
+    }
+
     for (const auto & lane : lanes_after_goal) {
       // If lane is already in the transformed lanes, ignore it
       if (checkHasSameLane(transformed_lanes, lane)) {
@@ -1122,8 +1132,8 @@ void generateDrivableArea(
       // Check if overlapped
       const bool is_overlapped =
         (checkHasSameLane(next_lanes_after_goal, lane)
-           ? has_overlap(lane, route_handler->getGoalLaneId())
-           : has_overlap(lane));
+          ? has_overlap(lane, goal_lanelets)
+          : has_overlap(lane));
       if (is_overlapped) {
         continue;
       }


### PR DESCRIPTION
## Description
Currently, the overlapping checker in the `generateDrivableLane` has a serious issue, that is, it cannot add extended goal lanelets when the goal lanelet has adjacent lanes. In this PR, I fixed this issue to enable it to add extended goal lane.

- Before this PR (It failed to extend the goal lanelet, and obstacle_avoidance_planner inserts zero_velocity)
![image](https://user-images.githubusercontent.com/43805014/217838085-1369aeac-19db-4e51-a477-8b8c163fb306.png)

- After this PR
![image](https://user-images.githubusercontent.com/43805014/217837838-630b1fee-bfb2-4e05-a46a-370bed032cde.png)



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
