### PR TITLE
fix(mpc_lateral_controller): over capacity

### DIFF
--- a/control/mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/mpc_lateral_controller/src/mpc_utils.cpp
@@ -249,6 +249,9 @@ bool convertToAutowareTrajectory(
     p.longitudinal_velocity_mps =
       static_cast<decltype(p.longitudinal_velocity_mps)>(input.vx.at(i));
     output.points.push_back(p);
+    if (output.points.size() == output.points.max_size()) {
+      break;
+    }
   }
   return true;
 }


### PR DESCRIPTION
## Description

MPC controller died when a very long trajectory is published due to the capacity error.

Detail: MPC applies interpolation to the `mpc_lateral_controller::MPCTrajectory` type which doesn't have a capacity. When the MPCTrajectory is converted to the `autoware_auto_planning_msgs::msg::Trajectory`, the process died due to over the capacity.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Run the planning_simulator, then run the following node:
```
ros2 launch planning_validator invalid_trajectory_publisher.launch.xml
```
This is a simple test node in the planning_validator publishing a very long trajectory. You can see the long trajectory on the Rviz and the message "process has died" on the terminal.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
