### PR TITLE
perf(ring_outlier_filter): a cache friendly impl

### DIFF
--- a/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
+++ b/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
@@ -22,13 +22,12 @@ This implementation inherits `pointcloud_preprocessor::Filter` class, please ref
 
 ### Core Parameters
 
-| Name                      | Type    | Default Value | Description                                                                         |
-| ------------------------- | ------- | ------------- | ----------------------------------------------------------------------------------- |
-| `distance_ratio`          | double  | 1.03          |                                                                                     |
-| `object_length_threshold` | double  | 0.1           |                                                                                     |
-| `num_points_threshold`    | int     | 4             |                                                                                     |
-| `max_rings_num`           | uint_16 | 128           |                                                                                     |
-| `max_points_num_per_ring` | size_t  | 4000          | Set this value large enough such that `HFoV / resolution < max_points_num_per_ring` |
+| Name                      | Type    | Default Value | Description |
+| ------------------------- | ------- | ------------- | ----------- |
+| `distance_ratio`          | double  | 1.03          |             |
+| `object_length_threshold` | double  | 0.1           |             |
+| `num_points_threshold`    | int     | 4             |             |
+| `max_rings_num`           | uint_16 | 128           |             |
 
 ## Assumptions / Known limits
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
@@ -45,28 +45,12 @@ private:
   double object_length_threshold_;
   int num_points_threshold_;
   uint16_t max_rings_num_;
-  size_t max_points_num_per_ring_;
 
   /** \brief Parameter service callback result : needed to be hold */
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 
   /** \brief Parameter service callback */
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
-
-  bool isCluster(
-    const PointCloud2ConstPtr & input, std::pair<int, int> data_idx_both_ends, int walk_size)
-  {
-    if (walk_size > num_points_threshold_) return true;
-
-    auto first_point = reinterpret_cast<const PointXYZI *>(&input->data[data_idx_both_ends.first]);
-    auto last_point = reinterpret_cast<const PointXYZI *>(&input->data[data_idx_both_ends.second]);
-
-    const auto x = first_point->x - last_point->x;
-    const auto y = first_point->y - last_point->y;
-    const auto z = first_point->z - last_point->z;
-
-    return x * x + y * y + z * z >= object_length_threshold_ * object_length_threshold_;
-  }
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/utility/utilities.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/utility/utilities.hpp
@@ -26,6 +26,7 @@
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <optional>
 #include <vector>
 
 using K = CGAL::Exact_predicates_inexact_constructions_kernel;
@@ -85,6 +86,33 @@ bool is_data_layout_compatible_with_PointXYZI(const sensor_msgs::msg::PointCloud
 /** \brief Return whether the input PointCloud2 data has the same layout than PointXYZIRADRT. That
  * is to say whether you can memcpy from the PointCloud2 data buffer to a PointXYZIRADRT */
 bool is_data_layout_compatible_with_PointXYZIRADRT(const sensor_msgs::msg::PointCloud2 & input);
+
+/** \brief Return offset of X field (if any). The field should match PointXYZIRADRT one */
+std::optional<std::size_t> getXOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+
+/** \brief Return offset of Y field (if any). The field should match PointXYZIRADRT one */
+std::optional<std::size_t> getYOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+
+/** \brief Return offset of Z field (if any). The field should match PointXYZIRADRT one */
+std::optional<std::size_t> getZOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+
+/** \brief Return offset of intensity field (if any). The field should match PointXYZIRADRT one */
+std::optional<std::size_t> getIntensityOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+
+/** \brief Return offset of ring field (if any). The field should match PointXYZIRADRT one */
+std::optional<std::size_t> getRingOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+
+/** \brief Return offset of azimuth field (if any). The field should match PointXYZIRADRT one */
+std::optional<std::size_t> getAzimuthOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+
+/** \brief Return offset of distance field (if any). The field should match PointXYZIRADRT one */
+std::optional<std::size_t> getDistanceOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+
+/** \brief Return offset of return type field (if any). The field should match PointXYZIRADRT one */
+std::optional<std::size_t> getReturnTypeOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+
+/** \brief Return offset of time stamp field (if any). The field should match PointXYZIRADRT one */
+std::optional<std::size_t> getTimeStampOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
 
 }  // namespace pointcloud_preprocessor::utils
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/utility/utilities.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/utility/utilities.hpp
@@ -88,36 +88,31 @@ bool is_data_layout_compatible_with_PointXYZI(const sensor_msgs::msg::PointCloud
 bool is_data_layout_compatible_with_PointXYZIRADRT(const sensor_msgs::msg::PointCloud2 & input);
 
 /** \brief Return offset of X field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getXOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getXOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
 /** \brief Return offset of Y field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getYOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getYOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
 /** \brief Return offset of Z field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getZOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getZOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
 /** \brief Return offset of intensity field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getIntensityOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getIntensityOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
 /** \brief Return offset of ring field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getRingOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getRingOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
 /** \brief Return offset of azimuth field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getAzimuthOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getAzimuthOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
 /** \brief Return offset of distance field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getDistanceOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getDistanceOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
 /** \brief Return offset of return type field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getReturnTypeOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getReturnTypeOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
 /** \brief Return offset of time stamp field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getTimeStampOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getTimeStampOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
 }  // namespace pointcloud_preprocessor::utils
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/utility/utilities.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/utility/utilities.hpp
@@ -97,22 +97,27 @@ std::optional<std::size_t> getYOffset(const std::vector<sensor_msgs::msg::PointF
 std::optional<std::size_t> getZOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
 
 /** \brief Return offset of intensity field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getIntensityOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getIntensityOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields);
 
 /** \brief Return offset of ring field (if any). The field should match PointXYZIRADRT one */
 std::optional<std::size_t> getRingOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
 
 /** \brief Return offset of azimuth field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getAzimuthOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getAzimuthOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields);
 
 /** \brief Return offset of distance field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getDistanceOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getDistanceOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields);
 
 /** \brief Return offset of return type field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getReturnTypeOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getReturnTypeOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields);
 
 /** \brief Return offset of time stamp field (if any). The field should match PointXYZIRADRT one */
-std::optional<std::size_t> getTimeStampOffset(const std::vector<sensor_msgs::msg::PointField> & fields);
+std::optional<std::size_t> getTimeStampOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields);
 
 }  // namespace pointcloud_preprocessor::utils
 

