### PR TITLE
refactor(behavior_path_planner): unify rtc_interface_ptr in SceneModuleInterface

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -49,9 +49,7 @@ public:
     const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters);
 #else
   AvoidanceModule(
-    const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters,
-    std::shared_ptr<RTCInterface> & rtc_interface_left,
-    std::shared_ptr<RTCInterface> & rtc_interface_right);
+    const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters);
 #endif
 
   bool isExecutionRequested() const override;
@@ -72,35 +70,6 @@ public:
     parameters_ = parameters;
   }
 #endif
-
-  void publishRTCStatus() override
-  {
-    rtc_interface_left_->publishCooperateStatus(clock_->now());
-    rtc_interface_right_->publishCooperateStatus(clock_->now());
-  }
-
-  bool isActivated() override
-  {
-    if (rtc_interface_left_->isRegistered(uuid_left_)) {
-      return rtc_interface_left_->isActivated(uuid_left_);
-    }
-    if (rtc_interface_right_->isRegistered(uuid_right_)) {
-      return rtc_interface_right_->isActivated(uuid_right_);
-    }
-    return false;
-  }
-
-  void lockRTCCommand() override
-  {
-    rtc_interface_left_->lockCommandUpdate();
-    rtc_interface_right_->lockCommandUpdate();
-  }
-
-  void unlockRTCCommand() override
-  {
-    rtc_interface_left_->unlockCommandUpdate();
-    rtc_interface_right_->unlockCommandUpdate();
-  }
   std::shared_ptr<AvoidanceDebugMsgArray> get_debug_msg_array() const;
 
 private:
@@ -118,29 +87,24 @@ private:
 
   PathShifter path_shifter_;
 
-  std::shared_ptr<RTCInterface> rtc_interface_left_;
-  std::shared_ptr<RTCInterface> rtc_interface_right_;
-
   RegisteredShiftLineArray left_shift_array_;
   RegisteredShiftLineArray right_shift_array_;
   UUID candidate_uuid_;
