### PR TITLE
feat(probablisitic_occupancy_grid_map): add scan_frame option for gridmap generation

### DIFF
--- a/launch/tier4_perception_launch/launch/occupancy_grid_map/laserscan_based_occupancy_grid_map.launch.py
+++ b/launch/tier4_perception_launch/launch/occupancy_grid_map/laserscan_based_occupancy_grid_map.launch.py
@@ -27,9 +27,15 @@ import yaml
 
 def launch_setup(context, *args, **kwargs):
     # load parameter files
-    param_file = LaunchConfiguration("param_file").parse(context)
+    param_file = LaunchConfiguration("param_file").perform(context)
     with open(param_file, "r") as f:
         laserscan_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"]["ros__parameters"]
+    laserscan_based_occupancy_grid_map_node_params["input_obstacle_pointcloud"] = bool(
+        LaunchConfiguration("input_obstacle_pointcloud").perform(context)
+    )
+    laserscan_based_occupancy_grid_map_node_params["input_obstacle_and_raw_pointcloud"] = bool(
+        LaunchConfiguration("input_obstacle_and_raw_pointcloud").perform(context)
+    )
 
     composable_nodes = [
         ComposableNode(
@@ -79,14 +85,7 @@ def launch_setup(context, *args, **kwargs):
                 ("~/input/raw_pointcloud", LaunchConfiguration("input/raw_pointcloud")),
                 ("~/output/occupancy_grid_map", LaunchConfiguration("output")),
             ],
-            parameters=[
-                {
-                    "input_obstacle_pointcloud": LaunchConfiguration("input_obstacle_pointcloud"),
-                    "input_obstacle_and_raw_pointcloud": LaunchConfiguration(
-                        "input_obstacle_and_raw_pointcloud"
-                    ),
-                }.update(laserscan_based_occupancy_grid_map_node_params)
-            ],
+            parameters=[laserscan_based_occupancy_grid_map_node_params],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),
     ]

--- a/launch/tier4_perception_launch/launch/occupancy_grid_map/pointcloud_based_occupancy_grid_map.launch.py
+++ b/launch/tier4_perception_launch/launch/occupancy_grid_map/pointcloud_based_occupancy_grid_map.launch.py
@@ -14,6 +14,7 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import OpaqueFunction
 from launch.actions import SetLaunchConfiguration
 from launch.conditions import IfCondition
 from launch.conditions import UnlessCondition
@@ -21,23 +22,16 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
+import yaml
 
 
-def generate_launch_description():
-    def add_launch_arg(name: str, default_value=None):
-        return DeclareLaunchArgument(name, default_value=default_value)
-
-    set_container_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container",
-        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
-    )
-
-    set_container_mt_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container_mt",
-        condition=IfCondition(LaunchConfiguration("use_multithread")),
-    )
+def launch_setup(context, *args, **kwargs):
+    # load parameter files
+    param_file = LaunchConfiguration("param_file").perform(context)
+    with open(param_file, "r") as f:
+        pointcloud_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"][
+            "ros__parameters"
+        ]
 
     composable_nodes = [
         ComposableNode(
@@ -49,12 +43,7 @@ def generate_launch_description():
                 ("~/input/raw_pointcloud", LaunchConfiguration("input/raw_pointcloud")),
                 ("~/output/occupancy_grid_map", LaunchConfiguration("output")),
             ],
-            parameters=[
-                {
-                    "map_resolution": 0.5,
-                    "use_height_filter": True,
-                }
-            ],
+            parameters=[pointcloud_based_occupancy_grid_map_node_params],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),
     ]
@@ -75,18 +64,37 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration("use_pointcloud_container")),
     )
 
