### PR TITLE
perf(behavior_path_palnner): improve performance of isPathInLanelets

### DIFF
--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -139,12 +139,14 @@ bool isPathInLanelets(
   const PathWithLaneId & path, const lanelet::ConstLanelets & original_lanelets,
   const lanelet::ConstLanelets & target_lanelets)
 {
-  const auto current_lane_poly_2d = lanelet::utils::to2D(
-    lanelet::utils::getPolygonFromArcLength(original_lanelets, 0, std::numeric_limits<double>::max())
-    ).basicPolygon();
-  const auto target_lane_poly_2d = lanelet::utils::to2D(
-    lanelet::utils::getPolygonFromArcLength(target_lanelets, 0, std::numeric_limits<double>::max())
-    ).basicPolygon();
+  const auto current_lane_poly_2d =
+    lanelet::utils::to2D(lanelet::utils::getPolygonFromArcLength(
+                           original_lanelets, 0, std::numeric_limits<double>::max()))
+      .basicPolygon();
+  const auto target_lane_poly_2d =
+    lanelet::utils::to2D(lanelet::utils::getPolygonFromArcLength(
+                           target_lanelets, 0, std::numeric_limits<double>::max()))
+      .basicPolygon();
 
   for (const auto & pt : path.points) {
     const lanelet::BasicPoint2d ll_pt(pt.point.pose.position.x, pt.point.pose.position.y);

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -139,21 +139,19 @@ bool isPathInLanelets(
   const PathWithLaneId & path, const lanelet::ConstLanelets & original_lanelets,
   const lanelet::ConstLanelets & target_lanelets)
 {
-  const auto current_lane_poly = lanelet::utils::getPolygonFromArcLength(
-    original_lanelets, 0, std::numeric_limits<double>::max());
-  const auto target_lane_poly =
-    lanelet::utils::getPolygonFromArcLength(target_lanelets, 0, std::numeric_limits<double>::max());
-  const auto current_lane_poly_2d = lanelet::utils::to2D(current_lane_poly).basicPolygon();
-  const auto target_lane_poly_2d = lanelet::utils::to2D(target_lane_poly).basicPolygon();
+  const auto current_lane_poly_2d = lanelet::utils::to2D(
+    lanelet::utils::getPolygonFromArcLength(original_lanelets, 0, std::numeric_limits<double>::max())
+    ).basicPolygon();
+  const auto target_lane_poly_2d = lanelet::utils::to2D(
+    lanelet::utils::getPolygonFromArcLength(target_lanelets, 0, std::numeric_limits<double>::max())
+    ).basicPolygon();
+
   for (const auto & pt : path.points) {
     const lanelet::BasicPoint2d ll_pt(pt.point.pose.position.x, pt.point.pose.position.y);
-    const auto is_in_current = boost::geometry::covered_by(ll_pt, current_lane_poly_2d);
-    if (is_in_current) {
-      continue;
-    }
-    const auto is_in_target = boost::geometry::covered_by(ll_pt, target_lane_poly_2d);
-    if (!is_in_target) {
-      return false;
+    if (!boost::geometry::covered_by(ll_pt, target_lane_poly_2d)) {
+      if (!boost::geometry::covered_by(ll_pt, current_lane_poly_2d)) {
+        return false;
+      }
     }
   }
   return true;


### PR DESCRIPTION
Signed-off-by: Taiga Takano taiga.takano@tier4.jp

# Description
Changed the order in which covered_by functions are executed. This change improves performance without changing output.

This function is called in the getSafePath function, which is heavily used in the lane_change module and has become a bottleneck.

<img width="591" alt="スクリーンショット 2023-03-13 19 31 43" src="https://user-images.githubusercontent.com/53041471/224676661-ea91c15e-2bee-41ae-8f19-0f85f12e16d4.png">

