### PR TITLE
perf(compare_map_segmentation): replace nearestKSearch by radiusSearch

### DIFF
--- a/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
@@ -58,8 +58,7 @@ void VoxelDistanceBasedCompareMapFilterComponent::filter(
     if (index == -1) {                 // empty voxel
       std::vector<int> nn_indices(1);  // nn means nearest neighbor
       std::vector<float> nn_distances(1);
-      tree_->nearestKSearch(pcl_input->points.at(i), 1, nn_indices, nn_distances);
-      if (distance_threshold_ * distance_threshold_ < nn_distances.at(0)) {
+      if (tree_->radiusSearch(pcl_input->points.at(i), distance_threshold_, nn_indices, nn_distances, 1) == 0) {
         pcl_output->points.push_back(pcl_input->points.at(i));
       }
     }

--- a/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
@@ -58,7 +58,9 @@ void VoxelDistanceBasedCompareMapFilterComponent::filter(
     if (index == -1) {                 // empty voxel
       std::vector<int> nn_indices(1);  // nn means nearest neighbor
       std::vector<float> nn_distances(1);
-      if (tree_->radiusSearch(pcl_input->points.at(i), distance_threshold_, nn_indices, nn_distances, 1) == 0) {
+      if (
+        tree_->radiusSearch(
+          pcl_input->points.at(i), distance_threshold_, nn_indices, nn_distances, 1) == 0) {
         pcl_output->points.push_back(pcl_input->points.at(i));
       }
     }


### PR DESCRIPTION
radiusSearch is faster than nearestKSearch as the search stops once no neighbor within the given radius is found (which is what we want to know here).

## Description

See https://pointclouds.org/documentation/classpcl_1_1search_1_1_search.html#af803bbb855706159fa2cd36e4e8f0c58

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
