### PR TITLE
fix(avoidance): fix unexpected behavior in yield scenario

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/util/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/avoidance/avoidance_module_data.hpp
@@ -408,6 +408,9 @@ struct AvoidancePlanningData
   // the others
   ObjectDataArray other_objects;
 
+  // nearest object that should be avoid
+  boost::optional<ObjectData> stop_target_object{boost::none};
+
   // raw shift point
   AvoidLineArray unapproved_raw_sl{};
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -733,7 +733,7 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
   }
 
   /**
-   * Check whether the ego should avoid the front object. When the ego follows reference path,
+   * Find the nearest object that should be avoid. When the ego follows reference path,
    * if the lateral distance is smaller than minimum margin, the ego should avoid the object.
    */
   for (const auto & o : data.target_objects) {
@@ -754,6 +754,10 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
       getLogger(), *clock_, 5000, "not found safe avoidance path. transit yield maneuver...");
   }
 
+  /**
+   * Even if data.avoid_required is false, the module cancels registerd shift point when the
+   * approved avoidance path is not safe.
+   */
   if (!data.safe && registered) {
     data.yield_required = true;
     data.candidate_path = toShiftedPath(data.reference_path);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -755,7 +755,7 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
   }
 
   /**
-   * Even if data.avoid_required is false, the module cancels registerd shift point when the
+   * Even if data.avoid_required is false, the module cancels registered shift point when the
    * approved avoidance path is not safe.
    */
   if (!data.safe && registered) {


### PR DESCRIPTION
## Description

In current logic, only when the front (nearest) target object should be avoid and the avoidance path is unsafe, the module executes YIELD maneuver. But, it should execute YIELD maneuver in following scenarios, too.

- Ego doesn't have to avoid the front object (passable without avoidance path).
- Ego has to avoid the behind object.
- Avoidance path is unsafe.

I found two bugs in the avoidance module:

1. The module never execute YILED maneuver if the front object is **NOT** `avoid_require = true`.
2. The module never cancel approved avoidance path if the front object is **NOT** `avoid_require = true`.

:arrow_down: Ego collides with NPC because of above bugs.

https://user-images.githubusercontent.com/44889564/223875419-f575247a-d020-40aa-843b-98c1dfb2d974.mp4

---

### Diff1

> The module never execute YILED maneuver if the front object is **NOT** `avoid_require = true`.

Search nearest object that should be avoid.

```c++
  for (const auto & o : data.target_objects) {
    if (o.avoid_required) {
      data.avoid_required = true;
      data.stop_target_object = o;
    }
  }
```

### Diff2

> The module never cancel approved avoidance path if the front object is **NOT** `avoid_require = true`.

Transit yield maneuver to cancel approved when the don't have to avoid.

```c++
  if (!data.safe && registered) {
    data.yield_required = true;
    data.candidate_path = toShiftedPath(data.reference_path);
    RCLCPP_WARN_THROTTLE(
      getLogger(), *clock_, 5000,
      "found safe avoidance path, but it is not safe. canceling avoidance path...");
  }
```

### Expected behavior

- Execute YIELD manauver even if the front object is **NOT** `avoid_require = true`.
- Keep enough distance in stopping behavior.

https://user-images.githubusercontent.com/44889564/223874980-660b1dac-f4cb-4e26-91f5-e519b62ed1b8.mp4

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
