### PR TITLE
fix(map_loader): address deprecated warning for some environment

### DIFF
--- a/map/map_loader/test/test_pointcloud_map_loader_module.cpp
+++ b/map/map_loader/test/test_pointcloud_map_loader_module.cpp
@@ -83,7 +83,7 @@ TEST_F(TestPointcloudMapLoaderModule, LoadPCDFilesNoDownsampleTest)
 
   auto pointcloud_sub = node->create_subscription<sensor_msgs::msg::PointCloud2>(
     "pointcloud_map_no_downsample", durable_qos,
-    [pointcloud_received, pointcloud_msg](const sensor_msgs::msg::PointCloud2::SharedPtr msg) {
+    [pointcloud_received, pointcloud_msg](const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg) {
       *pointcloud_received = true;
       *pointcloud_msg = *msg;
     });


### PR DESCRIPTION
## Description
Some people got the following error. Although not everyone encounters this error, I would like to address this by small modification.
```
/home/.../pilot-auto/src/autoware/universe/map/map_loader/test/test_pointcloud_map_loader_module.cpp:84:81:   required from here
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:391:21: error: 'void rclcpp::AnySubscriptionCallback<MessageT, AllocatorT>::set_deprecated(std::function<void(std::shared_ptr<_Yp>)>) [with SetT = sensor_msgs::msg::PointCloud2_<std::allocator<void> >; MessageT = sensor_msgs::msg::PointCloud2_<std::allocator<void> >; AllocatorT = std::allocator<void>]' is deprecated: use 'void(std::shared_ptr<const MessageT>)' instead [-Werror=deprecated-declarations]
  391 |       set_deprecated(static_cast<typename scbth::callback_type>(callback));
      |       ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:408:3: note: declared here
  408 |   set_deprecated(std::function<void(std::shared_ptr<SetT>)> callback)
      |   ^~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/test_pointcloud_map_loader_module.dir/build.make:76: CMakeFiles/test_pointcloud_map_loader_module.dir/test/test_pointcloud_map_loader_module.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:383: CMakeFiles/test_pointcloud_map_loader_module.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< map_loader [12.4s, exited with code 2]
```
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
