### PR TITLE
feat(behavior_path_planner): fix minimum prepare speed

### DIFF
--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -82,6 +82,7 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             {
                 "lateral_controller_mode": LaunchConfiguration("lateral_controller_mode"),
+                "longitudinal_controller_mode": LaunchConfiguration("longitudinal_controller_mode"),
             },
             nearest_search_param,
             trajectory_follower_node_param,

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -195,8 +195,7 @@ std::optional<LaneChangePath> constructCandidatePath(
   candidate_path.length.prepare = prepare_distance;
   candidate_path.length.lane_changing = lane_change_distance;
   candidate_path.duration.prepare = std::invoke([&]() {
-    const auto duration =
-      prepare_distance / std::max(lane_change_param.minimum_lane_change_velocity, speed.prepare);
+    const auto duration = prepare_distance / speed.prepare;
     return std::min(duration, lane_change_param.lane_change_prepare_duration);
   });
   candidate_path.duration.lane_changing = std::invoke([&]() {
@@ -286,11 +285,18 @@ std::pair<bool, bool> getLaneChangePaths(
   const auto prepare_duration = parameter.lane_change_prepare_duration;
   const auto minimum_prepare_distance = common_parameter.minimum_lane_change_prepare_distance;
   const auto minimum_lane_change_velocity = parameter.minimum_lane_change_velocity;
-  const auto maximum_deceleration = parameter.maximum_deceleration;
   const auto lane_change_sampling_num = parameter.lane_change_sampling_num;
 
   // get velocity
   const auto current_velocity = twist.linear.x;
+
+  // compute maximum_deceleration
+  const double maximum_deceleration =
+    std::invoke([&minimum_lane_change_velocity, &current_velocity, &parameter]() {
+      const double min_a =
+        (minimum_lane_change_velocity - current_velocity) / parameter.lane_change_prepare_duration;
+      return std::clamp(min_a, -std::fabs(parameter.maximum_deceleration), 0.0);
+    });
 
   const auto acceleration_resolution = std::abs(maximum_deceleration) / lane_change_sampling_num;
 
@@ -330,14 +336,11 @@ std::pair<bool, bool> getLaneChangePaths(
   LaneChangeTargetObjectIndices dynamic_object_indices;
 
   candidate_paths->reserve(lane_change_sampling_num);
-  for (double acceleration = 0.0; acceleration >= -maximum_deceleration;
+  for (double acceleration = 0.0; acceleration >= maximum_deceleration;
        acceleration -= acceleration_resolution) {
-    const double prepare_speed = current_velocity + acceleration * prepare_duration;
-
-    // skip if velocity becomes less than zero before starting lane change
-    if (prepare_speed < 0.0) {
-      break;
-    }
+    std::cerr << "maximum_deceleration: " << maximum_deceleration << std::endl;
+    const double prepare_speed =
+      std::max(current_velocity + acceleration * prepare_duration, minimum_lane_change_velocity);
 
     // get path on original lanes
     const double prepare_distance = std::max(
@@ -351,7 +354,7 @@ std::pair<bool, bool> getLaneChangePaths(
 #ifdef USE_OLD_ARCHITECTURE
     const auto prepare_segment = getPrepareSegment(
       route_handler, original_lanelets, arc_position_from_current.length, backward_path_length,
-      prepare_distance, std::max(prepare_speed, minimum_lane_change_velocity));
+      prepare_distance, prepare_speed);
 #else
     const auto prepare_segment = getPrepareSegment(
       original_path, original_lanelets, pose, backward_path_length, prepare_distance,
@@ -372,7 +375,7 @@ std::pair<bool, bool> getLaneChangePaths(
       lanelet::utils::getLateralDistanceToClosestLanelet(target_lanelets, lane_changing_start_pose);
 
     // we assume constant speed during lane change
-    const auto lane_changing_speed = std::max(prepare_speed, minimum_lane_change_velocity);
+    const auto lane_changing_speed = prepare_speed;
     const auto lane_changing_distance =
       calcLaneChangingDistance(lane_changing_speed, shift_length, common_parameter, parameter);
 

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -295,7 +295,8 @@ std::pair<bool, bool> getLaneChangePaths(
     std::invoke([&minimum_lane_change_velocity, &current_velocity, &parameter]() {
       const double min_a =
         (minimum_lane_change_velocity - current_velocity) / parameter.lane_change_prepare_duration;
-      return std::clamp(min_a, -std::abs(parameter.maximum_deceleration), 0.0);
+      return std::clamp(
+        min_a, -std::abs(parameter.maximum_deceleration), -std::numeric_limits<double>::epsilon());
     });
 
   const auto acceleration_resolution = std::abs(maximum_deceleration) / lane_change_sampling_num;

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -338,7 +338,6 @@ std::pair<bool, bool> getLaneChangePaths(
   candidate_paths->reserve(lane_change_sampling_num);
   for (double acceleration = 0.0; acceleration >= maximum_deceleration;
        acceleration -= acceleration_resolution) {
-    std::cerr << "maximum_deceleration: " << maximum_deceleration << std::endl;
     const double prepare_speed =
       std::max(current_velocity + acceleration * prepare_duration, minimum_lane_change_velocity);
 

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -291,11 +291,11 @@ std::pair<bool, bool> getLaneChangePaths(
   const auto current_velocity = twist.linear.x;
 
   // compute maximum_deceleration
-  const double maximum_deceleration =
+  const auto maximum_deceleration =
     std::invoke([&minimum_lane_change_velocity, &current_velocity, &parameter]() {
       const double min_a =
         (minimum_lane_change_velocity - current_velocity) / parameter.lane_change_prepare_duration;
-      return std::clamp(min_a, -std::fabs(parameter.maximum_deceleration), 0.0);
+      return std::clamp(min_a, -std::abs(parameter.maximum_deceleration), 0.0);
     });
 
   const auto acceleration_resolution = std::abs(maximum_deceleration) / lane_change_sampling_num;
@@ -338,7 +338,7 @@ std::pair<bool, bool> getLaneChangePaths(
   candidate_paths->reserve(lane_change_sampling_num);
   for (double acceleration = 0.0; acceleration >= maximum_deceleration;
        acceleration -= acceleration_resolution) {
-    const double prepare_speed =
+    const auto prepare_speed =
       std::max(current_velocity + acceleration * prepare_duration, minimum_lane_change_velocity);
 
     // get path on original lanes


### PR DESCRIPTION
## Description
Since the current code does not consider the maximum acceleration values correctly, I recalculated the maximum deceleration values using the minimum lane changing speed and current speed. Moreover, I fixed the prepared distance by adding the minimum velocity of the lane changing speed.

Scenario Test 1198/1199
[Tier4 Internal Link](https://evaluation.tier4.jp/evaluation/reports/73b5d228-56ec-505d-ae31-682bfee9a812?project_id=prd_jt)
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
