### PR TITLE
fix(avoidance): fix logic for RTC output decision

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -281,6 +281,7 @@ private:
     AvoidLineArray & shift_lines, const bool recalculate_start_length = true) const;
   AvoidLineArray fillAdditionalInfo(const AvoidLineArray & shift_lines) const;
   AvoidLine fillAdditionalInfo(const AvoidLine & shift_line) const;
+  AvoidLine getNonStraightShiftLine(const AvoidLineArray & shift_lines) const;
   void fillAdditionalInfoFromPoint(AvoidLineArray & shift_lines) const;
   void fillAdditionalInfoFromLongitudinal(AvoidLineArray & shift_lines) const;
 
@@ -350,6 +351,8 @@ private:
   double getFeasibleDecelDistance(const double target_velocity) const;
 
   double getMildDecelDistance(const double target_velocity) const;
+
+  double getRelativeLengthFromPath(const AvoidLine & avoid_line) const;
 
   // ========= safety check ==============
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2995,6 +2995,9 @@ BehaviorModuleOutput AvoidanceModule::plan()
       removePreviousRTCStatusLeft();
     } else {
       RCLCPP_WARN_STREAM(getLogger(), "Direction is UNKNOWN");
+      if (!parameters_->disable_path_update) {
+        addNewShiftLines(path_shifter_, data.safe_new_sl);
+      }
     }
     if (!parameters_->disable_path_update) {
       addShiftLineIfApproved(data.safe_new_sl);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -58,18 +58,6 @@ using tier4_planning_msgs::msg::AvoidanceDebugFactor;
 
 namespace
 {
-
-AvoidLine getNonStraightShiftLine(const AvoidLineArray & shift_lines)
-{
-  for (const auto & sl : shift_lines) {
-    if (fabs(sl.getRelativeLength()) > 0.01) {
-      return sl;
-    }
-  }
-
-  return {};
-}
-
 bool isEndPointsConnected(
   const lanelet::ConstLanelet & left_lane, const lanelet::ConstLanelet & right_lane)
 {
@@ -1189,6 +1177,17 @@ AvoidLine AvoidanceModule::fillAdditionalInfo(const AvoidLine & shift_line) cons
 {
   const auto ret = fillAdditionalInfo(AvoidLineArray{shift_line});
   return ret.front();
+}
+
+AvoidLine AvoidanceModule::getNonStraightShiftLine(const AvoidLineArray & shift_lines) const
+{
+  for (const auto & sl : shift_lines) {
+    if (fabs(getRelativeLengthFromPath(sl)) > 0.01) {
+      return sl;
+    }
+  }
+
+  return {};
 }
 
 void AvoidanceModule::fillAdditionalInfoFromPoint(AvoidLineArray & shift_lines) const
@@ -2989,15 +2988,12 @@ BehaviorModuleOutput AvoidanceModule::plan()
     printShiftLines(data.safe_new_sl, "new_shift_lines");
 
     const auto sl = getNonStraightShiftLine(data.safe_new_sl);
-    if (sl.getRelativeLength() > 0.0) {
+    if (getRelativeLengthFromPath(sl) > 0.0) {
       removePreviousRTCStatusRight();
-    } else if (sl.getRelativeLength() < 0.0) {
+    } else if (getRelativeLengthFromPath(sl) < 0.0) {
       removePreviousRTCStatusLeft();
     } else {
       RCLCPP_WARN_STREAM(getLogger(), "Direction is UNKNOWN");
-      if (!parameters_->disable_path_update) {
-        addNewShiftLines(path_shifter_, data.safe_new_sl);
-      }
     }
     if (!parameters_->disable_path_update) {
       addShiftLineIfApproved(data.safe_new_sl);
@@ -3072,7 +3068,7 @@ CandidateOutput AvoidanceModule::planCandidate() const
     const auto sl_front = data.safe_new_sl.front();
     const auto sl_back = data.safe_new_sl.back();
 
-    output.lateral_shift = sl.getRelativeLength();
+    output.lateral_shift = getRelativeLengthFromPath(sl);
     output.start_distance_to_path_change = sl_front.start_longitudinal;
     output.finish_distance_to_path_change = sl_back.end_longitudinal;
 
@@ -3130,9 +3126,9 @@ void AvoidanceModule::addShiftLineIfApproved(const AvoidLineArray & shift_lines)
     const auto sl_front = shift_lines.front();
     const auto sl_back = shift_lines.back();
 
-    if (sl.getRelativeLength() > 0.0) {
+    if (getRelativeLengthFromPath(sl) > 0.0) {
       left_shift_array_.push_back({uuid_left_, sl_front.start, sl_back.end});
-    } else if (sl.getRelativeLength() < 0.0) {
+    } else if (getRelativeLengthFromPath(sl) < 0.0) {
       right_shift_array_.push_back({uuid_right_, sl_front.start, sl_back.end});
     }
 
@@ -3721,6 +3717,18 @@ double AvoidanceModule::getMildDecelDistance(const double target_velocity) const
   const auto & j_lim = parameters_->nominal_jerk;
   return calcDecelDistWithJerkAndAccConstraints(
     getEgoSpeed(), target_velocity, a_now, a_lim, j_lim, -1.0 * j_lim);
+}
+
+double AvoidanceModule::getRelativeLengthFromPath(const AvoidLine & avoid_line) const
+{
+  if (prev_reference_.points.size() != prev_linear_shift_path_.path.points.size()) {
+    throw std::logic_error("prev_reference_ and prev_linear_shift_path_ must have same size.");
+  }
+
+  const auto current_shift_length = prev_linear_shift_path_.shift_length.at(
+    findNearestIndex(prev_reference_.points, avoid_line.end.position));
+
+  return avoid_line.end_shift_length - current_shift_length;
 }
 
 void AvoidanceModule::insertWaitPoint(


### PR DESCRIPTION
## Description

Avoidance module decides that which RTC approval (right or left) status should be output based on the relative lateral offset between shift line start and end, and the module doesn't output RTC for straight shift line whose relative lateral offset is less than threshold (< 0.01). However the module should output RTC status in following situation even if the relative lateral offset is small.

![Screenshot from 2023-03-07 10-57-04](https://user-images.githubusercontent.com/44889564/223309073-193b8802-db44-432f-ae80-e4b61d3fcece.png)

So, in this PR, I use the relative lateral offset between shift line end and current output path for decision of RTC outputs.

```c++
double AvoidanceModule::getRelativeLengthFromPath(const AvoidLine & avoid_line) const
{
  if (prev_reference_.points.size() != prev_linear_shift_path_.path.points.size()) {
    throw std::logic_error("prev_reference_ and prev_linear_shift_path_ must have same size.");
  }

  const auto current_shift_length = prev_linear_shift_path_.shift_length.at(
    findNearestIndex(prev_reference_.points, avoid_line.end.position));

  return avoid_line.end_shift_length - current_shift_length;
}
```

<!-- Write a brief description of this PR. -->

## Test result

[[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/fb7f3f9e-50ca-5be8-ac52-b54637c9d8f0?project_id=prd_jt) BEFORE 290/362
[[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/63cf24c9-bb02-572e-848e-eeeaa28bbac2?project_id=prd_jt) AFTER (This PR) 316/362

**NOTE**: Please see UC-A-04-00002-* ~ UC-A-04-00014-* scenarios. UC-A-04-00102-* ~ is out of scope.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
