### PR TITLE
chore(error_monitor): exclude ndt monitoring

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
@@ -18,11 +18,11 @@
           type: diagnostic_aggregator/AnalyzerGroup
           path: performance_monitoring
           analyzers:
-            matching_score:
-              type: diagnostic_aggregator/GenericAnalyzer
-              path: matching_score
-              contains: ["ndt_scan_matcher"]
-              timeout: 1.0
+            # matching_score:
+            #   type: diagnostic_aggregator/GenericAnalyzer
+            #   path: matching_score
+            #   contains: ["ndt_scan_matcher"]
+            #   timeout: 1.0
 
             localization_accuracy:
               type: diagnostic_aggregator/GenericAnalyzer

--- a/system/system_error_monitor/config/system_error_monitor.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.param.yaml
@@ -23,7 +23,7 @@
         /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false"}
 
         /autoware/localization/node_alive_monitoring: default
-        /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+        # /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         /autoware/localization/performance_monitoring/localization_accuracy: default
 
         /autoware/map/node_alive_monitoring: default


### PR DESCRIPTION
## Description

Changed the configuration file so that system error monitor does not monitor the diagnostics of `ndt_scan_matcher`.

This change is because ndt_scan_matcher will no longer be a node that is always launched. (cf. https://github.com/autowarefoundation/autoware.universe/pull/3063)
However, since NDT is the basic pose_estimator for a while, I have commented it out so that the settings can be easily restored.


* Must be merged with https://github.com/autowarefoundation/autoware_launch/pull/265

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
