### PR TITLE
feat(probablistic_occupancy_grid_map): add alternative to gridmap origin frame

### DIFF
--- a/perception/probabilistic_occupancy_grid_map/README.md
+++ b/perception/probabilistic_occupancy_grid_map/README.md
@@ -9,36 +9,38 @@ This package outputs the probability of having an obstacle as occupancy grid map
 
 Occupancy grid map is generated on `map_frame`, and grid orientation is fixed.
 
-You may need to choose `output_frame` which means grid map origin. Your main LiDAR sensor frame would be the best choice, otherwise set `base_link`.
+You may need to choose `output_frame` which means grid map origin. Default is `base_link`, but your main LiDAR sensor frame (e.g. `velodyne_top` in sample_vehicle) would be the better choice.
 
 ### Each config paramters
 
+Config parameters are managed in `config/*.yaml` and here shows its outline.
+
 - Pointcloud based occupancy grid map
 
-| Ros param name                    | Default value  |
-| --------------------------------- | -------------- |
-| map_frame                         | "map"          |
-| base_link_frame                   | "base_link"    |
-| output_frame                      | "velodyne_top" |
-| use_height_filter                 | true           |
-| enable_single_frame_mode          | false          |
-| map_length                        | 100.0 [m]      |
-| map_width                         | 100.0 [m]      |
-| map_resolution                    | 0.5 [m]        |
-| input_obstacle_pointcloud         | true           |
-| input_obstacle_and_raw_pointcloud | true           |
+| Ros param name                    | Default value |
+| --------------------------------- | ------------- |
+| map_frame                         | "map"         |
+| base_link_frame                   | "base_link"   |
+| output_frame                      | "base_link"   |
+| use_height_filter                 | true          |
+| enable_single_frame_mode          | false         |
+| map_length                        | 100.0 [m]     |
+| map_width                         | 100.0 [m]     |
+| map_resolution                    | 0.5 [m]       |
+| input_obstacle_pointcloud         | true          |
+| input_obstacle_and_raw_pointcloud | true          |
 
 - Laserscan based occupancy grid map
 
-| Ros param name           | Default value  |
-| ------------------------ | -------------- |
-| map_length               | 100 [m]        |
-| map_resolution           | 0.5 [m]        |
-| use_height_filter        | true           |
-| enable_single_frame_mode | false          |
-| map_frame                | "map"          |
-| base_link_frame          | "base_link"    |
-| output_frame             | "velodyne_top" |
+| Ros param name           | Default value |
+| ------------------------ | ------------- |
+| map_length               | 100 [m]       |
+| map_resolution           | 0.5 [m]       |
+| use_height_filter        | true          |
+| enable_single_frame_mode | false         |
+| map_frame                | "map"         |
+| base_link_frame          | "base_link"   |
+| output_frame             | "base_link"   |
 
 ## References/External links
 

--- a/perception/probabilistic_occupancy_grid_map/README.md
+++ b/perception/probabilistic_occupancy_grid_map/README.md
@@ -5,6 +5,41 @@
 This package outputs the probability of having an obstacle as occupancy grid map.
 ![pointcloud_based_occupancy_grid_map_sample_image](./image/pointcloud_based_occupancy_grid_map_sample_image.gif)
 
+## Settings
+
+Occupancy grid map is generated on `map_frame`, and grid orientation is fixed.
+
+You may need to choose `output_frame` which means grid map origin. Your main LiDAR sensor frame would be the best choice, otherwise set `base_link`.
+
+### Each config paramters
+
+- Pointcloud based occupancy grid map
+
+| Ros param name                    | Default value  |
+| --------------------------------- | -------------- |
+| map_frame                         | "map"          |
+| base_link_frame                   | "base_link"    |
+| output_frame                      | "velodyne_top" |
+| use_height_filter                 | true           |
+| enable_single_frame_mode          | false          |
+| map_length                        | 100.0 [m]      |
+| map_width                         | 100.0 [m]      |
+| map_resolution                    | 0.5 [m]        |
+| input_obstacle_pointcloud         | true           |
+| input_obstacle_and_raw_pointcloud | true           |
+
+- Laserscan based occupancy grid map
+
+| Ros param name           | Default value  |
+| ------------------------ | -------------- |
+| map_length               | 100 [m]        |
+| map_resolution           | 0.5 [m]        |
+| use_height_filter        | true           |
+| enable_single_frame_mode | false          |
+| map_frame                | "map"          |
+| base_link_frame          | "base_link"    |
+| output_frame             | "velodyne_top" |
+
 ## References/External links
 
 - [Pointcloud based occupancy grid map](pointcloud-based-occupancy-grid-map.md)

