### PR TITLE
feat(mission_planner): add the interface to reroute while driving

### DIFF
--- a/common/component_interface_specs/include/component_interface_specs/planning.hpp
+++ b/common/component_interface_specs/include/component_interface_specs/planning.hpp
@@ -39,6 +39,18 @@ struct SetRoute
   static constexpr char name[] = "/planning/mission_planning/set_route";
 };
 
+struct ChangeRoutePoints
+{
+  using Service = autoware_adapi_v1_msgs::srv::SetRoutePoints;
+  static constexpr char name[] = "/planning/mission_planning/change_route_points";
+};
+
+struct ChangeRoute
+{
+  using Service = autoware_planning_msgs::srv::SetRoute;
+  static constexpr char name[] = "/planning/mission_planning/change_route";
+};
+
 struct ClearRoute
 {
   using Service = autoware_adapi_v1_msgs::srv::ClearRoute;

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -25,29 +25,29 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 
 ### Services
 
-| Name                                 | Type                                        | Description                       |
-| ------------------------------------ | ------------------------------------------- | --------------------------------- |
-| `/planning/routing/clear_route`      | autoware_adapi_v1_msgs::srv::ClearRoute     | route clear request               |
-| `/planning/routing/set_route_points` | autoware_adapi_v1_msgs::srv::SetRoutePoints | route request with pose waypoints |
-| `/planning/routing/set_route`        | autoware_planning_msgs::srv::SetRoute       | route request with HAD map format |
-| `~/srv/clear_mrm`                    | std_srvs::srv::Trigger                      | clear emergency operation         |
+| Name                                 | Type                                              | Description                       |
+| ------------------------------------ | ------------------------------------------------- | --------------------------------- |
+| `/planning/routing/clear_route`      | autoware_adapi_v1_msgs/srv/ClearRoute             | route clear request               |
+| `/planning/routing/set_route_points` | autoware_adapi_v1_msgs/srv/SetRoutePoints         | route request with pose waypoints |
+| `/planning/routing/set_route`        | autoware_planning_msgs/srv/SetRoute               | route request with HAD map format |
+| `~/srv/set_mrm`                      | autoware_planning_msgs/srv/SetPoseWithUuidStamped | set emergency route               |
+| `~/srv/clear_mrm`                    | std_srvs/srv/Trigger                              | clear emergency route             |
 
 ### Subscriptions
 
-| Name               | Type                                 | Description                                |
-| ------------------ | ------------------------------------ | ------------------------------------------ |
-| `input/vector_map` | autoware_auto_mapping_msgs/HADMapBin | vector map of Lanelet2                     |
-| `~/sub/new_goal`   | geometry_msgs/PoseWithUuidStamped    | modified goal pose                         |
-| `~/sub/mrm_goal`   | geometry_msgs/PoseWithUuidStamped    | modified goal pose for emergency operation |
+| Name               | Type                                 | Description            |
+| ------------------ | ------------------------------------ | ---------------------- |
+| `input/vector_map` | autoware_auto_mapping_msgs/HADMapBin | vector map of Lanelet2 |
+| `~/sub/new_goal`   | geometry_msgs/PoseWithUuidStamped    | modified goal pose     |
 
 ### Publications
 
-| Name                            | Type                                    | Description              |
-| ------------------------------- | --------------------------------------- | ------------------------ |
-| `/planning/routing/route_state` | autoware_adapi_v1_msgs::msg::RouteState | route state              |
-| `/planning/routing/route`       | autoware_planning_msgs/LaneletRoute     | route                    |
-| `debug/route_marker`            | visualization_msgs::msg::MarkerArray    | route marker for debug   |
-| `debug/goal_footprint`          | visualization_msgs::msg::MarkerArray    | goal footprint for debug |
+| Name                            | Type                                  | Description              |
+| ------------------------------- | ------------------------------------- | ------------------------ |
+| `/planning/routing/route_state` | autoware_adapi_v1_msgs/msg/RouteState | route state              |
+| `/planning/routing/route`       | autoware_planning_msgs/LaneletRoute   | route                    |
+| `debug/route_marker`            | visualization_msgs/msg/MarkerArray    | route marker for debug   |
+| `debug/goal_footprint`          | visualization_msgs/msg/MarkerArray    | goal footprint for debug |
 
 ## Route section
 

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -30,13 +30,15 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 | `/planning/routing/clear_route`      | autoware_adapi_v1_msgs::srv::ClearRoute     | route clear request               |
 | `/planning/routing/set_route_points` | autoware_adapi_v1_msgs::srv::SetRoutePoints | route request with pose waypoints |
 | `/planning/routing/set_route`        | autoware_planning_msgs::srv::SetRoute       | route request with HAD map format |
+| `~/srv/clear_mrm`                    | std_srvs::srv::Trigger                      | clear emergency operation         |
 
 ### Subscriptions
 
-| Name                  | Type                                 | Description                 |
-| --------------------- | ------------------------------------ | --------------------------- |
-| `input/vector_map`    | autoware_auto_mapping_msgs/HADMapBin | vector map of Lanelet2      |
-| `input/modified_goal` | geometry_msgs/PoseStamped            | goal pose for arrival check |
+| Name               | Type                                 | Description                                |
+| ------------------ | ------------------------------------ | ------------------------------------------ |
+| `input/vector_map` | autoware_auto_mapping_msgs/HADMapBin | vector map of Lanelet2                     |
+| `~/sub/new_goal`   | geometry_msgs/PoseWithUuidStamped    | modified goal pose                         |
+| `~/sub/mrm_goal`   | geometry_msgs/PoseWithUuidStamped    | modified goal pose for emergency operation |
 
 ### Publications
 

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -38,7 +38,7 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 | Name                  | Type                                 | Description            |
 | --------------------- | ------------------------------------ | ---------------------- |
 | `input/vector_map`    | autoware_auto_mapping_msgs/HADMapBin | vector map of Lanelet2 |
-| `~/sub/modified_goal` | geometry_msgs/PoseWithUuidStamped    | modified goal pose     |
+| `input/modified_goal` | geometry_msgs/PoseWithUuidStamped    | modified goal pose     |
 
 ### Publications
 

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -25,13 +25,15 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 
 ### Services
 
-| Name                                 | Type                                              | Description                       |
-| ------------------------------------ | ------------------------------------------------- | --------------------------------- |
-| `/planning/routing/clear_route`      | autoware_adapi_v1_msgs/srv/ClearRoute             | route clear request               |
-| `/planning/routing/set_route_points` | autoware_adapi_v1_msgs/srv/SetRoutePoints         | route request with pose waypoints |
-| `/planning/routing/set_route`        | autoware_planning_msgs/srv/SetRoute               | route request with HAD map format |
-| `~/srv/set_mrm`                      | autoware_planning_msgs/srv/SetPoseWithUuidStamped | set emergency route               |
-| `~/srv/clear_mrm`                    | std_srvs/srv/Trigger                              | clear emergency route             |
+| Name                                             | Type                                              | Description                                 |
+| ------------------------------------------------ | ------------------------------------------------- | ------------------------------------------- |
+| `/planning/mission_planning/clear_route`         | autoware_adapi_v1_msgs/srv/ClearRoute             | route clear request                         |
+| `/planning/mission_planning/set_route_points`    | autoware_adapi_v1_msgs/srv/SetRoutePoints         | route request with pose waypoints           |
+| `/planning/mission_planning/set_route`           | autoware_planning_msgs/srv/SetRoute               | route request with lanelet waypoints        |
+| `/planning/mission_planning/change_route_points` | autoware_adapi_v1_msgs/srv/SetRoutePoints         | route change request with pose waypoints    |
+| `/planning/mission_planning/change_route`        | autoware_planning_msgs/srv/SetRoute               | route change request with lanelet waypoints |
+| `~/srv/set_mrm`                                  | autoware_planning_msgs/srv/SetPoseWithUuidStamped | set emergency route                         |
+| `~/srv/clear_mrm`                                | std_srvs/srv/Trigger                              | clear emergency route                       |
 
 ### Subscriptions
 

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -35,10 +35,10 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 
 ### Subscriptions
 
-| Name               | Type                                 | Description            |
-| ------------------ | ------------------------------------ | ---------------------- |
-| `input/vector_map` | autoware_auto_mapping_msgs/HADMapBin | vector map of Lanelet2 |
-| `~/sub/new_goal`   | geometry_msgs/PoseWithUuidStamped    | modified goal pose     |
+| Name                  | Type                                 | Description            |
+| --------------------- | ------------------------------------ | ---------------------- |
+| `input/vector_map`    | autoware_auto_mapping_msgs/HADMapBin | vector map of Lanelet2 |
+| `~/sub/modified_goal` | geometry_msgs/PoseWithUuidStamped    | modified goal pose     |
 
 ### Publications
 

--- a/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
@@ -1,0 +1,52 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MISSION_PLANNER__MISSION_PLANNER_INTERFACE_HPP_
+#define MISSION_PLANNER__MISSION_PLANNER_INTERFACE_HPP_
+
+#include <rclcpp/qos.hpp>
+
+#include <autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp>
+#include <std_srvs/srv/trigger.hpp>
+
+namespace mission_planner
+{
+
+struct NewGoal
+{
+  using Message = autoware_planning_msgs::msg::PoseWithUuidStamped;
+  static constexpr char name[] = "~/sub/new_goal";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct MrmGoal
+{
+  using Message = autoware_planning_msgs::msg::PoseWithUuidStamped;
+  static constexpr char name[] = "~/sub/mrm_goal";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct ClearMrm
+{
+  using Service = std_srvs::srv::Trigger;
+  static constexpr char name[] = "~/srv/clear_mrm";
+};
+
+}  // namespace mission_planner
+
+#endif  // MISSION_PLANNER__MISSION_PLANNER_INTERFACE_HPP_

--- a/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
@@ -27,7 +27,7 @@ namespace mission_planner
 struct NewGoal
 {
   using Message = autoware_planning_msgs::msg::PoseWithUuidStamped;
-  static constexpr char name[] = "~/sub/new_goal";
+  static constexpr char name[] = "~/sub/modified_goal";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;

--- a/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/qos.hpp>
 
 #include <autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp>
+#include <autoware_planning_msgs/srv/set_pose_with_uuid_stamped.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
 namespace mission_planner
@@ -32,13 +33,10 @@ struct NewGoal
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-struct MrmGoal
+struct SetMrm
 {
-  using Message = autoware_planning_msgs::msg::PoseWithUuidStamped;
-  static constexpr char name[] = "~/sub/mrm_goal";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+  using Service = autoware_planning_msgs::srv::SetPoseWithUuidStamped;
+  static constexpr char name[] = "~/srv/set_mrm";
 };
 
 struct ClearMrm

--- a/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
@@ -27,7 +27,7 @@ namespace mission_planner
 struct NewGoal
 {
   using Message = autoware_planning_msgs::msg::PoseWithUuidStamped;
-  static constexpr char name[] = "~/sub/modified_goal";
+  static constexpr char name[] = "input/modified_goal";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;

--- a/planning/mission_planner/launch/mission_planner.launch.xml
+++ b/planning/mission_planner/launch/mission_planner.launch.xml
@@ -6,7 +6,7 @@
 
   <node pkg="mission_planner" exec="mission_planner" name="mission_planner" output="screen">
     <param from="$(var mission_planner_param_path)"/>
-    <remap from="input/modified_goal" to="$(var modified_goal_topic_name)"/>
+    <remap from="~/sub/new_goal" to="$(var modified_goal_topic_name)"/>
     <remap from="input/vector_map" to="$(var map_topic_name)"/>
     <remap from="debug/route_marker" to="$(var visualization_topic_name)"/>
   </node>

--- a/planning/mission_planner/launch/mission_planner.launch.xml
+++ b/planning/mission_planner/launch/mission_planner.launch.xml
@@ -6,7 +6,7 @@
 
   <node pkg="mission_planner" exec="mission_planner" name="mission_planner" output="screen">
     <param from="$(var mission_planner_param_path)"/>
-    <remap from="~/sub/modified_goal" to="$(var modified_goal_topic_name)"/>
+    <remap from="input/modified_goal" to="$(var modified_goal_topic_name)"/>
     <remap from="input/vector_map" to="$(var map_topic_name)"/>
     <remap from="debug/route_marker" to="$(var visualization_topic_name)"/>
   </node>

--- a/planning/mission_planner/launch/mission_planner.launch.xml
+++ b/planning/mission_planner/launch/mission_planner.launch.xml
@@ -6,7 +6,7 @@
 
   <node pkg="mission_planner" exec="mission_planner" name="mission_planner" output="screen">
     <param from="$(var mission_planner_param_path)"/>
-    <remap from="~/sub/new_goal" to="$(var modified_goal_topic_name)"/>
+    <remap from="~/sub/modified_goal" to="$(var modified_goal_topic_name)"/>
     <remap from="input/vector_map" to="$(var map_topic_name)"/>
     <remap from="debug/route_marker" to="$(var visualization_topic_name)"/>
   </node>

--- a/planning/mission_planner/package.xml
+++ b/planning/mission_planner/package.xml
@@ -28,6 +28,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>route_handler</depend>
+  <depend>std_srvs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>

--- a/planning/mission_planner/src/mission_planner/arrival_checker.cpp
+++ b/planning/mission_planner/src/mission_planner/arrival_checker.cpp
@@ -27,10 +27,6 @@ ArrivalChecker::ArrivalChecker(rclcpp::Node * node) : vehicle_stop_checker_(node
   angle_ = tier4_autoware_utils::deg2rad(angle_deg);
   distance_ = node->declare_parameter<double>("arrival_check_distance");
   duration_ = node->declare_parameter<double>("arrival_check_duration");
-
-  sub_goal_ = node->create_subscription<PoseWithUuidStamped>(
-    "input/modified_goal", 1,
-    [this](const PoseWithUuidStamped::ConstSharedPtr msg) { modify_goal(*msg); });
 }
 
 void ArrivalChecker::set_goal()

--- a/planning/mission_planner/src/mission_planner/arrival_checker.hpp
+++ b/planning/mission_planner/src/mission_planner/arrival_checker.hpp
@@ -33,6 +33,7 @@ public:
   explicit ArrivalChecker(rclcpp::Node * node);
   void set_goal();
   void set_goal(const PoseWithUuidStamped & goal);
+  void modify_goal(const PoseWithUuidStamped & modified_goal);
   bool is_arrived(const PoseStamped & pose) const;
 
 private:
@@ -42,7 +43,6 @@ private:
   std::optional<PoseWithUuidStamped> goal_with_uuid_;
   rclcpp::Subscription<PoseWithUuidStamped>::SharedPtr sub_goal_;
   motion_utils::VehicleStopChecker vehicle_stop_checker_;
-  void modify_goal(const PoseWithUuidStamped & modified_goal);
 };
 
 }  // namespace mission_planner

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -87,6 +87,9 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   adaptor.init_srv(srv_set_route_points_, this, &MissionPlanner::on_set_route_points);
   adaptor.init_srv(srv_change_route_, this, &MissionPlanner::on_change_route);
   adaptor.init_srv(srv_change_route_points_, this, &MissionPlanner::on_change_route_points);
+  adaptor.init_sub(sub_new_goal_, this, &MissionPlanner::on_new_goal);
+  adaptor.init_sub(sub_mrm_goal_, this, &MissionPlanner::on_mrm_goal);
+  adaptor.init_srv(srv_clear_mrm_, this, &MissionPlanner::on_clear_mrm);
 
   change_state(RouteState::Message::UNSET);
 }
@@ -144,7 +147,7 @@ void MissionPlanner::change_state(RouteState::Message::_state_type state)
   pub_state_->publish(state_);
 }
 
-// NOTE: The route services should be mutually exclusive by callback group.
+// NOTE: The route interface should be mutually exclusive by callback group.
 void MissionPlanner::on_clear_route(
   const ClearRoute::Service::Request::SharedPtr, const ClearRoute::Service::Response::SharedPtr res)
 {
@@ -153,7 +156,7 @@ void MissionPlanner::on_clear_route(
   res->status.success = true;
 }
 
-// NOTE: The route services should be mutually exclusive by callback group.
+// NOTE: The route interface should be mutually exclusive by callback group.
 void MissionPlanner::on_set_route(
   const SetRoute::Service::Request::SharedPtr req, const SetRoute::Service::Response::SharedPtr res)
 {
@@ -190,7 +193,7 @@ void MissionPlanner::on_set_route(
   res->status.success = true;
 }
 
-// NOTE: The route services should be mutually exclusive by callback group.
+// NOTE: The route interface should be mutually exclusive by callback group.
 void MissionPlanner::on_set_route_points(
   const SetRoutePoints::Service::Request::SharedPtr req,
   const SetRoutePoints::Service::Response::SharedPtr res)
@@ -240,19 +243,44 @@ void MissionPlanner::on_set_route_points(
   res->status.success = true;
 }
 
-// NOTE: The route services should be mutually exclusive by callback group.
+// NOTE: The route interface should be mutually exclusive by callback group.
 void MissionPlanner::on_change_route(
   const SetRoute::Service::Request::SharedPtr req, const SetRoute::Service::Response::SharedPtr res)
 {
+  // TODO(Yutaka Shimizu): reroute
   (void)req;
   (void)res;
 }
 
-// NOTE: The route services should be mutually exclusive by callback group.
+// NOTE: The route interface should be mutually exclusive by callback group.
 void MissionPlanner::on_change_route_points(
   const SetRoutePoints::Service::Request::SharedPtr req,
   const SetRoutePoints::Service::Response::SharedPtr res)
 {
+  // TODO(Yutaka Shimizu): reroute
+  (void)req;
+  (void)res;
+}
+
+// NOTE: The route interface should be mutually exclusive by callback group.
+void MissionPlanner::on_new_goal(const NewGoal::Message::ConstSharedPtr msg)
+{
+  // TODO(Yutaka Shimizu): reroute if the goal is outside the lane.
+  arrival_checker_.modify_goal(*msg);
+}
+
+// NOTE: The route interface should be mutually exclusive by callback group.
+void MissionPlanner::on_mrm_goal(const MrmGoal::Message::ConstSharedPtr msg)
+{
+  // TODO(Yutaka Shimizu): reroute for MRM
+  (void)msg;
+}
+
+// NOTE: The route interface should be mutually exclusive by callback group.
+void MissionPlanner::on_clear_mrm(
+  const ClearMrm::Service::Request::SharedPtr req, const ClearMrm::Service::Response::SharedPtr res)
+{
+  // TODO(Yutaka Shimizu): reroute for MRM
   (void)req;
   (void)res;
 }

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -88,7 +88,7 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   adaptor.init_srv(srv_change_route_, this, &MissionPlanner::on_change_route);
   adaptor.init_srv(srv_change_route_points_, this, &MissionPlanner::on_change_route_points);
   adaptor.init_sub(sub_new_goal_, this, &MissionPlanner::on_new_goal);
-  adaptor.init_sub(sub_mrm_goal_, this, &MissionPlanner::on_mrm_goal);
+  adaptor.init_srv(srv_set_mrm_, this, &MissionPlanner::on_set_mrm);
   adaptor.init_srv(srv_clear_mrm_, this, &MissionPlanner::on_clear_mrm);
 
   change_state(RouteState::Message::UNSET);
@@ -270,10 +270,12 @@ void MissionPlanner::on_new_goal(const NewGoal::Message::ConstSharedPtr msg)
 }
 
 // NOTE: The route interface should be mutually exclusive by callback group.
-void MissionPlanner::on_mrm_goal(const MrmGoal::Message::ConstSharedPtr msg)
+void MissionPlanner::on_set_mrm(
+  const SetMrm::Service::Request::SharedPtr req, const SetMrm::Service::Response::SharedPtr res)
 {
   // TODO(Yutaka Shimizu): reroute for MRM
-  (void)msg;
+  (void)req;
+  (void)res;
 }
 
 // NOTE: The route interface should be mutually exclusive by callback group.

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -85,6 +85,8 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   adaptor.init_srv(srv_clear_route_, this, &MissionPlanner::on_clear_route);
   adaptor.init_srv(srv_set_route_, this, &MissionPlanner::on_set_route);
   adaptor.init_srv(srv_set_route_points_, this, &MissionPlanner::on_set_route_points);
+  adaptor.init_srv(srv_change_route_, this, &MissionPlanner::on_change_route);
+  adaptor.init_srv(srv_change_route_points_, this, &MissionPlanner::on_change_route_points);
 
   change_state(RouteState::Message::UNSET);
 }
@@ -236,6 +238,23 @@ void MissionPlanner::on_set_route_points(
   change_route(route);
   change_state(RouteState::Message::SET);
   res->status.success = true;
+}
+
+// NOTE: The route services should be mutually exclusive by callback group.
+void MissionPlanner::on_change_route(
+  const SetRoute::Service::Request::SharedPtr req, const SetRoute::Service::Response::SharedPtr res)
+{
+  (void)req;
+  (void)res;
+}
+
+// NOTE: The route services should be mutually exclusive by callback group.
+void MissionPlanner::on_change_route_points(
+  const SetRoutePoints::Service::Request::SharedPtr req,
+  const SetRoutePoints::Service::Response::SharedPtr res)
+{
+  (void)req;
+  (void)res;
 }
 
 }  // namespace mission_planner

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -87,7 +87,7 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   adaptor.init_srv(srv_set_route_points_, this, &MissionPlanner::on_set_route_points);
   adaptor.init_srv(srv_change_route_, this, &MissionPlanner::on_change_route);
   adaptor.init_srv(srv_change_route_points_, this, &MissionPlanner::on_change_route_points);
