### PR TITLE
chore(system_error_monitor): supress initial warning

### DIFF
--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -443,7 +443,7 @@ void AutowareErrorMonitor::onTimer()
   if (!isDataReady()) {
     if ((this->now() - initialized_time_).seconds() > params_.data_ready_timeout) {
       RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+        get_logger(), *get_clock(), std::chrono::milliseconds(5000).count(),
         "input data is timeout");
       updateTimeoutHazardStatus();
       publishHazardStatus(hazard_status_);


### PR DESCRIPTION
## Description
Suppress initial warning "input data is timeout" before initializing the ego pose.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
