### PR TITLE
fix(lane_departure_checker): use kinematic state for ego pose

### DIFF
--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
@@ -66,7 +66,6 @@ struct Param
 
 struct Input
 {
-  geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose{};
   nav_msgs::msg::Odometry::ConstSharedPtr current_odom{};
   lanelet::LaneletMapPtr lanelet_map{};
   LaneletRoute::ConstSharedPtr route{};

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker_node.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker_node.hpp
@@ -23,7 +23,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/ros/processing_time_publisher.hpp>
-#include <tier4_autoware_utils/ros/self_pose_listener.hpp>
 
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
@@ -61,7 +60,6 @@ public:
 
 private:
   // Subscriber
-  tier4_autoware_utils::SelfPoseListener self_pose_listener_{this};
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
   rclcpp::Subscription<HADMapBin>::SharedPtr sub_lanelet_map_bin_;
   rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;
@@ -69,7 +67,6 @@ private:
   rclcpp::Subscription<Trajectory>::SharedPtr sub_predicted_trajectory_;
 
   // Data Buffer
-  geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
   nav_msgs::msg::Odometry::ConstSharedPtr current_odom_;
   lanelet::LaneletMapPtr lanelet_map_;
   lanelet::ConstLanelets shoulder_lanelets_;

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -100,7 +100,7 @@ Output LaneDepartureChecker::update(const Input & input)
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
 
   output.trajectory_deviation = calcTrajectoryDeviation(
-    *input.reference_trajectory, input.current_pose->pose, param_.ego_nearest_dist_threshold,
+    *input.reference_trajectory, input.current_odom->pose.pose, param_.ego_nearest_dist_threshold,
     param_.ego_nearest_yaw_threshold);
   output.processing_time_map["calcTrajectoryDeviation"] = stop_watch.toc(true);
 


### PR DESCRIPTION
## Description

Use kinematic state for ego pose instead of tf.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
