### PR TITLE
fix(ndt_scan_matcher): fix initial pose timestamp for NDT algorithm

### DIFF
--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -313,8 +313,8 @@ void NDTScanMatcher::callback_initial_pose(
     // transform pose_frame to map_frame
     auto mapTF_initial_pose_msg_ptr =
       std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
-    // mapTF_initial_pose_msg_ptr->header.stamp = initial_pose_msg_ptr->header.stamp;
     *mapTF_initial_pose_msg_ptr = transform(*initial_pose_msg_ptr, *TF_pose_to_map_ptr);
+    mapTF_initial_pose_msg_ptr->header.stamp = initial_pose_msg_ptr->header.stamp;
     initial_pose_msg_ptr_array_.push_back(mapTF_initial_pose_msg_ptr);
   }
 }


### PR DESCRIPTION
## Description
An initial pose in `NDTScanMatcher::callback_initial_pose` is transformed to `map` frame with `tf2::doTransform` which uses the `transform` time stamp instead of the received message time stamp [LINK](https://github.com/ros2/geometry2/blob/d508d9c312e8cfa69e81bf5e53af38849f2bc870/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp#L639).

I my scenario I am using `map->odom->base_link` structure. In my current implementation 'map->odom' is a static identity transform, hence time stamp for `TF_pose_to_map_ptr` is 0.

This problem is still valid in case of non-static `map->odom` tranform, but with different frequency than `odom->base_link`. For example `map->odom` publishes 1Hz, while `odom->base_link` publishes 30Hz, in such a case messaeges in `initial_pose_msg_ptr_array_` would be stamped with low frequency `map->odom`.

## Tests performed
Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
