### PR TITLE
fix(lidar_centerpoint_tvm): wrong output when downsample_factor_> 1

### DIFF
--- a/perception/lidar_centerpoint_tvm/lib/postprocess/generate_detected_boxes.cpp
+++ b/perception/lidar_centerpoint_tvm/lib/postprocess/generate_detected_boxes.cpp
@@ -90,10 +90,8 @@ void generateBoxes3D_worker(
 
     const float offset_x = out_offset[grid_size * 0 + array_idx];
     const float offset_y = out_offset[grid_size * 1 + array_idx];
-    const float x =
-      config.voxel_size_x_ * (xi + offset_x) + config.range_min_x_;
-    const float y =
-      config.voxel_size_y_ * (yi + offset_y) + config.range_min_y_;
+    const float x = config.voxel_size_x_ * (xi + offset_x) + config.range_min_x_;
+    const float y = config.voxel_size_y_ * (yi + offset_y) + config.range_min_y_;
     const float z = out_z[array_idx];
     const float w = out_dim[grid_size * 0 + array_idx];
     const float l = out_dim[grid_size * 1 + array_idx];

--- a/perception/lidar_centerpoint_tvm/lib/postprocess/generate_detected_boxes.cpp
+++ b/perception/lidar_centerpoint_tvm/lib/postprocess/generate_detected_boxes.cpp
@@ -69,14 +69,15 @@ void generateBoxes3D_worker(
   // heatmap: N = class_size, offset: N = 2, z: N = 1, dim: N = 3, rot: N = 2, vel: N = 2
   for (std::size_t idx = 0; idx < grids_per_thread; idx++) {
     std::size_t grid_idx = thread_idx * grids_per_thread + idx;
-    std::size_t array_idx = config.downsample_factor_ * grid_idx;
     const auto grid_size = config.grid_size_y_ * config.grid_size_x_;
-    if (array_idx >= grid_size) {
+    const auto down_grid_size = config.down_grid_size_y_ * config.down_grid_size_x_;
+    if (grid_idx >= down_grid_size) {
       return;
     }
 
-    const auto yi = array_idx / config.grid_size_x_;
-    const auto xi = array_idx % config.grid_size_x_;
+    const auto yi = config.downsample_factor_ * (grid_idx / config.down_grid_size_x_);
+    const auto xi = config.downsample_factor_ * (grid_idx % config.down_grid_size_x_);
+    std::size_t array_idx = yi * config.grid_size_x_ + xi;
 
     int32_t label = -1;
     float max_score = -1;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fix #2649
I think downsample_factor_ is used in the generateBoxes3D_worker function incorrectly.
In fact, when downsample_factor_=1, the output by lidar_centerpoint_tvm is similar to the output by lidar_centerpoint ,
but when downsample_factor_=2, the output is different from the output by lidar_centerpoint.
I think that when downsample_factor_= 2, we must extract even-numbered rows and columns from 560x560 matrix.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I compared the output before and after the modification by single_centerpoint_node  in lidar_centerpoint_tvm. (#3130)

- before fix
![lidar_centerpoint_tvm](https://user-images.githubusercontent.com/13479009/229720602-25df5c39-18e6-4877-a7e1-b2f290915557.png)

- after fix
![lidar_centerpoint_new](https://user-images.githubusercontent.com/13479009/229943769-c514a269-d8a5-4a15-963c-f7570e359a36.png)

- (for reference) generated by single_centerpoint_node  in lidar_centerpoint
![lidar_centerpoint](https://user-images.githubusercontent.com/13479009/229944306-9bacf1a1-da53-43b5-9ba5-fc9157a3c160.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
