### PR TITLE
fix(avoidance): stop only when there is enough space to avoid

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -751,10 +751,12 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
 
   /**
    * Find the nearest object that should be avoid. When the ego follows reference path,
-   * if the lateral distance is smaller than minimum margin, the ego should avoid the object.
+   * if the both of following two conditions are satisfied, the module surely avoid the object.
+   * Condition1: there is risk to collide with object without avoidance.
+   * Condition2: there is enough space to avoid.
    */
   for (const auto & o : data.target_objects) {
-    if (o.avoid_required) {
+    if (o.avoid_required && o.is_avoidable) {
       data.avoid_required = true;
       data.stop_target_object = o;
     }


### PR DESCRIPTION
## Description

Previously, the vehicle stopped in front of the vehicle in not only Scenario A but B. However I think it is better that the avoidance module shonldn't insert stopping velocity, and obstacle stop/cruise planner should do it instead in Scenario B, because the avoidance module never execute avoidance maneuver. In this PR, I update behavior decision logic, and the vehicle stops only when there is enough space to avoid (Scenario A). 


|  | Scenario A | Scenerio B |
|:------------:|:------------:|:------------:|
| there is enough space to avoid | YES (`is_avoidanble = true`) | NO (`is_avoidanble = false`) |
| there is enough lateral margin | NO (< `lateral_passable_safety_buffer`) | NO (< `lateral_passable_safety_buffer`) |
| behavior | stop in front of the target object | **NOT** stop in front of the tqarget object |
|   | ![image](https://user-images.githubusercontent.com/44889564/224526720-86123452-aef0-4072-a86c-e4e02d81326f.png) | ![image](https://user-images.githubusercontent.com/44889564/224526690-d51481dc-ae9e-45df-b5be-a1af770bffec.png) |

## Test perform

### Scenario A

https://user-images.githubusercontent.com/44889564/224526590-491e0814-8851-42a3-b0ef-58c12889204d.mp4

### Scenario B

https://user-images.githubusercontent.com/44889564/224526619-7d560314-8412-4e64-98c8-b2bdc02ed3b6.mp4

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
