### PR TITLE
feat(crosswalk_traffic_light_estimator): estimate the corresponding pedestrian traffic light as red also when the vehicle traffic light is amber

### DIFF
--- a/perception/crosswalk_traffic_light_estimator/README.md
+++ b/perception/crosswalk_traffic_light_estimator/README.md
@@ -22,9 +22,9 @@
 
 ## Parameters
 
-| Name                    | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Default value |
-| :---------------------- | :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| `use_last_detect_color` | `bool` | If this parameter is `true`, this module estimates pedestrian's traffic signal as RED not only when vehicle's traffic signal is detected as GREEN but also when detection results change GREEN to UNKNOWN. (If detection results change RED or AMBER to UNKNOWN, this module estimates pedestrian's traffic signal as UNKNOWN.) If this parameter is `false`, this module use only latest detection results for estimation. (Only when the detection result is GREEN, this module estimates pedestrian's traffic signal as RED.) | `true`        |
+| Name                    | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default value |
+| :---------------------- | :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| `use_last_detect_color` | `bool` | If this parameter is `true`, this module estimates pedestrian's traffic signal as RED not only when vehicle's traffic signal is detected as GREEN/AMBER but also when detection results change GREEN/AMBER to UNKNOWN. (If detection results change RED or AMBER to UNKNOWN, this module estimates pedestrian's traffic signal as UNKNOWN.) If this parameter is `false`, this module use only latest detection results for estimation. (Only when the detection result is GREEN/AMBER, this module estimates pedestrian's traffic signal as RED.) | `true`        |
 
 ## Inner-workings / Algorithms
 
@@ -34,19 +34,19 @@ start
 :subscribe detected traffic signals & HDMap;
 :extract crosswalk lanelets from HDMap;
 :extract road lanelets that conflicts crosswalk;
-:initialize green_lanelets(lanelet::ConstLanelets);
-if (Latest detection result is **GREEN**?) then (yes)
-  :push back green_lanelets;
+:initialize non_red_lanelets(lanelet::ConstLanelets);
+if (Latest detection result is **GREEN** or **AMBER**?) then (yes)
+  :push back non_red_lanelets;
 else (no)
   if (use_last_detect_color is **true**?) then (yes)
-    if (Latest detection result is **UNKNOWN** and last detection result is **GREEN**?) then (yes)
-     :push back green_lanelets;
+    if (Latest detection result is **UNKNOWN** and last detection result is **GREEN** or **AMBER**?) then (yes)
+     :push back non_red_lanelets;
     endif
   endif
 endif
-if (Is there **STRAIGHT-GREEN** road lanelet in green_lanelets?) then (yes)
+if (Is there **STRAIGHT-NON-RED** road lanelet in non_red_lanelets?) then (yes)
   :estimate related pedestrian's traffic signal as **RED**;
-else if (Is there both **LEFT-GREEN** and **RIGHT-GREEN** road lanelet in green_lanelets?) then (yes)
+else if (Is there both **LEFT-NON-RED** and **RIGHT-NON-RED** road lanelet in non_red_lanelets?) then (yes)
   :estimate related pedestrian's traffic signal as **RED**;
 else (no)
   :estimate related pedestrian's traffic signal as **UNKNOWN**;
@@ -60,7 +60,7 @@ If traffic between pedestrians and vehicles is controlled by traffic signals, th
 ### Situation1
 
 - crosswalk conflicts **STRAIGHT** lanelet
-- the lanelet refers **GREEN** traffic signal
+- the lanelet refers **GREEN** or **AMBER** traffic signal (The following pictures show only **GREEN** case)
 
 <div align="center">
   <img src="images/straight.drawio.svg" width=80%>
@@ -72,7 +72,7 @@ If traffic between pedestrians and vehicles is controlled by traffic signals, th
 ### Situation2
 
 - crosswalk conflicts different turn direction lanelets (STRAIGHT and LEFT, LEFT and RIGHT, RIGHT and STRAIGHT)
-- the lanelets refer **GREEN** traffic signal
+- the lanelets refer **GREEN** or **AMBER** traffic signal (The following pictures show only **GREEN** case)
 
 <div align="center">
   <img src="images/intersection2.svg" width=80%>

--- a/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
+++ b/perception/crosswalk_traffic_light_estimator/include/crosswalk_traffic_light_estimator/node.hpp
@@ -77,11 +77,11 @@ private:
   void setCrosswalkTrafficSignal(
     const lanelet::ConstLanelet & crosswalk, const uint8_t color, TrafficSignalArray & msg) const;
 