--- a/sensing/pointcloud_preprocessor/package.xml
+++ b/sensing/pointcloud_preprocessor/package.xml
@@ -31,6 +31,7 @@
   <depend>pcl_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>point_cloud_msg_wrapper</depend>
+  <depend>range-v3</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -327,6 +327,7 @@ void RingOutlierFilterComponent::faster_filter(
       output_size += sizeof(PointXYZI);
     }
   }
+  output.data.resize(output_size);
 
   // Note that `input->header.frame_id` is data before converted when `transform_info.need_transform
   // == true`

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -335,7 +335,6 @@ void RingOutlierFilterComponent::faster_filter(
 
   output.height = 1;
   output.width = static_cast<uint32_t>(output.data.size() / output.height / output.point_step);
-  output.row_step = static_cast<uint32_t>(output.data.size() / output.height);
   output.is_bigendian = input->is_bigendian;
   output.is_dense = input->is_dense;
 

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 #include "pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp"
-#include "pointcloud_preprocessor/utility/utilities.hpp"
 
-#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include "pointcloud_preprocessor/utility/utilities.hpp"
 
 #include <range/v3/view/chunk.hpp>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/view/zip.hpp>
+
+#include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -130,13 +131,14 @@ void RingOutlierFilterComponent::faster_filter(
   //   1. Iterate over the input cloud and group point indices by ring
   //   2. For each ring:
   //   2.1. iterate over the ring points, and group points belonging to the same "walk"
-  //   2.2. when a walk is closed, copy indexed points to the output cloud if the walk is long enough.
+  //   2.2. when a walk is closed, copy indexed points to the output cloud if the walk is long
+  //   enough.
   //
-  // Because LIDAR data is naturally "azimut-major order" and not "ring-major order", such 
+  // Because LIDAR data is naturally "azimut-major order" and not "ring-major order", such
   // implementation is not cache friendly at all, and has negative impact on all the other nodes.
   //
-  // To tackle this issue, the algorithm has been rewritten so that points would be accessed in 
-  // order. To do so, all rings are being processing simultaneously instead of separately. The 
+  // To tackle this issue, the algorithm has been rewritten so that points would be accessed in
+  // order. To do so, all rings are being processing simultaneously instead of separately. The
   // overall logic is still the same.
 
   // ad-hoc struct to store finished walks information (for isCluster())

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -71,28 +71,28 @@ void RingOutlierFilterComponent::faster_filter(
 
   // FIXME(VRichardJP) Everything would be simpler if Autoware enforced strict PointCloud2 format
 
-  auto maybe_intensity_offset = utils::getIntensityOffset(input->fields);
+  auto maybe_intensity_offset = utils::getIntensityOffset(*input);
   if (!maybe_intensity_offset) {
     RCLCPP_ERROR(get_logger(), "input cloud does not contain 'intensity' data field");
     return;
   }
   const auto intensity_offset = *maybe_intensity_offset;
 
-  auto maybe_ring_offset = utils::getRingOffset(input->fields);
+  auto maybe_ring_offset = utils::getRingOffset(*input);
   if (!maybe_ring_offset) {
     RCLCPP_ERROR(get_logger(), "input cloud does not contain 'ring' data field");
     return;
   }
   const auto ring_offset = *maybe_ring_offset;
 
-  auto maybe_azimuth_offset = utils::getAzimuthOffset(input->fields);
+  auto maybe_azimuth_offset = utils::getAzimuthOffset(*input);
   if (!maybe_azimuth_offset) {
     RCLCPP_ERROR(get_logger(), "input cloud does not contain 'azimuth' data field");
     return;
   }
   const auto azimuth_offset = *maybe_azimuth_offset;
 
-  auto maybe_distance_offset = utils::getDistanceOffset(input->fields);
+  auto maybe_distance_offset = utils::getDistanceOffset(*input);
   if (!maybe_distance_offset) {
     RCLCPP_ERROR(get_logger(), "input cloud does not contain 'distance' data field");
     return;

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp
@@ -13,11 +13,18 @@
 // limitations under the License.
 
 #include "pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp"
+#include "pointcloud_preprocessor/utility/utilities.hpp"
 
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
+#include <range/v3/view/chunk.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/zip.hpp>
+
 #include <algorithm>
+#include <cstddef>
 #include <vector>
+
 namespace pointcloud_preprocessor
 {
 RingOutlierFilterComponent::RingOutlierFilterComponent(const rclcpp::NodeOptions & options)
@@ -40,8 +47,6 @@ RingOutlierFilterComponent::RingOutlierFilterComponent(const rclcpp::NodeOptions
       static_cast<double>(declare_parameter("object_length_threshold", 0.1));
     num_points_threshold_ = static_cast<int>(declare_parameter("num_points_threshold", 4));
     max_rings_num_ = static_cast<uint16_t>(declare_parameter("max_rings_num", 128));
-    max_points_num_per_ring_ =
-      static_cast<size_t>(declare_parameter("max_points_num_per_ring", 4000));
   }
 
   using std::placeholders::_1;
@@ -61,123 +66,265 @@ void RingOutlierFilterComponent::faster_filter(
   }
   stop_watch_ptr_->toc("processing_time", true);
 
-  output.point_step = sizeof(PointXYZI);
-  output.data.resize(output.point_step * input->width);
-  size_t output_size = 0;
+  // point field extraction helpers
 
-  const auto ring_offset =
-    input->fields.at(static_cast<size_t>(autoware_point_types::PointIndex::Ring)).offset;
-  const auto azimuth_offset =
-    input->fields.at(static_cast<size_t>(autoware_point_types::PointIndex::Azimuth)).offset;
-  const auto distance_offset =
-    input->fields.at(static_cast<size_t>(autoware_point_types::PointIndex::Distance)).offset;
-  const auto intensity_offset =
-    input->fields.at(static_cast<size_t>(autoware_point_types::PointIndex::Intensity)).offset;
+  // FIXME(VRichardJP) Everything would be simpler if Autoware enforced strict PointCloud2 format
 
-  std::vector<std::vector<size_t>> ring2indices;
-  ring2indices.reserve(max_rings_num_);
-
-  for (uint16_t i = 0; i < max_rings_num_; i++) {
-    ring2indices.push_back(std::vector<size_t>());
-    ring2indices.back().reserve(max_points_num_per_ring_);
+  auto maybe_intensity_offset = utils::getIntensityOffset(input->fields);
+  if (!maybe_intensity_offset) {
+    RCLCPP_ERROR(get_logger(), "input cloud does not contain 'intensity' data field");
+    return;
   }
+  const auto intensity_offset = *maybe_intensity_offset;
 
-  for (size_t data_idx = 0; data_idx < input->data.size(); data_idx += input->point_step) {
-    const uint16_t ring = *reinterpret_cast<const uint16_t *>(&input->data[data_idx + ring_offset]);
-    ring2indices[ring].push_back(data_idx);
+  auto maybe_ring_offset = utils::getRingOffset(input->fields);
+  if (!maybe_ring_offset) {
+    RCLCPP_ERROR(get_logger(), "input cloud does not contain 'ring' data field");
+    return;
   }
+  const auto ring_offset = *maybe_ring_offset;
 
-  // walk range: [walk_first_idx, walk_last_idx]
-  int walk_first_idx = 0;
-  int walk_last_idx = -1;
+  auto maybe_azimuth_offset = utils::getAzimuthOffset(input->fields);
+  if (!maybe_azimuth_offset) {
+    RCLCPP_ERROR(get_logger(), "input cloud does not contain 'azimuth' data field");
+    return;
+  }
+  const auto azimuth_offset = *maybe_azimuth_offset;
 
-  for (const auto & indices : ring2indices) {
-    if (indices.size() < 2) continue;
+  auto maybe_distance_offset = utils::getDistanceOffset(input->fields);
+  if (!maybe_distance_offset) {
+    RCLCPP_ERROR(get_logger(), "input cloud does not contain 'distance' data field");
+    return;
+  }
+  const auto distance_offset = *maybe_distance_offset;
 
-    walk_first_idx = 0;
-    walk_last_idx = -1;
+  // extract intensity from point raw data
+  auto getPointIntensity = [=](const unsigned char * raw_p) {
+    float intensity{};
+    std::memcpy(&intensity, &raw_p[intensity_offset], sizeof(intensity));
+    return intensity;
+  };
 
-    for (size_t idx = 0U; idx < indices.size() - 1; ++idx) {
-      const size_t & current_data_idx = indices[idx];
-      const size_t & next_data_idx = indices[idx + 1];
-      walk_last_idx = idx;
+  // extract ring from point raw data
+  auto getPointRing = [=](const unsigned char * raw_p) {
+    uint16_t ring{};
+    std::memcpy(&ring, &raw_p[ring_offset], sizeof(ring));
+    return ring;
+  };
 
-      // if(std::abs(iter->distance - (iter+1)->distance) <= std::sqrt(iter->distance) * 0.08)
+  // extract azimuth from point raw data
+  auto getPointAzimuth = [=](const unsigned char * raw_p) {
+    float azimuth{};
+    std::memcpy(&azimuth, &raw_p[azimuth_offset], sizeof(azimuth));
+    return azimuth;
+  };
 
-      const float & current_azimuth =
-        *reinterpret_cast<const float *>(&input->data[current_data_idx + azimuth_offset]);
-      const float & next_azimuth =
-        *reinterpret_cast<const float *>(&input->data[next_data_idx + azimuth_offset]);
-      float azimuth_diff = next_azimuth - current_azimuth;
+  // extract distance from point raw data
+  auto getPointDistance = [=](const unsigned char * raw_p) {
+    float distance{};
+    std::memcpy(&distance, &raw_p[distance_offset], sizeof(distance));
+    return distance;
+  };
+
+  // The initial implementation of ring outlier filter looked like this:
+  //   1. Iterate over the input cloud and group point indices by ring
+  //   2. For each ring:
+  //   2.1. iterate over the ring points, and group points belonging to the same "walk"
+  //   2.2. when a walk is closed, copy indexed points to the output cloud if the walk is long enough.
+  //
+  // Because LIDAR data is naturally "azimut-major order" and not "ring-major order", such 
+  // implementation is not cache friendly at all, and has negative impact on all the other nodes.
+  //
+  // To tackle this issue, the algorithm has been rewritten so that points would be accessed in 
+  // order. To do so, all rings are being processing simultaneously instead of separately. The 
+  // overall logic is still the same.
+
+  // ad-hoc struct to store finished walks information (for isCluster())
+  struct WalkInfo
+  {
+    int num_points;
+    float first_point_distance;
+    float first_point_azimuth;
+    float last_point_distance;
+    float last_point_azimuth;
+  };
+
+  // ad-hoc struct to keep track of each ring current walk
+  struct RingWalkInfo
+  {
+    size_t walk_idx;      // index of associated walk in walks vector
+    float prev_azimuth;   // azimuth of previous point on the ring
+    float prev_distance;  // distance of previous point on the ring
+  };
+
+  // helper functions
+
+  // check if walk is a valid cluster
+  const float object_length_threshold2 = object_length_threshold_ * object_length_threshold_;
+  auto isCluster = [=](const WalkInfo & walk_info) {
+    // A cluster is a walk which has many points or is long enough
+    if (walk_info.num_points > num_points_threshold_) return true;
+
+    // Using the law of cosines, the distance between 2 points can be written as:
+    //   |p2-p1|^2 = d1^2 + d2^2 - 2*d1*d2*cos(a)
+    // where d1 and d2 are the distance attribute of p1 and p2, and 'a' the azimuth diff between
+    // the 2 points.
+    const float dist2 =
+      walk_info.first_point_distance * walk_info.first_point_distance +
+      walk_info.last_point_distance * walk_info.last_point_distance -
+      2 * walk_info.first_point_distance * walk_info.last_point_distance *
+        std::cos((walk_info.last_point_azimuth - walk_info.first_point_azimuth) * (M_PI / 18000.0));
+    return dist2 > object_length_threshold2;
+  };
+
+  // check if 2 points belong to the same walk
+  auto isSameWalk =
+    [=](float curr_distance, float curr_azimuth, float prev_distance, float prev_azimuth) {
+      float azimuth_diff = curr_azimuth - prev_azimuth;
       azimuth_diff = azimuth_diff < 0.f ? azimuth_diff + 36000.f : azimuth_diff;
+      return std::max(curr_distance, prev_distance) <
+               std::min(curr_distance, prev_distance) * distance_ratio_ &&
+             azimuth_diff < 100.f;
+    };
 
-      const float & current_distance =
-        *reinterpret_cast<const float *>(&input->data[current_data_idx + distance_offset]);
-      const float & next_distance =
-        *reinterpret_cast<const float *>(&input->data[next_data_idx + distance_offset]);
+  // tmp vectors to keep track of walk/ring state while processing points in order (cache efficient)
+  std::vector<WalkInfo> walks;                // all walks
+  std::vector<RingWalkInfo> rings_curr_walk;  // each ring curr walk info
+  std::vector<size_t> rings_first_walk_idx;   // each ring very first walk idx
+  std::vector<size_t> points_walk_idx;        // each point walk idx
 
-      if (
-        std::max(current_distance, next_distance) <
-          std::min(current_distance, next_distance) * distance_ratio_ &&
-        azimuth_diff < 100.f) {
-        continue;  // Determined to be included in the same walk
-      }
+  walks.reserve(max_rings_num_);
+  // initialize each ring with empty walk
+  rings_curr_walk.resize(max_rings_num_, RingWalkInfo{-1U, 0., 0.});
+  rings_first_walk_idx.resize(max_rings_num_, -1U);
+  // points are initially associated to no walk
+  points_walk_idx.resize(input->width * input->height, -1U);
 
-      if (isCluster(
-            input, std::make_pair(indices[walk_first_idx], indices[walk_last_idx]),
-            walk_last_idx - walk_first_idx + 1)) {
-        for (int i = walk_first_idx; i <= walk_last_idx; i++) {
-          auto output_ptr = reinterpret_cast<PointXYZI *>(&output.data[output_size]);
-          auto input_ptr = reinterpret_cast<const PointXYZI *>(&input->data[indices[i]]);
+  int invalid_ring_count = 0;
 
-          if (transform_info.need_transform) {
-            Eigen::Vector4f p(input_ptr->x, input_ptr->y, input_ptr->z, 1);
-            p = transform_info.eigen_transform * p;
-            output_ptr->x = p[0];
-            output_ptr->y = p[1];
-            output_ptr->z = p[2];
-          } else {
-            *output_ptr = *input_ptr;
-          }
-          const float & intensity =
-            *reinterpret_cast<const float *>(&input->data[indices[i] + intensity_offset]);
-          output_ptr->intensity = intensity;
+  // Build walks and classify points
+  for (const auto & [raw_p, point_walk_idx] :
+       ranges::views::zip(input->data | ranges::views::chunk(input->point_step), points_walk_idx)) {
+    const uint16_t ring_idx = getPointRing(raw_p.data());
+    const float curr_azimuth = getPointAzimuth(raw_p.data());
+    const float curr_distance = getPointDistance(raw_p.data());
 
-          output_size += output.point_step;
-        }
-      }
-
-      walk_first_idx = idx + 1;
+    if (ring_idx >= max_rings_num_) {
+      // Either the data is corrupted or max_rings_num_ is not set correctly
+      // Note: point_walk_idx == -1 so the point will be filtered out
+      invalid_ring_count += 1;
+      continue;
     }
 
-    if (walk_first_idx > walk_last_idx) continue;
+    auto & ring = rings_curr_walk[ring_idx];
+    if (ring.walk_idx == -1U) {
+      // first walk ever for this ring
+      walks.push_back(WalkInfo{1, curr_distance, curr_azimuth, curr_distance, curr_azimuth});
+      const auto walk_idx = walks.size() - 1;
+      point_walk_idx = walk_idx;
+      rings_first_walk_idx[ring_idx] = walk_idx;
+      ring.walk_idx = walk_idx;
+      ring.prev_azimuth = curr_azimuth;
+      ring.prev_distance = curr_distance;
+      continue;
+    }
 
-    if (isCluster(
-          input, std::make_pair(indices[walk_first_idx], indices[walk_last_idx]),
-          walk_last_idx - walk_first_idx + 1)) {
-      for (int i = walk_first_idx; i <= walk_last_idx; i++) {
-        auto output_ptr = reinterpret_cast<PointXYZI *>(&output.data[output_size]);
-        auto input_ptr = reinterpret_cast<const PointXYZI *>(&input->data[indices[i]]);
+    auto & walk = walks[ring.walk_idx];
+    if (isSameWalk(curr_distance, curr_azimuth, ring.prev_distance, ring.prev_azimuth)) {
+      // current point is part of previous walk
+      walk.num_points += 1;
+      walk.last_point_distance = curr_distance;
+      walk.last_point_azimuth = curr_azimuth;
+      point_walk_idx = ring.walk_idx;
+    } else {
+      // previous walk is finished, start a new one
+      walks.push_back(WalkInfo{1, curr_distance, curr_azimuth, curr_distance, curr_azimuth});
+      point_walk_idx = walks.size() - 1;
+      ring.walk_idx = walks.size() - 1;
+    }
 
-        if (transform_info.need_transform) {
-          Eigen::Vector4f p(input_ptr->x, input_ptr->y, input_ptr->z, 1);
-          p = transform_info.eigen_transform * p;
-          output_ptr->x = p[0];
-          output_ptr->y = p[1];
-          output_ptr->z = p[2];
-        } else {
-          *output_ptr = *input_ptr;
-        }
-        const float & intensity =
-          *reinterpret_cast<const float *>(&input->data[indices[i] + intensity_offset]);
-        output_ptr->intensity = intensity;
+    ring.prev_azimuth = curr_azimuth;
+    ring.prev_distance = curr_distance;
+  }
 
-        output_size += output.point_step;
-      }
+  // So far, we have processed ring points as if rings were not circular. Of course, the last and
+  // first points of a ring could totally be part of the same walk. When such thing happens, we need
+  // to merge the two walks
+  for (const auto & [first_walk_idx, last_walk_idx] : ranges::views::zip(
+         rings_first_walk_idx, rings_curr_walk | ranges::views::transform([](const auto & ring) {
+                                 return ring.walk_idx;
+                               }))) {
+    if (first_walk_idx == -1U || last_walk_idx == -1U) {
+      continue;
+    }
+    auto & first_walk = walks[first_walk_idx];
+    auto & last_walk = walks[last_walk_idx];
+    // check if the two walks are connected
+    if (isSameWalk(
+          first_walk.first_point_distance, first_walk.first_point_azimuth,
+          last_walk.last_point_distance, last_walk.last_point_azimuth)) {
+      // merge
+      first_walk.first_point_distance = last_walk.first_point_distance;
+      first_walk.first_point_azimuth = last_walk.first_point_azimuth;
+      last_walk.last_point_distance = first_walk.last_point_distance;
+      last_walk.last_point_azimuth = first_walk.last_point_azimuth;
     }
   }
 
-  output.data.resize(output_size);
+  // segregate walks by cluster (for fast lookup)
+  std::vector<bool> walk_is_cluster;
+  walk_is_cluster.reserve(walks.size());
+  for (const auto & walk_info : walks) {
+    walk_is_cluster.push_back(isCluster(walk_info));
+  }
+
+  // finally copy points
+  output.point_step = sizeof(PointXYZI);
+  output.data.resize(output.point_step * input->width * input->height);
+  size_t output_size = 0;
+  if (transform_info.need_transform) {
+    for (const auto & [raw_p, point_walk_idx] : ranges::views::zip(
+           input->data | ranges::views::chunk(input->point_step), points_walk_idx)) {
+      if (point_walk_idx == -1U || !walk_is_cluster[point_walk_idx]) {
+        continue;
+      }
+
+      // assume binary representation of input point is compatible with PointXYZ*
+      PointXYZI out_point;
+      std::memcpy(&out_point, raw_p.data(), sizeof(PointXYZI));
+
+      Eigen::Vector4f p(out_point.x, out_point.y, out_point.z, 1);
+      p = transform_info.eigen_transform * p;
+      out_point.x = p[0];
+      out_point.y = p[1];
+      out_point.z = p[2];
+      // FIXME(VRichardJP) tmp fix because input data does not have the same layout than PointXYZI
+      out_point.intensity = getPointIntensity(raw_p.data());
+
+      std::memcpy(&output.data[output_size], &out_point, sizeof(PointXYZI));
+      output_size += sizeof(PointXYZI);
+    }
+  } else {
+    for (const auto & [raw_p, point_walk_idx] : ranges::views::zip(
+           input->data | ranges::views::chunk(input->point_step), points_walk_idx)) {
+      if (point_walk_idx == -1U || !walk_is_cluster[point_walk_idx]) {
+        continue;
+      }
+
+#if 0
+      // assume binary representation of input point is compatible with PointXYZI
+      std::memcpy(&output.data[output_size], raw_p.data(), sizeof(PointXYZI));
+#else
+      // FIXME(VRichardJP) tmp fix because input data does not have the same layout than PointXYZI
+      PointXYZI out_point;
+      std::memcpy(&out_point, raw_p.data(), sizeof(PointXYZI));
+      out_point.intensity = getPointIntensity(raw_p.data());
+      std::memcpy(&output.data[output_size], &out_point, sizeof(PointXYZI));
+#endif
+
+      output_size += sizeof(PointXYZI);
+    }
+  }
 
   // Note that `input->header.frame_id` is data before converted when `transform_info.need_transform
   // == true`
@@ -185,6 +332,7 @@ void RingOutlierFilterComponent::faster_filter(
 
   output.height = 1;
   output.width = static_cast<uint32_t>(output.data.size() / output.height / output.point_step);
+  output.row_step = static_cast<uint32_t>(output.data.size() / output.height);
   output.is_bigendian = input->is_bigendian;
   output.is_dense = input->is_dense;
 
@@ -195,6 +343,12 @@ void RingOutlierFilterComponent::faster_filter(
     num_fields, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1,
     sensor_msgs::msg::PointField::FLOAT32, "z", 1, sensor_msgs::msg::PointField::FLOAT32,
     "intensity", 1, sensor_msgs::msg::PointField::FLOAT32);
+
+  if (invalid_ring_count > 0) {
+    RCLCPP_WARN(
+      get_logger(), "%d points had ring index over max_rings_num (%d) and have been ignored.",
+      invalid_ring_count, max_rings_num_);
+  }
 
   // add processing time for debug
   if (debug_publisher_) {

--- a/sensing/pointcloud_preprocessor/src/utility/utilities.cpp
+++ b/sensing/pointcloud_preprocessor/src/utility/utilities.cpp
@@ -16,6 +16,9 @@
 
 #include <autoware_point_types/types.hpp>
 
+#include <algorithm>
+#include <cstring>
+
 namespace pointcloud_preprocessor::utils
 {
 void to_cgal_polygon(const geometry_msgs::msg::Polygon & polygon_in, PolygonCgal & polygon_out)
@@ -234,6 +237,105 @@ bool is_data_layout_compatible_with_PointXYZIRADRT(const sensor_msgs::msg::Point
   same_layout &= field_time_stamp.datatype == sensor_msgs::msg::PointField::FLOAT64;
   same_layout &= field_time_stamp.count == 1;
   return same_layout;
+}
+
+std::optional<std::size_t> getXOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  auto it = std::find_if(fields.begin(), fields.end(), 
+    [&](const auto& field) {
+      return std::strcmp(field.name.c_str(), "x") == 0
+              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
+              && field.count == 1;
+    });
+  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+}
+
+std::optional<std::size_t> getYOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  auto it = std::find_if(fields.begin(), fields.end(), 
+    [&](const auto& field) {
+      return std::strcmp(field.name.c_str(), "y") == 0
+              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
+              && field.count == 1;
+    });
+  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+}
+
+std::optional<std::size_t> getZOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  auto it = std::find_if(fields.begin(), fields.end(), 
+    [&](const auto& field) {
+      return std::strcmp(field.name.c_str(), "z") == 0
+              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
+              && field.count == 1;
+    });
+  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+}
+
+std::optional<std::size_t> getIntensityOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  auto it = std::find_if(fields.begin(), fields.end(), 
+    [&](const auto& field) {
+      return std::strcmp(field.name.c_str(), "intensity") == 0
+              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
+              && field.count == 1;
+    });
+  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+}
+
+std::optional<std::size_t> getRingOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  auto it = std::find_if(fields.begin(), fields.end(), 
+    [&](const auto& field) {
+      return std::strcmp(field.name.c_str(), "ring") == 0
+              && field.datatype == sensor_msgs::msg::PointField::UINT16
+              && field.count == 1;
+    });
+  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+}
+
+std::optional<std::size_t> getAzimuthOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  auto it = std::find_if(fields.begin(), fields.end(), 
+    [&](const auto& field) {
+      return std::strcmp(field.name.c_str(), "azimuth") == 0
+              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
+              && field.count == 1;
+    });
+  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+}
+
+std::optional<std::size_t> getDistanceOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  auto it = std::find_if(fields.begin(), fields.end(), 
+    [&](const auto& field) {
+      return std::strcmp(field.name.c_str(), "distance") == 0
+              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
+              && field.count == 1;
+    });
+  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+}
+
+std::optional<std::size_t> getReturnTypeOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  auto it = std::find_if(fields.begin(), fields.end(), 
+    [&](const auto& field) {
+      return std::strcmp(field.name.c_str(), "return_type") == 0
+              && field.datatype == sensor_msgs::msg::PointField::UINT8
+              && field.count == 1;
+    });
+  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+}
+
+std::optional<std::size_t> getTimeStampOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+{
+  auto it = std::find_if(fields.begin(), fields.end(), 
+    [&](const auto& field) {
+      return std::strcmp(field.name.c_str(), "time_stamp") == 0
+              && field.datatype == sensor_msgs::msg::PointField::FLOAT64
+              && field.count == 1;
+    });
+  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
 }
 
 }  // namespace pointcloud_preprocessor::utils

--- a/sensing/pointcloud_preprocessor/src/utility/utilities.cpp
+++ b/sensing/pointcloud_preprocessor/src/utility/utilities.cpp
@@ -241,101 +241,88 @@ bool is_data_layout_compatible_with_PointXYZIRADRT(const sensor_msgs::msg::Point
 
 std::optional<std::size_t> getXOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), 
-    [&](const auto& field) {
-      return std::strcmp(field.name.c_str(), "x") == 0
-              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
-              && field.count == 1;
-    });
-  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
+    return std::strcmp(field.name.c_str(), "x") == 0 &&
+           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
+  });
+  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
 }
 
 std::optional<std::size_t> getYOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), 
