### PR TITLE
fix(behavior_path_planner): not re-define registered_modules_

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
@@ -29,14 +29,14 @@
 namespace behavior_path_planner
 {
 
-class AvoidanceModuleManager : public SceneModuleManagerInterface
+class AvoidanceModuleManager : public SceneModuleManagerInterface<AvoidanceModule>
 {
 public:
   AvoidanceModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
     const std::shared_ptr<AvoidanceParameters> & parameters);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  std::shared_ptr<AvoidanceModule> createNewSceneModuleInstance() override
   {
     return std::make_shared<AvoidanceModule>(
       name_, *node_, parameters_, rtc_interface_left_, rtc_interface_right_);
@@ -50,8 +50,6 @@ private:
   std::shared_ptr<RTCInterface> rtc_interface_right_;
 
   std::shared_ptr<AvoidanceParameters> parameters_;
-
-  std::vector<std::shared_ptr<AvoidanceModule>> registered_modules_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
@@ -28,7 +28,7 @@
 namespace behavior_path_planner
 {
 
-class LaneChangeModuleManager : public SceneModuleManagerInterface
+class LaneChangeModuleManager : public SceneModuleManagerInterface<LaneChangeModule>
 {
 public:
   LaneChangeModuleManager(
@@ -36,7 +36,7 @@ public:
     std::shared_ptr<LaneChangeParameters> parameters, const Direction direction,
     const LaneChangeModuleType type);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  std::shared_ptr<LaneChangeModule> createNewSceneModuleInstance() override
   {
     return std::make_shared<LaneChangeModule>(
       name_, *node_, parameters_, rtc_interface_, direction_, type_);
@@ -48,8 +48,6 @@ private:
   std::shared_ptr<RTCInterface> rtc_interface_;
 
   std::shared_ptr<LaneChangeParameters> parameters_;
-
-  std::vector<std::shared_ptr<LaneChangeModule>> registered_modules_;
 
   Direction direction_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/manager.hpp
@@ -27,14 +27,14 @@
 namespace behavior_path_planner
 {
 
-class PullOutModuleManager : public SceneModuleManagerInterface
+class PullOutModuleManager : public SceneModuleManagerInterface<PullOutModule>
 {
 public:
   PullOutModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
     const std::shared_ptr<PullOutParameters> & parameters);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  std::shared_ptr<PullOutModule> createNewSceneModuleInstance() override
   {
     return std::make_shared<PullOutModule>(name_, *node_, parameters_, rtc_interface_);
   }
@@ -45,8 +45,6 @@ private:
   std::shared_ptr<PullOutParameters> parameters_;
 
   std::shared_ptr<RTCInterface> rtc_interface_;
-
-  std::vector<std::shared_ptr<PullOutModule>> registered_modules_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/manager.hpp
@@ -27,14 +27,14 @@
 namespace behavior_path_planner
 {
 
-class PullOverModuleManager : public SceneModuleManagerInterface
+class PullOverModuleManager : public SceneModuleManagerInterface<PullOverModule>
 {
 public:
   PullOverModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
     const std::shared_ptr<PullOverParameters> & parameters);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  std::shared_ptr<PullOverModule> createNewSceneModuleInstance() override
   {
     return std::make_shared<PullOverModule>(name_, *node_, parameters_, rtc_interface_);
   }
@@ -45,8 +45,6 @@ private:
   std::shared_ptr<PullOverParameters> parameters_;
 
   std::shared_ptr<RTCInterface> rtc_interface_;
-
-  std::vector<std::shared_ptr<PullOverModule>> registered_modules_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -34,10 +34,12 @@ namespace behavior_path_planner
 
 using tier4_autoware_utils::toHexString;
 using unique_identifier_msgs::msg::UUID;
-using SceneModulePtr = std::shared_ptr<SceneModuleInterface>;
 
+template <typename T>
 class SceneModuleManagerInterface
 {
+  using SceneModulePtr = std::shared_ptr<T>;
+
 public:
   SceneModuleManagerInterface(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config)
@@ -156,7 +158,10 @@ public:
   virtual void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) = 0;
 
 protected:
-  virtual std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() = 0;
+  virtual std::shared_ptr<T> createNewSceneModuleInstance()
+  {
+    return std::make_shared<T>(name_, *node_, parameters_);
+  }
 
   rclcpp::Node * node_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
@@ -28,24 +28,17 @@
 namespace behavior_path_planner
 {
 
-class SideShiftModuleManager : public SceneModuleManagerInterface
+class SideShiftModuleManager : public SceneModuleManagerInterface<SideShiftModule>
 {
 public:
   SideShiftModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
     const std::shared_ptr<SideShiftParameters> & parameters);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
-  {
-    return std::make_shared<SideShiftModule>(name_, *node_, parameters_);
-  }
-
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
 private:
   std::shared_ptr<SideShiftParameters> parameters_;
-
-  std::vector<std::shared_ptr<SideShiftModule>> registered_modules_;
 };
 
 }  // namespace behavior_path_planner


### PR DESCRIPTION
## Description

How to hold `registered_modules_` variable in SceneModuleManagerInterface and its derived classes seems wrong.
Currently, SceneModuleManagerInterface and its derived classes both have `registered_modules_` variable where they are assumed as the same variable though they are not.

The following code is a simple case to express the bug I referred to.
https://wandbox.org/permlink/1bLR2OMFJRirt30J

I think this PR fixes the bug.

TODO
- [ ] check if planning simulator works well with the PR.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
