### PR TITLE
fix(obstacle_avoidance_planner): remove the option march=native

### DIFF
--- a/planning/obstacle_avoidance_planner/CMakeLists.txt
+++ b/planning/obstacle_avoidance_planner/CMakeLists.txt
@@ -3,12 +3,14 @@ project(obstacle_avoidance_planner)
 
 include(CheckCXXCompilerFlag)
 
+# NOTE: With the following option, when the compile-time and runtime CPU
+#       architectures are different, the node will die.
 # For Eigen vectorization.
-check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
-if(COMPILER_SUPPORTS_MARCH_NATIVE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
-  message(STATUS "Enabling MARCH NATIVE ")
-endif()
+# check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
+# if(COMPILER_SUPPORTS_MARCH_NATIVE)
+#   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+#   message(STATUS "Enabling MARCH NATIVE ")
+# endif()
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()


### PR DESCRIPTION
## Description

Removed `-march=native` option in cmake since the building on CI sometimes fails maybe due to this option.
https://github.com/autowarefoundation/autoware.universe/actions/runs/4363535826/jobs/7629737397

I confirmed that the calculation time and accuracy did not change with this PR.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
