### PR TITLE
feat(accel_brake_map_calibrator): add option to use actuation_cmd

### DIFF
--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/README.md
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/README.md
@@ -146,21 +146,22 @@ You can also save accel and brake map in the default directory where Autoware re
 
 ## Algorithm Parameters
 
-| Name                    | Type   | Description                                                                                                                                         | Default value |
-| :---------------------- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| initial_covariance      | double | Covariance of initial acceleration map (larger covariance makes the update speed faster)                                                            | 0.05          |
-| velocity_min_threshold  | double | Speeds smaller than this are not used for updating.                                                                                                 | 0.1           |
-| velocity_diff_threshold | double | When the velocity data is more than this threshold away from the grid reference speed (center value), the associated data is not used for updating. | 0.556         |
-| max_steer_threshold     | double | If the steer angle is greater than this value, the associated data is not used for updating.                                                        | 0.2           |
-| max_pitch_threshold     | double | If the pitch angle is greater than this value, the associated data is not used for updating.                                                        | 0.02          |
-| max_jerk_threshold      | double | If the ego jerk calculated from ego acceleration is greater than this value, the associated data is not used for updating.                          | 0.7           |
-| pedal_velocity_thresh   | double | If the pedal moving speed is greater than this value, the associated data is not used for updating.                                                 | 0.15          |
-| pedal_diff_threshold    | double | If the current pedal value is more then this threshold away from the previous value, the associated data is not used for updating.                  | 0.03          |
-| max_accel               | double | Maximum value of acceleration calculated from velocity source.                                                                                      | 5.0           |
-| min_accel               | double | Minimum value of acceleration calculated from velocity source.                                                                                      | -5.0          |
-| pedal_to_accel_delay    | double | The delay time between actuation_cmd to acceleration, considered in the update logic.                                                               | 0.3           |
-| update_suggest_thresh   | double | threshold of RMSE ratio that update suggest flag becomes true. ( RMSE ratio: [RMSE of new map] / [RMSE of original map] )                           | 0.7           |
-| max_data_count          | int    | For visualization. When the data num of each grid gets this value, the grid color gets red.                                                         | 100           |
+| Name                     | Type   | Description                                                                                                                                         | Default value |
+| :----------------------- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| initial_covariance       | double | Covariance of initial acceleration map (larger covariance makes the update speed faster)                                                            | 0.05          |
+| velocity_min_threshold   | double | Speeds smaller than this are not used for updating.                                                                                                 | 0.1           |
+| velocity_diff_threshold  | double | When the velocity data is more than this threshold away from the grid reference speed (center value), the associated data is not used for updating. | 0.556         |
+| max_steer_threshold      | double | If the steer angle is greater than this value, the associated data is not used for updating.                                                        | 0.2           |
+| max_pitch_threshold      | double | If the pitch angle is greater than this value, the associated data is not used for updating.                                                        | 0.02          |
+| max_jerk_threshold       | double | If the ego jerk calculated from ego acceleration is greater than this value, the associated data is not used for updating.                          | 0.7           |
+| pedal_velocity_thresh    | double | If the pedal moving speed is greater than this value, the associated data is not used for updating.                                                 | 0.15          |
+| pedal_diff_threshold     | double | If the current pedal value is more then this threshold away from the previous value, the associated data is not used for updating.                  | 0.03          |
+| max_accel                | double | Maximum value of acceleration calculated from velocity source.                                                                                      | 5.0           |
+| min_accel                | double | Minimum value of acceleration calculated from velocity source.                                                                                      | -5.0          |
+| pedal_to_accel_delay     | double | The delay time between actuation_cmd to acceleration, considered in the update logic.                                                               | 0.3           |
+| update_suggest_thresh    | double | threshold of RMSE ratio that update suggest flag becomes true. ( RMSE ratio: [RMSE of new map] / [RMSE of original map] )                           | 0.7           |
+| max_data_count           | int    | For visualization. When the data num of each grid gets this value, the grid color gets red.                                                         | 100           |
+| accel_brake_value_source | string | Whether to use actuation_status or actuation_command as accel/brake sources. value                                                                  | status        |
 
 ## Test utility scripts
 