-    [&](const auto& field) {
-      return std::strcmp(field.name.c_str(), "y") == 0
-              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
-              && field.count == 1;
-    });
-  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
+    return std::strcmp(field.name.c_str(), "y") == 0 &&
+           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
+  });
+  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
 }
 
 std::optional<std::size_t> getZOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), 
-    [&](const auto& field) {
-      return std::strcmp(field.name.c_str(), "z") == 0
-              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
-              && field.count == 1;
-    });
-  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
+    return std::strcmp(field.name.c_str(), "z") == 0 &&
+           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
+  });
+  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
 }
 
-std::optional<std::size_t> getIntensityOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getIntensityOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), 
-    [&](const auto& field) {
-      return std::strcmp(field.name.c_str(), "intensity") == 0
-              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
-              && field.count == 1;
-    });
-  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
+    return std::strcmp(field.name.c_str(), "intensity") == 0 &&
+           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
+  });
+  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
 }
 
 std::optional<std::size_t> getRingOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), 
-    [&](const auto& field) {
-      return std::strcmp(field.name.c_str(), "ring") == 0
-              && field.datatype == sensor_msgs::msg::PointField::UINT16
-              && field.count == 1;
-    });
-  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
+    return std::strcmp(field.name.c_str(), "ring") == 0 &&
+           field.datatype == sensor_msgs::msg::PointField::UINT16 && field.count == 1;
+  });
+  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
 }
 
