### PR TITLE
fix(static_centerline_optimizer): add mission_planner's param for launch

### DIFF
--- a/planning/static_centerline_optimizer/launch/static_centerline_optimizer.launch.xml
+++ b/planning/static_centerline_optimizer/launch/static_centerline_optimizer.launch.xml
@@ -21,6 +21,7 @@
     name="obstacle_avoidance_planner_param"
     default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml"
   />
+  <arg name="mission_planner_param" default="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner/mission_planner.param.yaml"/>
 
   <!-- Global parameters (for PathFootprint in tier4_planning_rviz_plugin) -->
   <!-- Do not add "group" in order to propagate global parameters -->
@@ -61,6 +62,7 @@
     <!-- component param -->
     <param from="$(var map_loader_param)"/>
     <param from="$(var obstacle_avoidance_planner_param)"/>
+    <param from="$(var mission_planner_param)"/>
     <!-- node param -->
     <param from="$(find-pkg-share static_centerline_optimizer)/config/static_centerline_optimizer.param.yaml"/>
   </node>


### PR DESCRIPTION
## Description

static_centerline_optimizer cannot be launched from autoware_launch due to the following change.
https://github.com/autowarefoundation/autoware.universe/pull/3127

I added mission_planner's param when launching static_centerline_optimizer from launch.

FYI: The test to launch static_centerline_optimizer (not from autoware_launch) passed since mission_planner's parameter is given in this case.
https://github.com/autowarefoundation/autoware.universe/blob/59650ed5e5dbe40357aa2f883776d4c48f50fa89/planning/static_centerline_optimizer/test/test_static_centerline_optimizer.test.py#L46-L50
<!-- Write a brief description of this PR. -->

## Tests performed

launch test passed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
