### PR TITLE
refactor(occupancy_grid_map): add occupancy_grid_map method/param var to launcher

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,7 +68,7 @@ launch/tier4_autoware_api_launch/** isamu.takagi@tier4.jp kahhooi.tan@tier4.jp k
 launch/tier4_control_launch/** takamasa.horibe@tier4.jp takayuki.murooka@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_localization_launch/** kento.yabuuchi.2@tier4.jp koji.minoda@tier4.jp ryu.yamamoto@tier4.jp yamato.ando@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_map_launch/** koji.minoda@tier4.jp ryohsuke.mitsudome@tier4.jp ryu.yamamoto@tier4.jp @autowarefoundation/autoware-global-codeowners
-launch/tier4_perception_launch/** shunsuke.miura@tier4.jp yukihiro.saito@tier4.jp @autowarefoundation/autoware-global-codeowners
+launch/tier4_perception_launch/** shunsuke.miura@tier4.jp yukihiro.saito@tier4.jp yoshi.ri@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_planning_launch/** fumiya.watanabe@tier4.jp kosuke.takeuchi@tier4.jp kyoichi.sugahara@tier4.jp makoto.kurihara@tier4.jp mamoru.sobue@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp taiki.tanaka@tier4.jp takamasa.horibe@tier4.jp takayuki.murooka@tier4.jp tomohito.ando@tier4.jp tomoya.kimura@tier4.jp yutaka.shimizu@tier4.jp zulfaqar.azmi@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_sensing_launch/** yukihiro.saito@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_simulator_launch/** keisuke.shima@tier4.jp taiki.tanaka@tier4.jp takamasa.horibe@tier4.jp takayuki.murooka@tier4.jp tomoya.kimura@tier4.jp @autowarefoundation/autoware-global-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,7 +68,7 @@ launch/tier4_autoware_api_launch/** isamu.takagi@tier4.jp kahhooi.tan@tier4.jp k
 launch/tier4_control_launch/** takamasa.horibe@tier4.jp takayuki.murooka@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_localization_launch/** kento.yabuuchi.2@tier4.jp koji.minoda@tier4.jp ryu.yamamoto@tier4.jp yamato.ando@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_map_launch/** koji.minoda@tier4.jp ryohsuke.mitsudome@tier4.jp ryu.yamamoto@tier4.jp @autowarefoundation/autoware-global-codeowners
-launch/tier4_perception_launch/** shunsuke.miura@tier4.jp yukihiro.saito@tier4.jp yoshi.ri@tier4.jp @autowarefoundation/autoware-global-codeowners
+launch/tier4_perception_launch/** shunsuke.miura@tier4.jp yukihiro.saito@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_planning_launch/** fumiya.watanabe@tier4.jp kosuke.takeuchi@tier4.jp kyoichi.sugahara@tier4.jp makoto.kurihara@tier4.jp mamoru.sobue@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp taiki.tanaka@tier4.jp takamasa.horibe@tier4.jp takayuki.murooka@tier4.jp tomohito.ando@tier4.jp tomoya.kimura@tier4.jp yutaka.shimizu@tier4.jp zulfaqar.azmi@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_sensing_launch/** yukihiro.saito@tier4.jp @autowarefoundation/autoware-global-codeowners
 launch/tier4_simulator_launch/** keisuke.shima@tier4.jp taiki.tanaka@tier4.jp takamasa.horibe@tier4.jp takayuki.murooka@tier4.jp tomoya.kimura@tier4.jp @autowarefoundation/autoware-global-codeowners

--- a/launch/tier4_perception_launch/launch/occupancy_grid_map/probabilistic_occupancy_grid_map.launch.xml
+++ b/launch/tier4_perception_launch/launch/occupancy_grid_map/probabilistic_occupancy_grid_map.launch.xml
@@ -8,15 +8,11 @@
   <arg name="use_multithread" default="false"/>
   <arg name="use_pointcloud_container" default="false"/>
   <arg name="container_name" default="occupancy_grid_map_container"/>
-  <arg name="scan_origin" default="base_link"/>
-  <arg name="map_origin" default="base_link"/>
-
-  <!--default parameter follows node setting -->
-  <arg name="method" default="pointcloud_based_occupancy_grid_map"/>
-  <arg name="param_file" default="$(find-pkg-share probabilistic_occupancy_grid_map)/config/$(var method).param.yaml"/>
+  <arg name="occupancy_grid_map_method" description="options: pointcloud_based_occupancy_grid_map, laserscan_based_occupancy_grid_map"/>
+  <arg name="occupancy_grid_map_param_path"/>
 
   <!--pointcloud based method-->
-  <group if="$(eval &quot;'$(var method)'=='pointcloud_based_occupancy_grid_map'&quot;)">
+  <group if="$(eval &quot;'$(var occupancy_grid_map_method)'=='pointcloud_based_occupancy_grid_map'&quot;)">
     <include file="$(find-pkg-share probabilistic_occupancy_grid_map)/launch/pointcloud_based_occupancy_grid_map.launch.py">
       <arg name="input/obstacle_pointcloud" value="$(var input/obstacle_pointcloud)"/>
       <arg name="input/raw_pointcloud" value="$(var input/raw_pointcloud)"/>
@@ -25,14 +21,12 @@
       <arg name="use_multithread" value="$(var use_multithread)"/>
       <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
       <arg name="container_name" value="$(var container_name)"/>
-      <arg name="param_file" value="$(var param_file)"/>
-      <arg name="scan_origin" value="$(var scan_origin)"/>
-      <arg name="map_origin" value="$(var map_origin)"/>
+      <arg name="param_file" value="$(var occupancy_grid_map_param_path)"/>
     </include>
   </group>
 
   <!--laserscan based method-->
-  <group if="$(eval &quot;'$(var method)'=='laserscan_based_occupancy_grid_map'&quot;)">
+  <group if="$(eval &quot;'$(var occupancy_grid_map_method)'=='laserscan_based_occupancy_grid_map'&quot;)">
     <include file="$(find-pkg-share probabilistic_occupancy_grid_map)/launch/laserscan_based_occupancy_grid_map.launch.py">
       <arg name="input/obstacle_pointcloud" value="$(var input/obstacle_pointcloud)"/>
       <arg name="input/raw_pointcloud" value="$(var input/raw_pointcloud)"/>
@@ -41,9 +35,7 @@
       <arg name="use_multithread" value="$(var use_multithread)"/>
       <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
       <arg name="container_name" value="$(var container_name)"/>
-      <arg name="param_file" value="$(var param_file)"/>
-      <arg name="scan_origin" value="$(var scan_origin)"/>
-      <arg name="map_origin" value="$(var map_origin)"/>
+      <arg name="param_file" value="$(var occupancy_grid_map_param_path)"/>
     </include>
   </group>
 </launch>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -7,6 +7,8 @@
   <arg name="object_recognition_tracking_multi_object_tracker_data_association_matrix_param_path"/>
   <arg name="obstacle_segmentation_ground_segmentation_param_path"/>
   <arg name="obstacle_segmentation_ground_segmentation_elevation_map_param_path"/>
+  <arg name="occupancy_grid_map_method"/>
+  <arg name="occupancy_grid_map_param_path"/>
 
   <!-- centerpoint model configs -->
   <arg name="centerpoint_model_name" default="centerpoint_tiny" description="options: `centerpoint` or `centerpoint_tiny`"/>
@@ -79,8 +81,8 @@
         <arg name="use_multithread" value="true"/>
         <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="method" value="pointcloud_based_occupancy_grid_map"/>
-        <arg name="param_file" value="$(find-pkg-share probabilistic_occupancy_grid_map)/config/pointcloud_based_occupancy_grid_map.param.yaml"/>
+        <arg name="occupancy_grid_map_method" value="$(var occupancy_grid_map_method)"/>
+        <arg name="occupancy_grid_map_param_path" value="$(var occupancy_grid_map_param_path)"/>
       </include>
     </group>
 

--- a/launch/tier4_perception_launch/package.xml
+++ b/launch/tier4_perception_launch/package.xml
@@ -6,6 +6,7 @@
   <description>The tier4_perception_launch package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>
+  <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -2,6 +2,7 @@
   <!-- Parameter files -->
   <arg name="fault_injection_param_path"/>
   <arg name="obstacle_segmentation_ground_segmentation_elevation_map_param_path"/>
+  <arg name="laserscan_based_occupancy_grid_map_param_path"/>
   <arg name="pose_initializer_param_path"/>
   <arg name="pose_initializer_common_param_path"/>
 
@@ -44,9 +45,8 @@
       <arg name="input_obstacle_and_raw_pointcloud" value="false"/>
       <arg name="input/obstacle_pointcloud" value="/perception/obstacle_segmentation/pointcloud"/>
       <arg name="output" value="/perception/occupancy_grid_map/map"/>
-      <arg name="method" value="laserscan_based_occupancy_grid_map"/>
-      <arg name="map_origin" value="base_link"/>
-      <arg name="scan_origin" value="base_link"/>
+      <arg name="occupancy_grid_map_method" value="laserscan_based_occupancy_grid_map"/>
+      <arg name="occupancy_grid_map_param_path" value="$(var laserscan_based_occupancy_grid_map_param_path)"/>
     </include>
   </group>
 


### PR DESCRIPTION
## Description

Just like other packages I changed the auoware_launch to refer to launcher param file.

depend on launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/294.

## Related links

launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/294

## Tests performed

Psim works as before.

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
