### PR TITLE
fix(mpc): reset prev value when mpc failed

### DIFF
--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc.hpp
@@ -199,10 +199,7 @@ private:
    * @brief set the reference trajectory to follow
    */
   void storeSteerCmd(const double steer);
-  /**
-   * @brief reset previous result of MPC
-   */
-  void resetPrevResult(const SteeringReport & current_steer);
+
   /**
    * @brief set initial condition for mpc
    * @param [in] data mpc data
@@ -393,6 +390,12 @@ public:
     const bool enable_path_smoothing, const int path_filter_moving_ave_num,
     const int curvature_smoothing_num_traj, const int curvature_smoothing_num_ref_steer,
     const bool extend_trajectory_for_end_yaw_control);
+
+  /**
+   * @brief reset previous result of MPC
+   */
+  void resetPrevResult(const SteeringReport & current_steer);
+
   /**
    * @brief set the vehicle model of this MPC
    */

--- a/control/mpc_lateral_controller/src/mpc.cpp
+++ b/control/mpc_lateral_controller/src/mpc.cpp
@@ -264,12 +264,6 @@ bool MPC::getData(
   if (!MPCUtils::calcNearestPoseInterp(
         traj, current_pose, &(data->nearest_pose), &(nearest_idx), &(data->nearest_time),
         ego_nearest_dist_threshold, ego_nearest_yaw_threshold, m_logger, *m_clock)) {
-    // reset previous MPC result
-    // Note: When a large deviation from the trajectory occurs, the optimization stops and
-    // the vehicle will return to the path by re-planning the trajectory or external operation.
-    // After the recovery, the previous value of the optimization may deviate greatly from
-    // the actual steer angle, and it may make the optimization result unstable.
-    resetPrevResult(current_steer);
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       m_logger, *m_clock, duration, "calculateMPC: error in calculating nearest pose. stop mpc.");
     return false;

--- a/control/mpc_lateral_controller/src/mpc.cpp
+++ b/control/mpc_lateral_controller/src/mpc.cpp
@@ -248,8 +248,8 @@ void MPC::setReferenceTrajectory(
 
 void MPC::resetPrevResult(const SteeringReport & current_steer)
 {
-  // Consider limit. The prev value larger than limiation brakes the optimization constraint and
-  // resluts in optimization failure.
+  // Consider limit. The prev value larger than limitaion brakes the optimization constraint and
+  // results in optimization failure.
   const float steer_lim_f = static_cast<float>(m_steer_lim);
   m_raw_steer_cmd_prev = std::clamp(current_steer.steering_tire_angle, -steer_lim_f, steer_lim_f);
   m_raw_steer_cmd_pprev = std::clamp(current_steer.steering_tire_angle, -steer_lim_f, steer_lim_f);

--- a/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -204,6 +204,15 @@ trajectory_follower::LateralOutput MpcLateralController::run(
     m_current_steering, m_current_kinematic_state.twist.twist.linear.x,
     m_current_kinematic_state.pose.pose, ctrl_cmd, predicted_traj, debug_values);
 
+  // reset previous MPC result
+  // Note: When a large deviation from the trajectory occurs, the optimization stops and
+  // the vehicle will return to the path by re-planning the trajectory or external operation.
+  // After the recovery, the previous value of the optimization may deviate greatly from
+  // the actual steer angle, and it may make the optimization result unstable.
+  if (!is_mpc_solved) {
+    m_mpc.resetPrevResult(m_current_steering);
+  }
+
   if (enable_auto_steering_offset_removal_) {
     steering_offset_->updateOffset(
       m_current_kinematic_state.twist.twist,


### PR DESCRIPTION
## Description

**Before**

The previous steering value in MPC is updated with the actual steering only when `getData()` failed.
-> when `calculateMPC()` is failed for any reason other than `getData()` , the previous steering value is not updated, which is unexpected.

**After**

The previous steering value in MPC is updated with the actual steering whenever `calculateMPC()` failed.

## Related links



TIERIV'S INTERNAL LINK: https://tier4.atlassian.net/browse/T4PB-26780

## Tests performed

Run psim in several paths.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
