### PR TITLE
refactor(shift_decider): delete default values

### DIFF
--- a/control/shift_decider/src/shift_decider.cpp
+++ b/control/shift_decider/src/shift_decider.cpp
@@ -30,7 +30,7 @@ ShiftDecider::ShiftDecider(const rclcpp::NodeOptions & node_options)
   rclcpp::QoS durable_qos(queue_size);
   durable_qos.transient_local();
 
-  park_on_goal_ = declare_parameter("park_on_goal", true);
+  park_on_goal_ = declare_parameter<bool>("park_on_goal");
 
   pub_shift_cmd_ =
     create_publisher<autoware_auto_vehicle_msgs::msg::GearCommand>("output/gear_cmd", durable_qos);


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[shift_decider_delete_param.webm](https://user-images.githubusercontent.com/100691117/221151774-d0c33d41-34c1-4cdb-98ea-05b50e73f5bc.webm)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