-std::optional<std::size_t> getAzimuthOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getAzimuthOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), 
-    [&](const auto& field) {
-      return std::strcmp(field.name.c_str(), "azimuth") == 0
-              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
-              && field.count == 1;
-    });
-  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
+    return std::strcmp(field.name.c_str(), "azimuth") == 0 &&
+           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
+  });
+  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
 }
 
-std::optional<std::size_t> getDistanceOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getDistanceOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), 
-    [&](const auto& field) {
-      return std::strcmp(field.name.c_str(), "distance") == 0
-              && field.datatype == sensor_msgs::msg::PointField::FLOAT32
-              && field.count == 1;
-    });
-  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
+    return std::strcmp(field.name.c_str(), "distance") == 0 &&
+           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
+  });
+  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
 }
 
-std::optional<std::size_t> getReturnTypeOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getReturnTypeOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), 
-    [&](const auto& field) {
-      return std::strcmp(field.name.c_str(), "return_type") == 0
-              && field.datatype == sensor_msgs::msg::PointField::UINT8
-              && field.count == 1;
-    });
-  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
+    return std::strcmp(field.name.c_str(), "return_type") == 0 &&
+           field.datatype == sensor_msgs::msg::PointField::UINT8 && field.count == 1;
+  });
+  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
 }
 
