### PR TITLE
fix(avoidance): remove unnecessary shift line

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3272,6 +3272,8 @@ void AvoidanceModule::addNewShiftLines(
   }
 
   const auto current_shift_lines = path_shifter.getShiftLines();
+  const auto new_shift_length = new_shift_lines.front().end_shift_length;
+  const auto new_shift_end_idx = new_shift_lines.front().end_idx;
 
   DEBUG_PRINT("min_start_idx = %lu", min_start_idx);
 
@@ -3288,10 +3290,25 @@ void AvoidanceModule::addNewShiftLines(
     if (sl.start_idx >= min_start_idx) {
       DEBUG_PRINT(
         "sl.start_idx = %lu, this sl starts after new proposal. remove this one.", sl.start_idx);
-    } else {
-      DEBUG_PRINT("sl.start_idx = %lu, no conflict. keep this one.", sl.start_idx);
-      future.push_back(sl);
+      continue;
     }
+
+    if (sl.end_idx >= new_shift_end_idx) {
+      if (
+        sl.end_shift_length > -1e-3 && new_shift_length > -1e-3 &&
+        sl.end_shift_length < new_shift_length) {
+        continue;
+      }
+
+      if (
+        sl.end_shift_length < 1e-3 && new_shift_length < 1e-3 &&
+        sl.end_shift_length > new_shift_length) {
+        continue;
+      }
+    }
+
+    DEBUG_PRINT("sl.start_idx = %lu, no conflict. keep this one.", sl.start_idx);
+    future.push_back(sl);
   }
 
   path_shifter.setShiftLines(future);


### PR DESCRIPTION
## Description

The avoidance module remove conflict current shift line when new shift lines are added.

$$
INDEX_{start, new} <= INDEX_{start, current}
$$

https://github.com/autowarefoundation/autoware.universe/blob/d2a348bcc0af688d2e7ae8630f65dda63db3a18a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp#L3285-L3293

![image](https://user-images.githubusercontent.com/44889564/230235018-84efa3ea-20a8-434f-8b26-b8e40fa311d6.png)
---

On the other hand, the any current shift line will **NOT** be removed in the following scene. And, the shift line behind the ego will be removed in order. Then, the **GREEN** shift line will be removed thirdly as a result and `base_offset_` will be updated. However the gap between **TRANSLUCENT ORANGE** shift length and **GREEN** shift is huge, so this causes significant aviodance path change.

https://github.com/autowarefoundation/autoware.universe/blob/d2a348bcc0af688d2e7ae8630f65dda63db3a18a/planning/behavior_path_planner/src/util/path_shifter/path_shifter.cpp#L436-L442

![image](https://user-images.githubusercontent.com/44889564/230232633-1d79dcab-8a18-40e1-a9c2-1dd2a39fda10.png)

![image](https://user-images.githubusercontent.com/44889564/230242517-76d00ab9-71a1-4104-9b6e-1242664ede85.png)

- https://user-images.githubusercontent.com/44889564/230242529-04670aaa-b603-446e-9192-2b3c5e0da49a.mp4
---

In this PR, I fixed `addNewShiftLine` logic in order to remove following **GREEN** shift line when new shift lines are added. The removed shift line's conditions are following:

$$
\begin{align}
&INDEX_{end, new} < INDEX_{end, current}\\
&LENGTH_{end, new} > LENGTH_{end, current}\\
&LENGTH_{end, new} >= 0\\
&LENGTH_{end, current} >= 0
\end{align}
$$

or

$$
\begin{align}
&INDEX_{end, new} < INDEX_{end, current}\\
&LENGTH_{end, new} < LENGTH_{end, current}\\
&LENGTH_{end, new} <= 0\\
&LENGTH_{end, current} <= 0
\end{align}
$$

By this logic modification, it will prevent that unexpected significant path change.

![image](https://user-images.githubusercontent.com/44889564/230237987-f7305d74-56c1-497f-b1fd-5c52f29b3ded.png)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

```
webauto ci scenario run --project-id prd_jt --scenario-id 1c751792-1d44-4e98-a7dc-6c805a3ca991 --runtime-path /$HOME/pilot-auto --scenario-parameters __tier4_modifier_Ve=11.1111,__tier4_modifier_d=60
```

https://user-images.githubusercontent.com/44889564/230243047-d4d46625-a3bc-482a-b122-6337a5e69655.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
