### PR TITLE
fix(perception): remove UB reinterpret_cast

### DIFF
--- a/perception/tensorrt_yolo/lib/src/plugins/nms_plugin.cpp
+++ b/perception/tensorrt_yolo/lib/src/plugins/nms_plugin.cpp
@@ -39,10 +39,10 @@
 
 #include <cuda_runtime_api.h>
 #include <stdio.h>
-#include <string.h>
 
 #include <cassert>
 #include <cmath>
+#include <cstring>
 
 using nvinfer1::DataType;
 using nvinfer1::DimsExprs;
@@ -62,14 +62,14 @@ const char * NMS_PLUGIN_NAMESPACE{""};
 template <typename T>
 void write(char *& buffer, const T & val)
 {
-  *reinterpret_cast<T *>(buffer) = val;
+  std::memcpy(buffer, &val, sizeof(T));
   buffer += sizeof(T);
 }
 
 template <typename T>
 void read(const char *& buffer, T & val)
 {
-  val = *reinterpret_cast<const T *>(buffer);
+  std::memcpy(&val, buffer, sizeof(T));
   buffer += sizeof(T);
 }
 

--- a/perception/tensorrt_yolo/lib/src/plugins/yolo_layer_plugin.cpp
+++ b/perception/tensorrt_yolo/lib/src/plugins/yolo_layer_plugin.cpp
@@ -63,10 +63,10 @@
 
 #include <cuda_runtime_api.h>
 #include <stdio.h>
-#include <string.h>
 
 #include <cassert>
 #include <cmath>
+#include <cstring>
 #include <vector>
 
 using nvinfer1::DataType;
@@ -87,14 +87,14 @@ const char * YOLO_LAYER_PLUGIN_NAMESPACE{""};
 template <typename T>
 void write(char *& buffer, const T & val)
 {
-  *reinterpret_cast<T *>(buffer) = val;
+  std::memcpy(buffer, &val, sizeof(T));
   buffer += sizeof(T);
 }
 
 template <typename T>
 void read(const char *& buffer, T & val)
 {
-  val = *reinterpret_cast<const T *>(buffer);
+  std::memcpy(&val, buffer, sizeof(T));
   buffer += sizeof(T);
 }
 }  // namespace

--- a/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_nodelet.cpp
@@ -127,10 +127,11 @@ void CropBoxFilterComponent::faster_filter(
 
   for (size_t global_offset = 0; global_offset + input->point_step <= input->data.size();
        global_offset += input->point_step) {
-    Eigen::Vector4f point(
-      *reinterpret_cast<const float *>(&input->data[global_offset + x_offset]),
-      *reinterpret_cast<const float *>(&input->data[global_offset + y_offset]),
-      *reinterpret_cast<const float *>(&input->data[global_offset + z_offset]), 1);
+    Eigen::Vector4f point;
+    std::memcpy(&point[0], &input->data[global_offset + x_offset], sizeof(float));
+    std::memcpy(&point[1], &input->data[global_offset + y_offset], sizeof(float));
+    std::memcpy(&point[2], &input->data[global_offset + z_offset], sizeof(float));
+    point[3] = 1;
 
     if (!std::isfinite(point[0]) || !std::isfinite(point[1]) || !std::isfinite(point[2])) {
       RCLCPP_WARN(this->get_logger(), "Ignoring point containing NaN values");
@@ -148,9 +149,9 @@ void CropBoxFilterComponent::faster_filter(
       memcpy(&output.data[output_size], &input->data[global_offset], input->point_step);
 
       if (transform_info.need_transform) {
-        *reinterpret_cast<float *>(&output.data[output_size + x_offset]) = point[0];
-        *reinterpret_cast<float *>(&output.data[output_size + y_offset]) = point[1];
-        *reinterpret_cast<float *>(&output.data[output_size + z_offset]) = point[2];
+        std::memcpy(&output.data[output_size + x_offset], &point[0], sizeof(float));
+        std::memcpy(&output.data[output_size + y_offset], &point[1], sizeof(float));
+        std::memcpy(&output.data[output_size + z_offset], &point[2], sizeof(float));
       }
 
       output_size += input->point_step;

--- a/system/system_monitor/reader/hdd_reader/hdd_reader.cpp
+++ b/system/system_monitor/reader/hdd_reader/hdd_reader.cpp
@@ -385,11 +385,11 @@ int get_nvme_smart_data(int fd, HddInfo * info)
   // is from 1 to 1,000, three indicates that the number of 512 byte data
   // units written is from 2,001 to 3,000)
   info->is_valid_total_data_written_ = true;
-  info->total_data_written_ = *(reinterpret_cast<uint64_t *>(&data[48]));
+  std::memcpy(&info->total_data_written_, &data[48], sizeof(uint64_t));
 
   // Bytes 143:128 Power On Hours
   info->is_valid_power_on_hours_ = true;
-  info->power_on_hours_ = *(reinterpret_cast<uint64_t *>(&data[128]));
+  std::memcpy(&info->power_on_hours_, &data[128], sizeof(uint64_t));
 
   // NVMe S.M.A.R.T has no information of recovered error count
   info->is_valid_recovered_error_ = false;

--- a/system/system_monitor/reader/hdd_reader/hdd_reader.cpp
+++ b/system/system_monitor/reader/hdd_reader/hdd_reader.cpp
@@ -385,11 +385,11 @@ int get_nvme_smart_data(int fd, HddInfo * info)
   // is from 1 to 1,000, three indicates that the number of 512 byte data
   // units written is from 2,001 to 3,000)
   info->is_valid_total_data_written_ = true;
-  std::memcpy(&info->total_data_written_, &data[48], sizeof(uint64_t));
+  std::memcpy(&info->total_data_written_, &data[48], sizeof(info->total_data_written_));
 
   // Bytes 143:128 Power On Hours
   info->is_valid_power_on_hours_ = true;
-  std::memcpy(&info->power_on_hours_, &data[128], sizeof(uint64_t));
+  std::memcpy(&info->power_on_hours_, &data[128], sizeof(info->power_on_hours_));
 
   // NVMe S.M.A.R.T has no information of recovered error count
   info->is_valid_recovered_error_ = false;


### PR DESCRIPTION
see https://github.com/autowarefoundation/autoware.universe/issues/3215

## Description

Replace misc UB `reinterpret_cast` with the `memcpy` equivalent.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
