### PR TITLE
fix(behavior_path_planner): fix lane change distance check

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -55,7 +55,7 @@ bool isPathInLanelets(
   const lanelet::ConstLanelets & target_lanelets);
 
 double calcLaneChangingDistance(
-  const double lane_changing_velocity, const double shift_length, const double min_total_lc_len,
+  const double lane_changing_velocity, const double shift_length,
   const BehaviorPathPlannerParameters & com_param, const LaneChangeParameters & lc_param);
 
 std::optional<LaneChangePath> constructCandidatePath(


### PR DESCRIPTION
## Description
Currently, lane change distance check calculation is incorrect, and I fixed the problem in this PR.

In order to safely navigate the ego vehicle while doing lane change, it has to cancel the lane change if it satisfies the following condition
```
prepare_distance + lane_changing_distance > dist_to_end_of_current_lane
```
This equation suggests that the entire lane change length will exceed the length to the end of the current lane.

Scenario Test Result
[Internal Link](https://evaluation.tier4.jp/evaluation/reports/6433a3aa-df91-5820-9e29-f1117a1f7d5a?project_id=prd_jt) 
1194/1199
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
