### PR TITLE
fix(pointcloud_preprocessor): fix broken logic

### DIFF
--- a/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
@@ -133,7 +133,7 @@ void CropBoxFilterComponent::faster_filter(
       *reinterpret_cast<const float *>(&input->data[global_offset + z_offset]), 1);
 
     if (transform_info.need_transform) {
-      if (std::isfinite(point[0]) && std::isfinite(point[1]), std::isfinite(point[2])) {
+      if (std::isfinite(point[0]) && std::isfinite(point[1]) && std::isfinite(point[2])) {
         point = transform_info.eigen_transform * point;
       } else {
         // TODO(sykwer): Implement the appropriate logic for `max range point` and `invalid point`.


### PR DESCRIPTION
`if (a && b, c)` is the same as `if (c)` not `if (a && b && c)` !!

## Description

Comma `,` inside if is meant to assign values, not to evaluate condition. For example:
```
   if (y=f(x), y*y > 0) {
       // ...
   }
   // is same as
   {
       auto y = f(x)
       if (y*y > 0) {
           // ...
       }
   }
```

See:
https://stackoverflow.com/questions/16475032/comma-operator-in-if-condition

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
