### PR TITLE
fix(compare_map_segmentation): update remaining compare map filters for dynamic map loader

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
@@ -57,7 +57,7 @@ class PointcloudMapFilterPipeline:
         components.append(
             ComposableNode(
                 package="compare_map_segmentation",
-                plugin="compare_map_segmentation::VoxelDistanceBasedCompareMapFilterComponent",
+                plugin="compare_map_segmentation::VoxelBasedCompareMapFilterComponent",
                 name="voxel_based_compare_map_filter",
                 remappings=[
                     ("input", LaunchConfiguration("input_topic")),
@@ -113,7 +113,7 @@ class PointcloudMapFilterPipeline:
         components.append(
             ComposableNode(
                 package="compare_map_segmentation",
-                plugin="compare_map_segmentation::VoxelDistanceBasedCompareMapFilterComponent",
+                plugin="compare_map_segmentation::VoxelBasedCompareMapFilterComponent",
                 name="voxel_based_compare_map_filter",
                 remappings=[
                     ("input", down_sample_topic),

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
@@ -57,7 +57,7 @@ class PointcloudMapFilterPipeline:
         components.append(
             ComposableNode(
                 package="compare_map_segmentation",
-                plugin="compare_map_segmentation::VoxelBasedCompareMapFilterComponent",
+                plugin="compare_map_segmentation::VoxelDistanceBasedCompareMapFilterComponent",
                 name="voxel_based_compare_map_filter",
                 remappings=[
                     ("input", LaunchConfiguration("input_topic")),
@@ -113,7 +113,7 @@ class PointcloudMapFilterPipeline:
         components.append(
             ComposableNode(
                 package="compare_map_segmentation",
-                plugin="compare_map_segmentation::VoxelBasedCompareMapFilterComponent",
+                plugin="compare_map_segmentation::VoxelDistanceBasedCompareMapFilterComponent",
                 name="voxel_based_compare_map_filter",
                 remappings=[
                     ("input", down_sample_topic),

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
@@ -75,6 +75,7 @@ class PointcloudMapFilterPipeline:
                         "map_loader_radius": self.map_loader_radius,
                         "publish_debug_pcd": self.publish_debug_pcd,
                         "input_frame": "map",
+                        "debug": self.debug,
                     }
                 ],
                 extra_arguments=[
@@ -131,6 +132,7 @@ class PointcloudMapFilterPipeline:
                         "map_loader_radius": self.map_loader_radius,
                         "publish_debug_pcd": self.publish_debug_pcd,
                         "input_frame": "map",
+                        "debug": self.debug,
                     }
                 ],
                 extra_arguments=[

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
@@ -75,7 +75,6 @@ class PointcloudMapFilterPipeline:
                         "map_loader_radius": self.map_loader_radius,
                         "publish_debug_pcd": self.publish_debug_pcd,
                         "input_frame": "map",
-                        "debug": self.debug,
                     }
                 ],
                 extra_arguments=[
@@ -132,7 +131,6 @@ class PointcloudMapFilterPipeline:
                         "map_loader_radius": self.map_loader_radius,
                         "publish_debug_pcd": self.publish_debug_pcd,
                         "input_frame": "map",
-                        "debug": self.debug,
                     }
                 ],
                 extra_arguments=[

--- a/perception/compare_map_segmentation/README.md
+++ b/perception/compare_map_segmentation/README.md
@@ -16,11 +16,11 @@ Compare the z of the input points with the value of elevation_map. The height di
 
 ### Distance Based Compare Map Filter
 
-WIP
+This filter compares the input pointcloud with the map pointcloud using the `nearestKSearch` function of `kdtree` and removes points that are close to the map point cloud. The map pointcloud can be loaded statically at once at the beginning or dynamically as the vehicle moves.
 
 ### Voxel Based Approximate Compare Map Filter
 
-WIP
+The filter loads the map point cloud, which can be loaded statically at the beginning or dynamically during vehicle movement, and creates a voxel grid of the map point cloud. The filter uses the getCentroidIndexAt function in combination with the getGridCoordinates function from the VoxelGrid class to find input points that are inside the voxel grid and removes them.
 
 ### Voxel Based Compare Map Filter
 
@@ -30,7 +30,7 @@ For each point of input pointcloud, the filter use `getCentroidIndexAt` combine 
 
 ### Voxel Distance based Compare Map Filter
 
-WIP
+This filter is a combination of the distance_based_compare_map_filter and voxel_based_approximate_compare_map_filter. The filter loads the map point cloud, which can be loaded statically at the beginning or dynamically during vehicle movement, and creates a voxel grid and a k-d tree of the map point cloud. The filter uses the getCentroidIndexAt function in combination with the getGridCoordinates function from the VoxelGrid class to find input points that are inside the voxel grid and removes them. For points that do not belong to any voxel grid, they are compared again with the map point cloud using the radiusSearch function of the k-d tree and are removed if they are close enough to the map.
 
 ## Inputs / Outputs
 

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/distance_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/distance_based_compare_map_filter_nodelet.hpp
@@ -33,7 +33,6 @@ typedef typename pcl::Filter<pcl::PointXYZ>::PointCloud PointCloud;
 typedef typename PointCloud::Ptr PointCloudPtr;
 typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-// ******************************Static Map Loader ***************************************
 class DistanceBasedStaticMapLoader : public VoxelGridStaticMapLoader
 {
 private:
@@ -51,8 +50,6 @@ public:
   void onMapCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr map) override;
   bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold) override;
 };
-
-// ******************************  Dynamic Map Loader ************************************
 
 class DistanceBasedDynamicMapLoader : public VoxelGridDynamicMapLoader
 {
@@ -102,8 +99,6 @@ public:
     (*mutex_ptr_).unlock();
   }
 };
-
-// ****************************************************************************************
 
 class DistanceBasedCompareMapFilterComponent : public pointcloud_preprocessor::Filter
 {

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_approximate_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_approximate_compare_map_filter_nodelet.hpp
@@ -28,7 +28,6 @@
 namespace compare_map_segmentation
 {
 
-// ******************************Static Map Loader ***************************************
 class VoxelBasedApproximateStaticMapLoader : public VoxelGridStaticMapLoader
 {
 public:
@@ -41,7 +40,6 @@ public:
   bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold) override;
 };
 
-// ******************************  Dynamic Map Loader ************************************
 class VoxelBasedApproximateDynamicMapLoader : public VoxelGridDynamicMapLoader
 {
 public:
@@ -54,8 +52,6 @@ public:
   }
   bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold) override;
 };
-
-// ****************************************************************************************
 
 class VoxelBasedApproximateCompareMapFilterComponent : public pointcloud_preprocessor::Filter
 {

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_approximate_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_approximate_compare_map_filter_nodelet.hpp
@@ -16,35 +16,56 @@
 #define COMPARE_MAP_SEGMENTATION__VOXEL_BASED_APPROXIMATE_COMPARE_MAP_FILTER_NODELET_HPP_  // NOLINT
 
 #include "pointcloud_preprocessor/filter.hpp"
+#include "voxel_grid_map_loader.hpp"
 
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/search/pcl_search.h>
 
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace compare_map_segmentation
 {
+
+// ******************************Static Map Loader ***************************************
+class VoxelBasedApproximateStaticMapLoader : public VoxelGridStaticMapLoader
+{
+public:
+  explicit VoxelBasedApproximateStaticMapLoader(
+    rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex)
+  : VoxelGridStaticMapLoader(node, leaf_size, tf_map_input_frame, mutex)
+  {
+    RCLCPP_INFO(logger_, "VoxelBasedApproximateStaticMapLoader initialized.\n");
+  }
+  bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold) override;
+};
+
+// ******************************  Dynamic Map Loader ************************************
+class VoxelBasedApproximateDynamicMapLoader : public VoxelGridDynamicMapLoader
+{
+public:
+  VoxelBasedApproximateDynamicMapLoader(
+    rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex,
+    rclcpp::CallbackGroup::SharedPtr main_callback_group)
+  : VoxelGridDynamicMapLoader(node, leaf_size, tf_map_input_frame, mutex, main_callback_group)
+  {
+    RCLCPP_INFO(logger_, "VoxelBasedApproximateDynamicMapLoader initialized.\n");
+  }
+  bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold) override;
+};
+
+// ****************************************************************************************
+
 class VoxelBasedApproximateCompareMapFilterComponent : public pointcloud_preprocessor::Filter
 {
 protected:
   virtual void filter(
     const PointCloud2ConstPtr & input, const IndicesPtr & indices, PointCloud2 & output);
 
-  void input_target_callback(const PointCloud2ConstPtr map);
-
 private:
-  // pcl::SegmentDifferences<pcl::PointXYZ> impl_;
-  rclcpp::Subscription<PointCloud2>::SharedPtr sub_map_;
-  PointCloudPtr voxel_map_ptr_;
   double distance_threshold_;
-  pcl::VoxelGrid<pcl::PointXYZ> voxel_grid_;
-  bool set_map_in_voxel_grid_;
-
-  /** \brief Parameter service callback result : needed to be hold */
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
-
-  /** \brief Parameter service callback */
-  rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
+  std::unique_ptr<VoxelGridMapLoader> voxel_based_approximate_map_loader_;
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
@@ -74,8 +74,8 @@ public:
   inline void addMapCellAndFilter(
     const autoware_map_msgs::msg::PointCloudMapCellWithID & map_cell_to_add) override
   {
-    map_grid_size_x_ = map_cell_to_add.max_x - map_cell_to_add.min_x;
-    map_grid_size_y_ = map_cell_to_add.max_y - map_cell_to_add.min_y;
+    map_grid_size_x_ = map_cell_to_add.metadata.max_x - map_cell_to_add.metadata.min_x;
+    map_grid_size_y_ = map_cell_to_add.metadata.max_y - map_cell_to_add.metadata.min_y;
 
     pcl::PointCloud<pcl::PointXYZ> map_cell_pc_tmp;
     pcl::fromROSMsg(map_cell_to_add.pointcloud, map_cell_pc_tmp);
@@ -92,10 +92,10 @@ public:
     map_cell_voxel_grid_tmp.filter(*map_cell_downsampled_pc_ptr_tmp);
 
     MapGridVoxelInfo current_voxel_grid_list_item;
-    current_voxel_grid_list_item.min_b_x = map_cell_to_add.min_x;
-    current_voxel_grid_list_item.min_b_y = map_cell_to_add.min_y;
-    current_voxel_grid_list_item.max_b_x = map_cell_to_add.max_x;
-    current_voxel_grid_list_item.max_b_y = map_cell_to_add.max_y;
+    current_voxel_grid_list_item.min_b_x = map_cell_to_add.metadata.min_x;
+    current_voxel_grid_list_item.min_b_y = map_cell_to_add.metadata.min_y;
+    current_voxel_grid_list_item.max_b_x = map_cell_to_add.metadata.max_x;
+    current_voxel_grid_list_item.max_b_y = map_cell_to_add.metadata.max_y;
 
     current_voxel_grid_list_item.map_cell_voxel_grid.set_voxel_grid(
       &(map_cell_voxel_grid_tmp.leaf_layout_), map_cell_voxel_grid_tmp.get_min_b(),

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
@@ -33,7 +33,7 @@ namespace compare_map_segmentation
 typedef typename pcl::Filter<pcl::PointXYZ>::PointCloud PointCloud;
 typedef typename PointCloud::Ptr PointCloudPtr;
 typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-//******************************* Static map loader *****************************
+
 class VoxelDistanceBasedStaticMapLoader : public VoxelGridStaticMapLoader
 {
 private:
@@ -51,7 +51,6 @@ public:
   void onMapCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr map) override;
 };
 
-//******************************* Dynamic map loader ***********************************
 class VoxelDistanceBasedDynamicMapLoader : public VoxelGridDynamicMapLoader
 {
 protected:
@@ -121,7 +120,6 @@ public:
   }
 };
 
-// *************************************************************************************
 class VoxelDistanceBasedCompareMapFilterComponent : public pointcloud_preprocessor::Filter
 {
 protected:

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
@@ -16,6 +16,7 @@
 #define COMPARE_MAP_SEGMENTATION__VOXEL_DISTANCE_BASED_COMPARE_MAP_FILTER_NODELET_HPP_  // NOLINT
 
 #include "pointcloud_preprocessor/filter.hpp"
+#include "voxel_grid_map_loader.hpp"
 
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/search/pcl_search.h>
@@ -51,7 +52,7 @@ public:
     RCLCPP_INFO(logger_, "VoxelDistanceBasedStaticMapLoader initialized.\n");
   }
   bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold) override;
-  void onMapCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr map);
+  void onMapCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr map) override;
 };
 
 //******************************* Dynamic map loader ***********************************
@@ -134,20 +135,8 @@ protected:
   void input_target_callback(const PointCloud2ConstPtr map);
 
 private:
-  // pcl::SegmentDifferences<pcl::PointXYZ> impl_;
-  rclcpp::Subscription<PointCloud2>::SharedPtr sub_map_;
-  PointCloudPtr voxel_map_ptr_;
-  PointCloudConstPtr map_ptr_;
+  std::unique_ptr<VoxelGridMapLoader> voxel_distance_based_map_loader_;
   double distance_threshold_;
-  pcl::search::Search<pcl::PointXYZ>::Ptr tree_;
-  pcl::VoxelGrid<pcl::PointXYZ> voxel_grid_;
-  bool set_map_in_voxel_grid_;
-
-  /** \brief Parameter service callback result : needed to be hold */
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
-
-  /** \brief Parameter service callback */
-  rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
@@ -20,10 +20,115 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/search/pcl_search.h>
 
+#include <map>
 #include <vector>
 
 namespace compare_map_segmentation
 {
+
+typedef typename pcl::Filter<pcl::PointXYZ>::PointCloud PointCloud;
+typedef typename PointCloud::Ptr PointCloudPtr;
+typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+//******************************* Static map loader *****************************
+class VoxelDistanceBasedStaticMapLoader : public VoxelGridStaticMapLoader
+{
+private:
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_map_;
+  PointCloudPtr voxel_map_ptr_;
+  PointCloudConstPtr map_ptr_;
+  double distance_threshold_;
+  pcl::search::Search<pcl::PointXYZ>::Ptr tree_;
+  pcl::VoxelGrid<pcl::PointXYZ> voxel_grid_;
+
+public:
+  explicit VoxelDistanceBasedStaticMapLoader(
+    rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex)
+  : VoxelGridStaticMapLoader(node, leaf_size, tf_map_input_frame, mutex)
+  {
+  }
+  bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
+  void onMapCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr map);
+};
+
+//******************************* Dynamic map loader ***********************************
+class VoxelDistanceBasedDynamicMapLoader : public VoxelGridDynamicMapLoader
+{
+protected:
+  struct MapGridVoxelInfo
+  {
+    VoxelGridPointXYZ map_cell_voxel_grid;
+    // PointCloudPtr map_cell_pc_ptr;
+    pcl::search::Search<pcl::PointXYZ>::Ptr map_cell_kdtree;
+    float min_b_x, min_b_y, max_b_x, max_b_y;
+  };
+
+  typedef typename std::map<std::string, struct MapGridVoxelInfo> VoxelGridDict;
+  VoxelGridDict current_voxel_grid_dict_;
+  std::vector<std::shared_ptr<MapGridVoxelInfo>> current_voxel_grid_array_;
+
+private:
+  PointCloudConstPtr map_ptr_;
+  /* data */
+public:
+  explicit VoxelDistanceBasedDynamicMapLoader(
+    rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex,
+    rclcpp::CallbackGroup::SharedPtr main_callback_group)
+  : VoxelGridDynamicMapLoader(node, leaf_size, tf_map_input_frame, mutex, main_callback_group)
+  {
+  }
+  bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
+
+  inline void addMapCellAndFilter(
+    const autoware_map_msgs::msg::PointCloudMapCellWithID & map_cell_to_add)
+  {
+    map_grid_size_x_ = map_cell_to_add.max_x - map_cell_to_add.min_x;
+    map_grid_size_y_ = map_cell_to_add.max_y - map_cell_to_add.min_y;
+
+    pcl::PointCloud<pcl::PointXYZ> map_cell_pc_tmp;
+    pcl::fromROSMsg(map_cell_to_add.pointcloud, map_cell_pc_tmp);
+
+    VoxelGridPointXYZ map_cell_voxel_grid_tmp;
+    PointCloudPtr map_cell_downsampled_pc_ptr_tmp;
+
+    auto map_cell_voxel_input_tmp_ptr =
+      std::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_cell_pc_tmp);
+    map_cell_voxel_grid_tmp.setLeafSize(voxel_leaf_size_, voxel_leaf_size_, voxel_leaf_size_);
+    map_cell_downsampled_pc_ptr_tmp.reset(new pcl::PointCloud<pcl::PointXYZ>);
+    map_cell_voxel_grid_tmp.setInputCloud(map_cell_voxel_input_tmp_ptr);
+    map_cell_voxel_grid_tmp.setSaveLeafLayout(true);
+    map_cell_voxel_grid_tmp.filter(*map_cell_downsampled_pc_ptr_tmp);
+
+    MapGridVoxelInfo current_voxel_grid_list_item;
+    current_voxel_grid_list_item.min_b_x = map_cell_to_add.min_x;
+    current_voxel_grid_list_item.min_b_y = map_cell_to_add.min_y;
+    current_voxel_grid_list_item.max_b_x = map_cell_to_add.max_x;
+    current_voxel_grid_list_item.max_b_y = map_cell_to_add.max_y;
+
+    current_voxel_grid_list_item.map_cell_voxel_grid.set_voxel_grid(
+      &(map_cell_voxel_grid_tmp.leaf_layout_), map_cell_voxel_grid_tmp.get_min_b(),
+      map_cell_voxel_grid_tmp.get_max_b(), map_cell_voxel_grid_tmp.get_div_b(),
+      map_cell_voxel_grid_tmp.get_divb_mul(), map_cell_voxel_grid_tmp.get_inverse_leaf_size());
+
+    // add kdtree
+    pcl::search::Search<pcl::PointXYZ>::Ptr tree_tmp;
+    if (!tree_tmp) {
+      if (map_cell_voxel_input_tmp_ptr->isOrganized()) {
+        tree_tmp.reset(new pcl::search::OrganizedNeighbor<pcl::PointXYZ>());
+      } else {
+        tree_tmp.reset(new pcl::search::KdTree<pcl::PointXYZ>(false));
+      }
+    }
+    tree_tmp->setInputCloud(map_cell_voxel_input_tmp_ptr);
+    current_voxel_grid_list_item.map_cell_kdtree = tree_tmp;
+
+    // add
+    (*mutex_ptr_).lock();
+    current_voxel_grid_dict_.insert({map_cell_to_add.cell_id, current_voxel_grid_list_item});
+    (*mutex_ptr_).unlock();
+  }
+};
+
+// *************************************************************************************
 class VoxelDistanceBasedCompareMapFilterComponent : public pointcloud_preprocessor::Filter
 {
 protected:

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
@@ -37,12 +37,8 @@ typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 class VoxelDistanceBasedStaticMapLoader : public VoxelGridStaticMapLoader
 {
 private:
-  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_map_;
-  PointCloudPtr voxel_map_ptr_;
   PointCloudConstPtr map_ptr_;
-  double distance_threshold_;
   pcl::search::Search<pcl::PointXYZ>::Ptr tree_;
-  VoxelGridPointXYZ voxel_grid_;
 
 public:
   explicit VoxelDistanceBasedStaticMapLoader(

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -23,6 +23,7 @@
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
+#include <pcl/search/pcl_search.h>
 #include <pcl/filters/voxel_grid.h>
 #include <pcl_conversions/pcl_conversions.h>
 
@@ -106,6 +107,9 @@ public:
     rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex);
   virtual bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold) = 0;
   bool is_close_to_neighbor_voxels(
+    const pcl::PointXYZ & point, const double distance_threshold, VoxelGridPointXYZ & voxel,
+    pcl::search::Search<pcl::PointXYZ>::Ptr tree) const;
+  bool is_close_to_neighbor_voxels(
     const pcl::PointXYZ & point, const double distance_threshold, const PointCloudPtr & map,
     VoxelGridPointXYZ & voxel) const;
   bool is_in_voxel(
@@ -137,6 +141,7 @@ public:
 // *************** for Dynamic and Differential Map loader Voxel Grid Filter *************
 class VoxelGridDynamicMapLoader : public VoxelGridMapLoader
 {
+protected:
   struct MapGridVoxelInfo
   {
     VoxelGridPointXYZ map_cell_voxel_grid;

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -123,7 +123,6 @@ public:
   std::string * tf_map_input_frame_;
 };
 
-//*************************** for Static Map loader Voxel Grid Filter *************
 class VoxelGridStaticMapLoader : public VoxelGridMapLoader
 {
 protected:
@@ -138,7 +137,6 @@ public:
   virtual bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
 };
 
-// *************** for Dynamic and Differential Map loader Voxel Grid Filter *************
 class VoxelGridDynamicMapLoader : public VoxelGridMapLoader
 {
 protected:

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -23,8 +23,8 @@
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
-#include <pcl/search/pcl_search.h>
 #include <pcl/filters/voxel_grid.h>
+#include <pcl/search/pcl_search.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <map>
@@ -151,8 +151,6 @@ protected:
   };
 
   typedef typename std::map<std::string, struct MapGridVoxelInfo> VoxelGridDict;
-
-private:
   using InitializationState = localization_interface::InitializationState;
 
   /** \brief Map to hold loaded map grid id and it's voxel filter */

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -126,7 +126,7 @@ public:
 //*************************** for Static Map loader Voxel Grid Filter *************
 class VoxelGridStaticMapLoader : public VoxelGridMapLoader
 {
-private:
+protected:
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_map_;
   VoxelGridPointXYZ voxel_grid_;
   PointCloudPtr voxel_map_ptr_;

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -206,7 +206,7 @@ public:
   bool is_close_to_next_map_grid(
     const pcl::PointXYZ & point, const int current_map_grid_index, const double distance_threshold);
 
-  virtual inline pcl::PointCloud<pcl::PointXYZ> getCurrentDownsampledMapPc() const
+  inline pcl::PointCloud<pcl::PointXYZ> getCurrentDownsampledMapPc() const
   {
     pcl::PointCloud<pcl::PointXYZ> output;
     for (const auto & kv : current_voxel_grid_dict_) {

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -280,7 +280,6 @@ public:
   {
     map_grid_size_x_ = map_cell_to_add.metadata.max_x - map_cell_to_add.metadata.min_x;
     map_grid_size_y_ = map_cell_to_add.metadata.max_y - map_cell_to_add.metadata.min_y;
-
     pcl::PointCloud<pcl::PointXYZ> map_cell_pc_tmp;
     pcl::fromROSMsg(map_cell_to_add.pointcloud, map_cell_pc_tmp);
 

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -134,8 +134,8 @@ private:
 public:
   explicit VoxelGridStaticMapLoader(
     rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex);
-  void onMapCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr map);
-  bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
+  virtual void onMapCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr map);
+  virtual bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
 };
 
 // *************** for Dynamic and Differential Map loader Voxel Grid Filter *************
@@ -147,6 +147,7 @@ protected:
     VoxelGridPointXYZ map_cell_voxel_grid;
     PointCloudPtr map_cell_pc_ptr;
     float min_b_x, min_b_y, max_b_x, max_b_y;
+    pcl::search::Search<pcl::PointXYZ>::Ptr map_cell_kdtree;
   };
 
   typedef typename std::map<std::string, struct MapGridVoxelInfo> VoxelGridDict;
@@ -200,12 +201,12 @@ public:
   void timer_callback();
   bool should_update_map() const;
   void request_update_map(const geometry_msgs::msg::Point & position);
-  bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
+  virtual bool is_close_to_map(const pcl::PointXYZ & point, const double distance_threshold);
   /** \brief Check if point close to map pointcloud in the */
   bool is_close_to_next_map_grid(
     const pcl::PointXYZ & point, const int current_map_grid_index, const double distance_threshold);
 
-  inline pcl::PointCloud<pcl::PointXYZ> getCurrentDownsampledMapPc() const
+  virtual inline pcl::PointCloud<pcl::PointXYZ> getCurrentDownsampledMapPc() const
   {
     pcl::PointCloud<pcl::PointXYZ> output;
     for (const auto & kv : current_voxel_grid_dict_) {
@@ -236,7 +237,7 @@ public:
   }
 
   /** Update loaded map grid array for fast searching*/
-  inline void updateVoxelGridArray()
+  virtual inline void updateVoxelGridArray()
   {
     origin_x_ = std::floor((current_position_.value().x - map_loader_radius_) / map_grid_size_x_) *
                 map_grid_size_x_;
@@ -274,7 +275,7 @@ public:
     (*mutex_ptr_).unlock();
   }
 
-  inline void addMapCellAndFilter(
+  virtual inline void addMapCellAndFilter(
     const autoware_map_msgs::msg::PointCloudMapCellWithID & map_cell_to_add)
   {
     map_grid_size_x_ = map_cell_to_add.metadata.max_x - map_cell_to_add.metadata.min_x;

--- a/perception/compare_map_segmentation/package.xml
+++ b/perception/compare_map_segmentation/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>compare_map_segmentation</name>
   <version>0.1.0</version>
-  <description>The ROS2 compare_map_segmentation package</description>
+  <description>The ROS 2 compare_map_segmentation package</description>
   <maintainer email="abrahammonrroy@yahoo.com">amc-nu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="dai.nguyen@tier4.jp">badai nguyen</maintainer>

--- a/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
@@ -121,7 +121,7 @@ DistanceBasedCompareMapFilterComponent::DistanceBasedCompareMapFilterComponent(
     stop_watch_ptr_->tic("processing_time");
   }
 
-  distance_threshold_ = static_cast<double>(declare_parameter("distance_threshold", 0.3));
+  distance_threshold_ = declare_parameter<double>("distance_threshold");
   bool use_dynamic_map_loading = declare_parameter<bool>("use_dynamic_map_loading");
   if (use_dynamic_map_loading) {
     rclcpp::CallbackGroup::SharedPtr main_callback_group;

--- a/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
@@ -23,7 +23,6 @@
 namespace compare_map_segmentation
 {
 
-// ******************************Static Map Loader ***************************************
 void DistanceBasedStaticMapLoader::onMapCallback(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr map)
 {
@@ -70,7 +69,6 @@ bool DistanceBasedStaticMapLoader::is_close_to_map(
   return true;
 }
 
-// ******************************  Dynamic Map Loader ************************************
 bool DistanceBasedDynamicMapLoader::is_close_to_map(
   const pcl::PointXYZ & point, const double distance_threshold)
 {
@@ -104,8 +102,6 @@ bool DistanceBasedDynamicMapLoader::is_close_to_map(
   }
   return false;
 }
-
-// ****************************************************************************************
 
 DistanceBasedCompareMapFilterComponent::DistanceBasedCompareMapFilterComponent(
   const rclcpp::NodeOptions & options)

--- a/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
@@ -22,52 +22,18 @@
 
 namespace compare_map_segmentation
 {
-using pointcloud_preprocessor::get_param;
 
-DistanceBasedCompareMapFilterComponent::DistanceBasedCompareMapFilterComponent(
-  const rclcpp::NodeOptions & options)
-: Filter("DistanceBasedCompareMapFilter", options)
-{
-  distance_threshold_ = static_cast<double>(declare_parameter("distance_threshold", 0.3));
-
-  using std::placeholders::_1;
-  sub_map_ = this->create_subscription<PointCloud2>(
-    "map", rclcpp::QoS{1}.transient_local(),
-    std::bind(&DistanceBasedCompareMapFilterComponent::input_target_callback, this, _1));
-
-  set_param_res_ = this->add_on_set_parameters_callback(
-    std::bind(&DistanceBasedCompareMapFilterComponent::paramCallback, this, _1));
-}
-
-void DistanceBasedCompareMapFilterComponent::filter(
-  const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
-  PointCloud2 & output)
-{
-  std::scoped_lock lock(mutex_);
-  if (map_ptr_ == NULL || tree_ == NULL) {
-    output = *input;
-    return;
-  }
-  pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::fromROSMsg(*input, *pcl_input);
-  pcl_output->points.reserve(pcl_input->points.size());
-  pcl::getPointCloudDifference<pcl::PointXYZ>(
-    *pcl_input, distance_threshold_ * distance_threshold_, tree_, *pcl_output);
-
-  pcl::toROSMsg(*pcl_output, output);
-  output.header = input->header;
-}
-
-void DistanceBasedCompareMapFilterComponent::input_target_callback(const PointCloud2ConstPtr map)
+// ******************************Static Map Loader ***************************************
+void DistanceBasedStaticMapLoader::onMapCallback(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr map)
 {
   pcl::PointCloud<pcl::PointXYZ> map_pcl;
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
   const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 
-  std::scoped_lock lock(mutex_);
+  (*mutex_ptr_).lock();
   map_ptr_ = map_pcl_ptr;
-  tf_input_frame_ = map_ptr_->header.frame_id;
+  *tf_map_input_frame_ = map_ptr_->header.frame_id;
   if (!tree_) {
     if (map_ptr_->isOrganized()) {
       tree_.reset(new pcl::search::OrganizedNeighbor<pcl::PointXYZ>());
@@ -76,23 +42,103 @@ void DistanceBasedCompareMapFilterComponent::input_target_callback(const PointCl
     }
   }
   tree_->setInputCloud(map_ptr_);
+
+  (*mutex_ptr_).unlock();
 }
 
-rcl_interfaces::msg::SetParametersResult DistanceBasedCompareMapFilterComponent::paramCallback(
-  const std::vector<rclcpp::Parameter> & p)
+bool DistanceBasedStaticMapLoader::is_close_to_map(
+  const pcl::PointXYZ & point, const double distance_threshold)
 {
-  std::scoped_lock lock(mutex_);
-
-  if (get_param(p, "distance_threshold", distance_threshold_)) {
-    RCLCPP_DEBUG(get_logger(), "Setting new distance threshold to: %f.", distance_threshold_);
+  if (map_ptr_ == NULL) {
+    return false;
+  }
+  if (tree_ == NULL) {
+    return false;
   }
 
-  rcl_interfaces::msg::SetParametersResult result;
-  result.successful = true;
-  result.reason = "success";
-
-  return result;
+  std::vector<int> nn_indices(1);
+  std::vector<float> nn_distances(1);
+  if (!isFinite(point)) {
+    return false;
+  }
+  if (!tree_->nearestKSearch(point, 1, nn_indices, nn_distances)) {
+    return false;
+  }
+  if (nn_distances[0] > distance_threshold) {
+    return false;
+  }
+  return true;
 }
+
+// ******************************  Dynamic Map Loader ************************************
+bool DistanceBasedDynamicMapLoader::is_close_to_map(
+  const pcl::PointXYZ & point, const double distance_threshold)
+{
+  return true;
+}
+
+// ****************************************************************************************
+
+DistanceBasedCompareMapFilterComponent::DistanceBasedCompareMapFilterComponent(
+  const rclcpp::NodeOptions & options)
+: Filter("DistanceBasedCompareMapFilter", options)
+{  // initialize debug tool
+  {
+    using tier4_autoware_utils::DebugPublisher;
+    using tier4_autoware_utils::StopWatch;
+    stop_watch_ptr_ = std::make_unique<StopWatch<std::chrono::milliseconds>>();
+    debug_publisher_ =
+      std::make_unique<DebugPublisher>(this, "voxel_based_approximate_compare_map_filter");
+    stop_watch_ptr_->tic("cyclic_time");
+    stop_watch_ptr_->tic("processing_time");
+  }
+
+  distance_threshold_ = static_cast<double>(declare_parameter("distance_threshold", 0.3));
+  bool use_dynamic_map_loading = declare_parameter<bool>("use_dynamic_map_loading");
+  if (use_dynamic_map_loading) {
+    rclcpp::CallbackGroup::SharedPtr main_callback_group;
+    main_callback_group = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    distance_based_map_loader_ = std::make_unique<DistanceBasedDynamicMapLoader>(
+      this, distance_threshold_, &tf_input_frame_, &mutex_, main_callback_group);
+  } else {
+    distance_based_map_loader_ = std::make_unique<DistanceBasedStaticMapLoader>(
+      this, distance_threshold_, &tf_input_frame_, &mutex_);
+  }
+}
+
+void DistanceBasedCompareMapFilterComponent::filter(
+  const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
+  PointCloud2 & output)
+{
+  std::scoped_lock lock(mutex_);
+  stop_watch_ptr_->toc("processing_time", true);
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::fromROSMsg(*input, *pcl_input);
+  pcl_output->points.reserve(pcl_input->points.size());
+
+  for (size_t i = 0; i < pcl_input->points.size(); ++i) {
+    if (distance_based_map_loader_->is_close_to_map(pcl_input->points.at(i), distance_threshold_)) {
+      continue;
+    }
+    pcl_output->points.push_back(pcl_input->points.at(i));
+  }
+
+  pcl::toROSMsg(*pcl_output, output);
+  output.header = input->header;
+
+  // add processing time for debug
+  if (debug_publisher_) {
+    const double cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
+    const double processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
+    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+      "debug/cyclic_time_ms", cyclic_time_ms);
+    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+      "debug/processing_time_ms", processing_time_ms);
+  }
+}
+
 }  // namespace compare_map_segmentation
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
@@ -84,7 +84,7 @@ VoxelBasedApproximateCompareMapFilterComponent::VoxelBasedApproximateCompareMapF
     stop_watch_ptr_->tic("processing_time");
   }
 
-  distance_threshold_ = static_cast<double>(declare_parameter("distance_threshold", 0.3));
+  distance_threshold_ = declare_parameter<double>("distance_threshold");
   bool use_dynamic_map_loading = declare_parameter<bool>("use_dynamic_map_loading");
   if (use_dynamic_map_loading) {
     rclcpp::CallbackGroup::SharedPtr main_callback_group;

--- a/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
@@ -102,6 +102,7 @@ void VoxelBasedApproximateCompareMapFilterComponent::filter(
   PointCloud2 & output)
 {
   std::scoped_lock lock(mutex_);
+  stop_watch_ptr_->toc("processing_time", true);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::fromROSMsg(*input, *pcl_input);
@@ -115,6 +116,16 @@ void VoxelBasedApproximateCompareMapFilterComponent::filter(
   }
   pcl::toROSMsg(*pcl_output, output);
   output.header = input->header;
+
+  // add processing time for debug
+  if (debug_publisher_) {
+    const double cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
+    const double processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
+    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+      "debug/cyclic_time_ms", cyclic_time_ms);
+    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+      "debug/processing_time_ms", processing_time_ms);
+  }
 }
 
 }  // namespace compare_map_segmentation

--- a/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
@@ -22,7 +22,52 @@
 
 namespace compare_map_segmentation
 {
-using pointcloud_preprocessor::get_param;
+
+// ******************************Static Map Loader ***************************************
+bool VoxelBasedApproximateStaticMapLoader::is_close_to_map(
+  const pcl::PointXYZ & point, [[maybe_unused]] const double distance_threshold)
+{
+  if (voxel_map_ptr_ == NULL) {
+    return false;
+  }
+  const int index =
+    voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(point.x, point.y, point.z));
+  if (index == -1) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+// ******************************  Dynamic Map Loader ************************************
+bool VoxelBasedApproximateDynamicMapLoader::is_close_to_map(
+  const pcl::PointXYZ & point, [[maybe_unused]] const double distance_threshold)
+{
+  if (current_voxel_grid_dict_.size() == 0) {
+    return false;
+  }
+
+  const int map_grid_index = static_cast<int>(
+    std::floor((point.x - origin_x_) / map_grid_size_x_) +
+    map_grids_x_ * std::floor((point.y - origin_y_) / map_grid_size_y_));
+
+  if (static_cast<size_t>(map_grid_index) >= current_voxel_grid_array_.size()) {
+    return false;
+  }
+  if (current_voxel_grid_array_.at(map_grid_index) != NULL) {
+    const int index = current_voxel_grid_array_.at(map_grid_index)
+                        ->map_cell_voxel_grid.getCentroidIndexAt(
+                          current_voxel_grid_array_.at(map_grid_index)
+                            ->map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z));
+    if (index == -1) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+// ****************************************************************************************
 
 VoxelBasedApproximateCompareMapFilterComponent::VoxelBasedApproximateCompareMapFilterComponent(
   const rclcpp::NodeOptions & options)
@@ -40,16 +85,16 @@ VoxelBasedApproximateCompareMapFilterComponent::VoxelBasedApproximateCompareMapF
   }
 
   distance_threshold_ = static_cast<double>(declare_parameter("distance_threshold", 0.3));
-
-  set_map_in_voxel_grid_ = false;
-
-  using std::placeholders::_1;
-  sub_map_ = this->create_subscription<PointCloud2>(
-    "map", rclcpp::QoS{1}.transient_local(),
-    std::bind(&VoxelBasedApproximateCompareMapFilterComponent::input_target_callback, this, _1));
-
-  set_param_res_ = this->add_on_set_parameters_callback(
-    std::bind(&VoxelBasedApproximateCompareMapFilterComponent::paramCallback, this, _1));
+  bool use_dynamic_map_loading = declare_parameter<bool>("use_dynamic_map_loading");
+  if (use_dynamic_map_loading) {
+    rclcpp::CallbackGroup::SharedPtr main_callback_group;
+    main_callback_group = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    voxel_based_approximate_map_loader_ = std::make_unique<VoxelBasedApproximateDynamicMapLoader>(
+      this, distance_threshold_, &tf_input_frame_, &mutex_, main_callback_group);
+  } else {
+    voxel_based_approximate_map_loader_ = std::make_unique<VoxelBasedApproximateStaticMapLoader>(
+      this, distance_threshold_, &tf_input_frame_, &mutex_);
+  }
 }
 
 void VoxelBasedApproximateCompareMapFilterComponent::filter(
@@ -57,75 +102,21 @@ void VoxelBasedApproximateCompareMapFilterComponent::filter(
   PointCloud2 & output)
 {
   std::scoped_lock lock(mutex_);
-  if (voxel_map_ptr_ == NULL) {
-    output = *input;
-    return;
-  }
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_output(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::fromROSMsg(*input, *pcl_input);
   pcl_output->points.reserve(pcl_input->points.size());
   for (size_t i = 0; i < pcl_input->points.size(); ++i) {
-    const int index = voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(
-      pcl_input->points.at(i).x, pcl_input->points.at(i).y, pcl_input->points.at(i).z));
-    if (index == -1) {  // empty voxel
-      // map_ptr_->points.at(index)
-      pcl_output->points.push_back(pcl_input->points.at(i));
+    if (voxel_based_approximate_map_loader_->is_close_to_map(
+          pcl_input->points.at(i), distance_threshold_)) {
+      continue;
     }
+    pcl_output->points.push_back(pcl_input->points.at(i));
   }
-
   pcl::toROSMsg(*pcl_output, output);
   output.header = input->header;
 }
 
-void VoxelBasedApproximateCompareMapFilterComponent::input_target_callback(
-  const PointCloud2ConstPtr map)
-{
-  stop_watch_ptr_->toc("processing_time", true);
-  pcl::PointCloud<pcl::PointXYZ> map_pcl;
-  pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
-  const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
-
-  std::scoped_lock lock(mutex_);
-  set_map_in_voxel_grid_ = true;
-  tf_input_frame_ = map_pcl_ptr->header.frame_id;
-  voxel_map_ptr_.reset(new pcl::PointCloud<pcl::PointXYZ>);
-  voxel_grid_.setLeafSize(distance_threshold_, distance_threshold_, distance_threshold_);
-  voxel_grid_.setInputCloud(map_pcl_ptr);
-  voxel_grid_.setSaveLeafLayout(true);
-  voxel_grid_.filter(*voxel_map_ptr_);
-  // add processing time for debug
-  if (debug_publisher_) {
-    const double cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
-    const double processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
-      "debug/cyclic_time_ms", cyclic_time_ms);
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
-      "debug/processing_time_ms", processing_time_ms);
-  }
-}
-
-rcl_interfaces::msg::SetParametersResult
-VoxelBasedApproximateCompareMapFilterComponent::paramCallback(
-  const std::vector<rclcpp::Parameter> & p)
-{
-  std::scoped_lock lock(mutex_);
-
-  if (get_param(p, "distance_threshold", distance_threshold_)) {
-    voxel_grid_.setLeafSize(distance_threshold_, distance_threshold_, distance_threshold_);
-    voxel_grid_.setSaveLeafLayout(true);
-    if (set_map_in_voxel_grid_) {
-      voxel_grid_.filter(*voxel_map_ptr_);
-    }
-    RCLCPP_DEBUG(get_logger(), "Setting new distance threshold to: %f.", distance_threshold_);
-  }
-
-  rcl_interfaces::msg::SetParametersResult result;
-  result.successful = true;
-  result.reason = "success";
-
-  return result;
-}
 }  // namespace compare_map_segmentation
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
@@ -23,7 +23,6 @@
 namespace compare_map_segmentation
 {
 
-// ******************************Static Map Loader ***************************************
 bool VoxelBasedApproximateStaticMapLoader::is_close_to_map(
   const pcl::PointXYZ & point, [[maybe_unused]] const double distance_threshold)
 {
@@ -39,7 +38,6 @@ bool VoxelBasedApproximateStaticMapLoader::is_close_to_map(
   }
 }
 
-// ******************************  Dynamic Map Loader ************************************
 bool VoxelBasedApproximateDynamicMapLoader::is_close_to_map(
   const pcl::PointXYZ & point, [[maybe_unused]] const double distance_threshold)
 {
@@ -67,7 +65,6 @@ bool VoxelBasedApproximateDynamicMapLoader::is_close_to_map(
   }
   return false;
 }
-// ****************************************************************************************
 
 VoxelBasedApproximateCompareMapFilterComponent::VoxelBasedApproximateCompareMapFilterComponent(
   const rclcpp::NodeOptions & options)

--- a/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
@@ -23,7 +23,6 @@
 namespace compare_map_segmentation
 {
 
-//******************************* Static map loader *****************************
 void VoxelDistanceBasedStaticMapLoader::onMapCallback(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr map)
 {
@@ -72,7 +71,6 @@ bool VoxelDistanceBasedStaticMapLoader::is_close_to_map(
   return false;
 }
 
-//******************************* Dynamic map loader ***********************************
 bool VoxelDistanceBasedDynamicMapLoader::is_close_to_map(
   const pcl::PointXYZ & point, const double distance_threshold)
 {
@@ -97,7 +95,6 @@ bool VoxelDistanceBasedDynamicMapLoader::is_close_to_map(
   return false;
 }
 
-// *************************************************************************************
 VoxelDistanceBasedCompareMapFilterComponent::VoxelDistanceBasedCompareMapFilterComponent(
   const rclcpp::NodeOptions & options)
 : Filter("VoxelDistanceBasedCompareMapFilter", options)

--- a/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
@@ -74,7 +74,6 @@ void VoxelDistanceBasedCompareMapFilterComponent::filter(
 void VoxelDistanceBasedStaticMapLoader::onMapCallback(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr map)
 {
-  RCLCPP_INFO(logger_, "Voxelization for Static Map Loader ");
   pcl::PointCloud<pcl::PointXYZ> map_pcl;
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
   const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
@@ -90,7 +89,6 @@ void VoxelDistanceBasedStaticMapLoader::onMapCallback(
   // kdtree
   map_ptr_ = map_pcl_ptr;
 
-  RCLCPP_INFO(logger_, "Create tree for Static Map Loader ");
   if (!tree_) {
     if (map_ptr_->isOrganized()) {
       tree_.reset(new pcl::search::OrganizedNeighbor<pcl::PointXYZ>());

--- a/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
@@ -102,7 +102,7 @@ VoxelDistanceBasedCompareMapFilterComponent::VoxelDistanceBasedCompareMapFilterC
   const rclcpp::NodeOptions & options)
 : Filter("VoxelDistanceBasedCompareMapFilter", options)
 {
-  // initilize debug tool
+  // initialize debug tool
   {
     using tier4_autoware_utils::DebugPublisher;
     using tier4_autoware_utils::StopWatch;

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -49,11 +49,14 @@ bool VoxelGridMapLoader::is_close_to_neighbor_voxels(
   const pcl::PointXYZ & point, const double distance_threshold, VoxelGridPointXYZ & voxel,
   pcl::search::Search<pcl::PointXYZ>::Ptr tree) const
 {
+  // RCLCPP_INFO(logger_,"point coordinate: x: %f y: %f z: %f", point.x, point.y, point.z);
   const int index = voxel.getCentroidIndexAt(voxel.getGridCoordinates(point.x, point.y, point.z));
   if (index != -1) {
     return true;
   }
-
+  if (tree == NULL) {
+    return false;
+  }
   std::vector<int> nn_indices(1);
   std::vector<float> nn_distances(1);
   if (tree->radiusSearch(point, distance_threshold, nn_indices, nn_distances, 1) == 0) {

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -46,6 +46,23 @@ void VoxelGridMapLoader::publish_downsampled_map(
 }
 
 bool VoxelGridMapLoader::is_close_to_neighbor_voxels(
+  const pcl::PointXYZ & point, const double distance_threshold, VoxelGridPointXYZ & voxel,
+  pcl::search::Search<pcl::PointXYZ>::Ptr tree) const
+{
+  const int index = voxel.getCentroidIndexAt(voxel.getGridCoordinates(point.x, point.y, point.z));
+  if (index != -1) {
+    return true;
+  }
+
+  std::vector<int> nn_indices(1);
+  std::vector<float> nn_distances(1);
+  if (tree->radiusSearch(point, distance_threshold, nn_indices, nn_distances, 1) == 0) {
+    return false;
+  }
+  return true;
+}
+
+bool VoxelGridMapLoader::is_close_to_neighbor_voxels(
   const pcl::PointXYZ & point, const double distance_threshold, const PointCloudPtr & map,
   VoxelGridPointXYZ & voxel) const
 {

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -49,7 +49,6 @@ bool VoxelGridMapLoader::is_close_to_neighbor_voxels(
   const pcl::PointXYZ & point, const double distance_threshold, VoxelGridPointXYZ & voxel,
   pcl::search::Search<pcl::PointXYZ>::Ptr tree) const
 {
-  // RCLCPP_INFO(logger_,"point coordinate: x: %f y: %f z: %f", point.x, point.y, point.z);
   const int index = voxel.getCentroidIndexAt(voxel.getGridCoordinates(point.x, point.y, point.z));
   if (index != -1) {
     return true;
@@ -239,8 +238,6 @@ bool VoxelGridMapLoader::is_in_voxel(
   return false;
 }
 
-//*************************** for Static Map loader Voxel Grid Filter *************
-
 VoxelGridStaticMapLoader::VoxelGridStaticMapLoader(
   rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex)
 : VoxelGridMapLoader(node, leaf_size, tf_map_input_frame, mutex)
@@ -278,7 +275,6 @@ bool VoxelGridStaticMapLoader::is_close_to_map(
   }
   return false;
 }
-//*************** for Dynamic and Differential Map loader Voxel Grid Filter *************
 
 VoxelGridDynamicMapLoader::VoxelGridDynamicMapLoader(
   rclcpp::Node * node, double leaf_size, std::string * tf_map_input_frame, std::mutex * mutex,


### PR DESCRIPTION
## Description

This PR update voxel_based_approximate_compare_map_filter, voxel_distance_based_compare_map_filter and distance_based_compare_map_filter to support dynamic map loader interface to solve the issue described at https://github.com/autowarefoundation/autoware.universe/issues/3085 

## Related links

[TIERIV COMPANY INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-70)

## Tests performed

I have confirmed by logging simulator the performance of both static and dynamic map loader as similar as before the PR.
| - | Before | After: static map loader | After: dynamic map loader |
|---|---|---|---|
|   distance_based compare_map_filter |  ![image](https://user-images.githubusercontent.com/94814556/233335251-da4f605f-1e52-4943-bafb-c9f2ac65dc5d.png) | ![image](https://user-images.githubusercontent.com/94814556/233335287-3c504a90-08ca-487f-b5ae-abb6588167eb.png) |![image](https://user-images.githubusercontent.com/94814556/233335335-1c1f475f-5268-42b4-abdc-79797ef2d21d.png)|
|voxel_based_approximate compare_map_filter|![image](https://user-images.githubusercontent.com/94814556/233335904-35d56420-bab3-40e0-85a7-4ea9d4ac1111.png)|![image](https://user-images.githubusercontent.com/94814556/233335952-a6a739b9-be8b-4f8a-aa20-7c3973bb5a6c.png)|![image](https://user-images.githubusercontent.com/94814556/233335996-07edf563-fe54-4535-9e23-9406ba1f7623.png)|
|voxel_distance_based compare_map_filter|![image](https://user-images.githubusercontent.com/94814556/233336162-085fd2aa-2e0c-45d3-8eec-31c01029dbb3.png)|![image](https://user-images.githubusercontent.com/94814556/233336191-8e6636d0-e1b1-4ebc-936f-f32e20a4713a.png)|![image](https://user-images.githubusercontent.com/94814556/233336231-705c3d07-3cca-45ef-9805-5d584bc708c8.png)|


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
