### PR TITLE
feat(elevation_map_loader): add support for id_map_loader

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -321,10 +321,12 @@ class GroundSegmentationPipeline:
                     ("output/elevation_map", "map"),
                     ("input/pointcloud_map", "/map/pointcloud_map"),
                     ("input/vector_map", "/map/vector_map"),
+                    ("service/get_id_pcd_map", "/map/get_id_pointcloud_map"),
                 ],
                 parameters=[
                     {
                         "use_lane_filter": False,
+                        "use_id_load": False,
                         "use_inpaint": True,
                         "inpaint_radius": 1.0,
                         "lane_margin": 2.0,

--- a/perception/elevation_map_loader/README.md
+++ b/perception/elevation_map_loader/README.md
@@ -34,8 +34,8 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 
 ### Service
 
-| Name                               | Type                                                   | Description                                                                                                                                            |
-| ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Name                     | Type                                         | Description                                                                                                                                  |
+| ------------------------ | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `service/get_id_pcd_map` | `autoware_map_msgs::srv::GetIdPointCloudMap` | (Optional) service to request point cloud map. If pointcloud_map_loader sends id pointcloud map loading via ROS 2 service, use this service. |
 
 ## Parameters
@@ -53,7 +53,7 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 | use_elevation_map_cloud_publisher | bool        | Whether to publish `output/elevation_map_cloud`                                                                                   | false         |
 | use_lane_filter                   | bool        | Whether to filter elevation_map with vector_map                                                                                   | false         |
 | lane_margin                       | float       | Margin distance from the lane polygon of the area to be included in the inpainting mask [m]. Used only when use_lane_filter=True. | 0.0           |
-| use_sequential_load | bool | Whether to get point cloud map by service | false |
+| use_sequential_load               | bool        | Whether to get point cloud map by service                                                                                         | false         |
 
 ### GridMap parameters
 

--- a/perception/elevation_map_loader/README.md
+++ b/perception/elevation_map_loader/README.md
@@ -32,6 +32,12 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 | `output/elevation_map`       | `grid_map_msgs::msg::GridMap`   | The elevation map                                                    |
 | `output/elevation_map_cloud` | `sensor_msgs::msg::PointCloud2` | (Optional) The point cloud generated from the value of elevation map |
 
+### Service
+
+| Name                               | Type                                                   | Description                                                                                                                                            |
+| ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `service/get_id_pcd_map` | `autoware_map_msgs::srv::GetIdPointCloudMap` | (Optional) service to request point cloud map. If pointcloud_map_loader sends id pointcloud map loading via ROS 2 service, use this service. |
+
 ## Parameters
 
 ### Node parameters
@@ -47,6 +53,7 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 | use_elevation_map_cloud_publisher | bool        | Whether to publish `output/elevation_map_cloud`                                                                                   | false         |
 | use_lane_filter                   | bool        | Whether to filter elevation_map with vector_map                                                                                   | false         |
 | lane_margin                       | float       | Margin distance from the lane polygon of the area to be included in the inpainting mask [m]. Used only when use_lane_filter=True. | 0.0           |
+| use_sequential_load | bool | Whether to get point cloud map by service | false |
 
 ### GridMap parameters
 

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -66,19 +66,19 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_pointcloud_map_;
   rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_vector_map_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::MapHash>::SharedPtr sub_map_hash_;
-  rclcpp::Subscription<autoware_map_msgs::srv::PointCloudMapMetadata>::SharedPtr sub_pointcloud_metadata_;
+  rclcpp::Subscription<autoware_map_msgs::srv::PointCloudMapMetadata>::SharedPtr
+    sub_pointcloud_metadata_;
   rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr pub_elevation_map_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_elevation_map_cloud_;
-  rclcpp::Client<autoware_map_msgs::srv::GetIdPointCloudMap>::SharedPtr
-    pcd_loader_client_;
+  rclcpp::Client<autoware_map_msgs::srv::GetIdPointCloudMap>::SharedPtr pcd_loader_client_;
   rclcpp::CallbackGroup::SharedPtr group_;
   rclcpp::TimerBase::SharedPtr timer_;
   void onPointcloudMap(const sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_map);
   void onMapHash(const tier4_external_api_msgs::msg::MapHash::ConstSharedPtr map_hash);
   void timerCallback();
   void onVectorMap(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr vector_map);
-  void onPointCloudMapMetadata(const autoware_map_msgs::srv::PointCloudMapMetadata pointcloud_map_metadata)
-  void receiveMap();
+  void onPointCloudMapMetadata(
+    const autoware_map_msgs::srv::PointCloudMapMetadata pointcloud_map_metadata) void receiveMap();
   void concatPointCloundMaps(
     sensor_msgs::msg::PointCloud2 & pointcloud_map,
     const sensor_msgs::msg::PointCloud2 & new_pointcloud);

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -26,6 +26,8 @@
 
 #include "tier4_external_api_msgs/msg/map_hash.hpp"
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
+#include <autoware_map_msgs/msg/point_cloud_cell_metadata.hpp>
+#include <autoware_map_msgs/srv/get_id_point_cloud_map.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <pcl/pcl_base.h>
@@ -64,11 +66,22 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_pointcloud_map_;
   rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_vector_map_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::MapHash>::SharedPtr sub_map_hash_;
+  rclcpp::Subscription<autoware_map_msgs::srv::PointCloudMapMetadata>::SharedPtr sub_pointcloud_metadata_;
   rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr pub_elevation_map_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_elevation_map_cloud_;
+  rclcpp::Client<autoware_map_msgs::srv::GetIdPointCloudMap>::SharedPtr
+    pcd_loader_client_;
+  rclcpp::CallbackGroup::SharedPtr group_;
+  rclcpp::TimerBase::SharedPtr timer_;
   void onPointcloudMap(const sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_map);
   void onMapHash(const tier4_external_api_msgs::msg::MapHash::ConstSharedPtr map_hash);
+  void timerCallback();
   void onVectorMap(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr vector_map);
+  void onPointCloudMapMetadata(const autoware_map_msgs::srv::PointCloudMapMetadata pointcloud_map_metadata)
+  void receiveMap();
+  void concatPointCloundMaps(
+    sensor_msgs::msg::PointCloud2 & pointcloud_map,
+    const sensor_msgs::msg::PointCloud2 & new_pointcloud);
 
   void publish();
   void createElevationMap();
@@ -87,6 +100,8 @@ private:
   float inpaint_radius_;
   bool use_elevation_map_cloud_publisher_;
   std::string param_file_path_;
+  bool is_map_received_ = false;
+  bool is_elevation_map_published_ = false;
 
   DataManager data_manager_;
   struct LaneFilter
@@ -94,6 +109,7 @@ private:
     lanelet::ConstLanelets road_lanelets_;
     float lane_margin_;
     bool use_lane_filter_;
+    std::vector<std::string> pointcloud_map_ids_
   };
   LaneFilter lane_filter_;
 };

