### PR TITLE
fix(lane_change): fix build error

### DIFF
--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -315,7 +315,8 @@ std::pair<bool, bool> getLaneChangePaths(
   const auto required_total_min_distance =
     util::calcLaneChangeBuffer(common_parameter, num_to_preferred_lane);
 
-  const auto arc_position_from_current = lanelet::utils::getArcCoordinates(original_lanelets, pose);
+  [[maybe_unused]] const auto arc_position_from_current =
+    lanelet::utils::getArcCoordinates(original_lanelets, pose);
   const auto arc_position_from_target = lanelet::utils::getArcCoordinates(target_lanelets, pose);
 
   const auto target_lane_length = lanelet::utils::getLaneletLength2d(target_lanelets);


### PR DESCRIPTION
## Description

Since `[[maybe_unused]]` was removed in https://github.com/autowarefoundation/autoware.universe/pull/3083, build error are shown when it sets following flag to `FALSE`.

https://github.com/autowarefoundation/autoware.universe/blob/2a23a4bf9c74fa321f1483bbabe566f1c6246db9/planning/behavior_path_planner/CMakeLists.txt#L10

```
--- stderr: behavior_path_planner                                                                                                                                                                            
/home/satoshi/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/util/lane_change/util.cpp: In function 'std::pair<bool, bool> behavior_path_planner::lane_change_utils::getLaneChangePaths(const PathWithLaneId&, const route_handler::RouteHandler&, const ConstLanelets&, const ConstLanelets&, const Pose&, const Twist&, autoware_auto_perception_msgs::msg::PredictedObjects_<std::allocator<void> >::Con
stSharedPtr, const BehaviorPathPlannerParameters&, const behavior_path_planner::LaneChangeParameters&, double, behavior_path_planner::LaneChangePaths*, std::unordered_map<std::__cxx11::basic_string<char>, marker_utils::CollisionCheckDebug>*)':
/home/satoshi/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/util/lane_change/util.cpp:318:14: error: variable 'arc_position_from_current' set but not used [-Werror=unused-but-set-variable]
  318 |   const auto arc_position_from_current = lanelet::utils::getArcCoordinates(original_lanelets, pose);  
```

Related PR: https://github.com/autowarefoundation/autoware.universe/pull/3083

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
