### PR TITLE
refactor(behavior_path_planner): move utilities and rename the file

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -10,8 +10,6 @@ find_package(magic_enum CONFIG REQUIRED)
 set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
 
 set(common_src
-  src/utilities.cpp
-  src/path_utilities.cpp
   src/steering_factor_interface.cpp
   src/behavior_path_planner_node.cpp
   src/scene_module/scene_module_visitor.cpp
@@ -23,6 +21,8 @@ set(common_src
   src/scene_module/lane_change/lane_change_module.cpp
   src/scene_module/lane_change/external_request_lane_change_module.cpp
   src/turn_signal_decider.cpp
+  src/util/utils.cpp
+  src/util/path_utils.cpp
   src/util/safety_check.cpp
   src/util/avoidance/util.cpp
   src/util/lane_change/util.cpp
@@ -91,7 +91,7 @@ rclcpp_components_register_node(behavior_path_planner_node
 if(BUILD_TESTING)
   ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_utilities
     test/input.cpp
-    test/test_utilities.cpp
+    test/test_utils.cpp
     test/test_drivable_area_expansion.cpp
   )
   target_link_libraries(test_${CMAKE_PROJECT_NAME}_utilities

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -18,7 +18,7 @@
 #include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/module_status.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <behavior_path_planner/steering_factor_interface.hpp>
 #include <behavior_path_planner/turn_signal_decider.hpp>

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -19,7 +19,7 @@
 #include "behavior_path_planner/parameters.hpp"
 #include "behavior_path_planner/util/lane_change/lane_change_module_data.hpp"
 #include "behavior_path_planner/util/lane_change/lane_change_path.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <route_handler/route_handler.hpp>
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/path_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/path_utils.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BEHAVIOR_PATH_PLANNER__PATH_UTILITIES_HPP_
-#define BEHAVIOR_PATH_PLANNER__PATH_UTILITIES_HPP_
+#ifndef BEHAVIOR_PATH_PLANNER__UTIL__PATH_UTILS_HPP_
+#define BEHAVIOR_PATH_PLANNER__UTIL__PATH_UTILS_HPP_
 
 #include "behavior_path_planner/util/path_shifter/path_shifter.hpp"
 
@@ -94,4 +94,4 @@ std::vector<Pose> interpolatePose(
 
 }  // namespace behavior_path_planner::util
 
-#endif  // BEHAVIOR_PATH_PLANNER__PATH_UTILITIES_HPP_
+#endif  // BEHAVIOR_PATH_PLANNER__UTIL__PATH_UTILS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/pull_over/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/pull_over/util.hpp
@@ -16,7 +16,7 @@
 #define BEHAVIOR_PATH_PLANNER__UTIL__PULL_OVER__UTIL_HPP_
 
 #include "behavior_path_planner/util/pull_over/goal_searcher_base.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lane_departure_checker/lane_departure_checker.hpp>
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/util/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/utils.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_
-#define BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_
+#ifndef BEHAVIOR_PATH_PLANNER__UTIL__UTILS_HPP_
+#define BEHAVIOR_PATH_PLANNER__UTIL__UTILS_HPP_
 
 #include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/marker_util/debug_utilities.hpp"
@@ -351,4 +351,4 @@ lanelet::ConstLanelets getLaneletsFromPath(
 std::string convertToSnakeCase(const std::string & input_str);
 }  // namespace behavior_path_planner::util
 
-#endif  // BEHAVIOR_PATH_PLANNER__UTILITIES_HPP_
+#endif  // BEHAVIOR_PATH_PLANNER__UTIL__UTILS_HPP_

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -15,8 +15,8 @@
 #include "behavior_path_planner/behavior_path_planner_node.hpp"
 
 #include "behavior_path_planner/marker_util/debug_utilities.hpp"
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/util/drivable_area_expansion/map_utils.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -17,7 +17,7 @@
 #include "behavior_path_planner/scene_module/scene_module_bt_node_interface.hpp"
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <algorithm>
 #include <memory>

--- a/planning/behavior_path_planner/src/marker_util/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/marker_util/avoidance/debug.cpp
@@ -14,8 +14,8 @@
 
 #include "behavior_path_planner/marker_util/avoidance/debug.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <tf2/utils.h>
 

--- a/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
+++ b/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
@@ -14,8 +14,8 @@
 
 #include "behavior_path_planner/marker_util/debug_utilities.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <tier4_autoware_utils/ros/marker_helper.hpp>
 

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -14,8 +14,8 @@
 
 #include "behavior_path_planner/planner_manager.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -15,10 +15,10 @@
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module.hpp"
 
 #include "behavior_path_planner/marker_util/avoidance/debug.hpp"
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/util/avoidance/util.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -14,13 +14,13 @@
 
 #include "behavior_path_planner/scene_module/avoidance_by_lc/module.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/turn_signal_decider.hpp"
 #include "behavior_path_planner/util/avoidance/util.hpp"
 #include "behavior_path_planner/util/lane_change/util.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -14,11 +14,11 @@
 
 #include "behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/turn_signal_decider.hpp"
 #include "behavior_path_planner/util/lane_change/util.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -14,11 +14,11 @@
 
 #include "behavior_path_planner/scene_module/lane_change/lane_change_module.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/turn_signal_decider.hpp"
 #include "behavior_path_planner/util/lane_change/util.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -14,8 +14,8 @@
 
 #include "behavior_path_planner/scene_module/lane_following/lane_following_module.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
 

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -14,10 +14,10 @@
 
 #include "behavior_path_planner/scene_module/pull_out/pull_out_module.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/util/create_vehicle_footprint.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 #include "behavior_path_planner/util/pull_out/util.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -14,11 +14,11 @@
 
 #include "behavior_path_planner/scene_module/pull_over/pull_over_module.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/util/create_vehicle_footprint.hpp"
 #include "behavior_path_planner/util/path_shifter/path_shifter.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 #include "behavior_path_planner/util/pull_over/util.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -14,9 +14,9 @@
 
 #include "behavior_path_planner/scene_module/side_shift/side_shift_module.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 #include "behavior_path_planner/util/side_shift/util.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
 

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -14,7 +14,7 @@
 
 #include "behavior_path_planner/turn_signal_decider.hpp"
 
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/util/avoidance/util.cpp
+++ b/planning/behavior_path_planner/src/util/avoidance/util.cpp
@@ -14,9 +14,9 @@
 
 #include "behavior_path_planner/util/avoidance/util.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/util/avoidance/avoidance_module_data.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <autoware_auto_tf2/tf2_autoware_auto_msgs.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/util/geometric_parallel_parking/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/src/util/geometric_parallel_parking/geometric_parallel_parking.cpp
@@ -14,8 +14,8 @@
 
 #include "behavior_path_planner/util/geometric_parallel_parking/geometric_parallel_parking.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 #include "tier4_autoware_utils/geometry/geometry.hpp"
 
 #include <interpolation/spline_interpolation.hpp>

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -15,12 +15,12 @@
 #include "behavior_path_planner/util/lane_change/util.hpp"
 
 #include "behavior_path_planner/parameters.hpp"
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/util/lane_change/lane_change_module_data.hpp"
 #include "behavior_path_planner/util/lane_change/lane_change_path.hpp"
 #include "behavior_path_planner/util/path_shifter/path_shifter.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 #include "behavior_path_planner/util/safety_check.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/query.hpp>

--- a/planning/behavior_path_planner/src/util/path_shifter/path_shifter.cpp
+++ b/planning/behavior_path_planner/src/util/path_shifter/path_shifter.cpp
@@ -14,8 +14,8 @@
 
 #include "behavior_path_planner/util/path_shifter/path_shifter.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <interpolation/spline_interpolation.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/util/path_utils.cpp
+++ b/planning/behavior_path_planner/src/util/path_utils.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "behavior_path_planner/path_utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <interpolation/spline_interpolation.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/util/pull_out/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/util/pull_out/geometric_pull_out.cpp
@@ -15,7 +15,7 @@
 #include "behavior_path_planner/util/pull_out/geometric_pull_out.hpp"
 
 #include "behavior_path_planner/util/pull_out/util.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
 

--- a/planning/behavior_path_planner/src/util/pull_out/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/util/pull_out/shift_pull_out.cpp
@@ -14,9 +14,9 @@
 
 #include "behavior_path_planner/util/pull_out/shift_pull_out.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 #include "behavior_path_planner/util/pull_out/util.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
 

--- a/planning/behavior_path_planner/src/util/pull_out/util.cpp
+++ b/planning/behavior_path_planner/src/util/pull_out/util.cpp
@@ -14,10 +14,10 @@
 
 #include "behavior_path_planner/util/pull_out/util.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/util/create_vehicle_footprint.hpp"
 #include "behavior_path_planner/util/path_shifter/path_shifter.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/planning/behavior_path_planner/src/util/pull_over/freespace_pull_over.cpp
+++ b/planning/behavior_path_planner/src/util/pull_over/freespace_pull_over.cpp
@@ -14,7 +14,7 @@
 
 #include "behavior_path_planner/util/pull_over/freespace_pull_over.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 #include "behavior_path_planner/util/pull_over/util.hpp"
 
 #include <memory>

--- a/planning/behavior_path_planner/src/util/pull_over/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/src/util/pull_over/geometric_pull_over.cpp
@@ -14,7 +14,7 @@
 
 #include "behavior_path_planner/util/pull_over/geometric_pull_over.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 #include "behavior_path_planner/util/pull_over/util.hpp"
 
 #include <lanelet2_extension/utility/query.hpp>

--- a/planning/behavior_path_planner/src/util/pull_over/goal_searcher.cpp
+++ b/planning/behavior_path_planner/src/util/pull_over/goal_searcher.cpp
@@ -14,7 +14,7 @@
 
 #include "behavior_path_planner/util/pull_over/goal_searcher.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 #include "behavior_path_planner/util/pull_over/util.hpp"
 #include "lanelet2_extension/utility/utilities.hpp"
 

--- a/planning/behavior_path_planner/src/util/pull_over/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/src/util/pull_over/shift_pull_over.cpp
@@ -14,7 +14,7 @@
 
 #include "behavior_path_planner/util/pull_over/shift_pull_over.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 #include "behavior_path_planner/util/pull_over/util.hpp"
 
 #include <lanelet2_extension/utility/query.hpp>

--- a/planning/behavior_path_planner/src/util/pull_over/util.cpp
+++ b/planning/behavior_path_planner/src/util/pull_over/util.cpp
@@ -14,8 +14,8 @@
 
 #include "behavior_path_planner/util/pull_over/util.hpp"
 
-#include "behavior_path_planner/path_utilities.hpp"
 #include "behavior_path_planner/util/path_shifter/path_shifter.hpp"
+#include "behavior_path_planner/util/path_utils.hpp"
 
 #include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>

--- a/planning/behavior_path_planner/src/util/side_shift/util.cpp
+++ b/planning/behavior_path_planner/src/util/side_shift/util.cpp
@@ -14,7 +14,7 @@
 
 #include "behavior_path_planner/util/side_shift/util.hpp"
 
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/planning/behavior_path_planner/src/util/utils.cpp
+++ b/planning/behavior_path_planner/src/util/utils.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include "behavior_path_planner/util/drivable_area_expansion/drivable_area_expansion.hpp"
 #include "motion_utils/trajectory/path_with_lane_id.hpp"
@@ -524,7 +524,7 @@ bool setGoal(
     return true;
   } catch (std::out_of_range & ex) {
     RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("utilities"),
+      rclcpp::get_logger("behavior_path_planner").get_child("utils"),
       "failed to set goal: " << ex.what());
     return false;
   }
@@ -1337,7 +1337,7 @@ double getSignedDistanceFromShoulderLeftBoundary(
 
   } else {
     RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("utilities"),
+      rclcpp::get_logger("behavior_path_planner").get_child("utils"),
       "closest shoulder lanelet not found.");
   }
 
@@ -1391,7 +1391,7 @@ std::optional<double> getSignedDistanceFromShoulderLeftBoundary(
 
   if (!found_neighbor_shoulder_bound) {
     RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("utilities"),
+      rclcpp::get_logger("behavior_path_planner").get_child("utils"),
       "neighbor shoulder bound to footprint is not found.");
     return {};
   }
@@ -1411,7 +1411,7 @@ double getSignedDistanceFromRightBoundary(
       right_line_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
   } else {
     RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("utilities"),
+      rclcpp::get_logger("behavior_path_planner").get_child("utils"),
       "closest shoulder lanelet not found.");
   }
 
