### PR TITLE
fix(map_loader): fix a bug that occurs when loading multiple pcds

### DIFF
--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -96,7 +96,7 @@ std::map<std::string, PCDFileMetadata> PointCloudMapLoaderNode::getPCDMetadata(
     }
 
     pcd_metadata_dict = loadPCDMetadata(pcd_metadata_path);
-    pcd_metadata_dict = replaceWithAbsolutePath(pcd_metadata_dict_, pcd_paths);
+    pcd_metadata_dict = replaceWithAbsolutePath(pcd_metadata_dict, pcd_paths);
     RCLCPP_INFO_STREAM(get_logger(), "Loaded PCD metadata: " << pcd_metadata_path);
   } else {
     // An exception when using a single file PCD map so that the users do not have to provide

--- a/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.hpp
@@ -38,9 +38,6 @@ public:
   explicit PointCloudMapLoaderNode(const rclcpp::NodeOptions & options);
 
 private:
-  // ros param
-  std::map<std::string, PCDFileMetadata> pcd_metadata_dict_;
-
   std::unique_ptr<PointcloudMapLoaderModule> pcd_map_loader_;
   std::unique_ptr<PointcloudMapLoaderModule> downsampled_pcd_map_loader_;
   std::unique_ptr<PartialMapLoaderModule> partial_map_loader_;

--- a/map/map_loader/src/pointcloud_map_loader/utils.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/utils.cpp
@@ -54,6 +54,7 @@ std::map<std::string, PCDFileMetadata> replaceWithAbsolutePath(
 {
   std::map<std::string, PCDFileMetadata> absolute_path_map;
   for (const auto & path : pcd_paths) {
+    std::cout << "KOJI ERROR replaceWithAbsolutePath :" << path << std::endl;
     std::string filename = path.substr(path.find_last_of("/\\") + 1);
     auto it = pcd_metadata_path.find(filename);
     if (it != pcd_metadata_path.end()) {

--- a/map/map_loader/src/pointcloud_map_loader/utils.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/utils.cpp
@@ -54,7 +54,6 @@ std::map<std::string, PCDFileMetadata> replaceWithAbsolutePath(
 {
   std::map<std::string, PCDFileMetadata> absolute_path_map;
   for (const auto & path : pcd_paths) {
-    std::cout << "KOJI ERROR replaceWithAbsolutePath :" << path << std::endl;
     std::string filename = path.substr(path.find_last_of("/\\") + 1);
     auto it = pcd_metadata_path.find(filename);
     if (it != pcd_metadata_path.end()) {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d882d09</samp>

Fix a typo and remove an unused variable in `pointcloud_map_loader_node`. This improves the code quality and functionality of the node that loads point cloud map metadata.

## Description
Fix a bug
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
