### PR TITLE
feat(behavior_path_planner): fix z of extracted drivable area

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -704,11 +704,14 @@ void generateDrivableArea(
     const auto & obj_poly = object.envelope_poly;
 
     // get edge points of the object
+    const size_t nearest_path_idx = motion_utils::findNearestIndex(
+      path.points, obj_pose.position);  // to get z for object polygon
     std::vector<Point> edge_points;
     for (size_t i = 0; i < obj_poly.outer().size() - 1;
          ++i) {  // NOTE: There is a duplicated points
       edge_points.push_back(tier4_autoware_utils::createPoint(
-        obj_poly.outer().at(i).x(), obj_poly.outer().at(i).y(), 0.0));
+        obj_poly.outer().at(i).x(), obj_poly.outer().at(i).y(),
+        path.points.at(nearest_path_idx).point.pose.position.z));
     }
 
     // get a boundary that we have to change


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

When the object is extracted from the drivable area, its z is set wrong.

**before**
![image](https://user-images.githubusercontent.com/20228327/217869533-d6d7b97b-be8f-4127-bf45-f1cebcd935b8.png)


**after**
![image](https://user-images.githubusercontent.com/20228327/217870135-7e963291-6d65-42d8-b562-6b9d205ca322.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
