### PR TITLE
fix(behavior_path_planner): remove unused callback functions

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -65,7 +65,6 @@ inline void update_param(
 
 namespace behavior_path_planner
 {
-using ApprovalMsg = tier4_planning_msgs::msg::Approval;
 using autoware_auto_mapping_msgs::msg::HADMapBin;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::Path;
@@ -81,7 +80,6 @@ using rcl_interfaces::msg::SetParametersResult;
 using steering_factor_interface::SteeringFactorInterface;
 using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
 using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
-using tier4_planning_msgs::msg::PathChangeModule;
 using tier4_planning_msgs::msg::Scenario;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
@@ -147,8 +145,6 @@ private:
   void onAcceleration(const AccelWithCovarianceStamped::ConstSharedPtr msg);
   void onPerception(const PredictedObjects::ConstSharedPtr msg);
   void onOccupancyGrid(const OccupancyGrid::ConstSharedPtr msg);
-  void onExternalApproval(const ApprovalMsg::ConstSharedPtr msg);
-  void onForceApproval(const PathChangeModule::ConstSharedPtr msg);
   void onMap(const HADMapBin::ConstSharedPtr map_msg);
   void onRoute(const LaneletRoute::ConstSharedPtr route_msg);
   SetParametersResult onSetParam(const std::vector<rclcpp::Parameter> & parameters);

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
@@ -71,7 +71,6 @@ private:
   BT::Tree bt_tree_;
   BT::Blackboard::Ptr blackboard_;
 
-  BT::NodeStatus checkForceApproval(const std::string & name);
   void resetNotRunningModulePathCandidate();
 
   // For Groot monitoring

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -55,12 +55,6 @@ struct ModuleNameStamped
   rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
 };
 
-struct Approval
-{
-  BoolStamped is_approved{false};
-  ModuleNameStamped is_force_approved{};
-};
-
 struct DrivableLanes
 {
   lanelet::ConstLanelet right_lane;
@@ -80,7 +74,6 @@ struct PlannerData
   std::shared_ptr<RouteHandler> route_handler{std::make_shared<RouteHandler>()};
   BehaviorPathPlannerParameters parameters{};
   drivable_area_expansion::DrivableAreaExpansionParameters drivable_area_expansion_parameters{};
-  Approval approval{};
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1040,26 +1040,6 @@ void BehaviorPathPlannerNode::onOccupancyGrid(const OccupancyGrid::ConstSharedPt
   const std::lock_guard<std::mutex> lock(mutex_pd_);
   planner_data_->occupancy_grid = msg;
 }
-void BehaviorPathPlannerNode::onExternalApproval(const ApprovalMsg::ConstSharedPtr msg)
-{
-  const std::lock_guard<std::mutex> lock(mutex_pd_);
-  planner_data_->approval.is_approved.data = msg->approval;
-  // TODO(wep21): Replace msg stamp after {stamp: now} is implemented in ros2 topic pub
-  planner_data_->approval.is_approved.stamp = this->now();
-}
-void BehaviorPathPlannerNode::onForceApproval(const PathChangeModule::ConstSharedPtr msg)
-{
-  const std::lock_guard<std::mutex> lock(mutex_pd_);
-  auto getModuleName = [](PathChangeModuleId module) {
-    if (module.type == PathChangeModuleId::FORCE_LANE_CHANGE) {
-      return "ForceLaneChange";
-    } else {
-      return "NONE";
-    }
-  };
-  planner_data_->approval.is_force_approved.module_name = getModuleName(msg->module);
-  planner_data_->approval.is_force_approved.stamp = msg->header.stamp;
-}
 void BehaviorPathPlannerNode::onMap(const HADMapBin::ConstSharedPtr msg)
 {
   const std::lock_guard<std::mutex> lock(mutex_pd_);

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -117,18 +117,6 @@ BehaviorTreeManager::getModulesStatus()
   return modules_status_;
 }
 
-BT::NodeStatus BehaviorTreeManager::checkForceApproval(const std::string & name)
-{
-  const auto & approval = current_planner_data_->approval.is_force_approved;
-  if ((clock_.now() - approval.stamp).seconds() > 1.0) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, clock_, 3000, "BehaviorTreeManager : Force approval data is time out!");
-    return BT::NodeStatus::FAILURE;
-  }
-
-  return approval.module_name == name ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
-}
-
 void BehaviorTreeManager::resetNotRunningModulePathCandidate()
 {
   const bool is_any_module_running = std::any_of(


### PR DESCRIPTION
## Description

remove unused callback and member arg in `planner_data`.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
