### PR TITLE
refactor(behavior_velocity_planner): removed external input from behavior_velocity

### DIFF
--- a/planning/behavior_velocity_planner/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_planner/config/crosswalk.param.yaml
@@ -29,7 +29,6 @@
       ego_yield_query_stop_duration: 0.1 # [s] the amount of time which ego should be stopping to query whether it yields or not
 
       # param for input data
-      external_input_timeout: 1.0
       tl_state_timeout: 3.0 # [s] timeout threshold for traffic light signal
 
       # param for target area & object
@@ -43,4 +42,3 @@
     walkway:
       stop_duration_sec: 1.0 # [s] stop time at stop position
       stop_line_distance: 3.5 # [m] make stop line away from crosswalk when no explicit stop line exists
-      external_input_timeout: 1.0

--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -22,10 +22,6 @@
       assumed_front_car_decel: 1.0 # [m/ss] the expected deceleration of front car when front car as well as ego are turning
       enable_front_car_decel_prediction: false # By default this feature is disabled
       stop_overshoot_margin: 0.5 # [m] overshoot margin for stuck, collision detection
-      external_input_timeout: 1.0
 
-    merge_from_private_road:
-      stop_duration_sec: 1.0
     merge_from_private:
-      merge_from_private_area:
-        stop_duration_sec: 1.0
+      stop_duration_sec: 1.0

--- a/planning/behavior_velocity_planner/config/traffic_light.param.yaml
+++ b/planning/behavior_velocity_planner/config/traffic_light.param.yaml
@@ -3,6 +3,5 @@
     traffic_light:
       stop_margin: 0.0
       tl_state_timeout: 1.0
-      external_tl_state_timeout: 1.0
       yellow_lamp_period: 2.75
       enable_pass_judge: true

--- a/planning/behavior_velocity_planner/include/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/include/behavior_velocity_planner/node.hpp
@@ -63,12 +63,6 @@ private:
   rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_lanelet_map_;
   rclcpp::Subscription<autoware_auto_perception_msgs::msg::TrafficSignalArray>::SharedPtr
     sub_traffic_signals_;
-  rclcpp::Subscription<tier4_api_msgs::msg::CrosswalkStatus>::SharedPtr
-    sub_external_crosswalk_states_;
-  rclcpp::Subscription<tier4_api_msgs::msg::IntersectionStatus>::SharedPtr
-    sub_external_intersection_states_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::TrafficSignalArray>::SharedPtr
-    sub_external_traffic_signals_;
   rclcpp::Subscription<tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
     sub_virtual_traffic_light_states_;
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr sub_occupancy_grid_;
@@ -84,11 +78,6 @@ private:
   void onLaneletMap(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
   void onTrafficSignals(
     const autoware_auto_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr msg);
-  void onExternalTrafficSignals(
-    const autoware_auto_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr msg);
-  void onExternalCrosswalkStates(const tier4_api_msgs::msg::CrosswalkStatus::ConstSharedPtr msg);
-  void onExternalIntersectionStates(
-    const tier4_api_msgs::msg::IntersectionStatus::ConstSharedPtr msg);
   void onVirtualTrafficLightStates(
     const tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr msg);
   void onOccupancyGrid(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg);

--- a/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
+++ b/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
@@ -84,11 +84,6 @@ struct PlannerData
 
   // other internal data
   std::map<int, autoware_auto_perception_msgs::msg::TrafficSignalStamped> traffic_light_id_map;
-  // external data
-  std::map<int, autoware_auto_perception_msgs::msg::TrafficSignalStamped>
-    external_traffic_light_id_map;
-  boost::optional<tier4_api_msgs::msg::CrosswalkStatus> external_crosswalk_status_input;
-  boost::optional<tier4_api_msgs::msg::IntersectionStatus> external_intersection_status_input;
   boost::optional<tier4_planning_msgs::msg::VelocityLimit> external_velocity_limit;
   tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr virtual_traffic_light_states;
 
@@ -145,16 +140,6 @@ struct PlannerData
     }
     return std::make_shared<autoware_auto_perception_msgs::msg::TrafficSignalStamped>(
       traffic_light_id_map.at(id));
