### PR TITLE
refactor(behavior_velocity_planner): delete default values

### DIFF
--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -15,8 +15,6 @@
       detection_area_length: 200.0 # [m]
       detection_area_angle_threshold: 0.785 # [rad]
       min_predicted_path_confidence: 0.05
-      walkway:
-        external_input_timeout: 1.0
       minimum_ego_predicted_velocity: 1.388 # [m/s]
       collision_start_margin_time: 4.0 # [s] this + state_transit_margin_time should be higher to account for collision with fast/accelerating object
       collision_end_margin_time: 6.0 # [s] this + state_transit_margin_time should be higher to account for collision with slow/decelerating object

--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -15,6 +15,8 @@
       detection_area_length: 200.0 # [m]
       detection_area_angle_threshold: 0.785 # [rad]
       min_predicted_path_confidence: 0.05
+      walkway:
+        external_input_timeout: 1.0
       minimum_ego_predicted_velocity: 1.388 # [m/s]
       collision_start_margin_time: 4.0 # [s] this + state_transit_margin_time should be higher to account for collision with fast/accelerating object
       collision_end_margin_time: 6.0 # [s] this + state_transit_margin_time should be higher to account for collision with slow/decelerating object

--- a/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
+++ b/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
@@ -60,11 +60,11 @@ struct PlannerData
   explicit PlannerData(rclcpp::Node & node)
   : vehicle_info_(vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo())
   {
-    max_stop_acceleration_threshold = node.declare_parameter(
-      "max_accel", -5.0);  // TODO(someone): read min_acc in velocity_controller.param.yaml?
-    max_stop_jerk_threshold = node.declare_parameter("max_jerk", -5.0);
-    system_delay = node.declare_parameter("system_delay", 0.50);
-    delay_response_time = node.declare_parameter("delay_response_time", 0.50);
+    max_stop_acceleration_threshold = node.declare_parameter<double>(
+      "max_accel");  // TODO(someone): read min_acc in velocity_controller.param.yaml?
+    max_stop_jerk_threshold = node.declare_parameter<double>("max_jerk");
+    system_delay = node.declare_parameter<double>("system_delay");
+    delay_response_time = node.declare_parameter<double>("delay_response_time");
   }
 
   // msgs from callbacks that are used for data-ready

--- a/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
@@ -140,7 +140,7 @@ public:
     const auto ns = std::string("~/debug/") + module_name;
     pub_debug_ = node.create_publisher<visualization_msgs::msg::MarkerArray>(ns, 1);
     if (!node.has_parameter("is_publish_debug_path")) {
-      is_publish_debug_path_ = node.declare_parameter("is_publish_debug_path", false);
+      is_publish_debug_path_ = node.declare_parameter<bool>("is_publish_debug_path");
     } else {
       is_publish_debug_path_ = node.get_parameter("is_publish_debug_path").as_bool();
     }

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -149,9 +149,10 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
   debug_viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/path", 1);
 
   // Parameters
-  forward_path_length_ = this->declare_parameter("forward_path_length", 1000.0);
-  backward_path_length_ = this->declare_parameter("backward_path_length", 5.0);
-  planner_data_.stop_line_extend_length = this->declare_parameter("stop_line_extend_length", 5.0);
+  forward_path_length_ = this->declare_parameter<double>("forward_path_length");
+  backward_path_length_ = this->declare_parameter<double>("backward_path_length");
+  planner_data_.stop_line_extend_length =
+    this->declare_parameter<double>("stop_line_extend_length");
 
   // nearest search
   planner_data_.ego_nearest_dist_threshold =
@@ -160,43 +161,43 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
     this->declare_parameter<double>("ego_nearest_yaw_threshold");
 
   // Initialize PlannerManager
