### PR TITLE
refactor(control_performance_analysis): delete default values

### DIFF
--- a/control/control_performance_analysis/src/control_performance_analysis_node.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_node.cpp
@@ -45,14 +45,14 @@ ControlPerformanceAnalysisNode::ControlPerformanceAnalysisNode(
   param_.wheelbase_ = vehicle_info.wheel_base_m;
 
   // Node Parameters.
-  param_.curvature_interval_length_ = declare_parameter("curvature_interval_length", 10.0);
-  param_.prevent_zero_division_value_ = declare_parameter("prevent_zero_division_value", 0.001);
-  param_.odom_interval_ = declare_parameter("odom_interval", 2);
+  param_.curvature_interval_length_ = declare_parameter<double>("curvature_interval_length");
+  param_.prevent_zero_division_value_ = declare_parameter<double>("prevent_zero_division_value");
+  param_.odom_interval_ = declare_parameter<int>("odom_interval");
   param_.acceptable_max_distance_to_waypoint_ =
-    declare_parameter("acceptable_max_distance_to_waypoint", 1.5);
+    declare_parameter<double>("acceptable_max_distance_to_waypoint");
   param_.acceptable_max_yaw_difference_rad_ =
-    declare_parameter("acceptable_max_yaw_difference_rad", 1.0472);
-  param_.lpf_gain_ = declare_parameter("low_pass_filter_gain", 0.8);
+    declare_parameter<double>("acceptable_max_yaw_difference_rad");
+  param_.lpf_gain_ = declare_parameter<double>("low_pass_filter_gain");
 
   // Prepare error computation class with the wheelbase parameter.
   control_performance_core_ptr_ = std::make_unique<ControlPerformanceAnalysisCore>(param_);


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[controller_performance_analysis_delete_param.webm](https://user-images.githubusercontent.com/100691117/221135283-d6985907-c211-4fce-a7d8-6090941f644a.webm)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
