### PR TITLE
fix(lane_change): use previous module output

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -416,6 +416,10 @@ std::vector<Polygon2d> getTargetLaneletPolygons(
 
 void shiftPose(Pose * pose, double shift_length);
 
+PathWithLaneId getCenterLinePathFromRootLanelet(
+  const lanelet::ConstLanelet & root_lanelet,
+  const std::shared_ptr<const PlannerData> & planner_data);
+
 // route handler
 PathWithLaneId getCenterLinePath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & lanelet_sequence,
@@ -438,6 +442,9 @@ PathWithLaneId setDecelerationVelocityForTurnSignal(
 std::uint8_t getHighestProbLabel(const std::vector<ObjectClassification> & classification);
 
 lanelet::ConstLanelets getCurrentLanes(const std::shared_ptr<const PlannerData> & planner_data);
+
+lanelet::ConstLanelets getCurrentLanesFromPath(
+  const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data);
 
 lanelet::ConstLanelets extendLanes(
   const std::shared_ptr<RouteHandler> route_handler, const lanelet::ConstLanelets & lanes);

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1927,6 +1927,22 @@ void shiftPose(Pose * pose, double shift_length)
   pose->position.y += std::cos(yaw) * shift_length;
 }
 
+PathWithLaneId getCenterLinePathFromRootLanelet(
+  const lanelet::ConstLanelet & root_lanelet,
+  const std::shared_ptr<const PlannerData> & planner_data)
+{
+  const auto & route_handler = planner_data->route_handler;
+  const auto & current_pose = planner_data->self_odometry->pose.pose;
+  const auto & p = planner_data->parameters;
+
+  const auto reference_lanes = route_handler->getLaneletSequence(
+    root_lanelet, current_pose, p.backward_path_length, p.forward_path_length);
+
+  return getCenterLinePath(
+    *route_handler, reference_lanes, current_pose, p.backward_path_length, p.forward_path_length,
+    p);
+}
+
 PathWithLaneId getCenterLinePath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & lanelet_sequence,
   const Pose & pose, const double backward_path_length, const double forward_path_length,
@@ -2072,6 +2088,32 @@ lanelet::ConstLanelets getCurrentLanes(const std::shared_ptr<const PlannerData> 
   return route_handler->getLaneletSequence(
     current_lane, current_pose, common_parameters.backward_path_length,
     common_parameters.forward_path_length);
+}
+
+lanelet::ConstLanelets getCurrentLanesFromPath(
+  const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data)
+{
+  const auto & route_handler = planner_data->route_handler;
+  const auto & current_pose = planner_data->self_odometry->pose.pose;
+  const auto & p = planner_data->parameters;
+
+  std::set<uint64_t> lane_ids;
+  for (const auto & p : path.points) {
+    for (const auto & id : p.lane_ids) {
+      lane_ids.insert(id);
+    }
+  }
+
+  lanelet::ConstLanelets reference_lanes{};
+  for (const auto & id : lane_ids) {
+    reference_lanes.push_back(planner_data->route_handler->getLaneletsFromId(id));
+  }
+
+  lanelet::ConstLanelet current_lane;
+  lanelet::utils::query::getClosestLanelet(reference_lanes, current_pose, &current_lane);
+
+  return route_handler->getLaneletSequence(
+    current_lane, current_pose, p.backward_path_length, p.forward_path_length);
 }
 
 lanelet::ConstLanelets extendLanes(


### PR DESCRIPTION
## Description

In this PR, I added new function `util::getCurrentLanesFromPath` to get current lanelet from not current pose but previous module output.

```c++
#ifdef USE_OLD_ARCHITECTURE
  const auto current_lanes = util::getCurrentLanes(planner_data_);
#else
  const auto current_lanes =
    util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
#endif
```

Additionaly, I added `util::getCenterLinePathFromRootLanelet` to output reference path that is used in next module.

```c++
#ifdef USE_OLD_ARCHITECTURE
  path_reference_ = getPreviousModuleOutput().reference_path;
  prev_approved_path_ = path;
#else
  const auto reference_path =
    util::getCenterLinePathFromRootLanelet(status_.lane_change_lanes.front(), planner_data_);
  output.reference_path = std::make_shared<PathWithLaneId>(reference_path);
  path_reference_ = std::make_shared<PathWithLaneId>(reference_path);
  prev_approved_path_ = *getPreviousModuleOutput().path;
#endif
```

### Test in my local env

1.set option `COMPILE_WITH_OLD_ARCHITECTURE` to `FALSE`

https://github.com/autowarefoundation/autoware.universe/blob/2ace0d2b030cabf19ff037b56328cff07c2fb245/planning/behavior_path_planner/CMakeLists.txt#L10

2.set `enable_simultaneous_execution` to true (`lane_change`, `avoidance` only)

```yaml
...
    lane_change:
      enable_module: true
      enable_simultaneous_execution: true
      priority: 4
      max_module_size: 1
...
    avoidance:
      enable_module: true
      enable_simultaneous_execution: true
      priority: 3
      max_module_size: 1
```

https://github.com/autowarefoundation/autoware_launch/blob/17eed3623580804896d1a9417c1a49c7098deca8/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml#L41-L69

https://user-images.githubusercontent.com/44889564/224200020-81d1f2f5-7be0-4556-9e79-7b9d9772bdcc.mp4

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
