### PR TITLE
fix(behavior_path_planner): fix lane changing segment s_end

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -108,7 +108,7 @@ ShiftLine getLaneChangeShiftLine(
 PathWithLaneId getReferencePathFromTargetLane(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & lane_changing_start_pose, const double target_lane_length,
-  const LaneChangePhaseInfo dist_prepare_to_lc_end, const double min_total_lane_changing_distance,
+  const double lane_changing_distance, const double min_total_lane_changing_distance,
   const double forward_path_length, const double resample_interval, const bool is_goal_in_route);
 
 PathWithLaneId getLaneChangePathPrepareSegment(


### PR DESCRIPTION
## Description
Fix the end of the longitudinal distance of the reference target lane segment.

Scenario Results 822/822
[Internal Link](https://evaluation.tier4.jp/evaluation/reports/fbdf480d-cda9-5a78-9949-9255dd487365?project_id=prd_jt)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
