### PR TITLE
refactor(lane_change): rename lane_change_utils namespace

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -36,7 +36,7 @@
 #include <utility>
 #include <vector>
 
-namespace behavior_path_planner::lane_change_utils
+namespace behavior_path_planner::util::lane_change
 {
 using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
@@ -181,5 +181,5 @@ lanelet::ConstLanelets getLaneChangeLanes(
   const std::shared_ptr<const PlannerData> & planner_data,
   const lanelet::ConstLanelets & current_lanes, const double lane_change_lane_length,
   const double prepare_duration, const Direction direction, const LaneChangeModuleType type);
-}  // namespace behavior_path_planner::lane_change_utils
+}  // namespace behavior_path_planner::util::lane_change
 #endif  // BEHAVIOR_PATH_PLANNER__UTIL__LANE_CHANGE__UTIL_HPP_

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -639,7 +639,7 @@ ModuleStatus AvoidanceByLCModule::updateState()
     }
   }
 
-  const auto is_within_current_lane = lane_change_utils::isEgoWithinOriginalLane(
+  const auto is_within_current_lane = util::lane_change::isEgoWithinOriginalLane(
     status_.current_lanes, getEgoPose(), planner_data_->parameters);
   if (isAbortState() && !is_within_current_lane) {
     current_state_ = ModuleStatus::RUNNING;
@@ -715,7 +715,7 @@ void AvoidanceByLCModule::resetPathIfAbort()
 {
   if (!is_abort_approval_requested_) {
 #ifdef USE_OLD_ARCHITECTURE
-    const auto lateral_shift = lane_change_utils::getLateralShift(*abort_path_);
+    const auto lateral_shift = util::lane_change::getLateralShift(*abort_path_);
     if (lateral_shift > 0.0) {
       removePreviousRTCStatusRight();
       uuid_map_.at("right") = generateUUID();
@@ -779,7 +779,7 @@ CandidateOutput AvoidanceByLCModule::planCandidate() const
   }
 
   output.path_candidate = selected_path.path;
-  output.lateral_shift = lane_change_utils::getLateralShift(selected_path);
+  output.lateral_shift = util::lane_change::getLateralShift(selected_path);
   output.start_distance_to_path_change = motion_utils::calcSignedArcLength(
     selected_path.path.points, getEgoPose().position, selected_path.shift_line.start.position);
   output.finish_distance_to_path_change = motion_utils::calcSignedArcLength(
@@ -792,7 +792,7 @@ CandidateOutput AvoidanceByLCModule::planCandidate() const
 BehaviorModuleOutput AvoidanceByLCModule::planWaitingApproval()
 {
 #ifdef USE_OLD_ARCHITECTURE
-  const auto is_within_current_lane = lane_change_utils::isEgoWithinOriginalLane(
+  const auto is_within_current_lane = util::lane_change::isEgoWithinOriginalLane(
     status_.current_lanes, getEgoPose(), planner_data_->parameters);
   if (is_within_current_lane) {
     prev_approved_path_ = getReferencePath();
@@ -989,14 +989,14 @@ std::pair<bool, bool> AvoidanceByLCModule::getSafePath(
   // find candidate paths
   LaneChangePaths valid_paths;
 #ifdef USE_OLD_ARCHITECTURE
-  const auto [found_valid_path, found_safe_path] = lane_change_utils::getLaneChangePaths(
+  const auto [found_valid_path, found_safe_path] = util::lane_change::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     planner_data_->dynamic_object, common_parameters, *parameters_->lane_change, check_distance,
     &valid_paths, &object_debug_);
 #else
   const auto o_front = avoidance_data_.target_objects.front();
   const auto direction = isOnRight(o_front) ? Direction::LEFT : Direction::RIGHT;
-  const auto [found_valid_path, found_safe_path] = lane_change_utils::getLaneChangePaths(
+  const auto [found_valid_path, found_safe_path] = util::lane_change::getLaneChangePaths(
     *getPreviousModuleOutput().path, *route_handler, current_lanes, lane_change_lanes, current_pose,
     current_twist, planner_data_->dynamic_object, common_parameters, *parameters_->lane_change,
     check_distance, direction, &valid_paths, &object_debug_);
@@ -1038,7 +1038,7 @@ bool AvoidanceByLCModule::isValidPath(const PathWithLaneId & path) const
   const auto & route_handler = planner_data_->route_handler;
 
   // check lane departure
-  const auto drivable_lanes = lane_change_utils::generateDrivableLanes(
+  const auto drivable_lanes = util::lane_change::generateDrivableLanes(
     *route_handler, util::extendLanes(route_handler, status_.current_lanes),
     util::extendLanes(route_handler, status_.lane_change_lanes));
   const auto expanded_lanes = util::expandLanelets(
@@ -1103,7 +1103,7 @@ bool AvoidanceByLCModule::isAbortConditionSatisfied()
 
   if (!is_path_safe) {
     const auto & common_parameters = planner_data_->parameters;
-    const bool is_within_original_lane = lane_change_utils::isEgoWithinOriginalLane(
+    const bool is_within_original_lane = util::lane_change::isEgoWithinOriginalLane(
       status_.current_lanes, getEgoPose(), common_parameters);
 
     if (is_within_original_lane) {
@@ -1121,7 +1121,7 @@ bool AvoidanceByLCModule::isAbortConditionSatisfied()
       return false;
     }
 
-    const auto found_abort_path = lane_change_utils::getAbortPaths(
+    const auto found_abort_path = util::lane_change::getAbortPaths(
       planner_data_, status_.lane_change_path, ego_pose_before_collision, common_parameters,
       *parameters_->lane_change);
 
@@ -1283,7 +1283,7 @@ void AvoidanceByLCModule::generateExtendedDrivableArea(PathWithLaneId & path)
 {
   const auto & common_parameters = planner_data_->parameters;
   const auto & route_handler = planner_data_->route_handler;
-  const auto drivable_lanes = lane_change_utils::generateDrivableLanes(
+  const auto drivable_lanes = util::lane_change::generateDrivableLanes(
     *route_handler, status_.current_lanes, status_.lane_change_lanes);
   const auto shorten_lanes = util::cutOverlappedLanes(path, drivable_lanes);
   const auto expanded_lanes = util::expandLanelets(
@@ -1303,17 +1303,17 @@ bool AvoidanceByLCModule::isApprovedPathSafe(Pose & ego_pose_before_collision) c
   const auto & path = status_.lane_change_path;
 
   // get lanes used for detection
-  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+  const auto check_lanes = util::lane_change::getExtendedTargetLanesForCollisionCheck(
     *route_handler, path.target_lanelets.front(), current_pose, check_distance_);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
   const auto lateral_buffer =
-    lane_change_utils::calcLateralBufferForFiltering(common_parameters.vehicle_width);
-  const auto dynamic_object_indices = lane_change_utils::filterObjectIndices(
+    util::lane_change::calcLateralBufferForFiltering(common_parameters.vehicle_width);
+  const auto dynamic_object_indices = util::lane_change::filterObjectIndices(
     {path}, *dynamic_objects, check_lanes, current_pose, common_parameters.forward_path_length,
     *lane_change_parameters, lateral_buffer);
 
-  return lane_change_utils::isLaneChangePathSafe(
+  return util::lane_change::isLaneChangePathSafe(
     path, dynamic_objects, dynamic_object_indices, current_pose, current_twist, common_parameters,
     *parameters_->lane_change, common_parameters.expected_front_deceleration_for_abort,
     common_parameters.expected_rear_deceleration_for_abort, ego_pose_before_collision, debug_data,
@@ -1328,7 +1328,7 @@ void AvoidanceByLCModule::updateOutputTurnSignal(BehaviorModuleOutput & output)
     planner_data_->parameters);
   output.turn_signal_info.turn_signal.command = turn_signal_info.first.command;
 
-  lane_change_utils::get_turn_signal_info(status_.lane_change_path, &output.turn_signal_info);
+  util::lane_change::get_turn_signal_info(status_.lane_change_path, &output.turn_signal_info);
 }
 
 bool AvoidanceByLCModule::isTargetObjectType(const PredictedObject & object) const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -85,7 +85,7 @@ bool LaneChangeModule::isExecutionRequested() const
 #else
   const auto current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
-  const auto lane_change_lanes = lane_change_utils::getLaneChangeLanes(
+  const auto lane_change_lanes = util::lane_change::getLaneChangeLanes(
     planner_data_, current_lanes, lane_change_lane_length_, parameters_->prepare_duration,
     direction_, type_);
 #endif
@@ -113,7 +113,7 @@ bool LaneChangeModule::isExecutionReady() const
 #else
   const auto current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
-  const auto lane_change_lanes = lane_change_utils::getLaneChangeLanes(
+  const auto lane_change_lanes = util::lane_change::getLaneChangeLanes(
     planner_data_, current_lanes, lane_change_lane_length_, parameters_->prepare_duration,
     direction_, type_);
 #endif
@@ -137,7 +137,7 @@ ModuleStatus LaneChangeModule::updateState()
     return current_state_;
   }
 
-  const auto is_within_current_lane = lane_change_utils::isEgoWithinOriginalLane(
+  const auto is_within_current_lane = util::lane_change::isEgoWithinOriginalLane(
     status_.current_lanes, getEgoPose(), planner_data_->parameters);
   if (isAbortState() && !is_within_current_lane) {
     current_state_ = ModuleStatus::RUNNING;
@@ -213,7 +213,7 @@ void LaneChangeModule::resetPathIfAbort()
 {
   if (!is_abort_approval_requested_) {
 #ifdef USE_OLD_ARCHITECTURE
-    const auto lateral_shift = lane_change_utils::getLateralShift(*abort_path_);
+    const auto lateral_shift = util::lane_change::getLateralShift(*abort_path_);
     if (lateral_shift > 0.0) {
       removePreviousRTCStatusRight();
       uuid_map_.at("right") = generateUUID();
@@ -253,7 +253,7 @@ CandidateOutput LaneChangeModule::planCandidate() const
 #else
   const auto current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
-  const auto lane_change_lanes = lane_change_utils::getLaneChangeLanes(
+  const auto lane_change_lanes = util::lane_change::getLaneChangeLanes(
     planner_data_, current_lanes, lane_change_lane_length_, parameters_->prepare_duration,
     direction_, type_);
 #endif
@@ -280,7 +280,7 @@ CandidateOutput LaneChangeModule::planCandidate() const
   }
 
   output.path_candidate = selected_path.path;
-  output.lateral_shift = lane_change_utils::getLateralShift(selected_path);
+  output.lateral_shift = util::lane_change::getLateralShift(selected_path);
   output.start_distance_to_path_change = motion_utils::calcSignedArcLength(
     selected_path.path.points, getEgoPose().position, selected_path.shift_line.start.position);
   output.finish_distance_to_path_change = motion_utils::calcSignedArcLength(
@@ -293,7 +293,7 @@ CandidateOutput LaneChangeModule::planCandidate() const
 BehaviorModuleOutput LaneChangeModule::planWaitingApproval()
 {
 #ifdef USE_OLD_ARCHITECTURE
-  const auto is_within_current_lane = lane_change_utils::isEgoWithinOriginalLane(
+  const auto is_within_current_lane = util::lane_change::isEgoWithinOriginalLane(
     status_.current_lanes, getEgoPose(), planner_data_->parameters);
   if (is_within_current_lane) {
     prev_approved_path_ = getReferencePath();
@@ -333,7 +333,7 @@ void LaneChangeModule::updateLaneChangeStatus()
 #else
   status_.current_lanes =
     util::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
-  status_.lane_change_lanes = lane_change_utils::getLaneChangeLanes(
+  status_.lane_change_lanes = util::lane_change::getLaneChangeLanes(
     planner_data_, status_.current_lanes, lane_change_lane_length_, parameters_->prepare_duration,
     direction_, type_);
 #endif
@@ -465,12 +465,12 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
   // find candidate paths
   LaneChangePaths valid_paths;
 #ifdef USE_OLD_ARCHITECTURE
-  const auto [found_valid_path, found_safe_path] = lane_change_utils::getLaneChangePaths(
+  const auto [found_valid_path, found_safe_path] = util::lane_change::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     planner_data_->dynamic_object, common_parameters, *parameters_, check_distance, &valid_paths,
     &object_debug_);
 #else
-  const auto [found_valid_path, found_safe_path] = lane_change_utils::getLaneChangePaths(
+  const auto [found_valid_path, found_safe_path] = util::lane_change::getLaneChangePaths(
     *getPreviousModuleOutput().path, *route_handler, current_lanes, lane_change_lanes, current_pose,
     current_twist, planner_data_->dynamic_object, common_parameters, *parameters_, check_distance,
     direction_, &valid_paths, &object_debug_);
@@ -512,7 +512,7 @@ bool LaneChangeModule::isValidPath(const PathWithLaneId & path) const
   const auto & route_handler = planner_data_->route_handler;
 
   // check lane departure
-  const auto drivable_lanes = lane_change_utils::generateDrivableLanes(
+  const auto drivable_lanes = util::lane_change::generateDrivableLanes(
     *route_handler, util::extendLanes(route_handler, status_.current_lanes),
     util::extendLanes(route_handler, status_.lane_change_lanes));
   const auto expanded_lanes = util::expandLanelets(
@@ -577,7 +577,7 @@ bool LaneChangeModule::isAbortConditionSatisfied()
 
   if (!is_path_safe) {
     const auto & common_parameters = planner_data_->parameters;
-    const bool is_within_original_lane = lane_change_utils::isEgoWithinOriginalLane(
+    const bool is_within_original_lane = util::lane_change::isEgoWithinOriginalLane(
       status_.current_lanes, getEgoPose(), common_parameters);
 
     if (is_within_original_lane) {
@@ -595,7 +595,7 @@ bool LaneChangeModule::isAbortConditionSatisfied()
       return false;
     }
 
-    const auto found_abort_path = lane_change_utils::getAbortPaths(
+    const auto found_abort_path = util::lane_change::getAbortPaths(
       planner_data_, status_.lane_change_path, ego_pose_before_collision, common_parameters,
       *parameters_);
 
@@ -758,10 +758,10 @@ void LaneChangeModule::generateExtendedDrivableArea(PathWithLaneId & path)
 {
   const auto & common_parameters = planner_data_->parameters;
   const auto & route_handler = planner_data_->route_handler;
-  auto drivable_lanes = lane_change_utils::generateDrivableLanes(
+  auto drivable_lanes = util::lane_change::generateDrivableLanes(
     *route_handler, status_.current_lanes, status_.lane_change_lanes);
 #ifndef USE_OLD_ARCHITECTURE
-  drivable_lanes = lane_change_utils::combineDrivableLanes(
+  drivable_lanes = util::lane_change::combineDrivableLanes(
     getPreviousModuleOutput().drivable_lanes, drivable_lanes);
 #endif
   const auto shorten_lanes = util::cutOverlappedLanes(path, drivable_lanes);
@@ -782,17 +782,17 @@ bool LaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
   const auto & path = status_.lane_change_path;
 
   // get lanes used for detection
-  const auto check_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+  const auto check_lanes = util::lane_change::getExtendedTargetLanesForCollisionCheck(
     *route_handler, path.target_lanelets.front(), current_pose, check_distance_);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
   const auto lateral_buffer =
-    lane_change_utils::calcLateralBufferForFiltering(common_parameters.vehicle_width);
-  const auto dynamic_object_indices = lane_change_utils::filterObjectIndices(
+    util::lane_change::calcLateralBufferForFiltering(common_parameters.vehicle_width);
+  const auto dynamic_object_indices = util::lane_change::filterObjectIndices(
     {path}, *dynamic_objects, check_lanes, current_pose, common_parameters.forward_path_length,
     lane_change_parameters, lateral_buffer);
 
-  return lane_change_utils::isLaneChangePathSafe(
+  return util::lane_change::isLaneChangePathSafe(
     path, dynamic_objects, dynamic_object_indices, current_pose, current_twist, common_parameters,
     *parameters_, common_parameters.expected_front_deceleration_for_abort,
     common_parameters.expected_rear_deceleration_for_abort, ego_pose_before_collision, debug_data,
@@ -808,7 +808,7 @@ void LaneChangeModule::updateOutputTurnSignal(BehaviorModuleOutput & output)
     planner_data_->parameters);
   output.turn_signal_info.turn_signal.command = turn_signal_info.first.command;
 
-  lane_change_utils::get_turn_signal_info(status_.lane_change_path, &output.turn_signal_info);
+  util::lane_change::get_turn_signal_info(status_.lane_change_path, &output.turn_signal_info);
 }
 
 void LaneChangeModule::calcTurnSignalInfo()

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -110,7 +110,7 @@ std::vector<int64_t> replaceWithSortedIds(
 }
 }  // namespace
 
-namespace behavior_path_planner::lane_change_utils
+namespace behavior_path_planner::util::lane_change
 {
 using autoware_auto_planning_msgs::msg::PathPointWithLaneId;
 using lanelet::ArcCoordinates;
@@ -458,7 +458,7 @@ std::pair<bool, bool> getLaneChangePaths(
 
     if (candidate_paths->empty()) {
       // only compute dynamic object indices once
-      const auto backward_lanes = lane_change_utils::getExtendedTargetLanesForCollisionCheck(
+      const auto backward_lanes = util::lane_change::getExtendedTargetLanesForCollisionCheck(
         route_handler, target_lanelets.front(), pose, check_length);
       dynamic_object_indices = filterObjectIndices(
         {*candidate_path}, *dynamic_objects, backward_lanes, pose,
@@ -1444,4 +1444,4 @@ lanelet::ConstLanelets getLaneChangeLanes(
 
   return {};
 }
-}  // namespace behavior_path_planner::lane_change_utils
+}  // namespace behavior_path_planner::util::lane_change

--- a/planning/behavior_path_planner/test/test_lane_change_utils.cpp
+++ b/planning/behavior_path_planner/test/test_lane_change_utils.cpp
@@ -22,16 +22,16 @@ TEST(BehaviorPathPlanningLaneChangeUtilsTest, testStoppingDistance)
 
   const auto negative_accel = -1.5;
   const auto distance_when_negative =
-    behavior_path_planner::lane_change_utils::stoppingDistance(vehicle_velocity, negative_accel);
+    behavior_path_planner::util::lane_change::stoppingDistance(vehicle_velocity, negative_accel);
   ASSERT_NEAR(distance_when_negative, 23.1463, 1e-3);
 
   const auto positive_accel = 1.5;
   const auto distance_when_positive =
-    behavior_path_planner::lane_change_utils::stoppingDistance(vehicle_velocity, positive_accel);
+    behavior_path_planner::util::lane_change::stoppingDistance(vehicle_velocity, positive_accel);
   ASSERT_NEAR(distance_when_positive, 34.7194, 1e-3);
 
   const auto zero_accel = 0.0;
   const auto distance_when_zero =
-    behavior_path_planner::lane_change_utils::stoppingDistance(vehicle_velocity, zero_accel);
+    behavior_path_planner::util::lane_change::stoppingDistance(vehicle_velocity, zero_accel);
   ASSERT_NEAR(distance_when_zero, 34.7194, 1e-3);
 }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8527b7e</samp>

This pull request refactors the namespace of the lane change utility functions in the behavior path planner component. The old namespace `lane_change_utils` is replaced by `util::lane_change` for clarity and consistency. The change affects several header, source, and test files that use these functions for lane change planning and checking.

## Tests performed

1. Build success test
   - [X] COMPILE_WITH_OLD_ARCHITECTURE=TRUE
   - [X] COMPILE_WITH_OLD_ARCHITECTURE=FALSE

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