+    return [occupancy_grid_map_container, load_composable_nodes]
+
+
+def generate_launch_description():
+    def add_launch_arg(name: str, default_value=None):
+        return DeclareLaunchArgument(name, default_value=default_value)
+
+    set_container_executable = SetLaunchConfiguration(
+        "container_executable",
+        "component_container",
+        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
+    )
+
+    set_container_mt_executable = SetLaunchConfiguration(
+        "container_executable",
+        "component_container_mt",
+        condition=IfCondition(LaunchConfiguration("use_multithread")),
+    )
+
     return LaunchDescription(
         [
-            add_launch_arg("use_multithread", "False"),
-            add_launch_arg("use_intra_process", "True"),
-            add_launch_arg("use_pointcloud_container", "False"),
+            add_launch_arg("use_multithread", "false"),
+            add_launch_arg("use_intra_process", "true"),
+            add_launch_arg("use_pointcloud_container", "false"),
             add_launch_arg("container_name", "occupancy_grid_map_container"),
             add_launch_arg("input/obstacle_pointcloud", "no_ground/oneshot/pointcloud"),
             add_launch_arg("input/raw_pointcloud", "concatenated/pointcloud"),
             add_launch_arg("output", "occupancy_grid"),
+            add_launch_arg("param_file", "config/pointcloud_based_occupancy_grid_map.param.yaml"),
             set_container_executable,
             set_container_mt_executable,
-            occupancy_grid_map_container,
-            load_composable_nodes,
         ]
+        + [OpaqueFunction(function=launch_setup)]
     )

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -76,6 +76,7 @@
         <arg name="use_multithread" value="true"/>
         <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
+        <arg name="param_file" value="$(find-pkg-share probabilistic_occupancy_grid_map)/config/pointcloud_based_occupancy_grid_map.param.yaml"/>
       </include>
     </group>
 

