### PR TITLE
fix(lane_change): fix build error

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -86,8 +86,8 @@ bool LaneChangeModule::isExecutionRequested() const
   const auto current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
   const auto lane_change_lanes = lane_change_utils::getLaneChangeLanes(
-    planner_data_, current_lanes, lane_change_lane_length_,
-    parameters_->lane_change_prepare_duration, direction_, type_);
+    planner_data_, current_lanes, lane_change_lane_length_, parameters_->prepare_duration,
+    direction_, type_);
 #endif
 
   if (lane_change_lanes.empty()) {
@@ -114,8 +114,8 @@ bool LaneChangeModule::isExecutionReady() const
   const auto current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
   const auto lane_change_lanes = lane_change_utils::getLaneChangeLanes(
-    planner_data_, current_lanes, lane_change_lane_length_,
-    parameters_->lane_change_prepare_duration, direction_, type_);
+    planner_data_, current_lanes, lane_change_lane_length_, parameters_->prepare_duration,
+    direction_, type_);
 #endif
 
   if (lane_change_lanes.empty()) {
@@ -254,8 +254,8 @@ CandidateOutput LaneChangeModule::planCandidate() const
   const auto current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
   const auto lane_change_lanes = lane_change_utils::getLaneChangeLanes(
-    planner_data_, current_lanes, lane_change_lane_length_,
-    parameters_->lane_change_prepare_duration, direction_, type_);
+    planner_data_, current_lanes, lane_change_lane_length_, parameters_->prepare_duration,
+    direction_, type_);
 #endif
 
   if (lane_change_lanes.empty()) {
@@ -334,8 +334,8 @@ void LaneChangeModule::updateLaneChangeStatus()
   status_.current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
   status_.lane_change_lanes = lane_change_utils::getLaneChangeLanes(
-    planner_data_, status_.current_lanes, lane_change_lane_length_,
-    parameters_->lane_change_prepare_duration, direction_, type_);
+    planner_data_, status_.current_lanes, lane_change_lane_length_, parameters_->prepare_duration,
+    direction_, type_);
 #endif
 
   // Find lane change path

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -360,7 +360,7 @@ std::pair<bool, bool> getLaneChangePaths(
 #else
     const auto prepare_segment = getPrepareSegment(
       original_path, original_lanelets, pose, backward_path_length, prepare_distance,
-      std::max(prepare_speed, minimum_lane_change_velocity));
+      std::max(prepare_speed, minimum_lane_changing_velocity));
 #endif
 
     if (prepare_segment.points.empty()) {


### PR DESCRIPTION
## Description

old name variables are still remaining after https://github.com/autowarefoundation/autoware.universe/pull/3300

<!-- Write a brief description of this PR. -->

## Tests performed

I confirmed that planning module works well with new architecture. (`COMPILE_WITH_OLD_ARCHITECTURE`: `FALSE`)

https://github.com/autowarefoundation/autoware.universe/blob/ca9cac30795e9bf58732250df487c1db723d5ad0/planning/behavior_path_planner/CMakeLists.txt#L10

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
