### PR TITLE
refactor(behavior_path_planner): use tier4_autoware_utils::toHexString

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/util/avoidance/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/avoidance/util.hpp
@@ -92,10 +92,6 @@ void setStartData(
   AvoidLine & al, const double start_shift_length, const geometry_msgs::msg::Pose & start,
   const size_t start_idx, const double start_dist);
 
-std::string getUuidStr(const ObjectData & obj);
-
-std::vector<std::string> getUuidStr(const ObjectDataArray & objs);
-
 Polygon2d createEnvelopePolygon(
   const ObjectData & object_data, const Pose & closest_pose, const double envelope_buffer);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -354,8 +354,6 @@ lanelet::ConstLanelets calcLaneAroundPose(
   const std::shared_ptr<RouteHandler> route_handler, const geometry_msgs::msg::Pose & pose,
   const double forward_length, const double backward_length);
 
-std::string getUuidStr(const PredictedObject & obj);
-
 std::vector<PredictedPath> getPredictedPathFromObj(
   const PredictedObject & obj, const bool & is_use_all_predicted_path);
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -56,6 +56,7 @@ using tier4_autoware_utils::calcLongitudinalDeviation;
 using tier4_autoware_utils::calcYawDeviation;
 using tier4_autoware_utils::getPoint;
 using tier4_autoware_utils::getPose;
+using tier4_autoware_utils::toHexString;
 using tier4_planning_msgs::msg::AvoidanceDebugFactor;
 
 namespace
@@ -312,7 +313,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
 
     ObjectData object_data;
     object_data.object = object;
-    avoidance_debug_msg.object_id = getUuidStr(object_data);
+    avoidance_debug_msg.object_id = toHexString(object_data.object.object_id);
 
     if (!isTargetObjectType(object)) {
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::OBJECT_IS_NOT_TYPE);
@@ -1063,7 +1064,7 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
         avoidance_debug_msg_array.push_back(avoidance_debug_msg);
       };
 
-    avoidance_debug_msg.object_id = getUuidStr(o);
+    avoidance_debug_msg.object_id = toHexString(o.object.object_id);
     avoidance_debug_msg.longitudinal_distance = o.longitudinal;
     avoidance_debug_msg.lateral_distance_from_centerline = o.lateral;
     avoidance_debug_msg.to_furthest_linestring_distance = o.to_road_shoulder_distance;
@@ -3524,7 +3525,6 @@ void AvoidanceModule::updateRegisteredObject(const ObjectDataArray & now_objects
   // -- check registered_objects, remove if lost_count exceeds limit. --
   for (int i = static_cast<int>(registered_objects_.size()) - 1; i >= 0; --i) {
     auto & r = registered_objects_.at(i);
-    const std::string s = getUuidStr(r);
 
     // registered object is not detected this time. lost count up.
     if (!updateIfDetectedNow(r)) {

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -46,6 +46,7 @@ using motion_utils::findNearestIndex;
 using motion_utils::findNearestSegmentIndex;
 using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcLateralDeviation;
+using tier4_autoware_utils::toHexString;
 
 AvoidanceByLCModule::AvoidanceByLCModule(
   const std::string & name, rclcpp::Node & node,
@@ -552,7 +553,6 @@ void AvoidanceByLCModule::updateRegisteredObject(const ObjectDataArray & now_obj
   // -- check registered_objects, remove if lost_count exceeds limit. --
   for (int i = static_cast<int>(registered_objects_.size()) - 1; i >= 0; --i) {
     auto & r = registered_objects_.at(i);
-    const std::string s = getUuidStr(r);
 
     // registered object is not detected this time. lost count up.
     if (!updateIfDetectedNow(r)) {

--- a/planning/behavior_path_planner/src/util/avoidance/util.cpp
+++ b/planning/behavior_path_planner/src/util/avoidance/util.cpp
@@ -569,25 +569,6 @@ void setStartData(
   ap.start_longitudinal = start_dist;
 }
 
-std::string getUuidStr(const ObjectData & obj)
-{
-  std::stringstream hex_value;
-  for (const auto & uuid : obj.object.object_id.uuid) {
-    hex_value << std::hex << std::setfill('0') << std::setw(2) << +uuid;
-  }
-  return hex_value.str();
-}
-
-std::vector<std::string> getUuidStr(const ObjectDataArray & objs)
-{
-  std::vector<std::string> uuids;
-  uuids.reserve(objs.size());
-  for (const auto & o : objs) {
-    uuids.push_back(getUuidStr(o));
-  }
-  return uuids;
-}
-
 Polygon2d createEnvelopePolygon(
   const ObjectData & object_data, const Pose & closest_pose, const double envelope_buffer)
 {

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -581,10 +581,9 @@ bool isLaneChangePathSafe(
 
   const auto assignDebugData = [](const PredictedObject & obj) {
     CollisionCheckDebug debug;
-    const auto key = util::getUuidStr(obj);
     debug.current_pose = obj.kinematics.initial_pose_with_covariance.pose;
     debug.current_twist = obj.kinematics.initial_twist_with_covariance.twist;
-    return std::make_pair(key, debug);
+    return std::make_pair(tier4_autoware_utils::toHexString(obj.object_id), debug);
   };
 
   const auto appendDebugInfo =

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1900,15 +1900,6 @@ lanelet::ConstLanelets calcLaneAroundPose(
   return current_lanes;
 }
 
-std::string getUuidStr(const PredictedObject & obj)
-{
-  std::stringstream hex_value;
-  for (const auto & uuid : obj.object_id.uuid) {
-    hex_value << std::hex << std::setfill('0') << std::setw(2) << +uuid;
-  }
-  return hex_value.str();
-}
-
 template <typename Pythagoras>
 ProjectedDistancePoint pointToSegment(
   const Point2d & reference_point, const Point2d & point_from_ego,


### PR DESCRIPTION
## Description

use `tier4_autoware_utils::toHexString` instead of `getUuidStr()`

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed avoidance module works well in Psim.

![rviz_screenshot_2023_04_08-09_02_03](https://user-images.githubusercontent.com/44889564/230695422-0bc5ca62-d9e6-42d1-9eb4-8b55aede821a.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
