### PR TITLE
fix(behavior_path_planner): use cropPoints

### DIFF
--- a/planning/behavior_path_planner/src/path_utilities.cpp
+++ b/planning/behavior_path_planner/src/path_utilities.cpp
@@ -170,6 +170,7 @@ size_t getIdxByArclength(
   }
 }
 
+// TODO(murooka) This function should be replaced with motion_utils::cropPoints
 void clipPathLength(
   PathWithLaneId & path, const size_t target_idx, const double forward, const double backward)
 {
@@ -186,6 +187,7 @@ void clipPathLength(
   path.points = clipped_points;
 }
 
+// TODO(murooka) This function should be replaced with motion_utils::cropPoints
 void clipPathLength(
   PathWithLaneId & path, const size_t target_idx, const BehaviorPathPlannerParameters & params)
 {

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -134,9 +134,13 @@ PathWithLaneId LaneFollowingModule::getReferencePath() const
     p.forward_path_length, p);
 
   // clip backward length
+  // NOTE: In order to keep backward_path_length at least, resampling interval is added to the
+  // backward.
   const size_t current_seg_idx = planner_data_->findEgoSegmentIndex(reference_path.points);
-  util::clipPathLength(
-    reference_path, current_seg_idx, p.forward_path_length, p.backward_path_length);
+  reference_path.points = motion_utils::cropPoints(
+    reference_path.points, current_pose.position, current_seg_idx, p.forward_path_length,
+    p.backward_path_length + p.input_path_interval);
+
   const auto drivable_lanelets = getLaneletsFromPath(reference_path, route_handler);
   const auto drivable_lanes = util::generateDrivableLanes(drivable_lanelets);
 


### PR DESCRIPTION
## Description

use motion_utils::cropPoints instead of clipPathLength.

motion_utils::cropPoints considers the argument's position precisely for cropping.
See this. https://github.com/autowarefoundation/autoware.universe/pull/3176

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
