### PR TITLE
refactor(planning_debug_tools): delete default values

### DIFF
--- a/planning/planning_debug_tools/src/trajectory_analyzer.cpp
+++ b/planning/planning_debug_tools/src/trajectory_analyzer.cpp
@@ -20,10 +20,9 @@ TrajectoryAnalyzerNode::TrajectoryAnalyzerNode(const rclcpp::NodeOptions & optio
 : Node("trajectory_analyzer", options)
 {
   using TopicNames = std::vector<std::string>;
-  const auto path_topics = declare_parameter<TopicNames>("path_topics", TopicNames{});
-  const auto path_with_lane_id_topics =
-    declare_parameter<TopicNames>("path_with_lane_id_topics", TopicNames{});
-  const auto trajectory_topics = declare_parameter<TopicNames>("trajectory_topics", TopicNames{});
+  const auto path_topics = declare_parameter<TopicNames>("path_topics");
+  const auto path_with_lane_id_topics = declare_parameter<TopicNames>("path_with_lane_id_topics");
+  const auto trajectory_topics = declare_parameter<TopicNames>("trajectory_topics");
 
   for (const auto & s : path_topics) {
     path_analyzers_.push_back(std::make_shared<TrajectoryAnalyzer<Path>>(this, s));


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[planning_debug_tools_delete_param.webm](https://user-images.githubusercontent.com/100691117/226542260-a74e1c08-15f2-4540-9822-02ff9c5c46b4.webm)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
