### PR TITLE
fix(multi_voxel_grid_map_update): fix syntax error in namespace block

### DIFF
--- a/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/multi_voxel_grid_map_update.hpp
@@ -312,6 +312,6 @@ private:
   Eigen::Vector4f min_p, max_p;
 };
 
-};  // namespace compare_map_segmentation
+}  // namespace compare_map_segmentation
 
 #endif  // COMPARE_MAP_SEGMENTATION__MULTI_VOXEL_GRID_MAP_UPDATE_HPP_


### PR DESCRIPTION
## Description

**Namespace block should not end with semicolon as stated in cpp reference:**
https://en.cppreference.com/w/cpp/language/namespace

Thix syntax error breaks the build with some c++ compiler versions.

## Tests performed

Built in aarch64 (AGX Orin) and x86 platforms
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
