### PR TITLE
feat(obstacle_stop_planner): add margin behind goal

### DIFF
--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -92,7 +92,7 @@ This module has parameter `hold_stop_margin_distance` in order to prevent from t
 | Parameter                             | Type   | Description                                                                                                                                    |
 | ------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `max_longitudinal_margin`             | double | margin between obstacle and the ego's front [m]                                                                                                |
-| `max_longitudinal_margin_behind_goal` | double | margin between obstacle and the ego's front when the stop point is behind the goal[m]                                                                 |
+| `max_longitudinal_margin_behind_goal` | double | margin between obstacle and the ego's front when the stop point is behind the goal[m]                                                          |
 | `min_longitudinal_margin`             | double | if any obstacle exists within `max_longitudinal_margin`, this module set margin as the value of _stop margin_ to `min_longitudinal_margin` [m] |
 | `hold_stop_margin_distance`           | double | parameter for restart prevention (See above section) [m]                                                                                       |
 

--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -89,11 +89,12 @@ This module has parameter `hold_stop_margin_distance` in order to prevent from t
 
 #### Stop position
 
-| Parameter                   | Type   | Description                                                                                                                                    |
-| --------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `max_longitudinal_margin`   | double | margin between obstacle and the ego's front [m]                                                                                                |
-| `min_longitudinal_margin`   | double | if any obstacle exists within `max_longitudinal_margin`, this module set margin as the value of _stop margin_ to `min_longitudinal_margin` [m] |
-| `hold_stop_margin_distance` | double | parameter for restart prevention (See above section) [m]                                                                                       |
+| Parameter                             | Type   | Description                                                                                                                                    |
+| ------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_longitudinal_margin`             | double | margin between obstacle and the ego's front [m]                                                                                                |
+| `max_longitudinal_margin_behind_goal` | double | margin between obstacle and the ego's front when the stop point is behind the goal[m]                                                                 |
+| `min_longitudinal_margin`             | double | if any obstacle exists within `max_longitudinal_margin`, this module set margin as the value of _stop margin_ to `min_longitudinal_margin` [m] |
+| `hold_stop_margin_distance`           | double | parameter for restart prevention (See above section) [m]                                                                                       |
 
 #### Obstacle detection area
 

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -14,9 +14,10 @@
     stop_planner:
       # params for stop position
       stop_position:
-        max_longitudinal_margin: 5.0         # stop margin distance from obstacle on the path [m]
-        min_longitudinal_margin: 2.0         # stop margin distance when any other stop point is inserted in stop margin [m]
-        hold_stop_margin_distance: 0.0       # the ego keeps stopping if the ego is in this margin [m]
+        max_longitudinal_margin: 5.0             # stop margin distance from obstacle on the path [m]
+        max_longitudinal_margin_behind_goal: 3.0 # stop margin distance from obstacle behind the goal on the path [m]
+        min_longitudinal_margin: 2.0             # stop margin distance when any other stop point is inserted in stop margin [m]
+        hold_stop_margin_distance: 0.0           # the ego keeps stopping if the ego is in this margin [m]
 
       # params for detection area
       detection_area:

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -182,7 +182,7 @@ private:
   void insertVelocity(
     TrajectoryPoints & trajectory, PlannerData & planner_data, const Header & trajectory_header,
     const VehicleInfo & vehicle_info, const double current_acc, const double current_vel,
-    const StopParam & stop_param);
+    const StopParam & stop_param, const Pose & goal_pose);
 
   bool searchPointcloudNearTrajectory(
     const TrajectoryPoints & trajectory, const PointCloud2::ConstSharedPtr & input_points_ptr,
@@ -195,7 +195,7 @@ private:
 
   StopPoint searchInsertPoint(
     const int idx, const TrajectoryPoints & base_trajectory, const double dist_remain,
-    const StopParam & stop_param);
+    const StopParam & stop_param, const Pose & goal_pose);
 
   SlowDownSection createSlowDownSection(
     const int idx, const TrajectoryPoints & base_trajectory, const double lateral_deviation,

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -182,7 +182,7 @@ private:
   void insertVelocity(
     TrajectoryPoints & trajectory, PlannerData & planner_data, const Header & trajectory_header,
     const VehicleInfo & vehicle_info, const double current_acc, const double current_vel,
-    const StopParam & stop_param, const Pose & goal_pose);
+    const StopParam & stop_param);
 
   bool searchPointcloudNearTrajectory(
     const TrajectoryPoints & trajectory, const PointCloud2::ConstSharedPtr & input_points_ptr,
@@ -195,7 +195,7 @@ private:
 
   StopPoint searchInsertPoint(
     const int idx, const TrajectoryPoints & base_trajectory, const double dist_remain,
-    const StopParam & stop_param, const Pose & goal_pose);
+    const StopParam & stop_param);
 
   SlowDownSection createSlowDownSection(
     const int idx, const TrajectoryPoints & base_trajectory, const double lateral_deviation,

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
@@ -99,6 +99,7 @@ struct StopParam
 
   // margin between obstacle and the ego's front [m]
   double max_longitudinal_margin;
+  double max_longitudinal_margin_behind_goal;
 
   // margin between obstacle and the ego's front [m]
   // if any other stop point is inserted within max_longitudinal_margin.

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -85,6 +85,8 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
     // params for stop position
     p.max_longitudinal_margin =
       declare_parameter<double>(ns + "stop_position.max_longitudinal_margin");
+    p.max_longitudinal_margin_behind_goal =
+      declare_parameter<double>(ns + "stop_position.max_longitudinal_margin_behind_goal");
     p.min_longitudinal_margin =
       declare_parameter<double>(ns + "stop_position.min_longitudinal_margin");
     p.hold_stop_margin_distance =
@@ -104,6 +106,7 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode(const rclcpp::NodeOptions & nod
 
     // apply offset
     p.max_longitudinal_margin += i.max_longitudinal_offset_m;
+    p.max_longitudinal_margin_behind_goal += i.max_longitudinal_offset_m;
     p.min_longitudinal_margin += i.max_longitudinal_offset_m;
     p.stop_search_radius =
       p.step_length +
@@ -316,6 +319,9 @@ void ObstacleStopPlannerNode::onTrigger(const Trajectory::ConstSharedPtr input_m
     motion_utils::convertToTrajectoryPointArray(*input_msg), planner_data.current_pose,
     planner_data.trajectory_trim_index);
 
+  // get goal pose for margin after goal
+  const Pose goal_pose = base_trajectory.back().pose;
+
   // extend trajectory to consider obstacles after the goal
   if (stop_param.enable_stop_behind_goal_for_obstacle) {
     base_trajectory = extendTrajectory(base_trajectory, stop_param.max_longitudinal_margin);
@@ -336,7 +342,7 @@ void ObstacleStopPlannerNode::onTrigger(const Trajectory::ConstSharedPtr input_m
   // insert slow-down-section/stop-point
   insertVelocity(
     output_trajectory_points, planner_data, input_msg->header, vehicle_info, current_acc,
-    current_vel, stop_param);
+    current_vel, stop_param, goal_pose);
 
   const auto no_slow_down_section = !planner_data.slow_down_require && !latest_slow_down_section_;
   if (node_param_.enable_slow_down && no_slow_down_section && set_velocity_limit_) {
@@ -1079,7 +1085,8 @@ void ObstacleStopPlannerNode::searchPredictedObject(
 void ObstacleStopPlannerNode::insertVelocity(
   TrajectoryPoints & output, PlannerData & planner_data,
   [[maybe_unused]] const Header & trajectory_header, const VehicleInfo & vehicle_info,
-  const double current_acc, const double current_vel, const StopParam & stop_param)
+  const double current_acc, const double current_vel, const StopParam & stop_param,
+  const Pose & goal_pose)
 {
   const auto & base_link2front = vehicle_info.max_longitudinal_offset_m;
 
@@ -1113,8 +1120,8 @@ void ObstacleStopPlannerNode::insertVelocity(
         dist_baselink_to_obstacle + index_with_dist_remain.get().second - base_link2front);
 
       const auto stop_point = searchInsertPoint(
-        index_with_dist_remain.get().first, output, index_with_dist_remain.get().second,
-        stop_param);
+        index_with_dist_remain.get().first, output, index_with_dist_remain.get().second, stop_param,
+        goal_pose);
 
       const auto & ego_pose = planner_data.current_pose;
       const size_t ego_seg_idx = findFirstNearestIndexWithSoftConstraints(
@@ -1295,10 +1302,17 @@ void ObstacleStopPlannerNode::onExpandStopRange(const ExpandStopRange::ConstShar
 
 StopPoint ObstacleStopPlannerNode::searchInsertPoint(
   const int idx, const TrajectoryPoints & base_trajectory, const double dist_remain,
-  const StopParam & stop_param)
+  const StopParam & stop_param, const Pose & goal_pose)
 {
+  const int goal_idx = findFirstNearestIndexWithSoftConstraints(
+    base_trajectory, goal_pose, node_param_.ego_nearest_dist_threshold,
+    node_param_.ego_nearest_yaw_threshold);
+  const double max_longitudinal_margin = idx > goal_idx
+                                           ? stop_param.max_longitudinal_margin_behind_goal
+                                           : stop_param.max_longitudinal_margin;
+
   const auto max_dist_stop_point =
-    createTargetPoint(idx, stop_param.max_longitudinal_margin, base_trajectory, dist_remain);
+    createTargetPoint(idx, max_longitudinal_margin, base_trajectory, dist_remain);
   const auto min_dist_stop_point =
     createTargetPoint(idx, stop_param.min_longitudinal_margin, base_trajectory, dist_remain);
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Add margin for the obstacle behind the goal.


https://user-images.githubusercontent.com/39142679/221567808-deae4b13-b1e1-4200-87d3-b8bf44f439de.mp4


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

- psim
- [tier4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/bcb5ece4-8953-57cb-95e0-d0b58beb845c?project_id=prd_jt) 811/814

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
