### PR TITLE
feat(tensorrt_yolox): add build only option for tensorrt engine

### DIFF
--- a/perception/tensorrt_yolox/README.md
+++ b/perception/tensorrt_yolox/README.md
@@ -29,20 +29,21 @@ Zheng Ge, Songtao Liu, Feng Wang, Zeming Li, Jian Sun, "YOLOX: Exceeding YOLO Se
 
 ### Core Parameters
 
-| Name              | Type  | Default Value | Description                                                                           |
-| ----------------- | ----- | ------------- | ------------------------------------------------------------------------------------- |
-| `score_threshold` | float | 0.3           | If the objectness score is less than this value, the object is ignored in yolo layer. |
-| `nms_threshold`   | float | 0.7           | The IoU threshold for NMS method                                                      |
+| Name              | Type  | Default Value | Description                                                                            |
+| ----------------- | ----- | ------------- | -------------------------------------------------------------------------------------- |
+| `score_threshold` | float | 0.3           | If the objectness score is less than this value, the object is ignored in yolox layer. |
+| `nms_threshold`   | float | 0.7           | The IoU threshold for NMS method                                                       |
 
 **NOTE:** These two parameters are only valid for "plain" model (described later).
 
 ### Node Parameters
 
-| Name         | Type   | Default Value | Description                                                        |
-| ------------ | ------ | ------------- | ------------------------------------------------------------------ |
-| `onnx_file`  | string | ""            | The onnx file name for yolo model                                  |
-| `label_file` | string | ""            | The label file with label names for detected objects written on it |
-| `mode`       | string | "fp32"        | The inference mode: "fp32", "fp16", "int8"                         |
+| Name            | Type   | Default Value | Description                                                        |
+| --------------- | ------ | ------------- | ------------------------------------------------------------------ |
+| `model_path`    | string | ""            | The onnx file name for yolox model                                 |
+| `label_path`    | string | ""            | The label file with label names for detected objects written on it |
+| `trt_precision` | string | "fp32"        | The inference mode: "fp32", "fp16", "int8"                         |
+| `build_only`    | bool   | false         | shutdown node after TensorRT engin file is built                   |
 
 ## Assumptions / Known limits
 

--- a/perception/tensorrt_yolox/README.md
+++ b/perception/tensorrt_yolox/README.md
@@ -43,7 +43,7 @@ Zheng Ge, Songtao Liu, Feng Wang, Zeming Li, Jian Sun, "YOLOX: Exceeding YOLO Se
 | `model_path`    | string | ""            | The onnx file name for yolox model                                 |
 | `label_path`    | string | ""            | The label file with label names for detected objects written on it |
 | `trt_precision` | string | "fp32"        | The inference mode: "fp32", "fp16", "int8"                         |
-| `build_only`    | bool   | false         | shutdown node after TensorRT engin file is built                   |
+| `build_only`    | bool   | false         | shutdown node after TensorRT engine file is built                  |
 
 ## Assumptions / Known limits
 

--- a/perception/tensorrt_yolox/launch/yolox.launch.xml
+++ b/perception/tensorrt_yolox/launch/yolox.launch.xml
@@ -7,6 +7,7 @@
   <arg name="score_threshold" default="0.35"/>
   <arg name="nms_threshold" default="0.7"/>
   <arg name="use_decompress" default="true" description="use image decompress"/>
+  <arg name="build_only" default="false" description="exit after trt engine has been"/>
 
   <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="image_transport_decompressor_node" if="$(var use_decompress)">
     <remap from="~/input/compressed_image" to="$(var input/image)/compressed"/>
@@ -22,5 +23,6 @@
     <param name="trt_precision" value="fp16"/>
     <param name="score_threshold" value="$(var score_threshold)"/>
     <param name="nms_threshold" value="$(var nms_threshold)"/>
+    <param name="build_only" value="$(var build_only)"/>
   </node>
 </launch>

