### PR TITLE
feat(map_based_prediction): enable lane change detection from unconnected lane

### DIFF
--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -169,7 +169,7 @@ private:
   LaneletsData getCurrentLanelets(const TrackedObject & object);
   bool checkCloseLaneletCondition(
     const std::pair<double, lanelet::Lanelet> & lanelet, const TrackedObject & object,
-    const lanelet::BasicPoint2d & search_point, const bool allow_opposite_lane_condition);
+    const bool allow_opposite_lane_condition);
   float calculateLocalLikelihood(
     const lanelet::Lanelet & current_lanelet, const TrackedObject & object) const;
   void updateObjectData(TrackedObject & object);

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -169,7 +169,7 @@ private:
   LaneletsData getCurrentLanelets(const TrackedObject & object);
   bool checkCloseLaneletCondition(
     const std::pair<double, lanelet::Lanelet> & lanelet, const TrackedObject & object,
-    const lanelet::BasicPoint2d & search_point);
+    const lanelet::BasicPoint2d & search_point, const bool allow_opposite_lane_condition);
   float calculateLocalLikelihood(
     const lanelet::Lanelet & current_lanelet, const TrackedObject & object) const;
   void updateObjectData(TrackedObject & object);

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1205,17 +1205,17 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     } else if (!!adjacent_right) {
       right_paths = routing_graph_ptr_->possiblePaths(*adjacent_right, possible_params);
     } else {
-      // search for opposite lane
-      const auto opposite_rights =
-        getRightOppositeLanelets(current_lanelet_data.lanelet, lanelet_map_ptr_);
-      for (auto & opposite_right : opposite_rights) {
-        const double abs_norm_delta_yaw =
-          calcAbsYawDiffBetweenLaneletAndObject(object, opposite_right);
-        // do not predict path to opposite lane
-        if (abs_norm_delta_yaw > delta_yaw_threshold_for_searching_lanelet_) continue;
-        right_paths = routing_graph_ptr_->possiblePaths(opposite_right, possible_params);
-        break;  // currently just considering one path
-      }
+      // search for opposite lane. currently do nothing
+      // const auto opposite_rights =
+      //   getRightOppositeLanelets(current_lanelet_data.lanelet, lanelet_map_ptr_);
+      // for (auto & opposite_right : opposite_rights) {
+      //   const double abs_norm_delta_yaw =
+      //     calcAbsYawDiffBetweenLaneletAndObject(object, opposite_right);
+      //   // do not predict path to opposite lane
+      //   if (abs_norm_delta_yaw > delta_yaw_threshold_for_searching_lanelet_) continue;
+      //   right_paths = routing_graph_ptr_->possiblePaths(opposite_right, possible_params);
+      //   break;  // currently just considering one path
+      //}
     }
 
     // Step1.3 Get the centerline

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1011,15 +1011,21 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     // Step1.1 Get the left lanelet
     lanelet::routing::LaneletPaths left_paths;
     auto opt_left = routing_graph_ptr_->left(current_lanelet_data.lanelet);
+    auto adjacent_left = routing_graph_ptr_->adjacentLeft(current_lanelet_data.lanelet);
     if (!!opt_left) {
       left_paths = routing_graph_ptr_->possiblePaths(*opt_left, possible_params);
+    } else if (!!adjacent_left) {
+      left_paths = routing_graph_ptr_->possiblePaths(*adjacent_left, possible_params);
     }
 
     // Step1.2 Get the right lanelet
     lanelet::routing::LaneletPaths right_paths;
     auto opt_right = routing_graph_ptr_->right(current_lanelet_data.lanelet);
+    auto adjacent_right = routing_graph_ptr_->adjacentRight(current_lanelet_data.lanelet);
     if (!!opt_right) {
       right_paths = routing_graph_ptr_->possiblePaths(*opt_right, possible_params);
+    } else if (!!adjacent_right) {
+      right_paths = routing_graph_ptr_->possiblePaths(*adjacent_right, possible_params);
     }
 
     // Step1.3 Get the centerline


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

### TL;DR

- Currently map based prediction can not generate lane change detection paths from unconnected lane(cf. see the figure below)
- This PR enable to predict lane change to unconnected adjacent lane
  - Paths changing from the forward lane to the opposite lane are not predicted now
  - Therefore, cases in which the driver once moves out into the opposite lane to avoid on-street parking, etc., are not included.


![image](https://user-images.githubusercontent.com/20086766/223020172-733b27cf-3d90-4606-8a1e-515dc9bf6a1d.png)


### Background

Current prediction path generation for on-lane object is summarized as follows:

1. Extract left/right/center lanelets and paths
2. Calculate lane change probability
3. Generate actual paths for possible paths

in this part.1 uses `left()` function, which can only get connected left lane. Also, `adjacentLeft` can only get same direction lane, so that we need to extract opposite lane manually. (cf. see https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/147)

### Changes

- update searching lanelet path candidate search in `getPredictedReferencePath`
- changed current lanelet estimation in `getCurrentLanelets`

####  lanelets candidate searching

In `getPredictedReferencePath` function, we updated the predicted path candidate extraction so that it can predict the path from opposite lane to current lane cut-in

- get left/right lanelet to create a candidate path
- if left/right lanelet is empty, try to get adjacentLeft/adjacentRight lanelet
- if all above are empty, try to get opposite lane
  - if object is trying to change lane to opposite lane, do not predict that

#### get current lanet function update

- allow current lanelet search function to search opposite lanelet only if there are no possible lanelets in forward lanelets

### Links

- [TIER IV internal tickets](https://tier4.atlassian.net/browse/T4PB-26205)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
