### PR TITLE
fix(external_velocity_limit_selector): delete default values

### DIFF
--- a/planning/external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
+++ b/planning/external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
@@ -111,15 +111,15 @@ ExternalVelocityLimitSelectorNode::ExternalVelocityLimitSelectorNode(
   // Params
   {
     auto & p = node_param_;
-    p.max_velocity = this->declare_parameter<double>("max_velocity", 20.0);
-    p.normal_min_acc = this->declare_parameter<double>("normal.min_acc", -1.0);
-    p.normal_max_acc = this->declare_parameter<double>("normal.max_acc", 1.0);
-    p.normal_min_jerk = this->declare_parameter<double>("normal.min_jerk", -0.1);
-    p.normal_max_jerk = this->declare_parameter<double>("normal.max_jerk", 0.1);
-    p.limit_min_acc = this->declare_parameter<double>("limit.min_acc", -2.5);
-    p.limit_max_acc = this->declare_parameter<double>("limit.max_acc", 2.5);
-    p.limit_min_jerk = this->declare_parameter<double>("limit.min_jerk", -1.5);
-    p.limit_max_jerk = this->declare_parameter<double>("limit.max_jerk", 1.5);
+    p.max_velocity = this->declare_parameter<double>("max_velocity");
+    p.normal_min_acc = this->declare_parameter<double>("normal.min_acc");
+    p.normal_max_acc = this->declare_parameter<double>("normal.max_acc");
+    p.normal_min_jerk = this->declare_parameter<double>("normal.min_jerk");
+    p.normal_max_jerk = this->declare_parameter<double>("normal.max_jerk");
+    p.limit_min_acc = this->declare_parameter<double>("limit.min_acc");
+    p.limit_max_acc = this->declare_parameter<double>("limit.max_acc");
+    p.limit_min_jerk = this->declare_parameter<double>("limit.min_jerk");
+    p.limit_max_jerk = this->declare_parameter<double>("limit.max_jerk");
   }
 }
 


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[external_velocity_limit_selector_delte_param.webm](https://user-images.githubusercontent.com/100691117/220572944-9692a14e-8d83-4d10-b3e8-5bf35e49f423.webm)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
