### PR TITLE
refactor(rtc_auto_mode_manager): delete default values

### DIFF
--- a/planning/rtc_auto_mode_manager/src/node.cpp
+++ b/planning/rtc_auto_mode_manager/src/node.cpp
@@ -23,9 +23,9 @@ RTCAutoModeManagerNode::RTCAutoModeManagerNode(const rclcpp::NodeOptions & node_
 : Node("rtc_auto_mode_manager_node", node_options)
 {
   const std::vector<std::string> module_list =
-    declare_parameter("module_list", std::vector<std::string>());
+    declare_parameter<std::vector<std::string>>("module_list");
   const std::vector<std::string> default_enable_list =
-    declare_parameter("default_enable_list", std::vector<std::string>());
+    declare_parameter<std::vector<std::string>>("default_enable_list");
 
   for (const auto & module_name : module_list) {
     const bool enabled =


### PR DESCRIPTION
## Description

Removed default values defined in declare_parameter function.
[rtc_auto_mode_manager_delete_param.webm](https://user-images.githubusercontent.com/100691117/226099750-d44ae6ff-97c3-47c0-9a55-f31a61436efb.webm)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
