### PR TITLE
docs(obstacle_cruise_planner): fix wrong path

### DIFF
--- a/planning/obstacle_cruise_planner/docs/debug.md
+++ b/planning/obstacle_cruise_planner/docs/debug.md
@@ -6,40 +6,40 @@
 
 Green polygons which is a detection area is visualized by `detection_polygons` in the `~/debug/marker` topic.
 
-![detection_area](./image/detection_area.png)
+![detection_area](../image/detection_area.png)
 
 ### Collision point
 
 Red point which is a collision point with obstacle is visualized by `collision_points` in the `~/debug/marker` topic.
 
-![collision_point](./image/collision_point.png)
+![collision_point](../image/collision_point.png)
 
 ### Obstacle for cruise
 
 Yellow sphere which is a obstacle for cruise is visualized by `obstacles_to_cruise` in the `~/debug/marker` topic.
 
-![obstacle_to_cruise](./image/obstacle_to_cruise.png)
+![obstacle_to_cruise](../image/obstacle_to_cruise.png)
 
 ### Obstacle for stop
 
 Red sphere which is a obstacle for stop is visualized by `obstacles_to_stop` in the `~/debug/marker` topic.
 
-![obstacle_to_stop](./image/obstacle_to_stop.png)
+![obstacle_to_stop](../image/obstacle_to_stop.png)
 
 <!-- ### Obstacle ignored to cruise or stop intentionally -->
 
 <!-- Green sphere which is a obstacle ignored intentionally to cruise or stop is visualized by `intentionally_ignored_obstacles` in the `~/debug/marker` topic. -->
 
-<!-- ![intentionally_ignored_obstacle](./image/intentionally_ignored_obstacle.png) -->
+<!-- ![intentionally_ignored_obstacle](../image/intentionally_ignored_obstacle.png) -->
 
 ### Obstacle cruise wall
 
 Yellow wall which means a safe distance to cruise if the ego's front meets the wall is visualized in the `~/debug/cruise_wall_marker` topic.
 
-![obstacle_to_cruise](./image/obstacle_to_cruise.png)
+![obstacle_to_cruise](../image/obstacle_to_cruise.png)
 
 ### Obstacle stop wall
 
 Red wall which means a safe distance to stop if the ego's front meets the wall is visualized in the `~/debug/stop_wall_marker` topic.
 
-![obstacle_to_stop](./image/obstacle_to_stop.png)
+![obstacle_to_stop](../image/obstacle_to_stop.png)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- In pre-commit optional, wrong paths occur error below. So I fixed wrong path.

```
FILE: planning/obstacle_cruise_planner/docs/debug.md
  [✖] ./image/detection_area.png
  [✖] ./image/collision_point.png
  [✖] ./image/obstacle_to_cruise.png
  [✖] ./image/obstacle_to_stop.png

  4 links checked.

  ERROR: 4 dead links found!
  [✖] ./image/detection_area.png → Status: 400
  [✖] ./image/collision_point.png → Status: 400
  [✖] ./image/obstacle_to_cruise.png → Status: 400
  [✖] ./image/obstacle_to_stop.png → Status: 400
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