--- a/perception/probabilistic_occupancy_grid_map/CMakeLists.txt
+++ b/perception/probabilistic_occupancy_grid_map/CMakeLists.txt
@@ -48,4 +48,5 @@ rclcpp_components_register_node(laserscan_based_occupancy_grid_map
 ament_auto_package(
   INSTALL_TO_SHARE
     launch
+    config
 )

--- a/perception/probabilistic_occupancy_grid_map/README.md
+++ b/perception/probabilistic_occupancy_grid_map/README.md
@@ -9,7 +9,9 @@ This package outputs the probability of having an obstacle as occupancy grid map
 
 Occupancy grid map is generated on `map_frame`, and grid orientation is fixed.
 
-You may need to choose `output_frame` which means grid map origin. Default is `base_link`, but your main LiDAR sensor frame (e.g. `velodyne_top` in sample_vehicle) would be the better choice.
+You may need to choose `scan_origin_frame` and `gridmap_origin_frame` which means sensor origin and gridmap origin respectively. Especially, set your main LiDAR sensor frame (e.g. `velodyne_top` in sample_vehicle) as a `scan_origin_frame` would result in better performance.
+
+![image_for_frame_parameter_visualization](./image/gridmap_frame_settings.drawio.svg)
 
 ### Each config paramters
 
@@ -21,7 +23,8 @@ Config parameters are managed in `config/*.yaml` and here shows its outline.
 | --------------------------------- | ------------- |
 | map_frame                         | "map"         |
 | base_link_frame                   | "base_link"   |
-| output_frame                      | "base_link"   |
+| scan_origin_frame                 | "base_link"   |
+| gridmap_origin_frame              | "base_link"   |
 | use_height_filter                 | true          |
 | enable_single_frame_mode          | false         |
 | map_length                        | 100.0 [m]     |
@@ -40,7 +43,8 @@ Config parameters are managed in `config/*.yaml` and here shows its outline.
 | enable_single_frame_mode | false         |
 | map_frame                | "map"         |
 | base_link_frame          | "base_link"   |
-| output_frame             | "base_link"   |
+| scan_origin_frame        | "base_link"   |
+| gridmap_origin_frame     | "base_link"   |
 
 ## References/External links
 

--- a/perception/probabilistic_occupancy_grid_map/config/laserscan_based_occupancy_grid_map.param.yaml
+++ b/perception/probabilistic_occupancy_grid_map/config/laserscan_based_occupancy_grid_map.param.yaml
@@ -2,8 +2,10 @@
   ros__parameters:
     map_frame: "map"
     base_link_frame: "base_link"
-    output_frame: "base_link"
-    # using top of the main lidar frame is appropriate. ex) velodyne_top
+    # center of the grid map
+    gridmap_origin_frame: "base_link"
+    # ray-tracing center: main sensor frame is preferable like: "velodyne_top"
+    scan_origin_frame: "base_link"
 
     use_height_filter: true
     enable_single_frame_mode: false

--- a/perception/probabilistic_occupancy_grid_map/config/pointcloud_based_occupancy_grid_map.param.yaml
+++ b/perception/probabilistic_occupancy_grid_map/config/pointcloud_based_occupancy_grid_map.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    map_length: 100     # [m]
+    map_length: 100.0     # [m]
     map_resolution: 0.5 # [m]
 
     use_height_filter: true

--- a/perception/probabilistic_occupancy_grid_map/config/pointcloud_based_occupancy_grid_map.param.yaml
+++ b/perception/probabilistic_occupancy_grid_map/config/pointcloud_based_occupancy_grid_map.param.yaml
@@ -9,5 +9,7 @@
     # grid map coordinate
     map_frame: "map"
     base_link_frame: "base_link"
-    output_frame: "base_link"
-    # center of grid_map. Main LiDAR frame is preferable like: "velodyne_top"
+    # center of the grid map
+    gridmap_origin_frame: "base_link"
+    # ray-tracing center: main sensor frame is preferable like: "velodyne_top"
+    scan_origin_frame: "base_link"

--- a/perception/probabilistic_occupancy_grid_map/image/gridmap_frame_settings.drawio.svg
+++ b/perception/probabilistic_occupancy_grid_map/image/gridmap_frame_settings.drawio.svg
@@ -1,0 +1,80 @@
+<svg
+  host="65bd71144e"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  version="1.1"
+  width="321px"
+  height="361px"
+  viewBox="-0.5 -0.5 321 361"
+  content="&lt;mxfile&gt;&lt;diagram id=&quot;bXZzcvQcPpC1UQPAvKQk&quot; name=&quot;Page-1&quot;&gt;7Vpbb5swFP41SNtDI+4Jj0162cukSnnY9jS54IBVgjPjNEl//WxsA+bSJG3o0rVUavHnC5zvfMfHNjWc2XJ7S8Aq+Y4jmBq2GW0N58qwbTtw2W8O7ATg244AYoIiAVkVMEdPUIKmRNcogrnWkGKcUrTSwRBnGQyphgFC8EZvtsCp/tQViGELmIcgbaM/UEQTgU7scYV/gyhO1JMtPxA1S6AaS0vyBER4U4Oca8OZEYypuFtuZzDl3CleRL+bntryxQjM6CEdbNHhEaRraZt8L7pTxhK8ziLI25uGM90kiML5CoS8dsO8y7CELlNWstjtAqXpXPYFa4olNMMpJsVwzsLjPxzHGa3h4mJ4Tgl+gLUav7hYTds4ae8jJBRua5A09hbiJaRkx5qoWl8Sv2uUN5UfHeWcpObDEgRSO3E5dkUvu5EMd7M93s92zOheHW5oqXFwr0YwnyXAHusE2JM2AZbbQcD4BPY7++2HWXTJI5SVwhTkOQp1gbWpkaTCSIvZNgE1A70O+xRGYAooetQjvcto+YQ7jNiblPx6Or1ug7Ucr0kIZZ96XPYMo/pRQGJIW/0KwksbD/KB+3of5OxtqGqB2UgKu0HpB/OT9fwwp3ObdVzsZDiDTae1plXTLCbcxkRc4hHIk2Le592ZG8nuJ08CI08Vf9XrrrYyQ4jSTpZ6pzJBjZaFzkQaTkMbjv9CcbhNkQXDycM/G3lYtl8XiDkKgmCPSIrSHSSIWQzJp3LYaujtlHPAouRtlKOrZux9ziy9+mB5Z+RYQXW5ulwmwcifmNXlD6aeyXmq51M8z6xZGlsA1xpucgn+rTx63fy/+dR1mwvRwXx6QMQPvYl1zAZtanO+bxM7abDykk3scZLu2UD1qbpN2uSsBHv221s1lw29v/3wLny7na99bjlE+vN8lwonc7E+zsWACwWrw8l+SqWTNG/7f9b8eHx6D8KHuDidvgiFEy85dfH9F9vzDJs906zffC18qToXSUd5vgKVBmqQH/O/eQiy35igGGW/FwQsoXo9Zpl4Q9GuJU2W6qiuR5CiOONzDxMU3+1OeUJEIUgvZcUSRRHvPiUwR08yKfJV64ozXXDvTQ3vio+1pjgX30faUpehUD+Al1Cvpo84Se/WWD0Dd56jnyADe71ayVcgG0Irwrf8Y9QSrPpkIB7+vmVw/AeV4IVLsVMIwe6aNT63FwOcR/V5+fSZoPMjkZYJOudtcc6xL2ZZ76KjKYPONvGCZ/KExbEpm77rib1PtieIdNv09Bk/aEd6GdWvjHRWrL6BCxFV/0jgXP8F&lt;/diagram&gt;&lt;/mxfile&gt;"
+>
+  <defs/>
+  <g>
+    <rect x="0" y="0" width="320" height="320" fill="#f5f5f5" stroke="#666666" pointer-events="all"/>
+    <path d="M 160 160 L 160 126.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+    <path d="M 160 121.12 L 163.5 128.12 L 160 126.37 L 156.5 128.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+    <path d="M 157 160 L 126.37 160" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+    <ellipse cx="160" cy="160" rx="3" ry="3" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+    <path d="M 121.12 160 L 128.12 156.5 L 126.37 160 L 128.12 163.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+    <path d="M 190 200 L 160 320" fill="none" stroke="#660033" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="none"/>
+    <path d="M 190 200 L 40.32 319.68" fill="none" stroke="#660033" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="none"/>
+    <path d="M 190 200 L 0 240" fill="none" stroke="#660033" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="none"/>
+    <path d="M 190 200 L 0 160" fill="none" stroke="#660033" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="none"/>
+    <path d="M 190 200 L 280 240" fill="none" stroke="#660033" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="none"/>
+    <path d="M 190 200 L 190 166.37" fill="none" stroke="#660033" stroke-miterlimit="10" pointer-events="none"/>
+    <path d="M 190 161.12 L 193.5 168.12 L 190 166.37 L 186.5 168.12 Z" fill="#660033" stroke="#660033" stroke-miterlimit="10" pointer-events="none"/>
+    <path d="M 187 200 L 156.37 200" fill="none" stroke="#660033" stroke-miterlimit="10" pointer-events="none"/>
+    <ellipse cx="190" cy="200" rx="3" ry="3" fill="#660033" stroke="#660033" pointer-events="none"/>
+    <path d="M 151.12 200 L 158.12 196.5 L 156.37 200 L 158.12 203.5 Z" fill="#660033" stroke="#660033" stroke-miterlimit="10" pointer-events="none"/>
+    <path d="M 190 200 L 280 320" fill="none" stroke="#660033" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="none"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 215px; margin-left: 210px;">
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                <font color="#660033" style="background-color: rgb(255, 255, 255);">scan_origin_frame</font>
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="210" y="219" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">scan_origin_frame</text>
+      </switch>
+    </g>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 175px; margin-left: 100px;">
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                <span style="background-color: rgb(255, 255, 255);">gridmap_origin_frame</span>
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="100" y="179" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">gridmap_origin_frame</text>
+      </switch>
+    </g>
+    <path d="M 190 200 L 230 160" fill="none" stroke="#660033" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="none"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 345px; margin-left: 160px;">
+            <div data-drawio-colors="color: #660033; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(102, 0, 51); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                <font color="#000000">gridmap_origin = center of the gridmap</font>
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="160" y="349" fill="#660033" font-family="Helvetica" font-size="12px" text-anchor="middle">gridmap_origin = center of the gridmap</text>
+      </switch>
+    </g>
+  </g>
+  <switch>
+    <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+    <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+      <text text-anchor="middle" font-size="10px" x="50%" y="100%">Text is not SVG - cannot display</text>
+    </a>
+  </switch>
+</svg>

--- a/perception/probabilistic_occupancy_grid_map/include/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.hpp
+++ b/perception/probabilistic_occupancy_grid_map/include/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.hpp
@@ -92,7 +92,8 @@ private:
   // ROS Parameters
   std::string map_frame_;
   std::string base_link_frame_;
-  std::string output_frame_;
+  std::string gridmap_origin_frame_;
+  std::string scan_origin_frame_;
   bool use_height_filter_;
   bool enable_single_frame_mode_;
 };

