### PR TITLE
fix(static_centerline_optimizer): avoid to call declear_parameter twice

### DIFF
--- a/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
+++ b/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
@@ -81,10 +81,6 @@ private:
 
   // vehicle info
   vehicle_info_util::VehicleInfo vehicle_info_;
-
-  // parameters
-  double ego_nearest_dist_threshold_;
-  double ego_nearest_yaw_threshold_;
 };
 }  // namespace static_centerline_optimizer
 #endif  // STATIC_CENTERLINE_OPTIMIZER__STATIC_CENTERLINE_OPTIMIZER_NODE_HPP_

--- a/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
+++ b/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
@@ -81,6 +81,10 @@ private:
 
   // vehicle info
   vehicle_info_util::VehicleInfo vehicle_info_;
+
+  // parameters
+  double ego_nearest_dist_threshold_;
+  double ego_nearest_yaw_threshold_;
 };
 }  // namespace static_centerline_optimizer
 #endif  // STATIC_CENTERLINE_OPTIMIZER__STATIC_CENTERLINE_OPTIMIZER_NODE_HPP_

--- a/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
@@ -177,12 +177,6 @@ StaticCenterlineOptimizerNode::StaticCenterlineOptimizerNode(
   const rclcpp::NodeOptions & node_options)
 : Node("static_centerline_optimizer", node_options)
 {
-  // parameters
-
-  // ego nearest search parameters
-  ego_nearest_dist_threshold_ = declare_parameter<double>("ego_nearest_dist_threshold");
-  ego_nearest_yaw_threshold_ = declare_parameter<double>("ego_nearest_yaw_threshold");
-
   // publishers
   pub_map_bin_ = create_publisher<HADMapBin>("lanelet2_map_topic", create_transient_local_qos());
   pub_raw_path_with_lane_id_ =
@@ -379,10 +373,20 @@ std::vector<TrajectoryPoint> StaticCenterlineOptimizerNode::plan_path(
   const auto start_center_pose =
     utils::get_center_pose(*route_handler_ptr_, route_lane_ids.front());
 
+  // ego nearest search parameters
+  const double ego_nearest_dist_threshold =
+    has_parameter("ego_nearest_dist_threshold")
+      ? get_parameter("ego_nearest_dist_threshold").as_double()
+      : declare_parameter<double>("ego_nearest_dist_threshold");
+  const double ego_nearest_yaw_threshold =
+    has_parameter("ego_nearest_yaw_threshold")
+      ? get_parameter("ego_nearest_yaw_threshold").as_double()
+      : declare_parameter<double>("ego_nearest_yaw_threshold");
+
   // extract path with lane id from lanelets
   const auto raw_path_with_lane_id = utils::get_path_with_lane_id(
-    *route_handler_ptr_, route_lanelets, start_center_pose, ego_nearest_dist_threshold_,
-    ego_nearest_yaw_threshold_);
+    *route_handler_ptr_, route_lanelets, start_center_pose, ego_nearest_dist_threshold,
+    ego_nearest_yaw_threshold);
 
   pub_raw_path_with_lane_id_->publish(raw_path_with_lane_id);
   RCLCPP_INFO(get_logger(), "Calculated raw path with lane id and published.");

--- a/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
@@ -177,6 +177,12 @@ StaticCenterlineOptimizerNode::StaticCenterlineOptimizerNode(
   const rclcpp::NodeOptions & node_options)
 : Node("static_centerline_optimizer", node_options)
 {
+  // parameters
+
+  // ego nearest search parameters
+  ego_nearest_dist_threshold_ = declare_parameter<double>("ego_nearest_dist_threshold");
+  ego_nearest_yaw_threshold_ = declare_parameter<double>("ego_nearest_yaw_threshold");
+
   // publishers
   pub_map_bin_ = create_publisher<HADMapBin>("lanelet2_map_topic", create_transient_local_qos());
   pub_raw_path_with_lane_id_ =
@@ -373,14 +379,10 @@ std::vector<TrajectoryPoint> StaticCenterlineOptimizerNode::plan_path(
   const auto start_center_pose =
     utils::get_center_pose(*route_handler_ptr_, route_lane_ids.front());
 
-  // ego nearest search parameters
-  const double ego_nearest_dist_threshold = declare_parameter<double>("ego_nearest_dist_threshold");
-  const double ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
-
   // extract path with lane id from lanelets
   const auto raw_path_with_lane_id = utils::get_path_with_lane_id(
-    *route_handler_ptr_, route_lanelets, start_center_pose, ego_nearest_dist_threshold,
-    ego_nearest_yaw_threshold);
+    *route_handler_ptr_, route_lanelets, start_center_pose, ego_nearest_dist_threshold_,
+    ego_nearest_yaw_threshold_);
 
   pub_raw_path_with_lane_id_->publish(raw_path_with_lane_id);
   RCLCPP_INFO(get_logger(), "Calculated raw path with lane id and published.");


### PR DESCRIPTION
## Description
In the static_centerline_optimizer node, when the plan_route() is executed twice, the node dies with below error. I fixed it.
```
what():  parameter 'ego_nearest_dist_threshold' has already been declared
```


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
I confirmed that ```Plan Route``` can be executed many times from vector_map_builder.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
