### PR TITLE
chore(motion_utils): remove validCheckDecelPlan error message

### DIFF
--- a/common/motion_utils/src/distance/distance.cpp
+++ b/common/motion_utils/src/distance/distance.cpp
@@ -28,13 +28,9 @@ bool validCheckDecelPlan(
   const double a_max = a_target + std::abs(a_margin);
 
   if (v_end < v_min || v_max < v_end) {
-    std::cerr << "[validCheckDecelPlan] valid check error! v_target = " << v_target
-              << ", v_end = " << v_end << std::endl;
     return false;
   }
   if (a_end < a_min || a_max < a_end) {
-    std::cerr << "[validCheckDecelPlan] valid check error! a_target = " << a_target
-              << ", a_end = " << a_end << std::endl;
     return false;
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

remove noisy error message of `validCheckDecelPlan`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