--- a/perception/probabilistic_occupancy_grid_map/include/pointcloud_based_occupancy_grid_map/occupancy_grid_map.hpp
+++ b/perception/probabilistic_occupancy_grid_map/include/pointcloud_based_occupancy_grid_map/occupancy_grid_map.hpp
@@ -72,7 +72,7 @@ public:
 
   void updateWithPointCloud(
     const PointCloud2 & raw_pointcloud, const PointCloud2 & obstacle_pointcloud,
-    const Pose & robot_pose, const Pose & gridmap_origin);
+    const Pose & robot_pose, const Pose & scan_origin);
 
   void updateOrigin(double new_origin_x, double new_origin_y) override;
 

--- a/perception/probabilistic_occupancy_grid_map/include/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
+++ b/perception/probabilistic_occupancy_grid_map/include/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
@@ -82,7 +82,8 @@ private:
   // ROS Parameters
   std::string map_frame_;
   std::string base_link_frame_;
-  std::string output_frame_;
+  std::string gridmap_origin_frame_;
+  std::string scan_origin_frame_;
   bool use_height_filter_;
   bool enable_single_frame_mode_;
 };

--- a/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
+++ b/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
@@ -27,9 +27,15 @@ import yaml
 
 def launch_setup(context, *args, **kwargs):
     # load parameter files
