### PR TITLE
fix(motion_velocity_smoother): fix terminal velocity optimization

### DIFF
--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -199,9 +199,11 @@ bool JerkFilteredSmoother::apply(
   }
 
   for (size_t i = 0; i < N; ++i) {
-    const double v_max = std::max(v_max_arr.at(i), 0.1);
-    q.at(IDX_B0 + i) =
-      -1.0 / (v_max * v_max);  // |v_max_i^2 - b_i|/v_max^2 -> minimize (-bi) * ds / v_max^2
+    if (v_max_arr.at(i) > 0.01) {
+      // |v_max_i^2 - b_i|/v_max^2 -> minimize (-bi) * ds / v_max^2
+      // Note that if v_max[i] is too small, we did not minimize the corresponding b[i]
+      q.at(IDX_B0 + i) = -1.0 / (v_max_arr.at(i) * v_max_arr.at(i));
+    }
     if (i < N - 1) {
       q.at(IDX_B0 + i) *= std::max(interval_dist_arr.at(i), 0.0001);
     }

--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -198,10 +198,10 @@ bool JerkFilteredSmoother::apply(
     P(IDX_A0 + i + 1, IDX_A0 + i + 1) += smooth_weight * w_x_ds_inv * w_x_ds_inv * interval_dist;
   }
 
+  // |v_max_i^2 - b_i|/v_max^2 -> minimize (-bi) * ds / v_max^2
   for (size_t i = 0; i < N; ++i) {
     if (v_max_arr.at(i) > 0.01) {
-      // |v_max_i^2 - b_i|/v_max^2 -> minimize (-bi) * ds / v_max^2
-      // Note that if v_max[i] is too small, we did not minimize the corresponding b[i]
+      // Note that if v_max[i] is too small, we did not minimize the corresponding -b[i]
       q.at(IDX_B0 + i) = -1.0 / (v_max_arr.at(i) * v_max_arr.at(i));
     }
     if (i < N - 1) {

--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -202,10 +202,11 @@ bool JerkFilteredSmoother::apply(
   for (size_t i = 0; i < N; ++i) {
     if (v_max_arr.at(i) > 0.01) {
       // Note that if v_max[i] is too small, we did not minimize the corresponding -b[i]
-      q.at(IDX_B0 + i) = -1.0 / (v_max_arr.at(i) * v_max_arr.at(i));
-    }
-    if (i < N - 1) {
-      q.at(IDX_B0 + i) *= std::max(interval_dist_arr.at(i), 0.0001);
+      double v_weight_term = -1.0 / (v_max_arr.at(i) * v_max_arr.at(i));
+      if (i < N - 1) {
+        v_weight_term *= std::max(interval_dist_arr.at(i), 0.0001);
+      }
+      q.at(IDX_B0 + i) += v_weight_term;
     }
     P(IDX_DELTA0 + i, IDX_DELTA0 + i) += over_v_weight;  // over velocity cost
     P(IDX_SIGMA0 + i, IDX_SIGMA0 + i) += over_a_weight;  // over acceleration cost


### PR DESCRIPTION
## Description
Before this PR, motion velocity smoother computes optimal velocity with the terminal velocity = 0.1[m/s] even though we set the terminal velocity as 0.0[m/s]. This is caused by a inappropriate terminal velocity approximation in the optimization setting. In this PR, I fixed it by ignoring the terminal decision variable when the v_max is less than 0.01[m/s].

- Before the PR
```
[motion_velocity_smoother-26] v[0]: 0.25
[motion_velocity_smoother-26] v[1]: 0.287228
[motion_velocity_smoother-26] v[2]: 0.409081
[motion_velocity_smoother-26] v[3]: 0.544225
[motion_velocity_smoother-26] v[4]: 0.676198
[motion_velocity_smoother-26] v[5]: 0.802665
[motion_velocity_smoother-26] v[6]: 0.918985
[motion_velocity_smoother-26] v[7]: 1.02216
[motion_velocity_smoother-26] v[8]: 1.11583
[motion_velocity_smoother-26] v[9]: 1.20223
[motion_velocity_smoother-26] v[10]: 1.28282
[motion_velocity_smoother-26] v[11]: 3.13065
[motion_velocity_smoother-26] v[12]: 4.23153
[motion_velocity_smoother-26] v[13]: 5.09729
[motion_velocity_smoother-26] v[14]: 5.83432
[motion_velocity_smoother-26] v[15]: 6.487
[motion_velocity_smoother-26] v[16]: 7.07891
[motion_velocity_smoother-26] v[17]: 7.62433
[motion_velocity_smoother-26] v[18]: 8.13246
[motion_velocity_smoother-26] v[19]: 8.43285
[motion_velocity_smoother-26] v[20]: 8.50078
[motion_velocity_smoother-26] v[21]: 8.35221
[motion_velocity_smoother-26] v[22]: 7.97319
[motion_velocity_smoother-26] v[23]: 7.45419
[motion_velocity_smoother-26] v[24]: 6.89617
[motion_velocity_smoother-26] v[25]: 6.28872
[motion_velocity_smoother-26] v[26]: 5.61575
[motion_velocity_smoother-26] v[27]: 4.84995
[motion_velocity_smoother-26] v[28]: 3.93714
[motion_velocity_smoother-26] v[29]: 2.73211
[motion_velocity_smoother-26] v[30]: 0.100003
```

- After the PR
```
[motion_velocity_smoother-26] v[0]: 0.25
[motion_velocity_smoother-26] v[1]: 0.287228
[motion_velocity_smoother-26] v[2]: 0.40908
[motion_velocity_smoother-26] v[3]: 0.544224
[motion_velocity_smoother-26] v[4]: 0.676197
[motion_velocity_smoother-26] v[5]: 0.802664
[motion_velocity_smoother-26] v[6]: 0.918984
[motion_velocity_smoother-26] v[7]: 1.02216
[motion_velocity_smoother-26] v[8]: 1.11583
[motion_velocity_smoother-26] v[9]: 1.20222
[motion_velocity_smoother-26] v[10]: 1.28282
[motion_velocity_smoother-26] v[11]: 3.13056
[motion_velocity_smoother-26] v[12]: 4.2314
[motion_velocity_smoother-26] v[13]: 5.09713
[motion_velocity_smoother-26] v[14]: 5.83413
[motion_velocity_smoother-26] v[15]: 6.48679
[motion_velocity_smoother-26] v[16]: 7.07868
[motion_velocity_smoother-26] v[17]: 7.62409
[motion_velocity_smoother-26] v[18]: 8.13246
[motion_velocity_smoother-26] v[19]: 8.61061
[motion_velocity_smoother-26] v[20]: 9.06354
[motion_velocity_smoother-26] v[21]: 9.49486
[motion_velocity_smoother-26] v[22]: 9.9074
[motion_velocity_smoother-26] v[23]: 10.2131
[motion_velocity_smoother-26] v[24]: 10.3581
[motion_velocity_smoother-26] v[25]: 10.3547
[motion_velocity_smoother-26] v[26]: 10.2056
[motion_velocity_smoother-26] v[27]: 9.90129
[motion_velocity_smoother-26] v[28]: 9.48848
[motion_velocity_smoother-26] v[29]: 9.05686
[motion_velocity_smoother-26] v[30]: 8.60358
[motion_velocity_smoother-26] v[31]: 8.12501
[motion_velocity_smoother-26] v[32]: 7.61639
[motion_velocity_smoother-26] v[33]: 7.0712
[motion_velocity_smoother-26] v[34]: 6.48021
[motion_velocity_smoother-26] v[35]: 5.82946
[motion_velocity_smoother-26] v[36]: 5.09599
[motion_velocity_smoother-26] v[37]: 4.23681
[motion_velocity_smoother-26] v[38]: 3.14974
[motion_velocity_smoother-26] v[39]: 1.37441
[motion_velocity_smoother-26] v[40]: 0.00158448
```


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