-  }
-
-  std::shared_ptr<autoware_auto_perception_msgs::msg::TrafficSignalStamped>
-  getExternalTrafficSignal(const int id) const
-  {
-    if (external_traffic_light_id_map.count(id) == 0) {
-      return {};
-    }
-    return std::make_shared<autoware_auto_perception_msgs::msg::TrafficSignalStamped>(
-      external_traffic_light_id_map.at(id));
   }
 };
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -82,7 +82,6 @@ public:
     double max_yield_timeout;
     double ego_yield_query_stop_duration;
     // param for input data
-    double external_input_timeout;
     double tl_state_timeout;
     // param for target area & object
     double crosswalk_attention_range;
@@ -147,8 +146,6 @@ private:
   static bool isVehicle(const PredictedObject & object);
 
   bool isTargetType(const PredictedObject & object) const;
-
-  bool isTargetExternalInputStatus(const int target_status) const;
 
   static geometry_msgs::msg::Polygon createObjectPolygon(
     const double width_m, const double length_m);

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.hpp
@@ -42,7 +42,6 @@ public:
   {
     double stop_line_distance;
     double stop_duration_sec;
-    double external_input_timeout;
   };
   WalkwayModule(
     const int64_t module_id, lanelet::ConstLanelet walkway, const PlannerParam & planner_param,

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -85,7 +85,6 @@ public:
     double detection_area_angle_thr;     //! threshold in checking the angle of detecting objects
     double min_predicted_path_confidence;
     //! minimum confidence value of predicted path to use for collision detection
-    double external_input_timeout;          //! used to disable external input
     double minimum_ego_predicted_velocity;  //! used to calculate ego's future velocity profile
     double collision_start_margin_time;     //! start margin time to check collision
     double collision_end_margin_time;       //! end margin time to check collision
@@ -207,13 +206,6 @@ private:
    */
   bool isTargetStuckVehicleType(
     const autoware_auto_perception_msgs::msg::PredictedObject & object) const;
-
-  /**
-   * @brief Whether target tier4_api_msgs::Intersection::status is valid or not
-   * @param target_status target tier4_api_msgs::Intersection::status
-   * @return rue if the object has a target type
-   */
-  bool isTargetExternalInputStatus(const int target_status);
 
   /**
    * @brief Whether the given pose belongs to any target lanelet or not

--- a/planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
@@ -40,7 +40,7 @@ class TrafficLightModule : public SceneModuleInterface
 {
 public:
   enum class State { APPROACH, GO_OUT };
-  enum class Input { PERCEPTION, EXTERNAL, NONE };  // EXTERNAL: FOA, V2X, etc.
+  enum class Input { PERCEPTION, NONE };  // EXTERNAL: FOA, V2X, etc.
 
   struct DebugData
   {
@@ -61,7 +61,6 @@ public:
   {
     double stop_margin;
     double tl_state_timeout;
-    double external_tl_state_timeout;
     double yellow_lamp_period;
     bool enable_pass_judge;
   };
@@ -114,10 +113,6 @@ private:
   bool getHighestConfidenceTrafficSignal(
     const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,
     autoware_auto_perception_msgs::msg::TrafficSignalStamped & highest_confidence_tl_state);
-
-  bool getExternalTrafficSignal(
-    const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,
-    autoware_auto_perception_msgs::msg::TrafficSignalStamped & external_tl_state);
 
   bool updateTrafficSignal(const lanelet::ConstLineStringsOrPolygons3d & traffic_lights);
 

--- a/planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
+++ b/planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
@@ -5,7 +5,6 @@
 
   <arg name="input_route_topic_name" default="/planning/mission_planning/route"/>
   <arg name="input_traffic_light_topic_name" default="/perception/traffic_light_recognition/traffic_signals"/>
-  <arg name="external_traffic_light_topic_name" default="/external/traffic_light_recognition/traffic_signals"/>
   <arg name="virtual_traffic_light_topic_name" default="/awapi/tmp/virtual_traffic_light_states"/>
   <arg name="map_topic_name" default="/map/vector_map"/>
 
@@ -47,7 +46,6 @@
     <remap from="~/input/dynamic_objects" to="/perception/object_recognition/objects"/>
     <remap from="~/input/no_ground_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
     <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
-    <remap from="~/input/external_traffic_signals" to="$(var external_traffic_light_topic_name)"/>
     <remap from="~/input/virtual_traffic_light_states" to="$(var virtual_traffic_light_topic_name)"/>
     <remap from="~/input/occupancy_grid" to="/sensing/lidar/occupancy_grid"/>
     <remap from="~/output/path" to="path"/>

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -115,22 +115,9 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
       "~/input/traffic_signals", 1,
       std::bind(&BehaviorVelocityPlannerNode::onTrafficSignals, this, _1),
       createSubscriptionOptions(this));
-  sub_external_crosswalk_states_ = this->create_subscription<tier4_api_msgs::msg::CrosswalkStatus>(
-    "~/input/external_crosswalk_states", 1,
-    std::bind(&BehaviorVelocityPlannerNode::onExternalCrosswalkStates, this, _1),
-    createSubscriptionOptions(this));
-  sub_external_intersection_states_ =
-    this->create_subscription<tier4_api_msgs::msg::IntersectionStatus>(
-      "~/input/external_intersection_states", 1,
-      std::bind(&BehaviorVelocityPlannerNode::onExternalIntersectionStates, this, _1));
   sub_external_velocity_limit_ = this->create_subscription<VelocityLimit>(
     "~/input/external_velocity_limit_mps", rclcpp::QoS{1}.transient_local(),
     std::bind(&BehaviorVelocityPlannerNode::onExternalVelocityLimit, this, _1));
-  sub_external_traffic_signals_ =
-    this->create_subscription<autoware_auto_perception_msgs::msg::TrafficSignalArray>(
-      "~/input/external_traffic_signals", 1,
-      std::bind(&BehaviorVelocityPlannerNode::onExternalTrafficSignals, this, _1),
-      createSubscriptionOptions(this));
   sub_virtual_traffic_light_states_ =
     this->create_subscription<tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>(
       "~/input/virtual_traffic_light_states", 1,
@@ -358,36 +345,10 @@ void BehaviorVelocityPlannerNode::onTrafficSignals(
   }
 }
 
-void BehaviorVelocityPlannerNode::onExternalCrosswalkStates(
-  const tier4_api_msgs::msg::CrosswalkStatus::ConstSharedPtr msg)
-{
-  std::lock_guard<std::mutex> lock(mutex_);
-  planner_data_.external_crosswalk_status_input = *msg;
-}
-
-void BehaviorVelocityPlannerNode::onExternalIntersectionStates(
-  const tier4_api_msgs::msg::IntersectionStatus::ConstSharedPtr msg)
-{
-  std::lock_guard<std::mutex> lock(mutex_);
-  planner_data_.external_intersection_status_input = *msg;
-}
-
 void BehaviorVelocityPlannerNode::onExternalVelocityLimit(const VelocityLimit::ConstSharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   planner_data_.external_velocity_limit = *msg;
-}
-
-void BehaviorVelocityPlannerNode::onExternalTrafficSignals(
-  const autoware_auto_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr msg)
-{
-  std::lock_guard<std::mutex> lock(mutex_);
-  for (const auto & signal : msg->signals) {
-    autoware_auto_perception_msgs::msg::TrafficSignalStamped traffic_signal;
-    traffic_signal.header = msg->header;
-    traffic_signal.signal = signal;
-    planner_data_.external_traffic_light_id_map[signal.map_primitive_id] = traffic_signal;
-  }
 }
 
 void BehaviorVelocityPlannerNode::onVirtualTrafficLightStates(

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
@@ -113,7 +113,6 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
     node.declare_parameter<double>(ns + ".ego_yield_query_stop_duration");
 
   // param for input data
-  cp.external_input_timeout = node.declare_parameter<double>(ns + ".external_input_timeout");
   cp.tl_state_timeout = node.declare_parameter<double>(ns + ".tl_state_timeout");
 
   // param for target area & object
@@ -163,7 +162,6 @@ WalkwayModuleManager::WalkwayModuleManager(rclcpp::Node & node)
   auto & wp = walkway_planner_param_;
   wp.stop_line_distance = node.declare_parameter<double>(ns + ".stop_line_distance");
   wp.stop_duration_sec = node.declare_parameter<double>(ns + ".stop_duration_sec");
-  wp.external_input_timeout = node.declare_parameter<double>(ns + ".external_input_timeout");
 }
 
 void WalkwayModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -923,21 +923,6 @@ bool CrosswalkModule::isTargetType(const PredictedObject & object) const
   return false;
 }
 
-bool CrosswalkModule::isTargetExternalInputStatus(const int target_status) const
-{
-  const auto & ex_input = planner_data_->external_crosswalk_status_input;
-  if (!ex_input) {
-    return false;
-  }
-
-  const auto time_delta = (clock_->now() - ex_input.get().header.stamp).seconds();
-  if (planner_param_.external_input_timeout < time_delta) {
-    return false;
-  }
-
-  return ex_input.get().status == target_status;
-}
-
 geometry_msgs::msg::Polygon CrosswalkModule::createObjectPolygon(
   const double width_m, const double length_m)
 {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -51,7 +51,6 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
     node.declare_parameter<double>(ns + ".detection_area_angle_threshold");
   ip.min_predicted_path_confidence =
     node.declare_parameter<double>(ns + ".min_predicted_path_confidence");
-  ip.external_input_timeout = node.declare_parameter<double>(ns + ".external_input_timeout");
   ip.minimum_ego_predicted_velocity =
     node.declare_parameter<double>(ns + ".minimum_ego_predicted_velocity");
   ip.collision_start_margin_time =
@@ -69,8 +68,7 @@ MergeFromPrivateModuleManager::MergeFromPrivateModuleManager(rclcpp::Node & node
 {
   const std::string ns(getModuleName());
   auto & mp = merge_from_private_area_param_;
-  mp.stop_duration_sec =
-    node.declare_parameter<double>(ns + ".merge_from_private_area.stop_duration_sec");
+  mp.stop_duration_sec = node.declare_parameter<double>(ns + ".stop_duration_sec");
   mp.detection_area_length = node.get_parameter("intersection.detection_area_length").as_double();
   mp.detection_area_right_margin =
     node.get_parameter("intersection.detection_area_right_margin").as_double();

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -75,13 +75,8 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 {
   RCLCPP_DEBUG(logger_, "===== plan start =====");
 
-  const bool external_go = isTargetExternalInputStatus(tier4_api_msgs::msg::IntersectionStatus::GO);
-  const bool external_stop =
-    isTargetExternalInputStatus(tier4_api_msgs::msg::IntersectionStatus::STOP);
-  const StateMachine::State current_state = state_machine_.getState();
-
   debug_data_ = DebugData();
-
+  const StateMachine::State current_state = state_machine_.getState();
   *stop_reason = planning_utils::initializeStopReason(StopReason::INTERSECTION);
 
   RCLCPP_DEBUG(
@@ -223,14 +218,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   std::optional<size_t> stop_line_idx =
     stop_lines_idx_opt ? std::make_optional<size_t>(stop_lines_idx_opt.value().collision_stop_line)
                        : std::nullopt;
-  if (external_go) {
-    is_entry_prohibited = false;
-  } else if (external_stop) {
-    is_entry_prohibited = true;
-    stop_line_idx = stop_lines_idx_opt
-                      ? std::make_optional<size_t>(stop_lines_idx_opt.value().collision_stop_line)
-                      : std::nullopt;
-  } else if (is_stuck && stuck_line_idx_opt) {
+  if (is_stuck && stuck_line_idx_opt) {
     is_entry_prohibited = true;
     const size_t stuck_line_idx = stuck_line_idx_opt.value();
     const double dist_stuck_stopline = motion_utils::calcSignedArcLength(
@@ -641,14 +629,6 @@ bool IntersectionModule::isTargetStuckVehicleType(
     return true;
   }
   return false;
-}
-
-bool IntersectionModule::isTargetExternalInputStatus(const int target_status)
-{
-  return planner_data_->external_intersection_status_input &&
-         planner_data_->external_intersection_status_input.get().status == target_status &&
-         (clock_->now() - planner_data_->external_intersection_status_input.get().header.stamp)
-             .seconds() < planner_param_.external_input_timeout;
 }
 
 bool IntersectionModule::checkAngleForTargetLanelets(

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
@@ -32,8 +32,6 @@ TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
   const std::string ns(getModuleName());
   planner_param_.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
   planner_param_.tl_state_timeout = node.declare_parameter<double>(ns + ".tl_state_timeout");
-  planner_param_.external_tl_state_timeout =
-    node.declare_parameter<double>(ns + ".external_tl_state_timeout");
   planner_param_.enable_pass_judge = node.declare_parameter<bool>(ns + ".enable_pass_judge");
   planner_param_.yellow_lamp_period = node.declare_parameter<double>(ns + ".yellow_lamp_period");
   pub_tl_state_ = node.create_publisher<autoware_auto_perception_msgs::msg::LookingTrafficSignal>(

--- a/planning/behavior_velocity_planner/traffic-light-design.md
+++ b/planning/behavior_velocity_planner/traffic-light-design.md
@@ -2,10 +2,8 @@
 
 #### Role
 
-Judgement whether a vehicle can go into an intersection or not by internal and external traffic light status, and planning a velocity of the stop if necessary.
+Judgement whether a vehicle can go into an intersection or not by traffic light status, and planning a velocity of the stop if necessary.
 This module is designed for rule-based velocity decision that is easy for developers to design its behavior. It generates proper velocity for traffic light scene.
-
-In addition, the STOP/GO interface of behavior_velocity_planner allows external users / modules (e.g. remote operation) to intervene the decision of the internal perception. This function is expected to be used, for example, for remote intervention in detection failure or gathering information on operator decisions during development.
 
 ![brief](./docs/traffic_light/traffic_light.svg)
 
@@ -65,13 +63,12 @@ This module is activated when there is traffic light in ego lane.
 
 #### Module Parameters
 
-| Parameter                   | Type   | Description                                     |
-| --------------------------- | ------ | ----------------------------------------------- |
-| `stop_margin`               | double | [m] margin before stop point                    |
-| `tl_state_timeout`          | double | [s] time out for detected traffic light result. |
-| `external_tl_state_timeout` | double | [s] time out for external traffic input         |
-| `yellow_lamp_period`        | double | [s] time for yellow lamp                        |
-| `enable_pass_judge`         | bool   | [-] whether to use pass judge                   |
+| Parameter            | Type   | Description                                     |
+| -------------------- | ------ | ----------------------------------------------- |
+| `stop_margin`        | double | [m] margin before stop point                    |
+| `tl_state_timeout`   | double | [s] time out for detected traffic light result. |
+| `yellow_lamp_period` | double | [s] time for yellow lamp                        |
+| `enable_pass_judge`  | bool   | [-] whether to use pass judge                   |
 
 #### Flowchart
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

## Related links

launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/296

## Tests performed

In Psim

## Interface changes

Removed deprecated topic `~/input/external_{intersection, crosswalk, traffic_light}_status`.

## Effects on system behavior

No influence on current system configuration

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
