### PR TITLE
fix(avoidance): get nearest target object

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -759,6 +759,7 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
     if (o.avoid_required && o.is_avoidable) {
       data.avoid_required = true;
       data.stop_target_object = o;
+      break;
     }
   }
 


### PR DESCRIPTION
## Description

Fix bug in searching nearest target object that satisfies following two conditions:

1. should be avoid (otherwise, vehicle will collide with it.)
2. is avoidable (there is enough space to avoid.)

Before this PR, the `stop_target_object` is overwitten unintentionally by bihind object since the loop never breaks.

```c++
  for (const auto & o : data.target_objects) {
    if (o.avoid_required && o.is_avoidable) {
      data.avoid_required = true;
      data.stop_target_object = o;
      break; // ADD THIS LINE
    }
  }
```

NOTE: `target_objects` is sorted by `object.longitudinal`, so `target_objects.front()` is the nearest object in `target_objects`.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Before this PR.

Since only one object is detected, the stop point is inserted in front of the object.

![image](https://user-images.githubusercontent.com/44889564/227145387-7f2d049b-e341-40b9-a1e4-bdd8b8f35136.png)

At the moment of detection behind object, the stop point moves to in front of the behind object. It is an unexpected behavior.

![image](https://user-images.githubusercontent.com/44889564/227145894-c01ae881-a7e5-45b1-b51f-694ad1f40754.png)

After this PR.

The stop point never changes even if the behind object is detected.

![image](https://user-images.githubusercontent.com/44889564/227147174-ba4f9ad9-b872-49b7-b49f-ecd32cf1710e.png)

- https://user-images.githubusercontent.com/44889564/227147366-b9c04bdd-3d7e-471d-8f90-98289aea05e8.mp4

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
