### PR TITLE
fix(avoidance): fix shift line merging logic

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1379,7 +1379,7 @@ void AvoidanceModule::generateTotalShiftLine(
   for (size_t i = 1; i < N; ++i) {
     bool has_object = false;
     for (const auto & al : avoid_lines) {
-      if (al.start_idx < i && i < al.end_idx) {
+      if (al.start_idx <= i && i <= al.end_idx) {
         has_object = true;
         break;
       }


### PR DESCRIPTION
Signed-off-by: satoshi-ota <satoshi.ota928@gmail.com>

## Description

Fix shift line merging logic. Before this PR, at `start_idx` and `end_idx`, the shift length is same value as `start_idx - 1` and `end_idx - 1` because the flag `has_object` is set `true` only between `start_idx + 1` and `end_idx - 1`. Then, the total shift line may not include edge of the raw shift line.

![image](https://user-images.githubusercontent.com/44889564/224854446-74c46538-2659-43ef-98ff-7ab04db83387.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
