### PR TITLE
refactor(behavior_path_planner): remove overlapping function

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -285,8 +285,6 @@ PathWithLaneId refinePathForGoal(
   const double search_radius_range, const double search_rad_range, const PathWithLaneId & input,
   const Pose & goal, const int64_t goal_lane_id);
 
-PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path);
-
 bool containsGoal(const lanelet::ConstLanelets & lanes, const lanelet::Id & goal_id);
 
 // path management

--- a/planning/behavior_path_planner/src/util/geometric_parallel_parking/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/src/util/geometric_parallel_parking/geometric_parallel_parking.cpp
@@ -38,7 +38,6 @@
 #include <vector>
 
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
-using behavior_path_planner::util::removeOverlappingPoints;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseArray;
@@ -82,7 +81,9 @@ PathWithLaneId GeometricParallelParking::getFullPath() const
     path.points.insert(path.points.end(), partial_path.points.begin(), partial_path.points.end());
   }
 
-  return removeOverlappingPoints(path);
+  PathWithLaneId filtered_path = path;
+  filtered_path.points = motion_utils::removeOverlapPoints(filtered_path.points);
+  return filtered_path;
 }
 
 PathWithLaneId GeometricParallelParking::getArcPath() const
@@ -297,7 +298,7 @@ bool GeometricParallelParking::planPullOut(
       paths.back().points.end(),
       road_center_line_path.points.begin() + 1,  // to avoid overlapped point
       road_center_line_path.points.end());
-    paths.back() = removeOverlappingPoints(paths.back());
+    paths.back().points = motion_utils::removeOverlapPoints(paths.back().points);
 
     // if the end point is the goal, set the velocity to 0
     if (!goal_is_behind) {

--- a/planning/behavior_path_planner/src/util/pull_out/util.cpp
+++ b/planning/behavior_path_planner/src/util/pull_out/util.cpp
@@ -45,7 +45,9 @@ PathWithLaneId combineReferencePath(const PathWithLaneId path1, const PathWithLa
   // skip overlapping point
   path.points.insert(path.points.end(), next(path2.points.begin()), path2.points.end());
 
-  return util::removeOverlappingPoints(path);
+  PathWithLaneId filtered_path = path;
+  filtered_path.points = motion_utils::removeOverlapPoints(filtered_path.points);
+  return filtered_path;
 }
 
 PathWithLaneId getBackwardPath(


### PR DESCRIPTION
## Description
Remove `removeOverlappingPoints` function from utilities in the behavior path planner.
<!-- Write a brief description of this PR. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 838e1fb</samp>

The pull request refactors the code for removing overlapping points in parking paths by using a common function from `motion_utils` library. This reduces code duplication and improves consistency across different modules in `behavior_path_planner`. The files affected are `geometric_parallel_parking.cpp`, `utilities.cpp`, `utilities.hpp`, and `pull_out/util.cpp`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Scenario Test 1196/1199
[Internal Link](https://evaluation.tier4.jp/evaluation/reports/ed528c1b-e3cd-5428-8096-5d5d2a2acddf?project_id=prd_jt)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
