### PR TITLE
fix(surround_obstacle_checker): delete default param

### DIFF
--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -146,13 +146,13 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
   // Parameters
   {
     auto & p = node_param_;
-    p.use_pointcloud = this->declare_parameter("use_pointcloud", true);
-    p.use_dynamic_object = this->declare_parameter("use_dynamic_object", true);
-    p.surround_check_distance = this->declare_parameter("surround_check_distance", 2.0);
+    p.use_pointcloud = this->declare_parameter<bool>("use_pointcloud");
+    p.use_dynamic_object = this->declare_parameter<bool>("use_dynamic_object");
+    p.surround_check_distance = this->declare_parameter<double>("surround_check_distance");
     p.surround_check_recover_distance =
-      this->declare_parameter("surround_check_recover_distance", 2.5);
-    p.state_clear_time = this->declare_parameter("state_clear_time", 2.0);
-    p.publish_debug_footprints = this->declare_parameter("publish_debug_footprints", true);
+      this->declare_parameter<double>("surround_check_recover_distance");
+    p.state_clear_time = this->declare_parameter<double>("state_clear_time");
+    p.publish_debug_footprints = this->declare_parameter<bool>("publish_debug_footprints");
   }
 
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();


### PR DESCRIPTION
## Description

There was a problem that errors were not given by giving default_value in the declare_parameter function. 
Therefore, the declare parameter in the surround_obstacle_checker module was removed.

[delete_param.webm](https://user-images.githubusercontent.com/100691117/218953940-2bf14cef-727b-4e17-a183-b4c657f92ffd.webm)
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/


