### PR TITLE
feat(elevation_map_loader): add support for seleceted_map_loader

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -322,12 +322,12 @@ class GroundSegmentationPipeline:
                     ("input/pointcloud_map", "/map/pointcloud_map"),
                     ("input/vector_map", "/map/vector_map"),
                     ("input/pointcloud_map_metadata", "/map/pointcloud_map_metadata"),
-                    ("service/get_selected_pcd_map", "/map/get_selected_pointcloud_map"),
+                    ("service/get_selected_pointcloud_map", "/map/get_selected_pointcloud_map"),
                 ],
                 parameters=[
                     {
-                        "use_lane_filter": False,
-                        "use_sequential_load": False,
+                        "use_lane_filter": True,
+                        "use_sequential_load": True,
                         "use_inpaint": True,
                         "inpaint_radius": 1.0,
                         "lane_margin": 2.0,

--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -321,10 +321,13 @@ class GroundSegmentationPipeline:
                     ("output/elevation_map", "map"),
                     ("input/pointcloud_map", "/map/pointcloud_map"),
                     ("input/vector_map", "/map/vector_map"),
+                    ("input/pointcloud_map_metadata", "/map/pointcloud_map_metadata"),
+                    ("service/get_selected_pcd_map", "/map/get_selected_pointcloud_map"),
                 ],
                 parameters=[
                     {
                         "use_lane_filter": False,
+                        "use_sequential_load": False,
                         "use_inpaint": True,
                         "inpaint_radius": 1.0,
                         "lane_margin": 2.0,

--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -327,7 +327,8 @@ class GroundSegmentationPipeline:
                 parameters=[
                     {
                         "use_lane_filter": True,
-                        "use_sequential_load": True,
+                        "use_sequential_load": False,
+                        "sequential_map_load_num": 1,
                         "use_inpaint": True,
                         "inpaint_radius": 1.0,
                         "lane_margin": 2.0,

--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -326,7 +326,7 @@ class GroundSegmentationPipeline:
                 ],
                 parameters=[
                     {
-                        "use_lane_filter": True,
+                        "use_lane_filter": False,
                         "use_sequential_load": False,
                         "sequential_map_load_num": 1,
                         "use_inpaint": True,

--- a/perception/elevation_map_loader/README.md
+++ b/perception/elevation_map_loader/README.md
@@ -20,11 +20,11 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 
 ### Input
 
-| Name                   | Type                                         | Description                                |
-| ---------------------- | -------------------------------------------- | ------------------------------------------ |
-| `input/pointcloud_map` | `sensor_msgs::msg::PointCloud2`              | The point cloud map                        |
-| `input/vector_map`     | `autoware_auto_mapping_msgs::msg::HADMapBin` | (Optional) The binary data of lanelet2 map |
-| `input/vector_map`     | `autoware_auto_mapping_msgs::msg::HADMapBin` | (Optional) The binary data of lanelet2 map |
+| Name                            | Type                                            | Description                                |
+| ------------------------------- | ----------------------------------------------- | ------------------------------------------ |
+| `input/pointcloud_map`          | `sensor_msgs::msg::PointCloud2`                 | The point cloud map                        |
+| `input/vector_map`              | `autoware_auto_mapping_msgs::msg::HADMapBin`    | (Optional) The binary data of lanelet2 map |
+| `input/pointcloud_map_metadata` | `autoware_map_msgs::msg::PointCloudMapMetaData` | (Optional) The metadata of point cloud map |
 
 ### Output
 
@@ -35,9 +35,9 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 
 ### Service
 
-| Name                           | Type                                               | Description                                                                                                                                  |
-| ------------------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `service/get_selected_pcd_map` | `autoware_map_msgs::srv::GetSelectedPointCloudMap` | (Optional) service to request point cloud map. If pointcloud_map_loader sends id pointcloud map loading via ROS 2 service, use this service. |
+| Name                           | Type                                               | Description                                                                                                                               |
+| ------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `service/get_selected_pcd_map` | `autoware_map_msgs::srv::GetSelectedPointCloudMap` | (Optional) service to request point cloud map. If pointcloud_map_loader uses selected pointcloud map loading via ROS 2 service, use this. |
 
 ## Parameters
 
@@ -55,6 +55,7 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 | use_lane_filter                   | bool        | Whether to filter elevation_map with vector_map                                                                                   | false         |
 | lane_margin                       | float       | Margin distance from the lane polygon of the area to be included in the inpainting mask [m]. Used only when use_lane_filter=True. | 0.0           |
 | use_sequential_load               | bool        | Whether to get point cloud map by service                                                                                         | false         |
+| sequential_map_load_num           | int         | The number of point cloud maps to load at once (only used when use_sequential_load is set true)                                   | 1             |
 
 ### GridMap parameters
 

--- a/perception/elevation_map_loader/README.md
+++ b/perception/elevation_map_loader/README.md
@@ -24,6 +24,7 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 | ---------------------- | -------------------------------------------- | ------------------------------------------ |
 | `input/pointcloud_map` | `sensor_msgs::msg::PointCloud2`              | The point cloud map                        |
 | `input/vector_map`     | `autoware_auto_mapping_msgs::msg::HADMapBin` | (Optional) The binary data of lanelet2 map |
+| `input/vector_map`     | `autoware_auto_mapping_msgs::msg::HADMapBin` | (Optional) The binary data of lanelet2 map |
 
 ### Output
 
@@ -31,6 +32,12 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 | ---------------------------- | ------------------------------- | -------------------------------------------------------------------- |
 | `output/elevation_map`       | `grid_map_msgs::msg::GridMap`   | The elevation map                                                    |
 | `output/elevation_map_cloud` | `sensor_msgs::msg::PointCloud2` | (Optional) The point cloud generated from the value of elevation map |
+
+### Service
+
+| Name                           | Type                                               | Description                                                                                                                                  |
+| ------------------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `service/get_selected_pcd_map` | `autoware_map_msgs::srv::GetSelectedPointCloudMap` | (Optional) service to request point cloud map. If pointcloud_map_loader sends id pointcloud map loading via ROS 2 service, use this service. |
 
 ## Parameters
 
@@ -47,6 +54,7 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 | use_elevation_map_cloud_publisher | bool        | Whether to publish `output/elevation_map_cloud`                                                                                   | false         |
 | use_lane_filter                   | bool        | Whether to filter elevation_map with vector_map                                                                                   | false         |
 | lane_margin                       | float       | Margin distance from the lane polygon of the area to be included in the inpainting mask [m]. Used only when use_lane_filter=True. | 0.0           |
+| use_sequential_load               | bool        | Whether to get point cloud map by service                                                                                         | false         |
 
 ### GridMap parameters
 

--- a/perception/elevation_map_loader/README.md
+++ b/perception/elevation_map_loader/README.md
@@ -43,19 +43,19 @@ Cells with No elevation value can be inpainted using the values of neighboring c
 
 ### Node parameters
 
-| Name                              | Type        | Description                                                                                                                       | Default value |
-| :-------------------------------- | :---------- | :-------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| map_layer_name                    | std::string | elevation_map layer name                                                                                                          | elevation     |
-| param_file_path                   | std::string | GridMap parameters config                                                                                                         | path_default  |
-| elevation_map_directory           | std::string | elevation_map file (bag2)                                                                                                         | path_default  |
-| map_frame                         | std::string | map_frame when loading elevation_map file                                                                                         | map           |
-| use_inpaint                       | bool        | Whether to inpaint empty cells                                                                                                    | true          |
-| inpaint_radius                    | float       | Radius of a circular neighborhood of each point inpainted that is considered by the algorithm [m]                                 | 0.3           |
-| use_elevation_map_cloud_publisher | bool        | Whether to publish `output/elevation_map_cloud`                                                                                   | false         |
-| use_lane_filter                   | bool        | Whether to filter elevation_map with vector_map                                                                                   | false         |
-| lane_margin                       | float       | Margin distance from the lane polygon of the area to be included in the inpainting mask [m]. Used only when use_lane_filter=True. | 0.0           |
-| use_sequential_load               | bool        | Whether to get point cloud map by service                                                                                         | false         |
-| sequential_map_load_num           | int         | The number of point cloud maps to load at once (only used when use_sequential_load is set true)                                   | 1             |
+| Name                              | Type        | Description                                                                                                                                                          | Default value |
+| :-------------------------------- | :---------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| map_layer_name                    | std::string | elevation_map layer name                                                                                                                                             | elevation     |
+| param_file_path                   | std::string | GridMap parameters config                                                                                                                                            | path_default  |
+| elevation_map_directory           | std::string | elevation_map file (bag2)                                                                                                                                            | path_default  |
+| map_frame                         | std::string | map_frame when loading elevation_map file                                                                                                                            | map           |
+| use_inpaint                       | bool        | Whether to inpaint empty cells                                                                                                                                       | true          |
+| inpaint_radius                    | float       | Radius of a circular neighborhood of each point inpainted that is considered by the algorithm [m]                                                                    | 0.3           |
+| use_elevation_map_cloud_publisher | bool        | Whether to publish `output/elevation_map_cloud`                                                                                                                      | false         |
+| use_lane_filter                   | bool        | Whether to filter elevation_map with vector_map                                                                                                                      | false         |
+| lane_margin                       | float       | Margin distance from the lane polygon of the area to be included in the inpainting mask [m]. Used only when use_lane_filter=True.                                    | 0.0           |
+| use_sequential_load               | bool        | Whether to get point cloud map by service                                                                                                                            | false         |
+| sequential_map_load_num           | int         | The number of point cloud maps to load at once (only used when use_sequential_load is set true). This should not be larger than number of all point cloud map cells. | 1             |
 
 ### GridMap parameters
 

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -100,8 +100,10 @@ private:
   std::string elevation_map_directory_;
   bool use_inpaint_;
   float inpaint_radius_;
+  long unsigned int sequential_map_load_num_;
   bool use_elevation_map_cloud_publisher_;
   std::string param_file_path_;
+  bool is_map_metadata_received_ = false;
   bool is_map_received_ = false;
   bool is_elevation_map_published_ = false;
 

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -26,7 +26,7 @@
 
 #include "tier4_external_api_msgs/msg/map_hash.hpp"
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
-#include <autoware_map_msgs/msg/point_cloud_cell_metadata.hpp>
+#include <autoware_map_msgs/msg/point_cloud_map_meta_data.hpp>
 #include <autoware_map_msgs/srv/get_selected_point_cloud_map.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
@@ -55,6 +55,7 @@ public:
   pcl::PointCloud<pcl::PointXYZ>::Ptr map_pcl_ptr_;
   lanelet::LaneletMapPtr lanelet_map_ptr_;
   bool use_lane_filter_ = false;
+  std::vector<std::string> pointcloud_map_ids_;
 };
 
 class ElevationMapLoaderNode : public rclcpp::Node
@@ -66,7 +67,7 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_pointcloud_map_;
   rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_vector_map_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::MapHash>::SharedPtr sub_map_hash_;
-  rclcpp::Subscription<autoware_map_msgs::srv::PointCloudMapMetadataArray>::SharedPtr
+  rclcpp::Subscription<autoware_map_msgs::msg::PointCloudMapMetaData>::SharedPtr
     sub_pointcloud_metadata_;
   rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr pub_elevation_map_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_elevation_map_cloud_;
@@ -77,8 +78,8 @@ private:
   void onMapHash(const tier4_external_api_msgs::msg::MapHash::ConstSharedPtr map_hash);
   void timerCallback();
   void onVectorMap(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr vector_map);
-  void onPointCloudMapMetadata(
-    const autoware_map_msgs::srv::PointCloudMapMetadataArray pointcloud_map_metadata_array);
+  void onPointCloudMapMetaData(
+    const autoware_map_msgs::msg::PointCloudMapMetaData pointcloud_map_metadata);
   void receiveMap();
   void concatPointCloundMaps(
     sensor_msgs::msg::PointCloud2 & pointcloud_map,
@@ -110,7 +111,6 @@ private:
     lanelet::ConstLanelets road_lanelets_;
     float lane_margin_;
     bool use_lane_filter_;
-    std::vector<std::string> pointcloud_map_ids_
   };
   LaneFilter lane_filter_;
 };

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -81,7 +81,7 @@ private:
   void onPointCloudMapMetaData(
     const autoware_map_msgs::msg::PointCloudMapMetaData pointcloud_map_metadata);
   void receiveMap();
-  void concatPointCloundMaps(
+  void concatPointCloudMaps(
     sensor_msgs::msg::PointCloud2 & pointcloud_map,
     const sensor_msgs::msg::PointCloud2 & new_pointcloud);
 

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -83,8 +83,9 @@ private:
   void receiveMap();
   void concatPointCloudMaps(
     sensor_msgs::msg::PointCloud2 & pointcloud_map,
-    const sensor_msgs::msg::PointCloud2 & new_pointcloud);
-
+    const std::vector<autoware_map_msgs::msg::PointCloudMapCellWithID> & new_pointcloud_with_ids)
+    const;
+  std::vector<std::string> getRequestIDs(const unsigned int map_id_counter) const;
   void publish();
   void createElevationMap();
   void setVerbosityLevelToDebugIfFlagSet();
@@ -100,7 +101,7 @@ private:
   std::string elevation_map_directory_;
   bool use_inpaint_;
   float inpaint_radius_;
-  long unsigned int sequential_map_load_num_;
+  unsigned int sequential_map_load_num_;
   bool use_elevation_map_cloud_publisher_;
   std::string param_file_path_;
   bool is_map_metadata_received_ = false;

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -81,7 +81,7 @@ private:
   void onPointCloudMapMetaData(
     const autoware_map_msgs::msg::PointCloudMapMetaData pointcloud_map_metadata);
   void receiveMap();
-  void concatPointCloudMaps(
+  void concatenatePointCloudMaps(
     sensor_msgs::msg::PointCloud2 & pointcloud_map,
     const std::vector<autoware_map_msgs::msg::PointCloudMapCellWithID> & new_pointcloud_with_ids)
     const;

--- a/perception/elevation_map_loader/launch/elevation_map_loader.launch.xml
+++ b/perception/elevation_map_loader/launch/elevation_map_loader.launch.xml
@@ -3,6 +3,7 @@
   <arg name="param_file_path" default="$(find-pkg-share elevation_map_loader)/config/elevation_map_parameters.yaml"/>
   <arg name="use_lane_filter" default="false"/>
   <arg name="use_sequential_load" default="false"/>
+  <arg name="sequential_map_load_num" default="1"/>
   <arg name="use_inpaint" default="true"/>
   <arg name="inpaint_radius" default="1.0"/>
 
@@ -17,5 +18,6 @@
     <param name="param_file_path" value="$(var param_file_path)"/>
     <param name="use_lane_filter" value="$(var use_lane_filter)"/>
     <param name="use_sequential_load" value="$(var use_sequential_load)"/>
+    <param name="sequential_map_load_num" value="$(var sequential_map_load_num)"/>
   </node>
 </launch>

--- a/perception/elevation_map_loader/launch/elevation_map_loader.launch.xml
+++ b/perception/elevation_map_loader/launch/elevation_map_loader.launch.xml
@@ -2,16 +2,20 @@
   <arg name="elevation_map_directory" default="$(find-pkg-share elevation_map_loader)/data/elevation_maps"/>
   <arg name="param_file_path" default="$(find-pkg-share elevation_map_loader)/config/elevation_map_parameters.yaml"/>
   <arg name="use_lane_filter" default="false"/>
+  <arg name="use_sequential_load" default="false"/>
   <arg name="use_inpaint" default="true"/>
   <arg name="inpaint_radius" default="1.0"/>
 
   <node pkg="elevation_map_loader" exec="elevation_map_loader" name="elevation_map_loader" output="screen">
     <remap from="output/elevation_map" to="/map/elevation_map"/>
     <remap from="input/pointcloud_map" to="/map/pointcloud_map"/>
+    <remap from="input/pointcloud_map_metadata" to="/map/pointcloud_map_metadata"/>
     <remap from="input/vector_map" to="/map/vector_map"/>
+    <remap from="service/get_selected_pcd_map" to="/map/get_selected_pointcloud_map"/>
 
     <param name="elevation_map_directory" value="$(var elevation_map_directory)"/>
     <param name="param_file_path" value="$(var param_file_path)"/>
     <param name="use_lane_filter" value="$(var use_lane_filter)"/>
+    <param name="use_sequential_load" value="$(var use_sequential_load)"/>
   </node>
 </launch>

--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -13,6 +13,7 @@
   <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>grid_map_cv</depend>
   <depend>grid_map_pcl</depend>
   <depend>grid_map_ros</depend>

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -273,7 +273,7 @@ void ElevationMapLoaderNode::receiveMap()
 
     // concat maps
     for (const auto & new_pointcloud_with_id : result.get()->new_pointcloud_with_ids) {
-      concatPointCloundMaps(pointcloud_map, new_pointcloud_with_id.pointcloud);
+      concatPointCloudMaps(pointcloud_map, new_pointcloud_with_id.pointcloud);
     }
   }
   RCLCPP_INFO(this->get_logger(), "finish receiving");
@@ -281,7 +281,7 @@ void ElevationMapLoaderNode::receiveMap()
   data_manager_.map_pcl_ptr_ = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 }
 
-void ElevationMapLoaderNode::concatPointCloundMaps(
+void ElevationMapLoaderNode::concatPointCloudMaps(
   sensor_msgs::msg::PointCloud2 & pointcloud_map,
   const sensor_msgs::msg::PointCloud2 & new_pointcloud)
 {


### PR DESCRIPTION
Signed-off-by: Shin-kyoto <58775300+Shin-kyoto@users.noreply.github.com>

## Description

<!-- Write a brief description of this PR. -->

These PRs must be merged before this PR.

- https://github.com/autowarefoundation/autoware.universe/pull/3286
- https://github.com/autowarefoundation/autoware_launch/pull/285
- https://github.com/autowarefoundation/autoware_msgs/pull/57
   - add new service and msg

### Why?

- When you use large pointcloud map, map_loader cannot publish large map as one topic because of the limit size determined by [the default value in cyclonedds](https://github.com/eclipse-cyclonedds/cyclonedds/blob/09a02f5b2b9ba856d7d4c616510252cf9e508ec2/docs/manual/config/config_file_reference.rst#cycloneddsdomaininternalmaxsamplesize).
- So I want to add sequential map loading mode to `elevation_map_loader`. It is helpful to avoid exeeding the limit by using `selected_map_loader`.

### What?

- I would like to add `selected_map_loader` support to `elevation_map_loader`.
- In the default setting, `selected_map_loader` support is disabled. So if you want to use [this](https://github.com/Shin-kyoto/autoware.universe/commit/69b1e7b9cc2139858bef8922974b43b698a0e12a), please change your launcher like this.
- I assume that the each PCD file is not so large and the size of each PCD file does not exceed the limit size to receive(This is determined by [the default value in cyclonedds](https://github.com/eclipse-cyclonedds/cyclonedds/blob/09a02f5b2b9ba856d7d4c616510252cf9e508ec2/docs/manual/config/config_file_reference.rst#cycloneddsdomaininternalmaxsamplesize))

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

- [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-254)
- https://github.com/autowarefoundation/autoware.universe/pull/3286
- https://github.com/autowarefoundation/autoware_launch/pull/285
- https://github.com/autowarefoundation/autoware_msgs/pull/57


## Tests performed

<!-- Describe how you have tested this PR. -->

I tested with a data from Autoware tutorial. The map is divided into 20m grids ([sample-map-rosbag_split.zip](https://github.com/autowarefoundation/autoware.universe/files/10349104/sample-map-rosbag_split.zip)).

I have confirmed that the Autoware performs the same as the current Autoware when use_differential_load is set false.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

How to check

1. Check if these PRs are used in your environment.
   - https://github.com/autowarefoundation/autoware.universe/pull/3286
   - https://github.com/autowarefoundation/autoware_msgs/pull/56
2. Build autoware
3. Change your launcher like [this](Can you please output to console with throttle at about 5 second intervals?).
4. Run command below
```bash
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/data/map/sample-map-rosbag_split pointcloud_map_file:=pointcloud_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit planning:=false control:=false system:=false rviz:=true sensing:=false|grep -e elevation -e map
```
5. You should get the outputs like;
```bash
❯ ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/data/map/sample-map-rosbag_split pointcloud_map_file:=pointcloud_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit planning:=false control:=false system:=false rviz:=true sensing:=false|grep -e elevation -e map
........
[component_container-3] [INFO 1679896837.303861415] [map.pointcloud_map_loader]: Load /home/shintarotomie/data/map/sample-map-rosbag_split/pointcloud_map/89400_42300.pcd (1 out of 23)
........
[component_container_mt-1] [INFO 1679896838.796591044] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: Create elevation map from pointcloud map 
[component_container_mt-1] [INFO 1679896839.235498083] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: Finish creating elevation map. Total time: 0.433 sec
[component_container_mt-1] [INFO 1679896839.666728529] [rosbag2_storage]: Opened database '/home/shintarotomie/work/2023/0317/autoware/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/52fe0e6043a473758c9aab905232c887a7374632dabe1099c27b22effcbd93e1/52fe0e6043a473758c9aab905232c887a7374632dabe1099c27b22effcbd93e1_0.db3' for READ_WRITE.
[component_container_mt-1] [INFO 1679896839.672484128] [perception.obstacle_segmentation.elevation_map.elevation_map_loader]: Saving elevation map successful: true
```
6. Check rviz and you should see the elevation_map like;

![image](https://user-images.githubusercontent.com/58775300/227856478-811dfc18-b9d1-4e95-b57c-d4347599b161.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
