### PR TITLE
refactor(lane_change): move functions to lc utils

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -211,10 +211,8 @@ private:
 
   void updateLaneChangeStatus();
   void generateExtendedDrivableArea(PathWithLaneId & path);
-  void updateOutputTurnSignal(BehaviorModuleOutput & output);
   void updateSteeringFactorPtr(const BehaviorModuleOutput & output);
   bool isApprovedPathSafe(Pose & ego_pose_before_collision) const;
-  void calcTurnSignalInfo();
 
   void updateSteeringFactorPtr(
     const CandidateOutput & output, const LaneChangePath & selected_path) const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -15,6 +15,7 @@
 #ifndef BEHAVIOR_PATH_PLANNER__UTIL__LANE_CHANGE__UTIL_HPP_
 #define BEHAVIOR_PATH_PLANNER__UTIL__LANE_CHANGE__UTIL_HPP_
 
+#include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/marker_util/lane_change/debug.hpp"
 #include "behavior_path_planner/parameters.hpp"
 #include "behavior_path_planner/util/lane_change/lane_change_module_data.hpp"
@@ -173,5 +174,11 @@ lanelet::ConstLanelets getLaneChangeLanes(
   const std::shared_ptr<const PlannerData> & planner_data,
   const lanelet::ConstLanelets & current_lanes, const double lane_change_lane_length,
   const double prepare_duration, const Direction direction, const LaneChangeModuleType type);
+
+TurnSignalInfo calcTurnSignalInfo(
+  const std::string & module_name, const LaneChangePath & path, const double speed,
+  const Pose & pose, const BehaviorPathPlannerParameters & bpp_param);
+
+rclcpp::Logger getLogger(const std::string & module_name, const std::string & function_name);
 }  // namespace behavior_path_planner::lane_change_utils
 #endif  // BEHAVIOR_PATH_PLANNER__UTIL__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -18,6 +18,7 @@
 #include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/marker_util/lane_change/debug.hpp"
 #include "behavior_path_planner/parameters.hpp"
+#include "behavior_path_planner/steering_factor_interface.hpp"
 #include "behavior_path_planner/util/lane_change/lane_change_module_data.hpp"
 #include "behavior_path_planner/util/lane_change/lane_change_path.hpp"
 #include "behavior_path_planner/utilities.hpp"
@@ -48,6 +49,7 @@ using geometry_msgs::msg::Twist;
 using marker_utils::CollisionCheckDebug;
 using route_handler::Direction;
 using tier4_autoware_utils::Polygon2d;
+using steering_factor_interface::SteeringFactorInterface;
 
 PathWithLaneId combineReferencePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
 
@@ -180,5 +182,16 @@ TurnSignalInfo calcTurnSignalInfo(
   const Pose & pose, const BehaviorPathPlannerParameters & bpp_param);
 
 rclcpp::Logger getLogger(const std::string & module_name, const std::string & function_name);
+
+void updateSteeringFactorPtrWhenOutput(
+  const PathWithLaneId & output_path, const ShiftLine & shift_line, const Pose & current_pose,
+  [[maybe_unused]] const TurnIndicatorsCommand & turn_signal_indicator_cmd,
+  const std::unique_ptr<SteeringFactorInterface> & steering_factor_interface_ptr);
+
+void updateSteeringFactorPtrWhenPlanCandidate(
+  const double lateral_shift, const ShiftLine & shift_line,
+  const double start_distance_to_path_change, const double finish_distance_to_path_change,
+  const std::unique_ptr<SteeringFactorInterface> & steering_factor_interface_ptr);
 }  // namespace behavior_path_planner::lane_change_utils
+
 #endif  // BEHAVIOR_PATH_PLANNER__UTIL__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -48,8 +48,8 @@ using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
 using marker_utils::CollisionCheckDebug;
 using route_handler::Direction;
-using tier4_autoware_utils::Polygon2d;
 using steering_factor_interface::SteeringFactorInterface;