@@ -212,9 +213,9 @@ Update by Recursive Least Squares(RLS) method using data close enough to each gr
 
 Data selection is determined by the following thresholds.
 | Name | Default Value |
-| -------- | -------- |
-|velocity_diff_threshold|0.556|
-|pedal_diff_threshold|0.03|
+| ----------------------- | ------------- |
+| velocity_diff_threshold | 0.556 |
+| pedal_diff_threshold | 0.03 |
 
 #### Update formula
 

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/config/accel_brake_map_calibrator.param.yaml
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/config/accel_brake_map_calibrator.param.yaml
@@ -17,3 +17,4 @@
     update_method: "update_offset_four_cell_around" # or "update_offset_each_cell", "update_offset_total", "update_offset_four_cell_around"
     update_suggest_thresh: 0.7 # threshold of rmse rate that update suggest flag becomes true. ( rmse_rate: [rmse of update map] / [rmse of original map] )
     progress_file_output: false # flag to output log file
+    accel_brake_value_source: "status" # "status" or "command"

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
@@ -41,6 +41,7 @@
 #include "tier4_external_api_msgs/msg/calibration_status.hpp"
 #include "tier4_external_api_msgs/msg/calibration_status_array.hpp"
 #include "tier4_external_api_msgs/srv/get_accel_brake_map_calibration_data.hpp"
+#include "tier4_vehicle_msgs/msg/actuation_command_stamped.hpp"
 #include "tier4_vehicle_msgs/msg/actuation_status_stamped.hpp"
 #include "tier4_vehicle_msgs/srv/update_accel_brake_map.hpp"
 
@@ -64,6 +65,7 @@ using std_msgs::msg::Float32MultiArray;
 using tier4_debug_msgs::msg::Float32MultiArrayStamped;
 using tier4_debug_msgs::msg::Float32Stamped;
 using tier4_external_api_msgs::msg::CalibrationStatus;
+using tier4_vehicle_msgs::msg::ActuationCommandStamped;
 using tier4_vehicle_msgs::msg::ActuationStatusStamped;
 using visualization_msgs::msg::MarkerArray;
 
@@ -107,6 +109,7 @@ private:
   rclcpp::Subscription<VelocityReport>::SharedPtr velocity_sub_;
   rclcpp::Subscription<SteeringReport>::SharedPtr steer_sub_;
   rclcpp::Subscription<ActuationStatusStamped>::SharedPtr actuation_status_sub_;
+  rclcpp::Subscription<ActuationCommandStamped>::SharedPtr actuation_cmd_sub_;
 
   // Service
   rclcpp::Service<UpdateAccelBrakeMap>::SharedPtr update_map_dir_server_;
@@ -132,6 +135,7 @@ private:
 
   int get_pitch_method_;
   int update_method_;
+  int accel_brake_value_source_;
   double acceleration_ = 0.0;
   double acceleration_time_;
   double pre_acceleration_ = 0.0;
@@ -239,6 +243,9 @@ private:
     const int brake_pedal_index, const int brake_vel_index, const double measured_acc,
     const double map_acc);
   void updateTotalMapOffset(const double measured_acc, const double map_acc);
+  void callbackActuation(
+    const std_msgs::msg::Header header, const double accel, const double brake);
+  void callbackActuationCommand(const ActuationCommandStamped::ConstSharedPtr msg);
   void callbackActuationStatus(const ActuationStatusStamped::ConstSharedPtr msg);
   void callbackVelocity(const VelocityReport::ConstSharedPtr msg);
   void callbackSteer(const SteeringReport::ConstSharedPtr msg);
@@ -355,6 +362,11 @@ private:
     UPDATE_OFFSET_EACH_CELL = 0,
     UPDATE_OFFSET_TOTAL = 1,
     UPDATE_OFFSET_FOUR_CELL_AROUND = 2,