@@ -1511,7 +1511,7 @@ std::shared_ptr<PathWithLaneId> generateCenterLinePath(
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(pose, &current_lane)) {
     RCLCPP_ERROR(
-      rclcpp::get_logger("behavior_path_planner").get_child("utilities"),
+      rclcpp::get_logger("behavior_path_planner").get_child("utils"),
       "failed to find closest lanelet within route!!!");
     return {};  // TODO(Horibe) What should be returned?
   }
@@ -1548,7 +1548,7 @@ lanelet::ConstLineStrings3d getMaximumDrivableArea(
   lanelet::ConstLanelet current_lane;
   if (!route_handler->getClosestLaneletWithinRoute(ego_pose, &current_lane)) {
     RCLCPP_ERROR(
-      rclcpp::get_logger("behavior_path_planner").get_child("utilities"),
+      rclcpp::get_logger("behavior_path_planner").get_child("utils"),
       "failed to find closest lanelet within route!!!");
     return {};
   }

--- a/planning/behavior_path_planner/test/input.hpp
+++ b/planning/behavior_path_planner/test/input.hpp
@@ -16,7 +16,7 @@
 #define INPUT_HPP_
 
 #endif  // INPUT_HPP_
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 
 #include "autoware_auto_planning_msgs/msg/path_point.hpp"
 #include "geometry_msgs/msg/twist.hpp"

--- a/planning/behavior_path_planner/test/test_utils.cpp
+++ b/planning/behavior_path_planner/test/test_utils.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 #include "input.hpp"
 #include "lanelet2_core/Attribute.h"
 #include "lanelet2_core/geometry/Point.h"

--- a/planning/static_centerline_optimizer/src/utils.cpp
+++ b/planning/static_centerline_optimizer/src/utils.cpp
@@ -15,7 +15,7 @@
 #include "static_centerline_optimizer/utils.hpp"
 
 #include "behavior_path_planner/data_manager.hpp"
-#include "behavior_path_planner/utilities.hpp"
+#include "behavior_path_planner/util/utils.hpp"
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 
 namespace static_centerline_optimizer


### PR DESCRIPTION
## Description
Move utilities file to the `util` folder and rename it to utils. 
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
