### PR TITLE
feat(intersection): consider lane change in intersection based on associative ids

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/manager.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/manager.hpp
@@ -44,12 +44,7 @@ private:
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 
-  bool hasSameParentLaneletAndTurnDirectionWith(
-    const lanelet::ConstLanelet & lane, const size_t module_id,
-    const std::string & turn_direction_lane) const;
-
-  bool hasSameParentLaneletAndTurnDirectionWithRegistered(
-    const lanelet::ConstLanelet & lane, const std::string & turn_direction) const;
+  bool hasSameParentLaneletAndTurnDirectionWithRegistered(const lanelet::ConstLanelet & lane) const;
 };
 
 class MergeFromPrivateModuleManager : public SceneModuleManagerInterface
@@ -67,12 +62,7 @@ private:
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 
-  bool hasSameParentLaneletAndTurnDirectionWith(
-    const lanelet::ConstLanelet & lane, const size_t module_id,
-    const std::string & turn_direction_lane) const;
-
-  bool hasSameParentLaneletAndTurnDirectionWithRegistered(
-    const lanelet::ConstLanelet & lane, const std::string & turn_direction) const;
+  bool hasSameParentLaneletAndTurnDirectionWithRegistered(const lanelet::ConstLanelet & lane) const;
 };
 }  // namespace behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -141,9 +141,9 @@ private:
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
     const lanelet::ConstLanelets & detection_area_lanelets,
     const lanelet::ConstLanelets & adjacent_lanelets,
-    const std::optional<Polygon2d> & intersection_area,
+    const std::optional<Polygon2d> & intersection_area, const Polygon2d & ego_poly,
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr,
-    const int closest_idx, const Polygon2d & stuck_vehicle_detect_area, const double time_delay);
+    const int closest_idx, const double time_delay);
 
   /**
    * @brief Check if there is a stopped vehicle on the ego-lane.
@@ -167,10 +167,9 @@ private:
    * @param ignore_dist     ignore distance from the start point of the ego-intersection lane
    * @return generated polygon
    */
-  Polygon2d generateEgoIntersectionLanePolygon(
+  Polygon2d generateStuckVehicleDetectAreaPolygon(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
-    const double extra_dist, const double ignore_dist) const;
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx) const;
 
   /**
    * @brief Modify objects predicted path. remove path point if the time exceeds timer_thr.
@@ -227,11 +226,19 @@ private:
     const double margin = 0);
 
   /**
-   * @brief Get lanes including ego lanelet and next lanelet
-   * @param lanelet_map_ptr lanelet map
-   * @param path            ego-car lane
-   * @return ego lanelet and next lanelet
+   * @brief Get path polygon of intersection part and next lane part
+   * @return trimmed path polygon
    */
+  Polygon2d getIntersectionAndNextSegmentPolygon(
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double width) const;
+
+  /**
+   * @brief Get path polygon of intersetion part
+   * @return trimmed path polygon
+   */
+  Polygon2d getIntersectionSegmentPolygon(
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double width) const;
+
   lanelet::ConstLanelets getEgoLaneWithNextLane(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path) const;

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -50,7 +50,6 @@ public:
   {
     bool stop_required;
 
-    geometry_msgs::msg::Pose slow_wall_pose;
     geometry_msgs::msg::Pose stop_wall_pose;
     geometry_msgs::msg::Polygon stuck_vehicle_detect_area;
     geometry_msgs::msg::Polygon candidate_collision_ego_lane_polygon;
@@ -58,6 +57,7 @@ public:
     std::vector<lanelet::ConstLanelet> intersection_detection_lanelets;
     std::vector<lanelet::CompoundPolygon3d> detection_area;
     geometry_msgs::msg::Polygon intersection_area;
+    lanelet::CompoundPolygon3d ego_lane;
     std::vector<lanelet::CompoundPolygon3d> adjacent_area;
     autoware_auto_perception_msgs::msg::PredictedObjects conflicting_targets;
     autoware_auto_perception_msgs::msg::PredictedObjects stuck_targets;

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -141,7 +141,8 @@ private:
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
     const lanelet::ConstLanelets & detection_area_lanelets,
     const lanelet::ConstLanelets & adjacent_lanelets,
-    const std::optional<Polygon2d> & intersection_area, const Polygon2d & ego_poly,
+    const std::optional<Polygon2d> & intersection_area, const lanelet::ConstLanelet & ego_lane,
+    const lanelet::ConstLanelets & ego_lane_with_next_lane,
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects_ptr,
     const int closest_idx, const double time_delay);
 
@@ -168,8 +169,8 @@ private:
    * @return generated polygon
    */
   Polygon2d generateStuckVehicleDetectAreaPolygon(
-    lanelet::LaneletMapConstPtr lanelet_map_ptr,
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx) const;
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+    const lanelet::ConstLanelets & ego_lane_with_next_lane, const int closest_idx) const;
 
   /**
    * @brief Modify objects predicted path. remove path point if the time exceeds timer_thr.
@@ -229,19 +230,15 @@ private:
    * @brief Get path polygon of intersection part and next lane part
    * @return trimmed path polygon
    */
