### PR TITLE
fix(obstacle_avoidance_planner): use closest bound

### DIFF
--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -171,9 +171,12 @@ double calcLateralDistToBounds(
         tier4_autoware_utils::calcDistance2d(pose.position, *intersect_point) *
         (is_point_left ? 1.0 : -1.0);
 
-      closest_dist_to_bound =
-        is_left_bound ? std::min(dist_to_bound - additional_offset, closest_dist_to_bound)
-                      : std::max(dist_to_bound + additional_offset, closest_dist_to_bound);
+      // the bound which is closest to the centerline will be chosen
+      const double tmp_dist_to_bound =
+        is_left_bound ? dist_to_bound - additional_offset : dist_to_bound + additional_offset;
+      if (std::abs(tmp_dist_to_bound) < std::abs(closest_dist_to_bound)) {
+        closest_dist_to_bound = tmp_dist_to_bound;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

To deal with the case where multiple bounds are found (e.g. during the U-turn), the closest bound to the centerline is used for the constraint of collision free.
https://tier4.atlassian.net/browse/T4PB-27166
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
