### PR TITLE
feat(traffic_light_classifier): add build only option for tensort engine

### DIFF
--- a/perception/traffic_light_classifier/README.md
+++ b/perception/traffic_light_classifier/README.md
@@ -54,14 +54,15 @@ These colors and shapes are assigned to the message as follows:
 
 #### cnn_classifier
 
-| Name              | Type | Description                          |
-| ----------------- | ---- | ------------------------------------ |
-| `model_file_path` | str  | path to the model file               |
-| `label_file_path` | str  | path to the label file               |
-| `precision`       | str  | TensorRT precision, `fp16` or `int8` |
-| `input_c`         | str  | the channel size of an input image   |
-| `input_h`         | str  | the height of an input image         |
-| `input_w`         | str  | the width of an input image          |
+| Name              | Type | Description                                      |
+| ----------------- | ---- | ------------------------------------------------ |
+| `model_file_path` | str  | path to the model file                           |
+| `label_file_path` | str  | path to the label file                           |
+| `precision`       | str  | TensorRT precision, `fp16` or `int8`             |
+| `input_c`         | str  | the channel size of an input image               |
+| `input_h`         | str  | the height of an input image                     |
+| `input_w`         | str  | the width of an input image                      |
+| `build_only`      | bool | shutdown node after TensorRT engin file is built |
 
 #### hsv_classifier
 

--- a/perception/traffic_light_classifier/src/cnn_classifier.cpp
+++ b/perception/traffic_light_classifier/src/cnn_classifier.cpp
@@ -47,6 +47,11 @@ CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
 
   trt_ = std::make_shared<Tn::TrtCommon>(model_file_path, precision, input_name, output_name);
   trt_->setup();
+
+  if (node_ptr_->declare_parameter("build_only", false)) {
+    RCLCPP_INFO(node_ptr_->get_logger(), "TensorRT engine is built and shutdown node.");
+    rclcpp::shutdown();
+  }
 }
 
 bool CNNClassifier::getTrafficSignal(


### PR DESCRIPTION
## Description

- the option to build tensorrt engine without inference is required for test on cloud

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
