### PR TITLE
fix(crop_box_filter): invalid bool -> float -> bool conversion

### DIFF
--- a/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
@@ -79,7 +79,7 @@ CropBoxFilterComponent::CropBoxFilterComponent(const rclcpp::NodeOptions & optio
     p.max_x = static_cast<float>(declare_parameter("max_x", 1.0));
     p.max_y = static_cast<float>(declare_parameter("max_y", 1.0));
     p.max_z = static_cast<float>(declare_parameter("max_z", 1.0));
-    p.negative = static_cast<float>(declare_parameter("negative", false));
+    p.negative = static_cast<bool>(declare_parameter("negative", false));
     if (tf_input_frame_.empty()) {
       throw std::invalid_argument("Crop box requires non-empty input_frame");
     }


### PR DESCRIPTION
## Description

`bool negative` parameter was incorrectly converted from `bool` to `float`, then implicitly to `bool` again.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
