### PR TITLE
fix(lane_change): guard invalid lc start point

### DIFF
--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -371,6 +371,17 @@ std::pair<bool, bool> getLaneChangePaths(
     // lane changing start pose is at the end of prepare segment
     const auto & lane_changing_start_pose = prepare_segment.points.back().point.pose;
 
+#ifndef USE_OLD_ARCHITECTURE
+    const auto target_distance_from_lane_change_start_pose = util::getArcLengthToTargetLanelet(
+      original_lanelets, target_lanelets.front(), lane_changing_start_pose);
+    // In new architecture, there is a possibility that the lane change start pose is behind of the
+    // target lanelet, even if the condition prepare_distance > target_distance is satisfied. In
+    // that case, the lane change shouldn't be executed.
+    if (target_distance_from_lane_change_start_pose > 0.0) {
+      break;
+    }
+#endif
+
     const auto shift_length =
       lanelet::utils::getLateralDistanceToClosestLanelet(target_lanelets, lane_changing_start_pose);
 

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -371,7 +371,6 @@ std::pair<bool, bool> getLaneChangePaths(
     // lane changing start pose is at the end of prepare segment
     const auto & lane_changing_start_pose = prepare_segment.points.back().point.pose;
 
-#ifndef USE_OLD_ARCHITECTURE
     const auto target_distance_from_lane_change_start_pose = util::getArcLengthToTargetLanelet(
       original_lanelets, target_lanelets.front(), lane_changing_start_pose);
     // In new architecture, there is a possibility that the lane change start pose is behind of the
@@ -380,7 +379,6 @@ std::pair<bool, bool> getLaneChangePaths(
     if (target_distance_from_lane_change_start_pose > 0.0) {
       break;
     }
-#endif
 
     const auto shift_length =
       lanelet::utils::getLateralDistanceToClosestLanelet(target_lanelets, lane_changing_start_pose);


### PR DESCRIPTION
## Description

The lane change start pose must **NOT** be in front of the `target_lanelets.front()`, and this is check in here.

https://github.com/autowarefoundation/autoware.universe/blob/90ed30d63748fbef9a42c264c83ed7f084701d4f/planning/behavior_path_planner/src/util/lane_change/util.cpp#L350-L352

On the other hand, this guard doesn't support new architecture that can run multiple modules simultaneously.

If the lane change module uses avoidance path as input path, the start pose is generated on that path. In this case, there is a possibility that the start pose is in front of the `target_lanelets.front()` even if the above condition is satisfied.

![IMG_4849](https://user-images.githubusercontent.com/44889564/229669785-76d0a6aa-86b2-46fb-bdd6-c2e26e1f8b45.jpg)

So, I added another condition so that distance (orange line) between lc start pose and target lane's front pose does not have a positive value.

![image](https://user-images.githubusercontent.com/44889564/229670540-edd4b2dc-4807-49f3-a0f3-c4adbc5aa5e6.png)

<!-- Write a brief description of this PR. -->


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
