### PR TITLE
feat(compare_map_segmentation): add dynamic map loading for voxel_based_compare_map_filter

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
@@ -38,6 +38,12 @@ class PointcloudMapFilterPipeline:
         self.use_down_sample_filter = self.pointcloud_map_filter_param["use_down_sample_filter"]
         self.voxel_size = self.pointcloud_map_filter_param["down_sample_voxel_size"]
         self.distance_threshold = self.pointcloud_map_filter_param["distance_threshold"]
+        self.timer_interval_ms = self.pointcloud_map_filter_param["timer_interval_ms"]
+        self.use_dynamic_map_loading = self.pointcloud_map_filter_param["use_dynamic_map_loading"]
+        self.map_update_distance_threshold = self.pointcloud_map_filter_param[
+            "map_update_distance_threshold"
+        ]
+        self.map_loader_radius = self.pointcloud_map_filter_param["map_loader_radius"]
 
     def create_pipeline(self):
         if self.use_down_sample_filter:
@@ -57,15 +63,16 @@ class PointcloudMapFilterPipeline:
                     ("map", "/map/pointcloud_map"),
                     ("output", LaunchConfiguration("output_topic")),
                     ("map_loader_service", "/map/get_differential_pointcloud_map"),
+                    ("pose_with_covariance", "/localization/pose_estimator/pose_with_covariance"),
                 ],
                 parameters=[
                     {
                         "distance_threshold": self.distance_threshold,
+                        "timer_interval_ms": self.timer_interval_ms,
+                        "use_dynamic_map_loading": self.use_dynamic_map_loading,
+                        "map_update_distance_threshold": self.map_update_distance_threshold,
+                        "map_loader_radius": self.map_loader_radius,
                         "input_frame": "map",
-                        "timer_interval_ms": 100,
-                        "is_static_map": False,
-                        "map_update_distance_threshold": 10.0,
-                        "map_loader_radius": 150,
                     }
                 ],
                 extra_arguments=[

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
@@ -56,10 +56,16 @@ class PointcloudMapFilterPipeline:
                     ("input", LaunchConfiguration("input_topic")),
                     ("map", "/map/pointcloud_map"),
                     ("output", LaunchConfiguration("output_topic")),
+                    ("map_loader_service", "/map/get_differential_pointcloud_map"),
                 ],
                 parameters=[
                     {
                         "distance_threshold": self.distance_threshold,
+                        "input_frame": "map",
+                        "timer_interval_ms": 100,
+                        "is_static_map": False,
+                        "map_update_distance_threshold": 10.0,
+                        "map_loader_radius": 150,
                     }
                 ],
                 extra_arguments=[

--- a/launch/tier4_sensing_launch/launch/sensing.launch.xml
+++ b/launch/tier4_sensing_launch/launch/sensing.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="launch_driver" default="false" description="do launch driver"/>
+  <arg name="launch_driver" default="true" description="do launch driver"/>
   <arg name="sensor_model" default="sample_sensor_kit" description="sensor model name"/>
   <arg name="vehicle_mirror_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_mirror.param.yaml" description="path to the file of vehicle mirror position yaml"/>
   <arg name="use_pointcloud_container" default="false" description="launch pointcloud container"/>

--- a/launch/tier4_sensing_launch/launch/sensing.launch.xml
+++ b/launch/tier4_sensing_launch/launch/sensing.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="launch_driver" default="true" description="do launch driver"/>
+  <arg name="launch_driver" default="false" description="do launch driver"/>
   <arg name="sensor_model" default="sample_sensor_kit" description="sensor model name"/>
   <arg name="vehicle_mirror_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_mirror.param.yaml" description="path to the file of vehicle mirror position yaml"/>
   <arg name="use_pointcloud_container" default="false" description="launch pointcloud container"/>

--- a/perception/compare_map_segmentation/CMakeLists.txt
+++ b/perception/compare_map_segmentation/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(compare_map_segmentation SHARED
   src/voxel_based_compare_map_filter_nodelet.cpp
   src/voxel_distance_based_compare_map_filter_nodelet.cpp
   src/compare_elevation_map_filter_node.cpp
+  src/voxel_grid_map_loader.cpp
 )
 
 target_link_libraries(compare_map_segmentation
@@ -44,6 +45,8 @@ ament_target_dependencies(compare_map_segmentation
   rclcpp_components
   sensor_msgs
   tier4_autoware_utils
+  autoware_map_msgs
+  autoware_adapi_v1_msgs
 )
 
 if(OPENMP_FOUND)

--- a/perception/compare_map_segmentation/CMakeLists.txt
+++ b/perception/compare_map_segmentation/CMakeLists.txt
@@ -46,7 +46,6 @@ ament_target_dependencies(compare_map_segmentation
   sensor_msgs
   tier4_autoware_utils
   autoware_map_msgs
-  autoware_adapi_v1_msgs
 )
 
 if(OPENMP_FOUND)

--- a/perception/compare_map_segmentation/README.md
+++ b/perception/compare_map_segmentation/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The `compare_map_segmentation` is a node that filters the ground points from the input pointcloud by using map info (e.g. pcd, elevation map).
+The `compare_map_segmentation` is a node that filters the ground points from the input pointcloud by using map info (e.g. pcd, elevation map or split map pointcloud from map_loader interface).
 
 ## Inner-workings / Algorithms
 
@@ -24,7 +24,9 @@ WIP
 
 ### Voxel Based Compare Map Filter
 
-WIP
+The filter loads the map pointcloud (static loading whole map at once at beginning or dynamic loading during vehicle moving) and utilizes VoxelGrid to downsample map pointcloud.
+
+For each point of input pointcloud, the filter use `getCentroidIndexAt` combine with `getGridCoordinates` function from VoxelGrid class to check if the downsampled map point existing surrounding input points. Remove the input point which has downsampled map point in voxels containing or being close to the point.
 
 ### Voxel Distance based Compare Map Filter
 
@@ -47,14 +49,23 @@ WIP
 | ----------------- | ------------------------------- | --------------- |
 | `~/output/points` | `sensor_msgs::msg::PointCloud2` | filtered points |
 
+#### Parameters
+
+| Name                 | Type   | Description                                                                     | Default value |
+| :------------------- | :----- | :------------------------------------------------------------------------------ | :------------ |
+| `map_layer_name`     | string | elevation map layer name                                                        | elevation     |
+| `map_frame`          | float  | frame_id of the map that is temporarily used before elevation_map is subscribed | map           |
+| `height_diff_thresh` | float  | Remove points whose height difference is below this value [m]                   | 0.15          |
+
 ### Other Filters
 
 #### Input
 
-| Name             | Type                            | Description      |
-| ---------------- | ------------------------------- | ---------------- |
-| `~/input/points` | `sensor_msgs::msg::PointCloud2` | reference points |
-| `~/input/map`    | `grid_map::msg::GridMap`        | map              |
+| Name                     | Type                                            | Description                                            |
+| ------------------------ | ----------------------------------------------- | ------------------------------------------------------ |
+| `~/input/points`         | `sensor_msgs::msg::PointCloud2`                 | reference points                                       |
+| `~/input/map`            | `sensor_msgs::msg::PointCloud2`                 | map (in case static map loading)                       |
+| `~/pose_with_covariance` | `geometry_msgs::msg::PoseWithCovarianceStamped` | current ego-vehicle pose (in case dynamic map loading) |
 
 #### Output
 
@@ -62,15 +73,15 @@ WIP
 | ----------------- | ------------------------------- | --------------- |
 | `~/output/points` | `sensor_msgs::msg::PointCloud2` | filtered points |
 
-## Parameters
+#### Parameters
 
-### Core Parameters
-
-| Name                 | Type   | Description                                                                     | Default value |
-| :------------------- | :----- | :------------------------------------------------------------------------------ | :------------ |
-| `map_layer_name`     | string | elevation map layer name                                                        | elevation     |
-| `map_frame`          | float  | frame_id of the map that is temporarily used before elevation_map is subscribed | map           |
-| `height_diff_thresh` | float  | Remove points whose height difference is below this value [m]                   | 0.15          |
+| Name                            | Type  | Description                                                                                  | Default value |
+| :------------------------------ | :---- | :------------------------------------------------------------------------------------------- | :------------ |
+| `use_dynamic_map_loading`       | bool  | map loading mode selection, `true` for dynamic map loading, `false` for static map loading   | true          |
+| `distance_threshold`            | float | VoxelGrid's leaf_size also the threshold to check distance between input point and map point | 0.5           |
+| `map_update_distance_threshold` | float | Threshold of vehicle movement distance when map update is necessary [m]                      | 10.0          |
+| `map_loader_radius`             | float | Radius of map need to be loaded (in dynamic map loading) [m]                                 | 150.0         |
+| `timer_interval_ms`             | int   | time interval of timer to check if update the map is necessary (in dynamic map loading) [ms] | 100           |
 
 ## Assumptions / Known limits
 

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
@@ -1,0 +1,318 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPARE_MAP_SEGMENTATION__MULTI_VOXEL_GRID_MAP_UPDATE_HPP_
+#define COMPARE_MAP_SEGMENTATION__MULTI_VOXEL_GRID_MAP_UPDATE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <boost/sort/spreadsort/integer_sort.hpp>
+
+#include <pcl/common/centroid.h>
+#include <pcl/common/common.h>
+#include <pcl/common/io.h>
+#include <pcl/filters/filter.h>
+#include <pcl/filters/voxel_grid.h>
+
+#include <cfloat>  // for FLT_MAX
+#include <iostream>
+#include <map>
+#include <vector>
+
+namespace compare_map_segmentation
+{
+template <typename PointT>
+class MultiVoxelGrid : public pcl::VoxelGrid<PointT>
+{
+  typedef std::map<std::string, pcl::PointCloud<PointT>> MapCellDict;
+  struct cloud_point_index_idx
+  {
+    unsigned int idx;
+    unsigned int cloud_point_index;
+
+    cloud_point_index_idx() = default;
+    cloud_point_index_idx(unsigned int idx_, unsigned int cloud_point_index_)
+    : idx(idx_), cloud_point_index(cloud_point_index_)
+    {
+    }
+    bool operator<(const cloud_point_index_idx & p) const { return (idx < p.idx); }
+  };
+
+protected:
+  using pcl::VoxelGrid<PointT>::filter_name_;
+  using pcl::VoxelGrid<PointT>::downsample_all_data_;
+  using pcl::VoxelGrid<PointT>::input_;
+  using pcl::VoxelGrid<PointT>::save_leaf_layout_;
+  using pcl::VoxelGrid<PointT>::min_b_;
+  using pcl::VoxelGrid<PointT>::max_b_;
+  using pcl::VoxelGrid<PointT>::divb_mul_;
+  using pcl::VoxelGrid<PointT>::div_b_;
+  using pcl::VoxelGrid<PointT>::inverse_leaf_size_;
+
+  using pcl::VoxelGrid<PointT>::filter_limit_negative_;
+  using pcl::VoxelGrid<PointT>::filter_limit_max_;
+  using pcl::VoxelGrid<PointT>::filter_limit_min_;
+  using pcl::VoxelGrid<PointT>::indices_;
+  using pcl::VoxelGrid<PointT>::min_points_per_voxel_;
+  using pcl::VoxelGrid<PointT>::filter_field_name_;
+
+  using PointCloud = typename pcl::Filter<PointT>::PointCloud;
+  using PointCloudPtr = typename PointCloud::Ptr;
+  using PointCloudConstPtr = typename PointCloud::ConstPtr;
+
+public:
+  using pcl::VoxelGrid<PointT>::leaf_layout_;
+
+  inline void set_voxel_grid(
+    std::vector<int> * leaf_layout, const Eigen::Vector4i & min_b, const Eigen::Vector4i & max_b,
+    const Eigen::Vector4i & div_b, const Eigen::Vector4i & divb_mul,
+    const Eigen::Array4f & inverse_leaf_size)
+  {
+    auto exe_start_time = std::chrono::system_clock::now();
+    leaf_layout_ = std::move(*leaf_layout);
+    auto exe_stop_time = std::chrono::system_clock::now();
+    const double exe_run_time =
+      std::chrono::duration_cast<std::chrono::microseconds>(exe_stop_time - exe_start_time)
+        .count() /
+      1000.0;
+    std::cout << " Leaf_layout copying time: " << exe_run_time << "[ms]" << std::endl;
+    min_b_ = min_b;
+    max_b_ = max_b;
+    div_b_ = div_b;
+    divb_mul_ = divb_mul;
+    inverse_leaf_size_ = inverse_leaf_size;
+  }
+  inline Eigen::Vector4f get_min_p() { return min_p; };
+  inline Eigen::Vector4f get_max_p() { return max_p; };
+  inline Eigen::Vector4i get_min_b() { return min_b_; }
+  inline Eigen::Vector4i get_divb_mul() { return divb_mul_; }
+  inline Eigen::Vector4i get_max_b() { return max_b_; }
+  inline Eigen::Vector4i get_div_b() { return div_b_; }
+  inline Eigen::Array4f get_inverse_leaf_size() { return inverse_leaf_size_; }
+  inline std::vector<int> getLeafLayout() { return (leaf_layout_); }
+
+  inline void applyFilter(PointCloud & output) override
+  {
+    // Has the input dataset been set already?
+    if (!input_) {
+      // pcl::PCL_WARN ("[pcl::applyFilter] No input dataset given!\n");
+      output.width = output.height = 0;
+      output.clear();
+      return;
+    }
+
+    // Copy the header (and thus the frame_id) + allocate enough space for points
+    output.height = 1;       // downsampling breaks the organized structure
+    output.is_dense = true;  // we filter out invalid points
+
+    // Get the minimum and maximum dimensions
+    if (!filter_field_name_.empty())  // If we don't want to process the entire cloud...
+      pcl::getMinMax3D<PointT>(
+        input_, *indices_, filter_field_name_, static_cast<float>(filter_limit_min_),
+        static_cast<float>(filter_limit_max_), min_p, max_p, filter_limit_negative_);
+    else
+      pcl::getMinMax3D<PointT>(*input_, *indices_, min_p, max_p);
+
+    // Check that the leaf size is not too small, given the size of the data
+    std::int64_t dx = static_cast<std::int64_t>((max_p[0] - min_p[0]) * inverse_leaf_size_[0]) + 1;
+    std::int64_t dy = static_cast<std::int64_t>((max_p[1] - min_p[1]) * inverse_leaf_size_[1]) + 1;
+    std::int64_t dz = static_cast<std::int64_t>((max_p[2] - min_p[2]) * inverse_leaf_size_[2]) + 1;
+
+    if ((dx * dy * dz) > static_cast<std::int64_t>(std::numeric_limits<std::int32_t>::max())) {
+      // pcl::PCL_WARN("[pcl::applyFilter] Leaf size is too small for the input dataset. Integer
+      // indices would overflow.\n");
+      output = *input_;
+      return;
+    }
+
+    // Compute the minimum and maximum bounding box values
+    min_b_[0] = static_cast<int>(std::floor(min_p[0] * inverse_leaf_size_[0]));
+    max_b_[0] = static_cast<int>(std::floor(max_p[0] * inverse_leaf_size_[0]));
+    min_b_[1] = static_cast<int>(std::floor(min_p[1] * inverse_leaf_size_[1]));
+    max_b_[1] = static_cast<int>(std::floor(max_p[1] * inverse_leaf_size_[1]));
+    min_b_[2] = static_cast<int>(std::floor(min_p[2] * inverse_leaf_size_[2]));
+    max_b_[2] = static_cast<int>(std::floor(max_p[2] * inverse_leaf_size_[2]));
+
+    // Compute the number of divisions needed along all axis
+    div_b_ = max_b_ - min_b_ + Eigen::Vector4i::Ones();
+    div_b_[3] = 0;
+
+    // Set up the division multiplier
+    divb_mul_ = Eigen::Vector4i(1, div_b_[0], div_b_[0] * div_b_[1], 0);
+
+    // Storage for mapping leaf and pointcloud indexes
+    std::vector<cloud_point_index_idx> index_vector;
+    index_vector.reserve(indices_->size());
+
+    // If we don't want to process the entire cloud, but rather filter points far away from the
+    // viewpoint first...
+    if (!filter_field_name_.empty()) {
+      // Get the distance field index
+      std::vector<pcl::PCLPointField> fields;
+      int distance_idx = pcl::getFieldIndex<PointT>(filter_field_name_, fields);
+      if (distance_idx == -1)
+
+        // First pass: go over all points and insert them into the index_vector vector
+        // with calculated idx. Points with the same idx value will contribute to the
+        // same point of resulting CloudPoint
+        for (const auto & index : (*indices_)) {
+          if (!input_->is_dense)
+            // Check if the point is invalid
+            if (!pcl::isXYZFinite((*input_)[index])) continue;
+
+          // Get the distance value
+          const std::uint8_t * pt_data = reinterpret_cast<const std::uint8_t *>(&(*input_)[index]);
+          float distance_value = 0;
+          memcpy(&distance_value, pt_data + fields[distance_idx].offset, sizeof(float));
+
+          if (filter_limit_negative_) {
+            // Use a threshold for cutting out points which inside the interval
+            if ((distance_value < filter_limit_max_) && (distance_value > filter_limit_min_))
+              continue;
+          } else {
+            // Use a threshold for cutting out points which are too close/far away
+            if ((distance_value > filter_limit_max_) || (distance_value < filter_limit_min_))
+              continue;
+          }
+
+          int ijk0 = static_cast<int>(
+            std::floor((*input_)[index].x * inverse_leaf_size_[0]) - static_cast<float>(min_b_[0]));
+          int ijk1 = static_cast<int>(
+            std::floor((*input_)[index].y * inverse_leaf_size_[1]) - static_cast<float>(min_b_[1]));
+          int ijk2 = static_cast<int>(
+            std::floor((*input_)[index].z * inverse_leaf_size_[2]) - static_cast<float>(min_b_[2]));
+
+          // Compute the centroid leaf index
+          int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
+          index_vector.emplace_back(static_cast<unsigned int>(idx), index);
+        }
+    }
+    // No distance filtering, process all data
+    else {
+      // First pass: go over all points and insert them into the index_vector vector
+      // with calculated idx. Points with the same idx value will contribute to the
+      // same point of resulting CloudPoint
+      for (const auto & index : (*indices_)) {
+        if (!input_->is_dense)
+          // Check if the point is invalid
+          if (!pcl::isXYZFinite((*input_)[index])) continue;
+
+        int ijk0 = static_cast<int>(
+          std::floor((*input_)[index].x * inverse_leaf_size_[0]) - static_cast<float>(min_b_[0]));
+        int ijk1 = static_cast<int>(
+          std::floor((*input_)[index].y * inverse_leaf_size_[1]) - static_cast<float>(min_b_[1]));
+        int ijk2 = static_cast<int>(
+          std::floor((*input_)[index].z * inverse_leaf_size_[2]) - static_cast<float>(min_b_[2]));
+
+        // Compute the centroid leaf index
+        int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
+        index_vector.emplace_back(static_cast<unsigned int>(idx), index);
+      }
+    }
+
+    // Second pass: sort the index_vector vector using value representing target cell as index
+    // in effect all points belonging to the same output cell will be next to each other
+    auto rightshift_func = [](const cloud_point_index_idx & x, const unsigned offset) {
+      return x.idx >> offset;
+    };
+    boost::sort::spreadsort::integer_sort(
+      index_vector.begin(), index_vector.end(), rightshift_func);
+
+    // Third pass: count output cells
+    // we need to skip all the same, adjacent idx values
+    unsigned int total = 0;
+    unsigned int index = 0;
+    // first_and_last_indices_vector[i] represents the index in index_vector of the first point in
+    // index_vector belonging to the voxel which corresponds to the i-th output point,
+    // and of the first point not belonging to.
+    std::vector<std::pair<unsigned int, unsigned int>> first_and_last_indices_vector;
+    // Worst case size
+    first_and_last_indices_vector.reserve(index_vector.size());
+    while (index < index_vector.size()) {
+      unsigned int i = index + 1;
+      while (i < index_vector.size() && index_vector[i].idx == index_vector[index].idx) ++i;
+      if (i - index >= min_points_per_voxel_) {
+        ++total;
+        first_and_last_indices_vector.emplace_back(index, i);
+      }
+      index = i;
+    }
+
+    // Fourth pass: compute centroids, insert them into their final position
+    output.resize(total);
+    if (save_leaf_layout_) {
+      try {
+        // Resizing won't reset old elements to -1.  If leaf_layout_ has been used previously, it
+        // needs to be re-initialized to -1
+        std::uint32_t new_layout_size = div_b_[0] * div_b_[1] * div_b_[2];
+        // This is the number of elements that need to be re-initialized to -1
+        std::uint32_t reinit_size = std::min(
+          static_cast<unsigned int>(new_layout_size),
+          static_cast<unsigned int>(leaf_layout_.size()));
+        for (std::uint32_t i = 0; i < reinit_size; i++) {
+          leaf_layout_[i] = -1;
+        }
+        leaf_layout_.resize(new_layout_size, -1);
+      } catch (std::bad_alloc &) {
+        throw pcl::PCLException(
+          "VoxelGrid bin size is too low; impossible to allocate memory for layout",
+          "voxel_grid.hpp", "applyFilter");
+      } catch (std::length_error &) {
+        throw pcl::PCLException(
+          "VoxelGrid bin size is too low; impossible to allocate memory for layout",
+          "voxel_grid.hpp", "applyFilter");
+      }
+    }
+
+    index = 0;
+    for (const auto & cp : first_and_last_indices_vector) {
+      // calculate centroid - sum values from all input points, that have the same idx value in
+      // index_vector array
+      unsigned int first_index = cp.first;
+      unsigned int last_index = cp.second;
+
+      // index is centroid final position in resulting PointCloud
+      if (save_leaf_layout_) leaf_layout_[index_vector[first_index].idx] = index;
+
+      // Limit downsampling to coords
+      if (!downsample_all_data_) {
+        Eigen::Vector4f centroid(Eigen::Vector4f::Zero());
+
+        for (unsigned int li = first_index; li < last_index; ++li)
+          centroid += (*input_)[index_vector[li].cloud_point_index].getVector4fMap();
+
+        centroid /= static_cast<float>(last_index - first_index);
+        output[index].getVector4fMap() = centroid;
+      } else {
+        pcl::CentroidPoint<PointT> centroid;
+
+        // fill in the accumulator with leaf points
+        for (unsigned int li = first_index; li < last_index; ++li)
+          centroid.add((*input_)[index_vector[li].cloud_point_index]);
+
+        centroid.get(output[index]);
+      }
+
+      ++index;
+    }
+    output.width = output.size();
+  }
+
+private:
+  Eigen::Vector4f min_p, max_p;
+};
+
+};  // namespace compare_map_segmentation
+
+#endif  // COMPARE_MAP_SEGMENTATION__MULTI_VOXEL_GRID_MAP_UPDATE_HPP_

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
@@ -79,27 +79,20 @@ public:
     const Eigen::Vector4i & div_b, const Eigen::Vector4i & divb_mul,
     const Eigen::Array4f & inverse_leaf_size)
   {
-    auto exe_start_time = std::chrono::system_clock::now();
     leaf_layout_ = std::move(*leaf_layout);
-    auto exe_stop_time = std::chrono::system_clock::now();
-    const double exe_run_time =
-      std::chrono::duration_cast<std::chrono::microseconds>(exe_stop_time - exe_start_time)
-        .count() /
-      1000.0;
-    std::cout << " Leaf_layout copying time: " << exe_run_time << "[ms]" << std::endl;
     min_b_ = min_b;
     max_b_ = max_b;
     div_b_ = div_b;
     divb_mul_ = divb_mul;
     inverse_leaf_size_ = inverse_leaf_size;
   }
-  inline Eigen::Vector4f get_min_p() { return min_p; };
-  inline Eigen::Vector4f get_max_p() { return max_p; };
-  inline Eigen::Vector4i get_min_b() { return min_b_; }
-  inline Eigen::Vector4i get_divb_mul() { return divb_mul_; }
-  inline Eigen::Vector4i get_max_b() { return max_b_; }
-  inline Eigen::Vector4i get_div_b() { return div_b_; }
-  inline Eigen::Array4f get_inverse_leaf_size() { return inverse_leaf_size_; }
+  inline Eigen::Vector4f get_min_p() const { return min_p; };
+  inline Eigen::Vector4f get_max_p() const { return max_p; };
+  inline Eigen::Vector4i get_min_b() const { return min_b_; }
+  inline Eigen::Vector4i get_divb_mul() const { return divb_mul_; }
+  inline Eigen::Vector4i get_max_b() const { return max_b_; }
+  inline Eigen::Vector4i get_div_b() const { return div_b_; }
+  inline Eigen::Array4f get_inverse_leaf_size() const { return inverse_leaf_size_; }
   inline std::vector<int> getLeafLayout() { return (leaf_layout_); }
 
   inline void applyFilter(PointCloud & output) override

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
@@ -27,7 +27,10 @@
 
 #include <cfloat>  // for FLT_MAX
 #include <iostream>
+#include <limits>
 #include <map>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace compare_map_segmentation
@@ -86,8 +89,8 @@ public:
     divb_mul_ = divb_mul;
     inverse_leaf_size_ = inverse_leaf_size;
   }