-  if (this->declare_parameter("launch_crosswalk", true)) {
+  if (this->declare_parameter<bool>("launch_crosswalk")) {
     planner_manager_.launchSceneModule(std::make_shared<CrosswalkModuleManager>(*this));
     planner_manager_.launchSceneModule(std::make_shared<WalkwayModuleManager>(*this));
   }
-  if (this->declare_parameter("launch_traffic_light", true)) {
+  if (this->declare_parameter<bool>("launch_traffic_light")) {
     planner_manager_.launchSceneModule(std::make_shared<TrafficLightModuleManager>(*this));
   }
-  if (this->declare_parameter("launch_intersection", true)) {
+  if (this->declare_parameter<bool>("launch_intersection")) {
     // intersection module should be before merge from private to declare intersection parameters
     planner_manager_.launchSceneModule(std::make_shared<IntersectionModuleManager>(*this));
     planner_manager_.launchSceneModule(std::make_shared<MergeFromPrivateModuleManager>(*this));
   }
-  if (this->declare_parameter("launch_blind_spot", true)) {
+  if (this->declare_parameter<bool>("launch_blind_spot")) {
     planner_manager_.launchSceneModule(std::make_shared<BlindSpotModuleManager>(*this));
   }
-  if (this->declare_parameter("launch_detection_area", true)) {
+  if (this->declare_parameter<bool>("launch_detection_area")) {
     planner_manager_.launchSceneModule(std::make_shared<DetectionAreaModuleManager>(*this));
   }
-  if (this->declare_parameter("launch_virtual_traffic_light", true)) {
+  if (this->declare_parameter<bool>("launch_virtual_traffic_light")) {
     planner_manager_.launchSceneModule(std::make_shared<VirtualTrafficLightModuleManager>(*this));
   }
   // this module requires all the stop line.Therefore this modules should be placed at the bottom.
-  if (this->declare_parameter("launch_no_stopping_area", true)) {
+  if (this->declare_parameter<bool>("launch_no_stopping_area")) {
     planner_manager_.launchSceneModule(std::make_shared<NoStoppingAreaModuleManager>(*this));
   }
   // permanent stop line module should be after no stopping area
-  if (this->declare_parameter("launch_stop_line", true)) {
+  if (this->declare_parameter<bool>("launch_stop_line")) {
     planner_manager_.launchSceneModule(std::make_shared<StopLineModuleManager>(*this));
   }
   // to calculate ttc it's better to be after stop line
-  if (this->declare_parameter("launch_occlusion_spot", true)) {
+  if (this->declare_parameter<bool>("launch_occlusion_spot")) {
     planner_manager_.launchSceneModule(std::make_shared<OcclusionSpotModuleManager>(*this));
   }
-  if (this->declare_parameter("launch_run_out", false)) {
+  if (this->declare_parameter<bool>("launch_run_out")) {
     planner_manager_.launchSceneModule(std::make_shared<RunOutModuleManager>(*this));
   }
-  if (this->declare_parameter("launch_speed_bump", true)) {
+  if (this->declare_parameter<bool>("launch_speed_bump")) {
     planner_manager_.launchSceneModule(std::make_shared<SpeedBumpModuleManager>(*this));
   }
 }

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
@@ -29,16 +29,16 @@ BlindSpotModuleManager::BlindSpotModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterfaceWithRTC(node, getModuleName())
 {
   const std::string ns(getModuleName());
-  planner_param_.use_pass_judge_line = node.declare_parameter(ns + ".use_pass_judge_line", false);
-  planner_param_.stop_line_margin = node.declare_parameter(ns + ".stop_line_margin", 1.0);
-  planner_param_.backward_length = node.declare_parameter(ns + ".backward_length", 15.0);
+  planner_param_.use_pass_judge_line = node.declare_parameter<bool>(ns + ".use_pass_judge_line");
+  planner_param_.stop_line_margin = node.declare_parameter<double>(ns + ".stop_line_margin");
+  planner_param_.backward_length = node.declare_parameter<double>(ns + ".backward_length");
   planner_param_.ignore_width_from_center_line =
-    node.declare_parameter(ns + ".ignore_width_from_center_line", 1.0);
+    node.declare_parameter<double>(ns + ".ignore_width_from_center_line");
   planner_param_.max_future_movement_time =
-    node.declare_parameter(ns + ".max_future_movement_time", 10.0);
-  planner_param_.threshold_yaw_diff =
-    node.declare_parameter(ns + ".threshold_yaw_diff", M_PI / 6.0);
-  planner_param_.adjacent_extend_width = node.declare_parameter(ns + ".adjacent_extend_width", 0.5);
+    node.declare_parameter<double>(ns + ".max_future_movement_time");
+  planner_param_.threshold_yaw_diff = node.declare_parameter<double>(ns + ".threshold_yaw_diff");
+  planner_param_.adjacent_extend_width =
+    node.declare_parameter<double>(ns + ".adjacent_extend_width");
 }
 
 void BlindSpotModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
@@ -83,46 +83,45 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
 
   // for crosswalk parameters
   auto & cp = crosswalk_planner_param_;
-  cp.show_processing_time = node.declare_parameter(ns + ".show_processing_time", true);
+  cp.show_processing_time = node.declare_parameter<bool>(ns + ".show_processing_time");
 
   // param for stop position
-  cp.stop_line_distance = node.declare_parameter(ns + ".stop_line_distance", 1.5);
-  cp.stop_margin = node.declare_parameter(ns + ".stop_margin", 1.0);
-  cp.stop_line_margin = node.declare_parameter(ns + ".stop_line_margin", 5.0);
-  cp.stop_position_threshold = node.declare_parameter(ns + ".stop_position_threshold", 1.0);
+  cp.stop_line_distance = node.declare_parameter<double>(ns + ".stop_line_distance");
+  cp.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
+  cp.stop_line_margin = node.declare_parameter<double>(ns + ".stop_line_margin");
+  cp.stop_position_threshold = node.declare_parameter<double>(ns + ".stop_position_threshold");
 
   // param for ego velocity
-  cp.min_slow_down_velocity = node.declare_parameter(ns + ".min_slow_down_velocity", 5.0 / 3.6);
-  cp.max_slow_down_jerk = node.declare_parameter(ns + ".max_slow_down_jerk", -0.7);
-  cp.max_slow_down_accel = node.declare_parameter(ns + ".max_slow_down_accel", -2.5);
-  cp.no_relax_velocity = node.declare_parameter(ns + ".no_relax_velocity", 2.78);
+  cp.min_slow_down_velocity = node.declare_parameter<double>(ns + ".min_slow_down_velocity");
+  cp.max_slow_down_jerk = node.declare_parameter<double>(ns + ".max_slow_down_jerk");
+  cp.max_slow_down_accel = node.declare_parameter<double>(ns + ".max_slow_down_accel");
+  cp.no_relax_velocity = node.declare_parameter<double>(ns + ".no_relax_velocity");
 
   // param for stuck vehicle
-  cp.stuck_vehicle_velocity = node.declare_parameter(ns + ".stuck_vehicle_velocity", 1.0);
-  cp.max_lateral_offset = node.declare_parameter(ns + ".max_lateral_offset", 2.0);
+  cp.stuck_vehicle_velocity = node.declare_parameter<double>(ns + ".stuck_vehicle_velocity");
+  cp.max_lateral_offset = node.declare_parameter<double>(ns + ".max_lateral_offset");
   cp.stuck_vehicle_attention_range =
-    node.declare_parameter(ns + ".stuck_vehicle_attention_range", 10.0);
+    node.declare_parameter<double>(ns + ".stuck_vehicle_attention_range");
 
   // param for pass judge logic
-  cp.ego_pass_first_margin = node.declare_parameter(ns + ".ego_pass_first_margin", 6.0);
-  cp.ego_pass_later_margin = node.declare_parameter(ns + ".ego_pass_later_margin", 10.0);
-  cp.stop_object_velocity =
-    node.declare_parameter(ns + ".stop_object_velocity_threshold", 0.5 / 3.6);
-  cp.min_object_velocity = node.declare_parameter(ns + ".min_object_velocity", 5.0 / 3.6);
-  cp.max_yield_timeout = node.declare_parameter(ns + ".max_yield_timeout", 3.0);
+  cp.ego_pass_first_margin = node.declare_parameter<double>(ns + ".ego_pass_first_margin");
+  cp.ego_pass_later_margin = node.declare_parameter<double>(ns + ".ego_pass_later_margin");
+  cp.stop_object_velocity = node.declare_parameter<double>(ns + ".stop_object_velocity_threshold");
+  cp.min_object_velocity = node.declare_parameter<double>(ns + ".min_object_velocity");
+  cp.max_yield_timeout = node.declare_parameter<double>(ns + ".max_yield_timeout");
   cp.ego_yield_query_stop_duration =
-    node.declare_parameter(ns + ".ego_yield_query_stop_duration", 0.1);
+    node.declare_parameter<double>(ns + ".ego_yield_query_stop_duration");
 
   // param for input data
-  cp.external_input_timeout = node.declare_parameter(ns + ".external_input_timeout", 1.0);
-  cp.tl_state_timeout = node.declare_parameter(ns + ".tl_state_timeout", 1.0);
+  cp.external_input_timeout = node.declare_parameter<double>(ns + ".external_input_timeout");
+  cp.tl_state_timeout = node.declare_parameter<double>(ns + ".tl_state_timeout");
 
   // param for target area & object
-  cp.crosswalk_attention_range = node.declare_parameter(ns + ".crosswalk_attention_range", 10.0);
-  cp.look_unknown = node.declare_parameter(ns + ".target_object.unknown", true);
-  cp.look_bicycle = node.declare_parameter(ns + ".target_object.bicycle", true);
-  cp.look_motorcycle = node.declare_parameter(ns + ".target_object.motorcycle", true);
-  cp.look_pedestrian = node.declare_parameter(ns + ".target_object.pedestrian", true);
+  cp.crosswalk_attention_range = node.declare_parameter<double>(ns + ".crosswalk_attention_range");
+  cp.look_unknown = node.declare_parameter<bool>(ns + ".target_object.unknown");
+  cp.look_bicycle = node.declare_parameter<bool>(ns + ".target_object.bicycle");
+  cp.look_motorcycle = node.declare_parameter<bool>(ns + ".target_object.motorcycle");
+  cp.look_pedestrian = node.declare_parameter<bool>(ns + ".target_object.pedestrian");
 }
 
 void CrosswalkModuleManager::launchNewModules(const PathWithLaneId & path)
@@ -162,9 +161,9 @@ WalkwayModuleManager::WalkwayModuleManager(rclcpp::Node & node)
 
   // for walkway parameters
   auto & wp = walkway_planner_param_;
-  wp.stop_line_distance = node.declare_parameter(ns + ".stop_line_distance", 1.0);
-  wp.stop_duration_sec = node.declare_parameter(ns + ".stop_duration_sec", 1.0);
-  wp.external_input_timeout = node.declare_parameter(ns + ".external_input_timeout", 1.0);
+  wp.stop_line_distance = node.declare_parameter<double>(ns + ".stop_line_distance");
+  wp.stop_duration_sec = node.declare_parameter<double>(ns + ".stop_duration_sec");
+  wp.external_input_timeout = node.declare_parameter<double>(ns + ".external_input_timeout");
 }
 
 void WalkwayModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
@@ -32,15 +32,15 @@ DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterfaceWithRTC(node, getModuleName())
 {
   const std::string ns(getModuleName());
-  planner_param_.stop_margin = node.declare_parameter(ns + ".stop_margin", 0.0);
-  planner_param_.use_dead_line = node.declare_parameter(ns + ".use_dead_line", false);
-  planner_param_.dead_line_margin = node.declare_parameter(ns + ".dead_line_margin", 5.0);
-  planner_param_.use_pass_judge_line = node.declare_parameter(ns + ".use_pass_judge_line", false);
-  planner_param_.state_clear_time = node.declare_parameter(ns + ".state_clear_time", 2.0);
+  planner_param_.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
+  planner_param_.use_dead_line = node.declare_parameter<bool>(ns + ".use_dead_line");
+  planner_param_.dead_line_margin = node.declare_parameter<double>(ns + ".dead_line_margin");
+  planner_param_.use_pass_judge_line = node.declare_parameter<bool>(ns + ".use_pass_judge_line");
+  planner_param_.state_clear_time = node.declare_parameter<double>(ns + ".state_clear_time");
   planner_param_.hold_stop_margin_distance =
-    node.declare_parameter(ns + ".hold_stop_margin_distance", 0.0);
+    node.declare_parameter<double>(ns + ".hold_stop_margin_distance");
   planner_param_.distance_to_judge_over_stop_line =
-    node.declare_parameter(ns + ".distance_to_judge_over_stop_line", 0.5);
+    node.declare_parameter<double>(ns + ".distance_to_judge_over_stop_line");
 }
 
 void DetectionAreaModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -32,33 +32,37 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   const std::string ns(getModuleName());
   auto & ip = intersection_param_;
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
-  ip.state_transit_margin_time = node.declare_parameter(ns + ".state_transit_margin_time", 2.0);
-  ip.stop_line_margin = node.declare_parameter(ns + ".stop_line_margin", 1.0);
-  ip.keep_detection_vel_thr = node.declare_parameter(ns + ".keep_detection_vel_thr", 0.833);
-  ip.stuck_vehicle_detect_dist = node.declare_parameter(ns + ".stuck_vehicle_detect_dist", 3.0);
-  ip.stuck_vehicle_ignore_dist = node.declare_parameter(ns + ".stuck_vehicle_ignore_dist", 5.0) +
+  ip.state_transit_margin_time = node.declare_parameter<double>(ns + ".state_transit_margin_time");
+  ip.stop_line_margin = node.declare_parameter<double>(ns + ".stop_line_margin");
+  ip.keep_detection_vel_thr = node.declare_parameter<double>(ns + ".keep_detection_vel_thr");
+  ip.stuck_vehicle_detect_dist = node.declare_parameter<double>(ns + ".stuck_vehicle_detect_dist");
+  ip.stuck_vehicle_ignore_dist = node.declare_parameter<double>(ns + ".stuck_vehicle_ignore_dist") +
                                  vehicle_info.max_longitudinal_offset_m;
-  ip.stuck_vehicle_vel_thr = node.declare_parameter(ns + ".stuck_vehicle_vel_thr", 3.0 / 3.6);
-  ip.intersection_velocity = node.declare_parameter(ns + ".intersection_velocity", 10.0 / 3.6);
-  ip.intersection_max_acc = node.declare_parameter(ns + ".intersection_max_accel", 0.5);
-  ip.detection_area_margin = node.declare_parameter(ns + ".detection_area_margin", 0.5);
-  ip.detection_area_right_margin = node.declare_parameter(ns + ".detection_area_right_margin", 0.5);
-  ip.detection_area_left_margin = node.declare_parameter(ns + ".detection_area_left_margin", 0.5);
-  ip.detection_area_length = node.declare_parameter(ns + ".detection_area_length", 200.0);
+  ip.stuck_vehicle_vel_thr = node.declare_parameter<double>(ns + ".stuck_vehicle_vel_thr");
+  ip.intersection_velocity = node.declare_parameter<double>(ns + ".intersection_velocity");
+  ip.intersection_max_acc = node.declare_parameter<double>(ns + ".intersection_max_accel");
+  ip.detection_area_margin = node.declare_parameter<double>(ns + ".detection_area_margin");
+  ip.detection_area_right_margin =
+    node.declare_parameter<double>(ns + ".detection_area_right_margin");
+  ip.detection_area_left_margin =
+    node.declare_parameter<double>(ns + ".detection_area_left_margin");
+  ip.detection_area_length = node.declare_parameter<double>(ns + ".detection_area_length");
   ip.detection_area_angle_thr =
-    node.declare_parameter(ns + ".detection_area_angle_threshold", M_PI / 4.0);
+    node.declare_parameter<double>(ns + ".detection_area_angle_threshold");
   ip.min_predicted_path_confidence =
-    node.declare_parameter(ns + ".min_predicted_path_confidence", 0.05);
-  ip.external_input_timeout = node.declare_parameter(ns + ".walkway.external_input_timeout", 1.0);
+    node.declare_parameter<double>(ns + ".min_predicted_path_confidence");
+  ip.external_input_timeout =
+    node.declare_parameter<double>(ns + ".walkway.external_input_timeout");
   ip.minimum_ego_predicted_velocity =
-    node.declare_parameter(ns + ".minimum_ego_predicted_velocity", 1.388);
-  ip.collision_start_margin_time = node.declare_parameter(ns + ".collision_start_margin_time", 5.0);
-  ip.collision_end_margin_time = node.declare_parameter(ns + ".collision_end_margin_time", 2.0);
-  ip.use_stuck_stopline = node.declare_parameter(ns + ".use_stuck_stopline", true);
-  ip.assumed_front_car_decel = node.declare_parameter(ns + ".assumed_front_car_decel", 1.0);
+    node.declare_parameter<double>(ns + ".minimum_ego_predicted_velocity");
+  ip.collision_start_margin_time =
+    node.declare_parameter<double>(ns + ".collision_start_margin_time");
+  ip.collision_end_margin_time = node.declare_parameter<double>(ns + ".collision_end_margin_time");
+  ip.use_stuck_stopline = node.declare_parameter<bool>(ns + ".use_stuck_stopline");
+  ip.assumed_front_car_decel = node.declare_parameter<double>(ns + ".assumed_front_car_decel");
   ip.enable_front_car_decel_prediction =
-    node.declare_parameter(ns + ".enable_front_car_decel_prediction", false);
-  ip.stop_overshoot_margin = node.declare_parameter(ns + ".stop_overshoot_margin", 0.5);
+    node.declare_parameter<bool>(ns + ".enable_front_car_decel_prediction");
+  ip.stop_overshoot_margin = node.declare_parameter<double>(ns + ".stop_overshoot_margin");
 }
 
 MergeFromPrivateModuleManager::MergeFromPrivateModuleManager(rclcpp::Node & node)
@@ -67,7 +71,7 @@ MergeFromPrivateModuleManager::MergeFromPrivateModuleManager(rclcpp::Node & node
   const std::string ns(getModuleName());
   auto & mp = merge_from_private_area_param_;
   mp.stop_duration_sec =
-    node.declare_parameter(ns + ".merge_from_private_area.stop_duration_sec", 1.0);
+    node.declare_parameter<double>(ns + ".merge_from_private_area.stop_duration_sec");
   mp.detection_area_length = node.get_parameter("intersection.detection_area_length").as_double();
   mp.detection_area_right_margin =
     node.get_parameter("intersection.detection_area_right_margin").as_double();

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -51,8 +51,7 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
     node.declare_parameter<double>(ns + ".detection_area_angle_threshold");
   ip.min_predicted_path_confidence =
     node.declare_parameter<double>(ns + ".min_predicted_path_confidence");
-  ip.external_input_timeout =
-    node.declare_parameter<double>(ns + ".walkway.external_input_timeout");
+  ip.external_input_timeout = node.declare_parameter<double>(ns + ".external_input_timeout");
   ip.minimum_ego_predicted_velocity =
     node.declare_parameter<double>(ns + ".minimum_ego_predicted_velocity");
   ip.collision_start_margin_time =

--- a/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/manager.cpp
@@ -35,13 +35,14 @@ NoStoppingAreaModuleManager::NoStoppingAreaModuleManager(rclcpp::Node & node)
   const std::string ns(getModuleName());
   auto & pp = planner_param_;
   const auto & vi = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
-  pp.state_clear_time = node.declare_parameter(ns + ".state_clear_time", 2.0);
-  pp.stuck_vehicle_vel_thr = node.declare_parameter(ns + ".stuck_vehicle_vel_thr", 0.8333);
-  pp.stop_margin = node.declare_parameter(ns + ".stop_margin", 0.0);
-  pp.dead_line_margin = node.declare_parameter(ns + ".dead_line_margin", 1.0);
-  pp.stop_line_margin = node.declare_parameter(ns + ".stop_line_margin", 1.0);
-  pp.detection_area_length = node.declare_parameter(ns + ".detection_area_length", 200.0);
-  pp.stuck_vehicle_front_margin = node.declare_parameter(ns + ".stuck_vehicle_front_margin", 6.0);
+  pp.state_clear_time = node.declare_parameter<double>(ns + ".state_clear_time");
+  pp.stuck_vehicle_vel_thr = node.declare_parameter<double>(ns + ".stuck_vehicle_vel_thr");
+  pp.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
+  pp.dead_line_margin = node.declare_parameter<double>(ns + ".dead_line_margin");
+  pp.stop_line_margin = node.declare_parameter<double>(ns + ".stop_line_margin");
+  pp.detection_area_length = node.declare_parameter<double>(ns + ".detection_area_length");
+  pp.stuck_vehicle_front_margin =
+    node.declare_parameter<double>(ns + ".stuck_vehicle_front_margin");
   pp.path_expand_width = vi.vehicle_width_m * 0.5;
 }
 

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
@@ -34,7 +34,7 @@ OcclusionSpotModuleManager::OcclusionSpotModuleManager(rclcpp::Node & node)
   auto & pp = planner_param_;
   // for detection type
   {
-    const std::string method = node.declare_parameter(ns + ".detection_method", "occupancy_grid");
+    const std::string method = node.declare_parameter<std::string>(ns + ".detection_method");
     if (method == "occupancy_grid") {  // module id 0
       pp.detection_method = DETECTION_METHOD::OCCUPANCY_GRID;
       module_id_ = DETECTION_METHOD::OCCUPANCY_GRID;
@@ -48,7 +48,7 @@ OcclusionSpotModuleManager::OcclusionSpotModuleManager(rclcpp::Node & node)
   }
   // for passable judgement
   {
-    const std::string pass_judge = node.declare_parameter(ns + ".pass_judge", "current_velocity");
+    const std::string pass_judge = node.declare_parameter<std::string>(ns + ".pass_judge");
     if (pass_judge == "current_velocity") {
       pp.pass_judge = PASS_JUDGE::CURRENT_VELOCITY;
     } else if (pass_judge == "smooth_velocity") {
@@ -58,45 +58,48 @@ OcclusionSpotModuleManager::OcclusionSpotModuleManager(rclcpp::Node & node)
         "[behavior_velocity]: occlusion spot pass judge method has invalid argument"};
     }
   }
-  pp.use_object_info = node.declare_parameter(ns + ".use_object_info", true);
-  pp.use_moving_object_ray_cast = node.declare_parameter(ns + ".use_moving_object_ray_cast", true);
-  pp.use_partition_lanelet = node.declare_parameter(ns + ".use_partition_lanelet", false);
-  pp.pedestrian_vel = node.declare_parameter(ns + ".pedestrian_vel", 1.5);
-  pp.pedestrian_radius = node.declare_parameter(ns + ".pedestrian_radius", 0.5);
+  pp.use_object_info = node.declare_parameter<bool>(ns + ".use_object_info");
+  pp.use_moving_object_ray_cast = node.declare_parameter<bool>(ns + ".use_moving_object_ray_cast");
+  pp.use_partition_lanelet = node.declare_parameter<bool>(ns + ".use_partition_lanelet");
+  pp.pedestrian_vel = node.declare_parameter<double>(ns + ".pedestrian_vel");
+  pp.pedestrian_radius = node.declare_parameter<double>(ns + ".pedestrian_radius");
 
   // debug
-  pp.is_show_occlusion = node.declare_parameter(ns + ".debug.is_show_occlusion", false);
-  pp.is_show_cv_window = node.declare_parameter(ns + ".debug.is_show_cv_window", false);
-  pp.is_show_processing_time = node.declare_parameter(ns + ".debug.is_show_processing_time", false);
+  pp.is_show_occlusion = node.declare_parameter<bool>(ns + ".debug.is_show_occlusion");
+  pp.is_show_cv_window = node.declare_parameter<bool>(ns + ".debug.is_show_cv_window");
+  pp.is_show_processing_time = node.declare_parameter<bool>(ns + ".debug.is_show_processing_time");
 
   // threshold
-  pp.detection_area_offset = node.declare_parameter(ns + ".threshold.detection_area_offset", 30.0);
-  pp.detection_area_length = node.declare_parameter(ns + ".threshold.detection_area_length", 200.0);
-  pp.stuck_vehicle_vel = node.declare_parameter(ns + ".threshold.stuck_vehicle_vel", 1.0);
-  pp.lateral_distance_thr = node.declare_parameter(ns + ".threshold.lateral_distance", 10.0);
-  pp.dist_thr = node.declare_parameter(ns + ".threshold.search_dist", 10.0);
-  pp.angle_thr = node.declare_parameter(ns + ".threshold.search_angle", M_PI / 5.0);
+  pp.detection_area_offset =
+    node.declare_parameter<double>(ns + ".threshold.detection_area_offset");
+  pp.detection_area_length =
+    node.declare_parameter<double>(ns + ".threshold.detection_area_length");
+  pp.stuck_vehicle_vel = node.declare_parameter<double>(ns + ".threshold.stuck_vehicle_vel");
+  pp.lateral_distance_thr = node.declare_parameter<double>(ns + ".threshold.lateral_distance");
+  pp.dist_thr = node.declare_parameter<double>(ns + ".threshold.search_dist");
+  pp.angle_thr = node.declare_parameter<double>(ns + ".threshold.search_angle");
 
   // ego additional velocity config
-  pp.v.safety_ratio = node.declare_parameter(ns + ".motion.safety_ratio", 1.0);
-  pp.v.safe_margin = node.declare_parameter(ns + ".motion.safe_margin", 1.0);
-  pp.v.max_slow_down_jerk = node.declare_parameter(ns + ".motion.max_slow_down_jerk", -0.7);
-  pp.v.max_slow_down_accel = node.declare_parameter(ns + ".motion.max_slow_down_accel", -2.5);
-  pp.v.non_effective_jerk = node.declare_parameter(ns + ".motion.non_effective_jerk", -0.3);
+  pp.v.safety_ratio = node.declare_parameter<double>(ns + ".motion.safety_ratio");
+  pp.v.safe_margin = node.declare_parameter<double>(ns + ".motion.safe_margin");
+  pp.v.max_slow_down_jerk = node.declare_parameter<double>(ns + ".motion.max_slow_down_jerk");
+  pp.v.max_slow_down_accel = node.declare_parameter<double>(ns + ".motion.max_slow_down_accel");
+  pp.v.non_effective_jerk = node.declare_parameter<double>(ns + ".motion.non_effective_jerk");
   pp.v.non_effective_accel =
-    node.declare_parameter(ns + ".motion.non_effective_acceleration", -1.0);
-  pp.v.min_allowed_velocity = node.declare_parameter(ns + ".motion.min_allowed_velocity", 1.0);
+    node.declare_parameter<double>(ns + ".motion.non_effective_acceleration");
+  pp.v.min_allowed_velocity = node.declare_parameter<double>(ns + ".motion.min_allowed_velocity");
   // detection_area param
   pp.detection_area.min_occlusion_spot_size =
-    node.declare_parameter(ns + ".detection_area.min_occlusion_spot_size", 2.0);
+    node.declare_parameter<double>(ns + ".detection_area.min_occlusion_spot_size");
   pp.detection_area.min_longitudinal_offset =
-    node.declare_parameter(ns + ".detection_area.min_longitudinal_offset", 1.0);
+    node.declare_parameter<double>(ns + ".detection_area.min_longitudinal_offset");
   pp.detection_area.max_lateral_distance =
-    node.declare_parameter(ns + ".detection_area.max_lateral_distance", 4.0);
-  pp.detection_area.slice_length = node.declare_parameter(ns + ".detection_area.slice_length", 1.5);
+    node.declare_parameter<double>(ns + ".detection_area.max_lateral_distance");
+  pp.detection_area.slice_length =
+    node.declare_parameter<double>(ns + ".detection_area.slice_length");
   // occupancy grid param
-  pp.grid.free_space_max = node.declare_parameter(ns + ".grid.free_space_max", 10);
-  pp.grid.occupied_min = node.declare_parameter(ns + ".grid.occupied_min", 51);
+  pp.grid.free_space_max = node.declare_parameter<int>(ns + ".grid.free_space_max");
+  pp.grid.occupied_min = node.declare_parameter<int>(ns + ".grid.occupied_min");
 
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
   pp.baselink_to_front = vehicle_info.max_longitudinal_offset_m;

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/manager.cpp
@@ -45,74 +45,74 @@ RunOutModuleManager::RunOutModuleManager(rclcpp::Node & node)
 
   {
     auto & p = planner_param_.common;
-    p.normal_min_jerk = node.declare_parameter(".normal.min_jerk", -0.3);
-    p.normal_min_acc = node.declare_parameter(".normal.min_acc", -1.0);
-    p.limit_min_jerk = node.declare_parameter(".limit.min_jerk", -1.5);
-    p.limit_min_acc = node.declare_parameter(".limit.min_acc", -2.5);
+    p.normal_min_jerk = node.declare_parameter<double>(".normal.min_jerk");
+    p.normal_min_acc = node.declare_parameter<double>(".normal.min_acc");
+    p.limit_min_jerk = node.declare_parameter<double>(".limit.min_jerk");
+    p.limit_min_acc = node.declare_parameter<double>(".limit.min_acc");
   }
 
   {
     auto & p = planner_param_.run_out;
-    p.detection_method = node.declare_parameter(ns + ".detection_method", "Object");
-    p.use_partition_lanelet = node.declare_parameter(ns + ".use_partition_lanelet", true);
-    p.specify_decel_jerk = node.declare_parameter(ns + ".specify_decel_jerk", false);
-    p.stop_margin = node.declare_parameter(ns + ".stop_margin", 2.5);
-    p.passing_margin = node.declare_parameter(ns + ".passing_margin", 1.0);
-    p.deceleration_jerk = node.declare_parameter(ns + ".deceleration_jerk", -0.3);
-    p.detection_distance = node.declare_parameter(ns + ".detection_distance", 45.0);
-    p.detection_span = node.declare_parameter(ns + ".detection_span", 1.0);
-    p.min_vel_ego_kmph = node.declare_parameter(ns + ".min_vel_ego_kmph", 5.0);
+    p.detection_method = node.declare_parameter<std::string>(ns + ".detection_method");
+    p.use_partition_lanelet = node.declare_parameter<bool>(ns + ".use_partition_lanelet");
+    p.specify_decel_jerk = node.declare_parameter<bool>(ns + ".specify_decel_jerk");
+    p.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
+    p.passing_margin = node.declare_parameter<double>(ns + ".passing_margin");
+    p.deceleration_jerk = node.declare_parameter<double>(ns + ".deceleration_jerk");
+    p.detection_distance = node.declare_parameter<double>(ns + ".detection_distance");
+    p.detection_span = node.declare_parameter<double>(ns + ".detection_span");
+    p.min_vel_ego_kmph = node.declare_parameter<double>(ns + ".min_vel_ego_kmph");
   }
 
   {
     auto & p = planner_param_.detection_area;
     const std::string ns_da = ns + ".detection_area";
-    p.margin_ahead = node.declare_parameter(ns_da + ".margin_ahead", 1.0);
-    p.margin_behind = node.declare_parameter(ns_da + ".margin_behind", 0.5);
+    p.margin_ahead = node.declare_parameter<double>(ns_da + ".margin_ahead");
+    p.margin_behind = node.declare_parameter<double>(ns_da + ".margin_behind");
   }
 
   {
     auto & p = planner_param_.mandatory_area;
     const std::string ns_da = ns + ".mandatory_area";
-    p.decel_jerk = node.declare_parameter(ns_da + ".decel_jerk", -1.2);
+    p.decel_jerk = node.declare_parameter<double>(ns_da + ".decel_jerk");
   }
 
   {
     auto & p = planner_param_.dynamic_obstacle;
     const std::string ns_do = ns + ".dynamic_obstacle";
-    p.use_mandatory_area = node.declare_parameter(ns_do + ".use_mandatory_area", true);
-    p.min_vel_kmph = node.declare_parameter(ns_do + ".min_vel_kmph", 0.0);
-    p.max_vel_kmph = node.declare_parameter(ns_do + ".max_vel_kmph", 5.0);
-    p.diameter = node.declare_parameter(ns_do + ".diameter", 0.1);
-    p.height = node.declare_parameter(ns_do + ".height", 2.0);
-    p.max_prediction_time = node.declare_parameter(ns_do + ".max_prediction_time", 10.0);
-    p.time_step = node.declare_parameter(ns_do + ".time_step", 0.5);
-    p.points_interval = node.declare_parameter(ns_do + ".points_interval", 0.1);
+    p.use_mandatory_area = node.declare_parameter<bool>(ns_do + ".use_mandatory_area");
+    p.min_vel_kmph = node.declare_parameter<double>(ns_do + ".min_vel_kmph");
+    p.max_vel_kmph = node.declare_parameter<double>(ns_do + ".max_vel_kmph");
+    p.diameter = node.declare_parameter<double>(ns_do + ".diameter");
+    p.height = node.declare_parameter<double>(ns_do + ".height");
+    p.max_prediction_time = node.declare_parameter<double>(ns_do + ".max_prediction_time");
+    p.time_step = node.declare_parameter<double>(ns_do + ".time_step");
+    p.points_interval = node.declare_parameter<double>(ns_do + ".points_interval");
   }
 
   {
     auto & p = planner_param_.approaching;
     const std::string ns_a = ns + ".approaching";
-    p.enable = node.declare_parameter(ns_a + ".enable", false);
-    p.margin = node.declare_parameter(ns_a + ".margin", 0.0);
-    p.limit_vel_kmph = node.declare_parameter(ns_a + ".limit_vel_kmph", 5.0);
+    p.enable = node.declare_parameter<bool>(ns_a + ".enable");
+    p.margin = node.declare_parameter<double>(ns_a + ".margin");
+    p.limit_vel_kmph = node.declare_parameter<double>(ns_a + ".limit_vel_kmph");
   }
 
   {
     auto & p = planner_param_.state_param;
     const std::string ns_s = ns + ".state";
-    p.stop_thresh = node.declare_parameter(ns_s + ".stop_thresh", 0.01);
-    p.stop_time_thresh = node.declare_parameter(ns_s + ".stop_time_thresh", 3.0);
-    p.disable_approach_dist = node.declare_parameter(ns_s + ".disable_approach_dist", 4.0);
-    p.keep_approach_duration = node.declare_parameter(ns_s + ".keep_approach_duration", 1.0);
+    p.stop_thresh = node.declare_parameter<double>(ns_s + ".stop_thresh");
+    p.stop_time_thresh = node.declare_parameter<double>(ns_s + ".stop_time_thresh");
+    p.disable_approach_dist = node.declare_parameter<double>(ns_s + ".disable_approach_dist");
+    p.keep_approach_duration = node.declare_parameter<double>(ns_s + ".keep_approach_duration");
   }
 
   {
     auto & p = planner_param_.slow_down_limit;
     const std::string ns_m = ns + ".slow_down_limit";
-    p.enable = node.declare_parameter(ns_m + ".enable", true);
-    p.max_jerk = node.declare_parameter(ns_m + ".max_jerk", -0.7);
-    p.max_acc = node.declare_parameter(ns_m + ".max_acc", -2.0);
+    p.enable = node.declare_parameter<bool>(ns_m + ".enable");
+    p.max_jerk = node.declare_parameter<double>(ns_m + ".max_jerk");
+    p.max_acc = node.declare_parameter<double>(ns_m + ".max_acc");
   }
 
   debug_ptr_ = std::make_shared<RunOutDebug>(node);

--- a/planning/behavior_velocity_planner/src/scene_module/speed_bump/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/speed_bump/manager.cpp
@@ -33,20 +33,20 @@ SpeedBumpModuleManager::SpeedBumpModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
 {
   std::string ns(getModuleName());
-  planner_param_.slow_start_margin = node.declare_parameter(ns + ".slow_start_margin", 1.0);
-  planner_param_.slow_end_margin = node.declare_parameter(ns + ".slow_end_margin", 1.0);
-  planner_param_.print_debug_info = node.declare_parameter(ns + ".print_debug_info", false);
+  planner_param_.slow_start_margin = node.declare_parameter<double>(ns + ".slow_start_margin");
+  planner_param_.slow_end_margin = node.declare_parameter<double>(ns + ".slow_end_margin");
+  planner_param_.print_debug_info = node.declare_parameter<bool>(ns + ".print_debug_info");
 
   // limits for speed bump height and slow down speed
   ns += ".speed_calculation";
   planner_param_.speed_calculation_min_height =
-    static_cast<float>(node.declare_parameter(ns + ".min_height", 0.05));
+    static_cast<float>(node.declare_parameter<double>(ns + ".min_height"));
   planner_param_.speed_calculation_max_height =
-    static_cast<float>(node.declare_parameter(ns + ".max_height", 0.30));
+    static_cast<float>(node.declare_parameter<double>(ns + ".max_height"));
   planner_param_.speed_calculation_min_speed =
-    static_cast<float>(node.declare_parameter(ns + ".min_speed", 1.39));
+    static_cast<float>(node.declare_parameter<double>(ns + ".min_speed"));
   planner_param_.speed_calculation_max_speed =
-    static_cast<float>(node.declare_parameter(ns + ".max_speed", 2.78));
+    static_cast<float>(node.declare_parameter<double>(ns + ".max_speed"));
 }
 
 void SpeedBumpModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
@@ -28,14 +28,14 @@ StopLineModuleManager::StopLineModuleManager(rclcpp::Node & node)
 {
   const std::string ns(getModuleName());
   auto & p = planner_param_;
-  p.stop_margin = node.declare_parameter(ns + ".stop_margin", 0.0);
-  p.hold_stop_margin_distance = node.declare_parameter(ns + ".hold_stop_margin_distance", 2.0);
-  p.stop_duration_sec = node.declare_parameter(ns + ".stop_duration_sec", 1.0);
+  p.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
+  p.hold_stop_margin_distance = node.declare_parameter<double>(ns + ".hold_stop_margin_distance");
+  p.stop_duration_sec = node.declare_parameter<double>(ns + ".stop_duration_sec");
   p.use_initialization_stop_line_state =
-    node.declare_parameter(ns + ".use_initialization_stop_line_state", false);
+    node.declare_parameter<bool>(ns + ".use_initialization_stop_line_state");
   // debug
   p.show_stopline_collision_check =
-    node.declare_parameter(ns + ".debug.show_stopline_collision_check", false);
+    node.declare_parameter<bool>(ns + ".debug.show_stopline_collision_check");
 }
 
 std::vector<StopLineWithLaneId> StopLineModuleManager::getStopLinesWithLaneIdOnPath(

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
@@ -30,12 +30,12 @@ TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterfaceWithRTC(node, getModuleName())
 {
   const std::string ns(getModuleName());
-  planner_param_.stop_margin = node.declare_parameter(ns + ".stop_margin", 0.0);
-  planner_param_.tl_state_timeout = node.declare_parameter(ns + ".tl_state_timeout", 1.0);
+  planner_param_.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
+  planner_param_.tl_state_timeout = node.declare_parameter<double>(ns + ".tl_state_timeout");
   planner_param_.external_tl_state_timeout =
-    node.declare_parameter(ns + ".external_tl_state_timeout", 1.0);
-  planner_param_.enable_pass_judge = node.declare_parameter(ns + ".enable_pass_judge", true);
-  planner_param_.yellow_lamp_period = node.declare_parameter(ns + ".yellow_lamp_period", 2.75);
+    node.declare_parameter<double>(ns + ".external_tl_state_timeout");
+  planner_param_.enable_pass_judge = node.declare_parameter<bool>(ns + ".enable_pass_judge");
+  planner_param_.yellow_lamp_period = node.declare_parameter<double>(ns + ".yellow_lamp_period");
   pub_tl_state_ = node.create_publisher<autoware_auto_perception_msgs::msg::LookingTrafficSignal>(
     "~/output/traffic_signal", 1);
 }

--- a/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/manager.cpp
@@ -32,14 +32,14 @@ VirtualTrafficLightModuleManager::VirtualTrafficLightModuleManager(rclcpp::Node 
 
   {
     auto & p = planner_param_;
-    p.max_delay_sec = node.declare_parameter(ns + ".max_delay_sec", 3.0);
-    p.near_line_distance = node.declare_parameter(ns + ".near_line_distance", 1.0);
-    p.dead_line_margin = node.declare_parameter(ns + ".dead_line_margin", 1.0);
-    p.hold_stop_margin_distance = node.declare_parameter(ns + ".hold_stop_margin_distance", 0.0);
+    p.max_delay_sec = node.declare_parameter<double>(ns + ".max_delay_sec");
+    p.near_line_distance = node.declare_parameter<double>(ns + ".near_line_distance");
+    p.dead_line_margin = node.declare_parameter<double>(ns + ".dead_line_margin");
+    p.hold_stop_margin_distance = node.declare_parameter<double>(ns + ".hold_stop_margin_distance");
     p.max_yaw_deviation_rad =
-      tier4_autoware_utils::deg2rad(node.declare_parameter(ns + ".max_yaw_deviation_deg", 90.0));
+      tier4_autoware_utils::deg2rad(node.declare_parameter<double>(ns + ".max_yaw_deviation_deg"));
     p.check_timeout_after_stop_line =
-      node.declare_parameter(ns + ".check_timeout_after_stop_line", true);
+      node.declare_parameter<bool>(ns + ".check_timeout_after_stop_line");
   }
 }
 


### PR DESCRIPTION
## Description
Removed default values defined in declare_parameter function.

The following parameters need to be added
stop_line_extend_length: 5.0
detection_area.hold_stop_margin_distance: 2.0
intersection.walkway.external_input_timeout: 1.0
intersection.merge_from_private.merge_from_private_area.stop_duration_sec: 1.0
stop_line.hold_stop_margin_distance: 2.0
stop_line.use_initialization_stop_line_state: false
stop_line.debug.show_stopline_collision_check: false
virtual_traffic_light.hold_stop_margin_distance: 0.0
[Behavior velocity planner delete param.webm](https://user-images.githubusercontent.com/100691117/228428215-b434ba12-89bf-464c-b4ce-27766487bd62.webm)

:arrow_down: This PR must be merged before this PR.
https://github.com/autowarefoundation/autoware_launch/pull/272

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
