### PR TITLE
feat(lane change): support new framework external request

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -20,6 +20,7 @@ set(common_src
   src/scene_module/pull_over/pull_over_module.cpp
   src/scene_module/side_shift/side_shift_module.cpp
   src/scene_module/lane_change/lane_change_module.cpp
+  src/scene_module/lane_change/external_request_lane_change_module.cpp
   src/turn_signal_decider.cpp
   src/util/avoidance/util.cpp
   src/util/lane_change/util.cpp
@@ -49,7 +50,6 @@ if(COMPILE_WITH_OLD_ARCHITECTURE)
     src/behavior_tree_manager.cpp
     src/scene_module/scene_module_bt_node_interface.cpp
     src/scene_module/lane_following/lane_following_module.cpp
-    src/scene_module/lane_change/external_request_lane_change_module.cpp
     src/scene_module/pull_over/pull_over_module.cpp
     ${common_src}
   )

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -35,8 +35,8 @@ struct BehaviorPathPlannerParameters
   ModuleConfigParameters config_side_shift;
   ModuleConfigParameters config_lane_change_left;
   ModuleConfigParameters config_lane_change_right;
-  ModuleConfigParameters config_external_lane_change_left;
-  ModuleConfigParameters config_external_lane_change_right;
+  ModuleConfigParameters config_ext_request_lane_change_left;
+  ModuleConfigParameters config_ext_request_lane_change_right;
 
   double backward_path_length;
   double forward_path_length;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
@@ -47,6 +47,8 @@ using marker_utils::CollisionCheckDebug;
 using tier4_planning_msgs::msg::LaneChangeDebugMsg;
 using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
 
+#ifdef USE_OLD_ARCHITECTURE
+
 class ExternalRequestLaneChangeModule : public SceneModuleInterface
 {
 public:
@@ -151,6 +153,7 @@ public:
     const std::string & name, rclcpp::Node & node,
     std::shared_ptr<LaneChangeParameters> parameters);
 };
+#endif
 
 }  // namespace behavior_path_planner
 // clang-format off

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -60,7 +60,8 @@ public:
   LaneChangeModule(
     const std::string & name, rclcpp::Node & node,
     const std::shared_ptr<LaneChangeParameters> & parameters,
-    const std::shared_ptr<RTCInterface> & rtc_interface, Direction direction);
+    const std::shared_ptr<RTCInterface> & rtc_interface, Direction direction,
+    LaneChangeModuleType type);
 #endif
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
@@ -135,6 +136,7 @@ private:
   UUID candidate_uuid_;
 #else
   Direction direction_{Direction::NONE};
+  LaneChangeModuleType type_{LaneChangeModuleType::NORMAL};
 #endif
 
   void resetParameters();
@@ -198,8 +200,10 @@ private:
 #endif
 
   PathWithLaneId getReferencePath() const;
+#ifdef USE_OLD_ARCHITECTURE
   lanelet::ConstLanelets getLaneChangeLanes(
     const lanelet::ConstLanelets & current_lanes, const double lane_change_lane_length) const;
+#endif
   std::pair<bool, bool> getSafePath(
     const lanelet::ConstLanelets & lane_change_lanes, const double check_distance,
     LaneChangePath & safe_path) const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
@@ -33,12 +33,13 @@ class LaneChangeModuleManager : public SceneModuleManagerInterface
 public:
   LaneChangeModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
-    std::shared_ptr<LaneChangeParameters> parameters, Direction direction);
+    std::shared_ptr<LaneChangeParameters> parameters, const Direction direction,
+    const LaneChangeModuleType type);
 
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
     return std::make_shared<LaneChangeModule>(
-      name_, *node_, parameters_, rtc_interface_, direction_);
+      name_, *node_, parameters_, rtc_interface_, direction_, type_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
@@ -51,6 +52,8 @@ private:
   std::vector<std::shared_ptr<LaneChangeModule>> registered_modules_;
 
   Direction direction_;
+
+  LaneChangeModuleType type_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_visitor.hpp
@@ -28,7 +28,9 @@ namespace behavior_path_planner
 // Forward Declaration
 class AvoidanceModule;
 class LaneChangeModule;
+#ifdef USE_OLD_ARCHITECTURE
 class ExternalRequestLaneChangeModule;
+#endif
 class LaneFollowingModule;
 class PullOutModule;
 class PullOverModule;
