### PR TITLE
feat(detected_object_validation): add dynamic min pointcloud num

### DIFF
--- a/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
+++ b/perception/detected_object_validation/include/obstacle_pointcloud_based_validator/obstacle_pointcloud_based_validator.hpp
@@ -35,6 +35,12 @@
 
 namespace obstacle_pointcloud_based_validator
 {
+struct PointsNumThresholdParam
+{
+  size_t min_points_num;
+  size_t max_points_num;
+  float min_points_and_distance_ratio;
+};
 class ObstaclePointCloudBasedValidator : public rclcpp::Node
 {
 public:
@@ -52,7 +58,7 @@ private:
     SyncPolicy;
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
   Sync sync_;
-  size_t min_pointcloud_num_;
+  PointsNumThresholdParam points_num_threshold_param_;
 
   std::shared_ptr<Debugger> debugger_;
 

--- a/perception/detected_object_validation/obstacle-pointcloud-based-validator.md
+++ b/perception/detected_object_validation/obstacle-pointcloud-based-validator.md
@@ -26,10 +26,12 @@ In the debug image above, the red DetectedObject is the validated object. The bl
 
 ## Parameters
 
-| Name                 | Type  | Description                                                                  |
-| -------------------- | ----- | ---------------------------------------------------------------------------- |
-| `min_pointcloud_num` | float | Threshold for the minimum number of obstacle point clouds in DetectedObjects |
-| `enable_debugger`    | bool  | Whether to create debug topics or not?                                       |
+| Name                            | Type  | Description                                                                                                                                                                |
+| ------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `min_points_num`                | int   | The minimum number of obstacle point clouds in DetectedObjects                                                                                                             |
+| `max_points_num`                | int   | The max number of obstacle point clouds in DetectedObjects                                                                                                                 |
+| `min_points_and_distance_ratio` | float | Threshold value of the number of point clouds per object when the distance from baselink is 1m, because the number of point clouds varies with the distance from baselink. |
+| `enable_debugger`               | bool  | Whether to create debug topics or not?                                                                                                                                     |
 
 ## Assumptions / Known limits
 

--- a/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
@@ -92,7 +92,10 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
   objects_pub_ = create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
     "~/output/objects", rclcpp::QoS{1});
 
-  min_pointcloud_num_ = declare_parameter<int>("min_pointcloud_num", 10);
+  points_num_threshold_param_.min_points_num = declare_parameter<int>("min_points_num", 10);
+  points_num_threshold_param_.max_points_num = declare_parameter<int>("max_points_num", 10);
+  points_num_threshold_param_.min_points_and_distance_ratio =
+    declare_parameter<float>("min_points_and_distance_ratio", 500.0);
 
   const bool enable_debugger = declare_parameter<bool>("enable_debugger", false);
   if (enable_debugger) debugger_ = std::make_shared<Debugger>(this);
@@ -132,6 +135,8 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
   for (size_t i = 0; i < transformed_objects.objects.size(); ++i) {
     const auto & transformed_object = transformed_objects.objects.at(i);
     const auto & object = input_objects->objects.at(i);
+    const auto & transformed_object_position =
+      transformed_object.kinematics.pose_with_covariance.pose.position;
     const auto search_radius = getMaxRadius(transformed_object);
     if (!search_radius) {
       output.objects.push_back(object);
@@ -143,8 +148,7 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
     std::vector<int> indices;
     std::vector<float> distances;
     kdtree->radiusSearch(
-      toPCL(transformed_object.kinematics.pose_with_covariance.pose.position),
-      search_radius.value(), indices, distances);
+      toPCL(transformed_object_position), search_radius.value(), indices, distances);
     for (const auto & index : indices) {
       neighbor_pointcloud->push_back(obstacle_pointcloud->at(index));
     }
@@ -152,9 +156,15 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
 
     // Filter object that have few pointcloud in them.
     const auto num = getPointCloudNumWithinPolygon(transformed_object, neighbor_pointcloud);
+    const auto object_distance =
+      std::hypot(transformed_object_position.x, transformed_object_position.y);
+    size_t min_pointcloud_num = std::clamp(
+      static_cast<size_t>(
+        points_num_threshold_param_.min_points_and_distance_ratio / object_distance + 0.5f),
+      points_num_threshold_param_.min_points_num, points_num_threshold_param_.max_points_num);
     if (num) {
-      (min_pointcloud_num_ <= num.value()) ? output.objects.push_back(object)
-                                           : removed_objects.objects.push_back(object);
+      (min_pointcloud_num <= num.value()) ? output.objects.push_back(object)
+                                          : removed_objects.objects.push_back(object);
     } else {
       output.objects.push_back(object);
     }

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -296,15 +296,18 @@ PosePath PathGenerator::interpolateReferencePath(
     return interpolated_path;
   }
 
-  std::vector<double> base_path_x;
-  std::vector<double> base_path_y;
-  std::vector<double> base_path_z;
-  std::vector<double> base_path_s;
+  std::vector<double> base_path_x(base_path.size());
+  std::vector<double> base_path_y(base_path.size());
+  std::vector<double> base_path_z(base_path.size());
+  std::vector<double> base_path_s(base_path.size(), 0.0);
   for (size_t i = 0; i < base_path.size(); ++i) {
-    base_path_x.push_back(base_path.at(i).position.x);
-    base_path_y.push_back(base_path.at(i).position.y);
-    base_path_z.push_back(base_path.at(i).position.z);
-    base_path_s.push_back(motion_utils::calcSignedArcLength(base_path, 0, i));
+    base_path_x.at(i) = base_path.at(i).position.x;
+    base_path_y.at(i) = base_path.at(i).position.y;
+    base_path_z.at(i) = base_path.at(i).position.z;
+    if (i > 0) {
+      base_path_s.at(i) = base_path_s.at(i - 1) + tier4_autoware_utils::calcDistance2d(
+                                                    base_path.at(i - 1), base_path.at(i));
+    }
   }
 
   std::vector<double> resampled_s(frenet_predicted_path.size());


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Because the validator used fixed values, the point cloud density was lower for distant obstacles, and obstacles were removed.
In this PR, the value is changed so that it changes according to the distance.
However, the parameters are not tuned and remain the same as before.

A similar approach is used in the following package.
https://github.com/autowarefoundation/autoware.universe/blob/main/perception/occupancy_grid_map_outlier_filter/include/occupancy_grid_map_outlier_filter/occupancy_grid_map_outlier_filter_nodelet.hpp#L63-L65

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
