### PR TITLE
refactor(avoidance): remove unused utils

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/util/avoidance/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/avoidance/util.hpp
@@ -69,17 +69,8 @@ std::vector<size_t> concatParentIds(
 
 double lerpShiftLengthOnArc(double arc, const AvoidLine & al);
 
-void clipByMinStartIdx(const AvoidLineArray & shift_lines, PathWithLaneId & path);
-
-void fillLongitudinalAndLengthByClosestFootprint(
-  const PathWithLaneId & path, const PredictedObject & object, const Point & ego_pos,
-  ObjectData & obj);
-
 void fillLongitudinalAndLengthByClosestEnvelopeFootprint(
   const PathWithLaneId & path, const Point & ego_pos, ObjectData & obj);
-
-double calcOverhangDistance(
-  const ObjectData & object_data, const Pose & base_pose, Point & overhang_pose);
 
 double calcEnvelopeOverhangDistance(
   const ObjectData & object_data, const Pose & base_pose, Point & overhang_pose);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -312,8 +312,6 @@ std::vector<Polygon2d> getTargetLaneletPolygons(
   const lanelet::ConstLanelets & lanelets, const Pose & pose, const double check_length,
   const std::string & target_type);
 
-void shiftPose(Pose * pose, double shift_length);
-
 PathWithLaneId getCenterLinePathFromRootLanelet(
   const lanelet::ConstLanelet & root_lanelet,
   const std::shared_ptr<const PlannerData> & planner_data);

--- a/planning/behavior_path_planner/src/marker_util/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/marker_util/avoidance/debug.cpp
@@ -26,7 +26,6 @@ namespace marker_utils::avoidance_marker
 {
 
 using behavior_path_planner::AvoidLine;
-using behavior_path_planner::util::shiftPose;
 using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcOffsetPose;
@@ -249,15 +248,14 @@ MarkerArray createAvoidLineMarkerArray(
       auto marker_s = basic_marker;
       marker_s.id = id++;
       marker_s.pose = sl.start;
-      // shiftPose(&marker_s.pose, current_shift);  // old
-      shiftPose(&marker_s.pose, sl.start_shift_length);
+      marker_s.pose = calcOffsetPose(marker_s.pose, 0.0, sl.start_shift_length, 0.0);
       msg.markers.push_back(marker_s);
 
       // end point
       auto marker_e = basic_marker;
       marker_e.id = id++;
       marker_e.pose = sl.end;
-      shiftPose(&marker_e.pose, sl.end_shift_length);
+      marker_e.pose = calcOffsetPose(marker_e.pose, 0.0, sl.end_shift_length, 0.0);
       msg.markers.push_back(marker_e);
 
       // start-to-end line

--- a/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
+++ b/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
@@ -23,8 +23,8 @@ namespace marker_utils
 {
 using behavior_path_planner::ShiftLine;
 using behavior_path_planner::util::calcPathArcLengthArray;
-using behavior_path_planner::util::shiftPose;
 using std_msgs::msg::ColorRGBA;
+using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::createDefaultMarker;
 using tier4_autoware_utils::createMarkerColor;
 using tier4_autoware_utils::createMarkerOrientation;
@@ -112,14 +112,14 @@ MarkerArray createShiftLineMarkerArray(
       auto marker_s = basic_marker;
       marker_s.id = ++id;
       marker_s.pose = sp.start;
-      shiftPose(&marker_s.pose, current_shift);  // old
+      marker_s.pose = calcOffsetPose(marker_s.pose, 0.0, current_shift, 0.0);
       msg.markers.push_back(marker_s);
 
       // end point
       auto marker_e = basic_marker;
       marker_e.id = ++id;
       marker_e.pose = sp.end;
-      shiftPose(&marker_e.pose, sp.end_shift_length);
+      marker_e.pose = calcOffsetPose(marker_e.pose, 0.0, sp.end_shift_length, 0.0);
       msg.markers.push_back(marker_e);
 
       // start-to-end line
@@ -156,8 +156,8 @@ MarkerArray createShiftLengthMarkerArray(
   marker.points.reserve(shift_distance.size());
 
   for (size_t i = 0; i < shift_distance.size(); ++i) {
-    auto p = reference.points.at(i).point.pose;
-    shiftPose(&p, shift_distance.at(i));
+    const auto p =
+      calcOffsetPose(reference.points.at(i).point.pose, 0.0, shift_distance.at(i), 0.0);
     marker.points.push_back(p.position);
   }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -53,6 +53,7 @@ using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcInterpolatedPose;
 using tier4_autoware_utils::calcLateralDeviation;
 using tier4_autoware_utils::calcLongitudinalDeviation;
+using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::calcYawDeviation;
 using tier4_autoware_utils::getPoint;
 using tier4_autoware_utils::getPose;
@@ -3409,7 +3410,7 @@ Pose AvoidanceModule::getUnshiftedEgoPose(const ShiftedPath & prev_path) const
   // ego_pose.
   Pose unshifted_pose = motion_utils::calcInterpolatedPoint(prev_path.path, ego_pose).point.pose;
 
-  util::shiftPose(&unshifted_pose, -prev_path.shift_length.at(closest));
+  unshifted_pose = calcOffsetPose(unshifted_pose, 0.0, -prev_path.shift_length.at(closest), 0.0);
   unshifted_pose.orientation = ego_pose.orientation;
 
   return unshifted_pose;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3168,7 +3168,9 @@ CandidateOutput AvoidanceModule::planCandidate() const
   auto shifted_path = data.candidate_path;
 
   if (!data.safe_new_sl.empty()) {  // clip from shift start index for visualize
-    clipByMinStartIdx(data.safe_new_sl, shifted_path.path);
+    util::clipPathLength(
+      shifted_path.path, data.safe_new_sl.front().start_idx, 0.0,
+      std::numeric_limits<double>::max());
 
     const auto sl = getNonStraightShiftLine(data.safe_new_sl);
     const auto sl_front = data.safe_new_sl.front();

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -31,6 +31,7 @@ using motion_utils::calcSignedArcLength;
 using motion_utils::findNearestIndex;
 using motion_utils::findNearestSegmentIndex;
 using tier4_autoware_utils::calcDistance2d;
+using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::getPoint;
 
 #ifdef USE_OLD_ARCHITECTURE
@@ -437,7 +438,7 @@ Pose SideShiftModule::getUnshiftedEgoPose(const ShiftedPath & prev_path) const
 
   Pose unshifted_pose = ego_pose;
 
-  util::shiftPose(&unshifted_pose, -prev_path.shift_length.at(closest));
+  unshifted_pose = calcOffsetPose(unshifted_pose, 0.0, -prev_path.shift_length.at(closest), 0.0);
   unshifted_pose.orientation = ego_pose.orientation;
 
   return unshifted_pose;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1648,13 +1648,6 @@ PredictedObjects filterObjectsByVelocity(
   return filtered;
 }
 
-void shiftPose(Pose * pose, double shift_length)
-{
-  auto yaw = tf2::getYaw(pose->orientation);
-  pose->position.x -= std::sin(yaw) * shift_length;
-  pose->position.y += std::cos(yaw) * shift_length;
-}
-
 PathWithLaneId getCenterLinePathFromRootLanelet(
   const lanelet::ConstLanelet & root_lanelet,
   const std::shared_ptr<const PlannerData> & planner_data)


### PR DESCRIPTION
## Description

- remove unused utils
- use `tier4_autoware_utils::calcOffsetPos`e instead of `shiftPose`

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