-std::optional<std::size_t> getTimeStampOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getTimeStampOffset(
+  const std::vector<sensor_msgs::msg::PointField> & fields)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), 
-    [&](const auto& field) {
-      return std::strcmp(field.name.c_str(), "time_stamp") == 0
-              && field.datatype == sensor_msgs::msg::PointField::FLOAT64
-              && field.count == 1;
-    });
-  return (it != fields.end())? std::optional{it->offset} : std::nullopt; 
+  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
+    return std::strcmp(field.name.c_str(), "time_stamp") == 0 &&
+           field.datatype == sensor_msgs::msg::PointField::FLOAT64 && field.count == 1;
+  });
+  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
 }
 
 }  // namespace pointcloud_preprocessor::utils

--- a/sensing/pointcloud_preprocessor/src/utility/utilities.cpp
+++ b/sensing/pointcloud_preprocessor/src/utility/utilities.cpp
@@ -239,90 +239,85 @@ bool is_data_layout_compatible_with_PointXYZIRADRT(const sensor_msgs::msg::Point
   return same_layout;
 }
 
-std::optional<std::size_t> getXOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getXOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
-    return std::strcmp(field.name.c_str(), "x") == 0 &&
-           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
-  });
-  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
+  int idx = pcl::getFieldIndex(cloud_msg, "x");
+  if (idx < 0 || cloud_msg.fields[idx].datatype != sensor_msgs::msg::PointField::FLOAT32) {
+    return std::nullopt;
+  }
+  return std::optional{static_cast<std::size_t>(idx)};
 }
 
