### PR TITLE
fix(planner_manager): don't use failure module output

### DIFF
--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -278,16 +278,19 @@ BehaviorModuleOutput PlannerManager::update(const std::shared_ptr<PlannerData> &
     const auto result = run(*itr, data, output);  // execute approved module planning.
 
     // check the module is necessary or not.
-    if ((*itr)->getCurrentStatus() != ModuleStatus::RUNNING) {
+    const auto current_status = (*itr)->getCurrentStatus();
+    if (current_status != ModuleStatus::RUNNING) {
       if (itr == approved_module_ptrs_.begin()) {
         // update root lanelet when the lane change is done.
-        if (name.find("lane_change") != std::string::npos) {
-          root_lanelet_ = updateRootLanelet(data);
+        if (current_status == ModuleStatus::SUCCESS) {
+          if (name.find("lane_change") != std::string::npos) {
+            root_lanelet_ = updateRootLanelet(data);
+          }
+          output = result;
         }
 
         deleteExpiredModules(*itr);  // unregister the expired module from manager.
         itr = approved_module_ptrs_.erase(itr);
-        output = result;
         processing_time_.at(name) += stop_watch_.toc(name, true);
         continue;
       }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -141,7 +141,7 @@ ModuleStatus LaneChangeModule::updateState()
 {
   RCLCPP_DEBUG(getLogger(), "LANE_CHANGE updateState");
   if (!isValidPath()) {
-    current_state_ = ModuleStatus::SUCCESS;
+    current_state_ = ModuleStatus::FAILURE;
     return current_state_;
   }
 


### PR DESCRIPTION
## Description

Fix bug in planner manager.

The new manager updates current lanelet info and uses it as next module's input even when the lane change module exit with `ModuleStatus::FAILURE`, but I suppose that it should do that process only when the lane change module exit with `ModuleStatus::SUCCESS`.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

WIP (running evaluator now...)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
