### PR TITLE
feat(behavior_path_planner): add new manager independent from behavior tree

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -26,12 +26,12 @@ set(common_src
   src/util/pull_out/util.cpp
   src/util/pull_out/shift_pull_out.cpp
   src/util/pull_out/geometric_pull_out.cpp
+  src/util/path_shifter/path_shifter.cpp
   src/util/drivable_area_expansion/drivable_area_expansion.cpp
   src/util/drivable_area_expansion/map_utils.cpp
   src/util/drivable_area_expansion/footprints.cpp
   src/util/drivable_area_expansion/expansion.cpp
   src/util/geometric_parallel_parking/geometric_parallel_parking.cpp
-  src/util/path_shifter/path_shifter.cpp
   src/util/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.cpp
   src/marker_util/debug_utilities.cpp
   src/marker_util/avoidance/debug.cpp

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,22 +7,15 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-ament_auto_add_library(behavior_path_planner_node SHARED
-  src/behavior_path_planner_node.cpp
-  src/behavior_tree_manager.cpp
+# use planner manager that supports behavior tree
+set(USE_BT TRUE)
+message(STATUS "USE_BEHAVIOR_TREE: " ${USE_BT})
+
+set(common_src
   src/utilities.cpp
   src/path_utilities.cpp
   src/steering_factor_interface.cpp
   src/turn_signal_decider.cpp
-  src/scene_module/scene_module_bt_node_interface.cpp
-  src/scene_module/side_shift/side_shift_module.cpp
-  src/scene_module/avoidance/avoidance_module.cpp
-  src/scene_module/lane_following/lane_following_module.cpp
-  src/scene_module/lane_change/external_request_lane_change_module.cpp
-  src/scene_module/lane_change/lane_change_module.cpp
-  src/scene_module/pull_over/pull_over_module.cpp
-  src/scene_module/pull_out/pull_out_module.cpp
-  src/scene_module/scene_module_visitor.cpp
   src/util/avoidance/util.cpp
   src/util/lane_change/util.cpp
   src/util/side_shift/util.cpp
@@ -33,17 +26,51 @@ ament_auto_add_library(behavior_path_planner_node SHARED
   src/util/pull_out/util.cpp
   src/util/pull_out/shift_pull_out.cpp
   src/util/pull_out/geometric_pull_out.cpp
-  src/util/geometric_parallel_parking/geometric_parallel_parking.cpp
-  src/util/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.cpp
-  src/util/path_shifter/path_shifter.cpp
   src/util/drivable_area_expansion/drivable_area_expansion.cpp
   src/util/drivable_area_expansion/map_utils.cpp
   src/util/drivable_area_expansion/footprints.cpp
   src/util/drivable_area_expansion/expansion.cpp
+  src/util/geometric_parallel_parking/geometric_parallel_parking.cpp
+  src/util/path_shifter/path_shifter.cpp
+  src/util/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.cpp
   src/marker_util/debug_utilities.cpp
   src/marker_util/avoidance/debug.cpp
   src/marker_util/lane_change/debug.cpp
 )
+
+if(USE_BT)
+  ament_auto_add_library(behavior_path_planner_node SHARED
+    src/behavior_path_planner_node.cpp
+    src/behavior_tree_manager.cpp
+    src/scene_module/scene_module_visitor.cpp
+    src/scene_module/scene_module_bt_node_interface.cpp
+    src/scene_module/side_shift/side_shift_module.cpp
+    src/scene_module/avoidance/avoidance_module.cpp
+    src/scene_module/lane_following/lane_following_module.cpp
+    src/scene_module/lane_change/external_request_lane_change_module.cpp
+    src/scene_module/lane_change/lane_change_module.cpp
+    src/scene_module/pull_over/pull_over_module.cpp
+    src/scene_module/pull_out/pull_out_module.cpp
+    ${common_src}
+  )
+
+  target_compile_definitions(behavior_path_planner_node PRIVATE USE_BEHAVIOR_TREE)
+
+  message(WARNING "Build behavior_path_planner with BT...")
+
+else()
+  ament_auto_add_library(behavior_path_planner_node SHARED
+    src/behavior_path_planner_node.cpp
+    src/planner_manager.cpp
+    src/scene_module/scene_module_visitor.cpp
+    # src/scene_module_v2/avoidance
+    # src/scene_module_v2/lane_change
+    # src/scene_module_v2/...
+    ${common_src}
+  )
+
+  message(WARNING "Build behavior_path_planner without BT...")
+endif()
 
 target_include_directories(behavior_path_planner_node SYSTEM PUBLIC
   ${EIGEN3_INCLUDE_DIR}

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -21,6 +21,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <route_handler/route_handler.hpp>
 
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
@@ -40,6 +41,7 @@
 
 namespace behavior_path_planner
 {
+using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
@@ -97,6 +99,9 @@ struct BehaviorModuleOutput
   // path planed by module
   PlanResult path{};
 
+  // reference path planed by module
+  PlanResult reference_path{};
+
   TurnSignalInfo turn_signal_info{};
 
   std::optional<PoseWithUuidStamped> modified_goal{};
@@ -118,6 +123,7 @@ struct PlannerData
   AccelWithCovarianceStamped::ConstSharedPtr self_acceleration{};
   PredictedObjects::ConstSharedPtr dynamic_object{};
   OccupancyGrid::ConstSharedPtr occupancy_grid{};
+  OperationModeState::ConstSharedPtr operation_mode{};
   PathWithLaneId::SharedPtr reference_path{std::make_shared<PathWithLaneId>()};
   PathWithLaneId::SharedPtr prev_output_path{std::make_shared<PathWithLaneId>()};
   lanelet::ConstLanelets current_lanes{};

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -19,6 +19,8 @@
 
 struct BehaviorPathPlannerParameters
 {
+  bool verbose;
+
   double backward_path_length;
   double forward_path_length;
   double backward_length_buffer_for_end_of_lane;

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -93,6 +93,10 @@ public:
   {
     std::vector<std::shared_ptr<SceneModuleStatus>> ret;
 
+    const auto size = approved_module_ptrs_.size() + 1;
+
+    ret.reserve(size);
+
     for (const auto & m : approved_module_ptrs_) {
       auto s = std::make_shared<SceneModuleStatus>(m->name());
       s->is_waiting_approval = m->isWaitingApproval();
@@ -107,6 +111,8 @@ public:
       s->status = m->getCurrentStatus();
       ret.push_back(s);
     }
+
+    ret.shrink_to_fit();
 
     return ret;
   }

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -1,0 +1,257 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_PATH_PLANNER__PLANNER_MANAGER_HPP_
+#define BEHAVIOR_PATH_PLANNER__PLANNER_MANAGER_HPP_
+
+#include "behavior_path_planner/scene_module_v2/scene_module_interface.hpp"
+#include "behavior_path_planner/scene_module_v2/scene_module_manager_interface.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace behavior_path_planner
+{
+
+using autoware_auto_planning_msgs::msg::PathWithLaneId;
+using tier4_autoware_utils::generateUUID;
+using tier4_autoware_utils::StopWatch;
+using unique_identifier_msgs::msg::UUID;
+using ModuleID = std::pair<std::shared_ptr<SceneModuleManagerInterface>, UUID>;
+
+struct SceneModuleStatus
+{
+  explicit SceneModuleStatus(const std::string & n) : module_name(n) {}
+
+  std::string module_name;
+
+  bool is_execution_ready{false};
+  bool is_waiting_approval{false};
+
+  ModuleStatus status{ModuleStatus::SUCCESS};
+};
+
+class PlannerManager
+{
+public:
+  PlannerManager(rclcpp::Node & node, const bool verbose);
+
+  BehaviorModuleOutput run(const std::shared_ptr<PlannerData> & data);
+
+  void registerSceneModuleManager(
+    const std::shared_ptr<SceneModuleManagerInterface> & scene_module_manager_ptr)
+  {
+    RCLCPP_INFO(logger_, "register %s module", scene_module_manager_ptr->getModuleName().c_str());
+    scene_manager_ptrs_.push_back(scene_module_manager_ptr);
+    processing_time_.emplace(scene_module_manager_ptr->getModuleName(), 0.0);
+  }
+
+  void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters)
+  {
+    std::for_each(
+      scene_manager_ptrs_.begin(), scene_manager_ptrs_.end(),
+      [&parameters](const auto & m) { m->updateModuleParams(parameters); });
+  }
+
+  void reset()
+  {
+    approved_modules_.clear();
+    candidate_module_id_ = boost::none;
+    root_lanelet_ = boost::none;
+    std::for_each(
+      scene_manager_ptrs_.begin(), scene_manager_ptrs_.end(), [](const auto & m) { m->reset(); });
+    resetProcessingTime();
+  }
+
+  void publishDebugMarker()
+  {
+    std::for_each(scene_manager_ptrs_.begin(), scene_manager_ptrs_.end(), [](const auto & m) {
+      m->publishDebugMarker();
+    });
+  }
+
+  std::vector<std::shared_ptr<SceneModuleManagerInterface>> getSceneModuleManagers() const
+  {
+    return scene_manager_ptrs_;
+  }
+
+  std::vector<std::shared_ptr<SceneModuleStatus>> getSceneModuleStatus() const
+  {
+    std::vector<std::shared_ptr<SceneModuleStatus>> ret;
+
+    for (const auto & m : approved_modules_) {
+      const auto & manager = m.first;
+      const auto & uuid = m.second;
+      auto s = std::make_shared<SceneModuleStatus>(manager->getModuleName());
+      s->is_waiting_approval = manager->isWaitingApproval(uuid);
+      s->status = manager->getCurrentStatus(uuid);
+      ret.push_back(s);
+    }
+
+    if (!!candidate_module_id_) {
+      const auto & manager = candidate_module_id_.get().first;
+      const auto & uuid = candidate_module_id_.get().second;
+      auto s = std::make_shared<SceneModuleStatus>(manager->getModuleName());
+      s->is_waiting_approval = manager->isWaitingApproval(uuid);
+      s->status = manager->getCurrentStatus(uuid);
+      ret.push_back(s);
+    }
+
+    return ret;
+  }
+
+  void resetRootLanelet(const std::shared_ptr<PlannerData> & data);
+
+  void print() const;
+
+private:
+  BehaviorModuleOutput run(
+    const ModuleID & id, const BehaviorModuleOutput & previous_module_output) const
+  {
+    const auto & manager = id.first;
+    const auto & uuid = id.second;
+
+    if (manager == nullptr) {
+      return {};
+    }
+
+    if (!manager->exist(uuid)) {
+      return {};
+    }
+
+    return manager->run(uuid, previous_module_output);
+  }
+
+  bool isExecutionReady(const ModuleID & id) const
+  {
+    const auto & manager = id.first;
+    const auto & uuid = id.second;
+
+    if (manager == nullptr) {
+      return false;
+    }
+
+    if (!manager->exist(uuid)) {
+      return false;
+    }
+
+    return manager->isExecutionReady(uuid);
+  }
+
+  bool isWaitingApproval(const ModuleID & id) const
+  {
+    const auto & manager = id.first;
+    const auto & uuid = id.second;
+
+    if (manager == nullptr) {
+      return false;
+    }
+
+    if (!manager->exist(uuid)) {
+      return false;
+    }
+
+    return manager->isWaitingApproval(uuid);
+  }
+
+  bool isRunning(const ModuleID & id) const
+  {
+    const auto & manager = id.first;
+    const auto & uuid = id.second;
+
+    if (manager == nullptr) {
+      return false;
+    }
+
+    if (!manager->exist(uuid)) {
+      return false;
+    }
+
+    return manager->getCurrentStatus(uuid) == ModuleStatus::RUNNING;
+  }
+
+  void deleteExpiredModules(const ModuleID & id) const
+  {
+    const auto & manager = id.first;
+    const auto & uuid = id.second;
+
+    if (manager == nullptr) {
+      return;
+    }
+
+    if (!manager->exist(uuid)) {
+      return;
+    }
+
+    manager->deleteModules(uuid);
+  }
+
+  void addApprovedModule(const ModuleID & id) { approved_modules_.push_back(id); }
+
+  void resetProcessingTime()
+  {
+    for (auto & t : processing_time_) {
+      t.second = 0.0;
+    }
+  }
+
+  lanelet::ConstLanelet updateRootLanelet(const std::shared_ptr<PlannerData> & data)
+  {
+    lanelet::ConstLanelet ret{};
+    data->route_handler->getClosestLaneletWithinRoute(data->self_odometry->pose.pose, &ret);
+    RCLCPP_DEBUG(logger_, "update start lanelet. id:%ld", ret.id());
+    return ret;
+  }
+
+  BehaviorModuleOutput update(const std::shared_ptr<PlannerData> & data);
+
+  BehaviorModuleOutput getReferencePath(const std::shared_ptr<PlannerData> & data) const;
+
+  boost::optional<ModuleID> getCandidateModuleID(
+    const BehaviorModuleOutput & previous_module_output) const;
+
+  boost::optional<ModuleID> selectHighestPriorityModule(
+    std::vector<ModuleID> & request_modules) const;
+
+  boost::optional<ModuleID> candidate_module_id_{boost::none};
+
+  boost::optional<lanelet::ConstLanelet> root_lanelet_{boost::none};
+
+  std::vector<std::shared_ptr<SceneModuleManagerInterface>> scene_manager_ptrs_;
+
+  std::vector<ModuleID> approved_modules_;
+
+  rclcpp::Logger logger_;
+
+  rclcpp::Clock clock_;
+
+  mutable StopWatch<std::chrono::milliseconds> stop_watch_;
+
+  mutable std::unordered_map<std::string, double> processing_time_;
+
+  bool verbose_{false};
+};
+}  // namespace behavior_path_planner
+
+#endif  // BEHAVIOR_PATH_PLANNER__PLANNER_MANAGER_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_interface.hpp
@@ -63,7 +63,7 @@ public:
     logger_{node.get_logger().get_child(name)},
     clock_{node.get_clock()},
     is_waiting_approval_{false},
-    is_already_approved_{false},
+    is_locked_new_module_launch_{false},
     uuid_(generateUUID()),
     current_state_{ModuleStatus::SUCCESS}
   {
@@ -225,7 +225,7 @@ public:
 
   bool isWaitingApproval() const { return is_waiting_approval_; }
 
-  bool isAlreadyApproved() const { return is_already_approved_; }
+  bool isLockedNewModuleLaunch() const { return is_locked_new_module_launch_; }
 
   rclcpp::Logger getLogger() const { return logger_; }
 
@@ -265,9 +265,9 @@ protected:
     rtc_interface_ptr_->clearCooperateStatus();
   }
 
-  void alreadyApproved() { is_already_approved_ = true; }
+  void lockNewModuleLaunch() { is_locked_new_module_launch_ = true; }
 
-  void nothingApproved() { is_already_approved_ = false; }
+  void unlockNewModuleLaunch() { is_locked_new_module_launch_ = false; }
 
   void waitApproval() { is_waiting_approval_ = true; }
 
@@ -279,7 +279,7 @@ protected:
   std::unique_ptr<SteeringFactorInterface> steering_factor_interface_ptr_;
 
   bool is_waiting_approval_;
-  bool is_already_approved_;
+  bool is_locked_new_module_launch_;
 
   UUID uuid_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_interface.hpp
@@ -1,0 +1,298 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE_V2__SCENE_MODULE_INTERFACE_HPP_
+#define BEHAVIOR_PATH_PLANNER__SCENE_MODULE_V2__SCENE_MODULE_INTERFACE_HPP_
+
+#include "behavior_path_planner/data_manager.hpp"
+#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
+#include "behavior_path_planner/utilities.hpp"
+
+#include <behavior_path_planner/steering_factor_interface.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <route_handler/route_handler.hpp>
+#include <rtc_interface/rtc_interface.hpp>
+
+#include <autoware_adapi_v1_msgs/msg/steering_factor_array.hpp>
+#include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace behavior_path_planner
+{
+using autoware_adapi_v1_msgs::msg::SteeringFactor;
+using autoware_auto_planning_msgs::msg::PathWithLaneId;
+using rtc_interface::RTCInterface;
+using steering_factor_interface::SteeringFactorInterface;
+using tier4_autoware_utils::generateUUID;
+using unique_identifier_msgs::msg::UUID;
+using visualization_msgs::msg::MarkerArray;
+using PlanResult = PathWithLaneId::SharedPtr;
+
+enum class ModuleStatus {
+  IDLE = 0,
+  RUNNING = 1,
+  SUCCESS = 2,
+  FAILURE = 3,
+  // SKIPPED = 4,
+};
+
+class SceneModuleInterface
+{
+public:
+  SceneModuleInterface(const std::string & name, rclcpp::Node & node)
+  : name_{name},
+    logger_{node.get_logger().get_child(name)},
+    clock_{node.get_clock()},
+    is_waiting_approval_{false},
+    is_already_approved_{false},
+    uuid_(generateUUID()),
+    current_state_{ModuleStatus::SUCCESS}
+  {
+  }
+
+  virtual ~SceneModuleInterface() = default;
+
+  /**
+   * @brief Return SUCCESS if plan is not needed or plan is successfully finished,
+   *        FAILURE if plan has failed, RUNNING if plan is on going.
+   *        These condition is to be implemented in each modules.
+   */
+  virtual ModuleStatus updateState() = 0;
+
+  /**
+   * @brief If the module plan customized reference path while waiting approval, it should output
+   * SUCCESS. Otherwise, it should output FAILURE to check execution request of next module.
+   */
+  virtual ModuleStatus getNodeStatusWhileWaitingApproval() const { return ModuleStatus::FAILURE; }
+
+  /**
+   * @brief Return true if the module has request for execution (not necessarily feasible)
+   */
+  virtual bool isExecutionRequested() const = 0;
+
+  /**
+   * @brief Return true if the execution is available (e.g. safety check for lane change)
+   */
+  virtual bool isExecutionReady() const = 0;
+
+  /**
+   * @brief Calculate path. This function is called with the plan is approved.
+   */
+  virtual BehaviorModuleOutput plan() = 0;
+
+  /**
+   * @brief Calculate path under waiting_approval condition.
+   *        The default implementation is just to return the reference path.
+   */
+  virtual BehaviorModuleOutput planWaitingApproval()
+  {
+    BehaviorModuleOutput out;
+    out.path = util::generateCenterLinePath(planner_data_);
+    const auto candidate = planCandidate();
+    path_candidate_ = std::make_shared<PathWithLaneId>(candidate.path_candidate);
+    path_reference_ = previous_module_output_.reference_path;
+    return out;
+  }
+
+  /**
+   * @brief Get candidate path. This information is used for external judgement.
+   */
+  virtual CandidateOutput planCandidate() const = 0;
+
+  /**
+   * @brief update data for planning. Note that the call of this function does not mean
+   *        that the module executed. It should only updates the data necessary for
+   *        planCandidate (e.g., resampling of path).
+   */
+  virtual void updateData() {}
+
+  /**
+   * @brief Execute module. Once this function is executed,
+   *        it will continue to run as long as it is in the RUNNING state.
+   */
+  virtual BehaviorModuleOutput run()
+  {
+    current_state_ = ModuleStatus::RUNNING;
+
+    if (!isWaitingApproval()) {
+      return plan();
+    }
+
+    // module is waiting approval. Check it.
+    if (isActivated()) {
+      RCLCPP_DEBUG(logger_, "Was waiting approval, and now approved. Do plan().");
+      return plan();
+    } else {
+      RCLCPP_DEBUG(logger_, "keep waiting approval... Do planCandidate().");
+      return planWaitingApproval();
+    }
+  }
+
+  /**
+   * @brief Called on the first time when the module goes into RUNNING.
+   */
+  virtual void onEntry() = 0;
+
+  /**
+   * @brief Called when the module exit from RUNNING.
+   */
+  virtual void onExit() = 0;
+
+  /**
+   * @brief Publish status if the module is requested to run
+   */
+  virtual void publishRTCStatus()
+  {
+    if (!rtc_interface_ptr_) {
+      return;
+    }
+    rtc_interface_ptr_->publishCooperateStatus(clock_->now());
+  }
+
+  /**
+   * @brief Return true if the activation command is received
+   */
+  virtual bool isActivated()
+  {
+    if (!rtc_interface_ptr_) {
+      return true;
+    }
+    if (rtc_interface_ptr_->isRegistered(uuid_)) {
+      return rtc_interface_ptr_->isActivated(uuid_);
+    }
+    return false;
+  }
+
+  virtual void publishSteeringFactor()
+  {
+    if (!steering_factor_interface_ptr_) {
+      return;
+    }
+    steering_factor_interface_ptr_->publishSteeringFactor(clock_->now());
+  }
+
+  virtual void lockRTCCommand()
+  {
+    if (!rtc_interface_ptr_) {
+      return;
+    }
+    rtc_interface_ptr_->lockCommandUpdate();
+  }
+
+  virtual void unlockRTCCommand()
+  {
+    if (!rtc_interface_ptr_) {
+      return;
+    }
+    rtc_interface_ptr_->unlockCommandUpdate();
+  }
+
+  /**
+   * @brief set previous module's output as input for this module
+   */
+  void setPreviousModuleOutput(const BehaviorModuleOutput & previous_module_output)
+  {
+    previous_module_output_ = previous_module_output;
+  }
+
+  /**
+   * @brief set planner data
+   */
+  void setData(const std::shared_ptr<const PlannerData> & data) { planner_data_ = data; }
+
+  void resetPathCandidate() { path_candidate_.reset(); }
+
+  void resetPathReference() { path_reference_.reset(); }
+
+  bool isWaitingApproval() const { return is_waiting_approval_; }
+
+  bool isAlreadyApproved() const { return is_already_approved_; }
+
+  rclcpp::Logger getLogger() const { return logger_; }
+
+  PlanResult getPathCandidate() const { return path_candidate_; }
+
+  PlanResult getPathReference() const { return path_reference_; }
+
+  MarkerArray getDebugMarkers() { return debug_marker_; }
+
+  ModuleStatus getCurrentStatus() const { return current_state_; }
+
+  virtual void acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const = 0;
+
+  std::string name() const { return name_; }
+
+  std::shared_ptr<const PlannerData> planner_data_;
+
+private:
+  std::string name_;
+  rclcpp::Logger logger_;
+
+protected:
+  void updateRTCStatus(const double start_distance, const double finish_distance)
+  {
+    if (!rtc_interface_ptr_) {
+      return;
+    }
+    rtc_interface_ptr_->updateCooperateStatus(
+      uuid_, isExecutionReady(), start_distance, finish_distance, clock_->now());
+  }
+
+  virtual void removeRTCStatus()
+  {
+    if (!rtc_interface_ptr_) {
+      return;
+    }
+    rtc_interface_ptr_->clearCooperateStatus();
+  }
+
+  void alreadyApproved() { is_already_approved_ = true; }
+
+  void nothingApproved() { is_already_approved_ = false; }
+
+  void waitApproval() { is_waiting_approval_ = true; }
+
+  void clearWaitingApproval() { is_waiting_approval_ = false; }
+
+  rclcpp::Clock::SharedPtr clock_;
+
+  std::shared_ptr<RTCInterface> rtc_interface_ptr_;
+  std::unique_ptr<SteeringFactorInterface> steering_factor_interface_ptr_;
+
+  bool is_waiting_approval_;
+  bool is_already_approved_;
+
+  UUID uuid_;
+
+  PlanResult path_candidate_;
+  PlanResult path_reference_;
+
+  ModuleStatus current_state_;
+
+  BehaviorModuleOutput previous_module_output_;
+
+  mutable MarkerArray debug_marker_;
+};
+
+}  // namespace behavior_path_planner
+
+#endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE_V2__SCENE_MODULE_INTERFACE_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_manager_interface.hpp
@@ -75,7 +75,7 @@ public:
     return m->isExecutionReady();
   }
 
-  bool isAlreadyApproved(const UUID & uuid) const
+  bool isLockedNewModuleLaunch(const UUID & uuid) const
   {
     const auto m = findSceneModule(uuid);
 
@@ -83,7 +83,7 @@ public:
       return false;
     }
 
-    return m->isAlreadyApproved();
+    return m->isLockedNewModuleLaunch();
   }
 
   bool isWaitingApproval(const UUID & uuid) const

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_manager_interface.hpp
@@ -1,5 +1,5 @@
 
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module_v2/scene_module_manager_interface.hpp
@@ -1,0 +1,286 @@
+
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE_V2__SCENE_MODULE_MANAGER_INTERFACE_HPP_
+#define BEHAVIOR_PATH_PLANNER__SCENE_MODULE_V2__SCENE_MODULE_MANAGER_INTERFACE_HPP_
+
+#include "behavior_path_planner/scene_module_v2/scene_module_interface.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace behavior_path_planner
+{
+
+using tier4_autoware_utils::toHexString;
+using unique_identifier_msgs::msg::UUID;
+
+class SceneModuleManagerInterface
+{
+public:
+  SceneModuleManagerInterface(
+    rclcpp::Node * node, const std::string & name, const size_t max_module_num,
+    const size_t priority, const bool enable_simultaneous_execution)
+  : node_(node),
+    clock_(*node->get_clock()),
+    logger_(node->get_logger().get_child(name)),
+    name_(name),
+    max_module_num_(max_module_num),
+    priority_(priority),
+    enable_simultaneous_execution_(enable_simultaneous_execution)
+  {
+    pub_debug_marker_ = node->create_publisher<MarkerArray>("~/debug/" + name, 20);
+  }
+
+  virtual ~SceneModuleManagerInterface() = default;
+
+  bool isExecutionRequested(const BehaviorModuleOutput & previous_module_output)
+  {
+    const auto m = getIdlingModule();
+
+    m->setData(planner_data_);
+    m->setPreviousModuleOutput(previous_module_output);
+    m->updateData();
+
+    return m->isExecutionRequested();
+  }
+
+  bool isExecutionReady(const UUID & uuid) const
+  {
+    const auto m = findSceneModule(uuid);
+
+    if (m == nullptr) {
+      return false;
+    }
+
+    return m->isExecutionReady();
+  }
+
+  bool isAlreadyApproved(const UUID & uuid) const
+  {
+    const auto m = findSceneModule(uuid);
+
+    if (m == nullptr) {
+      return false;
+    }
+
+    return m->isAlreadyApproved();
+  }
+
+  bool isWaitingApproval(const UUID & uuid) const
+  {
+    const auto m = findSceneModule(uuid);
+
+    if (m == nullptr) {
+      return false;
+    }
+
+    if (!m->isActivated()) {
+      return m->isWaitingApproval();
+    }
+
+    return false;
+  }
+
+  ModuleStatus getCurrentStatus(const UUID & uuid) const
+  {
+    const auto m = findSceneModule(uuid);
+
+    if (m == nullptr) {
+      return ModuleStatus::IDLE;
+    }
+
+    return m->getCurrentStatus();
+  }
+
+  BehaviorModuleOutput run(
+    const UUID & uuid, const BehaviorModuleOutput & previous_module_output) const
+  {
+    const auto m = findSceneModule(uuid);
+
+    if (m == nullptr) {
+      return {};
+    }
+
+    m->setData(planner_data_);
+    m->setPreviousModuleOutput(previous_module_output);
+    m->updateData();
+
+    m->lockRTCCommand();
+    const auto result = m->run();
+    m->unlockRTCCommand();
+
+    m->updateState();
+
+    m->publishRTCStatus();
+
+    return result;
+  }
+
+  void registerNewModule(const BehaviorModuleOutput & previous_module_output, const UUID & uuid)
+  {
+    const auto m = createNewSceneModuleInstance();
+
+    m->setData(planner_data_);
+    m->setPreviousModuleOutput(previous_module_output);
+    m->onEntry();
+
+    registered_modules_.insert(std::make_pair(toHexString(uuid), m));
+  }
+
+  void deleteModules(const UUID & uuid)
+  {
+    const auto m = findSceneModule(uuid);
+
+    if (m == nullptr) {
+      return;
+    }
+
+    m->onExit();
+    m->publishRTCStatus();
+
+    registered_modules_.erase(toHexString(uuid));
+
+    pub_debug_marker_->publish(MarkerArray{});
+  }
+
+  void publishDebugMarker()
+  {
+    using tier4_autoware_utils::appendMarkerArray;
+
+    MarkerArray markers{};
+
+    for (const auto & m : registered_modules_) {
+      const uint32_t marker_id = std::stoul(m.first.substr(0, sizeof(uint32_t) / 4), nullptr, 16);
+      for (auto & marker : m.second->getDebugMarkers().markers) {
+        marker.id += marker_id;
+        markers.markers.push_back(marker);
+      }
+    }
+
+    if (registered_modules_.empty() && idling_module_ != nullptr) {
+      appendMarkerArray(idling_module_->getDebugMarkers(), &markers);
+    }
+
+    pub_debug_marker_->publish(markers);
+  }
+
+  bool exist(const UUID & uuid) const
+  {
+    if (registered_modules_.count(toHexString(uuid)) == 0) {
+      RCLCPP_DEBUG(
+        logger_, "uuid %s is not found in %s module.", toHexString(uuid).c_str(), name_.c_str());
+      return false;
+    }
+
+    return true;
+  }
+
+  bool canLaunchNewModule() const { return registered_modules_.size() < max_module_num_; }
+
+  bool isSimultaneousExecutable() const { return enable_simultaneous_execution_; }
+
+  void setData(const std::shared_ptr<PlannerData> & planner_data) { planner_data_ = planner_data; }
+
+  void reset()
+  {
+    std::for_each(registered_modules_.begin(), registered_modules_.end(), [](const auto & m) {
+      m.second->onExit();
+      m.second->publishRTCStatus();
+    });
+    registered_modules_.clear();
+
+    idling_module_->onExit();
+    idling_module_->publishRTCStatus();
+    idling_module_.reset();
+
+    pub_debug_marker_->publish(MarkerArray{});
+  }
+
+  size_t getPriority() const { return priority_; }
+
+  std::string getModuleName() const { return name_; }
+
+  std::vector<std::shared_ptr<SceneModuleInterface>> getSceneModules()
+  {
+    std::vector<std::shared_ptr<SceneModuleInterface>> modules;
+    for (const auto & m : registered_modules_) {
+      modules.push_back(m.second);
+    }
+
+    return modules;
+  }
+
+  virtual void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) = 0;
+
+protected:
+  virtual void getModuleParams(rclcpp::Node * node) = 0;
+
+  virtual std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() = 0;
+
+  rclcpp::Node * node_;
+
+  rclcpp::Clock clock_;
+
+  rclcpp::Logger logger_;
+
+  rclcpp::Publisher<MarkerArray>::SharedPtr pub_debug_marker_;
+
+  std::string name_;
+
+  std::shared_ptr<PlannerData> planner_data_;
+
+  std::shared_ptr<SceneModuleInterface> idling_module_;
+
+  std::unordered_map<std::string, std::shared_ptr<SceneModuleInterface>> registered_modules_;
+
+private:
+  std::shared_ptr<SceneModuleInterface> findSceneModule(const UUID & uuid) const
+  {
+    const auto itr = registered_modules_.find(toHexString(uuid));
+    if (itr == registered_modules_.end()) {
+      return nullptr;
+    }
+
+    return registered_modules_.at(toHexString(uuid));
+  }
+
+  std::shared_ptr<SceneModuleInterface> getIdlingModule()
+  {
+    if (idling_module_ != nullptr) {
+      return idling_module_;
+    }
+
+    idling_module_ = createNewSceneModuleInstance();
+    return idling_module_;
+  }
+
+  size_t max_module_num_;
+
+  size_t priority_;
+
+  bool enable_simultaneous_execution_{false};
+};
+
+}  // namespace behavior_path_planner
+
+#endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE_V2__SCENE_MODULE_MANAGER_INTERFACE_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -517,6 +517,9 @@ double calcTotalLaneChangeDistance(
 double calcLaneChangeBuffer(
   const BehaviorPathPlannerParameters & common_param, const int num_lane_change,
   const double length_to_intersection = 0.0);
+
+lanelet::ConstLanelets getLaneletsFromPath(
+  const PathWithLaneId & path, const std::shared_ptr<route_handler::RouteHandler> & route_handler);
 }  // namespace behavior_path_planner::util
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -157,7 +157,7 @@ boost::optional<ModuleID> PlannerManager::getCandidateModuleID(
 
     // when the approved module throw another approval request, block all. -> CLEAR REQUEST MODULES
     // AND PUSH BACK.
-    if (manager->isAlreadyApproved(candidate_module_id_.get().second)) {
+    if (manager->isLockedNewModuleLaunch(candidate_module_id_.get().second)) {
       request_modules.clear();
       request_modules.push_back(candidate_module_id_.get());
       processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
@@ -390,7 +390,7 @@ void PlannerManager::resetRootLanelet(const std::shared_ptr<PlannerData> & data)
   if (!!candidate_module_id_) {
     const auto & manager = candidate_module_id_.get().first;
     const auto & uuid = candidate_module_id_.get().second;
-    if (manager->isAlreadyApproved(uuid)) {
+    if (manager->isLockedNewModuleLaunch(uuid)) {
       return;
     }
   }

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -1,0 +1,444 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "behavior_path_planner/planner_manager.hpp"
+
+#include "behavior_path_planner/path_utilities.hpp"
+#include "behavior_path_planner/utilities.hpp"
+
+#include <lanelet2_extension/utility/utilities.hpp>
+
+#include <boost/format.hpp>
+
+#include <memory>
+#include <string>
+
+namespace behavior_path_planner
+{
+
+PlannerManager::PlannerManager(rclcpp::Node & node, const bool verbose)
+: logger_(node.get_logger().get_child("planner_manager")),
+  clock_(*node.get_clock()),
+  verbose_{verbose}
+{
+  processing_time_.emplace("total_time", 0.0);
+}
+
+BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & data)
+{
+  resetProcessingTime();
+  stop_watch_.tic("total_time");
+
+  if (!root_lanelet_) {
+    root_lanelet_ = updateRootLanelet(data);
+  }
+
+  std::for_each(scene_manager_ptrs_.begin(), scene_manager_ptrs_.end(), [&data](const auto & m) {
+    m->setData(data);
+  });
+
+  while (rclcpp::ok()) {
+    /**
+     * STEP1: get approved modules' output
+     */
+    const auto approved_path_data = update(data);
+
+    /**
+     * STEP2: check modules that need to be launched
+     */
+    const auto candidate_module_id = getCandidateModuleID(approved_path_data);
+
+    /**
+     * STEP3: if there is no module that need to be launched, return approved modules' output
+     */
+    if (!candidate_module_id) {
+      candidate_module_id_ = boost::none;
+      processing_time_.at("total_time") = stop_watch_.toc("total_time", true);
+      return approved_path_data;
+    }
+
+    /**
+     * STEP4: if there is module that should be launched, execute the module
+     */
+    const auto name = candidate_module_id.get().first->getModuleName();
+    stop_watch_.tic(name);
+    const auto result = run(candidate_module_id.get(), approved_path_data);
+    processing_time_.at(name) += stop_watch_.toc(name, true);
+
+    /**
+     * STEP5: if the candidate module's modification is NOT approved yet, return the result.
+     * NOTE: the result is output of the candidate module, but the output path don't contains path
+     * shape modification that needs approval. On the other hand, it could include velocity profile
+     * modification.
+     */
+    if (isWaitingApproval(candidate_module_id.get())) {
+      candidate_module_id_ = candidate_module_id.get();
+      processing_time_.at("total_time") = stop_watch_.toc("total_time", true);
+      return result;
+    }
+
+    /**
+     * STEP6: if the candidate module is approved, push the module into approved_modules_
+     */
+    candidate_module_id_ = boost::none;
+    addApprovedModule(candidate_module_id.get());
+  }
+
+  processing_time_.at("total_time") = stop_watch_.toc("total_time", true);
+
+  return {};
+}
+
+boost::optional<ModuleID> PlannerManager::getCandidateModuleID(
+  const BehaviorModuleOutput & previous_module_output) const
+{
+  std::vector<ModuleID> request_modules{};
+
+  const auto block_simultaneous_execution = [this]() {
+    for (const auto & m : approved_modules_) {
+      const auto & manager = m.first;
+      if (!manager->isSimultaneousExecutable()) {
+        return true;
+      }
+    }
+    return false;
+  }();
+
+  // pickup execution requested modules
+  for (const auto & m : scene_manager_ptrs_) {
+    stop_watch_.tic(m->getModuleName());
+
+    const auto uuid = generateUUID();  // generate temporary uuid
+
+    // already exist the modules that don't support simultaneous execution. -> DO NOTHING.
+    if (block_simultaneous_execution) {
+      processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
+      continue;
+    }
+
+    // the module doesn't support simultaneous execution. -> DO NOTHING.
+    if (!approved_modules_.empty() && !m->isSimultaneousExecutable()) {
+      processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
+      continue;
+    }
+
+    // check there is a launched module which is waiting approval as candidate.
+    if (!candidate_module_id_) {
+      // launched module num reach limit. -> CAN'T LAUNCH NEW MODULE. DO NOTHING.
+      if (!m->canLaunchNewModule()) {
+        processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
+        continue;
+      }
+
+      // the module requests it to be launch. -> CAN LAUNCH THE MODULE. PUSH BACK AS REQUEST
+      // MODULES.
+      if (m->isExecutionRequested(previous_module_output)) {
+        request_modules.emplace_back(m, uuid);
+      }
+
+      processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
+      continue;
+    }
+
+    // candidate module already exist
+    const auto & manager = candidate_module_id_.get().first;
+    const auto & name = manager->getModuleName();
+
+    // when the approved module throw another approval request, block all. -> CLEAR REQUEST MODULES
+    // AND PUSH BACK.
+    if (manager->isAlreadyApproved(candidate_module_id_.get().second)) {
+      request_modules.clear();
+      request_modules.push_back(candidate_module_id_.get());
+      processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
+      break;
+    }
+
+    // same name module already launched as candidate.
+    if (name == m->getModuleName()) {
+      // the module launched as candidate and is running now. the module hasn't thrown any approval
+      // yet. -> PUSH BACK AS REQUEST MODULES.
+      if (isRunning(candidate_module_id_.get())) {
+        request_modules.push_back(candidate_module_id_.get());
+      } else {
+        deleteExpiredModules(
+          candidate_module_id_
+            .get());  // TODO(Satoshi OTA) this line is no longer needed? think later.
+      }
+
+      processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
+      continue;
+    }
+
+    // different name module already launched as candidate.
+    // launched module num reach limit. -> CAN'T LAUNCH NEW MODULE. DO NOTHING.
+    if (!m->canLaunchNewModule()) {
+      processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
+      continue;
+    }
+
+    // the module requests it to be launch. -> CAN LAUNCH THE MODULE. PUSH BACK AS REQUEST MODULES.
+    if (!m->isExecutionRequested(previous_module_output)) {
+      processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
+      continue;
+    }
+
+    processing_time_.at(m->getModuleName()) += stop_watch_.toc(m->getModuleName(), true);
+    request_modules.emplace_back(m, uuid);
+  }
+
+  // select one module to run as candidate module.
+  const auto high_priority_module = selectHighestPriorityModule(request_modules);
+
+  if (!high_priority_module) {
+    return {};
+  }
+
+  // post process
+  {
+    const auto & manager = high_priority_module.get().first;
+    const auto & uuid = high_priority_module.get().second;
+
+    // if the selected module is NOT registered in manager, registered the module.
+    if (!manager->exist(uuid)) {
+      manager->registerNewModule(previous_module_output, uuid);
+    }
+
+    // if the current candidate module is NOT selected as high priority module, delete the candidate
+    // module from manager.
+    for (const auto & m : request_modules) {
+      if (m.first->getModuleName() != manager->getModuleName() && m.first->exist(m.second)) {
+        deleteExpiredModules(m);
+      }
+    }
+  }
+
+  return high_priority_module;
+}
+
+boost::optional<ModuleID> PlannerManager::selectHighestPriorityModule(
+  std::vector<ModuleID> & request_modules) const
+{
+  if (request_modules.empty()) {
+    return {};
+  }
+
+  // TODO(someone) enhance this priority decision method.
+  std::sort(request_modules.begin(), request_modules.end(), [](auto a, auto b) {
+    return a.first->getPriority() < b.first->getPriority();
+  });
+
+  return request_modules.front();
+}
+
+BehaviorModuleOutput PlannerManager::update(const std::shared_ptr<PlannerData> & data)
+{
+  BehaviorModuleOutput output = getReferencePath(data);  // generate root reference path.
+
+  bool remove_after_module = false;
+
+  for (auto itr = approved_modules_.begin(); itr != approved_modules_.end();) {
+    const auto & manager = itr->first;
+    const auto & name = manager->getModuleName();
+
+    stop_watch_.tic(name);
+
+    // if one of the approved modules changes to waiting approval, remove all behind modules.
+    if (remove_after_module) {
+      itr = approved_modules_.erase(itr);
+      processing_time_.at(name) += stop_watch_.toc(name, true);
+      continue;
+    }
+
+    const auto result = run(*itr, output);  // execute approved module planning.
+
+    // check the module is necessary or not.
+    if (!isRunning(*itr)) {
+      if (itr == approved_modules_.begin()) {
+        // update root lanelet when the lane change is done.
+        if (name == "lane_change") {
+          root_lanelet_ = updateRootLanelet(data);
+        }
+
+        deleteExpiredModules(*itr);  // unregister the expired module from manager.
+        itr = approved_modules_.erase(itr);
+        output = result;
+        processing_time_.at(name) += stop_watch_.toc(name, true);
+        continue;
+      }
+    }
+
+    // if one of the approved modules is waiting approval, the module is popped as candidate
+    // module again.
+    if (isWaitingApproval(*itr)) {
+      if (!!candidate_module_id_) {
+        deleteExpiredModules(candidate_module_id_.get());
+      }
+      candidate_module_id_ = *itr;
+      itr = approved_modules_.erase(itr);
+      remove_after_module = true;
+      processing_time_.at(name) += stop_watch_.toc(name, true);
+      continue;
+    }
+
+    processing_time_.at(name) += stop_watch_.toc(name, true);
+    output = result;
+    itr++;
+  }
+
+  return output;
+}
+
+BehaviorModuleOutput PlannerManager::getReferencePath(
+  const std::shared_ptr<PlannerData> & data) const
+{
+  PathWithLaneId reference_path{};
+
+  constexpr double extra_margin = 10.0;
+
+  const auto & route_handler = data->route_handler;
+  const auto & pose = data->self_odometry->pose.pose;
+  const auto p = data->parameters;
+
+  reference_path.header = route_handler->getRouteHeader();
+
+  const auto backward_length =
+    std::max(p.backward_path_length, p.backward_path_length + extra_margin);
+
+  const auto lanelet_sequence = route_handler->getLaneletSequence(
+    root_lanelet_.get(), pose, backward_length, std::numeric_limits<double>::max());
+
+  lanelet::ConstLanelet closest_lane{};
+  if (!lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lane)) {
+    return {};
+  }
+
+  const auto current_lanes =
+    route_handler->getLaneletSequence(closest_lane, pose, backward_length, p.forward_path_length);
+
+  reference_path = util::getCenterLinePath(
+    *route_handler, current_lanes, pose, backward_length, p.forward_path_length, p);
+
+  // clip backward length
+  const size_t current_seg_idx = data->findEgoSegmentIndex(reference_path.points);
+  util::clipPathLength(
+    reference_path, current_seg_idx, p.forward_path_length, p.backward_path_length);
+  const auto drivable_lanelets = util::getLaneletsFromPath(reference_path, route_handler);
+  const auto drivable_lanes = util::generateDrivableLanes(drivable_lanelets);
+
+  {
+    const int num_lane_change =
+      std::abs(route_handler->getNumLaneToPreferredLane(current_lanes.back()));
+
+    const double lane_change_buffer = util::calcLaneChangeBuffer(p, num_lane_change);
+
+    reference_path = util::setDecelerationVelocity(
+      *route_handler, reference_path, current_lanes, 2.0, lane_change_buffer);
+  }
+
+  const auto shorten_lanes = util::cutOverlappedLanes(reference_path, drivable_lanes);
+
+  const auto expanded_lanes = util::expandLanelets(shorten_lanes, 0.0, 0.0);
+
+  util::generateDrivableArea(reference_path, expanded_lanes, p.vehicle_length, data);
+
+  BehaviorModuleOutput output;
+  output.path = std::make_shared<PathWithLaneId>(reference_path);
+  output.reference_path = std::make_shared<PathWithLaneId>(reference_path);
+
+  return output;
+}
+
+void PlannerManager::resetRootLanelet(const std::shared_ptr<PlannerData> & data)
+{
+  if (!root_lanelet_) {
+    root_lanelet_ = updateRootLanelet(data);
+    return;
+  }
+
+  const auto root_lanelet = updateRootLanelet(data);
+
+  // check ego is in same lane
+  if (root_lanelet_.get().id() == root_lanelet.id()) {
+    return;
+  }
+
+  const auto route_handler = data->route_handler;
+  const auto next_lanelets = route_handler->getRoutingGraphPtr()->following(root_lanelet_.get());
+
+  // check ego is in next lane
+  for (const auto & next : next_lanelets) {
+    if (next.id() == root_lanelet_.get().id()) {
+      return;
+    }
+  }
+
+  if (!approved_modules_.empty()) {
+    return;
+  }
+
+  if (!!candidate_module_id_) {
+    const auto & manager = candidate_module_id_.get().first;
+    const auto & uuid = candidate_module_id_.get().second;
+    if (manager->isAlreadyApproved(uuid)) {
+      return;
+    }
+  }
+
+  reset();
+
+  RCLCPP_INFO_EXPRESSION(logger_, verbose_, "change ego's following lane. reset.");
+}
+
+void PlannerManager::print() const
+{
+  if (!verbose_) {
+    return;
+  }
+
+  std::ostringstream string_stream;
+  string_stream << "\n";
+  string_stream << "***********************************************************\n";
+  string_stream << "                  planner manager status\n";
+  string_stream << "-----------------------------------------------------------\n";
+  string_stream << "registered modules: ";
+  for (const auto & m : scene_manager_ptrs_) {
+    string_stream << "[" << m->getModuleName() << "]";
+  }
+
+  string_stream << "\n";
+  string_stream << "approved modules  : ";
+  for (const auto & id : approved_modules_) {
+    const auto & manager = id.first;
+    string_stream << "[" << manager->getModuleName() << "]->";
+  }
+
+  string_stream << "\n";
+  string_stream << "candidate module  : ";
+  if (!!candidate_module_id_) {
+    const auto & manager = candidate_module_id_.get().first;
+    string_stream << "[" << manager->getModuleName() << "]";
+  }
+
+  string_stream << "\n" << std::fixed << std::setprecision(1);
+  string_stream << "processing time   : ";
+  for (const auto & t : processing_time_) {
+    string_stream << std::right << "[" << std::setw(16) << std::left << t.first << ":"
+                  << std::setw(4) << std::right << t.second << "ms]\n"
+                  << std::setw(21);
+  }
+
+  RCLCPP_INFO_STREAM(logger_, string_stream.str());
+}
+
+}  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
+++ b/planning/behavior_path_planner/src/scene_module/scene_module_visitor.cpp
@@ -14,7 +14,11 @@
 
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 
+#ifdef USE_BEHAVIOR_TREE
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+#else
+#include "behavior_path_planner/scene_module_v2/scene_module_interface.hpp"
+#endif
 
 namespace behavior_path_planner
 {

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2464,4 +2464,27 @@ double calcLaneChangeBuffer(
 {
   return num_lane_change * calcTotalLaneChangeDistance(common_param) + length_to_intersection;
 }
+
+lanelet::ConstLanelets getLaneletsFromPath(
+  const PathWithLaneId & path, const std::shared_ptr<route_handler::RouteHandler> & route_handler)
+{
+  std::vector<int64_t> unique_lanelet_ids;
+  for (const auto & p : path.points) {
+    const auto & lane_ids = p.lane_ids;
+    for (const auto & lane_id : lane_ids) {
+      if (
+        std::find(unique_lanelet_ids.begin(), unique_lanelet_ids.end(), lane_id) ==
+        unique_lanelet_ids.end()) {
+        unique_lanelet_ids.push_back(lane_id);
+      }
+    }
+  }
+
+  lanelet::ConstLanelets lanelets;
+  for (const auto & lane_id : unique_lanelet_ids) {
+    lanelets.push_back(route_handler->getLaneletsFromId(lane_id));
+  }
+
+  return lanelets;
+}
 }  // namespace behavior_path_planner::util


### PR DESCRIPTION
## Description

:arrow_down: This must merge before this PR.
https://github.com/autowarefoundation/autoware_launch/pull/218

In this PR, I add new manager that doesn't depend on behavior tree library. The manager is implemented based on the new architecture on [this](https://github.com/orgs/autowarefoundation/discussions/3097) discussion.

### NOTE

- Conventional manager that based on BT library still remains, and that manager is activated by default.
- Change manager in CMakelist.
- The new manager is not compatible with the old one. We have to add the new scene modules that support new manager.
- In this PR, there is no scene modules that support new manager. The new manager can only execute lane following.
- The new scene modules will be added in the other PRs.

<!-- Write a brief description of this PR. -->

## Related links

- [discussion](https://github.com/orgs/autowarefoundation/discussions/3097)
- [autoware_launch](https://github.com/autowarefoundation/autoware_launch/pull/218)

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

### Evaluator

[[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/5ab36667-0cdb-51db-a50b-186b2b59f175?project_id=prd_jt) Baseline 811/814
[[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/b8cfb8fc-40ef-503b-88c4-aa00780bc722?project_id=prd_jt) This PR 812/814

### Test by Psim

Please cherry-pick [this](https://github.com/autowarefoundation/autoware_launch/pull/218) commit to your `autoware_launch` or add following line to `behavior_path_planner.param.yaml`.

```yaml
/**:
  ros__parameters:
    verbose: true # this line
   ...
```

If you want to use new manager, please set **USE_BT** to `FALSE`. For now, the manager can execute only lane following.

```cmake
# use planner manager that supports behavior tree
set(USE_BT FALSE)
message(STATUS "USE_BEHAVIOR_TREE: " ${USE_BT})
```

https://user-images.githubusercontent.com/44889564/220276091-0b1fa05a-5908-4e15-9f8b-4cbe85d32ecc.mp4

If you want to use conventional manager, please set **USE_BT** to `TRUE`.

```cmake
# use planner manager that supports behavior tree
set(USE_BT TRUE)
message(STATUS "USE_BEHAVIOR_TREE: " ${USE_BT})
```


https://user-images.githubusercontent.com/44889564/220276416-106ee601-674c-4873-aba9-d73ae99502bd.mp4

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
