### PR TITLE
fix(behavior_velocity_planner::stop_line): do not insert stop point for already traveled stop line

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -77,6 +77,10 @@ bool StopLineModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop
     stop_pose.position, stop_line_seg_idx);
   switch (state_) {
     case State::APPROACH: {
+      if (signed_arc_dist_to_stop_point < 0) {
+        // already passed the registered stop line
+        break;
+      }
       // Insert stop pose
       planning_utils::insertStopPoint(stop_pose.position, stop_line_seg_idx, *path);
 


### PR DESCRIPTION
## Description

If the stop_line primitive (`|` character) is defined as follows:

```
--->  ego's travel direction

++++++++++++++++++++++++++++++++++++++++++++++++++++
    Lane1            + |   Lane2
++++++++++++++++++++++++++++++++++++++++++++++++++++
```

stop_line module for `|`  keeps working even when ego has moved to Lane2.
After the transition to `STOP`, it changes to `START` after departed `|`, and then `APPROACH`. At that moment the signed distance to `|`  is  `< hold_stop_margin_distance` so a stop point is inserted again because the state is `APPROACH`.

I fixed it not to insert a stop point during `APPROACH` state if the signed distance is negative, or if ego already passed the stop point.

## Related links

https://tier4.atlassian.net/browse/T4PB-25725

## Tests performed

Psim

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
