### PR TITLE
refactor(behavior_path_planner): remove toPolygon functions

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -146,14 +146,6 @@ double getArcLengthToTargetLanelet(
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelet & target_lane,
   const Pose & pose);
 
-bool calcObjectPolygon(const PredictedObject & object, Polygon2d * object_polygon);
-
-bool calcObjectPolygon(
-  const Shape & object_shape, const Pose & object_pose, Polygon2d * object_polygon);
-
-bool calcObjectPolygon(
-  const Shape & object_shape, const Pose & object_pose, Polygon2d * object_polygon);
-
 double getDistanceBetweenPredictedPaths(
   const PredictedPath & path1, const PredictedPath & path2, const double start_time,
   const double end_time, const double resolution);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -360,11 +360,6 @@ Polygon2d convertBoundingBoxObjectToGeometryPolygon(
   const Pose & current_pose, const double & base_to_front, const double & base_to_rear,
   const double & base_to_width);
 
-Polygon2d convertCylindricalObjectToGeometryPolygon(
-  const Pose & current_pose, const Shape & obj_shape);
-
-Polygon2d convertPolygonObjectToGeometryPolygon(const Pose & current_pose, const Shape & obj_shape);
-
 std::string getUuidStr(const PredictedObject & obj);
 
 std::vector<PredictedPath> getPredictedPathFromObj(

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -635,9 +635,7 @@ void AvoidanceModule::fillObjectEnvelopePolygon(
     return;
   }
 
-  Polygon2d object_polygon{};
-  util::calcObjectPolygon(object_data.object, &object_polygon);
-
+  const auto object_polygon = tier4_autoware_utils::toPolygon2d(object_data.object);
   if (!within(object_polygon, same_id_obj->envelope_poly)) {
     object_data.envelope_poly =
       createEnvelopePolygon(object_data, closest_pose, parameters_->object_envelope_buffer);

--- a/planning/behavior_path_planner/src/util/avoidance/util.cpp
+++ b/planning/behavior_path_planner/src/util/avoidance/util.cpp
@@ -458,9 +458,7 @@ void fillLongitudinalAndLengthByClosestFootprint(
   const PathWithLaneId & path, const PredictedObject & object, const Point & ego_pos,
   ObjectData & obj)
 {
-  tier4_autoware_utils::Polygon2d object_poly{};
-  util::calcObjectPolygon(object, &object_poly);
-
+  const auto object_poly = tier4_autoware_utils::toPolygon2d(object);
   const double distance = motion_utils::calcSignedArcLength(
     path.points, ego_pos, object.kinematics.initial_pose_with_covariance.pose.position);
   double min_distance = distance;
@@ -499,9 +497,7 @@ double calcOverhangDistance(
 {
   double largest_overhang = isOnRight(object_data) ? -100.0 : 100.0;  // large number
 
-  tier4_autoware_utils::Polygon2d object_poly{};
-  util::calcObjectPolygon(object_data.object, &object_poly);
-
+  const auto object_poly = tier4_autoware_utils::toPolygon2d(object_data.object);
   for (const auto & p : object_poly.outer()) {
     const auto point = tier4_autoware_utils::createPoint(p.x(), p.y(), 0.0);
     const auto lateral = tier4_autoware_utils::calcLateralDeviation(base_pose, point);
@@ -600,8 +596,7 @@ Polygon2d createEnvelopePolygon(
   using tier4_autoware_utils::Polygon2d;
   using Box = bg::model::box<Point2d>;
 
-  Polygon2d object_polygon{};
-  util::calcObjectPolygon(object_data.object, &object_polygon);
+  const auto object_polygon = tier4_autoware_utils::toPolygon2d(object_data.object);
 
   const auto toPolygon2d = [](const geometry_msgs::msg::Polygon & polygon) {
     Polygon2d ret{};

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -385,51 +385,6 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByLanelets(
   return std::make_pair(target_objects, other_objects);
 }
 
-bool calcObjectPolygon(const PredictedObject & object, Polygon2d * object_polygon)
-{
-  if (object.shape.type == Shape::BOUNDING_BOX) {
-    const double & length_m = object.shape.dimensions.x / 2;
-    const double & width_m = object.shape.dimensions.y / 2;
-    *object_polygon = convertBoundingBoxObjectToGeometryPolygon(
-      object.kinematics.initial_pose_with_covariance.pose, length_m, length_m, width_m);
-
-  } else if (object.shape.type == Shape::CYLINDER) {
-    *object_polygon = convertCylindricalObjectToGeometryPolygon(
-      object.kinematics.initial_pose_with_covariance.pose, object.shape);
-  } else if (object.shape.type == Shape::POLYGON) {
-    *object_polygon = convertPolygonObjectToGeometryPolygon(
-      object.kinematics.initial_pose_with_covariance.pose, object.shape);
-  } else {
-    RCLCPP_WARN(
-      rclcpp::get_logger("behavior_path_planner").get_child("utilities"), "Object shape unknown!");
-    return false;
-  }
-
-  return true;
-}
-
-bool calcObjectPolygon(
-  const Shape & object_shape, const Pose & object_pose, Polygon2d * object_polygon)
-{
-  if (object_shape.type == Shape::BOUNDING_BOX) {
-    const double & length_m = object_shape.dimensions.x / 2;
-    const double & width_m = object_shape.dimensions.y / 2;
-    *object_polygon =
-      convertBoundingBoxObjectToGeometryPolygon(object_pose, length_m, length_m, width_m);
-
-  } else if (object_shape.type == Shape::CYLINDER) {
-    *object_polygon = convertCylindricalObjectToGeometryPolygon(object_pose, object_shape);
-  } else if (object_shape.type == Shape::POLYGON) {
-    *object_polygon = convertPolygonObjectToGeometryPolygon(object_pose, object_shape);
-  } else {
-    RCLCPP_WARN(
-      rclcpp::get_logger("behavior_path_planner").get_child("utilities"), "Object shape unknown!");
-    return false;
-  }
-
-  return true;
-}
-
 std::vector<double> calcObjectsDistanceToPath(
   const PredictedObjects & objects, const PathWithLaneId & ego_path)
 {

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1960,44 +1960,6 @@ Polygon2d convertBoundingBoxObjectToGeometryPolygon(
   return object_polygon;
 }
 
-Polygon2d convertCylindricalObjectToGeometryPolygon(
-  const Pose & current_pose, const Shape & obj_shape)
-{
-  Polygon2d object_polygon;
-
-  const double obj_x = current_pose.position.x;
-  const double obj_y = current_pose.position.y;
-
-  constexpr int N = 20;
-  const double r = obj_shape.dimensions.x / 2;
-  object_polygon.outer().reserve(N + 1);
-  for (int i = 0; i < N; ++i) {
-    object_polygon.outer().emplace_back(
-      obj_x + r * std::cos(2.0 * M_PI / N * i), obj_y + r * std::sin(2.0 * M_PI / N * i));
-  }
-
-  object_polygon.outer().push_back(object_polygon.outer().front());
-
-  return object_polygon;
-}
-
-Polygon2d convertPolygonObjectToGeometryPolygon(const Pose & current_pose, const Shape & obj_shape)
-{
-  Polygon2d object_polygon;
-  tf2::Transform tf_map2obj;
-  fromMsg(current_pose, tf_map2obj);
-  const auto obj_points = obj_shape.footprint.points;
-  object_polygon.outer().reserve(obj_points.size() + 1);
-  for (const auto & obj_point : obj_points) {
-    tf2::Vector3 obj(obj_point.x, obj_point.y, obj_point.z);
-    tf2::Vector3 tf_obj = tf_map2obj * obj;
-    object_polygon.outer().emplace_back(tf_obj.x(), tf_obj.y());
-  }
-  object_polygon.outer().push_back(object_polygon.outer().front());
-
-  return object_polygon;
-}
-
 std::string getUuidStr(const PredictedObject & obj)
 {
   std::stringstream hex_value;


### PR DESCRIPTION
## Description
Remove `toPolygon` functions from utils and avoidance module in the behavior path planner.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
