### PR TITLE
feat(behavior_path_planner): output shorten path if ego vehicle is out of route

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
@@ -19,6 +19,7 @@
 #include "behavior_path_planner/scene_module/scene_module_bt_node_interface.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 
+#include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
 
 #include <visualization_msgs/msg/marker_array.hpp>

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
@@ -19,6 +19,8 @@
 #include "behavior_path_planner/scene_module/scene_module_bt_node_interface.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 
+#include <lanelet2_extension/utility/utilities.hpp>
+
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <behaviortree_cpp_v3/behavior_tree.h>
@@ -81,6 +83,8 @@ private:
     uint16_t max_msg_per_second = 25);
 
   void resetGrootMonitor();
+
+  bool isEgoOutOfRoute(const std::shared_ptr<PlannerData> & data) const;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -148,6 +148,7 @@ struct PlannerData
   OperationModeState::ConstSharedPtr operation_mode{};
   PathWithLaneId::SharedPtr reference_path{std::make_shared<PathWithLaneId>()};
   PathWithLaneId::SharedPtr prev_output_path{std::make_shared<PathWithLaneId>()};
+  std::optional<PoseWithUuidStamped> prev_modified_goal{};
   lanelet::ConstLanelets current_lanes{};
   std::shared_ptr<RouteHandler> route_handler{std::make_shared<RouteHandler>()};
   BehaviorPathPlannerParameters parameters{};

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -19,6 +19,7 @@
 #include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
 #include "behavior_path_planner/utils/lane_following/module_data.hpp"
 
+#include <lanelet2_extension/utility/utilities.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
@@ -336,6 +337,7 @@ private:
   std::vector<SceneModulePtr> getRequestModules(
     const BehaviorModuleOutput & previous_module_output) const;
 
