### PR TITLE
refactor(behavior_path_planner): rename lane change variables and parameters

### DIFF
--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -28,8 +28,8 @@
         pedestrian: true
 
       # collision check
-      enable_collision_check_at_prepare_phase: true
-      prepare_phase_ignore_target_speed_thresh: 0.1 # [m/s]
+      enable_prepare_segment_collision_check: true
+      prepare_segment_ignore_object_velocity_thresh: 0.1 # [m/s]
       use_predicted_path_outside_lanelet: true
       use_all_predicted_path: false
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance_by_lc/module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance_by_lc/module.hpp
@@ -199,7 +199,7 @@ private:
   bool isValidPath() const;
   bool isValidPath(const PathWithLaneId & path) const;
   bool isNearEndOfLane() const;
-  bool isCurrentSpeedLow() const;
+  bool isCurrentVelocityLow() const;
   bool isAbortConditionSatisfied();
   bool hasFinishedLaneChange() const;
   bool isAvoidancePlanRunning() const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
@@ -121,7 +121,7 @@ protected:
   bool isValidPath(const PathWithLaneId & path) const;
   bool isApprovedPathSafe(Pose & ego_pose_before_collision) const;
   bool isNearEndOfLane() const;
-  bool isCurrentSpeedLow() const;
+  bool isCurrentVelocityLow() const;
   bool isAbortConditionSatisfied();
   bool hasFinishedLaneChange() const;
   bool isAbortState() const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -183,7 +183,7 @@ private:
   bool isValidPath() const;
   bool isValidPath(const PathWithLaneId & path) const;
   bool isNearEndOfLane() const;
-  bool isCurrentSpeedLow() const;
+  bool isCurrentVelocityLow() const;
   bool isAbortConditionSatisfied();
   bool hasFinishedLaneChange() const;
   bool isAbortState() const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/lane_change_module_data.hpp
@@ -36,8 +36,8 @@ struct LaneChangeParameters
   int lane_change_sampling_num{10};
 
   // collision check
