### PR TITLE
fix(behavior_velocity_planner::intersection): only zero hold velocity

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -58,7 +58,8 @@ std::optional<size_t> insertPoint(
   } else {
     // copy with velocity from prior point
     const size_t prior_ind = closest_idx > 0 ? closest_idx - 1 : 0;
-    inserted_point = inout_path->points.at(prior_ind);
+    inserted_point.point.longitudinal_velocity_mps =
+      inout_path->points.at(prior_ind).point.longitudinal_velocity_mps;
   }
   inserted_point.point.pose = in_pose;
 


### PR DESCRIPTION
## Description

In tier4's autoware.universe of version v0.6.0, stop line module did not work well due to the intersection modules' improper point insertion.
- before this PR, point insertion was using not only the velocity from prior point (zero order hold), but also the lane ids
- after this PR, only velocity is zero order holded.

See test result

## Related links

Internal JIRA link: https://tier4.atlassian.net/browse/RT1-480

## Tests performed

Before this PR (left), the point added by the intersection module is copying the lane ids from prior point. After this PR, the lane ids is that of the nearest point.

![image](https://user-images.githubusercontent.com/28677420/230829313-1a6d8db8-f51e-47a1-b5e0-019adf132197.png)

### Before this PR
the vehicle does not completely stop at the stop line.

https://user-images.githubusercontent.com/28677420/230830038-0549a0d2-bed3-4f09-b5c6-0b0b5d712a51.mp4

### After this PR
it completely stops and the stop line does not chatter.

https://user-images.githubusercontent.com/28677420/230829731-3d1f04ea-d43c-4a35-b49c-1c64c9bd1c67.mp4

### scenario

No degradation: https://evaluation.tier4.jp/evaluation/reports/6425fbba-c6b7-513b-b1ff-1016fe346ef9?project_id=prd_jt

## Notes for reviewers

This issue does not happen on latest universe thanks to the post processing, but this is still potential bug.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X]I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
