### PR TITLE
fix(behavior_velocity_planner): fix invalid access

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -221,7 +221,8 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 
   /* calculate final stop lines */
   std::optional<size_t> stop_line_idx =
-    std::make_optional<size_t>(stop_lines_idx_opt.value().collision_stop_line);
+    stop_lines_idx_opt ? std::make_optional<size_t>(stop_lines_idx_opt.value().collision_stop_line)
+                       : std::nullopt;
   if (external_go) {
     is_entry_prohibited = false;
   } else if (external_stop) {


### PR DESCRIPTION
## Description

Without this PR, the behavior_velocity_planner dies due to invalid access in the intersection module.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
