### PR TITLE
perf(avoidance): remove unnecessary sampling

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2306,7 +2306,6 @@ bool AvoidanceModule::isSafePath(
     getAdjacentLane(path_shifter, forward_check_distance, backward_check_distance);
 
   auto path_with_current_velocity = shifted_path.path;
-  path_with_current_velocity = util::resamplePathWithSpline(path_with_current_velocity, 0.5);
 
   const size_t ego_idx = planner_data_->findEgoIndex(path_with_current_velocity.points);
   util::clipPathLength(path_with_current_velocity, ego_idx, forward_check_distance, 0.0);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3144,6 +3144,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
 
   output.path = std::make_shared<PathWithLaneId>(avoidance_path.path);
   output.reference_path = getPreviousModuleOutput().reference_path;
+  path_reference_ = getPreviousModuleOutput().reference_path;
 
   const size_t ego_idx = planner_data_->findEgoIndex(output.path->points);
   util::clipPathLength(*output.path, ego_idx, planner_data_->parameters);


### PR DESCRIPTION
## Description

### remove unnecessary sampling (367dd37e52e471277b965f328d3dc4f0456837bb)

avoidance path already be sampled here.

https://github.com/autowarefoundation/autoware.universe/blob/6e3dbacad5ae6fc6343eb01c0d9a0757603e47ab/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp#L214-L215

### small bug fix (dd7d6a6da47a097cfe7d78d7b026f103aee5504a)

output reference path from avoidance module.

<!-- Write a brief description of this PR. -->

## Tests performed

Translucent violet path shows the reference path of avidance module.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

![rviz_screenshot_2023_04_07-22_34_20](https://user-images.githubusercontent.com/44889564/230617827-3dfccfb5-3dba-4eeb-add9-d8f68ac7804e.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