-  adaptor.init_sub(sub_new_goal_, this, &MissionPlanner::on_new_goal);
+  adaptor.init_sub(sub_modified_goal_, this, &MissionPlanner::on_modified_goal);
   adaptor.init_srv(srv_set_mrm_, this, &MissionPlanner::on_set_mrm);
   adaptor.init_srv(srv_clear_mrm_, this, &MissionPlanner::on_clear_mrm);
 
@@ -263,7 +263,7 @@ void MissionPlanner::on_change_route_points(
 }
 
 // NOTE: The route interface should be mutually exclusive by callback group.
-void MissionPlanner::on_new_goal(const NewGoal::Message::ConstSharedPtr msg)
+void MissionPlanner::on_modified_goal(const NewGoal::Message::ConstSharedPtr msg)
 {
   // TODO(Yutaka Shimizu): reroute if the goal is outside the lane.
   arrival_checker_.modify_goal(*msg);

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -19,6 +19,7 @@
 
 #include <component_interface_specs/planning.hpp>
 #include <component_interface_utils/rclcpp.hpp>
+#include <mission_planner/mission_planner_interface.hpp>
 #include <mission_planner/mission_planner_plugin.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -97,6 +98,15 @@ private:
   void on_change_route_points(
     const SetRoutePoints::Service::Request::SharedPtr req,
     const SetRoutePoints::Service::Response::SharedPtr res);
+
+  component_interface_utils::Subscription<NewGoal>::SharedPtr sub_new_goal_;
+  component_interface_utils::Subscription<MrmGoal>::SharedPtr sub_mrm_goal_;
+  component_interface_utils::Service<ClearMrm>::SharedPtr srv_clear_mrm_;
+  void on_new_goal(const NewGoal::Message::ConstSharedPtr msg);
+  void on_mrm_goal(const MrmGoal::Message::ConstSharedPtr msg);
+  void on_clear_mrm(
+    const ClearMrm::Service::Request::SharedPtr req,
+    const ClearMrm::Service::Response::SharedPtr res);
 };
 
 }  // namespace mission_planner

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -100,10 +100,11 @@ private:
     const SetRoutePoints::Service::Response::SharedPtr res);
 
   component_interface_utils::Subscription<NewGoal>::SharedPtr sub_new_goal_;
