### PR TITLE
chore(planning_evaluator): add dependency

### DIFF
--- a/launch/tier4_planning_launch/package.xml
+++ b/launch/tier4_planning_launch/package.xml
@@ -66,6 +66,7 @@
   <exec_depend>obstacle_avoidance_planner</exec_depend>
   <exec_depend>obstacle_cruise_planner</exec_depend>
   <exec_depend>obstacle_stop_planner</exec_depend>
+  <exec_depend>planning_evaluator</exec_depend>
   <exec_depend>planning_validator</exec_depend>
   <exec_depend>rtc_auto_mode_manager</exec_depend>
   <exec_depend>scenario_selector</exec_depend>


### PR DESCRIPTION
## Description
Add ```exec_depend``` of tier4_planning_launch to planning_evaluator.
The planning evaluator is called [here](https://github.com/autowarefoundation/autoware.universe/blob/main/launch/tier4_planning_launch/launch/planning.launch.xml#L92)

<!-- Write a brief description of this PR. -->

## Tests performed
Not applicable.

## Effects on system behavior
Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
