### PR TITLE
feat(planning_evaluator): push back metric only when output_file_str is defined

### DIFF
--- a/evaluator/planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/planning_evaluator/src/planning_evaluator_node.cpp
@@ -131,7 +131,9 @@ void PlanningEvaluatorNode::onTrajectory(const Trajectory::ConstSharedPtr traj_m
   }
 
   auto start = now();
-  stamps_.push_back(traj_msg->header.stamp);
+  if (!output_file_str_.empty()) {
+    stamps_.push_back(traj_msg->header.stamp);
+  }
 
   DiagnosticArray metrics_msg;
   metrics_msg.header.stamp = now();
@@ -141,7 +143,10 @@ void PlanningEvaluatorNode::onTrajectory(const Trajectory::ConstSharedPtr traj_m
       continue;
     }
 
-    metric_stats_[static_cast<size_t>(metric)].push_back(*metric_stat);
+    if (!output_file_str_.empty()) {
+      metric_stats_[static_cast<size_t>(metric)].push_back(*metric_stat);
+    }
+
     if (metric_stat->count() > 0) {
       metrics_msg.status.push_back(generateDiagnosticStatus(metric, *metric_stat));
     }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Only save output data when the output path is defined, in order to prevent memory leaks.
(default outpuf path defined config file is empty)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