-    param_file = LaunchConfiguration("param_file").parse(context)
+    param_file = LaunchConfiguration("param_file").perform(context)
     with open(param_file, "r") as f:
         laserscan_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"]["ros__parameters"]
+    laserscan_based_occupancy_grid_map_node_params["input_obstacle_pointcloud"] = bool(
+        LaunchConfiguration("input_obstacle_pointcloud").perform(context)
+    )
+    laserscan_based_occupancy_grid_map_node_params["input_obstacle_and_raw_pointcloud"] = bool(
+        LaunchConfiguration("input_obstacle_and_raw_pointcloud").perform(context)
+    )
 
     composable_nodes = [
         ComposableNode(
@@ -79,14 +85,7 @@ def launch_setup(context, *args, **kwargs):
                 ("~/input/raw_pointcloud", LaunchConfiguration("input/raw_pointcloud")),
                 ("~/output/occupancy_grid_map", LaunchConfiguration("output")),
             ],
-            parameters=[
-                {
-                    "input_obstacle_pointcloud": LaunchConfiguration("input_obstacle_pointcloud"),
-                    "input_obstacle_and_raw_pointcloud": LaunchConfiguration(
-                        "input_obstacle_and_raw_pointcloud"
-                    ),
-                }.update(laserscan_based_occupancy_grid_map_node_params)
-            ],
+            parameters=[laserscan_based_occupancy_grid_map_node_params],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),
     ]

--- a/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
+++ b/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import OpaqueFunction
 from launch.actions import SetLaunchConfiguration
 from launch.conditions import IfCondition
-from launch.conditions import LaunchConfigurationEquals
-from launch.conditions import LaunchConfigurationNotEquals
 from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
@@ -29,27 +25,9 @@ from launch_ros.descriptions import ComposableNode
 import yaml
 
 
-def generate_launch_description():
-    def add_launch_arg(name: str, default_value=None):
-        return DeclareLaunchArgument(name, default_value=default_value)
-
-    set_container_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container",
-        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
-    )
-
-    set_container_mt_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container_mt",
-        condition=IfCondition(LaunchConfiguration("use_multithread")),
-    )
-
+def launch_setup(context, *args, **kwargs):
     # load parameter files
