### PR TITLE
refactor(behavior_path_planner): remove unnecessary macros

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -34,6 +34,10 @@
 #include "behavior_path_planner/steering_factor_interface.hpp"
 #include "behavior_path_planner/turn_signal_decider.hpp"
 #include "behavior_path_planner/util/avoidance/avoidance_module_data.hpp"
+#include "behavior_path_planner/util/lane_change/lane_change_module_data.hpp"
+#include "behavior_path_planner/util/pull_out/pull_out_parameters.hpp"
+#include "behavior_path_planner/util/pull_over/pull_over_parameters.hpp"
+#include "behavior_path_planner/util/side_shift/side_shift_parameters.hpp"
 
 #include "tier4_planning_msgs/msg/detail/lane_change_debug_msg_array__struct.hpp"
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
@@ -107,9 +111,7 @@ private:
   rclcpp::Subscription<Scenario>::SharedPtr scenario_subscriber_;
   rclcpp::Subscription<PredictedObjects>::SharedPtr perception_subscriber_;
   rclcpp::Subscription<OccupancyGrid>::SharedPtr occupancy_grid_subscriber_;
-#ifndef USE_OLD_ARCHITECTURE
   rclcpp::Subscription<OperationModeState>::SharedPtr operation_mode_subscriber_;
-#endif
   rclcpp::Publisher<PathWithLaneId>::SharedPtr path_publisher_;
   rclcpp::Publisher<TurnIndicatorsCommand>::SharedPtr turn_signal_publisher_;
   rclcpp::Publisher<HazardLightsCommand>::SharedPtr hazard_signal_publisher_;
@@ -118,9 +120,7 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
 
   std::map<std::string, rclcpp::Publisher<Path>::SharedPtr> path_candidate_publishers_;
-#ifndef USE_OLD_ARCHITECTURE
   std::map<std::string, rclcpp::Publisher<Path>::SharedPtr> path_reference_publishers_;
-#endif
 
   std::shared_ptr<PlannerData> planner_data_;
 
@@ -149,23 +149,22 @@ private:
   // update planner data
   std::shared_ptr<PlannerData> createLatestPlannerData();
 
-#ifdef USE_OLD_ARCHITECTURE
   // parameters
-  std::shared_ptr<AvoidanceParameters> avoidance_param_ptr;
-  std::shared_ptr<LaneChangeParameters> lane_change_param_ptr;
-#endif
+  std::shared_ptr<AvoidanceParameters> avoidance_param_ptr_;
+  std::shared_ptr<LaneChangeParameters> lane_change_param_ptr_;
 
   BehaviorPathPlannerParameters getCommonParam();
 
 #ifdef USE_OLD_ARCHITECTURE
   BehaviorTreeManagerParam getBehaviorTreeManagerParam();
-  SideShiftParameters getSideShiftParam();
-  AvoidanceParameters getAvoidanceParam();
   LaneFollowingParameters getLaneFollowingParam();
+#endif
+
+  AvoidanceParameters getAvoidanceParam();
   LaneChangeParameters getLaneChangeParam();
+  SideShiftParameters getSideShiftParam();
   PullOverParameters getPullOverParam();
   PullOutParameters getPullOutParam();
-#endif
 
   // callback
   void onOdometry(const Odometry::ConstSharedPtr msg);
@@ -174,9 +173,7 @@ private:
   void onOccupancyGrid(const OccupancyGrid::ConstSharedPtr msg);
   void onMap(const HADMapBin::ConstSharedPtr map_msg);
   void onRoute(const LaneletRoute::ConstSharedPtr route_msg);
-#ifndef USE_OLD_ARCHITECTURE
   void onOperationMode(const OperationModeState::ConstSharedPtr msg);
