### PR TITLE
fix(avoidance): not run avoidance module when the shift line is empty

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -113,6 +113,9 @@ bool AvoidanceModule::isExecutionRequested() const
     return true;
   }
 
+  // Check avoidance targets exist
+  auto avoid_data = calcAvoidancePlanningData(debug_data_);
+
   // Check ego is in preferred lane
 #ifdef USE_OLD_ARCHITECTURE
   const auto current_lanes = util::getCurrentLanes(planner_data_);
@@ -124,10 +127,13 @@ bool AvoidanceModule::isExecutionRequested() const
   if (num != 0) {
     return false;
   }
-#endif
+#else
+  fillShiftLine(avoid_data, debug_data_);
 
-  // Check avoidance targets exist
-  const auto avoid_data = calcAvoidancePlanningData(debug_data_);
+  if (avoid_data.unapproved_new_sl.empty()) {
+    return false;
+  }
+#endif
 
   if (parameters_->publish_debug_marker) {
     setDebugData(avoid_data, path_shifter_, debug_data_);


### PR DESCRIPTION
## Description

The avoidance module check adjacent lane to find target object that should be avoid. On the other hand, the ego often don't have to shift even if the target object is not empty because there is enough lateral margin between the ego and that object.

In this PR, I added a new condition to `isExecutionRequested()`, and prevent module execution in scenario where the ego don't have to shift anymore.

NOTE: This modification only works on the new manager for now.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