--- a/perception/elevation_map_loader/launch/elevation_map_loader.launch.xml
+++ b/perception/elevation_map_loader/launch/elevation_map_loader.launch.xml
@@ -2,6 +2,7 @@
   <arg name="elevation_map_directory" default="$(find-pkg-share elevation_map_loader)/data/elevation_maps"/>
   <arg name="param_file_path" default="$(find-pkg-share elevation_map_loader)/config/elevation_map_parameters.yaml"/>
   <arg name="use_lane_filter" default="false"/>
+  <arg name="use_sequential_load" default="false"/>
   <arg name="use_inpaint" default="true"/>
   <arg name="inpaint_radius" default="1.0"/>
 
@@ -9,9 +10,11 @@
     <remap from="output/elevation_map" to="/map/elevation_map"/>
     <remap from="input/pointcloud_map" to="/map/pointcloud_map"/>
     <remap from="input/vector_map" to="/map/vector_map"/>
+    <remap from="service/get_id_pcd_map" to="/map/get_id_pointcloud_map"/>
 
     <param name="elevation_map_directory" value="$(var elevation_map_directory)"/>
     <param name="param_file_path" value="$(var param_file_path)"/>
     <param name="use_lane_filter" value="$(var use_lane_filter)"/>
+    <param name="use_sequential_load" value="$(var use_sequential_load)"/>
   </node>
 </launch>

