### PR TITLE
fix(lane_change): use previous output

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -78,6 +78,14 @@ std::pair<bool, bool> getLaneChangePaths(
   const double check_distance, LaneChangePaths * candidate_paths,
   std::unordered_map<std::string, CollisionCheckDebug> * debug_data);
 
+std::pair<bool, bool> getLaneChangePaths(
+  const PathWithLaneId & original_path, const RouteHandler & route_handler,
+  const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
+  const Pose & pose, const Twist & twist, const PredictedObjects::ConstSharedPtr dynamic_objects,
+  const BehaviorPathPlannerParameters & common_parameter, const LaneChangeParameters & parameter,
+  const double check_distance, LaneChangePaths * candidate_paths,
+  std::unordered_map<std::string, CollisionCheckDebug> * debug_data);
+
 bool isLaneChangePathSafe(
   const LaneChangePath & lane_change_path, const PredictedObjects::ConstSharedPtr dynamic_objects,
   const LaneChangeTargetObjectIndices & dynamic_object_indices, const Pose & current_pose,
@@ -107,6 +115,11 @@ PathWithLaneId getLaneChangePathPrepareSegment(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & original_lanelets,
   const double arc_length_from_current, const double backward_path_length,
   const double prepare_distance, const double prepare_speed);
+
+PathWithLaneId getLaneChangePathPrepareSegment(
+  const PathWithLaneId & original_path, const lanelet::ConstLanelets & original_lanelets,
+  const Pose & current_pose, const double backward_path_length, const double prepare_distance,
+  const double prepare_speed);
 
 PathWithLaneId getLaneChangePathLaneChangingSegment(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanelets,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -437,10 +437,17 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
 
   // find candidate paths
   LaneChangePaths valid_paths;
+#ifdef USE_OLD_ARCHITECTURE
   const auto [found_valid_path, found_safe_path] = lane_change_utils::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     planner_data_->dynamic_object, common_parameters, *parameters_, check_distance, &valid_paths,
     &object_debug_);
+#else
+  const auto [found_valid_path, found_safe_path] = lane_change_utils::getLaneChangePaths(
+    *getPreviousModuleOutput().path, *route_handler, current_lanes, lane_change_lanes, current_pose,
+    current_twist, planner_data_->dynamic_object, common_parameters, *parameters_, check_distance,
+    &valid_paths, &object_debug_);
+#endif
   debug_valid_path_ = valid_paths;
 
   if (parameters_->publish_debug_marker) {


### PR DESCRIPTION
## Description

add new lane change utils function to generate prepare segment from previous module output.

```c++
PathWithLaneId getLaneChangePathPrepareSegment(
  const PathWithLaneId & original_path, const lanelet::ConstLanelets & original_lanelets,
  const Pose & current_pose, const double backward_path_length, const double prepare_distance,
  const double prepare_speed);
```

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
