### PR TITLE
fix(pointcloud_preprocessor): throw error if crop box input frame is missing

### DIFF
--- a/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
@@ -80,6 +80,9 @@ CropBoxFilterComponent::CropBoxFilterComponent(const rclcpp::NodeOptions & optio
     p.max_y = static_cast<float>(declare_parameter("max_y", 1.0));
     p.max_z = static_cast<float>(declare_parameter("max_z", 1.0));
     p.negative = static_cast<float>(declare_parameter("negative", false));
+    if (tf_input_frame_.empty()) {
+      throw std::invalid_argument("Crop box requires non-empty input_frame");
+    }
   }
 
   // set additional publishers


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
See https://github.com/autowarefoundation/autoware.universe/issues/2974#issuecomment-1451169556

For example, crop box filters in euclidian cluster container would crash early before https://github.com/autowarefoundation/autoware.universe/pull/2979 fix:
```
[ERROR 1677724830.546998321] [perception.object_recognition.detection.clustering.euclidean_cluster_container]: Component constructor threw an exception: Crop box requires non-empty input_frame (on_load_node() at ./src/component_manager.cpp:278)
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