-  lanelet::ConstLanelets getGreenLanelets(
+  lanelet::ConstLanelets getNonRedLanelets(
     const lanelet::ConstLanelets & lanelets, const TrafficLightIdMap & traffic_light_id_map) const;
 
   uint8_t estimateCrosswalkTrafficSignal(
-    const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & green_lanelets) const;
+    const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & non_red_lanelets) const;
 
   boost::optional<uint8_t> getHighestConfidenceTrafficSignal(
     const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,

--- a/perception/crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/crosswalk_traffic_light_estimator/src/node.cpp
@@ -165,9 +165,9 @@ void CrosswalkTrafficLightEstimatorNode::onTrafficLightArray(
   for (const auto & crosswalk : conflicting_crosswalks_) {
     constexpr int VEHICLE_GRAPH_ID = 0;
     const auto conflict_lls = overall_graphs_ptr_->conflictingInGraph(crosswalk, VEHICLE_GRAPH_ID);
-    const auto green_lanelets = getGreenLanelets(conflict_lls, traffic_light_id_map);
+    const auto non_red_lanelets = getNonRedLanelets(conflict_lls, traffic_light_id_map);
 
-    const auto crosswalk_tl_color = estimateCrosswalkTrafficSignal(crosswalk, green_lanelets);
+    const auto crosswalk_tl_color = estimateCrosswalkTrafficSignal(crosswalk, non_red_lanelets);
     setCrosswalkTrafficSignal(crosswalk, crosswalk_tl_color, output);
   }
 
@@ -236,10 +236,10 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
   }
 }
 
-lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::getGreenLanelets(
+lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::getNonRedLanelets(
   const lanelet::ConstLanelets & lanelets, const TrafficLightIdMap & traffic_light_id_map) const
 {
-  lanelet::ConstLanelets green_lanelets{};
+  lanelet::ConstLanelets non_red_lanelets{};
 
   for (const auto & lanelet : lanelets) {
     const auto tl_reg_elems = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
@@ -258,7 +258,8 @@ lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::getGreenLanelets(
       continue;
     }
 
-    const auto is_green = current_detected_signal.get() == TrafficLight::GREEN;
+    const auto is_not_read = current_detected_signal.get() == TrafficLight::GREEN ||
+                             current_detected_signal.get() == TrafficLight::AMBER;
 
     const auto last_detected_signal =
       getHighestConfidenceTrafficSignal(traffic_lights_for_vehicle, last_detect_color_);
@@ -267,54 +268,55 @@ lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::getGreenLanelets(
       continue;
     }
 
-    const auto was_green = current_detected_signal.get() == TrafficLight::UNKNOWN &&
-                           last_detected_signal.get() == TrafficLight::GREEN &&
-                           use_last_detect_color_;
+    const auto was_not_read = current_detected_signal.get() == TrafficLight::UNKNOWN &&
+                              (last_detected_signal.get() == TrafficLight::GREEN ||
+                               last_detected_signal.get() == TrafficLight::AMBER) &&
+                              use_last_detect_color_;
 
-    if (!is_green && !was_green) {
+    if (!is_not_read && !was_not_read) {
       continue;
     }
 
-    green_lanelets.push_back(lanelet);
+    non_red_lanelets.push_back(lanelet);
   }
 
-  return green_lanelets;
+  return non_red_lanelets;
 }
 
 uint8_t CrosswalkTrafficLightEstimatorNode::estimateCrosswalkTrafficSignal(
-  const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & green_lanelets) const
+  const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & non_red_lanelets) const
 {
-  bool has_left_green_lane = false;
-  bool has_right_green_lane = false;
-  bool has_straight_green_lane = false;
-  bool has_related_green_tl = false;
+  bool has_left_non_red_lane = false;
+  bool has_right_non_red_lane = false;
+  bool has_straight_non_red_lane = false;
+  bool has_related_non_red_tl = false;
 
   const std::string related_tl_id = crosswalk.attributeOr("related_traffic_light", "none");
 
-  for (const auto & lanelet : green_lanelets) {
+  for (const auto & lanelet : non_red_lanelets) {
     const std::string turn_direction = lanelet.attributeOr("turn_direction", "none");
 
     if (turn_direction == "left") {
-      has_left_green_lane = true;
+      has_left_non_red_lane = true;
     } else if (turn_direction == "right") {
-      has_right_green_lane = true;
+      has_right_non_red_lane = true;
     } else {
-      has_straight_green_lane = true;
+      has_straight_non_red_lane = true;
     }
 
     const auto tl_reg_elems = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
     if (tl_reg_elems.front()->id() == std::atoi(related_tl_id.c_str())) {
-      has_related_green_tl = true;
+      has_related_non_red_tl = true;
     }
   }
 
-  if (has_straight_green_lane || has_related_green_tl) {
+  if (has_straight_non_red_lane || has_related_non_red_tl) {
     return TrafficLight::RED;
   }
 
-  const auto has_merge_lane = hasMergeLane(green_lanelets, routing_graph_ptr_);
-  return !has_merge_lane && has_left_green_lane && has_right_green_lane ? TrafficLight::RED
-                                                                        : TrafficLight::UNKNOWN;
+  const auto has_merge_lane = hasMergeLane(non_red_lanelets, routing_graph_ptr_);
+  return !has_merge_lane && has_left_non_red_lane && has_right_non_red_lane ? TrafficLight::RED
+                                                                            : TrafficLight::UNKNOWN;
 }
 
 boost::optional<uint8_t> CrosswalkTrafficLightEstimatorNode::getHighestConfidenceTrafficSignal(


### PR DESCRIPTION
## Description
estimate the corresponding pedestrian traffic light as red when the vehicle traffic light is not only green but also amber.

<!-- Write a brief description of this PR. -->

## Related links
(TierIV Intenal Link: https://star4.slack.com/archives/C4P0NSMB5/p1675914220312339 ) 
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
I checked that there was no degradation on traffic light recognition functionusing psim/lsim.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