-  Polygon2d getIntersectionAndNextSegmentPolygon(
+  lanelet::ConstLanelets getEgoLaneWithNextLane(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double width) const;
 
   /**
    * @brief Get path polygon of intersetion part
    * @return trimmed path polygon
    */
-  Polygon2d getIntersectionSegmentPolygon(
+  lanelet::ConstLanelet getEgoLane(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double width) const;
-
-  lanelet::ConstLanelets getEgoLaneWithNextLane(
-    lanelet::LaneletMapConstPtr lanelet_map_ptr,
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path) const;
 
   /**
    * @brief Calculate distance between closest path point and intersection lanelet along path

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -190,7 +190,7 @@ private:
    */
   TimeDistanceArray calcIntersectionPassingTime(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
-    const int objective_lane_id, const double time_delay) const;
+    const double time_delay) const;
 
   /**
    * @brief check if the object has a target type for collision check

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -97,8 +98,8 @@ public:
 
   IntersectionModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const PlannerParam & planner_param, const rclcpp::Logger logger,
-    const rclcpp::Clock::SharedPtr clock);
+    const PlannerParam & planner_param, const std::set<int> & assoc_ids,
+    const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
@@ -109,14 +110,19 @@ public:
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;
 
+  const std::set<int> & getAssocIds() const { return assoc_ids_; }
+
 private:
-  int64_t lane_id_;
+  const int64_t lane_id_;
   std::string turn_direction_;
   bool has_traffic_light_;
   bool is_go_out_;
   // Parameter
   PlannerParam planner_param_;
   std::optional<util::IntersectionLanelets> intersection_lanelets_;
+  // for an intersection lane l1, its associative lanes are those that share same parent lanelet and
+  // have same turn_direction
+  const std::set<int> assoc_ids_;
 
   /**
    * @brief check collision for all lanelet area & predicted objects (call checkPathCollision() as

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -234,13 +234,6 @@ private:
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double width) const;
 
   /**
-   * @brief Get path polygon of intersetion part
-   * @return trimmed path polygon
-   */
-  lanelet::ConstLanelet getEgoLane(
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double width) const;
-
-  /**
    * @brief Calculate distance between closest path point and intersection lanelet along path
    * @param lanelet_map_ptr lanelet map
    * @param path            ego-car lane

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.hpp
@@ -31,6 +31,7 @@
 #include <lanelet2_routing/RoutingGraph.h>
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -73,8 +74,8 @@ public:
 
   MergeFromPrivateRoadModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const PlannerParam & planner_param, const rclcpp::Logger logger,
-    const rclcpp::Clock::SharedPtr clock);
+    const PlannerParam & planner_param, const std::set<int> & assoc_ids,
+    const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
@@ -85,10 +86,11 @@ public:
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray() override;
 
+  const std::set<int> & getAssocIds() const { return assoc_ids_; }
+
 private:
-  int64_t lane_id_;
-  std::string turn_direction_;
-  bool has_traffic_light_;
+  const int64_t lane_id_;
+  const std::set<int> assoc_ids_;
 
   autoware_auto_planning_msgs::msg::PathWithLaneId extractPathNearExitOfPrivateRoad(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double extend_length);

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -57,7 +57,8 @@ std::optional<size_t> getDuplicatedPointIdx(
  */
 IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
-  const int lane_id, const double detection_area_length, const bool tl_arrow_solid_on = false);
+  const int lane_id, const std::set<int> & assoc_ids, const double detection_area_length,
+  const bool tl_arrow_solid_on = false);
 
 /**
  * @brief Generate a stop line and insert it into the path. If the stop line is defined in the map,

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -85,7 +85,7 @@ std::optional<StopLineIdx> generateStopLine(
  " @param use_stuck_stopline if true, a stop line is generated at the beginning of intersection lane
  */
 std::optional<size_t> generateStuckStopLine(
-  const int lane_id, const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
+  const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
   const std::shared_ptr<const PlannerData> & planner_data, const double stop_line_margin,
   const bool use_stuck_stopline, autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip, const double ip_interval,
@@ -101,8 +101,7 @@ std::optional<size_t> generateStuckStopLine(
  */
 std::optional<size_t> getFirstPointInsidePolygons(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t lane_interval_start,
-  const size_t lane_interval_end, const int lane_id,
-  const std::vector<lanelet::CompoundPolygon3d> & polygons);
+  const size_t lane_interval_end, const std::vector<lanelet::CompoundPolygon3d> & polygons);
 
 /**
  * @brief Get stop point from map if exists

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -30,6 +30,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -43,9 +44,10 @@ std::optional<size_t> insertPoint(
   const geometry_msgs::msg::Pose & in_pose,
   autoware_auto_planning_msgs::msg::PathWithLaneId * inout_path);
 
-bool hasLaneId(const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p, const int id);
-std::optional<std::pair<size_t, size_t>> findLaneIdInterval(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const int lane_id);
+bool hasLaneIds(
+  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p, const std::set<int> & ids);
+std::optional<std::pair<size_t, size_t>> findLaneIdsInterval(
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const std::set<int> & ids);
 std::optional<size_t> getDuplicatedPointIdx(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const geometry_msgs::msg::Point & point);

--- a/planning/behavior_velocity_planner/include/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/util.hpp
@@ -292,6 +292,15 @@ boost::optional<geometry_msgs::msg::Pose> insertStopPoint(
   const geometry_msgs::msg::Point & stop_point, PathWithLaneId & output);
 boost::optional<geometry_msgs::msg::Pose> insertStopPoint(
   const geometry_msgs::msg::Point & stop_point, const size_t stop_seg_idx, PathWithLaneId & output);
+
+/*
+  @brief return 'associatvie' lanes in the intersection. 'associative' means that a lane shares same
+  or lane-changeable parent lanes with `lane` and has same turn_direction value.
+ */
+std::set<int> getAssociativeIntersectionLanelets(
+  lanelet::ConstLanelet lane, const lanelet::LaneletMapPtr lanelet_map,
+  const lanelet::routing::RoutingGraphPtr routing_graph);
+
 }  // namespace planning_utils
 }  // namespace behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/include/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/util.hpp