--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -13,6 +13,7 @@
   <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>grid_map_cv</depend>
   <depend>grid_map_pcl</depend>
   <depend>grid_map_ros</depend>

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -54,6 +54,7 @@ ElevationMapLoaderNode::ElevationMapLoaderNode(const rclcpp::NodeOptions & optio
   layer_name_ = this->declare_parameter("map_layer_name", std::string("elevation"));
   param_file_path_ = this->declare_parameter("param_file_path", "path_default");
   map_frame_ = this->declare_parameter("map_frame", "map");
+  bool use_sequential_load = this->declare_parameter<bool>("use_sequential_load", true);
   use_inpaint_ = this->declare_parameter("use_inpaint", true);
   inpaint_radius_ = this->declare_parameter("inpaint_radius", 0.3);
   use_elevation_map_cloud_publisher_ =
@@ -79,11 +80,36 @@ ElevationMapLoaderNode::ElevationMapLoaderNode(const rclcpp::NodeOptions & optio
   sub_map_hash_ = create_subscription<tier4_external_api_msgs::msg::MapHash>(
     "/api/autoware/get/map/info/hash", durable_qos,
     std::bind(&ElevationMapLoaderNode::onMapHash, this, _1));
-  sub_pointcloud_map_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
-    "input/pointcloud_map", durable_qos,
-    std::bind(&ElevationMapLoaderNode::onPointcloudMap, this, _1));
   sub_vector_map_ = this->create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
     "input/vector_map", durable_qos, std::bind(&ElevationMapLoaderNode::onVectorMap, this, _1));
+  if (use_sequential_load) {
+    {
+      sub_pointcloud_metadata_ = this->create_subscription<autoware_map_msgs::srv::PointCloudMapMetadata>(
+        "input/pointcloud_map_metadata", durable_qos,std::bind(&ElevationMapLoaderNode::onPointCloudMapMetadata, this, _1));
+      constexpr auto period_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(1.0));
+      group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+      pcd_loader_client_ = create_client<autoware_map_msgs::srv::GetIdPointCloudMap>(
+        "service/get_id_pcd_map", rmw_qos_profile_services_default, group_);
+      
+      while (!pcd_loader_client_->wait_for_service(std::chrono::seconds(1)) && rclcpp::ok()) {
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Waiting for pcd map loader service. Check if the enable_id_load in "
+          "pointcloud_map_loader is set `true`.");
+      }
+      timer_ =
+        this->create_wall_timer(period_ns, std::bind(&ElevationMapLoaderNode::timerCallback, this));
+    }
+
+    if (data_manager_.isInitialized()) {
+      publish();
+    }
+  } else {
+    sub_pointcloud_map_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
+      "input/pointcloud_map", durable_qos,
+      std::bind(&ElevationMapLoaderNode::onPointcloudMap, this, _1));
+  }
 }
 
 void ElevationMapLoaderNode::publish()
@@ -128,6 +154,20 @@ void ElevationMapLoaderNode::publish()
     pcl::toROSMsg(*elevation_map_cloud_ptr, elevation_map_cloud_msg);
     pub_elevation_map_cloud_->publish(elevation_map_cloud_msg);
   }
+  is_elevation_map_published_ = true;
+}
+
+void ElevationMapLoaderNode::timerCallback()
+{
+  // flag to make receiveMap() called only once.
+  if (!is_map_received_) {
+    ElevationMapLoaderNode::receiveMap();
+    is_map_received_ = true;
+    RCLCPP_INFO(this->get_logger(), "receive service with pointcloud_map");
+  }
+  if (data_manager_.isInitialized() && !is_elevation_map_published_) {
+    publish();
+  }
 }
 
 void ElevationMapLoaderNode::onMapHash(
@@ -156,6 +196,20 @@ void ElevationMapLoaderNode::onPointcloudMap(
   }
 }
 