-#endif
   SetParametersResult onSetParam(const std::vector<rclcpp::Parameter> & parameters);
 
   /**

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -17,9 +17,19 @@
 
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
+struct ModuleConfigParameters
+{
+  bool enable_module{false};
+  bool enable_simultaneous_execution{false};
+  uint8_t priority{0};
+  uint8_t max_module_size{0};
+};
+
 struct BehaviorPathPlannerParameters
 {
   bool verbose;
+
+  ModuleConfigParameters config_avoidance;
 
   double backward_path_length;
   double forward_path_length;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -259,6 +259,8 @@ private:
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_debug_marker_;
 #endif
 
+  BehaviorModuleOutput previous_module_output_;
+
 protected:
   void updateRTCStatus(const double start_distance, const double finish_distance)
   {
@@ -276,6 +278,8 @@ protected:
     }
     rtc_interface_ptr_->clearCooperateStatus();
   }
+
+  BehaviorModuleOutput getPreviousModuleOutput() const { return previous_module_output_; }
 
   void lockNewModuleLaunch() { is_locked_new_module_launch_ = true; }
 
@@ -302,8 +306,6 @@ protected:
   PlanResult path_reference_;
 
   ModuleStatus current_state_;
-
-  BehaviorModuleOutput previous_module_output_;
 
   mutable MarkerArray debug_marker_;
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -40,15 +40,14 @@ class SceneModuleManagerInterface
 {
 public:
   SceneModuleManagerInterface(
-    rclcpp::Node * node, const std::string & name, const size_t max_module_num,
-    const size_t priority, const bool enable_simultaneous_execution)
+    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config)
   : node_(node),
     clock_(*node->get_clock()),
     logger_(node->get_logger().get_child(name)),
     name_(name),
-    max_module_num_(max_module_num),
-    priority_(priority),
-    enable_simultaneous_execution_(enable_simultaneous_execution)
+    max_module_num_(config.max_module_size),
+    priority_(config.priority),
+    enable_simultaneous_execution_(config.enable_simultaneous_execution)
   {
     pub_debug_marker_ = node->create_publisher<MarkerArray>("~/debug/" + name, 20);
   }
@@ -157,8 +156,6 @@ public:
   virtual void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) = 0;
 
 protected:
-  virtual void getModuleParams(rclcpp::Node * node) = 0;
-
   virtual std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() = 0;
 
   rclcpp::Node * node_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -17,6 +17,7 @@
 
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/util/path_shifter/path_shifter.hpp"
+#include "behavior_path_planner/util/side_shift/side_shift_parameters.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -34,25 +35,6 @@ using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::OccupancyGrid;
 using tier4_planning_msgs::msg::LateralOffset;
-
-enum class SideShiftStatus { STOP = 0, BEFORE_SHIFT, SHIFTING, AFTER_SHIFT };
-
-struct SideShiftParameters
-{
-  double time_to_start_shifting;
-  double min_distance_to_start_shifting;
-  double shifting_lateral_jerk;
-  double min_shifting_distance;
-  double min_shifting_speed;
-  double drivable_area_resolution;
-  double drivable_area_width;
-  double drivable_area_height;
-  double shift_request_time_limit;
-  // drivable area expansion
-  double drivable_area_right_bound_offset;
-  double drivable_area_left_bound_offset;
-  std::vector<std::string> drivable_area_types_to_skip;
-};
 
 class SideShiftModule : public SceneModuleInterface
 {

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/side_shift/side_shift_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/side_shift/side_shift_parameters.hpp
@@ -1,0 +1,47 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_PATH_PLANNER__UTIL__SIDE_SHIFT__SIDE_SHIFT_PARAMETERS_HPP_
+#define BEHAVIOR_PATH_PLANNER__UTIL__SIDE_SHIFT__SIDE_SHIFT_PARAMETERS_HPP_
+
+#include <tier4_planning_msgs/msg/lateral_offset.hpp>
+
+#include <string>
+#include <vector>
+
+namespace behavior_path_planner
+{
+using tier4_planning_msgs::msg::LateralOffset;
+
+enum class SideShiftStatus { STOP = 0, BEFORE_SHIFT, SHIFTING, AFTER_SHIFT };
+
+struct SideShiftParameters
+{
+  double time_to_start_shifting;
+  double min_distance_to_start_shifting;
+  double shifting_lateral_jerk;
+  double min_shifting_distance;
+  double min_shifting_speed;
+  double drivable_area_resolution;
+  double drivable_area_width;
+  double drivable_area_height;
+  double shift_request_time_limit;
+  // drivable area expansion
+  double drivable_area_right_bound_offset;
+  double drivable_area_left_bound_offset;
+  std::vector<std::string> drivable_area_types_to_skip;
+};
+
+}  // namespace behavior_path_planner
+#endif  // BEHAVIOR_PATH_PLANNER__UTIL__SIDE_SHIFT__SIDE_SHIFT_PARAMETERS_HPP_

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -91,12 +91,10 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
   occupancy_grid_subscriber_ = create_subscription<OccupancyGrid>(
     "~/input/occupancy_grid_map", 1, std::bind(&BehaviorPathPlannerNode::onOccupancyGrid, this, _1),
     createSubscriptionOptions(this));
-#ifndef USE_OLD_ARCHITECTURE
   operation_mode_subscriber_ = create_subscription<OperationModeState>(
     "/system/operation_mode/state", 1,
     std::bind(&BehaviorPathPlannerNode::onOperationMode, this, _1),
     createSubscriptionOptions(this));
-#endif
   scenario_subscriber_ = create_subscription<Scenario>(
     "~/input/scenario", 1,
     [this](const Scenario::ConstSharedPtr msg) {
@@ -113,10 +111,11 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     "~/input/route", qos_transient_local, std::bind(&BehaviorPathPlannerNode::onRoute, this, _1),
     createSubscriptionOptions(this));
 
-#ifdef USE_OLD_ARCHITECTURE
-  avoidance_param_ptr = std::make_shared<AvoidanceParameters>(getAvoidanceParam());
-  lane_change_param_ptr = std::make_shared<LaneChangeParameters>(getLaneChangeParam());
-#endif
+  // set parameters
+  {
+    avoidance_param_ptr_ = std::make_shared<AvoidanceParameters>(getAvoidanceParam());
+    lane_change_param_ptr_ = std::make_shared<LaneChangeParameters>(getLaneChangeParam());
+  }
 
   m_set_param_res = this->add_on_set_parameters_callback(
     std::bind(&BehaviorPathPlannerNode::onSetParam, this, std::placeholders::_1));
@@ -136,7 +135,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     bt_manager_->registerSceneModule(side_shift_module);
 
     auto avoidance_module =
-      std::make_shared<AvoidanceModule>("Avoidance", *this, avoidance_param_ptr);
+      std::make_shared<AvoidanceModule>("Avoidance", *this, avoidance_param_ptr_);
     path_candidate_publishers_.emplace(
       "Avoidance", create_publisher<Path>(path_candidate_name_space + "avoidance", 1));
     bt_manager_->registerSceneModule(avoidance_module);
@@ -147,7 +146,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
     auto ext_request_lane_change_right_module =
       std::make_shared<ExternalRequestLaneChangeRightModule>(
-        "ExternalRequestLaneChangeRight", *this, lane_change_param_ptr);
+        "ExternalRequestLaneChangeRight", *this, lane_change_param_ptr_);
     path_candidate_publishers_.emplace(
       "ExternalRequestLaneChangeRight",
       create_publisher<Path>(path_candidate_name_space + "ext_request_lane_change_right", 1));
@@ -155,14 +154,14 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
     auto ext_request_lane_change_left_module =
       std::make_shared<ExternalRequestLaneChangeLeftModule>(
-        "ExternalRequestLaneChangeLeft", *this, lane_change_param_ptr);
+        "ExternalRequestLaneChangeLeft", *this, lane_change_param_ptr_);
     path_candidate_publishers_.emplace(
       "ExternalRequestLaneChangeLeft",
       create_publisher<Path>(path_candidate_name_space + "ext_request_lane_change_left", 1));
     bt_manager_->registerSceneModule(ext_request_lane_change_left_module);
 
     auto lane_change_module =
-      std::make_shared<LaneChangeModule>("LaneChange", *this, lane_change_param_ptr);
+      std::make_shared<LaneChangeModule>("LaneChange", *this, lane_change_param_ptr_);
     path_candidate_publishers_.emplace(
       "LaneChange", create_publisher<Path>(path_candidate_name_space + "lane_change", 1));
     bt_manager_->registerSceneModule(lane_change_module);
@@ -224,9 +223,7 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
 {
   BehaviorPathPlannerParameters p{};
 
-#ifndef USE_OLD_ARCHITECTURE
   p.verbose = declare_parameter<bool>("verbose");
-#endif
 
   // vehicle info
   const auto vehicle_info = VehicleInfoUtil(*this).getVehicleInfo();
@@ -305,7 +302,6 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   return p;
 }
 
-#ifdef USE_OLD_ARCHITECTURE
 SideShiftParameters BehaviorPathPlannerNode::getSideShiftParam()
 {
   const auto dp = [this](const std::string & str, auto def_val) {
@@ -327,9 +323,7 @@ SideShiftParameters BehaviorPathPlannerNode::getSideShiftParam()
 
   return p;
 }
-#endif
 
-#ifdef USE_OLD_ARCHITECTURE
 AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
 {
   AvoidanceParameters p{};
@@ -489,7 +483,6 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
 
   return p;
 }
-#endif
 
 #ifdef USE_OLD_ARCHITECTURE
 LaneFollowingParameters BehaviorPathPlannerNode::getLaneFollowingParam()
@@ -507,7 +500,6 @@ LaneFollowingParameters BehaviorPathPlannerNode::getLaneFollowingParam()
 }
 #endif
 
-#ifdef USE_OLD_ARCHITECTURE
 LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
 {
   const auto dp = [this](const std::string & str, auto def_val) {
@@ -584,9 +576,7 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
 
   return p;
 }
-#endif
 
-#ifdef USE_OLD_ARCHITECTURE
 PullOverParameters BehaviorPathPlannerNode::getPullOverParam()
 {
   const auto dp = [this](const std::string & str, auto def_val) {
@@ -682,9 +672,7 @@ PullOverParameters BehaviorPathPlannerNode::getPullOverParam()
 
   return p;
 }
-#endif
 
-#ifdef USE_OLD_ARCHITECTURE
 PullOutParameters BehaviorPathPlannerNode::getPullOutParam()
 {
   const auto dp = [this](const std::string & str, auto def_val) {
@@ -740,7 +728,6 @@ PullOutParameters BehaviorPathPlannerNode::getPullOutParam()
 
   return p;
 }
-#endif
 
 #ifdef USE_OLD_ARCHITECTURE
 BehaviorTreeManagerParam BehaviorPathPlannerNode::getBehaviorTreeManagerParam()
@@ -785,11 +772,9 @@ bool BehaviorPathPlannerNode::isDataReady()
     return missing("self_acceleration");
   }
 
-#ifndef USE_OLD_ARCHITECTURE
   if (!planner_data_->operation_mode) {
     return missing("operation_mode");
   }
-#endif
 
   return true;
 }
@@ -1187,37 +1172,31 @@ void BehaviorPathPlannerNode::onRoute(const LaneletRoute::ConstSharedPtr msg)
   route_ptr_ = msg;
   has_received_route_ = true;
 }
-#ifndef USE_OLD_ARCHITECTURE
 void BehaviorPathPlannerNode::onOperationMode(const OperationModeState::ConstSharedPtr msg)
 {
   const std::lock_guard<std::mutex> lock(mutex_pd_);
   planner_data_->operation_mode = msg;
 }
-#endif
 
 SetParametersResult BehaviorPathPlannerNode::onSetParam(
   const std::vector<rclcpp::Parameter> & parameters)
 {
   rcl_interfaces::msg::SetParametersResult result;
 
-#ifdef USE_OLD_ARCHITECTURE
-  if (!lane_change_param_ptr && !avoidance_param_ptr) {
+  if (!lane_change_param_ptr_ && !avoidance_param_ptr_) {
     result.successful = false;
     result.reason = "param not initialized";
     return result;
   }
-#endif
 
   result.successful = true;
   result.reason = "success";
 
   try {
-#ifdef USE_OLD_ARCHITECTURE
     update_param(
-      parameters, "avoidance.publish_debug_marker", avoidance_param_ptr->publish_debug_marker);
+      parameters, "avoidance.publish_debug_marker", avoidance_param_ptr_->publish_debug_marker);
     update_param(
-      parameters, "lane_change.publish_debug_marker", lane_change_param_ptr->publish_debug_marker);
-#endif
+      parameters, "lane_change.publish_debug_marker", lane_change_param_ptr_->publish_debug_marker);
     // Drivable area expansion parameters
     using drivable_area_expansion::DrivableAreaExpansionParameters;
     update_param(


### PR DESCRIPTION
## Description

- remove unnecessary macros
- move `SideShiftParameters` definition to new header file `side_shift_parameters.hpp`

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/