-  UUID uuid_left_;
-  UUID uuid_right_;
 
   void updateCandidateRTCStatus(const CandidateOutput & candidate)
   {
     if (candidate.lateral_shift > 0.0) {
-      rtc_interface_left_->updateCooperateStatus(
-        uuid_left_, isExecutionReady(), candidate.start_distance_to_path_change,
+      rtc_interface_ptr_vec_.at(0)->updateCooperateStatus(
+        uuid_vec_.at(0), isExecutionReady(), candidate.start_distance_to_path_change,
         candidate.finish_distance_to_path_change, clock_->now());
-      candidate_uuid_ = uuid_left_;
+      candidate_uuid_ = uuid_vec_.at(0);
       return;
     }
     if (candidate.lateral_shift < 0.0) {
-      rtc_interface_right_->updateCooperateStatus(
-        uuid_right_, isExecutionReady(), candidate.start_distance_to_path_change,
+      rtc_interface_ptr_vec_.at(1)->updateCooperateStatus(
+        uuid_vec_.at(1), isExecutionReady(), candidate.start_distance_to_path_change,
         candidate.finish_distance_to_path_change, clock_->now());
-      candidate_uuid_ = uuid_right_;
+      candidate_uuid_ = uuid_vec_.at(1);
       return;
     }
 
@@ -158,7 +122,7 @@ private:
         calcSignedArcLength(path.points, ego_position, left_shift.start_pose.position);
       const double finish_distance =
         calcSignedArcLength(path.points, ego_position, left_shift.finish_pose.position);
-      rtc_interface_left_->updateCooperateStatus(
+      rtc_interface_ptr_vec_.at(0)->updateCooperateStatus(
         left_shift.uuid, true, start_distance, finish_distance, clock_->now());
       if (finish_distance > -1.0e-03) {
         steering_factor_interface_ptr_->updateSteeringFactor(
@@ -172,7 +136,7 @@ private:
         calcSignedArcLength(path.points, ego_position, right_shift.start_pose.position);
       const double finish_distance =
         calcSignedArcLength(path.points, ego_position, right_shift.finish_pose.position);
-      rtc_interface_right_->updateCooperateStatus(
+      rtc_interface_ptr_vec_.at(1)->updateCooperateStatus(
         right_shift.uuid, true, start_distance, finish_distance, clock_->now());
       if (finish_distance > -1.0e-03) {
         steering_factor_interface_ptr_->updateSteeringFactor(
@@ -183,32 +147,26 @@ private:
     }
   }
 
-  void removeRTCStatus() override
-  {
-    rtc_interface_left_->clearCooperateStatus();
-    rtc_interface_right_->clearCooperateStatus();
-  }
-
   void removeCandidateRTCStatus()
   {
-    if (rtc_interface_left_->isRegistered(candidate_uuid_)) {
-      rtc_interface_left_->removeCooperateStatus(candidate_uuid_);
-    } else if (rtc_interface_right_->isRegistered(candidate_uuid_)) {
-      rtc_interface_right_->removeCooperateStatus(candidate_uuid_);
+    if (rtc_interface_ptr_vec_.at(0)->isRegistered(candidate_uuid_)) {
+      rtc_interface_ptr_vec_.at(0)->removeCooperateStatus(candidate_uuid_);
+    } else if (rtc_interface_ptr_vec_.at(1)->isRegistered(candidate_uuid_)) {
+      rtc_interface_ptr_vec_.at(1)->removeCooperateStatus(candidate_uuid_);
     }
   }
 
   void removePreviousRTCStatusLeft()
   {
-    if (rtc_interface_left_->isRegistered(uuid_left_)) {
-      rtc_interface_left_->removeCooperateStatus(uuid_left_);
+    if (rtc_interface_ptr_vec_.at(0)->isRegistered(uuid_vec_.at(0))) {
+      rtc_interface_ptr_vec_.at(0)->removeCooperateStatus(uuid_vec_.at(0));
     }
   }
 
   void removePreviousRTCStatusRight()
   {
-    if (rtc_interface_right_->isRegistered(uuid_right_)) {
-      rtc_interface_right_->removeCooperateStatus(uuid_right_);
+    if (rtc_interface_ptr_vec_.at(1)->isRegistered(uuid_vec_.at(1))) {
+      rtc_interface_ptr_vec_.at(1)->removeCooperateStatus(uuid_vec_.at(1));
     }
   }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
@@ -38,17 +38,12 @@ public:
 
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<AvoidanceModule>(
-      name_, *node_, parameters_, rtc_interface_left_, rtc_interface_right_);
+    return std::make_shared<AvoidanceModule>(name_, *node_, parameters_, {"left", "right"});
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
 private:
-  std::shared_ptr<RTCInterface> rtc_interface_left_;
-
-  std::shared_ptr<RTCInterface> rtc_interface_right_;
-
   std::shared_ptr<AvoidanceParameters> parameters_;
 
   std::vector<std::shared_ptr<AvoidanceModule>> registered_modules_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
@@ -38,7 +38,7 @@ public:
 
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<AvoidanceModule>(name_, *node_, parameters_, {"left", "right"});
+    return std::make_shared<AvoidanceModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -59,8 +59,9 @@ public:
 #else
   LaneChangeModule(
     const std::string & name, rclcpp::Node & node,
-    const std::shared_ptr<LaneChangeParameters> & parameters, Direction direction,
-    LaneChangeModuleType type);
+    const std::shared_ptr<LaneChangeParameters> & parameters,
+    const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map,
+    Direction direction, LaneChangeModuleType type);
 #endif
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
@@ -110,32 +111,32 @@ private:
 #ifdef USE_OLD_ARCHITECTURE
   void waitApprovalLeft(const double start_distance, const double finish_distance)
   {
-    rtc_interface_ptr_vec_.at(0)->updateCooperateStatus(
-      uuid_vec_.at(0), isExecutionReady(), start_distance, finish_distance, clock_->now());
+    rtc_interface_ptr_map_.at("left")->updateCooperateStatus(
+      uuid_map_.at("left"), isExecutionReady(), start_distance, finish_distance, clock_->now());
     is_waiting_approval_ = true;
   }
 
   void waitApprovalRight(const double start_distance, const double finish_distance)
   {
-    rtc_interface_ptr_vec_.at(1)->updateCooperateStatus(
-      uuid_vec_.at(1), isExecutionReady(), start_distance, finish_distance, clock_->now());
+    rtc_interface_ptr_map_.at("right")->updateCooperateStatus(
+      uuid_map_.at("right"), isExecutionReady(), start_distance, finish_distance, clock_->now());
     is_waiting_approval_ = true;
   }
 
   void updateRTCStatus(const CandidateOutput & candidate)
   {
     if (candidate.lateral_shift > 0.0) {
-      rtc_interface_ptr_vec_.at(0)->updateCooperateStatus(
-        uuid_vec_.at(0), isExecutionReady(), candidate.start_distance_to_path_change,
+      rtc_interface_ptr_map_.at("left")->updateCooperateStatus(
+        uuid_map_.at("left"), isExecutionReady(), candidate.start_distance_to_path_change,
         candidate.finish_distance_to_path_change, clock_->now());
-      candidate_uuid_ = uuid_vec_.at(0);
+      candidate_uuid_ = uuid_map_.at("left");
       return;
     }
     if (candidate.lateral_shift < 0.0) {
-      rtc_interface_ptr_vec_.at(1)->updateCooperateStatus(
-        uuid_vec_.at(1), isExecutionReady(), candidate.start_distance_to_path_change,
+      rtc_interface_ptr_map_.at("right")->updateCooperateStatus(
+        uuid_map_.at("right"), isExecutionReady(), candidate.start_distance_to_path_change,
         candidate.finish_distance_to_path_change, clock_->now());
-      candidate_uuid_ = uuid_vec_.at(1);
+      candidate_uuid_ = uuid_map_.at("right");
       return;
     }
 
@@ -146,15 +147,15 @@ private:
 
   void removePreviousRTCStatusLeft()
   {
-    if (rtc_interface_ptr_vec_.at(0)->isRegistered(uuid_vec_.at(0))) {
-      rtc_interface_ptr_vec_.at(0)->removeCooperateStatus(uuid_vec_.at(0));
+    if (rtc_interface_ptr_map_.at("left")->isRegistered(uuid_map_.at("left"))) {
+      rtc_interface_ptr_map_.at("left")->removeCooperateStatus(uuid_map_.at("left"));
     }
   }
 
   void removePreviousRTCStatusRight()
   {
-    if (rtc_interface_ptr_vec_.at(1)->isRegistered(uuid_vec_.at(1))) {
-      rtc_interface_ptr_vec_.at(1)->removeCooperateStatus(uuid_vec_.at(1));
+    if (rtc_interface_ptr_map_.at("right")->isRegistered(uuid_map_.at("right"))) {
+      rtc_interface_ptr_map_.at("right")->removeCooperateStatus(uuid_map_.at("right"));
     }
   }
 #endif

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
@@ -39,7 +39,7 @@ public:
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
     return std::make_shared<LaneChangeModule>(
-      name_, *node_, parameters_, {"left", "right"}, direction_, type_);
+      name_, *node_, parameters_, rtc_interface_ptr_map_, direction_, type_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
@@ -39,14 +39,12 @@ public:
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
     return std::make_shared<LaneChangeModule>(
-      name_, *node_, parameters_, rtc_interface_, direction_, type_);
+      name_, *node_, parameters_, {"left", "right"}, direction_, type_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
 private:
-  std::shared_ptr<RTCInterface> rtc_interface_;
-
   std::shared_ptr<LaneChangeParameters> parameters_;
 
   std::vector<std::shared_ptr<LaneChangeModule>> registered_modules_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/manager.hpp
@@ -36,7 +36,7 @@ public:
 
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<PullOutModule>(name_, *node_, parameters_);
+    return std::make_shared<PullOutModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/manager.hpp
@@ -36,15 +36,13 @@ public:
 
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<PullOutModule>(name_, *node_, parameters_, rtc_interface_);
+    return std::make_shared<PullOutModule>(name_, *node_, parameters_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
 private:
   std::shared_ptr<PullOutParameters> parameters_;
-
-  std::shared_ptr<RTCInterface> rtc_interface_;
 
   std::vector<std::shared_ptr<PullOutModule>> registered_modules_;
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
@@ -70,8 +70,7 @@ public:
 #else
   PullOutModule(
     const std::string & name, rclcpp::Node & node,
-    const std::shared_ptr<PullOutParameters> & parameters,
-    const std::shared_ptr<RTCInterface> & rtc_interface);
+    const std::shared_ptr<PullOutParameters> & parameters);
 
   void updateModuleParams(const std::shared_ptr<PullOutParameters> & parameters)
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
@@ -36,6 +36,7 @@
 #include <deque>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -70,7 +71,8 @@ public:
 #else
   PullOutModule(
     const std::string & name, rclcpp::Node & node,
-    const std::shared_ptr<PullOutParameters> & parameters);
+    const std::shared_ptr<PullOutParameters> & parameters,
+    const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map);
 
   void updateModuleParams(const std::shared_ptr<PullOutParameters> & parameters)
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/manager.hpp
@@ -36,7 +36,7 @@ public:
 
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<PullOverModule>(name_, *node_, parameters_);
+    return std::make_shared<PullOverModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/manager.hpp
@@ -36,15 +36,13 @@ public:
 
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<PullOverModule>(name_, *node_, parameters_, rtc_interface_);
+    return std::make_shared<PullOverModule>(name_, *node_, parameters_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
 private:
   std::shared_ptr<PullOverParameters> parameters_;
-
-  std::shared_ptr<RTCInterface> rtc_interface_;
 
   std::vector<std::shared_ptr<PullOverModule>> registered_modules_;
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
@@ -35,6 +35,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -92,7 +93,8 @@ public:
 #else
   PullOverModule(
     const std::string & name, rclcpp::Node & node,
-    const std::shared_ptr<PullOverParameters> & parameters);
+    const std::shared_ptr<PullOverParameters> & parameters,
+    const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map);
 
   void updateModuleParams(const std::shared_ptr<PullOverParameters> & parameters)
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
@@ -92,8 +92,7 @@ public:
 #else
   PullOverModule(
     const std::string & name, rclcpp::Node & node,
-    const std::shared_ptr<PullOverParameters> & parameters,
-    const std::shared_ptr<RTCInterface> & rtc_interface);
+    const std::shared_ptr<PullOverParameters> & parameters);
 
   void updateModuleParams(const std::shared_ptr<PullOverParameters> & parameters)
   {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -277,7 +277,7 @@ protected:
   {
     std::unordered_map<std::string, std::shared_ptr<RTCInterface>> rtc_interface_ptr_map;
     for (const auto & rtc_type : rtc_types) {
-      const auto rtc_interface_name = rtc_type == "" ? rtc_type : name + "_" + rtc_type;
+      const auto rtc_interface_name = rtc_type == "" ? name : name + "_" + rtc_type;
       rtc_interface_ptr_map.emplace(
         rtc_type, std::make_shared<RTCInterface>(&node, rtc_interface_name));
     }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -277,7 +277,9 @@ protected:
   {
     std::unordered_map<std::string, std::shared_ptr<RTCInterface>> rtc_interface_ptr_map;
     for (const auto & rtc_type : rtc_types) {
-      const auto rtc_interface_name = rtc_type == "" ? name : name + "_" + rtc_type;
+      const auto snake_case_name = util::convertToSnakeCase(name);
+      const auto rtc_interface_name =
+        rtc_type == "" ? snake_case_name : snake_case_name + "_" + rtc_type;
       rtc_interface_ptr_map.emplace(
         rtc_type, std::make_shared<RTCInterface>(&node, rtc_interface_name));
     }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -172,7 +172,7 @@ public:
   /**
    * @brief Publish status if the module is requested to run
    */
-  virtual void publishRTCStatus()
+  void publishRTCStatus()
   {
     for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
       if (itr->second) {
@@ -184,7 +184,7 @@ public:
   /**
    * @brief Return true if the activation command is received
    */
-  virtual bool isActivated()
+  bool isActivated()
   {
     for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
       if (itr->second->isRegistered(uuid_map_.at(itr->first))) {
@@ -194,7 +194,7 @@ public:
     return false;
   }
 
-  virtual void publishSteeringFactor()
+  void publishSteeringFactor()
   {
     if (!steering_factor_interface_ptr_) {
       return;
@@ -202,7 +202,7 @@ public:
     steering_factor_interface_ptr_->publishSteeringFactor(clock_->now());
   }
 
-  virtual void lockRTCCommand()
+  void lockRTCCommand()
   {
     for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
       if (itr->second) {
@@ -211,7 +211,7 @@ public:
     }
   }
 
-  virtual void unlockRTCCommand()
+  void unlockRTCCommand()
   {
     for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
       if (itr->second) {
@@ -297,7 +297,7 @@ protected:
     }
   }
 
-  virtual void removeRTCStatus()
+  void removeRTCStatus()
   {
     for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
       if (itr->second) {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -51,7 +51,9 @@ public:
     enable_simultaneous_execution_(config.enable_simultaneous_execution)
   {
     for (const auto & rtc_type : rtc_types) {
-      const auto rtc_interface_name = rtc_type == "" ? name : name + "_" + rtc_type;
+      const auto snake_case_name = util::convertToSnakeCase(name);
+      const auto rtc_interface_name =
+        rtc_type == "" ? snake_case_name : snake_case_name + "_" + rtc_type;
       rtc_interface_ptr_map_.emplace(
         rtc_type, std::make_shared<RTCInterface>(node, rtc_interface_name));
     }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -40,7 +40,8 @@ class SceneModuleManagerInterface
 {
 public:
   SceneModuleManagerInterface(
-    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config)
+    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
+    const std::vector<std::string> & rtc_types)
   : node_(node),
     clock_(*node->get_clock()),
     logger_(node->get_logger().get_child(name)),
@@ -49,6 +50,12 @@ public:
     priority_(config.priority),
     enable_simultaneous_execution_(config.enable_simultaneous_execution)
   {
+    for (const auto & rtc_type : rtc_types) {
+      const auto rtc_interface_name = rtc_type == "" ? rtc_type : name + "_" + rtc_type;
+      rtc_interface_ptr_map_.emplace(
+        rtc_type, std::make_shared<RTCInterface>(node, rtc_interface_name));
+    }
+
     pub_debug_marker_ = node->create_publisher<MarkerArray>("~/debug/" + name, 20);
   }
 
@@ -173,6 +180,8 @@ protected:
   std::vector<SceneModulePtr> registered_modules_;
 
   SceneModulePtr idling_module_;
+
+  std::unordered_map<std::string, std::shared_ptr<RTCInterface>> rtc_interface_ptr_map_;
 
 private:
   size_t max_module_num_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -51,7 +51,7 @@ public:
     enable_simultaneous_execution_(config.enable_simultaneous_execution)
   {
     for (const auto & rtc_type : rtc_types) {
-      const auto rtc_interface_name = rtc_type == "" ? rtc_type : name + "_" + rtc_type;
+      const auto rtc_interface_name = rtc_type == "" ? name : name + "_" + rtc_type;
       rtc_interface_ptr_map_.emplace(
         rtc_type, std::make_shared<RTCInterface>(node, rtc_interface_name));
     }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
@@ -37,7 +37,7 @@ public:
 
   std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<SideShiftModule>(name_, *node_, parameters_);
+    return std::make_shared<SideShiftModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -39,9 +40,16 @@ using tier4_planning_msgs::msg::LateralOffset;
 class SideShiftModule : public SceneModuleInterface
 {
 public:
+#ifdef USE_OLD_ARCHITECTURE
   SideShiftModule(
     const std::string & name, rclcpp::Node & node,
     const std::shared_ptr<SideShiftParameters> & parameters);
+#else
+  SideShiftModule(
+    const std::string & name, rclcpp::Node & node,
+    const std::shared_ptr<SideShiftParameters> & parameters,
+    const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map);
+#endif
 
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -535,6 +535,8 @@ double calcLaneChangeBuffer(
 
 lanelet::ConstLanelets getLaneletsFromPath(
   const PathWithLaneId & path, const std::shared_ptr<route_handler::RouteHandler> & route_handler);
+
+std::string convertToSnakeCase(const std::string & input_str);
 }  // namespace behavior_path_planner::util
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -48,6 +48,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -80,27 +80,15 @@ void pushUniqueVector(T & base_vector, const T & additional_vector)
 #ifdef USE_OLD_ARCHITECTURE
 AvoidanceModule::AvoidanceModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters)
-: SceneModuleInterface{name, node},
-  parameters_{std::move(parameters)},
-  uuid_left_{generateUUID()},
-  uuid_right_{generateUUID()}
+: SceneModuleInterface{name, node, {"left", "right"}}, parameters_{std::move(parameters)}
 {
   using std::placeholders::_1;
-  rtc_interface_left_ = std::make_shared<RTCInterface>(&node, "avoidance_left"),
-  rtc_interface_right_ = std::make_shared<RTCInterface>(&node, "avoidance_right"),
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "avoidance");
 }
 #else
 AvoidanceModule::AvoidanceModule(
-  const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters,
-  std::shared_ptr<RTCInterface> & rtc_interface_left,
-  std::shared_ptr<RTCInterface> & rtc_interface_right)
-: SceneModuleInterface{name, node},
-  parameters_{std::move(parameters)},
-  rtc_interface_left_{rtc_interface_left},
-  rtc_interface_right_{rtc_interface_right},
-  uuid_left_{generateUUID()},
-  uuid_right_{generateUUID()}
+  const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters)
+: SceneModuleInterface{name, node}, parameters_{std::move(parameters)}
 {
   using std::placeholders::_1;
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "avoidance");
@@ -3250,13 +3238,13 @@ void AvoidanceModule::addShiftLineIfApproved(const AvoidLineArray & shift_lines)
     const auto sl_back = shift_lines.back();
 
     if (getRelativeLengthFromPath(sl) > 0.0) {
-      left_shift_array_.push_back({uuid_left_, sl_front.start, sl_back.end});
+      left_shift_array_.push_back({uuid_vec_.at(0), sl_front.start, sl_back.end});
     } else if (getRelativeLengthFromPath(sl) < 0.0) {
-      right_shift_array_.push_back({uuid_right_, sl_front.start, sl_back.end});
+      right_shift_array_.push_back({uuid_vec_.at(1), sl_front.start, sl_back.end});
     }
 
-    uuid_left_ = generateUUID();
-    uuid_right_ = generateUUID();
+    uuid_vec_.at(0) = generateUUID();
+    uuid_vec_.at(1) = generateUUID();
     candidate_uuid_ = generateUUID();
 
     lockNewModuleLaunch();

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -26,7 +26,7 @@ namespace behavior_path_planner
 AvoidanceModuleManager::AvoidanceModuleManager(
   rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
   const std::shared_ptr<AvoidanceParameters> & parameters)
-: SceneModuleManagerInterface(node, name, config), parameters_{parameters}
+: SceneModuleManagerInterface(node, name, config, {"left", "right"}), parameters_{parameters}
 {
 }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -28,8 +28,6 @@ AvoidanceModuleManager::AvoidanceModuleManager(
   const std::shared_ptr<AvoidanceParameters> & parameters)
 : SceneModuleManagerInterface(node, name, config), parameters_{parameters}
 {
-  rtc_interface_left_ = std::make_shared<RTCInterface>(node, name + "_left");
-  rtc_interface_right_ = std::make_shared<RTCInterface>(node, name + "_right");
 }
 
 void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parameter> & parameters)

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -43,9 +43,10 @@ std::string getTopicName(const ExternalRequestLaneChangeModule::Direction & dire
 ExternalRequestLaneChangeModule::ExternalRequestLaneChangeModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<LaneChangeParameters> parameters,
   const Direction & direction)
-: SceneModuleInterface{name, node}, parameters_{std::move(parameters)}, direction_{direction}
+: SceneModuleInterface{name, node, {getTopicName(direction)}},
+  parameters_{std::move(parameters)},
+  direction_{direction}
 {
-  rtc_interface_ptr_ = std::make_shared<RTCInterface>(&node, getTopicName(direction));
   steering_factor_interface_ptr_ =
     std::make_unique<SteeringFactorInterface>(&node, getTopicName(direction));
 }
@@ -174,7 +175,9 @@ void ExternalRequestLaneChangeModule::resetPathIfAbort()
 
   if (!is_abort_approval_requested_) {
     RCLCPP_DEBUG(getLogger(), "[abort] uuid is reset to request abort approval.");
-    uuid_ = generateUUID();
+    for (auto & uuid : uuid_vec_) {
+      uuid = generateUUID();
+    }
     is_abort_approval_requested_ = true;
     is_abort_path_approved_ = false;
     return;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -43,7 +43,7 @@ std::string getTopicName(const ExternalRequestLaneChangeModule::Direction & dire
 ExternalRequestLaneChangeModule::ExternalRequestLaneChangeModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<LaneChangeParameters> parameters,
   const Direction & direction)
-: SceneModuleInterface{name, node, {getTopicName(direction)}},
+: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {getTopicName(direction)})},
   parameters_{std::move(parameters)},
   direction_{direction}
 {
@@ -175,8 +175,8 @@ void ExternalRequestLaneChangeModule::resetPathIfAbort()
 
   if (!is_abort_approval_requested_) {
     RCLCPP_DEBUG(getLogger(), "[abort] uuid is reset to request abort approval.");
-    for (auto & uuid : uuid_vec_) {
-      uuid = generateUUID();
+    for (auto itr = uuid_map_.begin(); itr != uuid_map_.end(); ++itr) {
+      itr->second = generateUUID();
     }
     is_abort_approval_requested_ = true;
     is_abort_path_approved_ = false;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -33,22 +33,15 @@
 namespace behavior_path_planner
 {
 #ifdef USE_OLD_ARCHITECTURE
-std::string getTopicName(const ExternalRequestLaneChangeModule::Direction & direction)
-{
-  const std::string direction_name =
-    direction == ExternalRequestLaneChangeModule::Direction::RIGHT ? "right" : "left";
-  return "ext_request_lane_change_" + direction_name;
-}
-
 ExternalRequestLaneChangeModule::ExternalRequestLaneChangeModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<LaneChangeParameters> parameters,
   const Direction & direction)
-: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {getTopicName(direction)})},
+: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {""})},
   parameters_{std::move(parameters)},
   direction_{direction}
 {
   steering_factor_interface_ptr_ =
-    std::make_unique<SteeringFactorInterface>(&node, getTopicName(direction));
+    std::make_unique<SteeringFactorInterface>(&node, util::convertToSnakeCase(name));
 }
 
 void ExternalRequestLaneChangeModule::onEntry()

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -39,24 +39,20 @@ using autoware_auto_perception_msgs::msg::ObjectClassification;
 #ifdef USE_OLD_ARCHITECTURE
 LaneChangeModule::LaneChangeModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<LaneChangeParameters> parameters)
-: SceneModuleInterface{name, node},
-  parameters_{std::move(parameters)},
-  uuid_left_{generateUUID()},
-  uuid_right_{generateUUID()}
+: SceneModuleInterface{name, node, {"left", "right"}}, parameters_{std::move(parameters)}
 {
-  rtc_interface_left_ = std::make_shared<RTCInterface>(&node, "lane_change_left");
-  rtc_interface_right_ = std::make_shared<RTCInterface>(&node, "lane_change_right");
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "lane_change");
 }
 #else
 LaneChangeModule::LaneChangeModule(
   const std::string & name, rclcpp::Node & node,
   const std::shared_ptr<LaneChangeParameters> & parameters,
-  const std::shared_ptr<RTCInterface> & rtc_interface, Direction direction,
-  LaneChangeModuleType type)
-: SceneModuleInterface{name, node}, parameters_{parameters}, direction_{direction}, type_{type}
+  const std::vector<std::string> & rtc_types, Direction direction, LaneChangeModuleType type)
+: SceneModuleInterface{name, node, rtc_types},
+  parameters_{parameters},
+  direction_{direction},
+  type_{type}
 {
-  rtc_interface_ptr_ = rtc_interface;
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, name);
 }
 #endif
@@ -224,10 +220,10 @@ void LaneChangeModule::resetPathIfAbort()
     const auto lateral_shift = lane_change_utils::getLateralShift(*abort_path_);
     if (lateral_shift > 0.0) {
       removePreviousRTCStatusRight();
-      uuid_right_ = generateUUID();
+      uuid_vec_.at(1) = generateUUID();
     } else if (lateral_shift < 0.0) {
       removePreviousRTCStatusLeft();
-      uuid_left_ = generateUUID();
+      uuid_vec_.at(0) = generateUUID();
     }
 #else
     removeRTCStatus();

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -39,7 +39,8 @@ using autoware_auto_perception_msgs::msg::ObjectClassification;
 #ifdef USE_OLD_ARCHITECTURE
 LaneChangeModule::LaneChangeModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<LaneChangeParameters> parameters)
-: SceneModuleInterface{name, node, {"left", "right"}}, parameters_{std::move(parameters)}
+: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {"left", "right"})},
+  parameters_{std::move(parameters)}
 {
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "lane_change");
 }
@@ -47,8 +48,9 @@ LaneChangeModule::LaneChangeModule(
 LaneChangeModule::LaneChangeModule(
   const std::string & name, rclcpp::Node & node,
   const std::shared_ptr<LaneChangeParameters> & parameters,
-  const std::vector<std::string> & rtc_types, Direction direction, LaneChangeModuleType type)
-: SceneModuleInterface{name, node, rtc_types},
+  const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map,
+  Direction direction, LaneChangeModuleType type)
+: SceneModuleInterface{name, node, rtc_interface_ptr_map},
   parameters_{parameters},
   direction_{direction},
   type_{type}
@@ -220,10 +222,10 @@ void LaneChangeModule::resetPathIfAbort()
     const auto lateral_shift = lane_change_utils::getLateralShift(*abort_path_);
     if (lateral_shift > 0.0) {
       removePreviousRTCStatusRight();
-      uuid_vec_.at(1) = generateUUID();
+      uuid_map_.at("right") = generateUUID();
     } else if (lateral_shift < 0.0) {
       removePreviousRTCStatusLeft();
-      uuid_vec_.at(0) = generateUUID();
+      uuid_map_.at("left") = generateUUID();
     }
 #else
     removeRTCStatus();

--- a/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
@@ -28,7 +28,7 @@ LaneChangeModuleManager::LaneChangeModuleManager(
   rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
   std::shared_ptr<LaneChangeParameters> parameters, const Direction direction,
   const LaneChangeModuleType type)
-: SceneModuleManagerInterface(node, name, config),
+: SceneModuleManagerInterface(node, name, config, {""}),
   parameters_{std::move(parameters)},
   direction_{direction},
   type_{type}

--- a/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
@@ -32,9 +32,7 @@ LaneChangeModuleManager::LaneChangeModuleManager(
   parameters_{std::move(parameters)},
   direction_{direction},
   type_{type}
-
 {
-  rtc_interface_ = std::make_shared<RTCInterface>(node, name);
 }
 
 void LaneChangeModuleManager::updateModuleParams(

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -27,7 +27,8 @@ namespace behavior_path_planner
 LaneFollowingModule::LaneFollowingModule(
   const std::string & name, rclcpp::Node & node,
   const std::shared_ptr<LaneFollowingParameters> & parameters)
-: SceneModuleInterface{name, node}, parameters_{parameters}
+// RTCInterface is temporarily registered, but not used.
+: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {""})}, parameters_{parameters}
 {
   initParam();
 }

--- a/planning/behavior_path_planner/src/scene_module/pull_out/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/manager.cpp
@@ -28,7 +28,6 @@ PullOutModuleManager::PullOutModuleManager(
   const std::shared_ptr<PullOutParameters> & parameters)
 : SceneModuleManagerInterface(node, name, config), parameters_{parameters}
 {
-  rtc_interface_ = std::make_shared<RTCInterface>(node, name);
 }
 
 void PullOutModuleManager::updateModuleParams(

--- a/planning/behavior_path_planner/src/scene_module/pull_out/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/manager.cpp
@@ -26,7 +26,7 @@ namespace behavior_path_planner
 PullOutModuleManager::PullOutModuleManager(
   rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
   const std::shared_ptr<PullOutParameters> & parameters)
-: SceneModuleManagerInterface(node, name, config), parameters_{parameters}
+: SceneModuleManagerInterface(node, name, config, {""}), parameters_{parameters}
 {
 }
 

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -38,7 +38,7 @@ namespace behavior_path_planner
 PullOutModule::PullOutModule(
   const std::string & name, rclcpp::Node & node,
   const std::shared_ptr<PullOutParameters> & parameters)
-: SceneModuleInterface{name, node},
+: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {""})},
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
@@ -62,8 +62,9 @@ PullOutModule::PullOutModule(
 #else
 PullOutModule::PullOutModule(
   const std::string & name, rclcpp::Node & node,
-  const std::shared_ptr<PullOutParameters> & parameters)
-: SceneModuleInterface{name, node},
+  const std::shared_ptr<PullOutParameters> & parameters,
+  const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map)
+: SceneModuleInterface{name, node, rtc_interface_ptr_map},
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
@@ -739,8 +740,8 @@ void PullOutModule::checkBackFinished()
     // request pull_out approval
     waitApproval();
     removeRTCStatus();
-    for (auto & uuid : uuid_vec_) {
-      uuid = generateUUID();
+    for (auto itr = uuid_map_.begin(); itr != uuid_map_.end(); ++itr) {
+      itr->second = generateUUID();
     }
     current_state_ = ModuleStatus::SUCCESS;  // for breaking loop
   }

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -42,7 +42,6 @@ PullOutModule::PullOutModule(
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
-  rtc_interface_ptr_ = std::make_shared<RTCInterface>(&node, "pull_out");
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "pull_out");
   lane_departure_checker_ = std::make_shared<LaneDepartureChecker>();
   lane_departure_checker_->setVehicleInfo(vehicle_info_);
@@ -63,13 +62,11 @@ PullOutModule::PullOutModule(
 #else
 PullOutModule::PullOutModule(
   const std::string & name, rclcpp::Node & node,
-  const std::shared_ptr<PullOutParameters> & parameters,
-  const std::shared_ptr<RTCInterface> & rtc_interface)
+  const std::shared_ptr<PullOutParameters> & parameters)
 : SceneModuleInterface{name, node},
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
-  rtc_interface_ptr_ = rtc_interface;
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "pull_out");
   lane_departure_checker_ = std::make_shared<LaneDepartureChecker>();
   lane_departure_checker_->setVehicleInfo(vehicle_info_);
@@ -742,7 +739,9 @@ void PullOutModule::checkBackFinished()
     // request pull_out approval
     waitApproval();
     removeRTCStatus();
-    uuid_ = generateUUID();
+    for (auto & uuid : uuid_vec_) {
+      uuid = generateUUID();
+    }
     current_state_ = ModuleStatus::SUCCESS;  // for breaking loop
   }
 }

--- a/planning/behavior_path_planner/src/scene_module/pull_over/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/manager.cpp
@@ -26,7 +26,7 @@ namespace behavior_path_planner
 PullOverModuleManager::PullOverModuleManager(
   rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
   const std::shared_ptr<PullOverParameters> & parameters)
-: SceneModuleManagerInterface(node, name, config), parameters_{parameters}
+: SceneModuleManagerInterface(node, name, config, {""}), parameters_{parameters}
 {
 }
 

--- a/planning/behavior_path_planner/src/scene_module/pull_over/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/manager.cpp
@@ -28,7 +28,6 @@ PullOverModuleManager::PullOverModuleManager(
   const std::shared_ptr<PullOverParameters> & parameters)
 : SceneModuleManagerInterface(node, name, config), parameters_{parameters}
 {
-  rtc_interface_ = std::make_shared<RTCInterface>(node, name);
 }
 
 void PullOverModuleManager::updateModuleParams(

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -49,15 +49,16 @@ namespace behavior_path_planner
 PullOverModule::PullOverModule(
   const std::string & name, rclcpp::Node & node,
   const std::shared_ptr<PullOverParameters> & parameters)
-: SceneModuleInterface{name, node},
+: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {""})},
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
 #else
 PullOverModule::PullOverModule(
   const std::string & name, rclcpp::Node & node,
-  const std::shared_ptr<PullOverParameters> & parameters)
-: SceneModuleInterface{name, node},
+  const std::shared_ptr<PullOverParameters> & parameters,
+  const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map)
+: SceneModuleInterface{name, node, rtc_interface_ptr_map},
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
@@ -525,8 +526,8 @@ BehaviorModuleOutput PullOverModule::plan()
       waitApproval();
       removeRTCStatus();
       steering_factor_interface_ptr_->clearSteeringFactors();
-      for (auto & uuid : uuid_vec_) {
-        uuid = generateUUID();
+      for (auto itr = uuid_map_.begin(); itr != uuid_map_.end(); ++itr) {
+        itr->second = generateUUID();
       }
       current_state_ = ModuleStatus::SUCCESS;  // for breaking loop
       status_.has_requested_approval = true;

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -53,17 +53,14 @@ PullOverModule::PullOverModule(
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
-  rtc_interface_ptr_ = std::make_shared<RTCInterface>(&node, "pull_over");
 #else
 PullOverModule::PullOverModule(
   const std::string & name, rclcpp::Node & node,
-  const std::shared_ptr<PullOverParameters> & parameters,
-  const std::shared_ptr<RTCInterface> & rtc_interface)
+  const std::shared_ptr<PullOverParameters> & parameters)
 : SceneModuleInterface{name, node},
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
-  rtc_interface_ptr_ = rtc_interface;
 #endif
   steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "pull_over");
 
@@ -528,7 +525,9 @@ BehaviorModuleOutput PullOverModule::plan()
       waitApproval();
       removeRTCStatus();
       steering_factor_interface_ptr_->clearSteeringFactors();
-      uuid_ = generateUUID();
+      for (auto & uuid : uuid_vec_) {
+        uuid = generateUUID();
+      }
       current_state_ = ModuleStatus::SUCCESS;  // for breaking loop
       status_.has_requested_approval = true;
     } else if (isActivated() && isWaitingApproval()) {

--- a/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
@@ -26,7 +26,7 @@ namespace behavior_path_planner
 SideShiftModuleManager::SideShiftModuleManager(
   rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
   const std::shared_ptr<SideShiftParameters> & parameters)
-: SceneModuleManagerInterface(node, name, config), parameters_{parameters}
+: SceneModuleManagerInterface(node, name, config, {""}), parameters_{parameters}
 {
 }
 

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -33,16 +33,22 @@ using motion_utils::findNearestSegmentIndex;
 using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::getPoint;
 
+#ifdef USE_OLD_ARCHITECTURE
 SideShiftModule::SideShiftModule(
   const std::string & name, rclcpp::Node & node,
   const std::shared_ptr<SideShiftParameters> & parameters)
-: SceneModuleInterface{name, node}, parameters_{parameters}
+: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {""})}, parameters_{parameters}
 {
   using std::placeholders::_1;
-
-#ifdef USE_OLD_ARCHITECTURE
   lateral_offset_subscriber_ = node.create_subscription<LateralOffset>(
     "~/input/lateral_offset", 1, std::bind(&SideShiftModule::onLateralOffset, this, _1));
+#else
+SideShiftModule::SideShiftModule(
+  const std::string & name, rclcpp::Node & node,
+  const std::shared_ptr<SideShiftParameters> & parameters,
+  const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map)
+: SceneModuleInterface{name, node, rtc_interface_ptr_map}, parameters_{parameters}
+{
 #endif
 
   // If lateral offset is subscribed, it approves side shift module automatically

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2691,4 +2691,18 @@ lanelet::ConstLanelets getLaneletsFromPath(
 
   return lanelets;
 }
+
+std::string convertToSnakeCase(const std::string & input_str)
+{
+  std::string output_str = std::string{std::tolower(input_str.at(0))};
+  for (size_t i = 1; i < input_str.length(); ++i) {
+    const auto input_chr = input_str.at(i);
+    if (std::isupper(input_chr)) {
+      output_str += "_" + std::string{std::tolower(input_chr)};
+    } else {
+      output_str += input_chr;
+    }
+  }
+  return output_str;
+}
 }  // namespace behavior_path_planner::util

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -2694,11 +2694,11 @@ lanelet::ConstLanelets getLaneletsFromPath(
 
 std::string convertToSnakeCase(const std::string & input_str)
 {
-  std::string output_str = std::string{std::tolower(input_str.at(0))};
+  std::string output_str = std::string{static_cast<char>(std::tolower(input_str.at(0)))};
   for (size_t i = 1; i < input_str.length(); ++i) {
     const auto input_chr = input_str.at(i);
     if (std::isupper(input_chr)) {
-      output_str += "_" + std::string{std::tolower(input_chr)};
+      output_str += "_" + std::string{static_cast<char>(std::tolower(input_chr))};
     } else {
       output_str += input_chr;
     }


### PR DESCRIPTION
## Description

Currently, by default, SceneModuleInterface has `rtc_interface_ptr_` and its related functions such as lock/unlockRTCCommand.

However, some derived classes from SceneModuleInterface like avoidance have `rtc_interface_ptr_left/right_` though they still have `rtc_interface_ptr_`, which makes the developers confused.
In addition, lock/unlockRTCCommand functions have to be modified following an implicit rule depending on the types of `rtc_interface_ptr_` (e.g. only one rtc_interface_ptr, or left and right rtc_interface_ptrs)

To remove the implicit rule and redundant implementation for higher maintainability,
- I unified rtc_interface (and its uuid) as an unordered_map.
- I removed functions related to `rtc_interface_ptr_`  in detailed modules since they can be removed thanks to the above unification.

- TODO
    - [x] deal with the bt architecture
    - [x] check if planning simulator works well
    - [x] check scenarios
        - [x] with BT: 1196/1199 https://evaluation.tier4.jp/evaluation/reports/ccb1c338-04fc-5b2a-857a-6e6e29d84436?project_id=prd_jt
        - [x] including 2 random fails, no problem.
            - baseline: 1198/1199
        - [x] without BT: 1190/1199 https://evaluation.tier4.jp/evaluation/reports/d92e1695-96bd-5896-a6c4-102cf0949321?project_id=prd_jt
            - baseline: 1187/1199 https://evaluation.tier4.jp/evaluation/reports/f3654846-17fd-534b-a1f1-ffcf8495ca25?project_id=prd_jt
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
