### PR TITLE
fix(behavior_velocity_planner): properly get common params in 'run_out'

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/run_out/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/manager.cpp
@@ -45,10 +45,18 @@ RunOutModuleManager::RunOutModuleManager(rclcpp::Node & node)
 
   {
     auto & p = planner_param_.common;
-    p.normal_min_jerk = node.get_parameter("normal.min_jerk").get_value<double>();
-    p.normal_min_acc = node.get_parameter("normal.min_acc").get_value<double>();
-    p.limit_min_jerk = node.declare_parameter<double>("limit.min_jerk");
-    p.limit_min_acc = node.declare_parameter<double>("limit.min_acc");
+    p.normal_min_jerk = node.has_parameter("normal.min_jerk")
+                          ? node.get_parameter("normal.min_jerk").get_value<double>()
+                          : node.declare_parameter<double>("normal.min_jerk");
+    p.normal_min_acc = node.has_parameter("normal.min_acc")
+                         ? node.get_parameter("normal.min_acc").get_value<double>()
+                         : node.declare_parameter<double>("normal.min_acc");
+    p.limit_min_jerk = node.has_parameter("limit.min_jerk")
+                         ? node.get_parameter("limit.min_jerk").get_value<double>()
+                         : node.declare_parameter<double>("limit.min_jerk");
+    p.limit_min_acc = node.has_parameter("limit.min_acc")
+                        ? node.get_parameter("limit.min_acc").get_value<double>()
+                        : node.declare_parameter<double>("limit.min_acc");
   }
 
   {

--- a/planning/behavior_velocity_planner/src/scene_module/run_out/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/run_out/manager.cpp
@@ -45,10 +45,10 @@ RunOutModuleManager::RunOutModuleManager(rclcpp::Node & node)
 
   {
     auto & p = planner_param_.common;
-    p.normal_min_jerk = node.declare_parameter<double>(".normal.min_jerk");
-    p.normal_min_acc = node.declare_parameter<double>(".normal.min_acc");
-    p.limit_min_jerk = node.declare_parameter<double>(".limit.min_jerk");
-    p.limit_min_acc = node.declare_parameter<double>(".limit.min_acc");
+    p.normal_min_jerk = node.get_parameter("normal.min_jerk").get_value<double>();
+    p.normal_min_acc = node.get_parameter("normal.min_acc").get_value<double>();
+    p.limit_min_jerk = node.declare_parameter<double>("limit.min_jerk");
+    p.limit_min_acc = node.declare_parameter<double>("limit.min_acc");
   }
 
   {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
The `run_out` module in the `behavior_velocity_planner` node is currently broken and crashes if turned on.
The issue comes from the declaration of some parameters that are (i) incorrectly named (leading dot `.`) and (ii) already declared (for `normal.min_jerk` and `normal.min_acc`).

This issue was previously hidden by default parameters which were recently removed (https://github.com/autowarefoundation/autoware.universe/pull/3201).

## Tests performed

Start the `simple_planning_simulator` after setting `launch_run_out: true` (https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml#L12).
- Without this PR: crash.
- With this PR: no crash.
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