@@ -43,7 +45,9 @@ class SceneModuleVisitor
 {
 public:
   void visitLaneChangeModule(const LaneChangeModule * module) const;
+#ifdef USE_OLD_ARCHITECTURE
   void visitExternalRequestLaneChangeModule(const ExternalRequestLaneChangeModule * module) const;
+#endif
   void visitAvoidanceModule(const AvoidanceModule * module) const;
 
   std::shared_ptr<AvoidanceDebugMsgArray> getAvoidanceModuleDebugMsg() const;
@@ -51,7 +55,10 @@ public:
 
 protected:
   mutable std::shared_ptr<LaneChangeDebugMsgArray> lane_change_visitor_;
+
+#ifdef USE_OLD_ARCHITECTURE
   mutable std::shared_ptr<LaneChangeDebugMsgArray> ext_request_lane_change_visitor_;
+#endif
   mutable std::shared_ptr<AvoidanceDebugMsgArray> avoidance_visitor_;
 };
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/lane_change_module_data.hpp
@@ -80,10 +80,7 @@ struct LaneChangeTargetObjectIndices
   std::vector<size_t> other_lane{};
 };
 
-enum class LaneChangeType {
-  Normal = 0,
-  ExternalRequest = 1,
-};
+enum class LaneChangeModuleType { NORMAL = 0, EXTERNAL_REQUEST };
 }  // namespace behavior_path_planner
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTIL__LANE_CHANGE__LANE_CHANGE_MODULE_DATA_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -80,7 +80,7 @@ std::pair<bool, bool> getLaneChangePaths(
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
   const Pose & pose, const Twist & twist, const PredictedObjects::ConstSharedPtr dynamic_objects,
   const BehaviorPathPlannerParameters & common_parameter, const LaneChangeParameters & parameter,
-  const double check_distance, LaneChangePaths * candidate_paths,
+  const double check_distance, const Direction direction, LaneChangePaths * candidate_paths,
   std::unordered_map<std::string, CollisionCheckDebug> * debug_data);
 
 bool isLaneChangePathSafe(
@@ -93,10 +93,18 @@ bool isLaneChangePathSafe(
   std::unordered_map<std::string, CollisionCheckDebug> & debug_data,
   const double acceleration = 0.0);
 
+#ifdef USE_OLD_ARCHITECTURE
 bool hasEnoughDistance(
   const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes, const Pose & current_pose, const Pose & goal_pose,
   const RouteHandler & route_handler, const double minimum_lane_change_length);
+#else
+bool hasEnoughDistance(
+  const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,
+  const lanelet::ConstLanelets & target_lanes, const Pose & current_pose, const Pose & goal_pose,
+  const RouteHandler & route_handler, const double minimum_lane_change_length,
+  const Direction direction);
+#endif
 
 ShiftLine getLaneChangingShiftLine(
   const PathWithLaneId & prepare_segment, const PathWithLaneId & lane_changing_segment,

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -159,7 +159,11 @@ LaneChangeTargetObjectIndices filterObjectIndices(
 
 double calcLateralBufferForFiltering(const double vehicle_width, const double lateral_buffer = 0.0);
 
-std::string getStrDirection(const std::string name, const Direction direction);
+std::string getStrDirection(const std::string & name, const Direction direction);
 
+lanelet::ConstLanelets getLaneChangeLanes(
+  const std::shared_ptr<const PlannerData> & planner_data,
+  const lanelet::ConstLanelets & current_lanes, const double lane_change_lane_length,
+  const double prepare_duration, const Direction direction, const LaneChangeModuleType type);
 }  // namespace behavior_path_planner::lane_change_utils
 #endif  // BEHAVIOR_PATH_PLANNER__UTIL__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -204,6 +204,16 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     planner_manager_ =
       std::make_shared<PlannerManager>(*this, lane_following_param_ptr_, p.verbose);
 
+    const auto register_and_create_publisher = [&](const auto & manager) {
+      const auto & module_name =
+        manager->getModuleName();
+      planner_manager_->registerSceneModuleManager(manager);
+      path_candidate_publishers_.emplace(
+        module_name, create_publisher<Path>(path_candidate_name_space + module_name, 1));
+      path_reference_publishers_.emplace(
+        module_name, create_publisher<Path>(path_reference_name_space + module_name, 1));
+    };
+
     if (p.config_pull_out.enable_module) {
       auto manager = std::make_shared<PullOutModuleManager>(
         this, "pull_out", p.config_pull_out, pull_out_param_ptr_);
@@ -239,11 +249,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       auto manager = std::make_shared<LaneChangeModuleManager>(
         this, module_topic, p.config_lane_change_left, lane_change_param_ptr_,
         route_handler::Direction::LEFT, LaneChangeModuleType::NORMAL);
-      planner_manager_->registerSceneModuleManager(manager);
-      path_candidate_publishers_.emplace(
-        module_topic, create_publisher<Path>(path_candidate_name_space + module_topic, 1));
-      path_reference_publishers_.emplace(
-        module_topic, create_publisher<Path>(path_reference_name_space + module_topic, 1));
+      register_and_create_publisher(manager);
     }
 
     if (p.config_lane_change_right.enable_module) {
@@ -251,11 +257,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       auto manager = std::make_shared<LaneChangeModuleManager>(
         this, module_topic, p.config_lane_change_right, lane_change_param_ptr_,
         route_handler::Direction::RIGHT, LaneChangeModuleType::NORMAL);
-      planner_manager_->registerSceneModuleManager(manager);
-      path_candidate_publishers_.emplace(
-        module_topic, create_publisher<Path>(path_candidate_name_space + module_topic, 1));
-      path_reference_publishers_.emplace(
-        module_topic, create_publisher<Path>(path_reference_name_space + module_topic, 1));
+      register_and_create_publisher(manager);
     }
 
     if (p.config_ext_request_lane_change_right.enable_module) {
@@ -263,11 +265,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       auto manager = std::make_shared<LaneChangeModuleManager>(
         this, module_topic, p.config_ext_request_lane_change_right, lane_change_param_ptr_,
         route_handler::Direction::RIGHT, LaneChangeModuleType::EXTERNAL_REQUEST);
-      planner_manager_->registerSceneModuleManager(manager);
-      path_candidate_publishers_.emplace(
-        module_topic, create_publisher<Path>(path_candidate_name_space + module_topic, 1));
-      path_reference_publishers_.emplace(
-        module_topic, create_publisher<Path>(path_reference_name_space + module_topic, 1));
+      register_and_create_publisher(manager);
     }
 
     if (p.config_ext_request_lane_change_left.enable_module) {
@@ -275,11 +273,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       auto manager = std::make_shared<LaneChangeModuleManager>(
         this, module_topic, p.config_ext_request_lane_change_left, lane_change_param_ptr_,
         route_handler::Direction::LEFT, LaneChangeModuleType::EXTERNAL_REQUEST);
-      planner_manager_->registerSceneModuleManager(manager);
-      path_candidate_publishers_.emplace(
-        module_topic, create_publisher<Path>(path_candidate_name_space + module_topic, 1));
-      path_reference_publishers_.emplace(
-        module_topic, create_publisher<Path>(path_reference_name_space + module_topic, 1));
+      register_and_create_publisher(manager);
     }
 
     if (p.config_avoidance.enable_module) {

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -238,7 +238,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       const std::string module_topic = "lane_change_left";
       auto manager = std::make_shared<LaneChangeModuleManager>(
         this, module_topic, p.config_lane_change_left, lane_change_param_ptr_,
-        route_handler::Direction::LEFT);
+        route_handler::Direction::LEFT, LaneChangeModuleType::NORMAL);
       planner_manager_->registerSceneModuleManager(manager);
       path_candidate_publishers_.emplace(
         module_topic, create_publisher<Path>(path_candidate_name_space + module_topic, 1));
@@ -250,7 +250,31 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       const std::string module_topic = "lane_change_right";
       auto manager = std::make_shared<LaneChangeModuleManager>(
         this, module_topic, p.config_lane_change_right, lane_change_param_ptr_,
-        route_handler::Direction::RIGHT);
+        route_handler::Direction::RIGHT, LaneChangeModuleType::NORMAL);
+      planner_manager_->registerSceneModuleManager(manager);
+      path_candidate_publishers_.emplace(
+        module_topic, create_publisher<Path>(path_candidate_name_space + module_topic, 1));
+      path_reference_publishers_.emplace(
+        module_topic, create_publisher<Path>(path_reference_name_space + module_topic, 1));
+    }
+
+    if (p.config_ext_request_lane_change_right.enable_module) {
+      const std::string module_topic = "ext_request_lane_change_right";
+      auto manager = std::make_shared<LaneChangeModuleManager>(
+        this, module_topic, p.config_ext_request_lane_change_right, lane_change_param_ptr_,
+        route_handler::Direction::RIGHT, LaneChangeModuleType::EXTERNAL_REQUEST);
+      planner_manager_->registerSceneModuleManager(manager);
+      path_candidate_publishers_.emplace(
+        module_topic, create_publisher<Path>(path_candidate_name_space + module_topic, 1));
+      path_reference_publishers_.emplace(
+        module_topic, create_publisher<Path>(path_reference_name_space + module_topic, 1));
+    }
+
+    if (p.config_ext_request_lane_change_left.enable_module) {
+      const std::string module_topic = "ext_request_lane_change_left";
+      auto manager = std::make_shared<LaneChangeModuleManager>(
+        this, module_topic, p.config_ext_request_lane_change_left, lane_change_param_ptr_,
+        route_handler::Direction::LEFT, LaneChangeModuleType::EXTERNAL_REQUEST);
       planner_manager_->registerSceneModuleManager(manager);
       path_candidate_publishers_.emplace(
         module_topic, create_publisher<Path>(path_candidate_name_space + module_topic, 1));
@@ -344,6 +368,28 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
       declare_parameter<bool>(ns + "enable_simultaneous_execution");
     p.config_lane_change_right.priority = declare_parameter<int>(ns + "priority");
     p.config_lane_change_right.max_module_size = declare_parameter<int>(ns + "max_module_size");
+  }
+
+  {
+    const std::string ns = "ext_request_lane_change_right.";
+    p.config_ext_request_lane_change_right.enable_module =
+      declare_parameter<bool>(ns + "enable_module");
+    p.config_ext_request_lane_change_right.enable_simultaneous_execution =
+      declare_parameter<bool>(ns + "enable_simultaneous_execution");
+    p.config_ext_request_lane_change_right.priority = declare_parameter<int>(ns + "priority");
+    p.config_ext_request_lane_change_right.max_module_size =
+      declare_parameter<int>(ns + "max_module_size");
+  }
+
+  {
+    const std::string ns = "ext_request_lane_change_left.";
+    p.config_ext_request_lane_change_left.enable_module =
+      declare_parameter<bool>(ns + "enable_module");
+    p.config_ext_request_lane_change_left.enable_simultaneous_execution =
+      declare_parameter<bool>(ns + "enable_simultaneous_execution");
+    p.config_ext_request_lane_change_left.priority = declare_parameter<int>(ns + "priority");
+    p.config_ext_request_lane_change_left.max_module_size =
+      declare_parameter<int>(ns + "max_module_size");
   }
 
   {

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -205,8 +205,7 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       std::make_shared<PlannerManager>(*this, lane_following_param_ptr_, p.verbose);
 
     const auto register_and_create_publisher = [&](const auto & manager) {
-      const auto & module_name =
-        manager->getModuleName();
+      const auto & module_name = manager->getModuleName();
       planner_manager_->registerSceneModuleManager(manager);
       path_candidate_publishers_.emplace(
         module_name, create_publisher<Path>(path_candidate_name_space + module_name, 1));

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 namespace behavior_path_planner
 {
+#ifdef USE_OLD_ARCHITECTURE
 std::string getTopicName(const ExternalRequestLaneChangeModule::Direction & direction)
 {
   const std::string direction_name =
@@ -771,5 +772,6 @@ ExternalRequestLaneChangeLeftModule::ExternalRequestLaneChangeLeftModule(
 : ExternalRequestLaneChangeModule{name, node, parameters, Direction::LEFT}
 {
 }
+#endif
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -480,7 +480,7 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
   const auto [found_valid_path, found_safe_path] = lane_change_utils::getLaneChangePaths(
     *getPreviousModuleOutput().path, *route_handler, current_lanes, lane_change_lanes, current_pose,
     current_twist, planner_data_->dynamic_object, common_parameters, *parameters_, check_distance,
-    &valid_paths, &object_debug_);
+    direction_, &valid_paths, &object_debug_);
 #endif
   debug_valid_path_ = valid_paths;
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -51,11 +51,12 @@ LaneChangeModule::LaneChangeModule(
 LaneChangeModule::LaneChangeModule(
   const std::string & name, rclcpp::Node & node,
   const std::shared_ptr<LaneChangeParameters> & parameters,
-  const std::shared_ptr<RTCInterface> & rtc_interface, Direction direction)
-: SceneModuleInterface{name, node}, parameters_{parameters}, direction_{direction}
+  const std::shared_ptr<RTCInterface> & rtc_interface, Direction direction,
+  LaneChangeModuleType type)
+: SceneModuleInterface{name, node}, parameters_{parameters}, direction_{direction}, type_{type}
 {
   rtc_interface_ptr_ = rtc_interface;
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "lane_change");
+  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, name);
 }
 #endif
 
@@ -87,11 +88,14 @@ bool LaneChangeModule::isExecutionRequested() const
 
 #ifdef USE_OLD_ARCHITECTURE
   const auto current_lanes = util::getCurrentLanes(planner_data_);
+  const auto lane_change_lanes = getLaneChangeLanes(current_lanes, lane_change_lane_length_);
 #else
   const auto current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
+  const auto lane_change_lanes = lane_change_utils::getLaneChangeLanes(
+    planner_data_, current_lanes, lane_change_lane_length_,
+    parameters_->lane_change_prepare_duration, direction_, type_);
 #endif
-  const auto lane_change_lanes = getLaneChangeLanes(current_lanes, lane_change_lane_length_);
 
   if (lane_change_lanes.empty()) {
     return false;
@@ -112,11 +116,14 @@ bool LaneChangeModule::isExecutionReady() const
 
 #ifdef USE_OLD_ARCHITECTURE
   const auto current_lanes = util::getCurrentLanes(planner_data_);
+  const auto lane_change_lanes = getLaneChangeLanes(current_lanes, lane_change_lane_length_);
 #else
   const auto current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
+  const auto lane_change_lanes = lane_change_utils::getLaneChangeLanes(
+    planner_data_, current_lanes, lane_change_lane_length_,
+    parameters_->lane_change_prepare_duration, direction_, type_);
 #endif
-  const auto lane_change_lanes = getLaneChangeLanes(current_lanes, lane_change_lane_length_);
 
   if (lane_change_lanes.empty()) {
     return false;
@@ -249,11 +256,14 @@ CandidateOutput LaneChangeModule::planCandidate() const
   // Get lane change lanes
 #ifdef USE_OLD_ARCHITECTURE
   const auto current_lanes = util::getCurrentLanes(planner_data_);
+  const auto lane_change_lanes = getLaneChangeLanes(current_lanes, lane_change_lane_length_);
 #else
   const auto current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
+  const auto lane_change_lanes = lane_change_utils::getLaneChangeLanes(
+    planner_data_, current_lanes, lane_change_lane_length_,
+    parameters_->lane_change_prepare_duration, direction_, type_);
 #endif
-  const auto lane_change_lanes = getLaneChangeLanes(current_lanes, lane_change_lane_length_);
 
   if (lane_change_lanes.empty()) {
     return output;
@@ -326,11 +336,14 @@ void LaneChangeModule::updateLaneChangeStatus()
 {
 #ifdef USE_OLD_ARCHITECTURE
   status_.current_lanes = util::getCurrentLanes(planner_data_);
+  status_.lane_change_lanes = getLaneChangeLanes(status_.current_lanes, lane_change_lane_length_);
 #else
   status_.current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
+  status_.lane_change_lanes = lane_change_utils::getLaneChangeLanes(
+    planner_data_, status_.current_lanes, lane_change_lane_length_,
+    parameters_->lane_change_prepare_duration, direction_, type_);
 #endif
-  status_.lane_change_lanes = getLaneChangeLanes(status_.current_lanes, lane_change_lane_length_);
 
   // Find lane change path
   LaneChangePath selected_path;
@@ -402,6 +415,7 @@ PathWithLaneId LaneChangeModule::getReferencePath() const
   return reference_path;
 }
 
+#ifdef USE_OLD_ARCHITECTURE
 lanelet::ConstLanelets LaneChangeModule::getLaneChangeLanes(
   const lanelet::ConstLanelets & current_lanes, const double lane_change_lane_length) const
 {
@@ -423,20 +437,17 @@ lanelet::ConstLanelets LaneChangeModule::getLaneChangeLanes(
     std::max(current_twist.linear.x * lane_change_prepare_duration, minimum_lane_change_length);
   lanelet::ConstLanelets current_check_lanes =
     route_handler->getLaneletSequence(current_lane, current_pose, 0.0, lane_change_prepare_length);
-  lanelet::ConstLanelet lane_change_lane;
-#ifdef USE_OLD_ARCHITECTURE
-  if (route_handler->getLaneChangeTarget(current_check_lanes, &lane_change_lane)) {
-#else
-  if (route_handler->getLaneChangeTarget(current_check_lanes, &lane_change_lane, direction_)) {
-#endif
+  const auto lane_change_lane = route_handler->getLaneChangeTarget(current_check_lanes);
+  if (lane_change_lane) {
     lane_change_lanes = route_handler->getLaneletSequence(
-      lane_change_lane, current_pose, lane_change_lane_length, lane_change_lane_length);
+      lane_change_lane.get(), current_pose, lane_change_lane_length, lane_change_lane_length);
   } else {
     lane_change_lanes.clear();
   }
 
   return lane_change_lanes;
 }
+#endif
 
 std::pair<bool, bool> LaneChangeModule::getSafePath(
   const lanelet::ConstLanelets & lane_change_lanes, const double check_distance,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
@@ -26,10 +26,13 @@ namespace behavior_path_planner
 using route_handler::Direction;
 LaneChangeModuleManager::LaneChangeModuleManager(
   rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
-  std::shared_ptr<LaneChangeParameters> parameters, Direction direction)
+  std::shared_ptr<LaneChangeParameters> parameters, const Direction direction,
+  const LaneChangeModuleType type)
 : SceneModuleManagerInterface(node, name, config),
   parameters_{std::move(parameters)},
-  direction_{direction}
+  direction_{direction},
+  type_{type}
+
 {
   rtc_interface_ = std::make_shared<RTCInterface>(node, name);
 }

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -1207,7 +1207,7 @@ lanelet::ConstLanelets getLaneChangeLanes(
       return route_handler->getLaneChangeTarget(current_check_lanes, direction);
     }
 
-    return route_handler->getLaneChangeTargetExceptPrefferedLane(current_check_lanes, direction);
+    return route_handler->getLaneChangeTargetExceptPreferredLane(current_check_lanes, direction);
   });
 
   if (lane_change_lane) {

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -296,9 +296,10 @@ public:
   PathWithLaneId getCenterLinePath(
     const lanelet::ConstLanelets & lanelet_sequence, const double s_start, const double s_end,
     bool use_exact = true) const;
-  bool getLaneChangeTarget(
-    const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet,
-    const Direction direction = Direction::NONE) const;
+  boost::optional<lanelet::ConstLanelet> getLaneChangeTarget(
+    const lanelet::ConstLanelets & lanelets, const Direction direction = Direction::NONE) const;
+  boost::optional<lanelet::ConstLanelet> getLaneChangeTargetExceptPrefferedLane(
+    const lanelet::ConstLanelets & lanelets, const Direction direction) const;
   bool getRightLaneChangeTargetExceptPreferredLane(
     const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const;
   bool getLeftLaneChangeTargetExceptPreferredLane(

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -298,7 +298,7 @@ public:
     bool use_exact = true) const;
   boost::optional<lanelet::ConstLanelet> getLaneChangeTarget(
     const lanelet::ConstLanelets & lanelets, const Direction direction = Direction::NONE) const;
-  boost::optional<lanelet::ConstLanelet> getLaneChangeTargetExceptPrefferedLane(
+  boost::optional<lanelet::ConstLanelet> getLaneChangeTargetExceptPreferredLane(
     const lanelet::ConstLanelets & lanelets, const Direction direction) const;
   bool getRightLaneChangeTargetExceptPreferredLane(
     const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const;

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1134,7 +1134,7 @@ boost::optional<lanelet::ConstLanelet> RouteHandler::getLaneChangeTarget(
   return boost::none;
 }
 
-boost::optional<lanelet::ConstLanelet> RouteHandler::getLaneChangeTargetExceptPrefferedLane(
+boost::optional<lanelet::ConstLanelet> RouteHandler::getLaneChangeTargetExceptPreferredLane(
   const lanelet::ConstLanelets & lanelets, const Direction direction) const
 {
   for (const auto & lanelet : lanelets) {

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1105,9 +1105,8 @@ std::vector<lanelet::ConstLanelets> RouteHandler::getPrecedingLaneletSequence(
     routing_graph_ptr_, lanelet, length, exclude_lanelets);
 }
 
-bool RouteHandler::getLaneChangeTarget(
-  const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet,
-  const Direction direction) const
+boost::optional<lanelet::ConstLanelet> RouteHandler::getLaneChangeTarget(
+  const lanelet::ConstLanelets & lanelets, const Direction direction) const
 {
   for (const auto & lanelet : lanelets) {
     const int num = getNumLaneToPreferredLane(lanelet, direction);
@@ -1116,28 +1115,54 @@ bool RouteHandler::getLaneChangeTarget(
     }
 
     if (direction == Direction::NONE || direction == Direction::RIGHT) {
-      if (num < 0) {
-        if (!!routing_graph_ptr_->right(lanelet)) {
-          const auto right_lanelet = routing_graph_ptr_->right(lanelet);
-          *target_lanelet = right_lanelet.get();
-          return true;
-        }
+      if (num >= 0) {
+        continue;
+      }
+      if (!!routing_graph_ptr_->right(lanelet)) {
+        return routing_graph_ptr_->right(lanelet);
       }
     }
 
     if (direction == Direction::NONE || direction == Direction::LEFT) {
-      if (num > 0) {
-        if (!!routing_graph_ptr_->left(lanelet)) {
-          const auto left_lanelet = routing_graph_ptr_->left(lanelet);
-          *target_lanelet = left_lanelet.get();
-          return true;
-        }
+      if (num <= 0) {
+        continue;
+      }
+      if (!!routing_graph_ptr_->left(lanelet)) {
+        return routing_graph_ptr_->left(lanelet);
       }
     }
   }
 
-  *target_lanelet = lanelets.front();
-  return false;
+  return boost::none;
+}
+
+boost::optional<lanelet::ConstLanelet> RouteHandler::getLaneChangeTargetExceptPrefferedLane(
+  const lanelet::ConstLanelets & lanelets, const Direction direction) const
+{
+  for (const auto & lanelet : lanelets) {
+    if (direction == Direction::RIGHT) {
+      // Get right lanelet if preferred lane is on the left
+      if (getNumLaneToPreferredLane(lanelet, direction) < 0) {
+        continue;
+      }
+
+      if (!!routing_graph_ptr_->right(lanelet)) {
+        return routing_graph_ptr_->right(lanelet);
+      }
+    }
+
+    if (direction == Direction::LEFT) {
+      // Get left lanelet if preferred lane is on the right
+      if (getNumLaneToPreferredLane(lanelet, direction) > 0) {
+        continue;
+      }
+      if (!!routing_graph_ptr_->left(lanelet)) {
+        return routing_graph_ptr_->left(lanelet);
+      }
+    }
+  }
+
+  return boost::none;
 }
 
 bool RouteHandler::getRightLaneChangeTargetExceptPreferredLane(

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1115,20 +1115,18 @@ boost::optional<lanelet::ConstLanelet> RouteHandler::getLaneChangeTarget(
     }
 
     if (direction == Direction::NONE || direction == Direction::RIGHT) {
-      if (num >= 0) {
-        continue;
-      }
-      if (!!routing_graph_ptr_->right(lanelet)) {
-        return routing_graph_ptr_->right(lanelet);
+      if (num < 0) {
+        if (!!routing_graph_ptr_->right(lanelet)) {
+          return routing_graph_ptr_->right(lanelet);
+        }
       }
     }
 
     if (direction == Direction::NONE || direction == Direction::LEFT) {
-      if (num <= 0) {
-        continue;
-      }
-      if (!!routing_graph_ptr_->left(lanelet)) {
-        return routing_graph_ptr_->left(lanelet);
+      if (num > 0) {
+        if (!!routing_graph_ptr_->left(lanelet)) {
+          return routing_graph_ptr_->left(lanelet);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Use lane change module to generate external lane change.
Also support lane change new framework.

## Related links

⬇️ modified parameter to disable by default.
https://github.com/autowarefoundation/autoware.universe/pull/3068

## Tests performed

Please set following flag to `FALSE`, and confirm to pass all build.

https://github.com/autowarefoundation/autoware.universe/blob/ad5595389a629346476ee06391260ffea53159ef/planning/behavior_path_planner/CMakeLists.txt#L10

## Notes for reviewers

At the moment, external lane change still couldn't be executed simultaneously.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