--- a/perception/probabilistic_occupancy_grid_map/config/laserscan_based_occupancy_grid_map.param.yaml
+++ b/perception/probabilistic_occupancy_grid_map/config/laserscan_based_occupancy_grid_map.param.yaml
@@ -1,0 +1,12 @@
+/**:
+  ros__parameters:
+    map_frame: "map"
+    base_link_frame: "base_link"
+    output_frame: "velodyne_top"
+    use_height_filter: true
+    enable_single_frame_mode: false
+    map_length: 100.0
+    map_width: 100.0
+    map_resolution: 0.5
+    input_obstacle_pointcloud: true
+    input_obstacle_and_raw_pointcloud: true

--- a/perception/probabilistic_occupancy_grid_map/config/laserscan_based_occupancy_grid_map.param.yaml
+++ b/perception/probabilistic_occupancy_grid_map/config/laserscan_based_occupancy_grid_map.param.yaml
@@ -2,7 +2,9 @@
   ros__parameters:
     map_frame: "map"
     base_link_frame: "base_link"
-    output_frame: "velodyne_top"
+    output_frame: "base_link"
+    # using top of the main lidar frame is appropriate. ex) velodyne_top
+
     use_height_filter: true
     enable_single_frame_mode: false
     map_length: 100.0

--- a/perception/probabilistic_occupancy_grid_map/config/pointcloud_based_occupancy_grid_map.param.yaml
+++ b/perception/probabilistic_occupancy_grid_map/config/pointcloud_based_occupancy_grid_map.param.yaml
@@ -9,4 +9,5 @@
     # grid map coordinate
     map_frame: "map"
     base_link_frame: "base_link"
-    output_frame: "velodyne_top" # center of grid_map. Main LiDAR frame is preferable
+    output_frame: "base_link"
+    # center of grid_map. Main LiDAR frame is preferable like: "velodyne_top"

--- a/perception/probabilistic_occupancy_grid_map/config/pointcloud_based_occupancy_grid_map.param.yaml
+++ b/perception/probabilistic_occupancy_grid_map/config/pointcloud_based_occupancy_grid_map.param.yaml
@@ -1,0 +1,12 @@
+/**:
+  ros__parameters:
+    map_length: 100     # [m]
+    map_resolution: 0.5 # [m]
+
+    use_height_filter: true
+    enable_single_frame_mode: false
+
+    # grid map coordinate
+    map_frame: "map"
+    base_link_frame: "base_link"
+    output_frame: "velodyne_top" # center of grid_map. Main LiDAR frame is preferable

--- a/perception/probabilistic_occupancy_grid_map/include/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.hpp
+++ b/perception/probabilistic_occupancy_grid_map/include/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.hpp
@@ -92,6 +92,7 @@ private:
   // ROS Parameters
   std::string map_frame_;
   std::string base_link_frame_;
+  std::string output_frame_;
   bool use_height_filter_;
   bool enable_single_frame_mode_;
 };

--- a/perception/probabilistic_occupancy_grid_map/include/pointcloud_based_occupancy_grid_map/occupancy_grid_map.hpp
+++ b/perception/probabilistic_occupancy_grid_map/include/pointcloud_based_occupancy_grid_map/occupancy_grid_map.hpp
@@ -72,7 +72,7 @@ public:
 
   void updateWithPointCloud(
     const PointCloud2 & raw_pointcloud, const PointCloud2 & obstacle_pointcloud,
-    const Pose & robot_pose);
+    const Pose & robot_pose, const Pose & gridmap_origin);
 
   void updateOrigin(double new_origin_x, double new_origin_y) override;
 

--- a/perception/probabilistic_occupancy_grid_map/include/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
+++ b/perception/probabilistic_occupancy_grid_map/include/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
@@ -82,6 +82,7 @@ private:
   // ROS Parameters
   std::string map_frame_;
   std::string base_link_frame_;
+  std::string output_frame_;
   bool use_height_filter_;
   bool enable_single_frame_mode_;
 };

--- a/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
+++ b/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
@@ -67,7 +67,9 @@ def generate_launch_description():
             ],
             parameters=[
                 {
-                    "target_frame": "base_link",  # Leave disabled to output scan in pointcloud frame
+                    "target_frame": laserscan_based_occupancy_grid_map_node_params[
+                        "output_frame"
+                    ],  # Leave disabled to output scan in pointcloud frame
                     "transform_tolerance": 0.01,
                     "min_height": 0.0,
                     "max_height": 2.0,

--- a/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
+++ b/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import SetLaunchConfiguration
@@ -23,6 +26,7 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
+import yaml
 
 
 def generate_launch_description():
@@ -40,6 +44,14 @@ def generate_launch_description():
         "component_container_mt",
         condition=IfCondition(LaunchConfiguration("use_multithread")),
     )
+
+    # load parameter files
+    param_file = os.path.join(
+        get_package_share_directory("probablistic_occupancy_grid_map"),
+        "config/laserscan_based_occupancy_grid_map.param.yaml",
+    )
+    with open(param_file, "r") as f:
+        laserscan_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"]["ros__parameters"]
 
     composable_nodes = [
         ComposableNode(
@@ -89,13 +101,11 @@ def generate_launch_description():
             ],
             parameters=[
                 {
-                    "map_resolution": 0.5,
-                    "use_height_filter": True,
                     "input_obstacle_pointcloud": LaunchConfiguration("input_obstacle_pointcloud"),
                     "input_obstacle_and_raw_pointcloud": LaunchConfiguration(
                         "input_obstacle_and_raw_pointcloud"
                     ),
-                }
+                }.update(laserscan_based_occupancy_grid_map_node_params)
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),

--- a/perception/probabilistic_occupancy_grid_map/launch/pointcloud_based_occupancy_grid_map.launch.py
+++ b/perception/probabilistic_occupancy_grid_map/launch/pointcloud_based_occupancy_grid_map.launch.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import SetLaunchConfiguration
@@ -23,6 +26,7 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
+import yaml
 
 
 def generate_launch_description():
@@ -41,6 +45,16 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration("use_multithread")),
     )
 
+    # load parameter files
+    param_file = os.path.join(
+        get_package_share_directory("probablistic_occupancy_grid_map"),
+        "config/pointcloud_based_occupancy_grid_map.param.yaml",
+    )
+    with open(param_file, "r") as f:
+        pointcloud_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"][
+            "ros__parameters"
+        ]
+
     composable_nodes = [
         ComposableNode(
             package="probabilistic_occupancy_grid_map",
@@ -51,12 +65,7 @@ def generate_launch_description():
                 ("~/input/raw_pointcloud", LaunchConfiguration("input/raw_pointcloud")),
                 ("~/output/occupancy_grid_map", LaunchConfiguration("output")),
             ],
-            parameters=[
-                {
-                    "map_resolution": 0.5,
-                    "use_height_filter": True,
-                }
-            ],
+            parameters=[pointcloud_based_occupancy_grid_map_node_params],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),
     ]

--- a/perception/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
@@ -82,7 +82,7 @@ bool cropPointcloudByHeight(
   return true;
 }
 
-geometry_msgs::msg::Pose getPose(
+[[maybe_unused]] geometry_msgs::msg::Pose getPose(
   const std_msgs::msg::Header & source_header, const tf2_ros::Buffer & tf2,
   const std::string & target_frame)
 {
@@ -112,6 +112,7 @@ LaserscanBasedOccupancyGridMapNode::LaserscanBasedOccupancyGridMapNode(
   /* params */
   map_frame_ = declare_parameter("map_frame", "map");
   base_link_frame_ = declare_parameter("base_link_frame", "base_link");
