### PR TITLE
fix(tensorrt_yolox): resolve all output labels become unknown

### DIFF
--- a/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -148,8 +148,8 @@ void TrtYoloXNode::replaceLabelMap()
     if (label == "PERSON") {
       label = "PEDESTRIAN";
     } else if (
-      label != "CAR" || label != "PEDESTRIAN" || label != "BUS" || label != "TRUCK" ||
-      label != "BICYCLE" || label != "MOTORCYCLE") {
+      label != "CAR" && label != "PEDESTRIAN" && label != "BUS" && label != "TRUCK" &&
+      label != "BICYCLE" && label != "MOTORCYCLE") {
       label = "UNKNOWN";
     }
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Currently, `tensorrt_yolox` assigns `unknown` for all detected objects.
After this PR, it seems correct labels are assigned.

Before

https://user-images.githubusercontent.com/60615504/224645966-1a624ea3-1b29-4ae5-811c-a544e7ff07ff.mp4

After

https://user-images.githubusercontent.com/60615504/224646007-9b4a1dd7-8212-450a-ad58-e18ac20e6794.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
