### PR TITLE
fix(mission_planner): add route loop check

### DIFF
--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -449,6 +449,10 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequenceAfter(
     if (!getNextLaneletWithinRoute(current_lanelet, &next_lanelet)) {
       break;
     }
+    // loop check
+    if (lanelet.id() == next_lanelet.id()) {
+      break;
+    }
     lanelet_sequence_forward.push_back(next_lanelet);
     current_lanelet = next_lanelet;
     length +=
@@ -471,6 +475,12 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequenceUpTo(
   while (rclcpp::ok() && length < min_length) {
     lanelet::ConstLanelets candidate_lanelets;
     if (!getPreviousLaneletsWithinRoute(current_lanelet, &candidate_lanelets)) {
+      break;
+    }
+    // loop check
+    if (std::any_of(
+          candidate_lanelets.begin(), candidate_lanelets.end(),
+          [lanelet](auto & prev_llt) { return lanelet.id() == prev_llt.id(); })) {
       break;
     }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Add route loop check to `getLaneletSequenceAfter` and `getLaneletSequenceUpTo` for solving endless while loop when the route is a loop.

ex) 
if the route is following, `getLaneletSequence(current_lane)` can't end. 

![Screenshot from 2023-04-03 16-47-02](https://user-images.githubusercontent.com/39142679/229451912-e9127675-b384-4b10-8332-c8dd04cbd5c7.png)
![Screenshot from 2023-04-03 16-40-22](https://user-images.githubusercontent.com/39142679/229451921-209e7fad-0c82-4510-b9dd-7f204cba1dd9.png)

```
[component_container_mt-27] current_lanelet: 174, next_lanelet: 190162
[component_container_mt-27] current_lanelet: 190162, next_lanelet: 143
[component_container_mt-27] current_lanelet: 143, next_lanelet: 146
[component_container_mt-27] current_lanelet: 146, next_lanelet: 1003
[component_container_mt-27] current_lanelet: 1003, next_lanelet: 1506
[component_container_mt-27] current_lanelet: 1506, next_lanelet: 176321
[component_container_mt-27] current_lanelet: 176321, next_lanelet: 1520
[component_container_mt-27] current_lanelet: 1520, next_lanelet: 1509
[component_container_mt-27] current_lanelet: 1509, next_lanelet: 1368
[component_container_mt-27] current_lanelet: 1368, next_lanelet: 1489
[component_container_mt-27] current_lanelet: 1489, next_lanelet: 1492
[component_container_mt-27] current_lanelet: 1492, next_lanelet: 1495
[component_container_mt-27] current_lanelet: 1495, next_lanelet: 1176
[component_container_mt-27] current_lanelet: 1176, next_lanelet: 126
[component_container_mt-27] current_lanelet: 126, next_lanelet: 785
[component_container_mt-27] current_lanelet: 785, next_lanelet: 132
[component_container_mt-27] current_lanelet: 132, next_lanelet: 134
[component_container_mt-27] current_lanelet: 134, next_lanelet: 783
[component_container_mt-27] current_lanelet: 783, next_lanelet: 139
[component_container_mt-27] current_lanelet: 139, next_lanelet: 141
[component_container_mt-27] current_lanelet: 141, next_lanelet: 1133
[component_container_mt-27] current_lanelet: 1133, next_lanelet: 70
[component_container_mt-27] current_lanelet: 70, next_lanelet: 72
[component_container_mt-27] current_lanelet: 72, next_lanelet: 1145
[component_container_mt-27] current_lanelet: 1145, next_lanelet: 170
[component_container_mt-27] current_lanelet: 170, next_lanelet: 172
[component_container_mt-27] current_lanelet: 172, next_lanelet: 174
```

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
