### PR TITLE
fix(behavior_velocity_planner): keep intersection module for lanes with same parent and same direction

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/manager.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/manager.hpp
@@ -25,6 +25,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 
 namespace behavior_velocity_planner
 {
@@ -43,9 +44,12 @@ private:
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 
-  bool hasSameParentLaneletWith(const lanelet::ConstLanelet & lane, const size_t module_id) const;
+  bool hasSameParentLaneletAndTurnDirectionWith(
+    const lanelet::ConstLanelet & lane, const size_t module_id,
+    const std::string & turn_direction_lane) const;
 
-  bool hasSameParentLaneletWithRegistered(const lanelet::ConstLanelet & lane) const;
+  bool hasSameParentLaneletAndTurnDirectionWithRegistered(
+    const lanelet::ConstLanelet & lane, const std::string & turn_direction) const;
 };
 
 class MergeFromPrivateModuleManager : public SceneModuleManagerInterface
@@ -63,7 +67,12 @@ private:
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 
-  bool hasSameParentLaneletWith(const lanelet::ConstLanelet & lane, const size_t module_id) const;
+  bool hasSameParentLaneletAndTurnDirectionWith(
+    const lanelet::ConstLanelet & lane, const size_t module_id,
+    const std::string & turn_direction_lane) const;
+
+  bool hasSameParentLaneletAndTurnDirectionWithRegistered(
+    const lanelet::ConstLanelet & lane, const std::string & turn_direction) const;
 };
 }  // namespace behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -97,10 +97,6 @@ void IntersectionModuleManager::launchNewModules(
     const auto lane_id = ll.id();
     const auto module_id = lane_id;
 
-    if (hasSameParentLaneletWithRegistered(ll)) {
-      continue;
-    }
-
     // Is intersection?
     const std::string turn_direction = ll.attributeOr("turn_direction", "else");
     const auto is_intersection =