@@ -302,6 +302,18 @@ std::set<int> getAssociativeIntersectionLanelets(
   lanelet::ConstLanelet lane, const lanelet::LaneletMapPtr lanelet_map,
   const lanelet::routing::RoutingGraphPtr routing_graph);
 
+template <template <class> class Container>
+lanelet::ConstLanelets getConstLaneletsFromIds(
+  lanelet::LaneletMapConstPtr map, const Container<int> & ids)
+{
+  lanelet::ConstLanelets ret{};
+  for (const auto & id : ids) {
+    const auto ll = map->laneletLayer.get(id);
+    ret.push_back(ll);
+  }
+  return ret;
+}
+
 }  // namespace planning_utils
 }  // namespace behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/include/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/util.hpp
@@ -169,7 +169,8 @@ geometry_msgs::msg::Pose getAheadPose(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path);
 Polygon2d generatePathPolygon(
   const PathWithLaneId & path, const size_t start_idx, const size_t end_idx, const double width);
-
+lanelet::ConstLanelet generatePathLanelet(
+  const PathWithLaneId & path, const size_t start_idx, const size_t end_idx, const double width);
 double calcJudgeLineDistWithAccLimit(
   const double velocity, const double max_stop_acceleration, const double delay_response_time);
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -133,7 +133,10 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
       0.0, 0.0, 0.5, 0.5),
     &debug_marker_array, now);
 
