### PR TITLE
refactor(obstacle_collision_checker): delete default values

### DIFF
--- a/control/obstacle_collision_checker/src/obstacle_collision_checker_node/obstacle_collision_checker_node.cpp
+++ b/control/obstacle_collision_checker/src/obstacle_collision_checker_node/obstacle_collision_checker_node.cpp
@@ -52,14 +52,14 @@ ObstacleCollisionCheckerNode::ObstacleCollisionCheckerNode(const rclcpp::NodeOpt
   using std::placeholders::_1;
 
   // Node Parameter
-  node_param_.update_rate = declare_parameter("update_rate", 10.0);
+  node_param_.update_rate = declare_parameter<double>("update_rate");
 
   // Core Parameter
-  param_.delay_time = declare_parameter("delay_time", 0.3);
-  param_.footprint_margin = declare_parameter("footprint_margin", 0.0);
-  param_.max_deceleration = declare_parameter("max_deceleration", 2.0);
-  param_.resample_interval = declare_parameter("resample_interval", 0.5);
-  param_.search_radius = declare_parameter("search_radius", 5.0);
+  param_.delay_time = declare_parameter<double>("delay_time");
+  param_.footprint_margin = declare_parameter<double>("footprint_margin");
+  param_.max_deceleration = declare_parameter<double>("max_deceleration");
+  param_.resample_interval = declare_parameter<double>("resample_interval");
+  param_.search_radius = declare_parameter<double>("search_radius");
 
   // Dynamic Reconfigure
   set_param_res_ = this->add_on_set_parameters_callback(


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[obstacle_collision_checker_delete_param.webm](https://user-images.githubusercontent.com/100691117/221145444-a14a3547-31d8-42ba-aa84-5374407451b8.webm)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
