### PR TITLE
fix(tier4_perception_launch): remove unnecessary node

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -72,13 +72,6 @@
         <arg name="output/objects" value="objects_with_feature"/>
       </include>
     </group>
-    <!-- convert DynamicObjectsWithFeatureArray to DynamicObjects -->
-    <group>
-      <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
-        <arg name="input" value="objects_with_feature"/>
-        <arg name="output" value="objects"/>
-      </include>
-    </group>
 
     <group>
       <let name="input/clustering" value="/perception/object_recognition/detection/clustering/clusters"/>


### PR DESCRIPTION
## Description

This PR to remove `clustering/detected_object_feature_remover`  from detection architecture since it becomes unnecessary after PR #2845 is merged.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