-  component_interface_utils::Subscription<MrmGoal>::SharedPtr sub_mrm_goal_;
+  component_interface_utils::Service<SetMrm>::SharedPtr srv_set_mrm_;
   component_interface_utils::Service<ClearMrm>::SharedPtr srv_clear_mrm_;
   void on_new_goal(const NewGoal::Message::ConstSharedPtr msg);
-  void on_mrm_goal(const MrmGoal::Message::ConstSharedPtr msg);
+  void on_set_mrm(
+    const SetMrm::Service::Request::SharedPtr req, const SetMrm::Service::Response::SharedPtr res);
   void on_clear_mrm(
     const ClearMrm::Service::Request::SharedPtr req,
     const ClearMrm::Service::Response::SharedPtr res);

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -41,9 +41,11 @@ using PoseStamped = geometry_msgs::msg::PoseStamped;
 using PoseWithUuidStamped = autoware_planning_msgs::msg::PoseWithUuidStamped;
 using LaneletRoute = autoware_planning_msgs::msg::LaneletRoute;
 using MarkerArray = visualization_msgs::msg::MarkerArray;
+using ClearRoute = planning_interface::ClearRoute;
 using SetRoutePoints = planning_interface::SetRoutePoints;
 using SetRoute = planning_interface::SetRoute;
