### PR TITLE
fix(map_based_prediction): prevent unintended prediction generation for crosswalk users 

### DIFF
--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -462,10 +462,10 @@ ObjectClassification::_label_type changeLabelForPrediction(
       object.kinematics.twist_with_covariance.twist.linear.x > max_velocity_for_human_mps;
     // fast, human-like object: like segway
     if (within_road_lanelet && high_speed_object) {
-      return label; // currently do nothing
+      return label;  // currently do nothing
       // return ObjectClassification::MOTORCYCLE;
     } else if (high_speed_object) {
-      return label; // currently do nothing
+      return label;  // currently do nothing
       // fast human outside road lanelet will move like unknown object
       // return ObjectClassification::UNKNOWN;
     } else {

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -462,10 +462,12 @@ ObjectClassification::_label_type changeLabelForPrediction(
       object.kinematics.twist_with_covariance.twist.linear.x > max_velocity_for_human_mps;
     // fast, human-like object: like segway
     if (within_road_lanelet && high_speed_object) {
-      return ObjectClassification::MOTORCYCLE;
+      return label; // currently do nothing
+      // return ObjectClassification::MOTORCYCLE;
     } else if (high_speed_object) {
+      return label; // currently do nothing
       // fast human outside road lanelet will move like unknown object
-      return ObjectClassification::UNKNOWN;
+      // return ObjectClassification::UNKNOWN;
     } else {
       return label;
     }

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -188,6 +188,25 @@ void updateLateralKinematicsVector(
   }
 }
 
+/**
+ * @brief calc absolute normalized yaw difference between lanelet and object
+ *
+ * @param object
+ * @param lanelet
+ * @return double
+ */
+double calcAbsYawDiffBetweenLaneletAndObject(
+  const TrackedObject & object, const lanelet::ConstLanelet & lanelet)
+{
+  const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
+  const double lane_yaw =
+    lanelet::utils::getLaneletAngle(lanelet, object.kinematics.pose_with_covariance.pose.position);
+  const double delta_yaw = object_yaw - lane_yaw;
+  const double normalized_delta_yaw = tier4_autoware_utils::normalizeRadian(delta_yaw);
+  const double abs_norm_delta = std::fabs(normalized_delta_yaw);
+  return abs_norm_delta;
+}
+
 lanelet::ConstLanelets getLanelets(const map_based_prediction::LaneletsData & data)
 {
   lanelet::ConstLanelets lanelets;
@@ -213,7 +232,9 @@ EntryPoint getCrosswalkEntryPoint(const lanelet::ConstLanelet & crosswalk)
   return std::make_pair(front_entry_point, back_entry_point);
 }
 
-bool withinLanelet(const TrackedObject & object, const lanelet::ConstLanelet & lanelet)
+bool withinLanelet(
+  const TrackedObject & object, const lanelet::ConstLanelet & lanelet,
+  const bool use_yaw_information = false, const float yaw_threshold = 0.6)
 {
   using Point = boost::geometry::model::d2::point_xy<double>;
 
@@ -222,11 +243,24 @@ bool withinLanelet(const TrackedObject & object, const lanelet::ConstLanelet & l
 
   auto polygon = lanelet.polygon2d().basicPolygon();
   boost::geometry::correct(polygon);
+  bool with_in_polygon = boost::geometry::within(p_object, polygon);
 
-  return boost::geometry::within(p_object, polygon);
+  if (!use_yaw_information) {
+    return with_in_polygon;
+  } else {
+    // use yaw angle to compare
+    const double abs_yaw_diff = calcAbsYawDiffBetweenLaneletAndObject(object, lanelet);
+    if (abs_yaw_diff < yaw_threshold) {
+      return with_in_polygon;
+    } else {
+      return false;
+    }
+  }
 }
 
-bool withinRoadLanelet(const TrackedObject & object, const lanelet::LaneletMapPtr & lanelet_map_ptr)
+bool withinRoadLanelet(
+  const TrackedObject & object, const lanelet::LaneletMapPtr & lanelet_map_ptr,
+  const bool use_yaw_information = false)
 {
   using Point = boost::geometry::model::d2::point_xy<double>;
 
@@ -249,7 +283,7 @@ bool withinRoadLanelet(const TrackedObject & object, const lanelet::LaneletMapPt
       }
     }
 
-    if (withinLanelet(object, lanelet.second)) {
+    if (withinLanelet(object, lanelet.second, use_yaw_information)) {
       return true;
     }
   }
@@ -387,6 +421,48 @@ bool hasPotentialToReach(
   return false;
 }
 
+/**
+ * @brief change label for prediction
+ *
+ * @param label
+ * @return ObjectClassification::_label_type
+ */
+ObjectClassification::_label_type changeLabelForPrediction(
+  const ObjectClassification::_label_type & label, const TrackedObject & object,
+  const lanelet::LaneletMapPtr & lanelet_map_ptr_)
+{
+  // for car like vehicle do not change labels
+  if (
+    label == ObjectClassification::CAR || label == ObjectClassification::BUS ||
+    label == ObjectClassification::TRUCK || label == ObjectClassification::TRAILER ||
+    label == ObjectClassification::UNKNOWN) {
+    return label;
+  } else if (  // for bicycle and motorcycle
+    label == ObjectClassification::MOTORCYCLE || label == ObjectClassification::BICYCLE) {
+    // calculate existence in road lanelet
+    const bool within_road_lanelet = withinRoadLanelet(object, lanelet_map_ptr_, true);
+
+    // if the object is within lanelet, do the same estimation with vehicle
+    if (within_road_lanelet) {
+      return ObjectClassification::MOTORCYCLE;
+    } else {
+      return label == ObjectClassification::BICYCLE;
+    }
+  } else if (label == ObjectClassification::PEDESTRIAN) {
+    const bool within_road_lanelet = withinRoadLanelet(object, lanelet_map_ptr_, true);
+    const float max_velocity_for_human_mps = 7.5;  // Max human being motion speed is 27km/h
+    const bool high_speed_object =
+      object.kinematics.twist_with_covariance.twist.linear.x > max_velocity_for_human_mps;
+    if (within_road_lanelet && high_speed_object) {
+      return ObjectClassification::MOTORCYCLE;
+    } else {
+      return label;
+    }
+  } else {
+    return label;
+  }
+}
+
 MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_options)
 : Node("map_based_prediction", node_options), debug_accumulated_time_(0.0)
 {
@@ -514,7 +590,9 @@ void MapBasedPredictionNode::objectsCallback(const TrackedObjects::ConstSharedPt
       transformed_object.kinematics.pose_with_covariance.pose = pose_in_map.pose;
     }
 
-    const auto & label = transformed_object.classification.front().label;
+    // get tracking label and update it for the prediction
+    const auto & label_ = transformed_object.classification.front().label;
+    const auto label = changeLabelForPrediction(label_, object, lanelet_map_ptr_);
 
     // For crosswalk user
     if (label == ObjectClassification::PEDESTRIAN || label == ObjectClassification::BICYCLE) {


### PR DESCRIPTION
## Description

### Problems

Sometimes unintended prediction is created by crosswalk prediction module.
This is because non-crosswalk users(motor cycle) sometimes mistaken as crosswalk users(cyclist, pedestrian).

- path generation for crosswalk users 
![prediction](https://github.com/YoshiRi/autoware.universe/raw/feature/switch_occupancy_gridmap_launcher/perception/map_based_prediction/images/inside_road.svg)

- unintended prediction example

![image](https://user-images.githubusercontent.com/20086766/228705790-eebd0f27-2a97-4ea5-8f3c-190dc15e4ec9.png)


### Approach

Instead of using the Label for Tracking directly, a label for Prediction should be assigned according to the situation of the object.
In Prediction, pedestrians and cyclists are affected by CrossWalk when generating paths, so depending on the situation, they are temporarily assigned other labels and paths are generated.

The table below shows the correspondence between these processes.

| tracking label\ prediction label | Motorcycle                      | Unknown                                                               | Cyclist     | Pedestrian  |
|----------------------------------|---------------------------------|-----------------------------------------------------------------------|-------------|-------------|
| Cyclist or Motorcycle            | - if object is in the road lane | - if object is outside the road lane <br> - if speed is beyond 25km/h | other cases | -           |
| Pedestrian                       | - if objects in the road lane <br> - if speed is beyond 25km/h   | - if objects outside the road lane <br> - if speed is beyond 25km/h       | -           | other cases |


**Design intention**

- bike object which follow the lane would move like on-lane vehicles (set to Motorcycle)
- fast bike object outside the lane won't move like normal crosswalk users (set to Unknown)
- pedestrian in the lane and fast speed would act like on-lane vehicles (set to Motorcycle)
- fast pedestrian outside the lane won't act like normal crosswalk users (set to Unknown)


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