-  // TODO(Mamoru Sobue): should be changed path polygon for LC
+  appendMarkerArray(
+    createLaneletPolygonsMarkerArray({debug_data_.ego_lane}, "ego_lane", lane_id_, 1, 0.647, 0.0),
+    &debug_marker_array, now);
+
   appendMarkerArray(
     debug::createPolygonMarkerArray(
       debug_data_.candidate_collision_ego_lane_polygon, "candidate_collision_ego_lane_polygon",

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -26,18 +26,6 @@
 
 namespace behavior_velocity_planner
 {
-bool hasSameLanelet(const lanelet::ConstLanelets & lanes1, const lanelet::ConstLanelets & lanes2)
-{
-  for (const auto & lane1 : lanes1) {
-    for (const auto & lane2 : lanes2) {
-      if (lane1.id() == lane2.id()) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterfaceWithRTC(node, getModuleName())
 {
@@ -91,8 +79,11 @@ MergeFromPrivateModuleManager::MergeFromPrivateModuleManager(rclcpp::Node & node
 void IntersectionModuleManager::launchNewModules(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  const auto lanelets = planning_utils::getLaneletsOnPath(
-    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
+  const auto routing_graph = planner_data_->route_handler_->getRoutingGraphPtr();
+  const auto lanelet_map = planner_data_->route_handler_->getLaneletMapPtr();
+
+  const auto lanelets =
+    planning_utils::getLaneletsOnPath(path, lanelet_map, planner_data_->current_odometry->pose);
   for (size_t i = 0; i < lanelets.size(); i++) {
     const auto ll = lanelets.at(i);
     const auto lane_id = ll.id();
@@ -106,12 +97,14 @@ void IntersectionModuleManager::launchNewModules(
       continue;
     }
 
-    if (hasSameParentLaneletAndTurnDirectionWithRegistered(ll, turn_direction)) {
+    if (hasSameParentLaneletAndTurnDirectionWithRegistered(ll)) {
       continue;
     }
 
+    const auto assoc_ids =
+      planning_utils::getAssociativeIntersectionLanelets(ll, lanelet_map, routing_graph);
     registerModule(std::make_shared<IntersectionModule>(
-      module_id, lane_id, planner_data_, intersection_param_,
+      module_id, lane_id, planner_data_, intersection_param_, assoc_ids,
       logger_.get_child("intersection_module"), clock_));
     generateUUID(module_id);
     updateRTCStatus(
@@ -122,8 +115,11 @@ void IntersectionModuleManager::launchNewModules(
 void MergeFromPrivateModuleManager::launchNewModules(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  const auto lanelets = planning_utils::getLaneletsOnPath(
-    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
+  const auto routing_graph = planner_data_->route_handler_->getRoutingGraphPtr();
+  const auto lanelet_map = planner_data_->route_handler_->getLaneletMapPtr();
+
+  const auto lanelets =
+    planning_utils::getLaneletsOnPath(path, lanelet_map, planner_data_->current_odometry->pose);
   for (size_t i = 0; i < lanelets.size(); i++) {
     const auto ll = lanelets.at(i);
     const auto lane_id = ll.id();
@@ -148,12 +144,18 @@ void MergeFromPrivateModuleManager::launchNewModules(
       continue;
     }
 
+    if (hasSameParentLaneletAndTurnDirectionWithRegistered(ll)) {
+      continue;
+    }
+
     if (i + 1 < lanelets.size()) {
       const auto next_lane = lanelets.at(i + 1);
       const std::string next_lane_location = next_lane.attributeOr("location", "else");
       if (next_lane_location != "private") {
+        const auto assoc_ids =
+          planning_utils::getAssociativeIntersectionLanelets(ll, lanelet_map, routing_graph);
         registerModule(std::make_shared<MergeFromPrivateRoadModule>(
-          module_id, lane_id, planner_data_, merge_from_private_area_param_,
+          module_id, lane_id, planner_data_, merge_from_private_area_param_, assoc_ids,
           logger_.get_child("merge_from_private_road_module"), clock_));
         continue;
       }
@@ -164,8 +166,10 @@ void MergeFromPrivateModuleManager::launchNewModules(
       for (auto && conflicting_lanelet : conflicting_lanelets) {
         const std::string conflicting_attr = conflicting_lanelet.attributeOr("location", "else");
         if (conflicting_attr == "urban") {
+          const auto assoc_ids =
+            planning_utils::getAssociativeIntersectionLanelets(ll, lanelet_map, routing_graph);
           registerModule(std::make_shared<MergeFromPrivateRoadModule>(
-            module_id, lane_id, planner_data_, merge_from_private_area_param_,
+            module_id, lane_id, planner_data_, merge_from_private_area_param_, assoc_ids,
             logger_.get_child("merge_from_private_road_module"), clock_));
           continue;
         }
@@ -182,6 +186,8 @@ IntersectionModuleManager::getModuleExpiredFunction(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
   return [this, lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
+    const auto intersection_module = std::dynamic_pointer_cast<IntersectionModule>(scene_module);
+    const auto & assoc_ids = intersection_module->getAssocIds();
     for (const auto & lane : lane_set) {
       const std::string turn_direction = lane.attributeOr("turn_direction", "else");
       const auto is_intersection =
@@ -189,8 +195,8 @@ IntersectionModuleManager::getModuleExpiredFunction(
       if (!is_intersection) {
         continue;
       }
-      if (hasSameParentLaneletAndTurnDirectionWith(
-            lane, scene_module->getModuleId(), turn_direction)) {
+
+      if (assoc_ids.find(lane.id()) != assoc_ids.end() /* contains */) {
         return false;
       }
     }
@@ -206,6 +212,9 @@ MergeFromPrivateModuleManager::getModuleExpiredFunction(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
   return [this, lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
+    const auto merge_from_private_module =
+      std::dynamic_pointer_cast<IntersectionModule>(scene_module);
+    const auto & assoc_ids = merge_from_private_module->getAssocIds();
     for (const auto & lane : lane_set) {
       const std::string turn_direction = lane.attributeOr("turn_direction", "else");
       const auto is_intersection =
@@ -213,8 +222,8 @@ MergeFromPrivateModuleManager::getModuleExpiredFunction(
       if (!is_intersection) {
         continue;
       }
-      if (hasSameParentLaneletAndTurnDirectionWith(
-            lane, scene_module->getModuleId(), turn_direction)) {
+
+      if (assoc_ids.find(lane.id()) != assoc_ids.end() /* contains */) {
         return false;
       }
     }
@@ -222,68 +231,27 @@ MergeFromPrivateModuleManager::getModuleExpiredFunction(
   };
 }
 
-bool IntersectionModuleManager::hasSameParentLaneletAndTurnDirectionWith(
-  const lanelet::ConstLanelet & lane, const size_t module_id,
-  const std::string & turn_direction_lane) const
+bool IntersectionModuleManager::hasSameParentLaneletAndTurnDirectionWithRegistered(
+  const lanelet::ConstLanelet & lane) const
 {
-  const auto registered_lane = planner_data_->route_handler_->getLaneletsFromId(module_id);
-  const auto turn_direction_registered = registered_lane.attributeOr("turn_direction", "else");
-  if (turn_direction_registered != turn_direction_lane) {
-    return false;
-  }
-  lanelet::ConstLanelets registered_parents =
-    planner_data_->route_handler_->getPreviousLanelets(registered_lane);
-  lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
-  for (const auto & ll : registered_parents) {
-    auto neighbor_lanes = planner_data_->route_handler_->getLaneChangeableNeighbors(ll);
-    neighbor_lanes.push_back(ll);
-    if (hasSameLanelet(parents, neighbor_lanes)) {
+  for (const auto & scene_module : scene_modules_) {
+    const auto intersection_module = std::dynamic_pointer_cast<IntersectionModule>(scene_module);
+    const auto & assoc_ids = intersection_module->getAssocIds();
+    if (assoc_ids.find(lane.id()) != assoc_ids.end()) {
       return true;
     }
   }
   return false;
 }
 
-bool IntersectionModuleManager::hasSameParentLaneletAndTurnDirectionWithRegistered(
-  const lanelet::ConstLanelet & lane, const std::string & turn_direction) const
+bool MergeFromPrivateModuleManager::hasSameParentLaneletAndTurnDirectionWithRegistered(
+  const lanelet::ConstLanelet & lane) const
 {
-  lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
-
-  for (const auto & id : registered_module_id_set_) {
-    const auto registered_lane = planner_data_->route_handler_->getLaneletsFromId(id);
-    const auto turn_direction_registered = registered_lane.attributeOr("turn_direction", "else");
-    if (turn_direction_registered != turn_direction) {
-      continue;
-    }
-    lanelet::ConstLanelets registered_parents =
-      planner_data_->route_handler_->getPreviousLanelets(registered_lane);
-    for (const auto & ll : registered_parents) {
-      auto neighbor_lanes = planner_data_->route_handler_->getLaneChangeableNeighbors(ll);
-      neighbor_lanes.push_back(ll);
-      if (hasSameLanelet(parents, neighbor_lanes)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-bool MergeFromPrivateModuleManager::hasSameParentLaneletAndTurnDirectionWith(
-  const lanelet::ConstLanelet & lane, const size_t module_id,
-  const std::string & turn_direction) const
-{
-  const auto registered_lane = planner_data_->route_handler_->getLaneletsFromId(module_id);
-  const auto turn_direction_registered = registered_lane.attributeOr("turn_direction", "else");
-  if (turn_direction_registered != turn_direction) {
-    return false;
-  }
-  lanelet::ConstLanelets registered_parents =
-    planner_data_->route_handler_->getPreviousLanelets(registered_lane);
-  lanelet::ConstLanelets parents = planner_data_->route_handler_->getPreviousLanelets(lane);
-  for (const auto & ll : registered_parents) {
-    auto neighbor_lanes = planner_data_->route_handler_->getLaneChangeableNeighbors(ll);
-    neighbor_lanes.push_back(ll);
-    if (hasSameLanelet(parents, neighbor_lanes)) {
+  for (const auto & scene_module : scene_modules_) {
+    const auto merge_from_private_module =
+      std::dynamic_pointer_cast<MergeFromPrivateRoadModule>(scene_module);
+    const auto & assoc_ids = merge_from_private_module->getAssocIds();
+    if (assoc_ids.find(lane.id()) != assoc_ids.end()) {
       return true;
     }
   }

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -213,7 +213,7 @@ MergeFromPrivateModuleManager::getModuleExpiredFunction(
 
   return [this, lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
     const auto merge_from_private_module =
-      std::dynamic_pointer_cast<IntersectionModule>(scene_module);
+      std::dynamic_pointer_cast<MergeFromPrivateRoadModule>(scene_module);
     const auto & assoc_ids = merge_from_private_module->getAssocIds();
     for (const auto & lane : lane_set) {
       const std::string turn_direction = lane.attributeOr("turn_direction", "else");

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -670,20 +670,18 @@ lanelet::ConstLanelets IntersectionModule::getEgoLaneWithNextLane(
     return lanelet::ConstLanelets({});
   }
   const auto [ego_start, ego_end] = ego_lane_interval_opt.value();
-  std::cout << "getEgoLaneWithNextLane: ego_start = " << ego_start << ", ego_end = " << ego_end
-            << std::endl;
-  if (ego_end + 1 < path.points.size()) {
-    const int next_id = path.points.at(ego_end + 1).lane_ids.at(0);
+  if (ego_end < path.points.size() - 1) {
+    std::cout << std::endl;
+    const int next_id = path.points.at(ego_end).lane_ids.at(0);
     const auto next_lane_interval_opt = util::findLaneIdsInterval(path, {next_id});
     if (next_lane_interval_opt.has_value()) {
       const auto [next_start, next_end] = next_lane_interval_opt.value();
-      std::cout << "next_start = " << next_start << ", next_end = " << next_end << std::endl;
       return {
-        planning_utils::generatePathLanelet(path, ego_start, ego_end, width),
+        planning_utils::generatePathLanelet(path, ego_start, next_start - 1, width),
         planning_utils::generatePathLanelet(path, next_start, next_end, width)};
     }
   }
-  return {planning_utils::generatePathLanelet(path, ego_start, ego_end, width)};
+  return {planning_utils::generatePathLanelet(path, ego_start - 1, ego_end, width)};
 }
 
 lanelet::ConstLanelet IntersectionModule::getEgoLane(
@@ -696,8 +694,7 @@ lanelet::ConstLanelet IntersectionModule::getEgoLane(
   }
 
   const auto [ego_start, ego_end] = ego_lane_interval_opt.value();
-  std::cout << "getEgoLane: ego_start = " << ego_start << ", ego_end = " << ego_end << std::endl;
-  return planning_utils::generatePathLanelet(path, ego_start, ego_end, width);
+  return planning_utils::generatePathLanelet(path, ego_start, ego_end - 1, width);
 }
 
 double IntersectionModule::calcDistanceUntilIntersectionLanelet(

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -131,7 +131,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     setDistance(std::numeric_limits<double>::lowest());
     return false;
   }
-  const auto lane_interval_ip_opt = util::findLaneIdInterval(path_ip, lane_id_);
+  const auto lane_interval_ip_opt = util::findLaneIdsInterval(path_ip, assoc_ids_);
   if (!lane_interval_ip_opt.has_value()) {
     RCLCPP_WARN(logger_, "Path has no interval on intersection lane %ld", lane_id_);
     RCLCPP_DEBUG(logger_, "===== plan end =====");
@@ -385,8 +385,7 @@ bool IntersectionModule::checkCollision(
   /* check collision between target_objects predicted path and ego lane */
 
   // cut the predicted path at passing_time
-  const auto time_distance_array =
-    calcIntersectionPassingTime(path, closest_idx, lane_id_, time_delay);
+  const auto time_distance_array = calcIntersectionPassingTime(path, closest_idx, time_delay);
   const double passing_time = time_distance_array.back().first;
   cutPredictPathWithDuration(&target_objects, passing_time);
 
@@ -530,7 +529,7 @@ Polygon2d IntersectionModule::generateEgoIntersectionLanePolygon(
 
 TimeDistanceArray IntersectionModule::calcIntersectionPassingTime(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
-  const int objective_lane_id, const double time_delay) const
+  const double time_delay) const
 {
   double dist_sum = 0.0;
   int assigned_lane_found = false;
@@ -542,7 +541,7 @@ TimeDistanceArray IntersectionModule::calcIntersectionPassingTime(
     auto reference_point = path.points.at(i);
     reference_point.point.longitudinal_velocity_mps = planner_param_.intersection_velocity;
     reference_path.points.push_back(reference_point);
-    bool has_objective_lane_id = util::hasLaneId(path.points.at(i), objective_lane_id);
+    bool has_objective_lane_id = util::hasLaneIds(path.points.at(i), assoc_ids_);
     if (assigned_lane_found && !has_objective_lane_id) {
       break;
     }

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -53,9 +53,12 @@ static geometry_msgs::msg::Pose getObjectPoseWithVelocityDirection(
 
 IntersectionModule::IntersectionModule(
   const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const PlannerParam & planner_param, const std::set<int> & assoc_ids, const rclcpp::Logger logger,
   const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock), lane_id_(lane_id), is_go_out_(false)
+: SceneModuleInterface(module_id, logger, clock),
+  lane_id_(lane_id),
+  is_go_out_(false),
+  assoc_ids_(assoc_ids)
 {
   velocity_factor_.init(VelocityFactor::INTERSECTION);
   planner_param_ = planner_param;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -193,11 +193,10 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   const auto objects_ptr = planner_data_->predicted_objects;
 
   /* considering lane change in the intersection, these lanelets are generated from the path */
-  const auto ego_lane = getEgoLane(*path, planner_data_->vehicle_info_.vehicle_width_m);
-  debug_data_.ego_lane = ego_lane.polygon3d();
-
   const auto ego_lane_with_next_lane =
     getEgoLaneWithNextLane(*path, planner_data_->vehicle_info_.vehicle_width_m);
+  const auto ego_lane = ego_lane_with_next_lane.front();
+  debug_data_.ego_lane = ego_lane.polygon3d();
 
   /* check stuck vehicle */
   const auto stuck_vehicle_detect_area =
@@ -671,30 +670,16 @@ lanelet::ConstLanelets IntersectionModule::getEgoLaneWithNextLane(
   }
   const auto [ego_start, ego_end] = ego_lane_interval_opt.value();
   if (ego_end < path.points.size() - 1) {
-    std::cout << std::endl;
     const int next_id = path.points.at(ego_end).lane_ids.at(0);
     const auto next_lane_interval_opt = util::findLaneIdsInterval(path, {next_id});
     if (next_lane_interval_opt.has_value()) {
       const auto [next_start, next_end] = next_lane_interval_opt.value();
       return {
-        planning_utils::generatePathLanelet(path, ego_start, next_start - 1, width),
-        planning_utils::generatePathLanelet(path, next_start, next_end, width)};
+        planning_utils::generatePathLanelet(path, ego_start, next_start + 1, width),
+        planning_utils::generatePathLanelet(path, next_start + 1, next_end, width)};
     }
   }
-  return {planning_utils::generatePathLanelet(path, ego_start - 1, ego_end, width)};
-}
-
-lanelet::ConstLanelet IntersectionModule::getEgoLane(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double width) const
-{
-  // NOTE: findLaneIdsInterval returns (start, end) of assoc_ids
-  const auto ego_lane_interval_opt = util::findLaneIdsInterval(path, assoc_ids_);
-  if (!ego_lane_interval_opt.has_value()) {
-    return lanelet::ConstLanelet();
-  }
-
-  const auto [ego_start, ego_end] = ego_lane_interval_opt.value();
-  return planning_utils::generatePathLanelet(path, ego_start, ego_end - 1, width);
+  return {planning_utils::generatePathLanelet(path, ego_start, ego_end, width)};
 }
 
 double IntersectionModule::calcDistanceUntilIntersectionLanelet(

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -35,9 +35,9 @@ namespace bg = boost::geometry;
 MergeFromPrivateRoadModule::MergeFromPrivateRoadModule(
   const int64_t module_id, const int64_t lane_id,
   [[maybe_unused]] std::shared_ptr<const PlannerData> planner_data,
-  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const PlannerParam & planner_param, const std::set<int> & assoc_ids, const rclcpp::Logger logger,
   const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock), lane_id_(lane_id)
+: SceneModuleInterface(module_id, logger, clock), lane_id_(lane_id), assoc_ids_(assoc_ids)
 {
   velocity_factor_.init(VelocityFactor::MERGE);
   planner_param_ = planner_param;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -66,8 +66,8 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopR
   /* get detection area */
   if (!intersection_lanelets_.has_value()) {
     intersection_lanelets_ = util::getObjectiveLanelets(
-      lanelet_map_ptr, routing_graph_ptr, lane_id_, planner_param_.detection_area_length,
-      false /* tl_arrow_solid on does not matter here*/);
+      lanelet_map_ptr, routing_graph_ptr, lane_id_, {} /* not used here */,
+      planner_param_.detection_area_length, false /* tl_arrow_solid on does not matter here*/);
   }
   const auto & detection_area = intersection_lanelets_.value().attention_area;
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -82,7 +82,7 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopR
     setDistance(std::numeric_limits<double>::lowest());
     return false;
   }
-  const auto lane_interval_ip_opt = util::findLaneIdInterval(path_ip, lane_id_);
+  const auto lane_interval_ip_opt = util::findLaneIdsInterval(path_ip, assoc_ids_);
   if (!lane_interval_ip_opt.has_value()) {
     RCLCPP_WARN(logger_, "Path has no interval on intersection lane %ld", lane_id_);
     RCLCPP_DEBUG(logger_, "===== plan end =====");

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -366,7 +366,8 @@ bool getStopLineIndexFromMap(
 
 IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
-  const int lane_id, const double detection_area_length, const bool tl_arrow_solid_on)
+  const int lane_id, const std::set<int> & assoc_ids, const double detection_area_length,
+  const bool tl_arrow_solid_on)
 {
   const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id);
   const auto turn_direction = assigned_lanelet.attributeOr("turn_direction", "else");
@@ -466,8 +467,7 @@ IntersectionLanelets getObjectiveLanelets(
     result.attention = std::move(detection_lanelets);
   }
   result.conflicting = std::move(conflicting_ex_ego_lanelets);
-  result.adjacent =
-    extendedAdjacentDirectionLanes(lanelet_map_ptr, routing_graph_ptr, assigned_lanelet);
+  result.adjacent = planning_utils::getConstLaneletsFromIds(lanelet_map_ptr, assoc_ids);
   // compoundPolygon3d
   result.attention_area = getPolygon3dFromLanelets(result.attention);
   result.conflicting_area = getPolygon3dFromLanelets(result.conflicting);

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -85,6 +85,10 @@ std::optional<std::pair<size_t, size_t>> findLaneIdsInterval(
   bool found = false;
   size_t start = 0;
   size_t end = p.points.size() > 0 ? p.points.size() - 1 : 0;
+  if (start == end) {
+    // there is only one point in the path
+    return std::nullopt;
+  }
   for (size_t i = 0; i < p.points.size(); ++i) {
     if (hasLaneIds(p.points.at(i), ids)) {
       if (!found) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -120,8 +120,7 @@ std::optional<size_t> getDuplicatedPointIdx(
 
 std::optional<size_t> getFirstPointInsidePolygons(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const size_t lane_interval_start,
-  const size_t lane_interval_end, [[maybe_unused]] const int lane_id,
-  const std::vector<lanelet::CompoundPolygon3d> & polygons)
+  const size_t lane_interval_end, const std::vector<lanelet::CompoundPolygon3d> & polygons)
 {
   std::optional<size_t> first_idx_inside_lanelet = std::nullopt;
   for (size_t i = lane_interval_start; i <= lane_interval_end; ++i) {
@@ -180,7 +179,7 @@ std::optional<StopLineIdx> generateStopLine(
   } else {
     // find the index of the first point that intersects with detection_areas
     const auto first_inside_detection_idx_ip_opt = getFirstPointInsidePolygons(
-      path_ip, lane_interval_ip_start, lane_interval_ip_end, lane_id, detection_areas);
+      path_ip, lane_interval_ip_start, lane_interval_ip_end, detection_areas);
     // if path is not intersecting with detection_area, skip
     if (!first_inside_detection_idx_ip_opt.has_value()) {
       RCLCPP_DEBUG(
@@ -255,7 +254,7 @@ std::optional<StopLineIdx> generateStopLine(
 }
 
 std::optional<size_t> generateStuckStopLine(
-  const int lane_id, const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
+  const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
   const std::shared_ptr<const PlannerData> & planner_data, const double stop_line_margin,
   const bool use_stuck_stopline, autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip, const double interval,
@@ -267,7 +266,7 @@ std::optional<size_t> generateStuckStopLine(
     stuck_stop_line_idx_ip = lane_interval_ip_start;
   } else {
     const auto stuck_stop_line_idx_ip_opt = util::getFirstPointInsidePolygons(
-      path_ip, lane_interval_ip_start, lane_interval_ip_end, lane_id, conflicting_areas);
+      path_ip, lane_interval_ip_start, lane_interval_ip_end, conflicting_areas);
     if (!stuck_stop_line_idx_ip_opt.has_value()) {
       RCLCPP_DEBUG(
         logger,

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -68,24 +68,25 @@ std::optional<size_t> insertPoint(
   return insert_idx;
 }
 
-bool hasLaneId(const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p, const int id)
+bool hasLaneIds(
+  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p, const std::set<int> & ids)
 {
   for (const auto & pid : p.lane_ids) {
-    if (pid == id) {
+    if (ids.find(pid) != ids.end()) {
       return true;
     }
   }
   return false;
 }
 
-std::optional<std::pair<size_t, size_t>> findLaneIdInterval(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const int lane_id)
+std::optional<std::pair<size_t, size_t>> findLaneIdsInterval(
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const std::set<int> & ids)
 {
   bool found = false;
   size_t start = 0;
   size_t end = p.points.size() > 0 ? p.points.size() - 1 : 0;
   for (size_t i = 0; i < p.points.size(); ++i) {
-    if (hasLaneId(p.points.at(i), lane_id)) {
+    if (hasLaneIds(p.points.at(i), ids)) {
       if (!found) {
         // found interval for the first time
         found = true;

--- a/planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -301,8 +301,8 @@ lanelet::ConstLanelet generatePathLanelet(
   lanelet::Points3d lefts;
   for (size_t i = start_idx; i <= end_idx; ++i) {
     const double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
-    const double x = path.points.at(i).point.pose.position.x + width * std::sin(yaw);
-    const double y = path.points.at(i).point.pose.position.y - width * std::cos(yaw);
+    const double x = path.points.at(i).point.pose.position.x + width / 2 * std::sin(yaw);
+    const double y = path.points.at(i).point.pose.position.y - width / 2 * std::cos(yaw);
     const lanelet::Point3d p(lanelet::InvalId, x, y, path.points.at(i).point.pose.position.z);
     lefts.emplace_back(p);
   }
@@ -311,8 +311,8 @@ lanelet::ConstLanelet generatePathLanelet(
   lanelet::Points3d rights;
   for (size_t i = start_idx; i <= end_idx; ++i) {
     const double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
-    const double x = path.points.at(i).point.pose.position.x - width * std::sin(yaw);
-    const double y = path.points.at(i).point.pose.position.y + width * std::cos(yaw);
+    const double x = path.points.at(i).point.pose.position.x - width / 2 * std::sin(yaw);
+    const double y = path.points.at(i).point.pose.position.y + width / 2 * std::cos(yaw);
     const lanelet::Point3d p(lanelet::InvalId, x, y, path.points.at(i).point.pose.position.z);
     rights.emplace_back(p);
   }

--- a/planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -295,6 +295,30 @@ Polygon2d generatePathPolygon(
   return ego_area;
 }
 
+lanelet::ConstLanelet generatePathLanelet(
+  const PathWithLaneId & path, const size_t start_idx, const size_t end_idx, const double width)
+{
+  lanelet::Points3d lefts;
+  for (size_t i = start_idx; i <= end_idx; ++i) {
+    const double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
+    const double x = path.points.at(i).point.pose.position.x + width * std::sin(yaw);
+    const double y = path.points.at(i).point.pose.position.y - width * std::cos(yaw);
+    lefts.emplace_back(x, y, path.points.at(i).point.pose.position.z);
+  }
+  lanelet::LineString3d left = lanelet::LineString3d(lanelet::InvalId, lefts);
+
+  lanelet::Points3d rights;
+  for (size_t i = start_idx; i <= end_idx; ++i) {
+    const double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
+    const double x = path.points.at(i).point.pose.position.x - width * std::sin(yaw);
+    const double y = path.points.at(i).point.pose.position.y + width * std::cos(yaw);
+    rights.emplace_back(x, y, path.points.at(i).point.pose.position.z);
+  }
+  lanelet::LineString3d right = lanelet::LineString3d(lanelet::InvalId, rights);
+
+  return lanelet::Lanelet(lanelet::InvalId, left, right);
+}
+
 geometry_msgs::msg::Pose transformRelCoordinate2D(
   const geometry_msgs::msg::Pose & target, const geometry_msgs::msg::Pose & origin)
 {

--- a/planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -303,7 +303,8 @@ lanelet::ConstLanelet generatePathLanelet(
     const double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
     const double x = path.points.at(i).point.pose.position.x + width * std::sin(yaw);
     const double y = path.points.at(i).point.pose.position.y - width * std::cos(yaw);
-    lefts.emplace_back(x, y, path.points.at(i).point.pose.position.z);
+    const lanelet::Point3d p(lanelet::InvalId, x, y, path.points.at(i).point.pose.position.z);
+    lefts.emplace_back(p);
   }
   lanelet::LineString3d left = lanelet::LineString3d(lanelet::InvalId, lefts);
 
@@ -312,7 +313,8 @@ lanelet::ConstLanelet generatePathLanelet(
     const double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
     const double x = path.points.at(i).point.pose.position.x - width * std::sin(yaw);
     const double y = path.points.at(i).point.pose.position.y + width * std::cos(yaw);
-    rights.emplace_back(x, y, path.points.at(i).point.pose.position.z);
+    const lanelet::Point3d p(lanelet::InvalId, x, y, path.points.at(i).point.pose.position.z);
+    rights.emplace_back(p);
   }
   lanelet::LineString3d right = lanelet::LineString3d(lanelet::InvalId, rights);
 


### PR DESCRIPTION
## Description

Changed collision checking and some of the area generation based on the path, not the lane considering lane changing before  / inside intersection.

## Related links

Internal JIRA link: https://tier4.atlassian.net/browse/T4PB-25079

## Tests performed

### stuck vehicle detect area

#### Before this PR

![image](https://user-images.githubusercontent.com/28677420/220001611-2a8f2fa9-88c2-4fc5-8ac1-1b65dd9bc85f.png)

#### After this PR

![image](https://user-images.githubusercontent.com/28677420/220002166-753a8b73-ad3b-4b1b-ac74-6b872df11d74.png)

### collision checking

![image](https://user-images.githubusercontent.com/28677420/220020727-aa6b14b3-2853-48ce-aafe-642ce8201753.png)

working as before because `ego_lane` polygon(the orange polygon) is also generated from the path.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
