### PR TITLE
fix(avoidance): remove rtc status when the ego is in YIELD maneuver

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -735,6 +735,8 @@ void AvoidanceModule::updateEgoBehavior(const AvoidancePlanningData & data, Shif
       insertYieldVelocity(path);
       insertWaitPoint(parameters_->use_constraints_for_decel, path);
       removeAllRegisteredShiftPoints(path_shifter_);
+      clearWaitingApproval();
+      removeRTCStatus();
       break;
     }
     case AvoidanceState::AVOID_PATH_NOT_READY: {


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

bug: R(L) Avoid rtc status remain on FOA even after the avoidance module revert the avoidance path.

resolution: remove rtc status when the ego is in YIELD maneuver.

![image](https://user-images.githubusercontent.com/44889564/218607245-048e6b2a-74b6-42c3-aebc-b0a4279ec10f.png)

## Test performance

set this flat `true`

https://github.com/autowarefoundation/autoware_launch/blob/1a52b77d9eaf140039f939cbc6777899f1f487ec/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml#L18-L19

Remove approved R Avoid from FOA after the ego is in YIELD maneuver.

https://user-images.githubusercontent.com/44889564/218607813-cb509eaf-f73a-48b2-8e33-861c90a7b1b2.mp4

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author


The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
