### PR TITLE
perf(map_based_prediction): performance improvement of interpolateReferencePath with cumulative sum

### DIFF
--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -305,8 +305,8 @@ PosePath PathGenerator::interpolateReferencePath(
     base_path_y.at(i) = base_path.at(i).position.y;
     base_path_z.at(i) = base_path.at(i).position.z;
     if (i > 0) {
-      base_path_s.at(i) = base_path_s.at(i - 1)
-        + tier4_autoware_utils::calcDistance2d(base_path.at(i - 1), base_path.at(i));
+      base_path_s.at(i) = base_path_s.at(i - 1) + tier4_autoware_utils::calcDistance2d(
+                                                    base_path.at(i - 1), base_path.at(i));
     }
   }
 

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -296,15 +296,18 @@ PosePath PathGenerator::interpolateReferencePath(
     return interpolated_path;
   }
 
-  std::vector<double> base_path_x;
-  std::vector<double> base_path_y;
-  std::vector<double> base_path_z;
-  std::vector<double> base_path_s;
+  std::vector<double> base_path_x(base_path.size());
+  std::vector<double> base_path_y(base_path.size());
+  std::vector<double> base_path_z(base_path.size());
+  std::vector<double> base_path_s(base_path.size(), 0.0);
   for (size_t i = 0; i < base_path.size(); ++i) {
-    base_path_x.push_back(base_path.at(i).position.x);
-    base_path_y.push_back(base_path.at(i).position.y);
-    base_path_z.push_back(base_path.at(i).position.z);
-    base_path_s.push_back(motion_utils::calcSignedArcLength(base_path, 0, i));
+    base_path_x.at(i) = base_path.at(i).position.x;
+    base_path_y.at(i) = base_path.at(i).position.y;
+    base_path_z.at(i) = base_path.at(i).position.z;
+    if (i > 0) {
+      base_path_s.at(i) = base_path_s.at(i - 1)
+        + tier4_autoware_utils::calcDistance2d(base_path.at(i - 1), base_path.at(i));
+    }
   }
 
   std::vector<double> resampled_s(frenet_predicted_path.size());


### PR DESCRIPTION
Signed-off-by: veqcc <ryuta.kambe@tier4.jp>

### Description
The node `map_based_prediction` is too slow to publish `/perception/object_recognition/objects` topic when there are a lot of vehicles around the ego. This is due to the inefficient implementation of `interpolateReferencePath`, especially the calculation of the length of paths with `calcSignedArcLength`. It calls the `calcSignedArcLength` function for EVERY index of the path. This can be optimized with the idea cumulative sum, in which the path length of 0 to i-th index can be easily calculated with the value of 0 to (i-1)th.
The following figure shows how latencies are optimized with the idea. The red graph is the original latency, and the blue graph is the latency of the proposed implementation.
![image](https://user-images.githubusercontent.com/26951562/218696830-a17f7100-aa6a-47a6-8a36-0a0686e66be8.png)
