### PR TITLE
feat(obstacle_cruise_planner): implement slow down planner

### DIFF
--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -4,7 +4,7 @@
       planning_algorithm: "pid_base" # currently supported algorithm is "pid_base"
 
       enable_debug_info: false
-      enable_calculation_time_info: true
+      enable_calculation_time_info: false
 
       enable_slow_down_planning: true
 
@@ -93,8 +93,7 @@
           max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
 
       slow_down:
-        # TODO(murooka) re-tune
-        max_lat_margin: 5.0  # lateral margin between obstacle and trajectory band with ego's width
+        max_lat_margin: 1.0  # lateral margin between obstacle and trajectory band with ego's width
 
     cruise:
       pid_based_planner:
@@ -162,11 +161,10 @@
 
     slow_down:
       # parameters to calculate slow down velocity by linear interpolation
-      min_lat_margin: 0.0
-      max_lat_margin: 2.0
-      min_ego_velocity: 3.0
-      max_ego_velocity: 10.0
+      min_lat_margin: 0.2
+      max_lat_margin: 1.0
+      min_ego_velocity: 2.0
+      max_ego_velocity: 8.0
 
-      # TODO(murooka) enable this
-      # parameter for where to insert slow down point
-      # max_deceleration: -2.0
+      # max deceleration during slow down
+      max_deceleration: -1.0

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -125,12 +125,15 @@ struct SlowDownObstacle : public TargetObstacleInterface
   SlowDownObstacle(
     const std::string & arg_uuid, const rclcpp::Time & arg_stamp,
     const geometry_msgs::msg::Pose & arg_pose, const double arg_velocity,
-    const geometry_msgs::msg::Point arg_collision_point)
+    const double arg_precise_lat_dist, const geometry_msgs::msg::Point & arg_front_collision_point,
+    const geometry_msgs::msg::Point & arg_back_collision_point)
   : TargetObstacleInterface(arg_uuid, arg_stamp, arg_pose, arg_velocity),
-    collision_point(arg_collision_point)
-  {
-  }
-  geometry_msgs::msg::Point collision_point;
+    precise_lat_dist(arg_precise_lat_dist),
+    front_collision_point(arg_front_collision_point),
+    back_collision_point(arg_back_collision_point) {}
+  double precise_lat_dist;        // for efficient calculation
+  geometry_msgs::msg::Point front_collision_point;
+  geometry_msgs::msg::Point back_collision_point;
 };
 
 struct LongitudinalInfo
@@ -207,6 +210,7 @@ struct DebugData
   std::vector<SlowDownObstacle> obstacles_to_slow_down;
   MarkerArray stop_wall_marker;
   MarkerArray cruise_wall_marker;
+  MarkerArray slow_down_wall_marker;
   std::vector<tier4_autoware_utils::Polygon2d> detection_polygons;
   std::vector<geometry_msgs::msg::Point> collision_points;
 };

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -130,8 +130,10 @@ struct SlowDownObstacle : public TargetObstacleInterface
   : TargetObstacleInterface(arg_uuid, arg_stamp, arg_pose, arg_velocity),
     precise_lat_dist(arg_precise_lat_dist),
     front_collision_point(arg_front_collision_point),
-    back_collision_point(arg_back_collision_point) {}
-  double precise_lat_dist;        // for efficient calculation
+    back_collision_point(arg_back_collision_point)
+  {
+  }
+  double precise_lat_dist;  // for efficient calculation
   geometry_msgs::msg::Point front_collision_point;
   geometry_msgs::msg::Point back_collision_point;
 };
@@ -212,7 +214,6 @@ struct DebugData
   MarkerArray cruise_wall_marker;
   MarkerArray slow_down_wall_marker;
   std::vector<tier4_autoware_utils::Polygon2d> detection_polygons;
-  std::vector<geometry_msgs::msg::Point> collision_points;
 };
 
 struct EgoNearestParam

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -79,7 +79,8 @@ private:
     const std::vector<PointWithStamp> & collision_points,
     const std::vector<TrajectoryPoint> & traj_points, const bool is_driving_forward) const;
   std::optional<SlowDownObstacle> createSlowDownObstacle(
-    const Obstacle & obstacle, const double precise_lat_dist);
+    const std::vector<TrajectoryPoint> & traj_points, const Obstacle & obstacle,
+    const double precise_lat_dist);
   PlannerData createPlannerData(const std::vector<TrajectoryPoint> & traj_points) const;
 
   void checkConsistency(
@@ -114,6 +115,7 @@ private:
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_marker_pub_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_cruise_wall_marker_pub_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_stop_wall_marker_pub_;
+  rclcpp::Publisher<MarkerArray>::SharedPtr debug_slow_down_wall_marker_pub_;
   rclcpp::Publisher<Float32MultiArrayStamped>::SharedPtr debug_stop_planning_info_pub_;
   rclcpp::Publisher<Float32MultiArrayStamped>::SharedPtr debug_cruise_planning_info_pub_;
   rclcpp::Publisher<Float32Stamped>::SharedPtr debug_calculation_time_pub_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
@@ -19,7 +19,6 @@
 #include "obstacle_cruise_planner/pid_based_planner/pid_controller.hpp"
 #include "obstacle_cruise_planner/planner_interface.hpp"
 #include "signal_processing/lowpass_filter_1d.hpp"
-#include "tier4_autoware_utils/system/stop_watch.hpp"
 
 #include "visualization_msgs/msg/marker_array.hpp"
 
@@ -113,11 +112,6 @@ private:
     bool enable_jerk_limit_to_output_acc{false};
   };
   VelocityInsertionBasedPlannerParam velocity_insertion_based_planner_param_;
