### PR TITLE
fix(planning_error_monitor): delete default values

### DIFF
--- a/planning/planning_error_monitor/src/planning_error_monitor_node.cpp
+++ b/planning/planning_error_monitor/src/planning_error_monitor_node.cpp
@@ -54,10 +54,10 @@ PlanningErrorMonitorNode::PlanningErrorMonitorNode(const rclcpp::NodeOptions & n
     this, get_clock(), 100ms, std::bind(&PlanningErrorMonitorNode::onTimer, this));
 
   // Parameter
-  error_interval_ = declare_parameter("error_interval", 100.0);
-  error_curvature_ = declare_parameter("error_curvature", 1.0);
-  error_sharp_angle_ = declare_parameter("error_sharp_angle", M_PI_4);
-  ignore_too_close_points_ = declare_parameter("ignore_too_close_points", 0.05);
+  error_interval_ = declare_parameter<double>("error_interval");
+  error_curvature_ = declare_parameter<double>("error_curvature");
+  error_sharp_angle_ = declare_parameter<double>("error_sharp_angle");
+  ignore_too_close_points_ = declare_parameter<double>("ignore_too_close_points");
 }
 
 void PlanningErrorMonitorNode::onTimer()


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[planning_error_monitor_delete_param.webm](https://user-images.githubusercontent.com/100691117/221405792-6ed91ada-4ab5-46c3-98e5-f3f459e5a35e.webm)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
