### PR TITLE
feat(obstacle_avoidance_planner): consider behavior's drivable area violation

### DIFF
--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -61,7 +61,7 @@
     mpt:
       option:
         # TODO(murooka) enable the following. Currently enabling the flag makes QP so heavy
-        steer_limit_constraint: false # true
+        steer_limit_constraint: false
         visualize_sampling_num: 1
         enable_manual_warm_start: false
         enable_warm_start: true
@@ -102,10 +102,11 @@
 
       # avoidance
       avoidance:
-        max_avoidance_cost: 0.5            # [m]
-        avoidance_cost_margin: 0.0         # [m]
-        avoidance_cost_band_length: 5.0    # [m]
-        avoidance_cost_decrease_rate: 0.05 # decreased cost per point interval
+        max_longitudinal_margin_for_bound_violation: 1.0 # [m]
+        max_avoidance_cost: 0.5                          # [m]
+        avoidance_cost_margin: 0.0                       # [m]
+        avoidance_cost_band_length: 5.0                  # [m]
+        avoidance_cost_decrease_rate: 0.05               # decreased cost per point interval
 
         weight:
           lat_error_weight: 0.0     # weight for lateral error

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -249,6 +249,8 @@ private:
     std::vector<ReferencePoint> & ref_points,
     const std::vector<geometry_msgs::msg::Point> & left_bound,
     const std::vector<geometry_msgs::msg::Point> & right_bound) const;
+  std::vector<ReferencePoint> extendViolatedBounds(
+    const std::vector<ReferencePoint> & ref_points) const;
   void updateVehicleBounds(
     std::vector<ReferencePoint> & ref_points,
     const SplineInterpolationPoints2d & ref_points_spline) const;

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -178,6 +178,7 @@ private:
     double steer_rate_weight;
 
     // avoidance
+    double max_longitudinal_margin_for_bound_violation;
     double max_avoidance_cost;
     double avoidance_cost_margin;
     double avoidance_cost_band_length;

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -234,6 +234,8 @@ MPTOptimizer::MPTParam::MPTParam(
   }
 
   {  // avoidance
+    max_longitudinal_margin_for_bound_violation =
+      node->declare_parameter<double>("mpt.avoidance.max_longitudinal_margin_for_bound_violation");
     max_avoidance_cost = node->declare_parameter<double>("mpt.avoidance.max_avoidance_cost");
     avoidance_cost_margin = node->declare_parameter<double>("mpt.avoidance.avoidance_cost_margin");
     avoidance_cost_band_length =
@@ -374,6 +376,9 @@ void MPTOptimizer::MPTParam::onParam(const std::vector<rclcpp::Parameter> & para
   }
 
   {  // avoidance
+    updateParam<double>(
+      parameters, "mpt.avoidance.max_longitudinal_margin_for_bound_violation",
+      max_longitudinal_margin_for_bound_violation);
     updateParam<double>(parameters, "mpt.avoidance.max_avoidance_cost", max_avoidance_cost);
     updateParam<double>(parameters, "mpt.avoidance.avoidance_cost_margin", avoidance_cost_margin);
     updateParam<double>(
@@ -783,6 +788,29 @@ void MPTOptimizer::updateBounds(
     const double dist_to_right_bound =
       calcLateralDistToBounds(ref_point.pose, right_bound, soft_road_clearance, false);
     ref_point.bounds = Bounds{dist_to_right_bound, dist_to_left_bound};
+  }
+
+  // spread the ends of drivable area discontinuity
+  const int max_length_idx = std::floor(
+    mpt_param_.max_longitudinal_margin_for_bound_violation / mpt_param_.delta_arc_length);
+  for (int i = 0; i < static_cast<int>(ref_points.size()) - 1; ++i) {
+    if (
+      ref_points.at(i).bounds.lower_bound <= 0.0 &&
+      0.0 <= ref_points.at(i + 1).bounds.lower_bound) {
+      for (int j = -max_length_idx; j <= 0; ++j) {
+        const int k = std::clamp(i + j, 0, static_cast<int>(ref_points.size()) - 1);
+        ref_points.at(k).bounds.lower_bound = ref_points.at(i + 1).bounds.lower_bound;
+      }
+    }
+
+    if (
+      0.0 <= ref_points.at(i).bounds.upper_bound &&
+      ref_points.at(i + 1).bounds.upper_bound <= 0.0) {
+      for (int j = -max_length_idx; j <= 0; ++j) {
+        const int k = std::clamp(i + j, 0, static_cast<int>(ref_points.size()) - 1);
+        ref_points.at(k).bounds.upper_bound = ref_points.at(i + 1).bounds.upper_bound;
+      }
+    }
   }
 
   /*


### PR DESCRIPTION
## Description

When the behavior's path is outside the drivable area, sometimes the motion planner cannot fully make the trajectory inside the drivable area.
I fixed the issue by modifying the boundary's calculation in obstacle_avoidance_planner.

The following figures are NOT that different
before
![image](https://user-images.githubusercontent.com/20228327/225561404-5763ad9b-86f0-4f27-8014-3f05d6f16eab.png)

after
![image](https://user-images.githubusercontent.com/20228327/225516455-9b308761-ffa6-459e-a5e4-dca9ca761dff.png)

The difference is here.
After one tends to be inside the drivable area because of the boundary's calculation algorithm.
![image](https://user-images.githubusercontent.com/20228327/225516928-d3e742d9-6697-49d3-8f82-a1c190117514.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
