### PR TITLE
feat(behavior_path_planner): visualize unavoidable target object

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/marker_util/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/marker_util/avoidance/debug.hpp
@@ -58,7 +58,11 @@ MarkerArray createAvoidLineMarkerArray(
 
 MarkerArray createPredictedVehiclePositions(const PathWithLaneId & path, std::string && ns);
 
-MarkerArray createTargetObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);
+MarkerArray createAvoidableTargetObjectsMarkerArray(
+  const ObjectDataArray & objects, std::string && ns);
+
+MarkerArray createUnavoidableTargetObjectsMarkerArray(
+  const ObjectDataArray & objects, std::string && ns);
 
 MarkerArray createOtherObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3711,14 +3711,15 @@ void AvoidanceModule::setDebugData(
   using marker_utils::createPoseMarkerArray;
   using marker_utils::createShiftLengthMarkerArray;
   using marker_utils::createShiftLineMarkerArray;
+  using marker_utils::avoidance_marker::createAvoidableTargetObjectsMarkerArray;
   using marker_utils::avoidance_marker::createAvoidLineMarkerArray;
   using marker_utils::avoidance_marker::createEgoStatusMarkerArray;
   using marker_utils::avoidance_marker::createOtherObjectsMarkerArray;
   using marker_utils::avoidance_marker::createOverhangFurthestLineStringMarkerArray;
   using marker_utils::avoidance_marker::createPredictedVehiclePositions;
   using marker_utils::avoidance_marker::createSafetyCheckMarkerArray;
-  using marker_utils::avoidance_marker::createTargetObjectsMarkerArray;
   using marker_utils::avoidance_marker::createUnavoidableObjectsMarkerArray;
+  using marker_utils::avoidance_marker::createUnavoidableTargetObjectsMarkerArray;
   using marker_utils::avoidance_marker::createUnsafeObjectsMarkerArray;
   using marker_utils::avoidance_marker::makeOverhangToRoadShoulderMarkerArray;
   using motion_utils::createDeadLineVirtualWallMarker;
@@ -3775,9 +3776,22 @@ void AvoidanceModule::setDebugData(
 
   add(createSafetyCheckMarkerArray(data.state, getEgoPose(), debug));
 
+  std::vector<ObjectData> avoidable_target_objects;
+  std::vector<ObjectData> unavoidable_target_objects;
+  for (const auto & object : data.target_objects) {
+    if (object.is_avoidable) {
+      avoidable_target_objects.push_back(object);
+    } else {
+      unavoidable_target_objects.push_back(object);
+    }
+  }
+
   add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
   add(createLaneletsAreaMarkerArray(*debug.expanded_lanelets, "expanded_lanelet", 0.8, 0.8, 0.0));
-  add(createTargetObjectsMarkerArray(data.target_objects, "target_objects"));
+  add(
+    createAvoidableTargetObjectsMarkerArray(avoidable_target_objects, "avoidable_target_objects"));
+  add(createUnavoidableTargetObjectsMarkerArray(
+    unavoidable_target_objects, "unavoidable_target_objects"));
   add(createOtherObjectsMarkerArray(data.other_objects, "other_objects"));
   add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
   add(createOverhangFurthestLineStringMarkerArray(


### PR DESCRIPTION
## Description

visualize unavoidable target objects as red.
- green: other_objects
- yellow: target_objects, which can be avoidable by behavior
- red: target_objects, which cannot be avoidable by behavior but can be avoidable by motion.

![image](https://user-images.githubusercontent.com/20228327/225836389-200e6ec0-04a8-43ae-b8bd-5e6d712504a1.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
