### PR TITLE
fix(avoidance): return shift end pose

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2152,8 +2152,8 @@ void AvoidanceModule::addReturnShiftLineFromEgo(
     // avoidance points: No, shift points: No -> set the ego position to the last shift point
     // so that the return-shift will be generated from ego position.
     if (!has_candidate_point && !has_registered_point) {
-      last_sl.end = getEgoPose();
       last_sl.end_idx = avoidance_data_.ego_closest_path_index;
+      last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
       last_sl.end_shift_length = getCurrentBaseShift();
     }
   }
@@ -2188,8 +2188,8 @@ void AvoidanceModule::addReturnShiftLineFromEgo(
     // set the return-shift from ego.
     DEBUG_PRINT(
       "return shift already exists, but they are all candidates. Add return shift for overwrite.");
-    last_sl.end = getEgoPose();
     last_sl.end_idx = avoidance_data_.ego_closest_path_index;
+    last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
     last_sl.end_shift_length = current_base_shift;
   }
 
@@ -2284,7 +2284,7 @@ void AvoidanceModule::addReturnShiftLineFromEgo(
     al.start_shift_length = last_sl.end_shift_length;
     sl_candidates.push_back(al);
     printShiftLines(AvoidLineArray{al}, "return point");
-    debug_data_.extra_return_shift = AvoidLineArray{al};
+    debug_data_.extra_return_shift.push_back(al);
 
     // TODO(Horibe) think how to store the current object
     current_raw_shift_lines.push_back(al);


### PR DESCRIPTION
## Description

In `addReturnShiftLineFromEgo()`, perhaps wrong pose set to `last_sl.end` by mistake. As a result, unexpected shift line are shown in rviz.

![rviz_screenshot_2023_04_11-11_59_43](https://user-images.githubusercontent.com/44889564/231056205-39048b99-fad4-4111-8c13-74ecdbe9c1a2.png)

**NOTE** Apart from rviz visualization, I think that this bug doesn't cause any problem but it is better to fix.


<!-- Write a brief description of this PR. -->

## Tests performed

Unexpected shif line was removed.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

![rviz_screenshot_2023_04_11-11_53_25](https://user-images.githubusercontent.com/44889564/231057189-03ee3739-8e87-4a0e-97fc-8a871f99f013.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