-std::optional<std::size_t> getYOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getYOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
-    return std::strcmp(field.name.c_str(), "y") == 0 &&
-           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
-  });
-  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
+  int idx = pcl::getFieldIndex(cloud_msg, "y");
+  if (idx < 0 || cloud_msg.fields[idx].datatype != sensor_msgs::msg::PointField::FLOAT32) {
+    return std::nullopt;
+  }
+  return std::optional{static_cast<std::size_t>(idx)};
 }
 
-std::optional<std::size_t> getZOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getZOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
-    return std::strcmp(field.name.c_str(), "z") == 0 &&
-           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
-  });
-  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
+  int idx = pcl::getFieldIndex(cloud_msg, "z");
+  if (idx < 0 || cloud_msg.fields[idx].datatype != sensor_msgs::msg::PointField::FLOAT32) {
+    return std::nullopt;
+  }
+  return std::optional{static_cast<std::size_t>(idx)};
 }
 
-std::optional<std::size_t> getIntensityOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getIntensityOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
-    return std::strcmp(field.name.c_str(), "intensity") == 0 &&
-           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
-  });
-  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
+  int idx = pcl::getFieldIndex(cloud_msg, "intensity");
+  if (idx < 0 || cloud_msg.fields[idx].datatype != sensor_msgs::msg::PointField::FLOAT32) {
+    return std::nullopt;
+  }
+  return std::optional{static_cast<std::size_t>(idx)};
 }
 
