### PR TITLE
fix(system_error_monitor): fix dying node

### DIFF
--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -410,6 +410,10 @@ bool AutowareErrorMonitor::isDataReady()
 bool AutowareErrorMonitor::isDataHeartbeatTimeout()
 {
   auto isTimeout = [this](const rclcpp::Time & last_stamp, const double threshold) {
+    if (last_stamp.get_clock_type() != this->now().get_clock_type()) {
+      RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 5000, "clock type is different...");
+      return false;
+    }
     const auto time_diff = this->now() - last_stamp;
     return time_diff.seconds() > threshold;
   };


### PR DESCRIPTION
## Description

Currently, system_error_monitor died with the following error due to the time resource is different.
`what(): can't subtract times with different time sources [1 != 2]`

related discussion: https://answers.ros.org/question/380328/robot_localization-cant-subtract-times-with-different-time-sources/
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
