### PR TITLE
fix(planning_test_utils): fix build error

### DIFF
--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
@@ -334,7 +334,7 @@ void publishScenarioData(
 template <typename T>
 void createSubscription(
   rclcpp::Node::SharedPtr test_node, std::string topic_name,
-  std::function<void(const typename T::SharedPtr)> callback,
+  std::function<void(const typename T::ConstSharedPtr)> callback,
   std::shared_ptr<rclcpp::Subscription<T>> & subscriber)
 {
   if constexpr (std::is_same_v<T, Trajectory>) {
@@ -350,7 +350,7 @@ void setSubscriber(
   std::shared_ptr<rclcpp::Subscription<T>> & subscriber, size_t & count)
 {
   createSubscription(
-    test_node, topic_name, [&count](const typename T::SharedPtr) { count++; }, subscriber);
+    test_node, topic_name, [&count](const typename T::ConstSharedPtr) { count++; }, subscriber);
 }
 
 void updateNodeOptions(


### PR DESCRIPTION
## Description

fix build error

```
/home/satoshi/pilot-auto/src/autoware/universe/planning/planning_test_utils/src/planning_interface_test_manager.cpp:317:28:   required from here
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:391:21: error: 'void rclcpp::AnySubscriptionCallback<MessageT, AllocatorT>::set_deprecated(std::function<void(std::shared_ptr<_Yp>)>) [with SetT = autoware_auto_planning_msgs::msg::Path_<std::allocator<void> >; MessageT = autoware_auto_planning_msgs::msg::Path_<std::allocator<void> >; AllocatorT = std::allocator<void>]' is deprecated: use 'void(std::shared_ptr<const MessageT>)' instead [-Werror=deprecated-declarations]
  391 |       set_deprecated(static_cast<typename scbth::callback_type>(callback));
      |       ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:408:3: note: declared here
  408 |   set_deprecated(std::function<void(std::shared_ptr<SetT>)> callback)
```

<!-- Write a brief description of this PR. -->

## Tests performed

Build pass in my pc.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
