### PR TITLE
fix(behavior_path_planner): fix pull over deceleration when stopped

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -839,7 +839,7 @@ PathWithLaneId PullOverModule::generateStopPath()
   // if stop pose is closer than min_stop_distance, stop as soon as possible
   const double ego_to_stop_distance = calcSignedArcLengthFromEgo(reference_path, stop_pose);
   const auto min_stop_distance = calcFeasibleDecelDistance(0.0);
-  if (ego_to_stop_distance < min_stop_distance) {
+  if (min_stop_distance && ego_to_stop_distance < *min_stop_distance) {
     return generateFeasibleStopPath();
   }
 
@@ -1093,8 +1093,14 @@ boost::optional<double> PullOverModule::calcFeasibleDecelDistance(
     return 0.0;
   }
 
-  const auto min_stop_distance = calcDecelDistWithJerkAndAccConstraints(
+  auto min_stop_distance = calcDecelDistWithJerkAndAccConstraints(
     v_now, target_velocity, a_now, -a_lim, j_lim, -1.0 * j_lim);
+
+  if (!min_stop_distance) {
+    return {};
+  }
+
+  min_stop_distance = std::max(*min_stop_distance, 0.0);
 
   return min_stop_distance;
 }
@@ -1118,17 +1124,19 @@ void PullOverModule::decelerateForTurnSignal(const Pose & stop_pose, PathWithLan
   const Pose & current_pose = planner_data_->self_odometry->pose.pose;
 
   for (auto & point : path.points) {
-    const auto distance_to_stop = std::max(
+    const double distance_to_stop = std::max(
       0.0, calcSignedArcLength(path.points, point.point.pose.position, stop_pose.position));
     const float decel_vel =
       std::min(point.point.longitudinal_velocity_mps, static_cast<float>(distance_to_stop / time));
     const double distance_from_ego = calcSignedArcLengthFromEgo(path, stop_pose);
     const auto min_decel_distance = calcFeasibleDecelDistance(decel_vel);
-    if (!min_decel_distance) {
+
+    constexpr double eps_distance = 0.1;
+    if (!min_decel_distance || *min_decel_distance < eps_distance) {
       continue;
     }
 
-    if (0.0 < *min_decel_distance && *min_decel_distance < distance_from_ego) {
+    if (*min_decel_distance < distance_from_ego) {
       point.point.longitudinal_velocity_mps = decel_vel;
     } else {
       insertDecelPoint(current_pose.position, *min_decel_distance, decel_vel, path.points);
@@ -1138,7 +1146,7 @@ void PullOverModule::decelerateForTurnSignal(const Pose & stop_pose, PathWithLan
   const double stop_point_length = calcSignedArcLength(path.points, 0, stop_pose.position);
   const auto min_stop_distance = calcFeasibleDecelDistance(0.0);
 
-  if (*min_stop_distance && min_stop_distance < stop_point_length) {
+  if (min_stop_distance && *min_stop_distance < stop_point_length) {
     const auto stop_point = util::insertStopPoint(stop_point_length, path);
   }
 }

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -1131,7 +1131,7 @@ void PullOverModule::decelerateForTurnSignal(const Pose & stop_pose, PathWithLan
     const double distance_from_ego = calcSignedArcLengthFromEgo(path, stop_pose);
     const auto min_decel_distance = calcFeasibleDecelDistance(decel_vel);
 
-    // when current velocity alrealdy lower than decel_vel, min_decel_distance will be 0.0,
+    // when current velocity already lower than decel_vel, min_decel_distance will be 0.0,
     // and do not need to decelerate.
     // skip next process to avoid inserting decel point at the same current position.
     constexpr double eps_distance = 0.1;

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -1131,6 +1131,9 @@ void PullOverModule::decelerateForTurnSignal(const Pose & stop_pose, PathWithLan
     const double distance_from_ego = calcSignedArcLengthFromEgo(path, stop_pose);
     const auto min_decel_distance = calcFeasibleDecelDistance(decel_vel);
 
+    // when current velocity alrealdy lower than decel_vel, min_decel_distance will be 0.0,
+    // and do not need to decelerate.
+    // skip next process to avoid inserting decel point at the same current position.
     constexpr double eps_distance = 0.1;
     if (!min_decel_distance || *min_decel_distance < eps_distance) {
       continue;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- fix inserting 0 velocity to all path when stopped and waiting approval
- fix not inserting stop point after stop point

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b7ec81</samp>

Fix bugs and enhance logic of `pull_over_module` for behavior path planning. Ensure safety and correctness of vehicle's pull over behavior.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