-  bool enable_collision_check_at_prepare_phase{true};
-  double prepare_phase_ignore_target_speed_thresh{0.1};
+  bool enable_prepare_segment_collision_check{true};
+  double prepare_segment_ignore_object_velocity_thresh{0.1};
   bool use_predicted_path_outside_lanelet{false};
   bool use_all_predicted_path{false};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -62,9 +62,9 @@ std::optional<LaneChangePath> constructCandidatePath(
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_segment,
   const PathWithLaneId & target_lane_reference_path, const ShiftLine & shift_line,
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
-  const double acceleration, const double prepare_distance, const double prepare_duration,
-  const double prepare_speed, const double lane_change_distance, const double lane_changing_speed,
-  const BehaviorPathPlannerParameters & params, const LaneChangeParameters & lane_change_param);
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double acceleration,
+  const LaneChangePhaseInfo distance, const LaneChangePhaseInfo lane_change_velocity,
+  const LaneChangeParameters & lane_change_param);
 
 std::pair<bool, bool> getLaneChangePaths(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & original_lanelets,
@@ -118,18 +118,18 @@ PathWithLaneId getReferencePathFromTargetLane(
 PathWithLaneId getPrepareSegment(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & original_lanelets,
   const double arc_length_from_current, const double backward_path_length,
-  const double prepare_distance, const double prepare_speed);
+  const double prepare_distance, const double prepare_velocity);
 
 PathWithLaneId getPrepareSegment(
   const PathWithLaneId & original_path, const lanelet::ConstLanelets & original_lanelets,
   const Pose & current_pose, const double backward_path_length, const double prepare_distance,
-  const double prepare_speed);
+  const double prepare_velocity);
 
 PathWithLaneId getTargetSegment(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanelets,
   const double forward_path_length, const Pose & lane_changing_start_pose,
   const double target_lane_length, const double lane_changing_distance,
-  const double lane_changing_speed, const double total_required_min_dist);
+  const double lane_changing_velocity, const double total_required_min_dist);
 
 bool isEgoWithinOriginalLane(
   const lanelet::ConstLanelets & current_lanes, const Pose & current_pose,

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -727,10 +727,10 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.lane_change_sampling_num = declare_parameter<int>(parameter("lane_change_sampling_num"));
 
   // collision check
-  p.enable_collision_check_at_prepare_phase =
-    declare_parameter<bool>(parameter("enable_collision_check_at_prepare_phase"));
-  p.prepare_phase_ignore_target_speed_thresh =
-    declare_parameter<double>(parameter("prepare_phase_ignore_target_speed_thresh"));
+  p.enable_prepare_segment_collision_check =
+    declare_parameter<bool>(parameter("enable_prepare_segment_collision_check"));
+  p.prepare_segment_ignore_object_velocity_thresh =
+    declare_parameter<double>(parameter("prepare_segment_ignore_object_velocity_thresh"));
   p.use_predicted_path_outside_lanelet =
     declare_parameter<bool>(parameter("use_predicted_path_outside_lanelet"));
   p.use_all_predicted_path = declare_parameter<bool>(parameter("use_all_predicted_path"));

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -647,7 +647,7 @@ ModuleStatus AvoidanceByLCModule::updateState()
   }
 
   if (isAbortConditionSatisfied()) {
-    if ((isNearEndOfLane() && isCurrentSpeedLow()) || !is_within_current_lane) {
+    if ((isNearEndOfLane() && isCurrentVelocityLow()) || !is_within_current_lane) {
       current_state_ = ModuleStatus::RUNNING;
       return current_state_;
     }
@@ -678,7 +678,7 @@ BehaviorModuleOutput AvoidanceByLCModule::plan()
     status_.is_valid_path = true;
   }
 
-  if ((is_abort_condition_satisfied_ && isNearEndOfLane() && isCurrentSpeedLow())) {
+  if ((is_abort_condition_satisfied_ && isNearEndOfLane() && isCurrentVelocityLow())) {
     const auto stop_point = util::insertStopPoint(0.1, path);
   }
 
@@ -1079,7 +1079,7 @@ bool AvoidanceByLCModule::isNearEndOfLane() const
          threshold;
 }
 
-bool AvoidanceByLCModule::isCurrentSpeedLow() const
+bool AvoidanceByLCModule::isCurrentVelocityLow() const
 {
   constexpr double threshold_ms = 10.0 * 1000 / 3600;
   return util::l2Norm(getEgoTwist().linear) < threshold_ms;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -103,7 +103,7 @@ BT::NodeStatus ExternalRequestLaneChangeModule::updateState()
   }
 
   if (isAbortConditionSatisfied()) {
-    if (isNearEndOfLane() && isCurrentSpeedLow()) {
+    if (isNearEndOfLane() && isCurrentVelocityLow()) {
       current_state_ = BT::NodeStatus::RUNNING;
       return current_state_;
     }
@@ -132,7 +132,7 @@ BehaviorModuleOutput ExternalRequestLaneChangeModule::plan()
     return BehaviorModuleOutput{};
   }
 
-  if ((is_abort_condition_satisfied_ && isNearEndOfLane() && isCurrentSpeedLow())) {
+  if ((is_abort_condition_satisfied_ && isNearEndOfLane() && isCurrentVelocityLow())) {
     const auto stop_point = util::insertStopPoint(0.1, path);
   }
 
@@ -444,7 +444,7 @@ bool ExternalRequestLaneChangeModule::isNearEndOfLane() const
          threshold;
 }
 
-bool ExternalRequestLaneChangeModule::isCurrentSpeedLow() const
+bool ExternalRequestLaneChangeModule::isCurrentVelocityLow() const
 {
   constexpr double threshold_ms = 10.0 * 1000 / 3600;
   return getEgoTwist().linear.x < threshold_ms;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -145,7 +145,7 @@ ModuleStatus LaneChangeModule::updateState()
   }
 
   if (isAbortConditionSatisfied()) {
-    if ((isNearEndOfLane() && isCurrentSpeedLow()) || !is_within_current_lane) {
+    if ((isNearEndOfLane() && isCurrentVelocityLow()) || !is_within_current_lane) {
       current_state_ = ModuleStatus::RUNNING;
       return current_state_;
     }
@@ -176,7 +176,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
     status_.is_valid_path = true;
   }
 
-  if ((is_abort_condition_satisfied_ && isNearEndOfLane() && isCurrentSpeedLow())) {
+  if ((is_abort_condition_satisfied_ && isNearEndOfLane() && isCurrentVelocityLow())) {
     const auto stop_point = util::insertStopPoint(0.1, path);
   }
 
@@ -553,7 +553,7 @@ bool LaneChangeModule::isNearEndOfLane() const
          threshold;
 }
 
-bool LaneChangeModule::isCurrentSpeedLow() const
+bool LaneChangeModule::isCurrentVelocityLow() const
 {
   constexpr double threshold_ms = 10.0 * 1000 / 3600;
   return getEgoTwist().linear.x < threshold_ms;


### PR DESCRIPTION
## Description
Rename some lane change parameters. Use velocity rather than speed and segment rather than phase.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bb0c86</samp>

This pull request refactors the `behavior_path_planner` package to use consistent and accurate terminology for velocity instead of speed. It also updates the function signatures and parameters related to the lane change planning and collision check. The purpose of this pull request is to improve the readability, maintainability, and correctness of the code.
<!-- Write a brief description of this PR. -->

Related Link: https://github.com/autowarefoundation/autoware_launch/pull/284
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
