### PR TITLE
feat(route_handler): add lateral intervals calculator

### DIFF
--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -279,7 +279,10 @@ public:
    * @param lane change direction
    * @return number of lanes from input to the preferred lane
    */
-  double getLateralDistanceToPreferredLane(
+  double getTotalLateralDistanceToPreferredLane(
+    const lanelet::ConstLanelet & lanelet, const Direction direction = Direction::NONE) const;
+
+  std::vector<double> getLateralIntervalsToPreferredLane(
     const lanelet::ConstLanelet & lanelet, const Direction direction = Direction::NONE) const;
 
   bool getClosestLaneletWithinRoute(

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -273,15 +273,23 @@ public:
   /**
    * Query input lanelet to see whether it exist in the preferred lane. If it doesn't exist, return
    * the distance to the preferred lane from the give lane.
-   * The distance is computed from the front point of the centerline of the given lane to
+   * The total distance is computed from the front point of the centerline of the given lane to
    * the front point of the preferred lane.
-   * @param Desired lanelet to query
-   * @param lane change direction
+   * @param lanelet lanelet to query
+   * @param direction change direction
    * @return number of lanes from input to the preferred lane
    */
   double getTotalLateralDistanceToPreferredLane(
     const lanelet::ConstLanelet & lanelet, const Direction direction = Direction::NONE) const;
 
+  /**
+   * Query input lanelet to see whether it exist in the preferred lane. If it doesn't exist, return
+   * the distance to the preferred lane from the give lane.
+   * This computes each lateral interval to the preferred lane from the given lanelet
+   * @param lanelet lanelet to query
+   * @param direction change direction
+   * @return number of lanes from input to the preferred lane
+   */
   std::vector<double> getLateralIntervalsToPreferredLane(
     const lanelet::ConstLanelet & lanelet, const Direction direction = Direction::NONE) const;
 


### PR DESCRIPTION
## Description
Add an interval calculation function to the route handler. In this function, it computes each lateral interval to the preferred lane from the given lane.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
