### PR TITLE
perf(motion_utils): improve performance of findNearestIndex

### DIFF
--- a/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
+++ b/common/motion_utils/include/motion_utils/trajectory/trajectory.hpp
@@ -273,17 +273,13 @@ boost::optional<size_t> findNearestIndex(
 
   for (size_t i = 0; i < points.size(); ++i) {
     const auto squared_dist = tier4_autoware_utils::calcSquaredDistance2d(points.at(i), pose);
-    if (squared_dist > max_squared_dist) {
+    if (squared_dist > max_squared_dist || squared_dist >= min_squared_dist) {
       continue;
     }
 
     const auto yaw =
       tier4_autoware_utils::calcYawDeviation(tier4_autoware_utils::getPose(points.at(i)), pose);
     if (std::fabs(yaw) > max_yaw) {
-      continue;
-    }
-
-    if (squared_dist >= min_squared_dist) {
       continue;
     }
 


### PR DESCRIPTION
Signed-off-by: Taiga Takano [taiga.takano@tier4.jp](mailto:taiga.takano@tier4.jp)

## Description
One of the major bottlenecks of this function is the execution of the atan function called within the calcYawDeviation function. Therefore, the order of execution of the conditional expressions is changed to reduce the likelihood that the calcYawDeviation function will be called.

## Before and After
This change speeds up the process as shown in the table below.

findNearestIndex callback latency
|  PERCENTILE  |  BEFORE (us)  |  AFTER (us)  |
| ---- | ---- | ---- |
|  99%  |  5.85  |  3.83  |
|  90%  |  3.81  |  3.36  |
|  50%  |  3.64  |  1.91  |