### PR TITLE
feat(tier4_autoware_utils): add expandPolygon function

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/boost_polygon_utils.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/boost_polygon_utils.hpp
@@ -44,7 +44,7 @@ Polygon2d toPolygon2d(const autoware_auto_perception_msgs::msg::DetectedObject &
 Polygon2d toPolygon2d(const autoware_auto_perception_msgs::msg::TrackedObject & object);
 Polygon2d toPolygon2d(const autoware_auto_perception_msgs::msg::PredictedObject & object);
 double getArea(const autoware_auto_perception_msgs::msg::Shape & shape);
-
+Polygon2d expandPolygon(const Polygon2d & input_polygon, const double offset);
 }  // namespace tier4_autoware_utils
 
 #endif  // TIER4_AUTOWARE_UTILS__GEOMETRY__BOOST_POLYGON_UTILS_HPP_

--- a/common/tier4_autoware_utils/src/geometry/boost_polygon_utils.cpp
+++ b/common/tier4_autoware_utils/src/geometry/boost_polygon_utils.cpp
@@ -210,4 +210,34 @@ double getArea(const autoware_auto_perception_msgs::msg::Shape & shape)
 
   throw std::logic_error("The shape type is not supported in tier4_autoware_utils.");
 }
+
+Polygon2d expandPolygon(const Polygon2d & input_polygon, const double offset)
+{
+  // NOTE: There is a duplicated point.
+  const size_t num_points = input_polygon.outer().size() - 1;
+
+  Polygon2d expanded_polygon;
+  for (size_t i = 0; i < num_points; ++i) {
+    const auto & curr_p = input_polygon.outer().at(i);
+    const auto & next_p = input_polygon.outer().at(i + 1);
+    const auto & prev_p =
+      i == 0 ? input_polygon.outer().at(num_points - 1) : input_polygon.outer().at(i - 1);
+
+    Eigen::Vector2d current_to_next(next_p.x() - curr_p.x(), next_p.y() - curr_p.y());
+    Eigen::Vector2d current_to_prev(prev_p.x() - curr_p.x(), prev_p.y() - curr_p.y());
+    current_to_next.normalize();
+    current_to_prev.normalize();
+
+    const Eigen::Vector2d offset_vector = (-current_to_next - current_to_prev).normalized();
+    const double theta = std::acos(offset_vector.dot(current_to_next));
+    const double scaled_offset = offset / std::sin(theta);
+    const Eigen::Vector2d offset_point =
+      Eigen::Vector2d(curr_p.x(), curr_p.y()) + offset_vector * scaled_offset;
+
+    expanded_polygon.outer().push_back(Point2d(offset_point.x(), offset_point.y()));
+  }
+
+  boost::geometry::correct(expanded_polygon);
+  return expanded_polygon;
+}
 }  // namespace tier4_autoware_utils

--- a/common/tier4_autoware_utils/src/geometry/boost_polygon_utils.cpp
+++ b/common/tier4_autoware_utils/src/geometry/boost_polygon_utils.cpp
@@ -211,9 +211,12 @@ double getArea(const autoware_auto_perception_msgs::msg::Shape & shape)
   throw std::logic_error("The shape type is not supported in tier4_autoware_utils.");
 }
 
+// NOTE: The number of vertices on the expanded polygon by boost::geometry::buffer
+//       is larger than the original one.
+//       This function fixes the issue.
 Polygon2d expandPolygon(const Polygon2d & input_polygon, const double offset)
 {
-  // NOTE: There is a duplicated point.
+  // NOTE: input_polygon is supposed to have a duplicated point.
   const size_t num_points = input_polygon.outer().size() - 1;
 
   Polygon2d expanded_polygon;

--- a/common/tier4_autoware_utils/test/src/geometry/test_boost_polygon_utils.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_boost_polygon_utils.cpp
@@ -259,3 +259,45 @@ TEST(boost_geometry, boost_getArea)
     EXPECT_DOUBLE_EQ(anti_clock_wise_area, x * y);
   }
 }
+
+TEST(boost_geometry, boost_expandPolygon)
+{
+  using tier4_autoware_utils::expandPolygon;
+
+  {  // box with a certain offset
+    Polygon2d box_poly{{{-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
+    const auto expanded_poly = expandPolygon(box_poly, 1.0);
+
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(0).x(), -2.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(0).y(), -2.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(1).x(), -2.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(1).y(), 2.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(2).x(), 2.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(2).y(), 2.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(3).x(), 2.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(3).y(), -2.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(4).x(), -2.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(4).y(), -2.0);
+  }
+
+  {  // box with no offset
+    Polygon2d box_poly{{{-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0}, {-1.0, -1.0}}};
+    const auto expanded_poly = expandPolygon(box_poly, 0.0);
+
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(0).x(), -1.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(0).y(), -1.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(1).x(), -1.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(1).y(), 1.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(2).x(), 1.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(2).y(), 1.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(3).x(), 1.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(3).y(), -1.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(4).x(), -1.0);
+    EXPECT_DOUBLE_EQ(expanded_poly.outer().at(4).y(), -1.0);
+  }
+
+  {  // empty polygon
+    Polygon2d empty_poly;
+    EXPECT_THROW(expandPolygon(empty_poly, 1.0), std::out_of_range);
+  }
+}


### PR DESCRIPTION
## Description

move `expandPolygon` used in the behavior_path_planner package to `common/`.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