--- a/perception/tensorrt_yolox/launch/yolox.launch.xml
+++ b/perception/tensorrt_yolox/launch/yolox.launch.xml
@@ -7,7 +7,7 @@
   <arg name="score_threshold" default="0.35"/>
   <arg name="nms_threshold" default="0.7"/>
   <arg name="use_decompress" default="true" description="use image decompress"/>
-  <arg name="build_only" default="false" description="exit after trt engine has been"/>
+  <arg name="build_only" default="false" description="exit after trt engine is built"/>
 
   <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="image_transport_decompressor_node" if="$(var use_decompress)">
     <remap from="~/input/compressed_image" to="$(var input/image)/compressed"/>
@@ -18,11 +18,10 @@
     <remap from="~/in/image" to="$(var input/image)"/>
     <remap from="~/out/objects" to="$(var output/objects)"/>
     <param name="score_threshold" value="$(var score_threshold)"/>
+    <param name="nms_threshold" value="$(var nms_threshold)"/>
     <param name="model_path" value="$(var model_path)/$(var model_name).onnx"/>
     <param name="label_path" value="$(var model_path)/label.txt"/>
     <param name="trt_precision" value="fp16"/>
-    <param name="score_threshold" value="$(var score_threshold)"/>
-    <param name="nms_threshold" value="$(var nms_threshold)"/>
     <param name="build_only" value="$(var build_only)"/>
   </node>
 </launch>

--- a/perception/tensorrt_yolox/package.xml
+++ b/perception/tensorrt_yolox/package.xml
@@ -23,6 +23,7 @@
   <depend>cuda_utils</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
+  <depend>image_transport_decompressor</depend>
   <depend>libopencv-dev</depend>
   <depend>perception_utils</depend>
   <depend>rclcpp</depend>

--- a/perception/tensorrt_yolox/package.xml
+++ b/perception/tensorrt_yolox/package.xml
@@ -23,7 +23,6 @@
   <depend>cuda_utils</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
-  <depend>image_transport_decompressor</depend>
   <depend>libopencv-dev</depend>
   <depend>perception_utils</depend>
   <depend>rclcpp</depend>
@@ -31,6 +30,8 @@
   <depend>sensor_msgs</depend>
   <depend>tensorrt_common</depend>
   <depend>tier4_perception_msgs</depend>
+
+  <exec_depend>image_transport_decompressor</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -41,6 +41,7 @@ TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
   // Detection results will be ignored if IoU over this value.
   // This threshold will be ignored if specified model contains EfficientNMS_TRT module in it
   float nms_threshold = declare_parameter("nms_threshold", 0.7);
+  bool build_only = declare_parameter("build_only", false);
 
   if (!readLabelFile(label_path)) {
     RCLCPP_ERROR(this->get_logger(), "Could not find label file");
@@ -56,6 +57,11 @@ TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
   objects_pub_ = this->create_publisher<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
     "~/out/objects", 1);
   image_pub_ = image_transport::create_publisher(this, "~/out/image");
+
+  if (build_only) {
+    RCLCPP_INFO(this->get_logger(), "TensorRT engine file is built and exit.");
+    rclcpp::shutdown();
+  }
 }
 
 void TrtYoloXNode::onConnect()

--- a/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -41,7 +41,6 @@ TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
   // Detection results will be ignored if IoU over this value.
   // This threshold will be ignored if specified model contains EfficientNMS_TRT module in it
   float nms_threshold = declare_parameter("nms_threshold", 0.7);
-  bool build_only = declare_parameter("build_only", false);
 
   if (!readLabelFile(label_path)) {
     RCLCPP_ERROR(this->get_logger(), "Could not find label file");
@@ -58,7 +57,7 @@ TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
     "~/out/objects", 1);
   image_pub_ = image_transport::create_publisher(this, "~/out/image");
 
-  if (build_only) {
+  if (declare_parameter("build_only", false)) {
     RCLCPP_INFO(this->get_logger(), "TensorRT engine file is built and exit.");
     rclcpp::shutdown();
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- the option to build tensorrt engine without inference is required for test on cloud
- add depend package
- fix documentation

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