+using tier4_autoware_utils::Polygon2d;
 
 PathWithLaneId combineReferencePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -208,7 +208,9 @@ BehaviorModuleOutput LaneChangeModule::plan()
   path_reference_ = std::make_shared<PathWithLaneId>(reference_path);
   prev_approved_path_ = *getPreviousModuleOutput().path;
 #endif
-  updateOutputTurnSignal(output);
+  output.turn_signal_info = lane_change_utils::calcTurnSignalInfo(
+    name(), status_.lane_change_path, getEgoTwist().linear.x, getEgoPose(),
+    planner_data_->parameters);
 
   updateSteeringFactorPtr(output);
   clearWaitingApproval();
@@ -792,61 +794,6 @@ bool LaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
     common_parameters, *parameters_, common_parameters.expected_front_deceleration_for_abort,
     common_parameters.expected_rear_deceleration_for_abort, ego_pose_before_collision, debug_data,
     status_.lane_change_path.acceleration);
-}
-
-void LaneChangeModule::updateOutputTurnSignal(BehaviorModuleOutput & output)
-{
-  calcTurnSignalInfo();
-  const auto turn_signal_info = util::getPathTurnSignal(
-    status_.current_lanes, status_.lane_change_path.shifted_path,
-    status_.lane_change_path.shift_line, getEgoPose(), getEgoTwist().linear.x,
-    planner_data_->parameters);
-  output.turn_signal_info.turn_signal.command = turn_signal_info.first.command;
-
-  lane_change_utils::get_turn_signal_info(status_.lane_change_path, &output.turn_signal_info);
-}
-
-void LaneChangeModule::calcTurnSignalInfo()
-{
-  const auto get_blinker_pose =
-    [this](const PathWithLaneId & path, const lanelet::ConstLanelets & lanes, const double length) {
-      const auto & points = path.points;
-      const auto arc_front = lanelet::utils::getArcCoordinates(lanes, points.front().point.pose);
-      for (const auto & point : points) {
-        const auto & pt = point.point.pose;
-        const auto arc_current = lanelet::utils::getArcCoordinates(lanes, pt);
-        const auto diff = arc_current.length - arc_front.length;
-        if (diff > length) {
-          return pt;
-        }
-      }
-
-      RCLCPP_WARN(getLogger(), "unable to determine blinker pose...");
-      return points.front().point.pose;
-    };
-
-  const auto & path = status_.lane_change_path;
-  TurnSignalInfo turn_signal_info{};
-
-  turn_signal_info.desired_start_point = std::invoke([&]() {
-    const auto blinker_start_duration = planner_data_->parameters.turn_signal_search_time;
-    const auto prepare_duration = parameters_->lane_change_prepare_duration;
-    const auto prepare_to_blinker_start_diff = prepare_duration - blinker_start_duration;
-    if (prepare_to_blinker_start_diff < 1e-5) {
-      return path.path.points.front().point.pose;
-    }
-
-    return get_blinker_pose(path.path, path.reference_lanelets, prepare_to_blinker_start_diff);
-  });
-  turn_signal_info.desired_end_point = path.shift_line.end;
-
-  turn_signal_info.required_start_point = path.shift_line.start;
-  const auto mid_lane_change_length = path.length.prepare / 2;
-  const auto & shifted_path = path.shifted_path.path;
-  turn_signal_info.required_end_point =
-    get_blinker_pose(shifted_path, path.target_lanelets, mid_lane_change_length);
-
-  status_.lane_change_path.turn_signal_info = turn_signal_info;
 }
 
 void LaneChangeModule::resetParameters()


### PR DESCRIPTION
## Description

To reduce number of functions in lane change module class, some functions will be moved to `lane_change_utils`. 

For this PR, turn signal related functions will be moved.

## Related links

## Tests performed

Run autoware, test lane change scenarios and check the turn signal details and indication in `rviz`.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