+  output_frame_ = declare_parameter("output_frame", "velodyne_top");
   use_height_filter_ = declare_parameter("use_height_filter", true);
   enable_single_frame_mode_ = declare_parameter("enable_single_frame_mode", false);
   const double map_length{declare_parameter("map_length", 100.0)};
@@ -213,7 +214,12 @@ void LaserscanBasedOccupancyGridMapNode::onLaserscanPointCloud2WithObstacleAndRa
     transformPointcloud(*laserscan_pc_ptr, *tf2_, map_frame_, trans_laserscan_pc);
     transformPointcloud(filtered_obstacle_pc, *tf2_, map_frame_, trans_obstacle_pc);
     transformPointcloud(filtered_raw_pc, *tf2_, map_frame_, trans_raw_pc);
-    pose = getPose(laserscan_pc_ptr->header, *tf2_, map_frame_);
+    // pose = getPose(laserscan_pc_ptr->header, *tf2_, map_frame_);
+    geometry_msgs::msg::TransformStamped tf_stamped;
+    tf_stamped = tf2_->lookupTransform(
+      map_frame_, output_frame_, laserscan_pc_ptr->header.stamp,
+      rclcpp::Duration::from_seconds(0.5));
+    pose = tier4_autoware_utils::transform2pose(tf_stamped.transform);
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN_STREAM(get_logger(), ex.what());
     return;

