### PR TITLE
fix(behavior_path_planner): remove duplicated process updateData() in new manager

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -131,7 +131,6 @@ private:
   {
     module_ptr->setData(planner_data);
     module_ptr->setPreviousModuleOutput(previous_module_output);
-    module_ptr->updateData();
 
     module_ptr->lockRTCCommand();
     const auto result = module_ptr->run();


### PR DESCRIPTION
## Description

In new manager, `updateData()` is called both of  inside and outside of `run()` function.

1

https://github.com/autowarefoundation/autoware.universe/blob/279e43430510781ea182973d4cf3fe32443af09a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp#L134-L138

2

https://github.com/autowarefoundation/autoware.universe/blob/2a64ea607940eb3e354f33f7d962e7bf0d1f4be0/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp#L135-L153


In this PR, I remove the former one.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