-std::optional<std::size_t> getRingOffset(const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getRingOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
-    return std::strcmp(field.name.c_str(), "ring") == 0 &&
-           field.datatype == sensor_msgs::msg::PointField::UINT16 && field.count == 1;
-  });
-  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
+  int idx = pcl::getFieldIndex(cloud_msg, "ring");
+  if (idx < 0 || cloud_msg.fields[idx].datatype != sensor_msgs::msg::PointField::UINT16) {
+    return std::nullopt;
+  }
+  return std::optional{static_cast<std::size_t>(idx)};
 }
 
-std::optional<std::size_t> getAzimuthOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getAzimuthOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
-    return std::strcmp(field.name.c_str(), "azimuth") == 0 &&
-           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
-  });
-  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
+  int idx = pcl::getFieldIndex(cloud_msg, "azimuth");
+  if (idx < 0 || cloud_msg.fields[idx].datatype != sensor_msgs::msg::PointField::FLOAT32) {
+    return std::nullopt;
+  }
+  return std::optional{static_cast<std::size_t>(idx)};
 }
 
-std::optional<std::size_t> getDistanceOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getDistanceOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
-    return std::strcmp(field.name.c_str(), "distance") == 0 &&
-           field.datatype == sensor_msgs::msg::PointField::FLOAT32 && field.count == 1;
-  });
-  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
+  int idx = pcl::getFieldIndex(cloud_msg, "distance");
+  if (idx < 0 || cloud_msg.fields[idx].datatype != sensor_msgs::msg::PointField::FLOAT32) {
+    return std::nullopt;
+  }
+  return std::optional{static_cast<std::size_t>(idx)};
 }
 
