### PR TITLE
refactor(trajectory_follower_node): delete default values

### DIFF
--- a/control/trajectory_follower_node/src/controller_node.cpp
+++ b/control/trajectory_follower_node/src/controller_node.cpp
@@ -49,8 +49,8 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
       throw std::domain_error("[LateralController] invalid algorithm");
   }
 
-  const auto longitudinal_controller_mode = getLongitudinalControllerMode(
-    declare_parameter<std::string>("longitudinal_controller_mode"));
+  const auto longitudinal_controller_mode =
+    getLongitudinalControllerMode(declare_parameter<std::string>("longitudinal_controller_mode"));
   switch (longitudinal_controller_mode) {
     case LongitudinalControllerMode::PID: {
       longitudinal_controller_ =

--- a/control/trajectory_follower_node/src/controller_node.cpp
+++ b/control/trajectory_follower_node/src/controller_node.cpp
@@ -35,7 +35,7 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
   timeout_thr_sec_ = declare_parameter<double>("timeout_thr_sec");
 
   const auto lateral_controller_mode =
-    getLateralControllerMode(declare_parameter<std::string>("lateral_controller_mode", "mpc"));
+    getLateralControllerMode(declare_parameter<std::string>("lateral_controller_mode"));
   switch (lateral_controller_mode) {
     case LateralControllerMode::MPC: {
       lateral_controller_ = std::make_shared<mpc_lateral_controller::MpcLateralController>(*this);
@@ -50,7 +50,7 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
   }
 
   const auto longitudinal_controller_mode = getLongitudinalControllerMode(
-    declare_parameter<std::string>("longitudinal_controller_mode", "pid"));
+    declare_parameter<std::string>("longitudinal_controller_mode"));
   switch (longitudinal_controller_mode) {
     case LongitudinalControllerMode::PID: {
       longitudinal_controller_ =

--- a/control/trajectory_follower_node/src/simple_trajectory_follower.cpp
+++ b/control/trajectory_follower_node/src/simple_trajectory_follower.cpp
@@ -36,9 +36,9 @@ SimpleTrajectoryFollower::SimpleTrajectoryFollower(const rclcpp::NodeOptions & o
   sub_trajectory_ = create_subscription<Trajectory>(
     "input/trajectory", 1, [this](const Trajectory::SharedPtr msg) { trajectory_ = msg; });
 
-  use_external_target_vel_ = declare_parameter<bool>("use_external_target_vel", false);
-  external_target_vel_ = declare_parameter<float>("external_target_vel", 0.0);
-  lateral_deviation_ = declare_parameter<float>("lateral_deviation", 0.0);
+  use_external_target_vel_ = declare_parameter<bool>("use_external_target_vel");
+  external_target_vel_ = declare_parameter<float>("external_target_vel");
+  lateral_deviation_ = declare_parameter<float>("lateral_deviation");
 
   using namespace std::literals::chrono_literals;
   timer_ = rclcpp::create_timer(


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[trajectory_follower_node_delete_param.webm](https://user-images.githubusercontent.com/100691117/225812672-b6a31751-1a32-4c6d-a8dc-0f03a7b117be.webm)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
