### PR TITLE
build(signal_processing): add Boost to build_export_depend

### DIFF
--- a/common/signal_processing/package.xml
+++ b/common/signal_processing/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
+  <build_export_depend>libboost-dev</build_export_depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This makes sure that downstream packages have the correct dependencies (e.g. they can include `boost/optional.hpp`)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
