### PR TITLE
fix(crop_box_filter): deal with case when frame_id parameter is not set

### DIFF
--- a/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
@@ -155,7 +155,8 @@ void CropBoxFilterComponent::faster_filter(
 
   output.data.resize(output_size);
 
-  // Note that `input->header.frame_id` is data before converted when `transform_info.need_transform == true`
+  // Note that `input->header.frame_id` is data before converted when `transform_info.need_transform
+  // == true`
   output.header.frame_id = !tf_input_frame_.empty() ? tf_input_frame_ : tf_input_orig_frame_;
 
   output.height = 1;

--- a/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
@@ -154,8 +154,10 @@ void CropBoxFilterComponent::faster_filter(
   }
 
   output.data.resize(output_size);
-  output.header.frame_id =
-    tf_input_frame_;  // Note that `input->header.frame_id` is data before converted
+
+  // Note that `input->header.frame_id` is data before converted when `transform_info.need_transform == true`
+  output.header.frame_id = !tf_input_frame_.empty() ? tf_input_frame_ : tf_input_orig_frame_;
+
   output.height = 1;
   output.fields = input->fields;
   output.is_bigendian = input->is_bigendian;


### PR DESCRIPTION
## Description
- if `!tf_input_frame_.empty()` :  whether `transform_info.need_transform == true` or not, the frame_id during the computation phase should be `tf_input_frame_`.
- if `!tf_input_frame_.empty()` : `transform_info.need_transform == false` in this case, so we should assign `input->header.frame_id` as is, which means `tf_input_orig_frame_`.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
