### PR TITLE
fix(tier4_rviz_planning_plugin): clear objects before return

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/path/display.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display.hpp
@@ -127,6 +127,9 @@ public:
 protected:
   void visualizeDrivableArea(const typename T::ConstSharedPtr msg_ptr) override
   {
+    left_bound_object_->clear();
+    right_bound_object_->clear();
+
     if (!validateBoundFloats<T>(msg_ptr)) {
       this->setStatus(
         rviz_common::properties::StatusProperty::Error, "Topic",
@@ -134,8 +137,6 @@ protected:
       return;
     }
 
-    left_bound_object_->clear();
-    right_bound_object_->clear();
     if (property_drivable_area_view_->getBool()) {
       Ogre::ColourValue color =
         rviz_common::properties::qtToOgre(property_drivable_area_color_->getColor());

--- a/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
@@ -251,12 +251,12 @@ protected:
 
   void visualizePath(const typename T::ConstSharedPtr msg_ptr)
   {
+    path_manual_object_->clear();
+    velocity_manual_object_->clear();
+
     if (msg_ptr->points.empty()) {
       return;
     }
-
-    path_manual_object_->clear();
-    velocity_manual_object_->clear();
 
     Ogre::MaterialPtr material = Ogre::MaterialManager::getSingleton().getByName(
       "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
@@ -388,12 +388,12 @@ protected:
 
   void visualizePathFootprint(const typename T::ConstSharedPtr msg_ptr)
   {
+    footprint_manual_object_->clear();
+    point_manual_object_->clear();
+
     if (msg_ptr->points.empty()) {
       return;
     }
-
-    footprint_manual_object_->clear();
-    point_manual_object_->clear();
 
     Ogre::MaterialPtr material = Ogre::MaterialManager::getSingleton().getByName(
       "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
@@ -402,7 +402,6 @@ protected:
 
     footprint_manual_object_->estimateVertexCount(msg_ptr->points.size() * 4 * 2);
     footprint_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_LIST);
-
     point_manual_object_->estimateVertexCount(msg_ptr->points.size() * 3 * 8);
     point_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);
 

--- a/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
@@ -219,6 +219,11 @@ protected:
 
   void processMessage(const typename T::ConstSharedPtr msg_ptr) override
   {
+    path_manual_object_->clear();
+    velocity_manual_object_->clear();
+    footprint_manual_object_->clear();
+    point_manual_object_->clear();
+
     if (!validateFloats<T>(msg_ptr)) {
       this->setStatus(
         rviz_common::properties::StatusProperty::Error, "Topic",
@@ -251,9 +256,6 @@ protected:
 
   void visualizePath(const typename T::ConstSharedPtr msg_ptr)
   {
-    path_manual_object_->clear();
-    velocity_manual_object_->clear();
-
     if (msg_ptr->points.empty()) {
       return;
     }
@@ -388,9 +390,6 @@ protected:
 
   void visualizePathFootprint(const typename T::ConstSharedPtr msg_ptr)
   {
-    footprint_manual_object_->clear();
-    point_manual_object_->clear();
-
     if (msg_ptr->points.empty()) {
       return;
     }


### PR DESCRIPTION
## Description
Fix a problem that the old visualized path remains in Rviz.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
