### PR TITLE
refactor(behavior_path_planner): remove unnecessary flag

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/util/lane_change/util.hpp
@@ -66,7 +66,7 @@ std::optional<LaneChangePath> constructCandidatePath(
   const LaneChangePhaseInfo lane_change_length, const LaneChangePhaseInfo lane_change_velocity,
   const LaneChangeParameters & lane_change_param);
 
-std::pair<bool, bool> getLaneChangePaths(
+bool getLaneChangePaths(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & original_lanelets,
   const lanelet::ConstLanelets & target_lanelets, const Pose & pose, const Twist & twist,
   const PredictedObjects::ConstSharedPtr dynamic_objects,
@@ -74,7 +74,7 @@ std::pair<bool, bool> getLaneChangePaths(
   const double check_length, LaneChangePaths * candidate_paths,
   std::unordered_map<std::string, CollisionCheckDebug> * debug_data);
 
-std::pair<bool, bool> getLaneChangePaths(
+bool getLaneChangePaths(
   const PathWithLaneId & original_path, const RouteHandler & route_handler,
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
   const Pose & pose, const Twist & twist, const PredictedObjects::ConstSharedPtr dynamic_objects,

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -989,14 +989,14 @@ std::pair<bool, bool> AvoidanceByLCModule::getSafePath(
   // find candidate paths
   LaneChangePaths valid_paths;
 #ifdef USE_OLD_ARCHITECTURE
-  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
+  const auto found_safe_path = util::lane_change::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     planner_data_->dynamic_object, common_parameters, *parameters_->lane_change, check_distance,
     &valid_paths, &object_debug_);
 #else
   const auto o_front = avoidance_data_.target_objects.front();
   const auto direction = isOnRight(o_front) ? Direction::LEFT : Direction::RIGHT;
-  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
+  const auto found_safe_path = utils::lane_change::getLaneChangePaths(
     *getPreviousModuleOutput().path, *route_handler, current_lanes, lane_change_lanes, current_pose,
     current_twist, planner_data_->dynamic_object, common_parameters, *parameters_->lane_change,
     check_distance, direction, &valid_paths, &object_debug_);

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -989,14 +989,14 @@ std::pair<bool, bool> AvoidanceByLCModule::getSafePath(
   // find candidate paths
   LaneChangePaths valid_paths;
 #ifdef USE_OLD_ARCHITECTURE
-  const auto [found_valid_path, found_safe_path] = util::lane_change::getLaneChangePaths(
+  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     planner_data_->dynamic_object, common_parameters, *parameters_->lane_change, check_distance,
     &valid_paths, &object_debug_);
 #else
   const auto o_front = avoidance_data_.target_objects.front();
   const auto direction = isOnRight(o_front) ? Direction::LEFT : Direction::RIGHT;
-  const auto [found_valid_path, found_safe_path] = util::lane_change::getLaneChangePaths(
+  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
     *getPreviousModuleOutput().path, *route_handler, current_lanes, lane_change_lanes, current_pose,
     current_twist, planner_data_->dynamic_object, common_parameters, *parameters_->lane_change,
     check_distance, direction, &valid_paths, &object_debug_);
@@ -1009,7 +1009,7 @@ std::pair<bool, bool> AvoidanceByLCModule::getSafePath(
     debug_marker_.markers.clear();
   }
 
-  if (!found_valid_path) {
+  if (valid_paths.empty()) {
     return {false, false};
   }
 
@@ -1020,7 +1020,7 @@ std::pair<bool, bool> AvoidanceByLCModule::getSafePath(
     safe_path = valid_paths.front();
   }
 
-  return {found_valid_path, found_safe_path};
+  return {true, found_safe_path};
 }
 
 bool AvoidanceByLCModule::isSafe() const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -365,7 +365,7 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
 
   // find candidate paths
   LaneChangePaths valid_paths;
-  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
+  const auto found_safe_path = util::lane_change::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     planner_data_->dynamic_object, common_parameters, *parameters_, check_distance, &valid_paths,
     &object_debug_);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -365,7 +365,7 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
 
   // find candidate paths
   LaneChangePaths valid_paths;
-  const auto [found_valid_path, found_safe_path] = util::lane_change::getLaneChangePaths(
+  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     planner_data_->dynamic_object, common_parameters, *parameters_, check_distance, &valid_paths,
     &object_debug_);
@@ -377,7 +377,7 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
     debug_marker_.markers.clear();
   }
 
-  if (!found_valid_path) {
+  if (valid_paths.empty()) {
     return {false, false};
   }
 
@@ -388,7 +388,7 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
     safe_path = valid_paths.front();
   }
 
-  return {found_valid_path, found_safe_path};
+  return {true, found_safe_path};
 }
 
 bool ExternalRequestLaneChangeModule::isSafe() const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -465,12 +465,12 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
   // find candidate paths
   LaneChangePaths valid_paths;
 #ifdef USE_OLD_ARCHITECTURE
-  const auto [found_valid_path, found_safe_path] = util::lane_change::getLaneChangePaths(
+  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     planner_data_->dynamic_object, common_parameters, *parameters_, check_distance, &valid_paths,
     &object_debug_);
 #else
-  const auto [found_valid_path, found_safe_path] = util::lane_change::getLaneChangePaths(
+  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
     *getPreviousModuleOutput().path, *route_handler, current_lanes, lane_change_lanes, current_pose,
     current_twist, planner_data_->dynamic_object, common_parameters, *parameters_, check_distance,
     direction_, &valid_paths, &object_debug_);
@@ -483,7 +483,7 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
     debug_marker_.markers.clear();
   }
 
-  if (!found_valid_path) {
+  if (valid_paths.empty()) {
     return {false, false};
   }
 
@@ -494,7 +494,7 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
     safe_path = valid_paths.front();
   }
 
-  return {found_valid_path, found_safe_path};
+  return {true, found_safe_path};
 }
 
 bool LaneChangeModule::isSafe() const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -465,12 +465,12 @@ std::pair<bool, bool> LaneChangeModule::getSafePath(
   // find candidate paths
   LaneChangePaths valid_paths;
 #ifdef USE_OLD_ARCHITECTURE
-  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
+  const auto found_safe_path = util::lane_change::getLaneChangePaths(
     *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
     planner_data_->dynamic_object, common_parameters, *parameters_, check_distance, &valid_paths,
     &object_debug_);
 #else
-  const auto found_safe_path = lane_change_utils::getLaneChangePaths(
+  const auto found_safe_path = util::lane_change::getLaneChangePaths(
     *getPreviousModuleOutput().path, *route_handler, current_lanes, lane_change_lanes, current_pose,
     current_twist, planner_data_->dynamic_object, common_parameters, *parameters_, check_distance,
     direction_, &valid_paths, &object_debug_);

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -473,7 +473,7 @@ bool getLaneChangePaths(
       common_parameter.expected_rear_deceleration, ego_pose_before_collision, *debug_data,
       acceleration);
 
-    if (is_valid && is_safe) {
+    if (is_safe) {
       return true;
     }
   }

--- a/planning/behavior_path_planner/src/util/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/util/lane_change/util.cpp
@@ -256,7 +256,7 @@ std::optional<LaneChangePath> constructCandidatePath(
 }
 
 #ifdef USE_OLD_ARCHITECTURE
-std::pair<bool, bool> getLaneChangePaths(
+bool getLaneChangePaths(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & original_lanelets,
   const lanelet::ConstLanelets & target_lanelets, const Pose & pose, const Twist & twist,
   const PredictedObjects::ConstSharedPtr dynamic_objects,
@@ -264,7 +264,7 @@ std::pair<bool, bool> getLaneChangePaths(
   const double check_length, LaneChangePaths * candidate_paths,
   std::unordered_map<std::string, CollisionCheckDebug> * debug_data)
 #else
-std::pair<bool, bool> getLaneChangePaths(
+bool getLaneChangePaths(
   const PathWithLaneId & original_path, const RouteHandler & route_handler,
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
   const Pose & pose, const Twist & twist, const PredictedObjects::ConstSharedPtr dynamic_objects,
@@ -275,7 +275,7 @@ std::pair<bool, bool> getLaneChangePaths(
 {
   debug_data->clear();
   if (original_lanelets.empty() || target_lanelets.empty()) {
-    return {false, false};
+    return false;
   }
 
   Pose ego_pose_before_collision{};
@@ -474,15 +474,11 @@ std::pair<bool, bool> getLaneChangePaths(
       acceleration);
 
     if (is_valid && is_safe) {
-      return {true, true};
+      return true;
     }
   }
 
-  if (candidate_paths->empty()) {
-    return {false, false};
-  }
-
-  return {true, false};
+  return false;
 }
 
 #ifdef USE_OLD_ARCHITECTURE


### PR DESCRIPTION
## Description
Remove `valid_path` flag and use `empty()` method to check if the path is valid or not

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6e9c134</samp>

Refactored the logic and interface of the `getLaneChangePaths` function and its callers in the `behavior_path_planner` package. This function checks and returns lane change paths for different scenarios. The refactoring simplifies the code and avoids unnecessary checks.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