-    param_file = os.path.join(
-        get_package_share_directory("probablistic_occupancy_grid_map"),
-        "config/laserscan_based_occupancy_grid_map.param.yaml",
-    )
+    param_file = LaunchConfiguration("param_file").parse(context)
     with open(param_file, "r") as f:
         laserscan_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"]["ros__parameters"]
 
@@ -68,7 +46,7 @@ def generate_launch_description():
             parameters=[
                 {
                     "target_frame": laserscan_based_occupancy_grid_map_node_params[
-                        "output_frame"
+                        "scan_origin_frame"
                     ],  # Leave disabled to output scan in pointcloud frame
                     "transform_tolerance": 0.01,
                     "min_height": 0.0,
@@ -114,24 +92,42 @@ def generate_launch_description():
     ]
 
     occupancy_grid_map_container = ComposableNodeContainer(
-        condition=LaunchConfigurationEquals("container", ""),
-        name="occupancy_grid_map_container",
+        name=LaunchConfiguration("container_name"),
         namespace="",
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=composable_nodes,
+        condition=UnlessCondition(LaunchConfiguration("use_pointcloud_container")),
         output="screen",
     )
 
     load_composable_nodes = LoadComposableNodes(
-        condition=LaunchConfigurationNotEquals("container", ""),
         composable_node_descriptions=composable_nodes,
-        target_container=LaunchConfiguration("container"),
+        target_container=LaunchConfiguration("container_name"),
+        condition=IfCondition(LaunchConfiguration("use_pointcloud_container")),
+    )
+
+    return [occupancy_grid_map_container, load_composable_nodes]
+
+
+def generate_launch_description():
+    def add_launch_arg(name: str, default_value=None):
+        return DeclareLaunchArgument(name, default_value=default_value)
+
+    set_container_executable = SetLaunchConfiguration(
+        "container_executable",
+        "component_container",
+        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
+    )
+
+    set_container_mt_executable = SetLaunchConfiguration(
+        "container_executable",
+        "component_container_mt",
+        condition=IfCondition(LaunchConfiguration("use_multithread")),
     )
 
     return LaunchDescription(
         [
-            add_launch_arg("container", ""),
             add_launch_arg("use_multithread", "false"),
             add_launch_arg("use_intra_process", "false"),
             add_launch_arg("input/obstacle_pointcloud", "no_ground/oneshot/pointcloud"),
@@ -143,9 +139,11 @@ def generate_launch_description():
             add_launch_arg("output/stixel", "virtual_scan/stixel"),
             add_launch_arg("input_obstacle_pointcloud", "false"),
             add_launch_arg("input_obstacle_and_raw_pointcloud", "true"),
+            add_launch_arg("param_file", "config/laserscan_based_occupancy_grid_map.param.yaml"),
+            add_launch_arg("use_pointcloud_container", "false"),
+            add_launch_arg("container_name", "occupancy_grid_map_container"),
             set_container_executable,
             set_container_mt_executable,
-            occupancy_grid_map_container,
-            load_composable_nodes,
         ]
+        + [OpaqueFunction(function=launch_setup)]
     )

--- a/perception/probabilistic_occupancy_grid_map/launch/pointcloud_based_occupancy_grid_map.launch.py
+++ b/perception/probabilistic_occupancy_grid_map/launch/pointcloud_based_occupancy_grid_map.launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
 
     # load parameter files
     param_file = os.path.join(
-        get_package_share_directory("probablistic_occupancy_grid_map"),
+        get_package_share_directory("probabilistic_occupancy_grid_map"),
         "config/pointcloud_based_occupancy_grid_map.param.yaml",
     )
     with open(param_file, "r") as f:

--- a/perception/probabilistic_occupancy_grid_map/launch/pointcloud_based_occupancy_grid_map.launch.py
+++ b/perception/probabilistic_occupancy_grid_map/launch/pointcloud_based_occupancy_grid_map.launch.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import OpaqueFunction
 from launch.actions import SetLaunchConfiguration
 from launch.conditions import IfCondition
-from launch.conditions import LaunchConfigurationEquals
-from launch.conditions import LaunchConfigurationNotEquals
 from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
@@ -29,27 +25,9 @@ from launch_ros.descriptions import ComposableNode
 import yaml
 
 
-def generate_launch_description():
-    def add_launch_arg(name: str, default_value=None):
-        return DeclareLaunchArgument(name, default_value=default_value)
-
-    set_container_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container",
-        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
-    )
-
-    set_container_mt_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container_mt",
-        condition=IfCondition(LaunchConfiguration("use_multithread")),
-    )
-
+def launch_setup(context, *args, **kwargs):
     # load parameter files
