### PR TITLE
fix(planner_manager): remove succeeded candidate module

### DIFF
--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -294,8 +294,13 @@ std::pair<SceneModulePtr, BehaviorModuleOutput> PlannerManager::runCandidateModu
     processing_time_.at(name) += stop_watch_.toc(name, true);
   }
 
-  const auto remove_failure_modules = [this](auto & m) {
+  const auto remove_expired_modules = [this](auto & m) {
     if (m->getCurrentStatus() == ModuleStatus::FAILURE) {
+      deleteExpiredModules(m);
+      return true;
+    }
+
+    if (m->getCurrentStatus() == ModuleStatus::SUCCESS) {
       deleteExpiredModules(m);
       return true;
     }
@@ -304,7 +309,7 @@ std::pair<SceneModulePtr, BehaviorModuleOutput> PlannerManager::runCandidateModu
   };
 
   executable_modules.erase(
-    std::remove_if(executable_modules.begin(), executable_modules.end(), remove_failure_modules),
+    std::remove_if(executable_modules.begin(), executable_modules.end(), remove_expired_modules),
     executable_modules.end());
 
   if (executable_modules.empty()) {


### PR DESCRIPTION
## Description

There are some modules that return `ModuleStatus::SUCCESS` before approval (e.g. pull over, avoidance), but `planner_manager` doesn't remove such a expired candidate module for now. Thus, these modules are never removed and next new module can't be launch depending on `max_module_size` value (all module set this param to 1 by default). As a result , an unexpected bahevior happend like this :arrow_down: 

In this PR, the planner_manager removes not only `ModuleStatus::FAILURE` modules but also `ModuleStatus::SUCCESS` candidate modules.

https://user-images.githubusercontent.com/44889564/231032552-9703cc1d-75c5-47b9-937b-c09c5f4a30fa.mp4

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


```
webauto ci scenario run --project-id prd_jt --scenario-id f112364c-1b55-4c48-bebd-8a68b0e52122 --runtime-path /$HOME/pilot-auto --scenario-parameters __tier4_modifier_Ve=11.111
```

https://user-images.githubusercontent.com/44889564/231030818-c0d6dcd2-8bf1-434a-8409-07a9d0bc9487.mp4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