--- a/perception/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
@@ -112,7 +112,7 @@ LaserscanBasedOccupancyGridMapNode::LaserscanBasedOccupancyGridMapNode(
   /* params */
   map_frame_ = declare_parameter("map_frame", "map");
   base_link_frame_ = declare_parameter("base_link_frame", "base_link");
-  output_frame_ = declare_parameter("output_frame", "velodyne_top");
+  output_frame_ = declare_parameter("output_frame", "base_link");
   use_height_filter_ = declare_parameter("use_height_filter", true);
   enable_single_frame_mode_ = declare_parameter("enable_single_frame_mode", false);
   const double map_length{declare_parameter("map_length", 100.0)};

--- a/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
@@ -160,9 +160,17 @@ void OccupancyGridMap::updateOrigin(double new_origin_x, double new_origin_y)
   delete[] local_map;
 }
 
+/**
+ * @brief update Gridmap with PointCloud
+ *
+ * @param raw_pointcloud raw point cloud on a certain frame (usually base_link)
+ * @param obstacle_pointcloud raw point cloud on a certain frame (usually base_link)
+ * @param robot_pose frame of point cloud (usually base_link)
+ * @param gridmap_origin manually chosen grid map origin frame
+ */
 void OccupancyGridMap::updateWithPointCloud(
   const PointCloud2 & raw_pointcloud, const PointCloud2 & obstacle_pointcloud,
-  const Pose & robot_pose)
+  const Pose & robot_pose, const Pose & gridmap_origin)
 {
   constexpr double min_angle = tier4_autoware_utils::deg2rad(-180.0);
   constexpr double max_angle = tier4_autoware_utils::deg2rad(180.0);
@@ -240,7 +248,7 @@ void OccupancyGridMap::updateWithPointCloud(
                        : obstacle_pointcloud_angle_bin.back();
     }
     raytrace(
-      robot_pose.position.x, robot_pose.position.y, end_distance.wx, end_distance.wy,
+      gridmap_origin.position.x, gridmap_origin.position.y, end_distance.wx, end_distance.wy,
       occupancy_cost_value::FREE_SPACE);
   }
 

--- a/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -111,7 +111,7 @@ PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
   /* params */
   map_frame_ = declare_parameter("map_frame", "map");
   base_link_frame_ = declare_parameter("base_link_frame", "base_link");
-  output_frame_ = declare_parameter("output_frame", "velodyne_top");
+  output_frame_ = declare_parameter("output_frame", "base_link");
   use_height_filter_ = declare_parameter("use_height_filter", true);
   enable_single_frame_mode_ = declare_parameter("enable_single_frame_mode", false);
   const double map_length{declare_parameter("map_length", 100.0)};