+void ElevationMapLoaderNode::onPointCloudMapMetadata(
+  const autoware_map_msgs::srv::PointCloudMapMetadata pointcloud_map_metadata)
+{
+  RCLCPP_INFO(this->get_logger(), "subscribe pointcloud_map metadata");
+  {
+    for (const auto & pointcloud_map_metadata : pointcloud_map_metadata.cell_metadata) {
+      data_manager_.pointcloud_map_ids_.push_back(pointcloud_map_metadata.cell_id);
+    }
+  }
+  if (data_manager_.isInitialized()) {
+    publish();
+  }
+}
+
 void ElevationMapLoaderNode::onVectorMap(
   const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr vector_map)
 {
@@ -167,6 +221,63 @@ void ElevationMapLoaderNode::onVectorMap(
   lane_filter_.road_lanelets_ = lanelet::utils::query::roadLanelets(all_lanelets);
   if (data_manager_.isInitialized()) {
     publish();
+  }
+}
+
+void ElevationMapLoaderNode::receiveMap()
+{
+  pcl::PointCloud<pcl::PointXYZ> map_pcl;
+  sensor_msgs::msg::PointCloud2 pointcloud_map;
+  // create a loading request with mode = 1
+  auto request = std::make_shared<autoware_map_msgs::srv::GetIdPointCloudMap::Request>();
+  if (!pcd_loader_client_->service_is_ready()) {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Waiting for pcd map loader service. Check if the enable_differential_load in "
+      "pointcloud_map_loader is set `true`.");
+  }
+  std::vector<std::string> cached_ids{};
+  for (const auto & pointcloud_map_id : data_manager_.pointcloud_map_ids_) {
+    // update request
+    request->cell_ids = {pointcloud_map_id};
+    request->cached_ids = cached_ids;
+    // send a request to map_loader
+    RCLCPP_INFO(this->get_logger(), "send a request to map_loader");
+    auto result{pcd_loader_client_->async_send_request(
+      request,
+      [](rclcpp::Client<autoware_map_msgs::srv::GetIdPointCloudMap>::SharedFuture) {})};
+    std::future_status status = result.wait_for(std::chrono::seconds(0));
+    while (status != std::future_status::ready) {
+      RCLCPP_INFO(this->get_logger(), "waiting response");
+      if (!rclcpp::ok()) {
+        return;
+      }
+      status = result.wait_for(std::chrono::seconds(1));
+    }
+
+    // concat maps
+    RCLCPP_INFO(this->get_logger(), "concat maps");
+    for (const auto & new_pointcloud_with_id : result.get()->new_pointcloud_with_ids) {
+      concatPointCloundMaps(pointcloud_map, new_pointcloud_with_id.pointcloud);
+      cached_ids.push_back(new_pointcloud_with_id.cell_id);
+    }
+  }
+  RCLCPP_INFO(this->get_logger(), "finish receiving");
+  pcl::fromROSMsg<pcl::PointXYZ>(pointcloud_map, map_pcl);
+  data_manager_.map_pcl_ptr_ = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
+}
+
+void ElevationMapLoaderNode::concatPointCloundMaps(
+  sensor_msgs::msg::PointCloud2 & pointcloud_map,
+  const sensor_msgs::msg::PointCloud2 & new_pointcloud)
+{
+  if (pointcloud_map.width == 0) {
+    pointcloud_map = new_pointcloud;
+  } else {
+    pointcloud_map.width += new_pointcloud.width;
+    pointcloud_map.row_step += new_pointcloud.row_step;
+    pointcloud_map.data.insert(
+      pointcloud_map.data.end(), new_pointcloud.data.begin(), new_pointcloud.data.end());
   }
 }
 

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -84,14 +84,16 @@ ElevationMapLoaderNode::ElevationMapLoaderNode(const rclcpp::NodeOptions & optio
     "input/vector_map", durable_qos, std::bind(&ElevationMapLoaderNode::onVectorMap, this, _1));
   if (use_sequential_load) {
     {
-      sub_pointcloud_metadata_ = this->create_subscription<autoware_map_msgs::srv::PointCloudMapMetadata>(
-        "input/pointcloud_map_metadata", durable_qos,std::bind(&ElevationMapLoaderNode::onPointCloudMapMetadata, this, _1));
+      sub_pointcloud_metadata_ =
+        this->create_subscription<autoware_map_msgs::srv::PointCloudMapMetadata>(
+          "input/pointcloud_map_metadata", durable_qos,
+          std::bind(&ElevationMapLoaderNode::onPointCloudMapMetadata, this, _1));
       constexpr auto period_ns =
         std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(1.0));
       group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
       pcd_loader_client_ = create_client<autoware_map_msgs::srv::GetIdPointCloudMap>(
         "service/get_id_pcd_map", rmw_qos_profile_services_default, group_);
-      
+
       while (!pcd_loader_client_->wait_for_service(std::chrono::seconds(1)) && rclcpp::ok()) {
         RCLCPP_INFO(
           this->get_logger(),
@@ -244,8 +246,7 @@ void ElevationMapLoaderNode::receiveMap()
     // send a request to map_loader
     RCLCPP_INFO(this->get_logger(), "send a request to map_loader");
     auto result{pcd_loader_client_->async_send_request(
-      request,
-      [](rclcpp::Client<autoware_map_msgs::srv::GetIdPointCloudMap>::SharedFuture) {})};
+      request, [](rclcpp::Client<autoware_map_msgs::srv::GetIdPointCloudMap>::SharedFuture) {})};
     std::future_status status = result.wait_for(std::chrono::seconds(0));
     while (status != std::future_status::ready) {
       RCLCPP_INFO(this->get_logger(), "waiting response");


### PR DESCRIPTION
WIP

Signed-off-by: Shin-kyoto <58775300+Shin-kyoto@users.noreply.github.com>

## Description

<!-- Write a brief description of this PR. -->

These PRs must be merged before this PR.

- https://github.com/autowarefoundation/autoware.universe/pull/3286
- https://github.com/autowarefoundation/autoware_msgs/pull/56
   - add new service and msg

### Why?

- When you use large pointcloud map, map_loader cannot publish large map as one topic because of the limit size determined by [the default value in cyclonedds](https://github.com/eclipse-cyclonedds/cyclonedds/blob/09a02f5b2b9ba856d7d4c616510252cf9e508ec2/docs/manual/config/config_file_reference.rst#cycloneddsdomaininternalmaxsamplesize).
- So I want to add sequential map loading mode to `elevation_map_loader`. It is helpful to avoid exeeding the limit by using `id_map_loader`.

### What?

- I would like to add `id_map_loader` support to `elevation_map_loader`.
- In the default setting, `id_map_loader` support is disabled. So if you want to use [this](https://github.com/Shin-kyoto/autoware.universe/commit/69b1e7b9cc2139858bef8922974b43b698a0e12a), please change your launcher like this.
- I assume that the each PCD file is not so large and the size of each PCD file does not exceed the limit size to receive(This is determined by [the default value in cyclonedds](https://github.com/eclipse-cyclonedds/cyclonedds/blob/09a02f5b2b9ba856d7d4c616510252cf9e508ec2/docs/manual/config/config_file_reference.rst#cycloneddsdomaininternalmaxsamplesize))

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

- [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-254)
- https://github.com/autowarefoundation/autoware.universe/pull/3286
- https://github.com/autowarefoundation/autoware_msgs/pull/56


## Tests performed

<!-- Describe how you have tested this PR. -->

I tested with a data from Autoware tutorial. The map is divided into 20m grids ([sample-map-rosbag_split.zip](https://github.com/autowarefoundation/autoware.universe/files/10349104/sample-map-rosbag_split.zip)).

I have confirmed that the Autoware performs the same as the current Autoware when use_differential_load is set false.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

How to check

1. Check if these PRs are used in your environment.
   - https://github.com/autowarefoundation/autoware.universe/pull/3286
   - https://github.com/autowarefoundation/autoware_msgs/pull/56
2. Build autoware
3. Change your launcher like [this](https://github.com/Shin-kyoto/autoware.universe/commit/69b1e7b9cc2139858bef8922974b43b698a0e12a).
4. Run command below
```bash
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/data/map/sample-map-rosbag_split pointcloud_map_file:=pointcloud_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit planning:=false control:=false system:=false rviz:=true sensing:=false|grep -e elevation -e map
```
5. You should get the outputs like;
```bash
❯ ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/data/map/sample-map-rosbag_split pointcloud_map_file:=pointcloud_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit planning:=false control:=false system:=false rviz:=true sensing:=false|grep -e elevation -e map
........
[component_container-3] [INFO 1679896837.303861415] [map.pointcloud_map_loader]: Load /home/shintarotomie/data/map/sample-map-rosbag_split/pointcloud_map/89400_42300.pcd (1 out of 23)
........
[component_container_mt-1] [INFO 1679896838.782485794] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: send a request to map_loader
[component_container_mt-1] [INFO 1679896838.782555553] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: waiting response
[component_container_mt-1] [INFO 1679896838.792788277] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: concat maps
[component_container_mt-1] [INFO 1679896838.796591044] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: send a request to map_loader
[component_container_mt-1] [INFO 1679896838.796639893] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: waiting response
[component_container_mt-1] [INFO 1679896838.796889053] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: concat maps
[component_container_mt-1] [INFO 1679896838.796905702] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: finish receiving
[component_container_mt-1] [INFO 1679896838.799180362] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: receive service with pointcloud_map
[component_container_mt-1] [INFO 1679896838.799207985] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: Create elevation map from pointcloud map 
[component_container_mt-1] [INFO 1679896839.235498083] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: Finish creating elevation map. Total time: 0.433 sec
[component_container_mt-1] [INFO 1679896839.666728529] [rosbag2_storage]: Opened database '/home/shintarotomie/work/2023/0317/autoware/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/52fe0e6043a473758c9aab905232c887a7374632dabe1099c27b22effcbd93e1/52fe0e6043a473758c9aab905232c887a7374632dabe1099c27b22effcbd93e1_0.db3' for READ_WRITE.
[component_container_mt-1] [INFO 1679896839.672484128] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: Saving elevation map successful: true
```
6. Check rviz and you should see the elevation_map like;

![image](https://user-images.githubusercontent.com/58775300/227856478-811dfc18-b9d1-4e95-b57c-d4347599b161.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
