### PR TITLE
feat(diagnostic_converter): remove unit and blank in the value

### DIFF
--- a/evaluator/diagnostic_converter/src/converter_node.cpp
+++ b/evaluator/diagnostic_converter/src/converter_node.cpp
@@ -18,7 +18,7 @@
 
 namespace
 {
-std::string removeInvalidTopicString(std::string input_string)
+std::string removeInvalidTopicString(const std::string & input_string)
 {
   std::regex pattern{R"([a-zA-Z0-9/_]+)"};
 
@@ -28,6 +28,20 @@ std::string removeInvalidTopicString(std::string input_string)
     result += itr->str();
   }
   return result;
+}
+
+std::string removeUnit(const std::string & input_string)
+{
+  for (size_t i = 0; i < input_string.size(); ++i) {
+    if (input_string.at(i) == '[') {
+      if (i != 0 && input_string.at(i - 1) == ' ') {
+        // Blank is also removed
+        return std::string{input_string.begin(), input_string.begin() + i - 1};
+      }
+      return std::string{input_string.begin(), input_string.begin() + i};
+    }
+  }
+  return input_string;
 }
 }  // namespace
 
@@ -68,7 +82,7 @@ UserDefinedValue DiagnosticConverter::createUserDefinedValue(const KeyValue & ke
 {
   UserDefinedValue param_msg;
   param_msg.type.data = UserDefinedValueType::DOUBLE;
-  param_msg.value = key_value.value;
+  param_msg.value = removeUnit(key_value.value);
   return param_msg;
 }
 

--- a/evaluator/diagnostic_converter/src/converter_node.cpp
+++ b/evaluator/diagnostic_converter/src/converter_node.cpp
@@ -30,7 +30,7 @@ std::string removeInvalidTopicString(const std::string & input_string)
   return result;
 }
 
-std::string removeUnit(const std::string & input_string)
+std::string removeUnitString(const std::string & input_string)
 {
   for (size_t i = 0; i < input_string.size(); ++i) {
     if (input_string.at(i) == '[') {
@@ -82,7 +82,7 @@ UserDefinedValue DiagnosticConverter::createUserDefinedValue(const KeyValue & ke
 {
   UserDefinedValue param_msg;
   param_msg.type.data = UserDefinedValueType::DOUBLE;
-  param_msg.value = removeUnit(key_value.value);
+  param_msg.value = removeUnitString(key_value.value);
   return param_msg;
 }
 


### PR DESCRIPTION
## Description

Removed the unit and the blank if they exist in the value of diagnostics.

I confirmed that diagnostics with the unit works well with the scenario simulator v2 via diagnostic_converter.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
