### PR TITLE
build(lidar_centerpoint): use APT version of python3-open3d as dependency

### DIFF
--- a/perception/lidar_centerpoint/package.xml
+++ b/perception/lidar_centerpoint/package.xml
@@ -16,7 +16,7 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>perception_utils</depend>
-  <depend>python3-open3d-pip</depend>
+  <depend>python3-open3d</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2_eigen</depend>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

This uses the APT version of the dependency (instead of from PyPI), see https://github.com/ros/rosdistro/pull/36052

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
