### PR TITLE
fix(lane_change): prevent cancel at end of lane

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -549,8 +549,8 @@ bool LaneChangeModule::isNearEndOfLane() const
   const auto & current_pose = getEgoPose();
   const double threshold = util::calcTotalLaneChangeLength(planner_data_->parameters);
 
-  return std::max(0.0, util::getDistanceToEndOfLane(current_pose, status_.current_lanes)) <
-         threshold;
+  return (std::max(0.0, util::getDistanceToEndOfLane(current_pose, status_.current_lanes)) -
+          threshold) < planner_data_->parameters.backward_length_buffer_for_end_of_lane;
 }
 
 bool LaneChangeModule::isCurrentVelocityLow() const


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85921c0</samp>

Added a configurable buffer for the end of lane condition in the `isNearEndOfLane` function of the `lane_change_module`. This is to prevent lane change from cancelling when it is at the end of the lane.

Solve [TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/5cf6ce8a-d65e-50a8-a347-7e8c1d99ae35/tests/924fc1c8-e478-54ef-a90e-c4eb18d0bfae/bef021f8-7c1f-5478-b018-22e39a394d50/992e6644-87b7-5962-850d-54f93ba84572?project_id=prd_jt)

## Related links

None

## Tests performed

Test the scenarios in [TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/5cf6ce8a-d65e-50a8-a347-7e8c1d99ae35/tests/924fc1c8-e478-54ef-a90e-c4eb18d0bfae/bef021f8-7c1f-5478-b018-22e39a394d50/992e6644-87b7-5962-850d-54f93ba84572?project_id=prd_jt)

## Notes for reviewers

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 85921c0</samp>

*  Add a backward length buffer for the end of lane condition in `isNearEndOfLane` function ([link](https://github.com/autowarefoundation/autoware.universe/pull/3315/files?diff=unified&w=0#diff-945a9d9f8493a7690b7b7caa5aa4e22b935c5f70ef049d00dab5b3003f198eaaL552-R553))

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
