### PR TITLE
fix(mpc): optimization failure due to steer limit

### DIFF
--- a/control/mpc_lateral_controller/src/mpc.cpp
+++ b/control/mpc_lateral_controller/src/mpc.cpp
@@ -253,8 +253,11 @@ void MPC::setReferenceTrajectory(
 
 void MPC::resetPrevResult(const autoware_auto_vehicle_msgs::msg::SteeringReport & current_steer)
 {
-  m_raw_steer_cmd_prev = current_steer.steering_tire_angle;
-  m_raw_steer_cmd_pprev = current_steer.steering_tire_angle;
+  // Consider limit. The prev value larger than limiation brakes the optimization constraint and
+  // resluts in optimization failure.
+  float steer_lim_f = static_cast<float>(m_steer_lim);
+  m_raw_steer_cmd_prev = std::clamp(current_steer.steering_tire_angle, -steer_lim_f, steer_lim_f);
+  m_raw_steer_cmd_pprev = std::clamp(current_steer.steering_tire_angle, -steer_lim_f, steer_lim_f);
 }
 
 bool MPC::getData(

--- a/control/mpc_lateral_controller/src/mpc.cpp
+++ b/control/mpc_lateral_controller/src/mpc.cpp
@@ -255,7 +255,7 @@ void MPC::resetPrevResult(const autoware_auto_vehicle_msgs::msg::SteeringReport 
 {
   // Consider limit. The prev value larger than limiation brakes the optimization constraint and
   // resluts in optimization failure.
-  float steer_lim_f = static_cast<float>(m_steer_lim);
+  const float steer_lim_f = static_cast<float>(m_steer_lim);
   m_raw_steer_cmd_prev = std::clamp(current_steer.steering_tire_angle, -steer_lim_f, steer_lim_f);
   m_raw_steer_cmd_pprev = std::clamp(current_steer.steering_tire_angle, -steer_lim_f, steer_lim_f);
 }


### PR DESCRIPTION
## Description

MPC optimization sometimes failed when it receives a steering status larger than `mpc_steering_limit`. It is due to the break of the optimization constraint.
This PR fixes the `prev_steering_value` considering the steering limit.

## Related links

TIERIV COMPANY INTERNAL LINK: https://tier4.atlassian.net/browse/T4PB-26780

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
