### PR TITLE
fix(rtc_interface): fix initial auto mode

### DIFF
--- a/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
+++ b/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
@@ -81,7 +81,7 @@ private:
   Module module_;
   CooperateStatusArray registered_status_;
   std::vector<CooperateCommand> stored_commands_;
-  bool is_auto_mode_;
+  bool is_auto_mode_init_;
   bool is_locked_;
 
   std::string cooperate_status_namespace_ = "/planning/cooperate_status";

--- a/planning/rtc_interface/src/rtc_interface.cpp
+++ b/planning/rtc_interface/src/rtc_interface.cpp
@@ -74,7 +74,7 @@ namespace rtc_interface
 {
 RTCInterface::RTCInterface(rclcpp::Node * node, const std::string & name)
 : logger_{node->get_logger().get_child("RTCInterface[" + name + "]")},
-  is_auto_mode_{false},
+  is_auto_mode_init_{false},
   is_locked_{false}
 {
   using std::placeholders::_1;
@@ -160,7 +160,6 @@ void RTCInterface::updateCooperateCommandStatus(const std::vector<CooperateComma
     if (itr != registered_status_.statuses.end()) {
       itr->command_status = command.command;
       itr->auto_mode = false;
-      is_auto_mode_ = false;
     }
   }
 }
@@ -169,7 +168,7 @@ void RTCInterface::onAutoModeService(
   const AutoMode::Request::SharedPtr request, const AutoMode::Response::SharedPtr response)
 {
   std::lock_guard<std::mutex> lock(mutex_);
-  is_auto_mode_ = request->enable;
+  is_auto_mode_init_ = request->enable;
   for (auto & status : registered_status_.statuses) {
     status.auto_mode = request->enable;
   }
@@ -196,7 +195,7 @@ void RTCInterface::updateCooperateStatus(
     status.command_status.type = Command::DEACTIVATE;
     status.start_distance = start_distance;
     status.finish_distance = finish_distance;
-    status.auto_mode = is_auto_mode_;
+    status.auto_mode = is_auto_mode_init_;
     registered_status_.statuses.push_back(status);
     return;
   }
@@ -206,7 +205,6 @@ void RTCInterface::updateCooperateStatus(
   itr->safe = safe;
   itr->start_distance = start_distance;
   itr->finish_distance = finish_distance;
-  itr->auto_mode = is_auto_mode_;
 }
 
 void RTCInterface::removeCooperateStatus(const UUID & uuid)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Before this change, if `rtc_interface` receives an auto mode service, it changes initial auto mode.
This is not expected behavior.
Correct behavior is that initial auto mode will not be changed if rtc_interface` receives an auto mode service.
So, in this PR, I changed the code.

Furthermore, as the minor change, to clarify the meaning of `is_auto_mode_`, I change the name to `is_auto_mode_init_`.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
TIER IV internal test was passed.
882/882
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
