### PR TITLE
fix(lane_change): lane change module changes output path intentionally without approval

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -80,6 +80,7 @@ void LaneChangeModule::onEntry()
   current_state_ = ModuleStatus::SUCCESS;
 #else
   current_state_ = ModuleStatus::IDLE;
+  waitApproval();
 #endif
   current_lane_change_state_ = LaneChangeStates::Normal;
   updateLaneChangeStatus();


### PR DESCRIPTION
## Description

**Bug: Lane change module change it's output path without approval, and it is an unexpected behavior.**

https://user-images.githubusercontent.com/44889564/224465019-d7a9971f-333d-41ab-8a52-0ad03c81529a.mp4

---

In this PR, it set `waitApproval()` in onEntry() in order to block `plan()` execution at first time in following `run()` function.

https://github.com/autowarefoundation/autoware.universe/blob/e4bcc868b09d6d465d0f4fa4fc62b30b2de36413/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp#L135-L153

## Test perform

1.set option `COMPILE_WITH_OLD_ARCHITECTURE` to `FALSE`

https://github.com/autowarefoundation/autoware.universe/blob/2ace0d2b030cabf19ff037b56328cff07c2fb245/planning/behavior_path_planner/CMakeLists.txt#L10

2.disable rtc auto mode

```yaml
/**:
  ros__parameters:
    module_list:
      - "blind_spot"
      - "crosswalk"
      - "detection_area"
      - "intersection"
      - "no_stopping_area"
      - "traffic_light"
      # - "ext_request_lane_change_left"
      # - "ext_request_lane_change_right"
      - "lane_change_left"
      - "lane_change_right"
      - "avoidance_left"
      - "avoidance_right"
      - "pull_over"
      - "pull_out"

    default_enable_list:
      - "blind_spot"
      - "crosswalk"
      - "detection_area"
      - "intersection"
      - "no_stopping_area"
      - "traffic_light"
      # - "lane_change_left"
      # - "lane_change_right"
      - "avoidance_left"
      - "avoidance_right"
      - "pull_over"
      - "pull_out"
```

![rviz_screenshot_2023_03_11-13_30_10](https://user-images.githubusercontent.com/44889564/224465040-7623a677-50ae-4de6-9b30-5a901c4be69f.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
