### PR TITLE
chore(perception): workaround for nvcc > 11.6

### DIFF
--- a/perception/lidar_centerpoint/include/lidar_centerpoint/cuda_utils.hpp
+++ b/perception/lidar_centerpoint/include/lidar_centerpoint/cuda_utils.hpp
@@ -56,10 +56,10 @@ namespace cuda
 inline void check_error(const ::cudaError_t e, const char * f, int n)
 {
   if (e != ::cudaSuccess) {
-    std::stringstream s;
+    ::std::stringstream s;
     s << ::cudaGetErrorName(e) << " (" << e << ")@" << f << "#L" << n << ": "
       << ::cudaGetErrorString(e);
-    throw std::runtime_error{s.str()};
+    throw ::std::runtime_error{s.str()};
   }
 }
 
@@ -69,13 +69,13 @@ struct deleter
 };
 
 template <typename T>
-using unique_ptr = std::unique_ptr<T, deleter>;
+using unique_ptr = ::std::unique_ptr<T, deleter>;
 
 template <typename T>
-typename std::enable_if<std::is_array<T>::value, cuda::unique_ptr<T>>::type make_unique(
-  const std::size_t n)
+typename ::std::enable_if<::std::is_array<T>::value, cuda::unique_ptr<T>>::type make_unique(
+  const ::std::size_t n)
 {
-  using U = typename std::remove_extent<T>::type;
+  using U = typename ::std::remove_extent<T>::type;
   U * p;
   CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&p), sizeof(U) * n));
   return cuda::unique_ptr<T>{p};
@@ -107,7 +107,7 @@ inline T * get_next_ptr(size_t num_elem, void *& workspace, size_t & workspace_s
 {
   size_t size = get_size_aligned<T>(num_elem);
   if (size > workspace_size) {
-    throw std::runtime_error("Workspace is too small!");
+    throw ::std::runtime_error("Workspace is too small!");
   }
   workspace_size -= size;
   T * ptr = reinterpret_cast<T *>(workspace);

--- a/perception/tensorrt_yolo/lib/include/cuda_utils.hpp
+++ b/perception/tensorrt_yolo/lib/include/cuda_utils.hpp
@@ -57,10 +57,10 @@ namespace cuda
 void check_error(const ::cudaError_t e, const char * f, int n)
 {
   if (e != ::cudaSuccess) {
-    std::stringstream s;
+    ::std::stringstream s;
     s << ::cudaGetErrorName(e) << " (" << e << ")@" << f << "#L" << n << ": "
       << ::cudaGetErrorString(e);
-    throw std::runtime_error{s.str()};
+    throw ::std::runtime_error{s.str()};
   }
 }
 
@@ -69,13 +69,13 @@ struct deleter
   void operator()(void * p) const { CHECK_CUDA_ERROR(::cudaFree(p)); }
 };
 template <typename T>
-using unique_ptr = std::unique_ptr<T, deleter>;
+using unique_ptr = ::std::unique_ptr<T, deleter>;
 
 template <typename T>
-typename std::enable_if<std::is_array<T>::value, cuda::unique_ptr<T>>::type make_unique(
-  const std::size_t n)
+typename ::std::enable_if<::std::is_array<T>::value, cuda::unique_ptr<T>>::type make_unique(
+  const ::std::size_t n)
 {
-  using U = typename std::remove_extent<T>::type;
+  using U = typename ::std::remove_extent<T>::type;
   U * p;
   CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&p), sizeof(U) * n));
   return cuda::unique_ptr<T>{p};
@@ -107,7 +107,7 @@ inline T * get_next_ptr(size_t num_elem, void *& workspace, size_t & workspace_s
 {
   size_t size = get_size_aligned<T>(num_elem);
   if (size > workspace_size) {
-    throw std::runtime_error("Workspace is too small!");
+    throw ::std::runtime_error("Workspace is too small!");
   }
   workspace_size -= size;
   T * ptr = reinterpret_cast<T *>(workspace);


### PR DESCRIPTION
## Description

Fix the compile error `namespace cuda::std ...` for `.cu` files 

## Tests performed

The source files can be still compiled using nvcc == 11.6 on my local machine too.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
