### PR TITLE
refactor(lane_departure_checker): delete default values

### DIFF
--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -126,25 +126,25 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   using std::placeholders::_1;
 
   // Node Parameter
-  node_param_.update_rate = declare_parameter("update_rate", 10.0);
-  node_param_.visualize_lanelet = declare_parameter("visualize_lanelet", false);
-  node_param_.include_right_lanes = declare_parameter("include_right_lanes", false);
-  node_param_.include_left_lanes = declare_parameter("include_left_lanes", false);
-  node_param_.include_opposite_lanes = declare_parameter("include_opposite_lanes", false);
-  node_param_.include_conflicting_lanes = declare_parameter("include_conflicting_lanes", false);
+  node_param_.update_rate = declare_parameter<double>("update_rate");
+  node_param_.visualize_lanelet = declare_parameter<bool>("visualize_lanelet");
+  node_param_.include_right_lanes = declare_parameter<bool>("include_right_lanes");
+  node_param_.include_left_lanes = declare_parameter<bool>("include_left_lanes");
+  node_param_.include_opposite_lanes = declare_parameter<bool>("include_opposite_lanes");
+  node_param_.include_conflicting_lanes = declare_parameter<bool>("include_conflicting_lanes");
 
   // Vehicle Info
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();
   vehicle_length_m_ = vehicle_info.vehicle_length_m;
 
   // Core Parameter
-  param_.footprint_margin_scale = declare_parameter("footprint_margin_scale", 1.0);
-  param_.resample_interval = declare_parameter("resample_interval", 0.3);
-  param_.max_deceleration = declare_parameter("max_deceleration", 3.0);
-  param_.delay_time = declare_parameter("delay_time", 0.3);
-  param_.max_lateral_deviation = declare_parameter("max_lateral_deviation", 1.0);
-  param_.max_longitudinal_deviation = declare_parameter("max_longitudinal_deviation", 1.0);
-  param_.max_yaw_deviation_deg = declare_parameter("max_yaw_deviation_deg", 30.0);
+  param_.footprint_margin_scale = declare_parameter<double>("footprint_margin_scale");
+  param_.resample_interval = declare_parameter<double>("resample_interval");
+  param_.max_deceleration = declare_parameter<double>("max_deceleration");
+  param_.delay_time = declare_parameter<double>("delay_time");
+  param_.max_lateral_deviation = declare_parameter<double>("max_lateral_deviation");
+  param_.max_longitudinal_deviation = declare_parameter<double>("max_longitudinal_deviation");
+  param_.max_yaw_deviation_deg = declare_parameter<double>("max_yaw_deviation_deg");
   param_.ego_nearest_dist_threshold = declare_parameter<double>("ego_nearest_dist_threshold");
   param_.ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
   param_.min_braking_distance = declare_parameter<double>("min_braking_distance");


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[lane_departure_checker_delete_param.webm](https://user-images.githubusercontent.com/100691117/222089548-f6a7258f-a137-405f-995c-fa627cb701eb.webm)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