-  inline Eigen::Vector4f get_min_p() const { return min_p; };
-  inline Eigen::Vector4f get_max_p() const { return max_p; };
+  inline Eigen::Vector4f get_min_p() const { return min_p; }
+  inline Eigen::Vector4f get_max_p() const { return max_p; }
   inline Eigen::Vector4i get_min_b() const { return min_b_; }
   inline Eigen::Vector4i get_divb_mul() const { return divb_mul_; }
   inline Eigen::Vector4i get_max_b() const { return max_b_; }
@@ -190,9 +193,8 @@ public:
           int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
           index_vector.emplace_back(static_cast<unsigned int>(idx), index);
         }
-    }
-    // No distance filtering, process all data
-    else {
+    } else {
+      // No distance filtering, process all data
       // First pass: go over all points and insert them into the index_vector vector
       // with calculated idx. Points with the same idx value will contribute to the
       // same point of resulting CloudPoint

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
@@ -36,6 +36,8 @@
 namespace compare_map_segmentation
 {
 template <typename PointT>
+// TODO(badai-nguyen): when map loader I/F is updated, remove this class since
+// boundary point calculation become unnecessary
 class MultiVoxelGrid : public pcl::VoxelGrid<PointT>
 {
   typedef std::map<std::string, pcl::PointCloud<PointT>> MapCellDict;
@@ -98,6 +100,8 @@ public:
   inline Eigen::Array4f get_inverse_leaf_size() const { return inverse_leaf_size_; }
   inline std::vector<int> getLeafLayout() { return (leaf_layout_); }
 
+  // TODO(badai-nguyen): when map loader I/F is updated, use default Voxel applyFilter since
+  // boundary point calculation become unnecessary
   inline void applyFilter(PointCloud & output) override
   {
     // Has the input dataset been set already?

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_compare_map_filter_nodelet.hpp
@@ -15,6 +15,9 @@
 #ifndef COMPARE_MAP_SEGMENTATION__VOXEL_BASED_COMPARE_MAP_FILTER_NODELET_HPP_
 #define COMPARE_MAP_SEGMENTATION__VOXEL_BASED_COMPARE_MAP_FILTER_NODELET_HPP_
 
+#include "compare_map_segmentation/voxel_grid_map_loader.hpp"
+
+// #include "compare_map_segmentation/map_update_module.hpp"
 #include "pointcloud_preprocessor/filter.hpp"
 
 #include <pcl/filters/voxel_grid.h>
@@ -30,25 +33,18 @@ protected:
   virtual void filter(
     const PointCloud2ConstPtr & input, const IndicesPtr & indices, PointCloud2 & output);
 
-  void input_target_callback(const PointCloud2ConstPtr map);
-  bool is_in_voxel(
-    const pcl::PointXYZ & src_point, const pcl::PointXYZ & target_point,
-    const double distance_threshold, const PointCloudPtr & map,
-    /* Can not add const in PCL specification */ pcl::VoxelGrid<pcl::PointXYZ> & voxel) const;
-
 private:
   // pcl::SegmentDifferences<pcl::PointXYZ> impl_;
+  std::unique_ptr<VoxelGridMapLoader> voxel_grid_map_looader_;
+  // std::unique_ptr<MapUpdateModule> voxel_map_update_module_;
   rclcpp::Subscription<PointCloud2>::SharedPtr sub_map_;
-  PointCloudPtr voxel_map_ptr_;
   double distance_threshold_;
-  pcl::VoxelGrid<pcl::PointXYZ> voxel_grid_;
   bool set_map_in_voxel_grid_;
 
-  /** \brief Parameter service callback result : needed to be hold */
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
-
-  /** \brief Parameter service callback */
-  rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
+  bool dynamic_map_load_enable_;
+  // std::unique_ptr<MapUpdateModule> voxel_map_update_module_;
+  std::mutex * voxel_based_compare_map_mutex_ptr_;
+  double radius_search_;
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_compare_map_filter_nodelet.hpp
@@ -16,8 +16,6 @@
 #define COMPARE_MAP_SEGMENTATION__VOXEL_BASED_COMPARE_MAP_FILTER_NODELET_HPP_
 
 #include "compare_map_segmentation/voxel_grid_map_loader.hpp"
-
-// #include "compare_map_segmentation/map_update_module.hpp"
 #include "pointcloud_preprocessor/filter.hpp"
 
 #include <pcl/filters/voxel_grid.h>
@@ -36,15 +34,11 @@ protected:
 private:
   // pcl::SegmentDifferences<pcl::PointXYZ> impl_;
   std::unique_ptr<VoxelGridMapLoader> voxel_grid_map_looader_;
-  // std::unique_ptr<MapUpdateModule> voxel_map_update_module_;
   rclcpp::Subscription<PointCloud2>::SharedPtr sub_map_;
   double distance_threshold_;
   bool set_map_in_voxel_grid_;
 
   bool dynamic_map_load_enable_;
-  // std::unique_ptr<MapUpdateModule> voxel_map_update_module_;
-  std::mutex * voxel_based_compare_map_mutex_ptr_;
-  double radius_search_;
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_compare_map_filter_nodelet.hpp
@@ -21,6 +21,7 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/search/pcl_search.h>
 
+#include <memory>
 #include <vector>
 
 namespace compare_map_segmentation
@@ -33,7 +34,7 @@ protected:
 
 private:
   // pcl::SegmentDifferences<pcl::PointXYZ> impl_;
-  std::unique_ptr<VoxelGridMapLoader> voxel_grid_map_looader_;
+  std::unique_ptr<VoxelGridMapLoader> voxel_grid_map_loader_;
   rclcpp::Subscription<PointCloud2>::SharedPtr sub_map_;
   double distance_threshold_;
   bool set_map_in_voxel_grid_;

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -55,6 +55,7 @@ protected:
   rclcpp::Logger logger_;
   std::mutex * mutex_ptr_;
   double voxel_leaf_size_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr downsampled_map_pub_;
 
 public:
   typedef typename pcl::Filter<pcl::PointXYZ>::PointCloud PointCloud;
@@ -62,6 +63,7 @@ public:
   explicit VoxelGridMapLoader(
     rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex);
   virtual bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold) = 0;
+  void publish_downsampled_map(const pcl::PointCloud<pcl::PointXYZ> & downsampled_pc);
 
   inline pcl::PointCloud<pcl::PointXYZ> getNeighborVoxelPoints(
     pcl::PointXYZ point, double voxel_size);
@@ -114,7 +116,6 @@ private:
     map_update_client_;
   rclcpp::CallbackGroup::SharedPtr client_callback_group_;
   rclcpp::CallbackGroup::SharedPtr timer_callback_group_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr downsampled_map_pub_;
 
 public:
   explicit VoxelGridDynamicMapLoader(
@@ -125,7 +126,6 @@ public:
   void timer_callback();
   bool should_update_map();
   void request_update_map(const geometry_msgs::msg::Point & position);
-  void publish_downsampled_map();
   bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
 
   inline pcl::PointCloud<pcl::PointXYZ> getCurrentDownsampledMapPc()

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -19,16 +19,11 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #include <autoware_map_msgs/srv/get_differential_point_cloud_map.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
-#include <pcl/PointIndices.h>
-#include <pcl/common/io.h>  // for copyPointCloud
-#include <pcl/filters/filter.h>
 #include <pcl/filters/voxel_grid.h>
-#include <pcl/pcl_base.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <map>

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -1,0 +1,221 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPARE_MAP_SEGMENTATION__VOXEL_GRID_MAP_LOADER_HPP_
+#define COMPARE_MAP_SEGMENTATION__VOXEL_GRID_MAP_LOADER_HPP_
+
+#include "compare_map_segmentation/multi_voxel_grid_map_update.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
+#include <autoware_map_msgs/srv/get_differential_point_cloud_map.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <pcl/PointIndices.h>
+#include <pcl/common/io.h>  // for copyPointCloud
+#include <pcl/filters/filter.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/pcl_base.h>
+#include <pcl_conversions/pcl_conversions.h>
+// create map loader interface for static and dynamic map
+
+template <typename T, typename U>
+double distance3D(const T p1, const U p2)
+{
+  double dx = p1.x - p2.x;
+  double dy = p1.y - p2.y;
+  double dz = p1.z - p2.z;
+  return dx * dx + dy * dy + dz * dz;
+}
+
+template <typename T, typename U>
+double distance2D(const T p1, const U p2)
+{
+  double dx = p1.x - p2.x;
+  double dy = p1.y - p2.y;
+  return std::sqrt(dx * dx + dy * dy);
+}
+
+class VoxelGridMapLoader
+{
+protected:
+  rclcpp::Logger logger_;
+  std::mutex * mutex_ptr_;
+  double voxel_leaf_size_;
+
+public:
+  typedef typename pcl::Filter<pcl::PointXYZ>::PointCloud PointCloud;
+  typedef typename PointCloud::Ptr PointCloudPtr;
+  explicit VoxelGridMapLoader(
+    rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex);
+  virtual bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold) = 0;
+
+  inline pcl::PointCloud<pcl::PointXYZ> getNeighborVoxelPoints(
+    pcl::PointXYZ point, double voxel_size);
+
+  inline bool is_close_points(
+    const pcl::PointXYZ point, const pcl::PointXYZ target_point, const double distance_threshold);
+  std::string * tf_map_input_frame_;
+};
+
+//*************************** for Static Map loader Voxel Grid Filter *************
+class VoxelGridStaticMapLoader : public VoxelGridMapLoader
+{
+private:
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_map_;
+  pcl::VoxelGrid<pcl::PointXYZ> voxel_grid_;
+  PointCloudPtr voxel_map_ptr_;
+
+public:
+  explicit VoxelGridStaticMapLoader(
+    rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex);
+  void onMapCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr map);
+  bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
+};
+
+// *************** for Dynamic and Differential Map loader Voxel Grid Filter *************
+class VoxelGridDynamicMapLoader : public VoxelGridMapLoader
+{
+  typedef compare_map_segmentation::MultiVoxelGrid<pcl::PointXYZ> MultiVoxelGrid;
+  struct MapGridVoxelInfo
+  {
+    MultiVoxelGrid map_cell_voxel_grid;
+    PointCloudPtr map_cell_pc_ptr;
+    float min_b_x, min_b_y, max_b_x, max_b_y;
+    pcl::PointCloud<pcl::PointXYZ> voxel_grid_filtered_pc;
+  };
+
+  typedef typename std::map<std::string, struct MapGridVoxelInfo> VoxelGridDict;
+
+private:
+  /* data */
+  VoxelGridDict current_voxel_grid_list_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
+    sub_estimated_pose_;
+  std::optional<geometry_msgs::msg::Point> current_position_ = std::nullopt;
+  std::optional<geometry_msgs::msg::Point> last_updated_position_ = std::nullopt;
+  rclcpp::TimerBase::SharedPtr map_update_timer_;
+  double map_update_distance_threshold_;
+  double map_loader_radius_;
+  rclcpp::Client<autoware_map_msgs::srv::GetDifferentialPointCloudMap>::SharedPtr
+    map_update_client_;
+  rclcpp::CallbackGroup::SharedPtr client_callback_group_;
+  rclcpp::CallbackGroup::SharedPtr timer_callback_group_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr downsampled_map_pub_;
+
+public:
+  explicit VoxelGridDynamicMapLoader(
+    rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex,
+    rclcpp::CallbackGroup::SharedPtr main_callback_group);
+  void onEstimatedPoseCallback(geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr pose);
+
+  void timer_callback();
+  bool should_update_map();
+  void request_update_map(const geometry_msgs::msg::Point & position);
+  void publish_downsampled_map();
+  bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
+
+  inline pcl::PointCloud<pcl::PointXYZ> getCurrentDownsampledMapPc()
+  {
+    pcl::PointCloud<pcl::PointXYZ> output;
+    for (const auto & kv : current_voxel_grid_list_) {
+      output = output + kv.second.voxel_grid_filtered_pc;
+    }
+    return output;
+  }
+  inline std::vector<std::string> getCurrentMapIDs() const
+  {
+    std::vector<std::string> current_map_ids{};
+    for (auto & kv : current_voxel_grid_list_) {
+      current_map_ids.push_back(kv.first);
+    }
+    return current_map_ids;
+  }
+  inline void updateDifferentialMapCells(
+    const std::vector<autoware_map_msgs::msg::PointCloudMapCellWithID> & map_cells_to_add,
+    std::vector<std::string> map_cell_ids_to_remove)
+  {
+    if (map_cells_to_add.size() > 0) {
+      for (const auto & map_cell_to_add : map_cells_to_add) {
+        addMapCellAndFilter(map_cell_to_add);
+      }
+    }
+    if (map_cell_ids_to_remove.size() > 0) {
+      for (size_t i = 0; i < map_cell_ids_to_remove.size(); ++i) {
+        removeMapCell(map_cell_ids_to_remove.at(i));
+      }
+    }
+  }
+
+  inline void removeMapCell(const std::string map_cell_id_to_remove)
+  {
+    (*mutex_ptr_).lock();
+    current_voxel_grid_list_.erase(map_cell_id_to_remove);
+    (*mutex_ptr_).unlock();
+  }
+
+  inline void addMapCellAndFilter(
+    const autoware_map_msgs::msg::PointCloudMapCellWithID map_cell_to_add)
+  {
+    auto exe_start_time = std::chrono::system_clock::now();
+
+    pcl::PointCloud<pcl::PointXYZ> map_cell_pc_tmp;
+    pcl::fromROSMsg(map_cell_to_add.pointcloud, map_cell_pc_tmp);
+
+    MultiVoxelGrid map_cell_voxel_grid_tmp;
+    PointCloudPtr map_cell_downsampled_pc_ptr_tmp;
+
+    auto map_cell_voxel_input_tmp_ptr =
+      std::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_cell_pc_tmp);
+    map_cell_voxel_grid_tmp.setLeafSize(voxel_leaf_size_, voxel_leaf_size_, voxel_leaf_size_);
+    map_cell_downsampled_pc_ptr_tmp.reset(new pcl::PointCloud<pcl::PointXYZ>);
+    map_cell_voxel_grid_tmp.setInputCloud(map_cell_voxel_input_tmp_ptr);
+    map_cell_voxel_grid_tmp.setSaveLeafLayout(true);
+    map_cell_voxel_grid_tmp.filter(*map_cell_downsampled_pc_ptr_tmp);
+
+    MapGridVoxelInfo current_voxel_grid_list_item;
+    current_voxel_grid_list_item.voxel_grid_filtered_pc = *map_cell_downsampled_pc_ptr_tmp;
+    current_voxel_grid_list_item.min_b_x = map_cell_voxel_grid_tmp.get_min_p()[0];
+    current_voxel_grid_list_item.min_b_y = map_cell_voxel_grid_tmp.get_min_p()[1];
+    current_voxel_grid_list_item.max_b_x = map_cell_voxel_grid_tmp.get_max_p()[0];
+    current_voxel_grid_list_item.max_b_y = map_cell_voxel_grid_tmp.get_max_p()[1];
+
+    current_voxel_grid_list_item.map_cell_voxel_grid.set_voxel_grid(
+      &(map_cell_voxel_grid_tmp.leaf_layout_), map_cell_voxel_grid_tmp.get_min_b(),
+      map_cell_voxel_grid_tmp.get_max_b(), map_cell_voxel_grid_tmp.get_div_b(),
+      map_cell_voxel_grid_tmp.get_divb_mul(), map_cell_voxel_grid_tmp.get_inverse_leaf_size());
+
+    current_voxel_grid_list_item.map_cell_pc_ptr.reset(new pcl::PointCloud<pcl::PointXYZ>);
+    for (size_t i = 0; i < map_cell_downsampled_pc_ptr_tmp->points.size(); ++i) {
+      current_voxel_grid_list_item.map_cell_pc_ptr->points.push_back(
+        map_cell_downsampled_pc_ptr_tmp->points.at(i));
+    }
+    // add
+    (*mutex_ptr_).lock();
+    current_voxel_grid_list_.insert({map_cell_to_add.cell_id, current_voxel_grid_list_item});
+    (*mutex_ptr_).unlock();
+
+    auto exe_stop_time = std::chrono::system_clock::now();
+    const double exe_run_time =
+      std::chrono::duration_cast<std::chrono::microseconds>(exe_stop_time - exe_start_time)
+        .count() /
+      1000.0;
+    RCLCPP_INFO(
+      logger_, " map cell %s adding time: %lf", map_cell_to_add.cell_id.c_str(), exe_run_time);
+  }
+};
+
+#endif  // COMPARE_MAP_SEGMENTATION__VOXEL_GRID_MAP_LOADER_HPP_

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -105,7 +105,6 @@ class VoxelGridDynamicMapLoader : public VoxelGridMapLoader
     MultiVoxelGrid map_cell_voxel_grid;
     PointCloudPtr map_cell_pc_ptr;
     float min_b_x, min_b_y, max_b_x, max_b_y;
-    // pcl::PointCloud<pcl::PointXYZ> voxel_grid_filtered_pc;
   };
 
   typedef typename std::map<std::string, struct MapGridVoxelInfo> VoxelGridDict;
