### PR TITLE
fix(autoware_state_panel): change variable for fail safe behavior

### DIFF
--- a/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -488,7 +488,7 @@ void AutowareStatePanel::onMRMState(const MRMState::ConstSharedPtr msg)
   {
     QString text = "";
     QString style_sheet = "";
-    switch (msg->state) {
+    switch (msg->behavior) {
       case MRMState::NONE:
         text = "NONE";
         style_sheet = "background-color: #00FF00;";  // green


### PR DESCRIPTION
## Description

The reference variable for fail safe behavior was incorrect and has been corrected.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
