### PR TITLE
fix(behavior_velocity_planner): revert pr #2775

### DIFF
--- a/planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/CMakeLists.txt
@@ -11,35 +11,6 @@ find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common filters)
 find_package(OpenCV REQUIRED)
 
-# concatenate include_dirs
-set(${PROJECT_NAME}_INCLUDE_DIRS
-  ${${PROJECT_NAME}_FOUND_INCLUDE_DIRS}
-  ${BOOST_INCLUDE_DIRS}
-  ${PCL_INCLUDE_DIRS}
-  ${tf2_geometry_msgs_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-list(REMOVE_DUPLICATES ${PROJECT_NAME}_INCLUDE_DIRS)
-
-# concatenate link libraries
-set(${PROJECT_NAME}_LINK_LIBRARIES ${${PROJECT_NAME}_FOUND_LIBRARIES} ${PCL_LIBRARIES})
-list(REMOVE_DUPLICATES ${PROJECT_NAME}_LINK_LIBRARIES)
-
-# utilization library
-add_library(behavior_velocity_planner_utilization
-  SHARED
-  src/utilization/path_utilization.cpp
-  src/utilization/util.cpp
-  src/utilization/debug.cpp
-)
-target_include_directories(behavior_velocity_planner_utilization
-  SYSTEM PUBLIC
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
-)
-target_link_libraries(behavior_velocity_planner_utilization ${${PROJECT_NAME}_LINK_LIBRARIES})
-
-# scene modules libraries
 set(scene_modules
   detection_area
   blind_spot
@@ -55,30 +26,36 @@ set(scene_modules
   out_of_lane
 )
 
-set(behavior_velocity_planner_scene_modules behavior_velocity_planner_utilization)
 foreach(scene_module IN LISTS scene_modules)
   file(GLOB_RECURSE scene_module_src "src/scene_module/${scene_module}/*")
-  add_library(behavior_velocity_planner_${scene_module}
-    SHARED ${scene_module_src}
-  )
-  target_include_directories(behavior_velocity_planner_${scene_module}
-    SYSTEM PUBLIC
-    ${${PROJECT_NAME}_INCLUDE_DIRS}
-  )
-  target_link_libraries(behavior_velocity_planner_${scene_module} ${${PROJECT_NAME}_LINK_LIBRARIES} behavior_velocity_planner_utilization)
-  list(APPEND behavior_velocity_planner_scene_modules behavior_velocity_planner_${scene_module})
+  list(APPEND scene_modules_src ${scene_module_src})
 endforeach()
 
-# node library
-add_library(behavior_velocity_planner SHARED
+ament_auto_add_library(behavior_velocity_planner SHARED
   src/node.cpp
   src/planner_manager.cpp
+  src/utilization/path_utilization.cpp
+  src/utilization/util.cpp
+  src/utilization/debug.cpp
+  ${scene_modules_src}
 )
+
 target_include_directories(behavior_velocity_planner
   SYSTEM PUBLIC
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
+    ${BOOST_INCLUDE_DIRS}
+    ${PCL_INCLUDE_DIRS}
+    ${tf2_geometry_msgs_INCLUDE_DIRS}
+    ${EIGEN3_INCLUDE_DIR}
 )
-target_link_libraries(behavior_velocity_planner ${${PROJECT_NAME}_LINK_LIBRARIES} ${behavior_velocity_planner_scene_modules})
+
+ament_target_dependencies(behavior_velocity_planner
+  Boost
+  Eigen3
+  PCL
+  message_filters
+)
+
+target_link_libraries(behavior_velocity_planner ${PCL_LIBRARIES})
 
 rclcpp_components_register_node(behavior_velocity_planner
   PLUGIN "behavior_velocity_planner::BehaviorVelocityPlannerNode"
@@ -95,7 +72,6 @@ if(BUILD_TESTING)
   target_link_libraries(utilization-test
     gtest_main
     behavior_velocity_planner
-    ${${PROJECT_NAME}_LINK_LIBRARIES} ${behavior_velocity_planner_scene_modules}
   )
 
   # Gtest for occlusion spot
@@ -110,7 +86,6 @@ if(BUILD_TESTING)
   target_link_libraries(occlusion_spot-test
     gtest_main
     behavior_velocity_planner
-    ${${PROJECT_NAME}_LINK_LIBRARIES} ${behavior_velocity_planner_scene_modules}
   )
 endif()
 


### PR DESCRIPTION
## Description

PR #2775 causes runtime error in latest environment so should be reverted ASAP.
 
## Tests performed

Psim launches and runs properly.

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