+  };
+
+  enum ACCEL_BRAKE_SOURCE {
+    STATUS = 0,
+    COMMAND = 1,
   };
 
 public:

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/launch/accel_brake_map_calibrator.launch.xml
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/launch/accel_brake_map_calibrator.launch.xml
@@ -16,6 +16,7 @@
     <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
     <remap from="~/input/steer" to="/vehicle/status/steering_status"/>
     <remap from="~/input/actuation_status" to="/vehicle/status/actuation_status"/>
+    <remap from="~/input/actuation_cmd" to="/control/command/actuation_cmd"/>
     <remap from="~/input/update_map_dir" to="~/update_map_dir"/>
     <param name="csv_default_map_dir" value="$(var csv_default_map_dir)"/>
     <param name="csv_calibrated_map_dir" value="$(var csv_calibrated_map_dir)"/>

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -59,6 +59,18 @@ AccelBrakeMapCalibrator::AccelBrakeMapCalibrator(const rclcpp::NodeOptions & nod
     RCLCPP_ERROR_STREAM(get_logger(), "update_method_ is wrong. (available method: tf, file, none");
     return;
   }
+  const auto accel_brake_value_source_str =
+    declare_parameter("accel_brake_value_source", std::string("status"));
+  if (accel_brake_value_source_str == std::string("status")) {
+    accel_brake_value_source_ = ACCEL_BRAKE_SOURCE::STATUS;
+  } else if (accel_brake_value_source_str == std::string("command")) {
+    accel_brake_value_source_ = ACCEL_BRAKE_SOURCE::COMMAND;
+  } else {
+    RCLCPP_ERROR_STREAM(
+      get_logger(), "accel_brake_value_source is wrong. (available source: status, command");
+    return;
+  }
+
   update_suggest_thresh_ = declare_parameter<double>("update_suggest_thresh", 0.7);
   csv_calibrated_map_dir_ = declare_parameter("csv_calibrated_map_dir", std::string(""));
   output_accel_file_ = csv_calibrated_map_dir_ + "/accel_map.csv";
@@ -201,9 +213,16 @@ AccelBrakeMapCalibrator::AccelBrakeMapCalibrator(const rclcpp::NodeOptions & nod
     std::bind(&AccelBrakeMapCalibrator::callbackVelocity, this, _1));
   steer_sub_ = create_subscription<SteeringReport>(
     "~/input/steer", queue_size, std::bind(&AccelBrakeMapCalibrator::callbackSteer, this, _1));
