### PR TITLE
refactor(mission_planner): delete default values

### DIFF
--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -145,8 +145,8 @@ void DefaultPlanner::initialize_common(rclcpp::Node * node)
     node_->create_publisher<MarkerArray>("debug/goal_footprint", durable_qos);
 
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo();
-  param_.goal_angle_threshold_deg = node_->declare_parameter("goal_angle_threshold_deg", 45.0);
-  param_.enable_correct_goal_pose = node_->declare_parameter("enable_correct_goal_pose", false);
+  param_.goal_angle_threshold_deg = node_->declare_parameter("goal_angle_threshold_deg");
+  param_.enable_correct_goal_pose = node_->declare_parameter("enable_correct_goal_pose");
 }
 
 void DefaultPlanner::initialize(rclcpp::Node * node)

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -145,8 +145,8 @@ void DefaultPlanner::initialize_common(rclcpp::Node * node)
     node_->create_publisher<MarkerArray>("debug/goal_footprint", durable_qos);
 
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo();
-  param_.goal_angle_threshold_deg = node_->declare_parameter("goal_angle_threshold_deg");
-  param_.enable_correct_goal_pose = node_->declare_parameter("enable_correct_goal_pose");
+  param_.goal_angle_threshold_deg = node_->declare_parameter<double>("goal_angle_threshold_deg");
+  param_.enable_correct_goal_pose = node_->declare_parameter<bool>("enable_correct_goal_pose");
 }
 
 void DefaultPlanner::initialize(rclcpp::Node * node)

--- a/planning/static_centerline_optimizer/test/test_static_centerline_optimizer.test.py
+++ b/planning/static_centerline_optimizer/test/test_static_centerline_optimizer.test.py
@@ -45,7 +45,8 @@ def generate_test_description():
             {"end_lanelet_id": 216},
             os.path.join(
                 get_package_share_directory("mission_planner"),
-                "config/mission_planner.param.yaml",
+                "config",
+                "mission_planner.param.yaml",
             ),
             os.path.join(
                 get_package_share_directory("static_centerline_optimizer"),

--- a/planning/static_centerline_optimizer/test/test_static_centerline_optimizer.test.py
+++ b/planning/static_centerline_optimizer/test/test_static_centerline_optimizer.test.py
@@ -44,6 +44,10 @@ def generate_test_description():
             {"start_lanelet_id": 215},
             {"end_lanelet_id": 216},
             os.path.join(
+                get_package_share_directory("mission_planner"),
+                "config/mission_planner.param.yaml",
+            ),
+            os.path.join(
                 get_package_share_directory("static_centerline_optimizer"),
                 "config/static_centerline_optimizer.param.yaml",
             ),


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.
[mission_planner_delete_param.webm](https://user-images.githubusercontent.com/100691117/226554272-90b2e7d7-88c7-4d98-80b3-31e1a2183107.webm)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
