### PR TITLE
fix(AEB): suppress build error (-Werror=pedantic)

### DIFF
--- a/control/autonomous_emergency_braking/CMakeLists.txt
+++ b/control/autonomous_emergency_braking/CMakeLists.txt
@@ -4,6 +4,14 @@ project(autonomous_emergency_braking)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(PCL REQUIRED)
+
+include_directories(
+  include
+  SYSTEM
+  ${PCL_INCLUDE_DIRS}
+)
+
 set(AEB_NODE ${PROJECT_NAME}_node)
 ament_auto_add_library(${AEB_NODE} SHARED
   src/node.cpp


### PR DESCRIPTION
## Description

**Related link**: https://github.com/autowarefoundation/autoware.universe/issues/1219

Suppress build error.

```
In file included from /usr/include/pcl-1.12/pcl/point_types.h:354,                                                                                                                                                                                                                                                                                                                                                              
                 from /usr/include/pcl-1.12/pcl/common/transforms.h:43,                                                                                                                                                                                                                                                                                                                                                         
                 from /opt/ros/humble/include/pcl_ros/transforms.hpp:40,                                                                                                                                                                                                                                                                                                                                                        
                 from /home/satoshi/pilot-auto/src/autoware/universe/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp:19,                                                                                                                                                                                                                                                                     
                 from /home/satoshi/pilot-auto/src/autoware/universe/control/autonomous_emergency_braking/src/node.cpp:15:                                                                                                                                                                                                                                                                                                      
/usr/include/pcl-1.12/pcl/impl/point_types.hpp:241:12: error: ISO C++ prohibits anonymous structs [-Werror=pedantic]                                                                                                                                                                                                                                                                                                            
  241 |     struct { \                                                                                                                                                                                                                                                                                                                                                                                                          
      |            ^                                                                                                                                                                                                                                                                                                                                                                                                            
/usr/include/pcl-1.12/pcl/impl/point_types.hpp:259:3: note: in expansion of macro ‘PCL_ADD_UNION_POINT4D’                                                                                                                                                                                                                                                                                                                       
  259 |   PCL_ADD_UNION_POINT4D \                                                                                                                                                                                                                                                                                                                                                                                               
      |   ^~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                                                                                                                                                                                 
/usr/include/pcl-1.12/pcl/impl/point_types.hpp:337:5: note: in expansion of macro ‘PCL_ADD_POINT4D’                                                                                                                                                                                                                                                                                                                             
  337 |     PCL_ADD_POINT4D; // This adds the members x,y,z which can also be accessed using the point (which is float[4])                                                                                                                                                                                                                                                                                                      
      |     ^~~~~~~~~~~~~~~                                                                                                                                                                                                                                                                                                                                                                                                     
/usr/include/pcl-1.12/pcl/impl/point_types.hpp:289:7: error: ISO C++ prohibits anonymous structs [-Werror=pedantic]                                                                                                                                                                                                                                                                                                             
  289 |       { \                                                                                                                                                                                                                                                                                                                                                                                                               
      |       ^                                                                                                                                                                                                                                                                                                                                                                                                                 
/usr/include/pcl-1.12/pcl/impl/point_types.hpp:313:3: note: in expansion of macro ‘PCL_ADD_UNION_RGB’                                                                                                                                                                                                                                                                                                                           
  313 |   PCL_ADD_UNION_RGB \                                                                                                                                                                                                                                                                                                                                                                                                   
      |   ^~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                                                                                                                                                                                     
/usr/include/pcl-1.12/pcl/impl/point_types.hpp:368:5: note: in expansion of macro ‘PCL_ADD_RGB’                                                                                                                                                                                                                                                                                                                                 
  368 |     PCL_ADD_RGB;                                                                                                                                                                                                                                                                                                                                                                                                        
      |     ^~~~~~~~~~~                   
...
```

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
