### PR TITLE
fix(map_loader): disable partial map load by default

### DIFF
--- a/map/map_loader/config/pointcloud_map_loader.param.yaml
+++ b/map/map_loader/config/pointcloud_map_loader.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     enable_whole_load: true
     enable_downsampled_whole_load: false
-    enable_partial_load: true
+    enable_partial_load: false
     enable_differential_load: true
 
     # only used when downsample_whole_load enabled


### PR DESCRIPTION
## Description
Same as https://github.com/autowarefoundation/autoware_launch/pull/255

### Issue
pose_initializer took a long time especially when initializing with 2D GUI initialization, which was caused by `map_height_fitter` newly loading a partial map via [get_partial_point_cloud_map](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_map_msgs#getpartialpointcloudmapsrv). 

### Solution
Disabling `partial_map_load` interface in map_loader by default. By doing so, `map_height_fitter` will load map from `/map/pointcloud_map` topic, and 2D GUI initialization won't take that long any longer.

One of the disadvantages is that we need to change the above  `enable_partial_load` parameter to `true` when handling large size map.

Related link (INTERNAL): https://star4.slack.com/archives/C4P0NSMB5/p1678939151674569

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
