### PR TITLE
feat(obstacle_avoidance_planner): visualize bounds

### DIFF
--- a/planning/obstacle_avoidance_planner/src/debug_marker.cpp
+++ b/planning/obstacle_avoidance_planner/src/debug_marker.cpp
@@ -72,7 +72,7 @@ MarkerArray getFootprintsMarkerArray(
   return marker_array;
 }
 
-MarkerArray getBoundsLineMarkerArray(
+MarkerArray getBoundsWidthMarkerArray(
   const std::vector<ReferencePoint> & ref_points, const double vehicle_width,
   const size_t sampling_num)
 {
@@ -137,6 +137,40 @@ MarkerArray getBoundsLineMarkerArray(
       marker_array.markers.push_back(ub_marker);
     }
   }
+
+  return marker_array;
+}
+
+MarkerArray getBoundsLineMarkerArray(
+  const std::vector<ReferencePoint> & ref_points, const double vehicle_width)
+{
+  MarkerArray marker_array;
+
+  if (ref_points.empty()) return marker_array;
+
+  auto ub_marker = createDefaultMarker(
+    "map", rclcpp::Clock().now(), "left_bounds", 0, Marker::LINE_STRIP,
+    createMarkerScale(0.05, 0.0, 0.0), createMarkerColor(0.0, 1.0, 1.0, 0.8));
+  ub_marker.lifetime = rclcpp::Duration::from_seconds(1.5);
+
+  auto lb_marker = createDefaultMarker(
+    "map", rclcpp::Clock().now(), "right_bounds", 0, Marker::LINE_STRIP,
+    createMarkerScale(0.05, 0.0, 0.0), createMarkerColor(0.0, 1.0, 1.0, 0.8));
+  lb_marker.lifetime = rclcpp::Duration::from_seconds(1.5);
+
+  for (size_t i = 0; i < ref_points.size(); i++) {
+    const geometry_msgs::msg::Pose & pose = ref_points.at(i).pose;
+
+    const double ub_y = ref_points.at(i).bounds.upper_bound + vehicle_width / 2.0;
+    const auto ub = tier4_autoware_utils::calcOffsetPose(pose, 0.0, ub_y, 0.0).position;
+    ub_marker.points.push_back(ub);
+
+    const double lb_y = ref_points.at(i).bounds.lower_bound - vehicle_width / 2.0;
+    const auto lb = tier4_autoware_utils::calcOffsetPose(pose, 0.0, lb_y, 0.0).position;
+    lb_marker.points.push_back(lb);
+  }
+  marker_array.markers.push_back(ub_marker);
+  marker_array.markers.push_back(lb_marker);
 
   return marker_array;
 }
@@ -308,9 +342,13 @@ MarkerArray getDebugMarker(
     getFootprintsMarkerArray(optimized_points, vehicle_info, debug_data.mpt_visualize_sampling_num),
     &marker_array);
 
-  // bounds
+  // bounds lines
   appendMarkerArray(
-    getBoundsLineMarkerArray(
+    getBoundsLineMarkerArray(debug_data.ref_points, vehicle_info.vehicle_width_m), &marker_array);
+
+  // bounds width
+  appendMarkerArray(
+    getBoundsWidthMarkerArray(
       debug_data.ref_points, vehicle_info.vehicle_width_m, debug_data.mpt_visualize_sampling_num),
     &marker_array);
 


### PR DESCRIPTION
## Description

visualize road bounds considered in obstacle_avoidance_planner
The bounds in obstacle_avoidance_planner and behavior_path_planner may be a bit different due to some changes like https://github.com/autowarefoundation/autoware.universe/pull/3086
![image](https://user-images.githubusercontent.com/20228327/225614612-8fab515d-c1ae-4b7a-86e2-13fef823b27a.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