@@ -190,6 +189,7 @@ public:
     map_cell_voxel_grid_tmp.filter(*map_cell_downsampled_pc_ptr_tmp);
 
     MapGridVoxelInfo current_voxel_grid_list_item;
+    // TODO(badai-nguyen): use map cell info from map cell, when map loader I/F is updated
     current_voxel_grid_list_item.min_b_x = map_cell_voxel_grid_tmp.get_min_p()[0];
     current_voxel_grid_list_item.min_b_y = map_cell_voxel_grid_tmp.get_min_p()[1];
     current_voxel_grid_list_item.max_b_x = map_cell_voxel_grid_tmp.get_max_p()[0];

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -67,10 +67,10 @@ public:
   void publish_downsampled_map(const pcl::PointCloud<pcl::PointXYZ> & downsampled_pc);
 
   /** \brief Get representative points of 27 neighboor voxels*/
-  inline pcl::PointCloud<pcl::PointXYZ> getNeighborVoxelPoints(
+  pcl::PointCloud<pcl::PointXYZ> getNeighborVoxelPoints(
     pcl::PointXYZ point, double voxel_size);
 
-  inline bool is_close_points(
+  bool is_close_points(
     const pcl::PointXYZ point, const pcl::PointXYZ target_point,
     const double distance_threshold) const;
   std::string * tf_map_input_frame_;
@@ -167,8 +167,6 @@ public:
   inline void addMapCellAndFilter(
     const autoware_map_msgs::msg::PointCloudMapCellWithID & map_cell_to_add)
   {
-    auto exe_start_time = std::chrono::system_clock::now();
-
     pcl::PointCloud<pcl::PointXYZ> map_cell_pc_tmp;
     pcl::fromROSMsg(map_cell_to_add.pointcloud, map_cell_pc_tmp);
 
@@ -205,14 +203,6 @@ public:
     (*mutex_ptr_).lock();
     current_voxel_grid_dict_.insert({map_cell_to_add.cell_id, current_voxel_grid_list_item});
     (*mutex_ptr_).unlock();
-
-    auto exe_stop_time = std::chrono::system_clock::now();
-    const double exe_run_time =
-      std::chrono::duration_cast<std::chrono::microseconds>(exe_stop_time - exe_start_time)
-        .count() /
-      1000.0;
-    RCLCPP_INFO(
-      logger_, " map cell %s adding time: %lf", map_cell_to_add.cell_id.c_str(), exe_run_time);
   }
 };
 

--- a/perception/compare_map_segmentation/launch/voxel_based_compare_map_filter.launch.xml
+++ b/perception/compare_map_segmentation/launch/voxel_based_compare_map_filter.launch.xml
@@ -1,13 +1,23 @@
 <launch>
   <arg name="input" default="/input" description="input topic name"/>
   <arg name="input_map" default="/map" description="input map topic name"/>
+  <arg name="pose_with_covariance" default="/localization/pose_estimator/pose_with_covariance" description="input vehicle pose topic name"/>
   <arg name="output" default="/output" description="output topic name"/>
+  <arg name="map_loader_service" default="/map/get_differential_pointcloud_map" description="map loader service name"/>
   <arg name="distance_threshold" default="0.3"/>
+  <arg name="use_dynamic_map_loading" default="true"/>
+  <arg name="timer_interval_ms" default="100"/>
+  <arg name="map_update_distance_threshold" default="10.0"/>
+  <arg name="map_loader_radius" default="150.0"/>
 
   <node pkg="compare_map_segmentation" exec="voxel_based_compare_map_filter_node" name="voxel_based_compare_map_filter_node" output="screen">
     <remap from="input" to="$(var input)"/>
     <remap from="map" to="$(var input_map)"/>
     <remap from="output" to="$(var output)"/>
     <param name="distance_threshold" value="$(var distance_threshold)"/>
+    <param name="use_dynamic_map_loading" value="$(var use_dynamic_map_loading)"/>
+    <param name="timer_interval_ms" value="$(var timer_interval_ms)"/>
+    <param name="map_update_distance_threshold" value="$(var map_update_distance_threshold)"/>
+    <param name="map_loader_radius" value="$(var map_loader_radius)"/>
   </node>
 </launch>

--- a/perception/compare_map_segmentation/package.xml
+++ b/perception/compare_map_segmentation/package.xml
@@ -17,6 +17,8 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>grid_map_pcl</depend>
   <depend>grid_map_ros</depend>
   <depend>pcl_conversions</depend>

--- a/perception/compare_map_segmentation/package.xml
+++ b/perception/compare_map_segmentation/package.xml
@@ -17,7 +17,6 @@
 
   <build_depend>autoware_cmake</build_depend>
 
-  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>grid_map_pcl</depend>
   <depend>grid_map_ros</depend>

--- a/perception/compare_map_segmentation/src/multi_voxel_grid_map_update.cpp
+++ b/perception/compare_map_segmentation/src/multi_voxel_grid_map_update.cpp
@@ -1,0 +1,17 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <compare_map_segmentation/multi_voxel_grid_map_update.hpp>
+
+template class compare_map_segmentation::MultiVoxelGrid<pcl::PointXYZ>;

--- a/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
@@ -39,16 +39,19 @@ VoxelBasedCompareMapFilterComponent::VoxelBasedCompareMapFilterComponent(
   }
 
   distance_threshold_ = static_cast<double>(declare_parameter("distance_threshold", 0.3));
+  bool is_static_map = static_cast<bool>(declare_parameter("is_static_map", true));
 
   set_map_in_voxel_grid_ = false;
-
-  using std::placeholders::_1;
-  sub_map_ = this->create_subscription<PointCloud2>(
-    "map", rclcpp::QoS{1}.transient_local(),
-    std::bind(&VoxelBasedCompareMapFilterComponent::input_target_callback, this, _1));
-
-  set_param_res_ = this->add_on_set_parameters_callback(
-    std::bind(&VoxelBasedCompareMapFilterComponent::paramCallback, this, _1));
+  if (is_static_map) {
+    voxel_grid_map_looader_ = std::make_unique<VoxelGridStaticMapLoader>(
+      this, distance_threshold_, &tf_input_frame_, &mutex_);
+  } else {
+    rclcpp::CallbackGroup::SharedPtr main_callback_group;
+    main_callback_group = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    voxel_grid_map_looader_ = std::make_unique<VoxelGridDynamicMapLoader>(
+      this, distance_threshold_, &tf_input_frame_, &mutex_, main_callback_group);
+  }
+  tf_input_frame_ = *(voxel_grid_map_looader_->tf_map_input_frame_);
 }
 
 void VoxelBasedCompareMapFilterComponent::filter(
@@ -57,171 +60,16 @@ void VoxelBasedCompareMapFilterComponent::filter(
 {
   std::scoped_lock lock(mutex_);
   stop_watch_ptr_->toc("processing_time", true);
-  if (voxel_map_ptr_ == NULL) {
-    output = *input;
-    return;
-  }
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::fromROSMsg(*input, *pcl_input);
   pcl_output->points.reserve(pcl_input->points.size());
   for (size_t i = 0; i < pcl_input->points.size(); ++i) {
     const pcl::PointXYZ point = pcl_input->points.at(i);
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x, point.y, point.z), point, distance_threshold_, voxel_map_ptr_,
-          voxel_grid_)) {
+    if (voxel_grid_map_looader_->is_close_to_map(point, distance_threshold_)) {
       continue;
     }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x, point.y - distance_threshold_, point.z - distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x, point.y - distance_threshold_, point.z), point,
-          distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x, point.y - distance_threshold_, point.z + distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x, point.y, point.z - distance_threshold_), point,
-          distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x, point.y, point.z + distance_threshold_), point,
-          distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x, point.y + distance_threshold_, point.z - distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x, point.y + distance_threshold_, point.z), point,
-          distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x, point.y + distance_threshold_, point.z + distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-
-    if (is_in_voxel(
-          pcl::PointXYZ(
-            point.x - distance_threshold_, point.y - distance_threshold_,
-            point.z - distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x - distance_threshold_, point.y - distance_threshold_, point.z),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(
-            point.x - distance_threshold_, point.y - distance_threshold_,
-            point.z + distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x - distance_threshold_, point.y, point.z - distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x - distance_threshold_, point.y, point.z), point,
-          distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x - distance_threshold_, point.y, point.z + distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(
-            point.x - distance_threshold_, point.y + distance_threshold_,
-            point.z - distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x - distance_threshold_, point.y + distance_threshold_, point.z),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(
-            point.x - distance_threshold_, point.y + distance_threshold_,
-            point.z + distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-
-    if (is_in_voxel(
-          pcl::PointXYZ(
-            point.x + distance_threshold_, point.y - distance_threshold_,
-            point.z - distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x + distance_threshold_, point.y - distance_threshold_, point.z),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(
-            point.x + distance_threshold_, point.y - distance_threshold_,
-            point.z + distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x + distance_threshold_, point.y, point.z - distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x + distance_threshold_, point.y, point.z), point,
-          distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x + distance_threshold_, point.y, point.z + distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(
-            point.x + distance_threshold_, point.y + distance_threshold_,
-            point.z - distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(point.x + distance_threshold_, point.y + distance_threshold_, point.z),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-    if (is_in_voxel(
-          pcl::PointXYZ(
-            point.x + distance_threshold_, point.y + distance_threshold_,
-            point.z + distance_threshold_),
-          point, distance_threshold_, voxel_map_ptr_, voxel_grid_)) {
-      continue;
-    }
-
-    pcl_output->points.push_back(pcl_input->points.at(i));
+    pcl_output->points.push_back(point);
   }
   pcl::toROSMsg(*pcl_output, output);
   output.header = input->header;
@@ -237,61 +85,6 @@ void VoxelBasedCompareMapFilterComponent::filter(
   }
 }
 
-bool VoxelBasedCompareMapFilterComponent::is_in_voxel(
-  const pcl::PointXYZ & src_point, const pcl::PointXYZ & target_point,
-  const double distance_threshold, const PointCloudPtr & map,
-  pcl::VoxelGrid<pcl::PointXYZ> & voxel) const
-{
-  int voxel_index =
-    voxel.getCentroidIndexAt(voxel.getGridCoordinates(src_point.x, src_point.y, src_point.z));
-  if (voxel_index != -1) {  // not empty voxel
-    const double dist_x = map->points.at(voxel_index).x - target_point.x;
-    const double dist_y = map->points.at(voxel_index).y - target_point.y;
-    const double dist_z = map->points.at(voxel_index).z - target_point.z;
-    const double sqr_distance = dist_x * dist_x + dist_y * dist_y + dist_z * dist_z;
-    if (sqr_distance < distance_threshold * distance_threshold) {
-      return true;
-    }
-  }
-  return false;
-}
-
-void VoxelBasedCompareMapFilterComponent::input_target_callback(const PointCloud2ConstPtr map)
-{
-  pcl::PointCloud<pcl::PointXYZ> map_pcl;
-  pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
-  const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
-
-  std::scoped_lock lock(mutex_);
-  set_map_in_voxel_grid_ = true;
-  tf_input_frame_ = map_pcl_ptr->header.frame_id;
-  voxel_map_ptr_.reset(new pcl::PointCloud<pcl::PointXYZ>);
-  voxel_grid_.setLeafSize(distance_threshold_, distance_threshold_, distance_threshold_);
-  voxel_grid_.setInputCloud(map_pcl_ptr);
-  voxel_grid_.setSaveLeafLayout(true);
-  voxel_grid_.filter(*voxel_map_ptr_);
-}
-
-rcl_interfaces::msg::SetParametersResult VoxelBasedCompareMapFilterComponent::paramCallback(
-  const std::vector<rclcpp::Parameter> & p)
-{
-  std::scoped_lock lock(mutex_);
-
-  if (get_param(p, "distance_threshold", distance_threshold_)) {
-    voxel_grid_.setLeafSize(distance_threshold_, distance_threshold_, distance_threshold_);
-    voxel_grid_.setSaveLeafLayout(true);
-    if (set_map_in_voxel_grid_) {
-      voxel_grid_.filter(*voxel_map_ptr_);
-    }
-    RCLCPP_DEBUG(get_logger(), "Setting new distance threshold to: %f.", distance_threshold_);
-  }
-
-  rcl_interfaces::msg::SetParametersResult result;
-  result.successful = true;
-  result.reason = "success";
-
-  return result;
-}
 }  // namespace compare_map_segmentation
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
@@ -83,7 +83,6 @@ void VoxelBasedCompareMapFilterComponent::filter(
     debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
       "debug/processing_time_ms", processing_time_ms);
   }
-
 }
 
 }  // namespace compare_map_segmentation