-  actuation_status_sub_ = create_subscription<ActuationStatusStamped>(
-    "~/input/actuation_status", queue_size,
-    std::bind(&AccelBrakeMapCalibrator::callbackActuationStatus, this, _1));
+  if (accel_brake_value_source_ = ACCEL_BRAKE_SOURCE::STATUS) {
+    actuation_status_sub_ = create_subscription<ActuationStatusStamped>(
+      "~/input/actuation_status", queue_size,
+      std::bind(&AccelBrakeMapCalibrator::callbackActuationStatus, this, _1));
+  }
+  if (accel_brake_value_source_ = ACCEL_BRAKE_SOURCE::COMMAND) {
+    actuation_cmd_sub_ = create_subscription<ActuationCommandStamped>(
+      "~/input/actuation_cmd", queue_size,
+      std::bind(&AccelBrakeMapCalibrator::callbackActuationCommand, this, _1));
+  }
 
   // Service
   update_map_dir_server_ = create_service<UpdateAccelBrakeMap>(
@@ -481,12 +500,11 @@ void AccelBrakeMapCalibrator::callbackSteer(const SteeringReport::ConstSharedPtr
   steer_ptr_ = msg;
 }
 
-void AccelBrakeMapCalibrator::callbackActuationStatus(
-  const ActuationStatusStamped::ConstSharedPtr msg)
+void AccelBrakeMapCalibrator::callbackActuation(
+  const std_msgs::msg::Header header, const double accel, const double brake)
 {
   // get accel data
-  accel_pedal_ptr_ =
-    std::make_shared<DataStamped>(msg->status.accel_status, rclcpp::Time(msg->header.stamp));
+  accel_pedal_ptr_ = std::make_shared<DataStamped>(accel, rclcpp::Time(header.stamp));
   if (!accel_pedal_vec_.empty()) {
     const auto past_accel_ptr =
       getNearestTimeDataFromVec(accel_pedal_ptr_, dif_pedal_time_, accel_pedal_vec_);
@@ -502,8 +520,7 @@ void AccelBrakeMapCalibrator::callbackActuationStatus(
     getNearestTimeDataFromVec(accel_pedal_ptr_, pedal_to_accel_delay_, accel_pedal_vec_);
 
   // get brake data
-  brake_pedal_ptr_ =
-    std::make_shared<DataStamped>(msg->status.brake_status, rclcpp::Time(msg->header.stamp));
+  brake_pedal_ptr_ = std::make_shared<DataStamped>(brake, rclcpp::Time(header.stamp));
   if (!brake_pedal_vec_.empty()) {
     const auto past_brake_ptr =
       getNearestTimeDataFromVec(brake_pedal_ptr_, dif_pedal_time_, brake_pedal_vec_);
@@ -517,6 +534,24 @@ void AccelBrakeMapCalibrator::callbackActuationStatus(
   pushDataToVec(brake_pedal_ptr_, pedal_vec_max_size_, &brake_pedal_vec_);
   delayed_brake_pedal_ptr_ =
     getNearestTimeDataFromVec(brake_pedal_ptr_, pedal_to_accel_delay_, brake_pedal_vec_);
+}
+
+void AccelBrakeMapCalibrator::callbackActuationCommand(
+  const ActuationCommandStamped::ConstSharedPtr msg)
+{
+  const auto header = msg->header;
+  const auto accel = msg->actuation.accel_cmd;
+  const auto brake = msg->actuation.brake_cmd;
+  callbackActuation(header, accel, brake);
+}
+
+void AccelBrakeMapCalibrator::callbackActuationStatus(
+  const ActuationStatusStamped::ConstSharedPtr msg)
+{
+  const auto header = msg->header;
+  const auto accel = msg->status.accel_status;
+  const auto brake = msg->status.brake_status;
+  callbackActuation(header, accel, brake);
 }
 
 bool AccelBrakeMapCalibrator::callbackUpdateMapService(

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -213,12 +213,12 @@ AccelBrakeMapCalibrator::AccelBrakeMapCalibrator(const rclcpp::NodeOptions & nod
     std::bind(&AccelBrakeMapCalibrator::callbackVelocity, this, _1));
   steer_sub_ = create_subscription<SteeringReport>(
     "~/input/steer", queue_size, std::bind(&AccelBrakeMapCalibrator::callbackSteer, this, _1));
-  if (accel_brake_value_source_ = ACCEL_BRAKE_SOURCE::STATUS) {
+  if (accel_brake_value_source_ == ACCEL_BRAKE_SOURCE::STATUS) {
     actuation_status_sub_ = create_subscription<ActuationStatusStamped>(
       "~/input/actuation_status", queue_size,
       std::bind(&AccelBrakeMapCalibrator::callbackActuationStatus, this, _1));
   }
-  if (accel_brake_value_source_ = ACCEL_BRAKE_SOURCE::COMMAND) {
+  if (accel_brake_value_source_ == ACCEL_BRAKE_SOURCE::COMMAND) {
     actuation_cmd_sub_ = create_subscription<ActuationCommandStamped>(
       "~/input/actuation_cmd", queue_size,
       std::bind(&AccelBrakeMapCalibrator::callbackActuationCommand, this, _1));


### PR DESCRIPTION
## Description
Add option to use actuation_cmd as the value of the accel/brake pedal for calibration.
This is an option for vehicles for which actuation_status is not available for some reason.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
I confirmed that the calibration is performed both of when accel_brake_value_source is "status" and "command".
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