-
-  // stop watch
-  tier4_autoware_utils::StopWatch<
-    std::chrono::milliseconds, std::chrono::microseconds, std::chrono::steady_clock>
-    stop_watch_;
 
   std::optional<double> prev_target_acc_;
 

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/pid_based_planner/pid_based_planner.hpp
@@ -58,7 +58,7 @@ public:
     const std::vector<CruiseObstacle> & obstacles,
     std::optional<VelocityLimit> & vel_limit) override;
 
-  void updateParam(const std::vector<rclcpp::Parameter> & parameters) override;
+  void updateCruiseParam(const std::vector<rclcpp::Parameter> & parameters) override;
 
 private:
   Float32MultiArrayStamped getCruisePlanningDebugMessage(

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -94,6 +94,11 @@ protected:
   LongitudinalInfo longitudinal_info_;
   double min_behavior_stop_margin_;
 
+  // stop watch
+  tier4_autoware_utils::StopWatch<
+    std::chrono::milliseconds, std::chrono::microseconds, std::chrono::steady_clock>
+    stop_watch_;
+
   // Publishers
   rclcpp::Publisher<StopReasonArray>::SharedPtr stop_reasons_pub_;
   rclcpp::Publisher<VelocityFactorArray>::SharedPtr velocity_factors_pub_;
@@ -150,6 +155,11 @@ protected:
   }
 
 private:
+  double calculateSlowDownVelocity(const SlowDownObstacle & obstacle) const;
+  double calculateDistanceToSlowDownWithAccConstraint(
+    const PlannerData & planner_data, const std::vector<TrajectoryPoint> & traj_points,
+    const SlowDownObstacle & obstacle, const double dist_to_ego, const double slow_down_vel) const;
+
   struct SlowDownInfo
   {
     // NOTE: Acceleration limit is applied to lon_dist not to occur sudden brake.
@@ -165,6 +175,7 @@ private:
       min_lat_margin = node.declare_parameter<double>("slow_down.min_lat_margin");
       max_ego_velocity = node.declare_parameter<double>("slow_down.max_ego_velocity");
       min_ego_velocity = node.declare_parameter<double>("slow_down.min_ego_velocity");
+      max_deceleration = node.declare_parameter<double>("slow_down.max_deceleration");
     }
 
     void onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -177,12 +188,15 @@ private:
         parameters, "slow_down.max_ego_velocity", max_ego_velocity);
       tier4_autoware_utils::updateParam<double>(
         parameters, "slow_down.min_ego_velocity", min_ego_velocity);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.max_deceleration", max_deceleration);
     }
 
     double max_lat_margin;
     double min_lat_margin;
     double max_ego_velocity;
     double min_ego_velocity;
+    double max_deceleration;
   };
   SlowDownParam slow_down_param_;
 };

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -36,7 +36,8 @@ public:
   : longitudinal_info_(longitudinal_info),
     vehicle_info_(vehicle_info),
     ego_nearest_param_(ego_nearest_param),
-    debug_data_ptr_(debug_data_ptr)
+    debug_data_ptr_(debug_data_ptr),
+    slow_down_param_(SlowDownParam(node))
   {
     stop_reasons_pub_ = node.create_publisher<StopReasonArray>("~/output/stop_reasons", 1);
     velocity_factors_pub_ =
@@ -64,17 +65,16 @@ public:
     const std::vector<CruiseObstacle> & cruise_obstacles,
     std::optional<VelocityLimit> & vel_limit) = 0;
 
-  std::optional<VelocityLimit> getSlowDownVelocityLimit(
-    [[maybe_unused]] const PlannerData & planner_data,
-    [[maybe_unused]] const std::vector<SlowDownObstacle> & slow_down_obstacles)
-  {
-    return std::nullopt;
-  }
+  std::vector<TrajectoryPoint> generateSlowDownTrajectory(
+    const PlannerData & planner_data, const std::vector<TrajectoryPoint> & stop_traj_points,
+    const std::vector<SlowDownObstacle> & slow_down_obstacles,
+    std::optional<VelocityLimit> & vel_limit);
 
   void onParam(const std::vector<rclcpp::Parameter> & parameters)
   {
     updateCommonParam(parameters);
-    updateParam(parameters);
+    updateCruiseParam(parameters);
+    slow_down_param_.onParam(parameters);
   }
 
   Float32MultiArrayStamped getStopPlanningDebugMessage(const rclcpp::Time & current_time) const
