### PR TITLE
fix(planner_manager): break while loop when the candidate module fails to generate valid path

### DIFF
--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -78,6 +78,15 @@ BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & da
     const auto result = run(candidate_module_opt.get(), data, approved_path_data);
     processing_time_.at(name) += stop_watch_.toc(name, true);
 
+    // if the candidate module fails to generate path, use approved modules output and discard the
+    // failed candidate module.
+    if (candidate_module_opt.get()->getCurrentStatus() == ModuleStatus::FAILURE) {
+      deleteExpiredModules(candidate_module_opt.get());
+      candidate_module_opt_ = boost::none;
+      processing_time_.at("total_time") = stop_watch_.toc("total_time", true);
+      return approved_path_data;
+    }
+
     /**
      * STEP5: if the candidate module's modification is NOT approved yet, return the result.
      * NOTE: the result is output of the candidate module, but the output path don't contains path


### PR DESCRIPTION
## Description

Before this PR, the manager registers the highest priority module as candidate moduls even if the module **FAILs** to generate path. This causes following un/register loop, and some chattering happen.

#### First cycle

- run request module (fails to generate path)
- register the request module pointer to `candidate_module_opt_`

https://github.com/autowarefoundation/autoware.universe/blob/b78b17d6be85611e0686b1c319f3ae0ffe7bd890/planning/behavior_path_planner/src/planner_manager.cpp#L88

#### Second cycle

- request module return ModuleStatus::FAILURE in `getCandidateModule()`
- unregister the module
- return First cycle

https://github.com/autowarefoundation/autoware.universe/blob/b78b17d6be85611e0686b1c319f3ae0ffe7bd890/planning/behavior_path_planner/src/planner_manager.cpp#L186-L191


Then, I fixed it in order to break the while loop without registering to `candidate_module_opt_`.

https://user-images.githubusercontent.com/44889564/230304972-fb0f8d1d-c827-4168-a9eb-0d4719b35a2f.mp4

<!-- Write a brief description of this PR. -->

## Tests performed

- Use new architecture

https://github.com/autowarefoundation/autoware.universe/blob/b78b17d6be85611e0686b1c319f3ae0ffe7bd890/planning/behavior_path_planner/CMakeLists.txt#L10

- Set LC canceling scenario in Psim

https://user-images.githubusercontent.com/44889564/230305603-1023ad1b-1d78-4578-b9dc-fe5ee79f4b2d.mp4

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