--- a/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
@@ -83,6 +83,7 @@ void VoxelBasedCompareMapFilterComponent::filter(
     debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
       "debug/processing_time_ms", processing_time_ms);
   }
+
 }
 
 }  // namespace compare_map_segmentation

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -177,7 +177,8 @@ bool VoxelGridDynamicMapLoader::is_close_to_map(
     return false;
   }
   for (const auto & kv : current_voxel_grid_dict_) {
-    // TODO(badai-nguyen): add neighboor map cells checking for points on boundary
+    // TODO(badai-nguyen): add neighboor map cells checking for points on boundary when map loader
+    // I/F is updated
     if (point.x < kv.second.min_b_x) {
       continue;
     }

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -300,27 +300,35 @@ bool VoxelGridDynamicMapLoader::is_close_to_map(
   if (current_voxel_grid_dict_.size() == 0) {
     return false;
   }
+  std::vector<std::string> neighbor_map_cells_id;
+
   for (auto & kv : current_voxel_grid_dict_) {
     // TODO(badai-nguyen): add neighboor map cells checking for points on boundary when map loader
     // I/F is updated
-    if (point.x < kv.second.min_b_x) {
+
+    if (point.x < kv.second.min_b_x - distance_threshold) {
       continue;
     }
-    if (point.y < kv.second.min_b_y) {
+    if (point.y < kv.second.min_b_y - distance_threshold) {
       continue;
     }
-    if (point.x > kv.second.max_b_x) {
+    if (point.x > kv.second.max_b_x + distance_threshold) {
       continue;
     }
-    if (point.y > kv.second.max_b_y) {
+    if (point.y > kv.second.max_b_y + distance_threshold) {
       continue;
     }
     // the map cell is found
-    if (kv.second.map_cell_pc_ptr == NULL) {
+    neighbor_map_cells_id.push_back(kv.first);
+  }
+  for (auto & neighbor_map_cell_id : neighbor_map_cells_id) {
+    if (current_voxel_grid_dict_.find(neighbor_map_cell_id)->second.map_cell_pc_ptr == NULL) {
       return false;
     }
     if (is_close_to_neighbor_voxels(
-          point, distance_threshold, kv.second.map_cell_pc_ptr, kv.second.map_cell_voxel_grid)) {
+          point, distance_threshold,
+          current_voxel_grid_dict_.find(neighbor_map_cell_id)->second.map_cell_pc_ptr,
+          current_voxel_grid_dict_.find(neighbor_map_cell_id)->second.map_cell_voxel_grid)) {
       return true;
     }
   }

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -62,7 +62,8 @@ pcl::PointCloud<pcl::PointXYZ> VoxelGridMapLoader::getNeighborVoxelPoints(
 }
 
 bool VoxelGridMapLoader::is_close_points(
-  const pcl::PointXYZ point, const pcl::PointXYZ target_point, const double distance_threshold)
+  const pcl::PointXYZ point, const pcl::PointXYZ target_point,
+  const double distance_threshold) const
 {
   if (distance3D(point, target_point) < distance_threshold * distance_threshold) {
     return true;
@@ -70,7 +71,8 @@ bool VoxelGridMapLoader::is_close_points(
   return false;
 }
 
-void VoxelGridMapLoader::publish_downsampled_map(const pcl::PointCloud<pcl::PointXYZ> & downsampled_pc)
+void VoxelGridMapLoader::publish_downsampled_map(
+  const pcl::PointCloud<pcl::PointXYZ> & downsampled_pc)
 {
   sensor_msgs::msg::PointCloud2 downsampled_map_msg;
   pcl::toROSMsg(downsampled_pc, downsampled_map_msg);
@@ -107,7 +109,7 @@ void VoxelGridStaticMapLoader::onMapCallback(
   publish_downsampled_map(*voxel_map_ptr_);
 }
 bool VoxelGridStaticMapLoader::is_close_to_map(
-  const pcl::PointXYZ & point, const double distance_threshold) 
+  const pcl::PointXYZ & point, const double distance_threshold)
 {
   // check map downsampled pc
   if (voxel_map_ptr_ == NULL) {
@@ -119,7 +121,7 @@ bool VoxelGridStaticMapLoader::is_close_to_map(
     voxel_index = voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(
       neighbor_voxel_points[j].x, neighbor_voxel_points[j].y, neighbor_voxel_points[j].z));
 
-    if (voxel_index == -1){
+    if (voxel_index == -1) {
       continue;
     }
     if (is_close_points(voxel_map_ptr_->points.at(voxel_index), point, distance_threshold)) {
@@ -161,7 +163,6 @@ VoxelGridDynamicMapLoader::VoxelGridDynamicMapLoader(
   map_update_timer_ = node->create_wall_timer(
     std::chrono::milliseconds(timer_interval_ms),
     std::bind(&VoxelGridDynamicMapLoader::timer_callback, this), timer_callback_group_);
-
 }
 
 void VoxelGridDynamicMapLoader::onEstimatedPoseCallback(
@@ -173,12 +174,12 @@ void VoxelGridDynamicMapLoader::onEstimatedPoseCallback(
 bool VoxelGridDynamicMapLoader::is_close_to_map(
   const pcl::PointXYZ & point, const double distance_threshold)
 {
-  if (current_voxel_grid_list_.size() == 0) {
+  if (current_voxel_grid_dict_.size() == 0) {
     return false;
   }
-  for (const auto & kv : current_voxel_grid_list_) {
+  for (const auto & kv : current_voxel_grid_dict_) {
     if (
-      // TODO(badai-nguyen): add neighboor map cell checking for point on boundary
+      // TODO(badai-nguyen): add neighboor map cells checking for points on boundary
       point.x >= kv.second.min_b_x && point.y >= kv.second.min_b_y &&
       point.x <= kv.second.max_b_x && point.y <= kv.second.max_b_y) {
       if (kv.second.map_cell_pc_ptr == NULL) {
@@ -223,7 +224,7 @@ void VoxelGridDynamicMapLoader::timer_callback()
   }
 }
 
-bool VoxelGridDynamicMapLoader::should_update_map()
+bool VoxelGridDynamicMapLoader::should_update_map() const
 {
   if (
     distance2D(current_position_.value(), last_updated_position_.value()) >
@@ -271,7 +272,5 @@ void VoxelGridDynamicMapLoader::request_update_map(const geometry_msgs::msg::Poi
 
   publish_downsampled_map(getCurrentDownsampledMapPc());
 }
-
-
 
 // VoxelGridDynamicMapLoader::~VoxelGridDynamicMapLoader() {}

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -303,9 +303,6 @@ bool VoxelGridDynamicMapLoader::is_close_to_map(
   std::vector<std::string> neighbor_map_cells_id;
 
   for (auto & kv : current_voxel_grid_dict_) {
-    // TODO(badai-nguyen): add neighboor map cells checking for points on boundary when map loader
-    // I/F is updated
-
     if (point.x < kv.second.min_b_x - distance_threshold) {
       continue;
     }
@@ -320,15 +317,12 @@ bool VoxelGridDynamicMapLoader::is_close_to_map(
     }
     // the map cell is found
     neighbor_map_cells_id.push_back(kv.first);
-  }
-  for (auto & neighbor_map_cell_id : neighbor_map_cells_id) {
-    if (current_voxel_grid_dict_.find(neighbor_map_cell_id)->second.map_cell_pc_ptr == NULL) {
-      return false;
+    // check distance
+    if (kv.second.map_cell_pc_ptr == NULL) {
+      continue;
     }
     if (is_close_to_neighbor_voxels(
-          point, distance_threshold,
-          current_voxel_grid_dict_.find(neighbor_map_cell_id)->second.map_cell_pc_ptr,
-          current_voxel_grid_dict_.find(neighbor_map_cell_id)->second.map_cell_voxel_grid)) {
+          point, distance_threshold, kv.second.map_cell_pc_ptr, kv.second.map_cell_voxel_grid)) {
       return true;
     }
   }

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -1,0 +1,270 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "compare_map_segmentation/voxel_grid_map_loader.hpp"
+
+VoxelGridMapLoader::VoxelGridMapLoader(
+  rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex)
+: logger_(node->get_logger()), voxel_leaf_size_(leaf_size)
+{
+  tf_map_input_frame_ = tf_map_input_frame;
+  mutex_ptr_ = mutex;
+};
+
+pcl::PointCloud<pcl::PointXYZ> VoxelGridMapLoader::getNeighborVoxelPoints(
+  pcl::PointXYZ point, double voxel_size)
+{
+  pcl::PointCloud<pcl::PointXYZ> output;
+  output.push_back(pcl::PointXYZ(point.x, point.y, point.z));
+  output.push_back(pcl::PointXYZ(point.x, point.y - voxel_size, point.z - voxel_size));
+  output.push_back(pcl::PointXYZ(point.x, point.y - voxel_size, point.z));
+  output.push_back(pcl::PointXYZ(point.x, point.y - voxel_size, point.z + voxel_size));
+  output.push_back(pcl::PointXYZ(point.x, point.y, point.z - voxel_size));
+  output.push_back(pcl::PointXYZ(point.x, point.y, point.z + voxel_size));
+  output.push_back(pcl::PointXYZ(point.x, point.y + voxel_size, point.z - voxel_size));
+  output.push_back(pcl::PointXYZ(point.x, point.y + voxel_size, point.z));
+  output.push_back(pcl::PointXYZ(point.x, point.y + voxel_size, point.z + voxel_size));
+
+  output.push_back(pcl::PointXYZ(point.x - voxel_size, point.y - voxel_size, point.z - voxel_size));
+  output.push_back(pcl::PointXYZ(point.x - voxel_size, point.y - voxel_size, point.z));
+  output.push_back(pcl::PointXYZ(point.x - voxel_size, point.y - voxel_size, point.z + voxel_size));
+  output.push_back(pcl::PointXYZ(point.x - voxel_size, point.y, point.z - voxel_size));
+  output.push_back(pcl::PointXYZ(point.x - voxel_size, point.y, point.z));
+  output.push_back(pcl::PointXYZ(point.x - voxel_size, point.y, point.z + voxel_size));
+  output.push_back(pcl::PointXYZ(point.x - voxel_size, point.y + voxel_size, point.z - voxel_size));
+  output.push_back(pcl::PointXYZ(point.x - voxel_size, point.y + voxel_size, point.z));
+  output.push_back(pcl::PointXYZ(point.x - voxel_size, point.y + voxel_size, point.z + voxel_size));
+
+  output.push_back(pcl::PointXYZ(point.x + voxel_size, point.y - voxel_size, point.z - voxel_size));
+  output.push_back(pcl::PointXYZ(point.x + voxel_size, point.y - voxel_size, point.z));
+  output.push_back(pcl::PointXYZ(point.x + voxel_size, point.y - voxel_size, point.z + voxel_size));
+  output.push_back(pcl::PointXYZ(point.x + voxel_size, point.y, point.z - voxel_size));
+  output.push_back(pcl::PointXYZ(point.x + voxel_size, point.y, point.z));
+  output.push_back(pcl::PointXYZ(point.x + voxel_size, point.y, point.z + voxel_size));
+  output.push_back(pcl::PointXYZ(point.x + voxel_size, point.y + voxel_size, point.z - voxel_size));
+  output.push_back(pcl::PointXYZ(point.x + voxel_size, point.y + voxel_size, point.z));
+  output.push_back(pcl::PointXYZ(point.x + voxel_size, point.y + voxel_size, point.z + voxel_size));
+  return output;
+}
+
+bool VoxelGridMapLoader::is_close_points(
+  const pcl::PointXYZ point, const pcl::PointXYZ target_point, const double distance_threshold)
+{
+  if (distance3D(point, target_point) < distance_threshold * distance_threshold) {
+    return true;
+  }
+  return false;
+}
+//*************************** for Static Map loader Voxel Grid Filter *************
+
+VoxelGridStaticMapLoader::VoxelGridStaticMapLoader(
+  rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex)
+: VoxelGridMapLoader(node, leaf_size, tf_map_input_frame, mutex)
+{
+  sub_map_ = node->create_subscription<sensor_msgs::msg::PointCloud2>(
+    "map", rclcpp::QoS{1}.transient_local(),
+    std::bind(&VoxelGridStaticMapLoader::onMapCallback, this, std::placeholders::_1));
+  RCLCPP_INFO(logger_, "VoxelGridStaticMapLoader initialized.\n");
+}
+
+void VoxelGridStaticMapLoader::onMapCallback(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr map)
+{
+  pcl::PointCloud<pcl::PointXYZ> map_pcl;
+  pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
+  const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
+  *tf_map_input_frame_ = map_pcl_ptr->header.frame_id;
+  (*mutex_ptr_).lock();
+  voxel_map_ptr_.reset(new pcl::PointCloud<pcl::PointXYZ>);
+  voxel_grid_.setLeafSize(voxel_leaf_size_, voxel_leaf_size_, voxel_leaf_size_);
+  voxel_grid_.setInputCloud(map_pcl_ptr);
+  voxel_grid_.setSaveLeafLayout(true);
+  voxel_grid_.filter(*voxel_map_ptr_);
+  (*mutex_ptr_).unlock();
+}
+bool VoxelGridStaticMapLoader::is_close_to_map(
+  const pcl::PointXYZ & point, const double distance_threshold)
+{
+  // check map downsampled pc
+  if (voxel_map_ptr_ == NULL) {
+    return false;
+  }
+  auto neighbor_voxel_points = getNeighborVoxelPoints(point, distance_threshold);
+  int voxel_index;
+  for (size_t j = 0; j < neighbor_voxel_points.size(); ++j) {
+    voxel_index = voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(
+      neighbor_voxel_points[j].x, neighbor_voxel_points[j].y, neighbor_voxel_points[j].z));
+
+    if (voxel_index != -1) {
+      if (is_close_points(voxel_map_ptr_->points.at(voxel_index), point, distance_threshold)) {
+        return true;
+      };
+    }
+  }
+  return false;
+};
+//*************** for Dynamic and Differential Map loader Voxel Grid Filter *************
+
+VoxelGridDynamicMapLoader::VoxelGridDynamicMapLoader(
+  rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex,
+  rclcpp::CallbackGroup::SharedPtr main_callback_group)
+: VoxelGridMapLoader(node, leaf_size, tf_map_input_frame, mutex)
+{
+  auto timer_interval_ms = static_cast<int>(node->declare_parameter("timer_interval_ms", 500));
+  map_update_distance_threshold_ =
+    static_cast<double>(node->declare_parameter("map_update_distance_threshold", 10.0));
+  map_loader_radius_ = static_cast<double>(node->declare_parameter("map_loader_radius", 100));
+  auto main_sub_opt = rclcpp::SubscriptionOptions();
+  main_sub_opt.callback_group = main_callback_group;
+
+  sub_estimated_pose_ = node->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    "/localization/pose_estimator/pose_with_covariance", rclcpp::QoS{1},
+    std::bind(&VoxelGridDynamicMapLoader::onEstimatedPoseCallback, this, std::placeholders::_1),
+    main_sub_opt);
+  RCLCPP_INFO(logger_, "VoxelGridDynamicMapLoader initialized.\n");
+
+  client_callback_group_ =
+    node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  map_update_client_ = node->create_client<autoware_map_msgs::srv::GetDifferentialPointCloudMap>(
+    "map_loader_service", rmw_qos_profile_services_default, client_callback_group_);
+
+  while (!map_update_client_->wait_for_service(std::chrono::seconds(1)) && rclcpp::ok()) {
+    RCLCPP_INFO(logger_, "service not available, waiting again ...");
+  }
+
+  timer_callback_group_ = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  map_update_timer_ = node->create_wall_timer(
+    std::chrono::milliseconds(timer_interval_ms),
+    std::bind(&VoxelGridDynamicMapLoader::timer_callback, this), timer_callback_group_);
+
+  downsampled_map_pub_ = node->create_publisher<sensor_msgs::msg::PointCloud2>(
+    "debug/downsampled_map/pointcloud", rclcpp::QoS{1}.transient_local());
+}
+
+void VoxelGridDynamicMapLoader::onEstimatedPoseCallback(
+  geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg)
+{
+  current_position_ = msg->pose.pose.position;
+}
+
+bool VoxelGridDynamicMapLoader::is_close_to_map(
+  const pcl::PointXYZ & point, const double distance_threshold)
+{
+  if (current_voxel_grid_list_.size() == 0) {
+    return false;
+  }
+  for (const auto & kv : current_voxel_grid_list_) {
+    if (
+      // TODO(badai-nguyen): add neighboor map cell checking for point on boundary
+      point.x >= kv.second.min_b_x && point.y >= kv.second.min_b_y &&
+      point.x <= kv.second.max_b_x && point.y <= kv.second.max_b_y) {
+      if (kv.second.map_cell_pc_ptr == NULL) {
+        return false;
+      }
+      auto neighbor_voxel_points = getNeighborVoxelPoints(point, distance_threshold);
+      int voxel_index;
+      for (size_t j = 0; j < neighbor_voxel_points.size(); ++j) {
+        voxel_index = kv.second.map_cell_voxel_grid.getCentroidIndexAt(
+          kv.second.map_cell_voxel_grid.getGridCoordinates(
+            neighbor_voxel_points[j].x, neighbor_voxel_points[j].y, neighbor_voxel_points[j].z));
+
+        if (voxel_index == -1) {
+          continue;
+        }
+        if (is_close_points(
+              kv.second.map_cell_pc_ptr->points.at(voxel_index), point, distance_threshold)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+void VoxelGridDynamicMapLoader::timer_callback()
+{
+  if (current_position_ == std::nullopt) {
+    return;
+  }
+  if (last_updated_position_ == std::nullopt) {
+    request_update_map(current_position_.value());
+    last_updated_position_ = current_position_;
+    return;
+  }
+
+  if (should_update_map()) {
+    RCLCPP_INFO(logger_, "Vehicle moved. Update current map!.\n");
+    last_updated_position_ = current_position_;
+    request_update_map((current_position_.value()));
+    last_updated_position_ = current_position_;
+  }
+}
+
+bool VoxelGridDynamicMapLoader::should_update_map()
+{
+  if (
+    distance2D(current_position_.value(), last_updated_position_.value()) >
+    map_update_distance_threshold_) {
+    return true;
+  }
+  return false;
+}
+
+void VoxelGridDynamicMapLoader::request_update_map(const geometry_msgs::msg::Point & position)
+{
+  auto exe_start_time = std::chrono::system_clock::now();
+  auto request = std::make_shared<autoware_map_msgs::srv::GetDifferentialPointCloudMap::Request>();
+  request->area.center = position;
+  request->area.radius = map_loader_radius_;
+  request->cached_ids = getCurrentMapIDs();
+
+  auto result{map_update_client_->async_send_request(
+    request,
+    [](rclcpp::Client<autoware_map_msgs::srv::GetDifferentialPointCloudMap>::SharedFuture) {})};
+
+  std::future_status status = result.wait_for(std::chrono::seconds(0));
+  while (status != std::future_status::ready) {
+    RCLCPP_INFO(logger_, "Waiting for response...\n");
+    if (!rclcpp::ok()) {
+      return;
+    }
+    status = result.wait_for(std::chrono::seconds(1));
+  }
+
+  //
+  if (status == std::future_status::ready) {
+    if (
+      result.get()->new_pointcloud_with_ids.size() > 0 || result.get()->ids_to_remove.size() > 0) {
+      updateDifferentialMapCells(
+        result.get()->new_pointcloud_with_ids, result.get()->ids_to_remove);
+    }
+  }
+
+  auto exe_stop_time = std::chrono::system_clock::now();
+  const double exe_run_time =
+    std::chrono::duration_cast<std::chrono::microseconds>(exe_stop_time - exe_start_time).count() /
+    1000.0;
+  RCLCPP_INFO(logger_, "Current map updating time: %lf [ms]", exe_run_time);
+
+  publish_downsampled_map();
+}
+
+void VoxelGridDynamicMapLoader::publish_downsampled_map()
+{
+  sensor_msgs::msg::PointCloud2 downsampled_map_msg;
+  pcl::toROSMsg(getCurrentDownsampledMapPc(), downsampled_map_msg);
+  downsampled_map_msg.header.frame_id = "map";
+  downsampled_map_pub_->publish(downsampled_map_msg);
+}
+
+// VoxelGridDynamicMapLoader::~VoxelGridDynamicMapLoader() {}

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -280,5 +280,3 @@ void VoxelGridDynamicMapLoader::request_update_map(const geometry_msgs::msg::Poi
 
   publish_downsampled_map(getCurrentDownsampledMapPc());
 }
-
-// VoxelGridDynamicMapLoader::~VoxelGridDynamicMapLoader() {}


### PR DESCRIPTION
## Description

This PR to solve this issue [3085](https://github.com/autowarefoundation/autoware.universe/issues/3085)  for voxel_based_compare_map_filter nodelete.

The PR utilize the dynamic map loading interface to update current utilize pointcloud map cells. 


## Related links

[TIERIV COMPANY INTERNAL LINK](https://tier4.atlassian.net/browse/T4PB-26400)
https://github.com/autowarefoundation/autoware_launch/pull/257
## Tests performed

I tested on sample rosbag from Autoware tutorial using split map here: [sample-map-rosbag_split.zip](https://github.com/autowarefoundation/autoware.universe/files/10349104/sample-map-rosbag_split.zip)

- I have comfirmed that the performance is the same as current Autoware when `use_dynamic_map_loading` is set as `false`
- I have confirmed that when `use_dynamic_map_loading` is set as `true`: the performance is almost the same with current Autoware, with very small degradation. The reason is:
     。This PR storing voxel grid information of each current surrounding map cells + map cell position and size. However, the precise map cell region and position still cannot receive from map loader interface yet. It is still discussed here: https://github.com/orgs/autowarefoundation/discussions/3328. So map cell position and region are calculate by searching max and min pointcloud. 
   。So some input poincloud located between calculated map cell region will be passed through filter. However, this issue occurrs mostly around map cells with sparse pointcloud which far from lanelet and which should not have significant effect to the vehicle behavior. 
This will be fixed after map loader interface is updated. 
![image](https://user-images.githubusercontent.com/94814556/225523968-e5428fc4-7ab8-4b06-9bca-f9259b701bbe.png)

Current Autoware result: 
rviz pc rendering, pink:filter output 
![image](https://user-images.githubusercontent.com/94814556/225524468-7ca6f524-717b-4e65-bb01-52a8317d725f.png)
Poincloud number: 
red: filter input, blue: filter output 
![image](https://user-images.githubusercontent.com/94814556/225524537-5bfd09a2-44a5-407d-b097-e1cef8db4ad3.png)

Updated Autoware:
rviz pc rendering, pink:filter output 
![image](https://user-images.githubusercontent.com/94814556/225525195-b56d5c2d-4e68-4b0d-b660-63266e0e12e2.png)

Poincloud number: 
red: filter input, blue: filter output 
![image](https://user-images.githubusercontent.com/94814556/225525221-2ec568b3-3261-496e-83bc-b4214a4c1f64.png)



## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
