### PR TITLE
feat(behavior_path_planner): use lanelet utils for lateral calculation

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -534,9 +534,6 @@ double calcLaneChangeBuffer(
 
 lanelet::ConstLanelets getLaneletsFromPath(
   const PathWithLaneId & path, const std::shared_ptr<route_handler::RouteHandler> & route_handler);
-
-double calcLateralDistanceToLanelet(
-  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose);
 }  // namespace behavior_path_planner::util
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -356,7 +356,7 @@ std::pair<bool, bool> getLaneChangePaths(
       std::max(prepare_speed, minimum_lane_change_velocity));
 #endif
 
-    const auto estimated_shift_length = util::calcLateralDistanceToLanelet(
+    const auto estimated_shift_length = lanelet::utils::getLateralDistanceToClosestLanelet(
       target_lanelets, prepare_segment.points.front().point.pose);
 
     const auto [lane_changing_speed, lane_changing_distance] = calcLaneChangingSpeedAndDistance(
@@ -617,7 +617,7 @@ ShiftLine getLaneChangingShiftLine(
 
   ShiftLine shift_line;
   shift_line.end_shift_length =
-    util::calcLateralDistanceToLanelet(target_lanes, lane_changing_start_pose);
+    lanelet::utils::getLateralDistanceToClosestLanelet(target_lanes, lane_changing_start_pose);
   shift_line.start = lane_changing_start_pose;
   shift_line.end = lane_changing_end_pose;
   shift_line.start_idx =

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2691,16 +2691,4 @@ lanelet::ConstLanelets getLaneletsFromPath(
 
   return lanelets;
 }
-
-double calcLateralDistanceToLanelet(
-  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose)
-{
-  lanelet::ConstLanelet closest_lanelet;
-  lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lanelet);
-  const auto & centerline_2d = lanelet::utils::to2D(closest_lanelet.centerline());
-
-  const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(pose.position);
-  return lanelet::geometry::signedDistance(
-    centerline_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
-}
 }  // namespace behavior_path_planner::util


### PR DESCRIPTION
## Description
Use lanelet utils for lateral distance calculation in the lane change module
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
