### PR TITLE
fix(avoidance): output stop point inserted reference path

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -50,6 +50,10 @@ public:
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
   BT::NodeStatus updateState() override;
+  BT::NodeStatus getNodeStatusWhileWaitingApproval() const override
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
   BehaviorModuleOutput plan() override;
   CandidateOutput planCandidate() const override;
   BehaviorModuleOutput planWaitingApproval() override;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1008,11 +1008,12 @@ bool BehaviorPathPlannerNode::skipSmoothGoalConnection(
 bool BehaviorPathPlannerNode::keepInputPoints(
   const std::vector<std::shared_ptr<SceneModuleStatus>> & statuses) const
 {
-  const auto target_module = "PullOver";
+  const auto target_module_1 = "PullOver";
+  const auto target_module_2 = "Avoidance";
 
   for (auto & status : statuses) {
     if (status->is_waiting_approval || status->status == BT::NodeStatus::RUNNING) {
-      if (target_module == status->module_name) {
+      if (target_module_1 == status->module_name || target_module_2 == status->module_name) {
         return true;
       }
     }


### PR DESCRIPTION
## Description

The avoidance module outputs customized (stop/decel point inserted) reference path in waiting approval phase, but for now, the  node don't output the avoidance's customized path.

![rviz_screenshot_2023_02_26-16_01_17](https://user-images.githubusercontent.com/44889564/221397130-f7e348f1-42da-453c-8432-ac2edff8eef5.png)

In this PR, it is able to output customized reference path even if it is in waiting approval phase.

![rviz_screenshot_2023_02_26-15_52_40](https://user-images.githubusercontent.com/44889564/221397125-441f0594-8ff7-4aac-95b1-5151e071292c.png)

**NOTE: pull out/over is fixed in following PR.**
https://github.com/autowarefoundation/autoware.universe/pull/2577

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