-std::optional<std::size_t> getReturnTypeOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getReturnTypeOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
-    return std::strcmp(field.name.c_str(), "return_type") == 0 &&
-           field.datatype == sensor_msgs::msg::PointField::UINT8 && field.count == 1;
-  });
-  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
+  int idx = pcl::getFieldIndex(cloud_msg, "return_type");
+  if (idx < 0 || cloud_msg.fields[idx].datatype != sensor_msgs::msg::PointField::UINT8) {
+    return std::nullopt;
+  }
+  return std::optional{static_cast<std::size_t>(idx)};
 }
 
-std::optional<std::size_t> getTimeStampOffset(
-  const std::vector<sensor_msgs::msg::PointField> & fields)
+std::optional<std::size_t> getTimeStampOffset(const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  auto it = std::find_if(fields.begin(), fields.end(), [&](const auto & field) {
-    return std::strcmp(field.name.c_str(), "time_stamp") == 0 &&
-           field.datatype == sensor_msgs::msg::PointField::FLOAT64 && field.count == 1;
-  });
-  return (it != fields.end()) ? std::optional{it->offset} : std::nullopt;
+  int idx = pcl::getFieldIndex(cloud_msg, "time_stamp");
+  if (idx < 0 || cloud_msg.fields[idx].datatype != sensor_msgs::msg::PointField::FLOAT64) {
+    return std::nullopt;
+  }
+  return std::optional{static_cast<std::size_t>(idx)};
 }
 
 }  // namespace pointcloud_preprocessor::utils


### PR DESCRIPTION
## Description

This is a "cache friendly" reimplementation of ring outlier filter. See https://github.com/autowarefoundation/autoware.universe/issues/3269 for more details.

The code is based on @sykwer WiP improvements (see https://github.com/autowarefoundation/autoware.universe/pull/3014), which I rewrote to improve memory access (hopefully).

This implementation produce slightly different output than the original implementation:
- output points are in same order than input. In the original implementation, points are reordered and copied by ring.
- Fixes https://github.com/autowarefoundation/autoware.universe/issues/3217
- Fixes https://github.com/autowarefoundation/autoware.universe/issues/3218

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/3269
https://github.com/autowarefoundation/autoware.universe/pull/3014

## Tests performed

Note: these tests are fairly old and refer to older implementation of ring outlier filters. See recent comments for comparisons between the current implementation and this PR.

Simple test on a few random rosbags. Plot data is the output of `/ring_outlier_filter/debug/processing_time_ms`. In blue the current implementation (with hashmap), in orange the proposed implementation (see the more recent comments for more accurate benchmarks):

- On VLP-16 data (~20000 points per message):
![image](https://user-images.githubusercontent.com/18645627/230264541-0672edee-c302-4056-8e47-b55dc7416332.png)

- On VLP-32 data (~50000 points per message):
![image](https://user-images.githubusercontent.com/18645627/230308580-84bd1286-9c30-4abc-a335-317898cc1f78.png)

In both cases, my implementation is roughly 3 times faster than the original one. Note that I am not using the TLSF allocator.

This is of course just a very simple benchmark and I will need to test more. In particular, I want to:
- compare cache performance with old implementation
- compare performance with @sykwer implementation (after his changes have been merged)
- compare performance on vehicle, with all autoware modules running

I don't necessarily expect this implementation to shine when the filter is the only process running on the machine. However I expect it will perform way better when the machine is stressed.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
