### PR TITLE
fix(behavior_path_planner): fix pull over deceleration before search area start

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -469,18 +469,18 @@ BehaviorModuleOutput PullOverModule::plan()
       break;
     }
 
-    // Decelerate before the minimum shift distance from the goal search area.
+    // decelerate before the search area start
     if (status_.is_safe) {
-      auto & first_path = status_.pull_over_path.partial_paths.front();
       const auto search_start_pose = calcLongitudinalOffsetPose(
-        first_path.points, refined_goal_pose_.position,
+        status_.pull_over_path.getFullPath().points, refined_goal_pose_.position,
         -parameters_.backward_goal_search_length - planner_data_->parameters.base_link2front);
-      const Pose deceleration_pose =
-        search_start_pose ? *search_start_pose : first_path.points.front().point.pose;
-      constexpr double deceleration_buffer = 15.0;
-      first_path = util::setDecelerationVelocity(
-        first_path, parameters_.pull_over_velocity, deceleration_pose, -deceleration_buffer,
-        parameters_.deceleration_interval);
+      if (search_start_pose) {
+        auto & first_path = status_.pull_over_path.partial_paths.front();
+        constexpr double deceleration_buffer = 15.0;
+        first_path = util::setDecelerationVelocity(
+          first_path, parameters_.pull_over_velocity, *search_start_pose, -deceleration_buffer,
+          parameters_.deceleration_interval);
+      }
     }
 
     // generate drivable area for each partial path


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Fix the sudden stop in pull over.
When the goal is at the edge of goal search area, the deceleration point can not be calculated with geometric pull over because the search area start point is after the first partial path. And set deceleration velocity to all path points including the current position. This causes 0 velocity at the current position with motion velocity smoother.
In this PR, use the full path to calculate the search area start.


https://user-images.githubusercontent.com/39142679/219312964-b9065207-a006-46ce-bf1e-2f19ce9aa026.mp4



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->



## Tests performed

<!-- Describe how you have tested this PR. -->

psim, 
scenario test (tier4 internal https://evaluation.tier4.jp/evaluation/reports/12d7c886-0d45-5103-995d-bdabc35acf92?project_id=prd_jt)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
