### PR TITLE
fix(behavior_velocity_planner): continue collision checking after pass judge

### DIFF
--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -3,6 +3,7 @@
     intersection:
       state_transit_margin_time: 1.0
       stop_line_margin: 3.0
+      keep_detection_vel_thr: 0.833 # == 3.0km/h. keep detection if ego is ego.vel < keep_detection_vel_thr
       stuck_vehicle_detect_dist: 3.0 # this should be the length between cars when they are stopped. The actual stuck vehicle detection length will be this value + vehicle_length.
       stuck_vehicle_ignore_dist: 10.0 # obstacle stop max distance(5.0m) + stuck vehicle size / 2 (0.0m-)
       stuck_vehicle_vel_thr: 0.833 # 0.833m/s = 3.0km/h

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -68,6 +68,7 @@ public:
   {
     double state_transit_margin_time;
     double stop_line_margin;  //! distance from auto-generated stopline to detection_area boundary
+    double keep_detection_vel_thr;     //! keep detection if ego is ego.vel < keep_detection_vel_thr
     double stuck_vehicle_detect_dist;  //! distance from end point to finish stuck vehicle check
     double
       stuck_vehicle_ignore_dist;   //! distance from intersection start to start stuck vehicle check

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -46,6 +46,7 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
   ip.state_transit_margin_time = node.declare_parameter(ns + ".state_transit_margin_time", 2.0);
   ip.stop_line_margin = node.declare_parameter(ns + ".stop_line_margin", 1.0);
+  ip.keep_detection_vel_thr = node.declare_parameter(ns + ".keep_detection_vel_thr", 0.833);
   ip.stuck_vehicle_detect_dist = node.declare_parameter(ns + ".stuck_vehicle_detect_dist", 3.0);
   ip.stuck_vehicle_ignore_dist = node.declare_parameter(ns + ".stuck_vehicle_ignore_dist", 5.0) +
                                  vehicle_info.max_longitudinal_offset_m;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -160,6 +160,28 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   }
   const size_t closest_idx = closest_idx_opt.get();
 
+  if (stop_lines_idx_opt.has_value()) {
+    const auto stop_line_idx = stop_lines_idx_opt.value().collision_stop_line;
+    const auto pass_judge_line_idx = stop_lines_idx_opt.value().pass_judge_line;
+
+    const bool is_over_pass_judge_line =
+      util::isOverTargetIndex(*path, closest_idx, current_pose, pass_judge_line_idx);
+
+    /* if ego is over the pass judge line before collision is detected, keep going */
+    const double current_velocity = planner_data_->current_velocity->twist.linear.x;
+    if (
+      is_over_pass_judge_line && is_go_out_ &&
+      current_velocity > planner_param_.keep_detection_vel_thr) {
+      RCLCPP_DEBUG(logger_, "over the pass judge line. no plan needed.");
+      RCLCPP_DEBUG(logger_, "===== plan end =====");
+      setSafe(true);
+      setDistance(motion_utils::calcSignedArcLength(
+        path->points, planner_data_->current_odometry->pose.position,
+        path->points.at(stop_line_idx).point.pose.position));
+      return true;
+    }
+  }
+
   /* collision checking */
   bool is_entry_prohibited = false;
 
@@ -215,25 +237,6 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     is_entry_prohibited ? StateMachine::State::STOP : StateMachine::State::GO,
     logger_.get_child("state_machine"), *clock_);
   setSafe(state_machine_.getState() == StateMachine::State::GO);
-
-  if (stop_lines_idx_opt.has_value()) {
-    const auto stop_line_idx = stop_lines_idx_opt.value().collision_stop_line;
-    const auto pass_judge_line_idx = stop_lines_idx_opt.value().pass_judge_line;
-
-    const bool is_over_pass_judge_line =
-      util::isOverTargetIndex(*path, closest_idx, current_pose, pass_judge_line_idx);
-
-    /* if ego is over the pass judge line before collision is detected, keep going */
-    if (is_over_pass_judge_line && !is_entry_prohibited) {
-      RCLCPP_DEBUG(logger_, "over the pass judge line. no plan needed.");
-      RCLCPP_DEBUG(logger_, "===== plan end =====");
-      setSafe(true);
-      setDistance(motion_utils::calcSignedArcLength(
-        path->points, planner_data_->current_odometry->pose.position,
-        path->points.at(stop_line_idx).point.pose.position));
-      return true;
-    }
-  }
 
   if (!stop_line_idx.has_value()) {
     RCLCPP_DEBUG(logger_, "detection_area is empty, no plan needed");


### PR DESCRIPTION
## Description

This PR reverts part of #2719 to continue collision checking after pass judge line.
- In case ego speed is slower than expected due to the later deceleration/control
- In small intersection lane

## Related links

parameter PR(awf): https://github.com/autowarefoundation/autoware_launch/pull/203
parameter PR(tier4): https://github.com/tier4/autoware_launch/pull/769
## Tests performed

CI result is OK
https://evaluation.tier4.jp/evaluation/reports/f76d27e4-ef8a-5036-ae27-0b2574cbb0d1?project_id=prd_jt

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
