### PR TITLE
feat(default_ad_api_helpers): support goal modification for rviz

### DIFF
--- a/system/default_ad_api_helpers/ad_api_adaptors/README.md
+++ b/system/default_ad_api_helpers/ad_api_adaptors/README.md
@@ -20,9 +20,10 @@ When a goal pose topic is received, reset the waypoints and call the API.
 When a waypoint pose topic is received, append it to the end of the waypoints to call the API.
 The clear API is called automatically before setting the route.
 
-| Interface    | Local Name       | Global Name                           | Description                 |
-| ------------ | ---------------- | ------------------------------------- | --------------------------- |
-| Subscription | ~/input/goal     | /planning/mission_planning/goal       | The goal pose of route.     |
-| Subscription | ~/input/waypoint | /planning/mission_planning/checkpoint | The waypoint pose of route. |
-| Client       | -                | /api/routing/clear_route              | The route clear API.        |
-| Client       | -                | /api/routing/set_route_points         | The route points set API.   |
+| Interface    | Local Name         | Global Name                           | Description                                        |
+| ------------ | ------------------ | ------------------------------------- | -------------------------------------------------- |
+| Subscription | ~/input/fixed_goal | /planning/mission_planning/goal       | The goal pose of route. Disable goal modification. |
+| Subscription | ~/input/rough_goal | /rviz/routing/rough_goal              | The goal pose of route. Enable goal modification.  |
+| Subscription | ~/input/waypoint   | /planning/mission_planning/checkpoint | The waypoint pose of route.                        |
+| Client       | -                  | /api/routing/clear_route              | The route clear API.                               |
+| Client       | -                  | /api/routing/set_route_points         | The route points set API.                          |

--- a/system/default_ad_api_helpers/ad_api_adaptors/launch/rviz_adaptors.launch.xml
+++ b/system/default_ad_api_helpers/ad_api_adaptors/launch/rviz_adaptors.launch.xml
@@ -9,7 +9,8 @@
       <remap from="~/partial_map_load" to="/map/get_partial_pointcloud_map"/>
     </node>
     <node pkg="ad_api_adaptors" exec="routing_adaptor" name="routing_adaptor">
-      <remap from="~/input/goal" to="/planning/mission_planning/goal"/>
+      <remap from="~/input/fixed_goal" to="/planning/mission_planning/goal"/>
+      <remap from="~/input/rough_goal" to="/rviz/routing/rough_goal"/>
       <remap from="~/input/waypoint" to="/planning/mission_planning/checkpoint"/>
     </node>
   </group>

--- a/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
+++ b/system/default_ad_api_helpers/ad_api_adaptors/src/routing_adaptor.hpp
@@ -39,7 +39,8 @@ private:
   component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_route_;
   component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;
   component_interface_utils::Subscription<RouteState>::SharedPtr sub_state_;
-  rclcpp::Subscription<PoseStamped>::SharedPtr sub_goal_;
+  rclcpp::Subscription<PoseStamped>::SharedPtr sub_fixed_goal_;
+  rclcpp::Subscription<PoseStamped>::SharedPtr sub_rough_goal_;
   rclcpp::Subscription<PoseStamped>::SharedPtr sub_waypoint_;
   rclcpp::TimerBase::SharedPtr timer_;
 
@@ -49,7 +50,8 @@ private:
   RouteState::Message::_state_type state_;
 
   void on_timer();
-  void on_goal(const PoseStamped::ConstSharedPtr pose);
+  void on_fixed_goal(const PoseStamped::ConstSharedPtr pose);
+  void on_rough_goal(const PoseStamped::ConstSharedPtr pose);
   void on_waypoint(const PoseStamped::ConstSharedPtr pose);
 };
 


### PR DESCRIPTION
## Description

Add new goal pose topic with goal modification for rviz.

## Related links

https://github.com/autowarefoundation/autoware/issues/3406

## Tests performed

Check allow_goal_modification value using `/service_log` topic.
- False by default
- True if change the rviz goal topic to `/rviz/routing/rough_goal`

## Notes for reviewers

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
