### PR TITLE
feat(route_handler): add lateral distance calculator

### DIFF
--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -270,6 +270,18 @@ public:
   int getNumLaneToPreferredLane(
     const lanelet::ConstLanelet & lanelet, const Direction direction = Direction::NONE) const;
 
+  /**
+   * Query input lanelet to see whether it exist in the preferred lane. If it doesn't exist, return
+   * the distance to the preferred lane from the give lane.
+   * The distance is computed from the front point of the centerline of the given lane to
+   * the front point of the preferred lane.
+   * @param Desired lanelet to query
+   * @param lane change direction
+   * @return number of lanes from input to the preferred lane
+   */
+  double getLateralDistanceToPreferredLane(
+    const lanelet::ConstLanelet & lanelet, const Direction direction = Direction::NONE) const;
+
   bool getClosestLaneletWithinRoute(
     const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;
   bool getClosestLaneletWithConstrainsWithinRoute(

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1338,8 +1338,8 @@ double RouteHandler::getLateralDistanceToPreferredLane(
       if (current_centerline.empty() || next_centerline.empty()) {
         return -accumulated_distance;
       }
-      const auto & curr_pt = current_centerline[0];
-      const auto & next_pt = next_centerline[0];
+      const auto & curr_pt = current_centerline.front();
+      const auto & next_pt = next_centerline.front();
       accumulated_distance += lanelet::geometry::distance2d(to2D(curr_pt), to2D(next_pt));
 
       if (exists(preferred_lanelets_, right)) {

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1319,6 +1319,61 @@ int RouteHandler::getNumLaneToPreferredLane(
   return 0;  // TODO(Horibe) check if return 0 is appropriate.
 }
 
+double RouteHandler::getLateralDistanceToPreferredLane(
+  const lanelet::ConstLanelet & lanelet, const Direction direction) const
+{
+  if (exists(preferred_lanelets_, lanelet)) {
+    return 0.0;
+  }
+
+  double accumulated_distance = 0.0;
+  lanelet::ConstLanelet current_lanelet = lanelet;
+
+  if ((direction == Direction::NONE) || (direction == Direction::RIGHT)) {
+    const auto & right_lanes =
+      lanelet::utils::query::getAllNeighborsRight(routing_graph_ptr_, lanelet);
+    for (const auto & right : right_lanes) {
+      const auto & current_centerline = current_lanelet.centerline();
+      const auto & next_centerline = right.centerline();
+      if (current_centerline.empty() || next_centerline.empty()) {
+        return -accumulated_distance;
+      }
+      const auto & curr_pt = current_centerline[0];
+      const auto & next_pt = next_centerline[0];
+      accumulated_distance += lanelet::geometry::distance2d(to2D(curr_pt), to2D(next_pt));
+
+      if (exists(preferred_lanelets_, right)) {
+        return -accumulated_distance;
+      }
+      current_lanelet = right;
+    }
+  }
+
+  accumulated_distance = 0.0;
+  current_lanelet = lanelet;
+  if ((direction == Direction::NONE) || (direction == Direction::LEFT)) {
+    const auto & left_lanes =
+      lanelet::utils::query::getAllNeighborsLeft(routing_graph_ptr_, lanelet);
+    for (const auto & left : left_lanes) {
+      const auto & current_centerline = current_lanelet.centerline();
+      const auto & next_centerline = left.centerline();
+      if (current_centerline.empty() || next_centerline.empty()) {
+        return accumulated_distance;
+      }
+      const auto & curr_pt = current_centerline[0];
+      const auto & next_pt = next_centerline[0];
+      accumulated_distance += lanelet::geometry::distance2d(to2D(curr_pt), to2D(next_pt));
+
+      if (exists(preferred_lanelets_, left)) {
+        return accumulated_distance;
+      }
+      current_lanelet = left;
+    }
+  }
+
+  return 0.0;
+}
+
 bool RouteHandler::isInPreferredLane(const PoseStamped & pose) const
 {
   lanelet::ConstLanelet lanelet;

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1326,10 +1326,9 @@ double RouteHandler::getLateralDistanceToPreferredLane(
     return 0.0;
   }
 
-  double accumulated_distance = 0.0;
-  lanelet::ConstLanelet current_lanelet = lanelet;
-
   if ((direction == Direction::NONE) || (direction == Direction::RIGHT)) {
+    double accumulated_distance = 0.0;
+    lanelet::ConstLanelet current_lanelet = lanelet;
     const auto & right_lanes =
       lanelet::utils::query::getAllNeighborsRight(routing_graph_ptr_, lanelet);
     for (const auto & right : right_lanes) {
@@ -1349,9 +1348,9 @@ double RouteHandler::getLateralDistanceToPreferredLane(
     }
   }
 
-  accumulated_distance = 0.0;
-  current_lanelet = lanelet;
   if ((direction == Direction::NONE) || (direction == Direction::LEFT)) {
+    double accumulated_distance = 0.0;
+    lanelet::ConstLanelet current_lanelet = lanelet;
     const auto & left_lanes =
       lanelet::utils::query::getAllNeighborsLeft(routing_graph_ptr_, lanelet);
     for (const auto & left : left_lanes) {

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1359,8 +1359,8 @@ double RouteHandler::getLateralDistanceToPreferredLane(
       if (current_centerline.empty() || next_centerline.empty()) {
         return accumulated_distance;
       }
-      const auto & curr_pt = current_centerline[0];
-      const auto & next_pt = next_centerline[0];
+      const auto & curr_pt = current_centerline.front();
+      const auto & next_pt = next_centerline.front();
       accumulated_distance += lanelet::geometry::distance2d(to2D(curr_pt), to2D(next_pt));
 
       if (exists(preferred_lanelets_, left)) {


### PR DESCRIPTION
## Description
Add a member function to RouteHandler that computes the lateral distance to the preferred lane from the given lane.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a469954</samp>

Add a new function `getLateralDistanceToPreferredLane` to the `RouteHandler` class in `planning/route_handler`. The function calculates the distance from the current lane to the preferred lane for lane change planning.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
