### PR TITLE
fix(AEB): add marker for object data

### DIFF
--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -100,7 +100,9 @@ public:
   void onCheckCollision(DiagnosticStatusWrapper & stat);
   bool checkCollision();
   bool hasCollision(
-    const double current_v, const Path & ego_path, const std::vector<Polygon2d> & ego_polys);
+    const double current_v, const Path & ego_path, const std::vector<Polygon2d> & ego_polys,
+    const rclcpp::Time & current_time, const std_msgs::msg::ColorRGBA & color,
+    const std::string & ns, MarkerArray & debug_markers);
 
   void generateEgoPath(
     const double curr_v, const double curr_w, Path & path, std::vector<Polygon2d> & polygons);
@@ -112,8 +114,11 @@ public:
 
   void addMarker(
     const rclcpp::Time & current_time, const Path & path, const std::vector<Polygon2d> & polygons,
-    const double color_r, const double color_g, const double color_b, const double color_a,
-    const std::string & path_ns, const std::string & poly_ns, MarkerArray & debug_markers);
+    const std_msgs::msg::ColorRGBA & color, const std::string & ns, MarkerArray & debug_markers);
+
+  void addObjectDataMarker(
+    const std::vector<ObjectData> & objects, const rclcpp::Time & current_time,
+    const std_msgs::msg::ColorRGBA & color, const std::string & ns, MarkerArray & debug_markers);
 
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};


### PR DESCRIPTION
## Description

- add marker for object data
- rearrange code

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
it works in my environment, some green spheres are object data.
![image](https://user-images.githubusercontent.com/9547070/229689536-4aa25fae-3a32-4fa0-b1e9-43b255f5af3d.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
