### PR TITLE
refactor(lane_change): add debug messages for getLaneChangePaths

### DIFF
--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -183,7 +183,7 @@ std::optional<LaneChangePath> constructCandidatePath(
 
   if (!path_shifter.generate(&shifted_path, offset_back)) {
     RCLCPP_DEBUG(
-      rclcpp::get_logger("behavior_path_planner").get_child("lane_change").get_child("util"),
+      rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
       "failed to generate shifted path.");
   }
 
@@ -222,7 +222,7 @@ std::optional<LaneChangePath> constructCandidatePath(
 
   if (!lane_change_end_idx) {
     RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("lane_change").get_child("util"),
+      rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
       "lane change end idx not found on target path.");
     return std::nullopt;
   }
@@ -348,6 +348,9 @@ std::pair<bool, bool> getLaneChangePaths(
       minimum_prepare_length);
 
     if (prepare_length < target_length) {
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+        "prepare length is shorter than distance to target lane!!");
       break;
     }
 
@@ -363,8 +366,8 @@ std::pair<bool, bool> getLaneChangePaths(
 
     if (prepare_segment.points.empty()) {
       RCLCPP_ERROR_STREAM(
-        rclcpp::get_logger("behavior_path_planner").get_child("lane_change").get_child("util"),
-        "prepare segment is empty!! something wrong...");
+        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+        "prepare segment is empty!!");
       continue;
     }
 
@@ -377,6 +380,9 @@ std::pair<bool, bool> getLaneChangePaths(
     // target lanelet, even if the condition prepare_length > target_length is satisfied. In
     // that case, the lane change shouldn't be executed.
     if (target_length_from_lane_change_start_pose > 0.0) {
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+        "[only new arch] lane change start pose is behind target lanelet!!");
       break;
     }
 
@@ -389,7 +395,9 @@ std::pair<bool, bool> getLaneChangePaths(
       calcLaneChangingLength(lane_changing_velocity, shift_length, common_parameter, parameter);
 
     if (lane_changing_length + prepare_length > dist_to_end_of_current_lanes) {
-      // total lane changing length it too long
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+        "lane changing path too long");
       continue;
     }
 
@@ -402,6 +410,9 @@ std::pair<bool, bool> getLaneChangePaths(
         s_start + lane_changing_length + parameter.lane_change_finish_judge_buffer +
           required_total_min_length >
         s_goal) {
+        RCLCPP_ERROR_STREAM(
+          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+          "length of lane changing path is longer than length to goal!!");
         continue;
       }
     }
@@ -412,7 +423,7 @@ std::pair<bool, bool> getLaneChangePaths(
 
     if (target_segment.points.empty()) {
       RCLCPP_ERROR_STREAM(
-        rclcpp::get_logger("behavior_path_planner").get_child("lane_change").get_child("util"),
+        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
         "target segment is empty!! something wrong...");
       continue;
     }
@@ -426,6 +437,9 @@ std::pair<bool, bool> getLaneChangePaths(
       lc_length.lane_changing, forward_path_length, resample_interval, is_goal_in_route);
 
     if (target_lane_reference_path.points.empty()) {
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+        "target_lane_reference_path is empty!!");
       continue;
     }
 
@@ -439,6 +453,9 @@ std::pair<bool, bool> getLaneChangePaths(
       target_lanelets, sorted_lane_ids, acceleration, lc_length, lc_velocity, parameter);
 
     if (!candidate_path) {
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+        "no candidate path!!");
       continue;
     }
 
@@ -453,6 +470,9 @@ std::pair<bool, bool> getLaneChangePaths(
 #endif
 
     if (!is_valid) {
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+        "invalid candidate path!!");
       continue;
     }
 
@@ -1151,7 +1171,7 @@ std::optional<LaneChangePath> getAbortPaths(
 
   if (abort_start_idx >= abort_return_idx) {
     RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("lane_change").get_child("util"),
+      rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
       "abort start idx and return idx is equal. can't compute abort path.");
     return std::nullopt;
   }
@@ -1159,7 +1179,7 @@ std::optional<LaneChangePath> getAbortPaths(
   if (!hasEnoughLengthToLaneChangeAfterAbort(
         *route_handler, reference_lanelets, current_pose, abort_return_dist, common_param)) {
     RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("lane_change").get_child("util"),
+      rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
       "insufficient distance to abort.");
     return std::nullopt;
   }
@@ -1211,7 +1231,7 @@ std::optional<LaneChangePath> getAbortPaths(
   // bool offset_back = false;
   if (!path_shifter.generate(&shifted_path)) {
     RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("lane_change").get_child("util"),
+      rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
       "failed to generate abort shifted path.");
   }
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e394634</samp>

Fixed logger name conflicts and added error messages in `util.cpp` for lane change planning. This improves the debugging and error handling of the behavior path planner component.

## Tests performed

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
