### PR TITLE
chore(ground_segmentation): add recheck ground cluster option param

### DIFF
--- a/perception/ground_segmentation/docs/scan-ground-filter.md
+++ b/perception/ground_segmentation/docs/scan-ground-filter.md
@@ -47,6 +47,7 @@ This implementation inherits `pointcloud_preprocessor::Filter` class, please ref
 | `gnd_grid_buffer_size`            | uint16 | 4             | Number of grids using to estimate local ground slope,<br /> applied only for elevation_grid_mode                                                  |
 | `low_priority_region_x`           | float  | -20.0         | The non-zero x threshold in back side from which small objects detection is low priority [m]                                                      |
 | `elevation_grid_mode`             | bool   | true          | Elevation grid scan mode option                                                                                                                   |
+| `use_recheck_ground_cluster`      | bool   | true          | Enable recheck ground cluster                                                                                                                     |
 
 ## Assumptions / Known limits
 

--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -170,6 +170,7 @@ private:
   double                                    // minimum height threshold regardless the slope,
     split_height_distance_;                 // useful for close points
   bool use_virtual_ground_point_;
+  bool use_recheck_ground_cluster_;  // to enable recheck ground cluster
   size_t radial_dividers_num_;
   VehicleInfo vehicle_info_;
 


### PR DESCRIPTION
## Description

This PR to add param to enable/off recheck ground cluster in scan_ground_filter_nodelet

## Related links

[TIERIV COMPANY INTERNAL LINK](https://star4.slack.com/archives/CRUE57C30/p1679011743529499?thread_ts=1678861138.096609&cid=CRUE57C30)

https://github.com/autowarefoundation/autoware_launch/pull/259

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
