### PR TITLE
fix(behavior_path_planner): move module output interface definition

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -27,9 +27,6 @@
 
 #include <autoware_adapi_v1_msgs/msg/steering_factor_array.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
-#include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
-#include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
-#include <autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp>
 #include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
@@ -47,37 +44,12 @@ namespace behavior_path_planner
 {
 using autoware_adapi_v1_msgs::msg::SteeringFactor;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
-using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
-using autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand;
-using autoware_planning_msgs::msg::PoseWithUuidStamped;
 using rtc_interface::RTCInterface;
 using steering_factor_interface::SteeringFactorInterface;
 using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
 using unique_identifier_msgs::msg::UUID;
 using visualization_msgs::msg::MarkerArray;
 using PlanResult = PathWithLaneId::SharedPtr;
-
-struct BehaviorModuleOutput
-{
-  BehaviorModuleOutput() = default;
-
-  // path planed by module
-  PlanResult path{};
-
-  TurnSignalInfo turn_signal_info{};
-
-  std::optional<PoseWithUuidStamped> modified_goal{};
-};
-
-struct CandidateOutput
-{
-  CandidateOutput() = default;
-  explicit CandidateOutput(const PathWithLaneId & path) : path_candidate{path} {}
-  PathWithLaneId path_candidate{};
-  double lateral_shift{0.0};
-  double start_distance_to_path_change{std::numeric_limits<double>::lowest()};
-  double finish_distance_to_path_change{std::numeric_limits<double>::lowest()};
-};
 
 class SceneModuleInterface
 {

--- a/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
@@ -39,24 +39,6 @@ using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using route_handler::RouteHandler;
 
-struct TurnSignalInfo
-{
-  TurnSignalInfo()
-  {
-    turn_signal.command = TurnIndicatorsCommand::NO_COMMAND;
-    hazard_signal.command = HazardLightsCommand::NO_COMMAND;
-  }
-
-  // desired turn signal
-  TurnIndicatorsCommand turn_signal;
-  HazardLightsCommand hazard_signal;
-
-  geometry_msgs::msg::Pose desired_start_point;
-  geometry_msgs::msg::Pose desired_end_point;
-  geometry_msgs::msg::Pose required_start_point;
-  geometry_msgs::msg::Pose required_end_point;
-};
-
 const std::map<std::string, uint8_t> signal_map = {
   {"left", TurnIndicatorsCommand::ENABLE_LEFT},
   {"right", TurnIndicatorsCommand::ENABLE_RIGHT},


### PR DESCRIPTION
## Description

[DIFF]

move following struct definition to data_manager.hpp
- TurnSignalInfo
- BehaviorModuleOutput
- CandidateOutput

[BACKGROUND]

I plan to add new framework and **another scene_module_interface.hpp** that supports new framework. Then, I avoid to define same struct in both of old and new scene_module_interface.hpp. Therefore, I want to move those definition from scene_module_interface.hpp.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
