### PR TITLE
fix(lane_change): use previous module drivable lanes in drivable are generation

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -107,6 +107,9 @@ struct BehaviorModuleOutput
   TurnSignalInfo turn_signal_info{};
 
   std::optional<PoseWithUuidStamped> modified_goal{};
+
+  // drivable lanes
+  std::vector<DrivableLanes> drivable_lanes;
 };
 
 struct CandidateOutput

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -304,7 +304,7 @@ private:
 
   // -- path generation --
   ShiftedPath generateAvoidancePath(PathShifter & shifter) const;
-  void generateExtendedDrivableArea(PathWithLaneId & path) const;
+  void generateExtendedDrivableArea(BehaviorModuleOutput & output) const;
 
   // -- velocity planning --
   std::shared_ptr<double> ego_velocity_starting_avoidance_ptr_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -132,6 +132,10 @@ void get_turn_signal_info(
   const LaneChangePath & lane_change_path, TurnSignalInfo * turn_signal_info);
 
 std::vector<DrivableLanes> generateDrivableLanes(
+  const std::vector<DrivableLanes> original_drivable_lanes, const RouteHandler & route_handler,
+  const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & lane_change_lanes);
+
+std::vector<DrivableLanes> generateDrivableLanes(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & lane_change_lanes);
 

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -373,6 +373,7 @@ BehaviorModuleOutput PlannerManager::getReferencePath(
   BehaviorModuleOutput output;
   output.path = std::make_shared<PathWithLaneId>(reference_path);
   output.reference_path = std::make_shared<PathWithLaneId>(reference_path);
+  output.drivable_lanes = drivable_lanes;
 
   return output;
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -743,8 +743,14 @@ void LaneChangeModule::generateExtendedDrivableArea(PathWithLaneId & path)
 {
   const auto & common_parameters = planner_data_->parameters;
   const auto & route_handler = planner_data_->route_handler;
+#ifdef USE_OLD_ARCHITECTURE
   const auto drivable_lanes = lane_change_utils::generateDrivableLanes(
     *route_handler, status_.current_lanes, status_.lane_change_lanes);
+#else
+  const auto drivable_lanes = lane_change_utils::generateDrivableLanes(
+    getPreviousModuleOutput().drivable_lanes, *route_handler, status_.current_lanes,
+    status_.lane_change_lanes);
+#endif
   const auto shorten_lanes = util::cutOverlappedLanes(path, drivable_lanes);
   const auto expanded_lanes = util::expandLanelets(
     shorten_lanes, parameters_->drivable_area_left_bound_offset,

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -851,6 +851,125 @@ std::vector<DrivableLanes> generateDrivableLanes(
   return drivable_lanes;
 }
 
+std::vector<DrivableLanes> generateDrivableLanes(
+  const std::vector<DrivableLanes> original_drivable_lanes, const RouteHandler & route_handler,
+  const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & lane_change_lanes)
+{
+  const auto has_same_lane =
+    [](const lanelet::ConstLanelets lanes, const lanelet::ConstLanelet & lane) {
+      if (lanes.empty()) return false;
+      const auto has_same = [&](const auto & ll) { return ll.id() == lane.id(); };
+      return std::find_if(lanes.begin(), lanes.end(), has_same) != lanes.end();
+    };
+
+  const auto checkMiddle = [&](const auto & lane) {
+    for (const auto & drivable_lane : original_drivable_lanes) {
+      if (has_same_lane(drivable_lane.middle_lanes, lane)) {
+        return std::make_pair(true, drivable_lane);
+      }
+    }
+    return std::make_pair(false, DrivableLanes());
+  };
+
+  const auto checkLeft = [&](const auto & lane) {
+    for (const auto & drivable_lane : original_drivable_lanes) {
+      if (drivable_lane.left_lane.id() == lane.id()) {
+        return std::make_pair(true, drivable_lane);
+      }
+    }
+    return std::make_pair(false, DrivableLanes());
+  };
+
+  const auto checkRight = [&](const auto & lane) {
+    for (const auto & drivable_lane : original_drivable_lanes) {
+      if (drivable_lane.right_lane.id() == lane.id()) {
+        return std::make_pair(true, drivable_lane);
+      }
+    }
+    return std::make_pair(false, DrivableLanes());
+  };
+
+  size_t current_lc_idx = 0;
+  std::vector<DrivableLanes> drivable_lanes(current_lanes.size());
+  for (size_t i = 0; i < current_lanes.size(); ++i) {
+    const auto & current_lane = current_lanes.at(i);
+
+    const auto [is_middle, drivable_lane_1] = checkMiddle(current_lane);
+    if (is_middle) {
+      drivable_lanes.at(i) = drivable_lane_1;
+    }
+
+    const auto [is_left, drivable_lane_2] = checkLeft(current_lane);
+    if (is_left) {
+      drivable_lanes.at(i) = drivable_lane_2;
+    }
+
+    const auto [is_right, drivable_lane_3] = checkRight(current_lane);
+    if (is_right) {
+      drivable_lanes.at(i) = drivable_lane_3;
+    }
+
+    if (!is_middle && !is_left && !is_right) {
+      drivable_lanes.at(i).left_lane = current_lane;
+      drivable_lanes.at(i).right_lane = current_lane;
+    }
+
+    const auto left_lane = route_handler.getLeftLanelet(current_lane);
+    const auto right_lane = route_handler.getRightLanelet(current_lane);
+    if (!left_lane && !right_lane) {
+      continue;
+    }
+
+    for (size_t lc_idx = current_lc_idx; lc_idx < lane_change_lanes.size(); ++lc_idx) {
+      const auto & lc_lane = lane_change_lanes.at(lc_idx);
+      if (left_lane && lc_lane.id() == left_lane->id()) {
+        if (is_left) {
+          drivable_lanes.at(i).left_lane = lc_lane;
+        }
+        current_lc_idx = lc_idx;
+        break;
+      }
+
+      if (right_lane && lc_lane.id() == right_lane->id()) {
+        if (is_right) {
+          drivable_lanes.at(i).right_lane = lc_lane;
+        }
+        current_lc_idx = lc_idx;
+        break;
+      }
+    }
+  }
+
+  for (size_t i = current_lc_idx + 1; i < lane_change_lanes.size(); ++i) {
+    const auto & lc_lane = lane_change_lanes.at(i);
+    DrivableLanes drivable_lane;
+
+    const auto [is_middle, drivable_lane_1] = checkMiddle(lc_lane);
+    if (is_middle) {
+      drivable_lane = drivable_lane_1;
+    }
+
+    const auto [is_left, drivable_lane_2] = checkLeft(lc_lane);
+    if (is_left) {
+      drivable_lane = drivable_lane_2;
+    }
+
+    const auto [is_right, drivable_lane_3] = checkRight(lc_lane);
+    if (is_right) {
+      drivable_lane = drivable_lane_3;
+    }
+
+    if (!is_middle && !is_left && !is_right) {
+      drivable_lane.left_lane = lc_lane;
+      drivable_lane.right_lane = lc_lane;
+    }
+
+    drivable_lanes.push_back(drivable_lane);
+  }
+
+  return drivable_lanes;
+}
+
 std::optional<LaneChangePath> getAbortPaths(
   const std::shared_ptr<const PlannerData> & planner_data, const LaneChangePath & selected_path,
   [[maybe_unused]] const Pose & ego_pose_before_collision,


### PR DESCRIPTION
## Description

In the new manager, multiple modules run simultaneously in series. (e.g. avoidance -> lane change) But, the drivable area which the previous module generated is always overwritten by next module. As a result, the output drivable area is inconsistent.

In the following scene, the avoidance module's drivable area is overwritten by lane change module at the moment of lane change execution.

In this PR, I fixed lane change drivable generation logic to use previous module's drivable lanes.

![image](https://user-images.githubusercontent.com/44889564/225813180-3852aa0b-f51b-498f-8e65-70f210c40c25.png)

- https://user-images.githubusercontent.com/44889564/225811909-855f6556-df6a-4667-8882-dc766a8de68c.mp4

**NOTE: For now, I fixed only lane change and avoidance module because the other modules are not able to execute simlutaneouly now.**

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Please set following flag to `FALSE`, and confirm to pass all build.

https://github.com/autowarefoundation/autoware.universe/blob/ad5595389a629346476ee06391260ffea53159ef/planning/behavior_path_planner/CMakeLists.txt#L10

https://user-images.githubusercontent.com/44889564/225833762-c2196d32-2c02-401a-b0df-867bc5879183.mp4

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