--- a/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -111,6 +111,7 @@ PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
   /* params */
   map_frame_ = declare_parameter("map_frame", "map");
   base_link_frame_ = declare_parameter("base_link_frame", "base_link");
+  output_frame_ = declare_parameter("output_frame", "velodyne_top");
   use_height_filter_ = declare_parameter("use_height_filter", true);
   enable_single_frame_mode_ = declare_parameter("enable_single_frame_mode", false);
   const double map_length{declare_parameter("map_length", 100.0)};
@@ -171,9 +172,14 @@ void PointcloudBasedOccupancyGridMapNode::onPointcloudWithObstacleAndRaw(
   const PointCloud2 & filtered_raw_pc = use_height_filter_ ? cropped_raw_pc : *input_raw_msg;
 
   // Get from map to sensor frame pose
-  Pose pose{};
+  Pose robot_pose{};
+  Pose gridmap_origin{};
   try {
-    pose = getPose(input_raw_msg->header, *tf2_, map_frame_);
+    robot_pose = getPose(input_raw_msg->header, *tf2_, map_frame_);
+    geometry_msgs::msg::TransformStamped tf_stamped;
+    tf_stamped = tf2_->lookupTransform(
+      map_frame_, output_frame_, input_raw_msg->header.stamp, rclcpp::Duration::from_seconds(0.5));
+    gridmap_origin = tier4_autoware_utils::transform2pose(tf_stamped.transform);
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN_STREAM(get_logger(), ex.what());
     return;
@@ -185,21 +191,24 @@ void PointcloudBasedOccupancyGridMapNode::onPointcloudWithObstacleAndRaw(
     occupancy_grid_map_updater_ptr_->getSizeInCellsY(),
     occupancy_grid_map_updater_ptr_->getResolution());
   single_frame_occupancy_grid_map.updateOrigin(
-    pose.position.x - single_frame_occupancy_grid_map.getSizeInMetersX() / 2,
-    pose.position.y - single_frame_occupancy_grid_map.getSizeInMetersY() / 2);
-  single_frame_occupancy_grid_map.updateWithPointCloud(filtered_raw_pc, filtered_obstacle_pc, pose);
+    gridmap_origin.position.x - single_frame_occupancy_grid_map.getSizeInMetersX() / 2,
+    gridmap_origin.position.y - single_frame_occupancy_grid_map.getSizeInMetersY() / 2);
+  single_frame_occupancy_grid_map.updateWithPointCloud(
+    filtered_raw_pc, filtered_obstacle_pc, robot_pose, gridmap_origin);
 
   if (enable_single_frame_mode_) {
     // publish
     occupancy_grid_map_pub_->publish(OccupancyGridMapToMsgPtr(
-      map_frame_, input_raw_msg->header.stamp, pose.position.z, single_frame_occupancy_grid_map));
+      map_frame_, input_raw_msg->header.stamp, robot_pose.position.z,
+      single_frame_occupancy_grid_map));  // (todo) robot_pose may be altered with gridmap_origin
   } else {
     // Update with bayes filter
     occupancy_grid_map_updater_ptr_->update(single_frame_occupancy_grid_map);
 
     // publish
     occupancy_grid_map_pub_->publish(OccupancyGridMapToMsgPtr(
-      map_frame_, input_raw_msg->header.stamp, pose.position.z, *occupancy_grid_map_updater_ptr_));
+      map_frame_, input_raw_msg->header.stamp, robot_pose.position.z,
+      *occupancy_grid_map_updater_ptr_));
   }
 
   if (debug_publisher_ptr_ && stop_watch_ptr_) {


### PR DESCRIPTION
## Description
According to https://github.com/autowarefoundation/autoware.universe/issues/2906, grid map origin should be mutable depending on the use-case.

This PR tries to provide variable-frame-orientated grid map. (Called plan A in above issue)

![](https://user-images.githubusercontent.com/20086766/219593386-ac4a00b2-a426-4a4e-a2d6-be3d5d7fedea.png)

TODO:
- Not using specific frame name (currently I set `velodyne_top` ), using main LiDAR message header to represent target frame should be better

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
