### PR TITLE
feat(tier4_simulator_launch): convert /diagnostics_err

### DIFF
--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -109,7 +109,7 @@
   <!-- Diagnostic Converter -->
   <group if="$(var launch_diagnostic_converter)">
     <node name="diagnostic_converter" exec="diagnostic_converter" pkg="diagnostic_converter" output="screen">
-      <param name="diagnostic_topics" value="[/diagnostic/planning_evaluator/metrics]"/>
+      <param name="diagnostic_topics" value="[/diagnostic/planning_evaluator/metrics, /diagnostics_err]"/>
     </node>
   </group>
 


### PR DESCRIPTION
## Description

convert `/diagnostics_err` to UserDefinedValue so that scenario_simulator_v2 can watch it.

FYI, I chose `/diagnostics_err` instead of `/diagnostics` to suppress the number of topics.
We can change to `/diagnostics` if the diagnostics we want to check are not contained in  `/diagnostics_err` (= system_error_monitor does not monitor them).


I confirmed that scenario simulation works well with this PR.
https://evaluation.tier4.jp/evaluation/reports/9eb5bb67-ce26-5665-8bef-8da802e9e384?project_id=prd_jt
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
