### PR TITLE
fix(behavior_path_planner): fix drivable area expansion method outside intersection

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2573,12 +2573,8 @@ void AvoidanceModule::generateExtendedDrivableArea(PathWithLaneId & path) const
 
     // 2. when there are multiple turning lanes whose previous lanelet is the same in
     // intersection
-    const lanelet::ConstLanelets next_lanes_from_intersection = std::invoke(
+    const lanelet::ConstLanelets next_lanes = std::invoke(
       [&route_handler](const lanelet::ConstLanelet & lane) {
-        if (!lane.hasAttribute("turn_direction")) {
-          return lanelet::ConstLanelets{};
-        }
-
         // get previous lane, and return false if previous lane does not exist
         lanelet::ConstLanelets prev_lanes;
         if (!route_handler->getPreviousLaneletsWithinRoute(lane, &prev_lanes)) {
@@ -2598,7 +2594,7 @@ void AvoidanceModule::generateExtendedDrivableArea(PathWithLaneId & path) const
 
     // 2.1 look for neighbour lane, where end line of the lane is connected to end line of the
     // original lane
-    for (const auto & next_lane : next_lanes_from_intersection) {
+    for (const auto & next_lane : next_lanes) {
       if (current_lane.id() == next_lane.id()) {
         continue;
       }


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

The drivable area expansion algorithm I modified should be applied not only to intersection but also outside the intersection as follows.

before
![image](https://user-images.githubusercontent.com/20228327/218036111-ba69df1d-0530-4965-8cb3-75d0c39885aa.png)

after
![image](https://user-images.githubusercontent.com/20228327/218035443-999e4f4d-33ab-466b-81ec-976aece9ab68.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
