### PR TITLE
feat(behavior_path_planner): add camel to snake case string converter

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -235,6 +235,9 @@ private:
    * @brief publish path candidate
    */
 #ifdef USE_OLD_ARCHITECTURE
+
+  void createPathCandidatePublisher(
+    const std::vector<std::shared_ptr<SceneModuleInterface>> & scene_modules);
   void publishPathCandidate(
     const std::vector<std::shared_ptr<SceneModuleInterface>> & scene_modules);
 #else

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -64,12 +64,8 @@ public:
     current_state_{ModuleStatus::SUCCESS}
   {
 #ifdef USE_OLD_ARCHITECTURE
-    std::string module_ns;
-    module_ns.resize(name.size());
-    std::transform(name.begin(), name.end(), module_ns.begin(), tolower);
-
-    const auto ns = std::string("~/debug/") + module_ns;
-    pub_debug_marker_ = node.create_publisher<MarkerArray>(ns, 20);
+    pub_debug_marker_ =
+      node.create_publisher<MarkerArray>(std::string("~/debug/") + util::toSnakeCase(name), 20);
 #endif
   }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -529,6 +529,8 @@ lanelet::ConstLanelets getLaneletsFromPath(
   const PathWithLaneId & path, const std::shared_ptr<route_handler::RouteHandler> & route_handler);
 
 std::string toSnakeCase(const std::string & str);
+
+std::string toSnakeCaseWithSubstringRemoved(const std::string & str, const std::string & substring);
 }  // namespace behavior_path_planner::util
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -527,6 +527,8 @@ double calcLaneChangeBuffer(
 
 lanelet::ConstLanelets getLaneletsFromPath(
   const PathWithLaneId & path, const std::shared_ptr<route_handler::RouteHandler> & route_handler);
+
+std::string toSnakeCase(const std::string & str);
 }  // namespace behavior_path_planner::util
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -97,7 +97,8 @@ AvoidanceModule::AvoidanceModule(
   uuid_right_{generateUUID()}
 {
   using std::placeholders::_1;
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "avoidance");
+  steering_factor_interface_ptr_ =
+    std::make_unique<SteeringFactorInterface>(&node, util::toSnakeCase(name));
 }
 
 bool AvoidanceModule::isExecutionRequested() const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -32,21 +32,14 @@
 #include <vector>
 namespace behavior_path_planner
 {
-std::string getTopicName(const ExternalRequestLaneChangeModule::Direction & direction)
-{
-  const std::string direction_name =
-    direction == ExternalRequestLaneChangeModule::Direction::RIGHT ? "right" : "left";
-  return "ext_request_lane_change_" + direction_name;
-}
-
 ExternalRequestLaneChangeModule::ExternalRequestLaneChangeModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<LaneChangeParameters> parameters,
   const Direction & direction)
 : SceneModuleInterface{name, node}, parameters_{std::move(parameters)}, direction_{direction}
 {
-  rtc_interface_ptr_ = std::make_shared<RTCInterface>(&node, getTopicName(direction));
-  steering_factor_interface_ptr_ =
-    std::make_unique<SteeringFactorInterface>(&node, getTopicName(direction));
+  const auto topic_name = util::toSnakeCaseWithSubstringRemoved(name, "ernal");
+  rtc_interface_ptr_ = std::make_shared<RTCInterface>(&node, topic_name);
+  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, topic_name);
 }
 
 void ExternalRequestLaneChangeModule::onEntry()

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -53,7 +53,8 @@ LaneChangeModule::LaneChangeModule(
   uuid_left_{generateUUID()},
   uuid_right_{generateUUID()}
 {
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "lane_change");
+  steering_factor_interface_ptr_ =
+    std::make_unique<SteeringFactorInterface>(&node, util::toSnakeCase(name));
 }
 
 void LaneChangeModule::onEntry()

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -40,8 +40,9 @@ PullOutModule::PullOutModule(
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
-  rtc_interface_ptr_ = std::make_shared<RTCInterface>(&node, "pull_out");
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "pull_out");
+  rtc_interface_ptr_ = std::make_shared<RTCInterface>(&node, util::toSnakeCase(name));
+  steering_factor_interface_ptr_ =
+    std::make_unique<SteeringFactorInterface>(&node, util::toSnakeCase(name));
   lane_departure_checker_ = std::make_shared<LaneDepartureChecker>();
   lane_departure_checker_->setVehicleInfo(vehicle_info_);
 

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -51,8 +51,9 @@ PullOverModule::PullOverModule(
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
-  rtc_interface_ptr_ = std::make_shared<RTCInterface>(&node, "pull_over");
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "pull_over");
+  rtc_interface_ptr_ = std::make_shared<RTCInterface>(&node, util::toSnakeCase(name));
+  steering_factor_interface_ptr_ =
+    std::make_unique<SteeringFactorInterface>(&node, util::toSnakeCase(name));
 
   LaneDepartureChecker lane_departure_checker{};
   lane_departure_checker.setVehicleInfo(vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo());

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2679,4 +2679,14 @@ std::string toSnakeCase(const std::string & str)
 
   return snake;
 }
+
+std::string toSnakeCaseWithSubstringRemoved(const std::string & str, const std::string & substring)
+{
+  auto new_string = str;
+  const auto substring_ptr = str.find(substring);
+  if (substring_ptr != std::string::npos) {
+    new_string.erase(substring_ptr, substring.length());
+  }
+  return toSnakeCase(new_string);
+}
 }  // namespace behavior_path_planner::util

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2649,4 +2649,34 @@ lanelet::ConstLanelets getLaneletsFromPath(
 
   return lanelets;
 }
+
+std::string toSnakeCase(const std::string & str)
+{
+  const auto to_lower = [](char ch) {
+    // See notes: https://en.cppreference.com/w/cpp/string/byte/tolower
+    return static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  };
+  const auto is_lower = [](char ch) { return std::islower(static_cast<unsigned char>(ch)); };
+
+  if (str.empty()) {
+    return str;
+  }
+
+  std::string snake{to_lower(str.front())};
+
+  if (str.size() == 1) {
+    return snake;
+  }
+
+  std::for_each(str.begin() + 1, str.end(), [&](char c) {
+    if (is_lower(c)) {
+      snake += c;
+      return;
+    }
+    snake += '_';
+    snake += to_lower(c);
+  });
+
+  return snake;
+}
 }  // namespace behavior_path_planner::util


### PR DESCRIPTION
## Description

In each module, the snake case version of the modules' name are re-written, this cause some naming is not standardize. Using lane change for example
1. debug marker is named as `lanechange` because of the common function
2. other places besides debug marker is `lane_change` because the name is re-writtten each time.

I think it will be better if we have a `camelCase` to `snake_case` converter to avoid having to retype the name. The string converter function will also ensure that naming is standardized.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