-    param_file = os.path.join(
-        get_package_share_directory("probabilistic_occupancy_grid_map"),
-        "config/pointcloud_based_occupancy_grid_map.param.yaml",
-    )
+    param_file = LaunchConfiguration("param_file").perform(context)
     with open(param_file, "r") as f:
         pointcloud_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"][
             "ros__parameters"
@@ -71,32 +49,52 @@ def generate_launch_description():
     ]
 
     occupancy_grid_map_container = ComposableNodeContainer(
-        condition=LaunchConfigurationEquals("container", ""),
-        name="occupancy_grid_map_container",
+        name=LaunchConfiguration("container_name"),
         namespace="",
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=composable_nodes,
+        condition=UnlessCondition(LaunchConfiguration("use_pointcloud_container")),
         output="screen",
     )
 
     load_composable_nodes = LoadComposableNodes(
-        condition=LaunchConfigurationNotEquals("container", ""),
         composable_node_descriptions=composable_nodes,
-        target_container=LaunchConfiguration("container"),
+        target_container=LaunchConfiguration("container_name"),
+        condition=IfCondition(LaunchConfiguration("use_pointcloud_container")),
+    )
+
+    return [occupancy_grid_map_container, load_composable_nodes]
+
+
+def generate_launch_description():
+    def add_launch_arg(name: str, default_value=None):
+        return DeclareLaunchArgument(name, default_value=default_value)
+
+    set_container_executable = SetLaunchConfiguration(
+        "container_executable",
+        "component_container",
+        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
+    )
+
+    set_container_mt_executable = SetLaunchConfiguration(
+        "container_executable",
+        "component_container_mt",
+        condition=IfCondition(LaunchConfiguration("use_multithread")),
     )
 
     return LaunchDescription(
         [
-            add_launch_arg("container", ""),
             add_launch_arg("use_multithread", "false"),
-            add_launch_arg("use_intra_process", "false"),
+            add_launch_arg("use_intra_process", "true"),
+            add_launch_arg("use_pointcloud_container", "false"),
+            add_launch_arg("container_name", "occupancy_grid_map_container"),
             add_launch_arg("input/obstacle_pointcloud", "no_ground/oneshot/pointcloud"),
             add_launch_arg("input/raw_pointcloud", "concatenated/pointcloud"),
             add_launch_arg("output", "occupancy_grid"),
+            add_launch_arg("param_file", "config/pointcloud_based_occupancy_grid_map.param.yaml"),
             set_container_executable,
             set_container_mt_executable,
-            occupancy_grid_map_container,
-            load_composable_nodes,
         ]
+        + [OpaqueFunction(function=launch_setup)]
     )


### PR DESCRIPTION
## Description

### main changes

In last PR https://github.com/autowarefoundation/autoware.universe/pull/2939, we set option for choosing occupancy grid map.  
This PR tries to add another option that enables to separate gridmap origin frame and scan sensor frame. (See figure below)

![](https://github.com/YoshiRi/autoware.universe/raw/feature/add_option_to_gridmap_generation/perception/probabilistic_occupancy_grid_map/image/gridmap_frame_settings.drawio.svg)

This change will be useful in asymmetric range sensor such as Hokuyo Lidar or stereo camera, and multiple-sensor-based grid map fusion.

### additional 

fixed some bags that prevents this PR working.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
