### PR TITLE
feat(mission_planner): move modified goal callback for reroute

### DIFF
--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -33,10 +33,10 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 
 ### Subscriptions
 
-| Name                  | Type                                 | Description                 |
-| --------------------- | ------------------------------------ | --------------------------- |
-| `input/vector_map`    | autoware_auto_mapping_msgs/HADMapBin | vector map of Lanelet2      |
-| `input/modified_goal` | geometry_msgs/PoseStamped            | goal pose for arrival check |
+| Name                  | Type                                 | Description            |
+| --------------------- | ------------------------------------ | ---------------------- |
+| `input/vector_map`    | autoware_auto_mapping_msgs/HADMapBin | vector map of Lanelet2 |
+| `input/modified_goal` | geometry_msgs/PoseWithUuidStamped    | modified goal pose     |
 
 ### Publications
 

--- a/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_interface.hpp
@@ -1,0 +1,36 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MISSION_PLANNER__MISSION_PLANNER_INTERFACE_HPP_
+#define MISSION_PLANNER__MISSION_PLANNER_INTERFACE_HPP_
+
+#include <rclcpp/qos.hpp>
+
+#include <autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp>
+
+namespace mission_planner
+{
+
+struct ModifiedGoal
+{
+  using Message = autoware_planning_msgs::msg::PoseWithUuidStamped;
+  static constexpr char name[] = "input/modified_goal";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+}  // namespace mission_planner
+
+#endif  // MISSION_PLANNER__MISSION_PLANNER_INTERFACE_HPP_

--- a/planning/mission_planner/src/mission_planner/arrival_checker.cpp
+++ b/planning/mission_planner/src/mission_planner/arrival_checker.cpp
@@ -27,10 +27,6 @@ ArrivalChecker::ArrivalChecker(rclcpp::Node * node) : vehicle_stop_checker_(node
   angle_ = tier4_autoware_utils::deg2rad(angle_deg);
   distance_ = node->declare_parameter<double>("arrival_check_distance");
   duration_ = node->declare_parameter<double>("arrival_check_duration");
-
-  sub_goal_ = node->create_subscription<PoseWithUuidStamped>(
-    "input/modified_goal", 1,
-    [this](const PoseWithUuidStamped::ConstSharedPtr msg) { modify_goal(*msg); });
 }
 
 void ArrivalChecker::set_goal()

--- a/planning/mission_planner/src/mission_planner/arrival_checker.hpp
+++ b/planning/mission_planner/src/mission_planner/arrival_checker.hpp
@@ -33,6 +33,7 @@ public:
   explicit ArrivalChecker(rclcpp::Node * node);
   void set_goal();
   void set_goal(const PoseWithUuidStamped & goal);
+  void modify_goal(const PoseWithUuidStamped & modified_goal);
   bool is_arrived(const PoseStamped & pose) const;
 
 private:
@@ -42,7 +43,6 @@ private:
   std::optional<PoseWithUuidStamped> goal_with_uuid_;
   rclcpp::Subscription<PoseWithUuidStamped>::SharedPtr sub_goal_;
   motion_utils::VehicleStopChecker vehicle_stop_checker_;
-  void modify_goal(const PoseWithUuidStamped & modified_goal);
 };
 
 }  // namespace mission_planner

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -85,6 +85,7 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   adaptor.init_srv(srv_clear_route_, this, &MissionPlanner::on_clear_route);
   adaptor.init_srv(srv_set_route_, this, &MissionPlanner::on_set_route);
   adaptor.init_srv(srv_set_route_points_, this, &MissionPlanner::on_set_route_points);
+  adaptor.init_sub(sub_modified_goal_, this, &MissionPlanner::on_modified_goal);
 
   change_state(RouteState::Message::UNSET);
 }
@@ -236,6 +237,13 @@ void MissionPlanner::on_set_route_points(
   change_route(route);
   change_state(RouteState::Message::SET);
   res->status.success = true;
+}
+
+// NOTE: The route interface should be mutually exclusive by callback group.
+void MissionPlanner::on_modified_goal(const ModifiedGoal::Message::ConstSharedPtr msg)
+{
+  // TODO(Yutaka Shimizu): reroute if the goal is outside the lane.
+  arrival_checker_.modify_goal(*msg);
 }
 
 }  // namespace mission_planner

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -19,6 +19,7 @@
 
 #include <component_interface_specs/planning.hpp>
 #include <component_interface_utils/rclcpp.hpp>
+#include <mission_planner/mission_planner_interface.hpp>
 #include <mission_planner/mission_planner_plugin.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -87,6 +88,9 @@ private:
   void on_set_route_points(
     const SetRoutePoints::Service::Request::SharedPtr req,
     const SetRoutePoints::Service::Response::SharedPtr res);
+
+  component_interface_utils::Subscription<ModifiedGoal>::SharedPtr sub_modified_goal_;
+  void on_modified_goal(const ModifiedGoal::Message::ConstSharedPtr msg);
 };
 
 }  // namespace mission_planner


### PR DESCRIPTION
## Description

Move callback to allow reroute when modified_route is received.
https://github.com/autowarefoundation/autoware/issues/3406

## Tests performed

Check `/api/routing/state` will be ARRIVED when the goal is changed by pull over.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
