### PR TITLE
fix(run_out): place of clearing points

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/run_out/dynamic_obstacle.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/dynamic_obstacle.cpp
@@ -463,13 +463,9 @@ void DynamicObstacleCreatorForPoints::onSynchronizedPointCloud(
   const PointCloud2::ConstSharedPtr compare_map_filtered_points,
   const PointCloud2::ConstSharedPtr vector_map_filtered_points)
 {
-  // clear previous obstacle points
-  {
+  if (compare_map_filtered_points->data.empty() && vector_map_filtered_points->data.empty()) {
     std::lock_guard<std::mutex> lock(mutex_);
     obstacle_points_map_filtered_.clear();
-  }
-
-  if (compare_map_filtered_points->data.empty() && vector_map_filtered_points->data.empty()) {
     debug_ptr_->publishEmptyPointCloud();
     return;
   }


### PR DESCRIPTION
## Description

Detected points are sometimes unintentionally deleted because the place of `obstacle_points_map_filtered_.clear()` was inappropriate.

I confirmed this works with Planning Simulator.
![image](https://user-images.githubusercontent.com/11865769/223606665-91a51f66-7eb3-47f6-8868-624788501903.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