-using ClearRoute = planning_interface::ClearRoute;
+using ChangeRoutePoints = planning_interface::ChangeRoutePoints;
+using ChangeRoute = planning_interface::ChangeRoute;
 using Route = planning_interface::Route;
 using RouteState = planning_interface::RouteState;
 using Odometry = nav_msgs::msg::Odometry;
@@ -78,6 +80,8 @@ private:
   component_interface_utils::Service<ClearRoute>::SharedPtr srv_clear_route_;
   component_interface_utils::Service<SetRoute>::SharedPtr srv_set_route_;
   component_interface_utils::Service<SetRoutePoints>::SharedPtr srv_set_route_points_;
+  component_interface_utils::Service<ChangeRoute>::SharedPtr srv_change_route_;
+  component_interface_utils::Service<ChangeRoutePoints>::SharedPtr srv_change_route_points_;
   void on_clear_route(
     const ClearRoute::Service::Request::SharedPtr req,
     const ClearRoute::Service::Response::SharedPtr res);
@@ -85,6 +89,12 @@ private:
     const SetRoute::Service::Request::SharedPtr req,
     const SetRoute::Service::Response::SharedPtr res);
   void on_set_route_points(
+    const SetRoutePoints::Service::Request::SharedPtr req,
+    const SetRoutePoints::Service::Response::SharedPtr res);
+  void on_change_route(
+    const SetRoute::Service::Request::SharedPtr req,
+    const SetRoute::Service::Response::SharedPtr res);
+  void on_change_route_points(
     const SetRoutePoints::Service::Request::SharedPtr req,
     const SetRoutePoints::Service::Response::SharedPtr res);
 };

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -99,10 +99,10 @@ private:
     const SetRoutePoints::Service::Request::SharedPtr req,
     const SetRoutePoints::Service::Response::SharedPtr res);
 
-  component_interface_utils::Subscription<NewGoal>::SharedPtr sub_new_goal_;
+  component_interface_utils::Subscription<NewGoal>::SharedPtr sub_modified_goal_;
   component_interface_utils::Service<SetMrm>::SharedPtr srv_set_mrm_;
   component_interface_utils::Service<ClearMrm>::SharedPtr srv_clear_mrm_;
-  void on_new_goal(const NewGoal::Message::ConstSharedPtr msg);
+  void on_modified_goal(const NewGoal::Message::ConstSharedPtr msg);
   void on_set_mrm(
     const SetMrm::Service::Request::SharedPtr req, const SetMrm::Service::Response::SharedPtr res);
   void on_clear_mrm(


### PR DESCRIPTION
## Description

Add interfaces for rerouting while driving https://github.com/autowarefoundation/autoware/issues/3406.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/3221
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/T4PB-27191).

## Tests performed

Tested that the vehicle can reach the road shoulder goal in planning simulator.

## Notes for reviewers

Need following PRs to build.
- https://github.com/autowarefoundation/autoware_msgs/pull/54

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