@@ -108,6 +104,11 @@ void IntersectionModuleManager::launchNewModules(
     if (!is_intersection) {
       continue;
     }
+
+    if (hasSameParentLaneletAndTurnDirectionWithRegistered(ll, turn_direction)) {
+      continue;
+    }
+
     registerModule(std::make_shared<IntersectionModule>(
       module_id, lane_id, planner_data_, intersection_param_,
       logger_.get_child("intersection_module"), clock_));
@@ -142,28 +143,30 @@ void MergeFromPrivateModuleManager::launchNewModules(
     // Is merging from private road?
     // In case the goal is in private road, check if this lanelet is conflicting with urban lanelet
     const std::string lane_location = ll.attributeOr("location", "else");
-    if (lane_location == "private") {
-      if (i + 1 < lanelets.size()) {
-        const auto next_lane = lanelets.at(i + 1);
-        const std::string next_lane_location = next_lane.attributeOr("location", "else");
-        if (next_lane_location != "private") {
+    if (lane_location != "private") {
+      continue;
+    }
+
+    if (i + 1 < lanelets.size()) {
+      const auto next_lane = lanelets.at(i + 1);
+      const std::string next_lane_location = next_lane.attributeOr("location", "else");
+      if (next_lane_location != "private") {
+        registerModule(std::make_shared<MergeFromPrivateRoadModule>(
+          module_id, lane_id, planner_data_, merge_from_private_area_param_,
+          logger_.get_child("merge_from_private_road_module"), clock_));
+        continue;
+      }
+    } else {
+      const auto routing_graph_ptr = planner_data_->route_handler_->getRoutingGraphPtr();
+      const auto conflicting_lanelets =
+        lanelet::utils::getConflictingLanelets(routing_graph_ptr, ll);
+      for (auto && conflicting_lanelet : conflicting_lanelets) {
+        const std::string conflicting_attr = conflicting_lanelet.attributeOr("location", "else");
+        if (conflicting_attr == "urban") {
           registerModule(std::make_shared<MergeFromPrivateRoadModule>(
             module_id, lane_id, planner_data_, merge_from_private_area_param_,
             logger_.get_child("merge_from_private_road_module"), clock_));
           continue;
-        }
-      } else {
-        const auto routing_graph_ptr = planner_data_->route_handler_->getRoutingGraphPtr();
-        const auto conflicting_lanelets =
-          lanelet::utils::getConflictingLanelets(routing_graph_ptr, ll);
-        for (auto && conflicting_lanelet : conflicting_lanelets) {
-          const std::string conflicting_attr = conflicting_lanelet.attributeOr("location", "else");
-          if (conflicting_attr == "urban") {
-            registerModule(std::make_shared<MergeFromPrivateRoadModule>(
-              module_id, lane_id, planner_data_, merge_from_private_area_param_,
-              logger_.get_child("merge_from_private_road_module"), clock_));
-            continue;
-          }
         }
       }
     }
@@ -185,7 +188,8 @@ IntersectionModuleManager::getModuleExpiredFunction(
       if (!is_intersection) {
         continue;
       }
-      if (hasSameParentLaneletWith(lane, scene_module->getModuleId())) {
+      if (hasSameParentLaneletAndTurnDirectionWith(
+            lane, scene_module->getModuleId(), turn_direction)) {
         return false;
       }
     }
@@ -208,7 +212,8 @@ MergeFromPrivateModuleManager::getModuleExpiredFunction(
       if (!is_intersection) {
         continue;
       }
-      if (hasSameParentLaneletWith(lane, scene_module->getModuleId())) {
+      if (hasSameParentLaneletAndTurnDirectionWith(
+            lane, scene_module->getModuleId(), turn_direction)) {
         return false;
       }
     }
@@ -216,14 +221,18 @@ MergeFromPrivateModuleManager::getModuleExpiredFunction(
   };
 }
 
-bool IntersectionModuleManager::hasSameParentLaneletWith(
-  const lanelet::ConstLanelet & lane, const size_t module_id) const
+bool IntersectionModuleManager::hasSameParentLaneletAndTurnDirectionWith(
+  const lanelet::ConstLanelet & lane, const size_t module_id,
+  const std::string & turn_direction_lane) const
 {
-  lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
-
   const auto registered_lane = planner_data_->route_handler_->getLaneletsFromId(module_id);
+  const auto turn_direction_registered = registered_lane.attributeOr("turn_direction", "else");
+  if (turn_direction_registered != turn_direction_lane) {
+    return false;
+  }
   lanelet::ConstLanelets registered_parents =
     planner_data_->route_handler_->getPreviousLanelets(registered_lane);
+  lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
   for (const auto & ll : registered_parents) {
     auto neighbor_lanes = planner_data_->route_handler_->getLaneChangeableNeighbors(ll);
     neighbor_lanes.push_back(ll);
@@ -234,13 +243,17 @@ bool IntersectionModuleManager::hasSameParentLaneletWith(
   return false;
 }
 
-bool IntersectionModuleManager::hasSameParentLaneletWithRegistered(
-  const lanelet::ConstLanelet & lane) const
+bool IntersectionModuleManager::hasSameParentLaneletAndTurnDirectionWithRegistered(
+  const lanelet::ConstLanelet & lane, const std::string & turn_direction) const
 {
   lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
 
   for (const auto & id : registered_module_id_set_) {
     const auto registered_lane = planner_data_->route_handler_->getLaneletsFromId(id);
+    const auto turn_direction_registered = registered_lane.attributeOr("turn_direction", "else");
+    if (turn_direction_registered != turn_direction) {
+      continue;
+    }
     lanelet::ConstLanelets registered_parents =
       planner_data_->route_handler_->getPreviousLanelets(registered_lane);
     for (const auto & ll : registered_parents) {
@@ -254,14 +267,18 @@ bool IntersectionModuleManager::hasSameParentLaneletWithRegistered(
   return false;
 }
 
-bool MergeFromPrivateModuleManager::hasSameParentLaneletWith(
-  const lanelet::ConstLanelet & lane, const size_t module_id) const
+bool MergeFromPrivateModuleManager::hasSameParentLaneletAndTurnDirectionWith(
+  const lanelet::ConstLanelet & lane, const size_t module_id,
+  const std::string & turn_direction) const
 {
-  lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
-
   const auto registered_lane = planner_data_->route_handler_->getLaneletsFromId(module_id);
+  const auto turn_direction_registered = registered_lane.attributeOr("turn_direction", "else");
+  if (turn_direction_registered != turn_direction) {
+    return false;
+  }
   lanelet::ConstLanelets registered_parents =
     planner_data_->route_handler_->getPreviousLanelets(registered_lane);
+  lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
   for (const auto & ll : registered_parents) {
     auto neighbor_lanes = planner_data_->route_handler_->getLaneChangeableNeighbors(ll);
     neighbor_lanes.push_back(ll);


### PR DESCRIPTION
## Description

Additional fix for following PRs. I restricted the condition for keeping the existing intersection module to check if the turn_direction is identical.

## Related links

- https://github.com/autowarefoundation/autoware.universe/pull/2720
- https://github.com/autowarefoundation/autoware.universe/pull/2790

## Tests performed

Checked by changing the left-turn route by placing a checkpoint.

![image](https://user-images.githubusercontent.com/28677420/218378970-56315a57-6bd1-4296-aebe-55549a241e5b.png)

### Before this change

After changing the path from a left-turn route to straight one, the intersection module for left-turn lane was still running.

![image](https://user-images.githubusercontent.com/28677420/218379154-1e744284-5677-43e1-9253-543b2709eb85.png)

### After this change

The intersection module for left-turn lane is not running, and the one for straight lane is running instead.

![image](https://user-images.githubusercontent.com/28677420/218379261-58611f2b-4049-4b2b-a7a6-5d5a588569a5.png)

## Notes for reviewers

- We may need a mechanism to reset the planning module when the route is changed externally.
- For merge_from_private module, LC is not considered
- intersection module needs additional change for generating stop line position based on the path, not a specific lane
  - the stop position for traffic  light module looks OK:
 
![Screenshot from 2023-02-13 14-50-34](https://user-images.githubusercontent.com/28677420/218381428-bc0bd1d5-3fbb-4143-bad2-9e87b45543ad.png)
![Screenshot from 2023-02-13 14-50-52](https://user-images.githubusercontent.com/28677420/218381450-0fce741c-81bb-4fa6-8ea3-c1aeca676de6.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
