### PR TITLE
feat(avoidance): add another same grad filter

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/util/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/avoidance/avoidance_module_data.hpp
@@ -497,6 +497,7 @@ struct DebugData
   AvoidLineArray quantized;
   AvoidLineArray trim_small_shift;
   AvoidLineArray trim_similar_grad_shift_second;
+  AvoidLineArray trim_similar_grad_shift_third;
   AvoidLineArray trim_momentary_return;
   AvoidLineArray trim_too_sharp_shift;
   std::vector<double> pos_shift;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1619,6 +1619,14 @@ AvoidLineArray AvoidanceModule::trimShiftLine(
     printShiftLines(sl_array_trimmed, "after trimSharpReturn");
   }
 
+  // - Combine avoid points that have almost same gradient (again)
+  {
+    const auto CHANGE_SHIFT_THRESHOLD = 0.2;
+    trimSimilarGradShiftLine(sl_array_trimmed, CHANGE_SHIFT_THRESHOLD);
+    debug.trim_similar_grad_shift_third = sl_array_trimmed;
+    printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
+  }
+
   return sl_array_trimmed;
 }
 
@@ -3824,6 +3832,7 @@ void AvoidanceModule::setDebugData(
     debug.trim_similar_grad_shift_second, "c_4_trim_similar_grad_shift", 0.97, 0.32, 0.91);
   addAvoidLine(debug.trim_momentary_return, "c_5_trim_momentary_return", 0.976, 0.078, 0.878);
   addAvoidLine(debug.trim_too_sharp_shift, "c_6_trim_too_sharp_shift", 0.576, 0.0, 0.978);
+  addAvoidLine(debug.trim_similar_grad_shift_third, "c_7_trim_too_sharp_shift", 1.0, 0.0, 0.0);
 
   addShiftLine(shifter.getShiftLines(), "path_shifter_registered_points", 0.99, 0.99, 0.0, 0.5);
   addAvoidLine(debug.new_shift_lines, "path_shifter_proposed_points", 0.99, 0.0, 0.0, 0.5);


### PR DESCRIPTION
## Description

After the trimSharpReturn process, sometimes there are shift lines that all have similar gradient. It maybe cause jerk value to be calculated larger than expected.

$$
Jerk \propto \frac{length}{longidudinal^3}
$$

https://github.com/autowarefoundation/autoware.universe/blob/319577a9caeac1ca899dbf3ec15490e97910f6a9/planning/behavior_path_planner/src/util/path_shifter/path_shifter.cpp#L514-L522

![Screenshot from 2023-03-24 10-04-33](https://user-images.githubusercontent.com/44889564/227399861-39c4ce54-747a-4aa0-bbe7-296f095970f8.png)

In this PR, I add `trimSimilarGradShiftLine` filter at the end of trimShiftLine.

```c++
  // - Combine avoid points that have almost same gradient (again)
  {
    const auto CHANGE_SHIFT_THRESHOLD = 0.2;
    trimSimilarGradShiftLine(sl_array_trimmed, CHANGE_SHIFT_THRESHOLD);
    debug.trim_similar_grad_shift_third = sl_array_trimmed;
    printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
  }
```

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
