### PR TITLE
fix(tier4_simulator_launch): fix occupancy grid map not appearing problem in psim 

### DIFF
--- a/launch/tier4_perception_launch/launch/occupancy_grid_map/laserscan_based_occupancy_grid_map.launch.py
+++ b/launch/tier4_perception_launch/launch/occupancy_grid_map/laserscan_based_occupancy_grid_map.launch.py
@@ -26,15 +26,19 @@ from launch_ros.descriptions import ComposableNode
 import yaml
 
 
+def str2bool(s):
+    return s.lower() in ["true", "True"]
+
+
 def launch_setup(context, *args, **kwargs):
     # load parameter files
     param_file = LaunchConfiguration("param_file").perform(context)
     with open(param_file, "r") as f:
         laserscan_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"]["ros__parameters"]
-    laserscan_based_occupancy_grid_map_node_params["input_obstacle_pointcloud"] = bool(
+    laserscan_based_occupancy_grid_map_node_params["input_obstacle_pointcloud"] = str2bool(
         LaunchConfiguration("input_obstacle_pointcloud").perform(context)
     )
-    laserscan_based_occupancy_grid_map_node_params["input_obstacle_and_raw_pointcloud"] = bool(
+    laserscan_based_occupancy_grid_map_node_params["input_obstacle_and_raw_pointcloud"] = str2bool(
         LaunchConfiguration("input_obstacle_and_raw_pointcloud").perform(context)
     )
 

--- a/launch/tier4_perception_launch/launch/occupancy_grid_map/laserscan_based_occupancy_grid_map.launch.py
+++ b/launch/tier4_perception_launch/launch/occupancy_grid_map/laserscan_based_occupancy_grid_map.launch.py
@@ -26,21 +26,11 @@ from launch_ros.descriptions import ComposableNode
 import yaml
 
 
-def str2bool(s):
-    return s.lower() in ["true", "True"]
-
-
 def launch_setup(context, *args, **kwargs):
     # load parameter files
     param_file = LaunchConfiguration("param_file").perform(context)
     with open(param_file, "r") as f:
         laserscan_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"]["ros__parameters"]
-    laserscan_based_occupancy_grid_map_node_params["input_obstacle_pointcloud"] = str2bool(
-        LaunchConfiguration("input_obstacle_pointcloud").perform(context)
-    )
-    laserscan_based_occupancy_grid_map_node_params["input_obstacle_and_raw_pointcloud"] = str2bool(
-        LaunchConfiguration("input_obstacle_and_raw_pointcloud").perform(context)
-    )
 
     composable_nodes = [
         ComposableNode(
@@ -90,7 +80,15 @@ def launch_setup(context, *args, **kwargs):
                 ("~/input/raw_pointcloud", LaunchConfiguration("input/raw_pointcloud")),
                 ("~/output/occupancy_grid_map", LaunchConfiguration("output")),
             ],
-            parameters=[laserscan_based_occupancy_grid_map_node_params],
+            parameters=[
+                laserscan_based_occupancy_grid_map_node_params,
+                {
+                    "input_obstacle_pointcloud": LaunchConfiguration("input_obstacle_pointcloud"),
+                    "input_obstacle_and_raw_pointcloud": LaunchConfiguration(
+                        "input_obstacle_and_raw_pointcloud"
+                    ),
+                },
+            ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),
     ]

--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -39,15 +39,12 @@
   <group unless="$(var scenario_simulation)">
     <!-- Occupancy Grid -->
     <push-ros-namespace namespace="occupancy_grid_map"/>
-    <include file="$(find-pkg-share tier4_perception_launch)/launch/occupancy_grid_map/pointcloud_based_occupancy_grid_map.launch.py">
-      <arg name="input/obstacle_pointcloud" value="/perception/obstacle_segmentation/single_frame/pointcloud_raw"/>
-      <arg name="input/raw_pointcloud" value="/sensing/lidar/concatenated/pointcloud"/>
+    <include file="$(find-pkg-share tier4_perception_launch)/launch/occupancy_grid_map/laserscan_based_occupancy_grid_map.launch.py">
+      <arg name="input_obstacle_pointcloud" value="true"/>
+      <arg name="input_obstacle_and_raw_pointcloud" value="false"/>
+      <arg name="input/obstacle_pointcloud" value="/perception/obstacle_segmentation/pointcloud"/>
       <arg name="output" value="/perception/occupancy_grid_map/map"/>
-      <arg name="use_intra_process" value="true"/>
-      <arg name="use_multithread" value="true"/>
-      <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
-      <arg name="container_name" value="$(var pointcloud_container_name)"/>
-      <arg name="param_file" value="$(find-pkg-share probabilistic_occupancy_grid_map)/config/pointcloud_based_occupancy_grid_map.param.yaml"/>
+      <arg name="param_file" value="$(find-pkg-share probabilistic_occupancy_grid_map)/config/laserscan_based_occupancy_grid_map.param.yaml"/>
     </include>
   </group>
 

--- a/perception/probabilistic_occupancy_grid_map/config/laserscan_based_occupancy_grid_map.param.yaml
+++ b/perception/probabilistic_occupancy_grid_map/config/laserscan_based_occupancy_grid_map.param.yaml
@@ -12,5 +12,3 @@
     map_length: 100.0
     map_width: 100.0
     map_resolution: 0.5
-    input_obstacle_pointcloud: true
-    input_obstacle_and_raw_pointcloud: true

--- a/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
+++ b/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import OpaqueFunction
@@ -25,15 +26,19 @@ from launch_ros.descriptions import ComposableNode
 import yaml
 
 
+def str2bool(s):
+    return s.lower() in ["true", "True"]
+
+
 def launch_setup(context, *args, **kwargs):
     # load parameter files
     param_file = LaunchConfiguration("param_file").perform(context)
     with open(param_file, "r") as f:
         laserscan_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"]["ros__parameters"]
-    laserscan_based_occupancy_grid_map_node_params["input_obstacle_pointcloud"] = bool(
+    laserscan_based_occupancy_grid_map_node_params["input_obstacle_pointcloud"] = str2bool(
         LaunchConfiguration("input_obstacle_pointcloud").perform(context)
     )
-    laserscan_based_occupancy_grid_map_node_params["input_obstacle_and_raw_pointcloud"] = bool(
+    laserscan_based_occupancy_grid_map_node_params["input_obstacle_and_raw_pointcloud"] = str2bool(
         LaunchConfiguration("input_obstacle_and_raw_pointcloud").perform(context)
     )
 
@@ -138,7 +143,11 @@ def generate_launch_description():
             add_launch_arg("output/stixel", "virtual_scan/stixel"),
             add_launch_arg("input_obstacle_pointcloud", "false"),
             add_launch_arg("input_obstacle_and_raw_pointcloud", "true"),
-            add_launch_arg("param_file", "config/laserscan_based_occupancy_grid_map.param.yaml"),
+            add_launch_arg(
+                "param_file",
+                get_package_share_directory("probabilistic_occupancy_grid_map")
+                + "/config/laserscan_based_occupancy_grid_map.param.yaml",
+            ),
             add_launch_arg("use_pointcloud_container", "false"),
             add_launch_arg("container_name", "occupancy_grid_map_container"),
             set_container_executable,

--- a/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
+++ b/perception/probabilistic_occupancy_grid_map/launch/laserscan_based_occupancy_grid_map.launch.py
@@ -26,21 +26,11 @@ from launch_ros.descriptions import ComposableNode
 import yaml
 
 
-def str2bool(s):
-    return s.lower() in ["true", "True"]
-
-
 def launch_setup(context, *args, **kwargs):
     # load parameter files
     param_file = LaunchConfiguration("param_file").perform(context)
     with open(param_file, "r") as f:
         laserscan_based_occupancy_grid_map_node_params = yaml.safe_load(f)["/**"]["ros__parameters"]
-    laserscan_based_occupancy_grid_map_node_params["input_obstacle_pointcloud"] = str2bool(
-        LaunchConfiguration("input_obstacle_pointcloud").perform(context)
-    )
-    laserscan_based_occupancy_grid_map_node_params["input_obstacle_and_raw_pointcloud"] = str2bool(
-        LaunchConfiguration("input_obstacle_and_raw_pointcloud").perform(context)
-    )
 
     composable_nodes = [
         ComposableNode(
@@ -90,7 +80,15 @@ def launch_setup(context, *args, **kwargs):
                 ("~/input/raw_pointcloud", LaunchConfiguration("input/raw_pointcloud")),
                 ("~/output/occupancy_grid_map", LaunchConfiguration("output")),
             ],
-            parameters=[laserscan_based_occupancy_grid_map_node_params],
+            parameters=[
+                laserscan_based_occupancy_grid_map_node_params,
+                {
+                    "input_obstacle_pointcloud": LaunchConfiguration("input_obstacle_pointcloud"),
+                    "input_obstacle_and_raw_pointcloud": LaunchConfiguration(
+                        "input_obstacle_and_raw_pointcloud"
+                    ),
+                },
+            ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),
     ]


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
**Problem**

occupancy grid map is not generated in latest changes.
This is due to:

- psim should not use pointcloud based method since pointcloud based method yields both raw and obstacle pointclouds
- fixed args in laserscan based launch.py due to unintended bugs


**Changes**

- use laserscan-based method instead of pointcloud
  - fix some args to fit psim environment
- fix laserscan based launch.py to make bool args changable


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
