### PR TITLE
refactor(static_centerline_optimizer): delete default values

### DIFF
--- a/planning/static_centerline_optimizer/src/collision_free_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/collision_free_optimizer_node.cpp
@@ -182,8 +182,7 @@ CollisionFreeOptimizerNode::CollisionFreeOptimizerNode(const rclcpp::NodeOptions
     traj_param_.is_avoiding_unknown =
       declare_parameter<bool>("object.avoiding_object_type.unknown");
     traj_param_.is_avoiding_car = declare_parameter<bool>("object.avoiding_object_type.car");
-    traj_param_.is_avoiding_truck =
-      declare_parameter<bool>("object.avoiding_object_type.truck");
+    traj_param_.is_avoiding_truck = declare_parameter<bool>("object.avoiding_object_type.truck");
     traj_param_.is_avoiding_bus = declare_parameter<bool>("object.avoiding_object_type.bus");
     traj_param_.is_avoiding_bicycle =
       declare_parameter<bool>("object.avoiding_object_type.bicycle");
@@ -191,8 +190,7 @@ CollisionFreeOptimizerNode::CollisionFreeOptimizerNode(const rclcpp::NodeOptions
       declare_parameter<bool>("object.avoiding_object_type.motorbike");
     traj_param_.is_avoiding_pedestrian =
       declare_parameter<bool>("object.avoiding_object_type.pedestrian");
-    traj_param_.is_avoiding_animal =
-      declare_parameter<bool>("object.avoiding_object_type.animal");
+    traj_param_.is_avoiding_animal = declare_parameter<bool>("object.avoiding_object_type.animal");
 
     // ego nearest search
     traj_param_.ego_nearest_dist_threshold =
@@ -259,8 +257,8 @@ CollisionFreeOptimizerNode::CollisionFreeOptimizerNode(const rclcpp::NodeOptions
     // By default, optimization_center_offset will be vehicle_info.wheel_base * 0.8
     // The 0.8 scale is adopted as it performed the best.
     constexpr double default_wheelbase_ratio = 0.8;
-    mpt_param_.optimization_center_offset = declare_parameter<double>(
-      "mpt.kinematics.optimization_center_offset");
+    mpt_param_.optimization_center_offset =
+      declare_parameter<double>("mpt.kinematics.optimization_center_offset");
 
     // bounds search
     mpt_param_.bounds_search_widths =

--- a/planning/static_centerline_optimizer/src/collision_free_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/collision_free_optimizer_node.cpp
@@ -180,19 +180,19 @@ CollisionFreeOptimizerNode::CollisionFreeOptimizerNode(const rclcpp::NodeOptions
     traj_param_.max_avoiding_objects_velocity_ms =
       declare_parameter<double>("object.max_avoiding_objects_velocity_ms");
     traj_param_.is_avoiding_unknown =
-      declare_parameter<bool>("object.avoiding_object_type.unknown", true);
-    traj_param_.is_avoiding_car = declare_parameter<bool>("object.avoiding_object_type.car", true);
+      declare_parameter<bool>("object.avoiding_object_type.unknown");
+    traj_param_.is_avoiding_car = declare_parameter<bool>("object.avoiding_object_type.car");
     traj_param_.is_avoiding_truck =
-      declare_parameter<bool>("object.avoiding_object_type.truck", true);
-    traj_param_.is_avoiding_bus = declare_parameter<bool>("object.avoiding_object_type.bus", true);
+      declare_parameter<bool>("object.avoiding_object_type.truck");
+    traj_param_.is_avoiding_bus = declare_parameter<bool>("object.avoiding_object_type.bus");
     traj_param_.is_avoiding_bicycle =
-      declare_parameter<bool>("object.avoiding_object_type.bicycle", true);
+      declare_parameter<bool>("object.avoiding_object_type.bicycle");
     traj_param_.is_avoiding_motorbike =
-      declare_parameter<bool>("object.avoiding_object_type.motorbike", true);
+      declare_parameter<bool>("object.avoiding_object_type.motorbike");
     traj_param_.is_avoiding_pedestrian =
-      declare_parameter<bool>("object.avoiding_object_type.pedestrian", true);
+      declare_parameter<bool>("object.avoiding_object_type.pedestrian");
     traj_param_.is_avoiding_animal =
-      declare_parameter<bool>("object.avoiding_object_type.animal", true);
+      declare_parameter<bool>("object.avoiding_object_type.animal");
 
     // ego nearest search
     traj_param_.ego_nearest_dist_threshold =
@@ -260,8 +260,7 @@ CollisionFreeOptimizerNode::CollisionFreeOptimizerNode(const rclcpp::NodeOptions
     // The 0.8 scale is adopted as it performed the best.
     constexpr double default_wheelbase_ratio = 0.8;
     mpt_param_.optimization_center_offset = declare_parameter<double>(
-      "mpt.kinematics.optimization_center_offset",
-      vehicle_param_.wheelbase * default_wheelbase_ratio);
+      "mpt.kinematics.optimization_center_offset");
 
     // bounds search
     mpt_param_.bounds_search_widths =


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[static_centerline_optimizer_delete_param.webm](https://user-images.githubusercontent.com/100691117/226096965-ebc78a76-d5b9-4d92-883b-eb2259a984cc.webm)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
