### PR TITLE
fix(freespace_planning_algorithms): fix uninitialized build error for self-hosted 

### DIFF
--- a/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp
+++ b/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp
@@ -64,18 +64,16 @@ struct VehicleShape
   VehicleShape() = default;
 
   VehicleShape(double length, double width, double base2back)
+  : length(length), width(width), base2back(base2back)
   {
-    length = length;
-    width = width;
-    base2back = base2back;
   }
 
   explicit VehicleShape(
     const vehicle_info_util::VehicleInfo & vehicle_info, const double margin = 0.0)
+  : length(vehicle_info.vehicle_length_m + margin),
+    width(vehicle_info.vehicle_width_m + margin),
+    base2back(vehicle_info.rear_overhang_m + margin / 2.0)
   {
-    length = vehicle_info.vehicle_length_m + margin;
-    width = vehicle_info.vehicle_width_m + margin;
-    base2back = vehicle_info.rear_overhang_m + margin / 2.0;
   }
 };
 

--- a/planning/freespace_planning_algorithms/src/rrtstar.cpp
+++ b/planning/freespace_planning_algorithms/src/rrtstar.cpp
@@ -31,11 +31,10 @@ RRTStar::RRTStar(
   const PlannerCommonParam & planner_common_param, const VehicleShape & original_vehicle_shape,
   const RRTStarParam & rrtstar_param)
 : AbstractPlanningAlgorithm(
-    planner_common_param,
-    VehicleShape{
-      original_vehicle_shape.length + 2 * rrtstar_param.margin,
-      original_vehicle_shape.width + 2 * rrtstar_param.margin,
-      original_vehicle_shape.base2back + rrtstar_param.margin}),
+    planner_common_param, VehicleShape(
+                            original_vehicle_shape.length + 2 * rrtstar_param.margin,
+                            original_vehicle_shape.width + 2 * rrtstar_param.margin,
+                            original_vehicle_shape.base2back + rrtstar_param.margin)),
   rrtstar_param_(rrtstar_param),
   original_vehicle_shape_(original_vehicle_shape)
 {

--- a/planning/freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
+++ b/planning/freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
@@ -37,7 +37,7 @@ namespace fpa = freespace_planning_algorithms;
 
 const double length_lexus = 5.5;
 const double width_lexus = 2.75;
-const fpa::VehicleShape vehicle_shape = fpa::VehicleShape{length_lexus, width_lexus, 1.5};
+const fpa::VehicleShape vehicle_shape = fpa::VehicleShape(length_lexus, width_lexus, 1.5);
 const double pi = 3.1415926;
 const std::array<double, 3> start_pose{5.5, 4., pi * 0.5};
 const std::array<double, 3> goal_pose1{8.0, 26.3, pi * 1.5};   // easiest


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

https://github.com/autowarefoundation/autoware/actions/runs/4335928129/jobs/7570862841#logs

```
[ 62%] Building CXX object CMakeFiles/freespace_planning_algorithms.dir/src/rrtstar.cpp.o
In file included from /__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/rrtstar.hpp:18,
                 from /__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/src/rrtstar.cpp:15:
In constructor ‘freespace_planning_algorithms::AbstractPlanningAlgorithm::AbstractPlanningAlgorithm(const freespace_planning_algorithms::PlannerCommonParam&, const freespace_planning_algorithms::VehicleShape&)’,
    inlined from ‘freespace_planning_algorithms::RRTStar::RRTStar(const freespace_planning_algorithms::PlannerCommonParam&, const freespace_planning_algorithms::VehicleShape&, const freespace_planning_algorithms::RRTStarParam&)’ at /__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/src/rrtstar.cpp:40:49:
/__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp:123:50: error: ‘<unnamed>’ is used uninitialized [-Werror=uninitialized]
  123 |   : planner_common_param_(planner_common_param), collision_vehicle_shape_(collision_vehicle_shape)
      |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/src/rrtstar.cpp: In constructor ‘freespace_planning_algorithms::RRTStar::RRTStar(const freespace_planning_algorithms::PlannerCommonParam&, const freespace_planning_algorithms::VehicleShape&, const freespace_planning_algorithms::RRTStarParam&)’:
/__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/src/rrtstar.cpp:38:62: note: ‘<anonymous>’ declared here
   38 |       original_vehicle_shape.base2back + rrtstar_param.margin}),
      |                                                              ^
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/freespace_planning_algorithms.dir/build.make:104: CMakeFiles/freespace_planning_algorithms.dir/src/rrtstar.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:216: CMakeFiles/freespace_planning_algorithms.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
--- stderr: freespace_planning_algorithms
In file included from /__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/rrtstar.hpp:18,
                 from /__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/src/rrtstar.cpp:15:
In constructor ‘freespace_planning_algorithms::AbstractPlanningAlgorithm::AbstractPlanningAlgorithm(const freespace_planning_algorithms::PlannerCommonParam&, const freespace_planning_algorithms::VehicleShape&)’,
    inlined from ‘freespace_planning_algorithms::RRTStar::RRTStar(const freespace_planning_algorithms::PlannerCommonParam&, const freespace_planning_algorithms::VehicleShape&, const freespace_planning_algorithms::RRTStarParam&)’ at /__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/src/rrtstar.cpp:40:49:
/__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp:123:50: error: ‘<unnamed>’ is used uninitialized [-Werror=uninitialized]
  123 |   : planner_common_param_(planner_common_param), collision_vehicle_shape_(collision_vehicle_shape)
      |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/src/rrtstar.cpp: In constructor ‘freespace_planning_algorithms::RRTStar::RRTStar(const freespace_planning_algorithms::PlannerCommonParam&, const freespace_planning_algorithms::VehicleShape&, const freespace_planning_algorithms::RRTStarParam&)’:
/__w/autoware/autoware/src/universe/autoware.universe/planning/freespace_planning_algorithms/src/rrtstar.cpp:38:62: note: ‘<anonymous>’ declared here
   38 |       original_vehicle_shape.base2back + rrtstar_param.margin}),
      |                                                              ^
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/freespace_planning_algorithms.dir/build.make:104: CMakeFiles/freespace_planning_algorithms.dir/src/rrtstar.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:216: CMakeFiles/freespace_planning_algorithms.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
