### PR TITLE
fix(pure_pursuit): return zero curvature when neighboring idx isn't found

### DIFF
--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -186,16 +186,19 @@ double PurePursuitLateralController::calcCurvature(const size_t closest_idx)
   if (static_cast<size_t>(closest_idx) >= idx_dist) {
     prev_idx = closest_idx - idx_dist;
   } else {
-    // return zero curvature because prev_idx can't be found
+    // return zero curvature when forward distance is not long enough in the trajectory
     return 0.0;
   }
 
   if (trajectory_resampled_->points.size() - 1 >= closest_idx + idx_dist) {
     next_idx = closest_idx + idx_dist;
   } else {
-    // return zero curvature because next_idx can't be found
+    // return zero curvature when backward distance is not long enough in the trajectory
     return 0.0;
   }
+  // TODO: shift the center point of the curvature calculation to allow sufficient distance,
+  // because if sufficient distance cannot be obtained in front or behind, the curvature will be
+  // zero in the current implementation.
 
   // Calculate curvature assuming the trajectory points interval is constant
   double current_curvature = 0.0;

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -196,9 +196,9 @@ double PurePursuitLateralController::calcCurvature(const size_t closest_idx)
     // return zero curvature when forward distance is not long enough in the trajectory
     return 0.0;
   }
-  // TODO: shift the center point of the curvature calculation to allow sufficient distance,
-  // because if sufficient distance cannot be obtained in front or behind, the curvature will be
-  // zero in the current implementation.
+  // TODO(k.sugahara): shift the center point of the curvature calculation to allow sufficient
+  // distance, because if sufficient distance cannot be obtained in front or behind, the curvature
+  // will be zero in the current implementation.
 
   // Calculate curvature assuming the trajectory points interval is constant
   double current_curvature = 0.0;

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -186,14 +186,14 @@ double PurePursuitLateralController::calcCurvature(const size_t closest_idx)
   if (static_cast<size_t>(closest_idx) >= idx_dist) {
     prev_idx = closest_idx - idx_dist;
   } else {
-    // return zero curvature when forward distance is not long enough in the trajectory
+    // return zero curvature when backward distance is not long enough in the trajectory
     return 0.0;
   }
 
   if (trajectory_resampled_->points.size() - 1 >= closest_idx + idx_dist) {
     next_idx = closest_idx + idx_dist;
   } else {
-    // return zero curvature when backward distance is not long enough in the trajectory
+    // return zero curvature when forward distance is not long enough in the trajectory
     return 0.0;
   }
   // TODO: shift the center point of the curvature calculation to allow sufficient distance,

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -185,9 +185,16 @@ double PurePursuitLateralController::calcCurvature(const size_t closest_idx)
 
   if (static_cast<size_t>(closest_idx) >= idx_dist) {
     prev_idx = closest_idx - idx_dist;
+  } else {
+    // return zero curvature because prev_idx can't be found
+    return 0.0;
   }
+
   if (trajectory_resampled_->points.size() - 1 >= closest_idx + idx_dist) {
     next_idx = closest_idx + idx_dist;
+  } else {
+    // return zero curvature because next_idx can't be found
+    return 0.0;
   }
 
   // Calculate curvature assuming the trajectory points interval is constant


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
When candidate point for the curvature calculation isn't found, 0 is returned to avoid unnecessary warnings.

But there is a still space to solve this probelem by 
- shifting closest point so that enough distance can be gotten.
- changing distane from the closest point between forward direction and backward direction.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
