### PR TITLE
fix(avoidance): fix bug in yield judge logic

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -754,7 +754,8 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
    * Condition2: there is enough space to avoid.
    */
   for (const auto & o : data.target_objects) {
-    if (o.avoid_required && o.is_avoidable) {
+    const auto enough_space = o.is_avoidable || o.reason == AvoidanceDebugFactor::TOO_LARGE_JERK;
+    if (o.avoid_required && enough_space) {
       data.avoid_required = true;
       data.stop_target_object = o;
       break;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1076,7 +1076,11 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::INSUFFICIENT_LATERAL_MARGIN);
       o.reason = AvoidanceDebugFactor::INSUFFICIENT_LATERAL_MARGIN;
       debug.unavoidable_objects.push_back(o);
-      continue;
+      if (o.avoid_required) {
+        break;
+      } else {
+        continue;
+      }
     }
 
     const auto is_object_on_right = isOnRight(o);
@@ -1085,7 +1089,11 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
       avoidance_debug_array_false_and_push_back(AvoidanceDebugFactor::SAME_DIRECTION_SHIFT);
       o.reason = AvoidanceDebugFactor::SAME_DIRECTION_SHIFT;
       debug.unavoidable_objects.push_back(o);
-      continue;
+      if (o.avoid_required) {
+        break;
+      } else {
+        continue;
+      }
     }
 
     const auto avoiding_shift = shift_length - current_ego_shift;
@@ -1115,7 +1123,11 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
         if (!data.avoiding_now) {
           o.reason = AvoidanceDebugFactor::REMAINING_DISTANCE_LESS_THAN_ZERO;
           debug.unavoidable_objects.push_back(o);
-          continue;
+          if (o.avoid_required) {
+            break;
+          } else {
+            continue;
+          }
         }
       }
 
@@ -1129,7 +1141,11 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
         if (!data.avoiding_now) {
           o.reason = AvoidanceDebugFactor::TOO_LARGE_JERK;
           debug.unavoidable_objects.push_back(o);
-          continue;
+          if (o.avoid_required) {
+            break;
+          } else {
+            continue;
+          }
         }
       }
     }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -752,6 +752,8 @@ void AvoidanceModule::fillShiftLine(AvoidancePlanningData & data, DebugData & de
    * if the both of following two conditions are satisfied, the module surely avoid the object.
    * Condition1: there is risk to collide with object without avoidance.
    * Condition2: there is enough space to avoid.
+   * In TOO_LARGE_JERK condition, it is possible to avoid object by deceleration even if the flag
+   * is_avoidable is FALSE. So, the module inserts stop point for such a object.
    */
   for (const auto & o : data.target_objects) {
     const auto enough_space = o.is_avoidable || o.reason == AvoidanceDebugFactor::TOO_LARGE_JERK;


### PR DESCRIPTION
## Description

Fix two bugs in yield judgement logic.

### YIELD for  `TOO_LARGE_JERK` objects (https://github.com/autowarefoundation/autoware.universe/pull/3322/commits/ed6c49a7e114e5dc4b16cb5a6acb92f0a7b55d2a)

The avoidance module executes yield (and stop) maneuver only when there is enough space to avoid. 

Now, there are several factor thats make avoidance impossible, and even when the one of the following factor is satisfied, the ego don't yield for target object.

- `INSUFFICIENT_LATERAL_MARGIN`
- `SAME_DIRECTION_SHIFT`
- `REMAINING_DISTANCE_LESS_THAN_ZERO`
- `TOO_LARGE_JERK`

But, in `TOO_LARGE_JERK`, the module also should embed stop point so that ego avoid the object. For now, the ego doesn't stop at avoidable position and close to obstacle stop position. This is an unexpected behavior.

![image](https://user-images.githubusercontent.com/44889564/230883522-d5fb1c28-6257-4f0e-9ff2-77b0b503687d.png)

- https://user-images.githubusercontent.com/44889564/230867633-711311c7-ea2c-4c0d-998d-836799d52dc2.mp4

---

### don't generate shift line for behind object when it fails to create shift line for front object (https://github.com/autowarefoundation/autoware.universe/pull/3322/commits/1adb6427f227b5efd21a810b0d47fbac3959cdb5)

The avoidance module generate shift line for all avoidable objects for now. So, the module generate avidance path for behind objects even when the front (nearest) object that should be avoid is unavoidable. This causes unexpected behavior like :arrow_down: (ego doesn't avoid front vehicle.)

So, the module should break the shift line generation loop when it fails to generate shif line for the nearest object that should be avoid.

![image](https://user-images.githubusercontent.com/44889564/230883759-ef5c68c2-6eaf-4600-980c-d9bfc5e46fc0.png)

- https://user-images.githubusercontent.com/44889564/230869697-bd78af3e-d17b-450a-9a6a-9eaba15ab1fe.mp4

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

### After https://github.com/autowarefoundation/autoware.universe/pull/3322/commits/ed6c49a7e114e5dc4b16cb5a6acb92f0a7b55d2a

Test result: [[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/227d3ed6-cdf6-59b5-a432-170bf5a78861/tests/7c7bd35d-f1a9-5d63-9c4f-1f4b07818dbb/f6659fe4-7912-5d6c-8b60-917c8e620172?project_id=prd_jt)

https://user-images.githubusercontent.com/44889564/230886592-4cf5c287-cd8b-4e86-ab10-f1ae8d444306.mp4

### After https://github.com/autowarefoundation/autoware.universe/pull/3322/commits/1adb6427f227b5efd21a810b0d47fbac3959cdb5

Test result: [[TIER IV INTERNAL LINK]](https://evaluation.tier4.jp/evaluation/reports/227d3ed6-cdf6-59b5-a432-170bf5a78861/tests/7c7bd35d-f1a9-5d63-9c4f-1f4b07818dbb/2d2a16d8-551a-5f4b-9c5d-a8235af5ac13?project_id=prd_jt)

https://user-images.githubusercontent.com/44889564/230885909-23163806-d5d9-45b4-9489-2bc0baabbe6e.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