+<<<<<<< HEAD
   /**
    * @brief checks whether a path of trajectory has forward driving direction
    * @param modules that make execution request.
@@ -346,6 +348,14 @@ private:
   std::pair<SceneModulePtr, BehaviorModuleOutput> runRequestModules(
     const std::vector<SceneModulePtr> & request_modules, const std::shared_ptr<PlannerData> & data,
     const BehaviorModuleOutput & previous_module_output);
+=======
+  boost::optional<std::pair<SceneModuleManagerPtr, SceneModulePtr>> selectHighestPriorityModule(
+    std::vector<std::pair<SceneModuleManagerPtr, SceneModulePtr>> & request_modules) const;
+
+  bool isEgoOutOfRoute(const std::shared_ptr<PlannerData> & data) const;
+
+  boost::optional<SceneModulePtr> candidate_module_opt_{boost::none};
+>>>>>>> f5171a0f90 (fix(behavior_path_planner): output shorten path if ego vehicle is out of route)
 
   boost::optional<lanelet::ConstLanelet> root_lanelet_{boost::none};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -337,7 +337,6 @@ private:
   std::vector<SceneModulePtr> getRequestModules(
     const BehaviorModuleOutput & previous_module_output) const;
 
-<<<<<<< HEAD
   /**
    * @brief checks whether a path of trajectory has forward driving direction
    * @param modules that make execution request.
@@ -348,14 +347,8 @@ private:
   std::pair<SceneModulePtr, BehaviorModuleOutput> runRequestModules(
     const std::vector<SceneModulePtr> & request_modules, const std::shared_ptr<PlannerData> & data,
     const BehaviorModuleOutput & previous_module_output);
-=======
-  boost::optional<std::pair<SceneModuleManagerPtr, SceneModulePtr>> selectHighestPriorityModule(
-    std::vector<std::pair<SceneModuleManagerPtr, SceneModulePtr>> & request_modules) const;
 
   bool isEgoOutOfRoute(const std::shared_ptr<PlannerData> & data) const;
-
-  boost::optional<SceneModulePtr> candidate_module_opt_{boost::none};
->>>>>>> f5171a0f90 (fix(behavior_path_planner): output shorten path if ego vehicle is out of route)
 
   boost::optional<lanelet::ConstLanelet> root_lanelet_{boost::none};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -292,6 +292,10 @@ PathWithLaneId refinePathForGoal(
 
 bool containsGoal(const lanelet::ConstLanelets & lanes, const lanelet::Id & goal_id);
 
+PathWithLaneId createGoalAroundPath(
+  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::optional<PoseWithUuidStamped> & modified_goal);
+
 // path management
 
 // TODO(Horibe) There is a similar function in route_handler. Check.

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -296,6 +296,8 @@ PathWithLaneId createGoalAroundPath(
   const std::shared_ptr<RouteHandler> & route_handler,
   const std::optional<PoseWithUuidStamped> & modified_goal);
 
+bool isInLanelets(const Pose & pose, const lanelet::ConstLanelets & lanes);
+
 // path management
 
 // TODO(Horibe) There is a similar function in route_handler. Check.

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1113,6 +1113,7 @@ void BehaviorPathPlannerNode::run()
   if (output.modified_goal) {
     PoseWithUuidStamped modified_goal = *(output.modified_goal);
     modified_goal.header.stamp = path->header.stamp;
+    planner_data_->prev_modified_goal = modified_goal;
     modified_goal_publisher_->publish(modified_goal);
   }
 

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -27,24 +27,41 @@
 
 namespace behavior_path_planner
 {
-PathWithLaneId createShortenPath(const std::shared_ptr<RouteHandler> & route_handler)
+bool isInLanelets(const lanelet::ConstLanelets & lanes, const Pose & pose)
 {
-  constexpr double backward_length = 1.0;
+  for (const auto & lane : lanes) {
+    if (lanelet::utils::isInLanelet(pose, lane)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+PathWithLaneId createGoalAroundPath(
+  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::optional<PoseWithUuidStamped> & modified_goal)
+{
+  const Pose goal_pose = modified_goal ? modified_goal->pose : route_handler->getGoalPose();
+  const auto shoulder_lanes = route_handler->getShoulderLanelets();
 
   lanelet::ConstLanelet goal_lane;
-  if (!route_handler->getGoalLanelet(&goal_lane)) {
+  const bool is_failed_getting_lanelet = std::invoke([&]() {
+    if (isInLanelets(shoulder_lanes, goal_pose)) {
+      return !lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &goal_lane);
+    }
+    return !route_handler->getGoalLanelet(&goal_lane);
+  });
+  if (is_failed_getting_lanelet) {
     PathWithLaneId path{};
     return path;
   }
-  lanelet::ConstLanelets goal_lanes = route_handler->getLaneletSequence(
-    goal_lane, route_handler->getGoalPose(), backward_length, 0.0);
 
-  const auto arc_coord =
-    lanelet::utils::getArcCoordinates(goal_lanes, route_handler->getGoalPose());
+  constexpr double backward_length = 1.0;
+  const auto arc_coord = lanelet::utils::getArcCoordinates({goal_lane}, goal_pose);
   const double s_start = std::max(arc_coord.length - backward_length, 0.0);
   const double s_end = arc_coord.length;
 
-  return route_handler->getCenterLinePath(goal_lanes, s_start, s_end);
+  return route_handler->getCenterLinePath({goal_lane}, s_start, s_end);
 }
 
 BehaviorTreeManager::BehaviorTreeManager(
@@ -111,9 +128,9 @@ BehaviorModuleOutput BehaviorTreeManager::run(const std::shared_ptr<PlannerData>
 
   if (isEgoOutOfRoute(data)) {
     BehaviorModuleOutput output{};
-    output.path = std::make_shared<PathWithLaneId>(createShortenPath(data->route_handler));
-    output.reference_path =
-      std::make_shared<PathWithLaneId>(createShortenPath(data->route_handler));
+    const auto output_path = createGoalAroundPath(data->route_handler, data->prev_modified_goal);
+    output.path = std::make_shared<PathWithLaneId>(output_path);
+    output.reference_path = std::make_shared<PathWithLaneId>(output_path);
     return output;
   }
 
@@ -181,18 +198,29 @@ void BehaviorTreeManager::resetGrootMonitor()
 bool BehaviorTreeManager::isEgoOutOfRoute(const std::shared_ptr<PlannerData> & data) const
 {
   const auto self_pose = data->self_odometry->pose.pose;
+  const Pose goal_pose =
+    data->prev_modified_goal ? data->prev_modified_goal->pose : data->route_handler->getGoalPose();
+  const auto shoulder_lanes = data->route_handler->getShoulderLanelets();
+
   lanelet::ConstLanelet goal_lane;
-  if (!data->route_handler->getGoalLanelet(&goal_lane)) {
+  const bool is_failed_getting_lanelet = std::invoke([&]() {
+    if (isInLanelets(shoulder_lanes, goal_pose)) {
+      return !lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &goal_lane);
+    }
+    return !data->route_handler->getGoalLanelet(&goal_lane);
+  });
+  if (is_failed_getting_lanelet) {
     RCLCPP_WARN_STREAM(logger_, "cannot find goal lanelet");
     return true;
   }
 
   // If ego vehicle is over goal on goal lane, return true
   if (lanelet::utils::isInLanelet(self_pose, goal_lane)) {
+    constexpr double buffer = 1.0;
     const auto ego_arc_coord = lanelet::utils::getArcCoordinates({goal_lane}, self_pose);
     const auto goal_arc_coord =
       lanelet::utils::getArcCoordinates({goal_lane}, data->route_handler->getGoalPose());
-    if (ego_arc_coord.length > goal_arc_coord.length) {
+    if (ego_arc_coord.length > goal_arc_coord.length + buffer) {
       return true;
     } else {
       return false;

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -37,33 +37,6 @@ bool isInLanelets(const lanelet::ConstLanelets & lanes, const Pose & pose)
   return false;
 }
 
-PathWithLaneId createGoalAroundPath(
-  const std::shared_ptr<RouteHandler> & route_handler,
-  const std::optional<PoseWithUuidStamped> & modified_goal)
-{
-  const Pose goal_pose = modified_goal ? modified_goal->pose : route_handler->getGoalPose();
-  const auto shoulder_lanes = route_handler->getShoulderLanelets();
-
-  lanelet::ConstLanelet goal_lane;
-  const bool is_failed_getting_lanelet = std::invoke([&]() {
-    if (isInLanelets(shoulder_lanes, goal_pose)) {
-      return !lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &goal_lane);
-    }
-    return !route_handler->getGoalLanelet(&goal_lane);
-  });
-  if (is_failed_getting_lanelet) {
-    PathWithLaneId path{};
-    return path;
-  }
-
-  constexpr double backward_length = 1.0;
-  const auto arc_coord = lanelet::utils::getArcCoordinates({goal_lane}, goal_pose);
-  const double s_start = std::max(arc_coord.length - backward_length, 0.0);
-  const double s_end = arc_coord.length;
-
-  return route_handler->getCenterLinePath({goal_lane}, s_start, s_end);
-}
-
 BehaviorTreeManager::BehaviorTreeManager(
   rclcpp::Node & node, const BehaviorTreeManagerParam & param)
 : bt_manager_param_(param),
@@ -128,7 +101,8 @@ BehaviorModuleOutput BehaviorTreeManager::run(const std::shared_ptr<PlannerData>
 
   if (isEgoOutOfRoute(data)) {
     BehaviorModuleOutput output{};
-    const auto output_path = createGoalAroundPath(data->route_handler, data->prev_modified_goal);
+    const auto output_path =
+      utils::createGoalAroundPath(data->route_handler, data->prev_modified_goal);
     output.path = std::make_shared<PathWithLaneId>(output_path);
     output.reference_path = std::make_shared<PathWithLaneId>(output_path);
     return output;
@@ -227,7 +201,7 @@ bool BehaviorTreeManager::isEgoOutOfRoute(const std::shared_ptr<PlannerData> & d
     }
   }
 
-  // If ego vehicle is out of the closest lanelet, return false
+  // If ego vehicle is out of the closest lanelet, return true
   lanelet::ConstLanelet closest_lane;
   if (!data->route_handler->getClosestLaneletWithinRoute(self_pose, &closest_lane)) {
     RCLCPP_WARN_STREAM(logger_, "cannot find closest lanelet");

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -27,7 +27,7 @@
 
 namespace behavior_path_planner
 {
-PathWithLaneId createPath(const std::shared_ptr<RouteHandler> & route_handler)
+PathWithLaneId createShortenPath(const std::shared_ptr<RouteHandler> & route_handler)
 {
   constexpr double backward_length = 1.0;
 
@@ -111,8 +111,9 @@ BehaviorModuleOutput BehaviorTreeManager::run(const std::shared_ptr<PlannerData>
 
   if (isEgoOutOfRoute(data)) {
     BehaviorModuleOutput output{};
-    output.path = std::make_shared<PathWithLaneId>(createPath(data->route_handler));
-    output.reference_path = std::make_shared<PathWithLaneId>(createPath(data->route_handler));
+    output.path = std::make_shared<PathWithLaneId>(createShortenPath(data->route_handler));
+    output.reference_path =
+      std::make_shared<PathWithLaneId>(createShortenPath(data->route_handler));
     return output;
   }
 

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -27,16 +27,6 @@
 
 namespace behavior_path_planner
 {
-bool isInLanelets(const lanelet::ConstLanelets & lanes, const Pose & pose)
-{
-  for (const auto & lane : lanes) {
-    if (lanelet::utils::isInLanelet(pose, lane)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 BehaviorTreeManager::BehaviorTreeManager(
   rclcpp::Node & node, const BehaviorTreeManagerParam & param)
 : bt_manager_param_(param),
@@ -178,7 +168,7 @@ bool BehaviorTreeManager::isEgoOutOfRoute(const std::shared_ptr<PlannerData> & d
 
   lanelet::ConstLanelet goal_lane;
   const bool is_failed_getting_lanelet = std::invoke([&]() {
-    if (isInLanelets(shoulder_lanes, goal_pose)) {
+    if (utils::isInLanelets(goal_pose, shoulder_lanes)) {
       return !lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &goal_lane);
     }
     return !data->route_handler->getGoalLanelet(&goal_lane);

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -26,7 +26,8 @@
 
 namespace behavior_path_planner
 {
-PathWithLaneId createPath(const std::shared_ptr<RouteHandler> & route_handler)
+
+PathWithLaneId createShortenPath(const std::shared_ptr<RouteHandler> & route_handler)
 {
   constexpr double backward_length = 1.0;
 
@@ -68,8 +69,9 @@ BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & da
   auto result_output = [&]() {
     if (isEgoOutOfRoute(data)) {
       BehaviorModuleOutput output{};
-      output.path = std::make_shared<PathWithLaneId>(createPath(data->route_handler));
-      output.reference_path = std::make_shared<PathWithLaneId>(createPath(data->route_handler));
+      output.path = std::make_shared<PathWithLaneId>(createShortenPath(data->route_handler));
+      output.reference_path =
+        std::make_shared<PathWithLaneId>(createShortenPath(data->route_handler));
       return output;
     }
     while (rclcpp::ok()) {

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -26,16 +26,6 @@
 
 namespace behavior_path_planner
 {
-bool isInLanelets(const lanelet::ConstLanelets & lanes, const Pose & pose)
-{
-  for (const auto & lane : lanes) {
-    if (lanelet::utils::isInLanelet(pose, lane)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 PlannerManager::PlannerManager(rclcpp::Node & node, const bool verbose)
 : logger_(node.get_logger().get_child("planner_manager")),
   clock_(*node.get_clock()),
@@ -632,7 +622,7 @@ bool PlannerManager::isEgoOutOfRoute(const std::shared_ptr<PlannerData> & data) 
 
   lanelet::ConstLanelet goal_lane;
   const bool is_failed_getting_lanelet = std::invoke([&]() {
-    if (isInLanelets(shoulder_lanes, goal_pose)) {
+    if (utils::isInLanelets(goal_pose, shoulder_lanes)) {
       return !lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &goal_lane);
     }
     return !data->route_handler->getGoalLanelet(&goal_lane);

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -921,6 +921,33 @@ bool containsGoal(const lanelet::ConstLanelets & lanes, const lanelet::Id & goal
   return false;
 }
 
+PathWithLaneId createGoalAroundPath(
+  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::optional<PoseWithUuidStamped> & modified_goal)
+{
+  const Pose goal_pose = modified_goal ? modified_goal->pose : route_handler->getGoalPose();
+  const auto shoulder_lanes = route_handler->getShoulderLanelets();
+
+  lanelet::ConstLanelet goal_lane;
+  const bool is_failed_getting_lanelet = std::invoke([&]() {
+    if (isInLanelets(shoulder_lanes, goal_pose)) {
+      return !lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &goal_lane);
+    }
+    return !route_handler->getGoalLanelet(&goal_lane);
+  });
+  if (is_failed_getting_lanelet) {
+    PathWithLaneId path{};
+    return path;
+  }
+
+  constexpr double backward_length = 1.0;
+  const auto arc_coord = lanelet::utils::getArcCoordinates({goal_lane}, goal_pose);
+  const double s_start = std::max(arc_coord.length - backward_length, 0.0);
+  const double s_end = arc_coord.length;
+
+  return route_handler->getCenterLinePath({goal_lane}, s_start, s_end);
+}
+
 lanelet::ConstLanelets transformToLanelets(const DrivableLanes & drivable_lanes)
 {
   lanelet::ConstLanelets lanes;

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -930,7 +930,7 @@ PathWithLaneId createGoalAroundPath(
 
   lanelet::ConstLanelet goal_lane;
   const bool is_failed_getting_lanelet = std::invoke([&]() {
-    if (isInLanelets(shoulder_lanes, goal_pose)) {
+    if (isInLanelets(goal_pose, shoulder_lanes)) {
       return !lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &goal_lane);
     }
     return !route_handler->getGoalLanelet(&goal_lane);
@@ -946,6 +946,16 @@ PathWithLaneId createGoalAroundPath(
   const double s_end = arc_coord.length;
 
   return route_handler->getCenterLinePath({goal_lane}, s_start, s_end);
+}
+
+bool isInLanelets(const Pose & pose, const lanelet::ConstLanelets & lanes)
+{
+  for (const auto & lane : lanes) {
+    if (lanelet::utils::isInLanelet(pose, lane)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 lanelet::ConstLanelets transformToLanelets(const DrivableLanes & drivable_lanes)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Before this change, behavior_path_planner outputs an improper path if the ego vehicle is out of route.
To fix it, I add the feature to output shorten path such a situation.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Tested in planning simulator.

https://user-images.githubusercontent.com/10190493/226199820-d6693759-2bf2-485a-8a82-9a10dab81a36.mp4

TIER IV internal test result 882/882

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
