### PR TITLE
feat(detected_object_validator): parameterize validator threshold for each label

### DIFF
--- a/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
+++ b/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
@@ -8,4 +8,4 @@
       TRAILER : 10
       MOTORCYCLE : 5
       BICYCLE : 5
-      PEDESTRIAN : 8
+      PEDESTRIAN : 10

--- a/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
+++ b/perception/detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
@@ -1,0 +1,11 @@
+/**:
+  ros__parameters:
+    min_pointcloud_num:
+      UNKNOWN: 10
+      CAR : 10
+      TRUCK : 10
+      BUS : 10
+      TRAILER : 10
+      MOTORCYCLE : 5
+      BICYCLE : 5
+      PEDESTRIAN : 8

--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -20,6 +20,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_auto_perception_msgs/msg/object_classification.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <message_filters/subscriber.h>
@@ -32,9 +33,23 @@
 
 #include <memory>
 #include <optional>
+#include <unordered_map>
 
 namespace obstacle_pointcloud_based_validator
 {
+
+struct Min_pointcloud_num
+{
+  unsigned int UNKNOWN;
+  unsigned int CAR;
+  unsigned int TRUCK;
+  unsigned int BUS;
+  unsigned int TRAILER;
+  unsigned int MOTORCYCLE;
+  unsigned int BICYCLE;
+  unsigned int PEDESTRIAN;
+};
+
 class ObstaclePointCloudBasedValidator : public rclcpp::Node
 {
 public:
@@ -52,8 +67,8 @@ private:
     SyncPolicy;
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
   Sync sync_;
-  size_t min_pointcloud_num_;
-
+  Min_pointcloud_num min_pointcloud_num_;
+  std::unordered_map<uint8_t, unsigned int> class2min_pointcloud_num_;
   std::shared_ptr<Debugger> debugger_;
 
 private:

--- a/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
+++ b/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
@@ -10,6 +10,6 @@
     <remap from="~/input/obstacle_pointcloud" to="$(var input/obstacle_pointcloud)"/>
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param name="enable_debugger" value="false"/>
-	<param from="$(var filtering_param)"/>
+    <param from="$(var filtering_param)"/>
   </node>
 </launch>

--- a/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
+++ b/perception/detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
@@ -3,11 +3,13 @@
   <arg name="input/detected_objects" default="/perception/object_recognition/detection/objects"/>
   <arg name="input/obstacle_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output/objects" default="/perception/object_recognition/detection/validation/obstacle_pointcloud_based/objects"/>
+  <arg name="filtering_param" default="$(find-pkg-share detected_object_validation)/config/obstacle_pointcloud_based_validator.param.yaml"/>
 
   <node pkg="detected_object_validation" exec="obstacle_pointcloud_based_validator_node" name="obstacle_pointcloud_based_validator_node" output="screen">
     <remap from="~/input/detected_objects" to="$(var input/detected_objects)"/>
     <remap from="~/input/obstacle_pointcloud" to="$(var input/obstacle_pointcloud)"/>
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param name="enable_debugger" value="false"/>
+	<param from="$(var filtering_param)"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description

This PR add parameter for `min_pointcloud_num` in obstacle_pointcloud_based_validator which is hardcoded in validator node file. For small categories this value can be set to a smaller one than the current value of `10`.

## Tests performed

WIP

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