@@ -127,7 +127,9 @@ protected:
     longitudinal_info_.onParam(parameters);
   }
 
-  virtual void updateParam([[maybe_unused]] const std::vector<rclcpp::Parameter> & parameters) {}
+  virtual void updateCruiseParam([[maybe_unused]] const std::vector<rclcpp::Parameter> & parameters)
+  {
+  }
 
   size_t findEgoIndex(
     const std::vector<TrajectoryPoint> & traj_points,
@@ -146,6 +148,43 @@ protected:
     return motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
       traj_points, ego_pose, p.dist_threshold, p.yaw_threshold);
   }
+
+private:
+  struct SlowDownInfo
+  {
+    // NOTE: Acceleration limit is applied to lon_dist not to occur sudden brake.
+    const double lon_dist;  // from ego pose to slow down point
+    const double vel;       // slow down velocity
+  };
+
+  struct SlowDownParam
+  {
+    explicit SlowDownParam(rclcpp::Node & node)
+    {
+      max_lat_margin = node.declare_parameter<double>("slow_down.max_lat_margin");
+      min_lat_margin = node.declare_parameter<double>("slow_down.min_lat_margin");
+      max_ego_velocity = node.declare_parameter<double>("slow_down.max_ego_velocity");
+      min_ego_velocity = node.declare_parameter<double>("slow_down.min_ego_velocity");
+    }
+
+    void onParam(const std::vector<rclcpp::Parameter> & parameters)
+    {
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.max_lat_margin", max_lat_margin);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.min_lat_margin", min_lat_margin);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.max_ego_velocity", max_ego_velocity);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.min_ego_velocity", min_ego_velocity);
+    }
+
+    double max_lat_margin;
+    double min_lat_margin;
+    double max_ego_velocity;
+    double min_ego_velocity;
+  };
+  SlowDownParam slow_down_param_;
 };
 
 #endif  // OBSTACLE_CRUISE_PLANNER__PLANNER_INTERFACE_HPP_

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -1006,8 +1006,10 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
     }
   }
 
-  return SlowDownObstacle(
-    obstacle.uuid, obstacle.pose, precise_lat_dist, front_collision_point, back_collision_point);
+  const double obstacle_projected_vel = calcObstacleProjectedVelocity(traj_points, obstacle);
+  return SlowDownObstacle{obstacle.uuid,          obstacle.stamp,   obstacle.pose,
+                          obstacle_projected_vel, precise_lat_dist, front_collision_point,
+                          back_collision_point};
 }
 
 void ObstacleCruisePlannerNode::checkConsistency(

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -310,8 +310,11 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::planCruise(
       const size_t wall_idx = obstacle_cruise_utils::getIndexWithLongitudinalOffset(
         stop_traj_points, dist_to_rss_wall, ego_idx);
 
-      const auto markers = motion_utils::createSlowDownVirtualWallMarker(
+      auto markers = motion_utils::createSlowDownVirtualWallMarker(
         stop_traj_points.at(wall_idx).pose, "obstacle cruise", planner_data.current_time, 0);
+      // NOTE: use a different color from slow down one to visualize cruise and slow down
+      // separately.
+      markers.markers.front().color = tier4_autoware_utils::createMarkerColor(1.0, 0.3, 0.0, 0.5);
       tier4_autoware_utils::appendMarkerArray(markers, &debug_data_ptr_->cruise_wall_marker);
 
       // cruise obstacle

--- a/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -613,7 +613,7 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::getAccelerationLimitedTrajectory(
   return acc_limited_traj_points;
 }
 
-void PIDBasedPlanner::updateParam(const std::vector<rclcpp::Parameter> & parameters)
+void PIDBasedPlanner::updateCruiseParam(const std::vector<rclcpp::Parameter> & parameters)
 {
   tier4_autoware_utils::updateParam<double>(
     parameters, "cruise.pid_based_planner.min_accel_during_cruise", min_accel_during_cruise_);

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -270,7 +270,8 @@ double PlannerInterface::calcDistanceToCollisionPoint(
 
 std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
   const PlannerData & planner_data, const std::vector<TrajectoryPoint> & cruise_traj_points,
-  const std::vector<SlowDownObstacle> & obstacles, std::optional<VelocityLimit> & vel_limit)
+  const std::vector<SlowDownObstacle> & obstacles,
+  [[maybe_unused]] std::optional<VelocityLimit> & vel_limit)
 {
   // stop_watch_.tic(__func__);
   const auto & p = slow_down_param_;


### PR DESCRIPTION
## Description

Implemented slow down planner, inserting slow down point in the trajectory where the point is close to the dynamic/static obstacles.

<!-- Write a brief description of this PR. -->

## Related links
launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/288

## Tests performed

Planning simulator works well.
- TODO
    - [x] scenario sim: https://evaluation.tier4.jp/evaluation/reports/50ce7861-d8b3-5ef9-87b1-f68421f860a8?project_id=prd_jt
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
