### PR TITLE
refactor(behavior_path_planner): unify onEntry/Exit function

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -61,8 +61,8 @@ public:
   BehaviorModuleOutput plan() override;
   CandidateOutput planCandidate() const override;
   BehaviorModuleOutput planWaitingApproval() override;
-  void onEntry() override;
-  void onExit() override;
+  void processOnEntry() override;
+  void processOnExit() override;
   void updateData() override;
   void acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const override;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
@@ -67,8 +67,8 @@ public:
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   CandidateOutput planCandidate() const override;
-  void onEntry() override;
-  void onExit() override;
+  void processOnEntry() override;
+  void processOnExit() override;
 
   std::shared_ptr<LaneChangeDebugMsgArray> get_debug_msg_array() const;
   void acceptVisitor(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -69,8 +69,8 @@ public:
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   CandidateOutput planCandidate() const override;
-  void onEntry() override;
-  void onExit() override;
+  void processOnEntry() override;
+  void processOnExit() override;
 
   std::shared_ptr<LaneChangeDebugMsgArray> get_debug_msg_array() const;
   void acceptVisitor(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_following/lane_following_module.hpp
@@ -42,8 +42,8 @@ public:
   BT::NodeStatus updateState() override;
   BehaviorModuleOutput plan() override;
   CandidateOutput planCandidate() const override;
-  void onEntry() override;
-  void onExit() override;
+  void processOnEntry() override;
+  void processOnExit() override;
 
   void setParameters(const std::shared_ptr<LaneFollowingParameters> & parameters);
   void acceptVisitor(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
@@ -88,8 +88,8 @@ public:
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   CandidateOutput planCandidate() const override;
-  void onEntry() override;
-  void onExit() override;
+  void processOnEntry() override;
+  void processOnExit() override;
 
   void setParameters(const std::shared_ptr<PullOutParameters> & parameters)
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
@@ -110,8 +110,8 @@ public:
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   CandidateOutput planCandidate() const override;
-  void onEntry() override;
-  void onExit() override;
+  void processOnEntry() override;
+  void processOnExit() override;
 
   void setParameters(const std::shared_ptr<PullOverParameters> & parameters);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -155,12 +155,38 @@ public:
   /**
    * @brief Called on the first time when the module goes into RUNNING.
    */
-  virtual void onEntry() = 0;
+  void onEntry()
+  {
+    RCLCPP_DEBUG(getLogger(), "%s %s", name_.c_str(), __func__);
+
+#ifdef USE_OLD_ARCHITECTURE
+    current_state_ = ModuleStatus::SUCCESS;
+#else
+    current_state_ = ModuleStatus::IDLE;
+#endif
+
+    processOnEntry();
+  }
+
+  virtual void processOnEntry() {}
 
   /**
    * @brief Called when the module exit from RUNNING.
    */
-  virtual void onExit() = 0;
+  void onExit()
+  {
+    RCLCPP_DEBUG(getLogger(), "%s %s", name_.c_str(), __func__);
+
+    current_state_ = ModuleStatus::SUCCESS;
+    clearWaitingApproval();
+    removeRTCStatus();
+    unlockNewModuleLaunch();
+    steering_factor_interface_ptr_->clearSteeringFactors();
+
+    processOnExit();
+  }
+
+  virtual void processOnExit() {}
 
   /**
    * @brief Publish status if the module is requested to run

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -52,8 +52,8 @@ public:
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   CandidateOutput planCandidate() const override;
-  void onEntry() override;
-  void onExit() override;
+  void processOnEntry() override;
+  void processOnExit() override;
 
   void setParameters(const std::shared_ptr<SideShiftParameters> & parameters);
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3581,9 +3581,15 @@ void AvoidanceModule::compensateDetectionLost(
   DEBUG_PRINT("object size: %lu -> %lu", old_size, now_objects.size());
 }
 
-void AvoidanceModule::processOnEntry() { initVariables(); }
+void AvoidanceModule::processOnEntry()
+{
+  initVariables();
+}
 
-void AvoidanceModule::processOnExit() { initVariables(); }
+void AvoidanceModule::processOnExit()
+{
+  initVariables();
+}
 
 void AvoidanceModule::initVariables()
 {

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3581,27 +3581,9 @@ void AvoidanceModule::compensateDetectionLost(
   DEBUG_PRINT("object size: %lu -> %lu", old_size, now_objects.size());
 }
 
-void AvoidanceModule::onEntry()
-{
-  DEBUG_PRINT("AVOIDANCE onEntry. wait approval!");
-  initVariables();
-#ifdef USE_OLD_ARCHITECTURE
-  current_state_ = ModuleStatus::SUCCESS;
-#else
-  current_state_ = ModuleStatus::IDLE;
-#endif
-}
+void AvoidanceModule::processOnEntry() { initVariables(); }
 
-void AvoidanceModule::onExit()
-{
-  DEBUG_PRINT("AVOIDANCE onExit");
-  initVariables();
-  current_state_ = ModuleStatus::SUCCESS;
-  clearWaitingApproval();
-  removeRTCStatus();
-  unlockNewModuleLaunch();
-  steering_factor_interface_ptr_->clearSteeringFactors();
-}
+void AvoidanceModule::processOnExit() { initVariables(); }
 
 void AvoidanceModule::initVariables()
 {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -50,20 +50,13 @@ ExternalRequestLaneChangeModule::ExternalRequestLaneChangeModule(
     std::make_unique<SteeringFactorInterface>(&node, getTopicName(direction));
 }
 
-void ExternalRequestLaneChangeModule::onEntry()
+void ExternalRequestLaneChangeModule::processOnEntry()
 {
-  RCLCPP_DEBUG(getLogger(), "LANE_CHANGE onEntry");
-  current_state_ = BT::NodeStatus::SUCCESS;
   current_lane_change_state_ = LaneChangeStates::Normal;
   updateLaneChangeStatus();
 }
 
-void ExternalRequestLaneChangeModule::onExit()
-{
-  resetParameters();
-  current_state_ = BT::NodeStatus::SUCCESS;
-  RCLCPP_DEBUG(getLogger(), "LANE_CHANGE onExit");
-}
+void ExternalRequestLaneChangeModule::processOnExit() { resetParameters(); }
 
 bool ExternalRequestLaneChangeModule::isExecutionRequested() const
 {
@@ -742,10 +735,7 @@ void ExternalRequestLaneChangeModule::calcTurnSignalInfo()
 
 void ExternalRequestLaneChangeModule::resetParameters()
 {
-  clearWaitingApproval();
-  removeRTCStatus();
   resetPathCandidate();
-  steering_factor_interface_ptr_->clearSteeringFactors();
   object_debug_.clear();
   debug_marker_.markers.clear();
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -56,7 +56,10 @@ void ExternalRequestLaneChangeModule::processOnEntry()
   updateLaneChangeStatus();
 }
 
-void ExternalRequestLaneChangeModule::processOnExit() { resetParameters(); }
+void ExternalRequestLaneChangeModule::processOnExit()
+{
+  resetParameters();
+}
 
 bool ExternalRequestLaneChangeModule::isExecutionRequested() const
 {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -61,25 +61,16 @@ LaneChangeModule::LaneChangeModule(
 }
 #endif
 
-void LaneChangeModule::onEntry()
+void LaneChangeModule::processOnEntry()
 {
-  RCLCPP_DEBUG(getLogger(), "LANE_CHANGE onEntry");
-#ifdef USE_OLD_ARCHITECTURE
-  current_state_ = ModuleStatus::SUCCESS;
-#else
-  current_state_ = ModuleStatus::IDLE;
+#ifndef USE_OLD_ARCHITECTURE
   waitApproval();
 #endif
   current_lane_change_state_ = LaneChangeStates::Normal;
   updateLaneChangeStatus();
 }
 
-void LaneChangeModule::onExit()
-{
-  resetParameters();
-  current_state_ = ModuleStatus::SUCCESS;
-  RCLCPP_DEBUG(getLogger(), "LANE_CHANGE onExit");
-}
+void LaneChangeModule::processOnExit() { resetParameters(); }
 
 bool LaneChangeModule::isExecutionRequested() const
 {
@@ -874,10 +865,6 @@ void LaneChangeModule::resetParameters()
   current_lane_change_state_ = LaneChangeStates::Normal;
   abort_path_ = nullptr;
 
-  clearWaitingApproval();
-  unlockNewModuleLaunch();
-  removeRTCStatus();
-  steering_factor_interface_ptr_->clearSteeringFactors();
   object_debug_.clear();
   debug_marker_.markers.clear();
   resetPathCandidate();

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -70,7 +70,10 @@ void LaneChangeModule::processOnEntry()
   updateLaneChangeStatus();
 }
 
-void LaneChangeModule::processOnExit() { resetParameters(); }
+void LaneChangeModule::processOnExit()
+{
+  resetParameters();
+}
 
 bool LaneChangeModule::isExecutionRequested() const
 {

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -30,6 +30,9 @@ LaneFollowingModule::LaneFollowingModule(
 : SceneModuleInterface{name, node}, parameters_{parameters}
 {
   initParam();
+  // TODO(murooka) The following is temporary implementation for new architecture's refactoring
+  steering_factor_interface_ptr_ =
+    std::make_unique<SteeringFactorInterface>(&node, "lane_following");
 }
 
 void LaneFollowingModule::initParam()
@@ -65,13 +68,11 @@ CandidateOutput LaneFollowingModule::planCandidate() const
 }
 void LaneFollowingModule::processOnEntry()
 {
-  // TODO(murooka)
   initParam();
   current_state_ = BT::NodeStatus::RUNNING;
 }
 void LaneFollowingModule::processOnExit()
 {
-  // TODO(murooka)
   initParam();
   current_state_ = BT::NodeStatus::SUCCESS;
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -63,17 +63,17 @@ CandidateOutput LaneFollowingModule::planCandidate() const
 {
   return CandidateOutput(getReferencePath());
 }
-void LaneFollowingModule::onEntry()
+void LaneFollowingModule::processOnEntry()
 {
+  // TODO(murooka)
   initParam();
   current_state_ = BT::NodeStatus::RUNNING;
-  RCLCPP_DEBUG(getLogger(), "LANE_FOLLOWING onEntry");
 }
-void LaneFollowingModule::onExit()
+void LaneFollowingModule::processOnExit()
 {
+  // TODO(murooka)
   initParam();
   current_state_ = BT::NodeStatus::SUCCESS;
-  RCLCPP_DEBUG(getLogger(), "LANE_FOLLOWING onExit");
 }
 
 void LaneFollowingModule::setParameters(const std::shared_ptr<LaneFollowingParameters> & parameters)

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -132,7 +132,6 @@ void PullOutModule::processOnEntry()
 
 void PullOutModule::processOnExit()
 {
-  // TODO(murooka) unlockNewModuleLaunch was missing
   resetPathCandidate();
   resetPathReference();
 }

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -102,15 +102,8 @@ BehaviorModuleOutput PullOutModule::run()
   return plan();
 }
 
-void PullOutModule::onEntry()
+void PullOutModule::processOnEntry()
 {
-  RCLCPP_DEBUG(getLogger(), "PULL_OUT onEntry");
-#ifdef USE_OLD_ARCHITECTURE
-  current_state_ = ModuleStatus::SUCCESS;
-#else
-  current_state_ = ModuleStatus::IDLE;
-#endif
-
   // initialize when receiving new route
   if (
     last_route_received_time_ == nullptr ||
@@ -137,15 +130,11 @@ void PullOutModule::onEntry()
   updatePullOutStatus();
 }
 
-void PullOutModule::onExit()
+void PullOutModule::processOnExit()
 {
-  clearWaitingApproval();
-  removeRTCStatus();
-  steering_factor_interface_ptr_->clearSteeringFactors();
+  // TODO(murooka) unlockNewModuleLaunch was missing
   resetPathCandidate();
   resetPathReference();
-  current_state_ = ModuleStatus::SUCCESS;
-  RCLCPP_DEBUG(getLogger(), "PULL_OUT onExit");
 }
 
 bool PullOutModule::isExecutionRequested() const

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -306,7 +306,6 @@ void PullOverModule::processOnEntry()
 
 void PullOverModule::processOnExit()
 {
-  // TODO(murooka) unlockNewModuleLaunch was missing
   resetPathCandidate();
   resetPathReference();
   debug_marker_.markers.clear();

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -264,15 +264,8 @@ ParallelParkingParameters PullOverModule::getGeometricPullOverParameters() const
   return params;
 }
 
-void PullOverModule::onEntry()
+void PullOverModule::processOnEntry()
 {
-  RCLCPP_DEBUG(getLogger(), "PULL_OVER onEntry");
-#ifdef USE_OLD_ARCHITECTURE
-  current_state_ = ModuleStatus::SUCCESS;
-#else
-  current_state_ = ModuleStatus::IDLE;
-#endif
-
   // Initialize occupancy grid map
   if (parameters_->use_occupancy_grid) {
     OccupancyGridMapParam occupancy_grid_map_param{};
@@ -311,16 +304,12 @@ void PullOverModule::onEntry()
     std::make_unique<rclcpp::Time>(planner_data_->route_handler->getRouteHeader().stamp);
 }
 
-void PullOverModule::onExit()
+void PullOverModule::processOnExit()
 {
-  RCLCPP_DEBUG(getLogger(), "PULL_OVER onExit");
-  clearWaitingApproval();
-  removeRTCStatus();
+  // TODO(murooka) unlockNewModuleLaunch was missing
   resetPathCandidate();
   resetPathReference();
-  steering_factor_interface_ptr_->clearSteeringFactors();
   debug_marker_.markers.clear();
-  current_state_ = ModuleStatus::SUCCESS;
 }
 
 bool PullOverModule::isExecutionRequested() const

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -64,20 +64,17 @@ void SideShiftModule::initVariables()
   resetPathReference();
 }
 
-void SideShiftModule::onEntry()
+void SideShiftModule::processOnEntry()
 {
   // write me... (Don't initialize variables, otherwise lateral offset gets zero on entry.)
   start_pose_reset_request_ = false;
-#ifdef USE_OLD_ARCHITECTURE
-  current_state_ = ModuleStatus::IDLE;
-#endif
 }
 
-void SideShiftModule::onExit()
+void SideShiftModule::processOnExit()
 {
   // write me...
   initVariables();
-  current_state_ = ModuleStatus::SUCCESS;
+  // TODO(murooka) lots of process was missing compared to other modules
 }
 
 void SideShiftModule::setParameters(const std::shared_ptr<SideShiftParameters> & parameters)

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -45,6 +45,9 @@ SideShiftModule::SideShiftModule(
     "~/input/lateral_offset", 1, std::bind(&SideShiftModule::onLateralOffset, this, _1));
 #endif
 
+  // TODO(murooka) The following is temporary implementation for new architecture's refactoring
+  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "sideshift");
+
   // If lateral offset is subscribed, it approves side shift module automatically
   clearWaitingApproval();
 }
@@ -74,7 +77,6 @@ void SideShiftModule::processOnExit()
 {
   // write me...
   initVariables();
-  // TODO(murooka) lots of process was missing compared to other modules
 }
 
 void SideShiftModule::setParameters(const std::shared_ptr<SideShiftParameters> & parameters)

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -46,7 +46,7 @@ SideShiftModule::SideShiftModule(
 #endif
 
   // TODO(murooka) The following is temporary implementation for new architecture's refactoring
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "sideshift");
+  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "side_shift");
 
   // If lateral offset is subscribed, it approves side shift module automatically
   clearWaitingApproval();


### PR DESCRIPTION
## Description

With the current implementation of SceneModuleInterface, we have to follow an implicit rule with redundant implementation when implementing `onEntry` and `onExit` in detailed modules
Also the most part of the implicit rule is common which calls
- clearWaitingApproval
- removeRTCStatus
- unlockNewModuleLaunch
- etc.

As a refactoring, I split `onEntry` into new `onEntry` and `processOnEntry` where new `onEntry` has the above rule's implementation so that in detailed modules we just implement extra process in `processOnEntry`.
The same change was done to `onExit`.

This refactoring helps developers with creating a new module in the behavior_path_planner by removing the implicit rule and redundant implementation.

- TODO
    - [x] resolve TODOs in changes
    - [x] check if planning simulator works well
    - [x] check scenario tests
        - [x] with BT: 1198/1199 https://evaluation.tier4.jp/evaluation/reports/471d4294-ac37-5fd1-a367-9defd0e31260?project_id=prd_jt
            - baseline: 1198/1199
        - [x] without BT: 1191/1199 https://evaluation.tier4.jp/evaluation/reports/6a798758-8612-5131-8200-c4586fcf071b?project_id=prd_jt
            - baseline: 1187/1199 https://evaluation.tier4.jp/evaluation/reports/f3654846-17fd-534b-a1f1-ffcf8495ca25?project_id=prd_jt

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
