### PR TITLE
fix(behavior_velocity_planner::intersection): show virtual wall when interrupted by RTC

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -48,6 +48,8 @@ class IntersectionModule : public SceneModuleInterface
 public:
   struct DebugData
   {
+    bool stop_required = false;
+
     geometry_msgs::msg::Pose stop_wall_pose;
     geometry_msgs::msg::Polygon stuck_vehicle_detect_area;
     geometry_msgs::msg::Polygon candidate_collision_ego_lane_polygon;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -176,7 +176,7 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createVirtualWallMarker
 
   const auto now = this->clock_->now();
 
-  if (state_machine_.getState() == StateMachine::State::STOP) {
+  if (debug_data_.stop_required) {
     appendMarkerArray(
       virtual_wall_marker_creator_->createStopVirtualWallMarker(
         {debug_data_.stop_wall_pose}, "intersection", now, module_id_),
@@ -207,7 +207,6 @@ visualization_msgs::msg::MarkerArray MergeFromPrivateRoadModule::createVirtualWa
   visualization_msgs::msg::MarkerArray wall_marker;
 
   const auto state = state_machine_.getState();
-
   const auto now = this->clock_->now();
   if (state == StateMachine::State::STOP) {
     const std::vector<Pose> & pose = {debug_data_.virtual_wall_pose};


### PR DESCRIPTION
## Description

Due to recent changes when intersection is interrupted by RTC and set to STOP, the virtual wall does not appear and `distance` was not properly set.

### After this PR

![image](https://user-images.githubusercontent.com/28677420/228117571-4d111203-d830-4ed0-88cb-bb7bf45f4bd6.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
