### PR TITLE
refactor(mission_planner): merge set route service

### DIFF
--- a/common/component_interface_specs/include/component_interface_specs/planning.hpp
+++ b/common/component_interface_specs/include/component_interface_specs/planning.hpp
@@ -19,10 +19,10 @@
 
 #include <autoware_adapi_v1_msgs/msg/route_state.hpp>
 #include <autoware_adapi_v1_msgs/srv/clear_route.hpp>
+#include <autoware_adapi_v1_msgs/srv/set_route.hpp>
 #include <autoware_adapi_v1_msgs/srv/set_route_points.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <autoware_planning_msgs/srv/set_route.hpp>
 
 namespace planning_interface
 {
@@ -35,7 +35,7 @@ struct SetRoutePoints
 
 struct SetRoute
 {
-  using Service = autoware_planning_msgs::srv::SetRoute;
+  using Service = autoware_adapi_v1_msgs::srv::SetRoute;
   static constexpr char name[] = "/planning/mission_planning/set_route";
 };
 
@@ -47,7 +47,7 @@ struct ChangeRoutePoints
 
 struct ChangeRoute
 {
-  using Service = autoware_planning_msgs::srv::SetRoute;
+  using Service = autoware_adapi_v1_msgs::srv::SetRoute;
   static constexpr char name[] = "/planning/mission_planning/change_route";
 };
 

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -29,9 +29,9 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 | ------------------------------------------------ | ----------------------------------------- | ------------------------------------------- |
 | `/planning/mission_planning/clear_route`         | autoware_adapi_v1_msgs/srv/ClearRoute     | route clear request                         |
 | `/planning/mission_planning/set_route_points`    | autoware_adapi_v1_msgs/srv/SetRoutePoints | route request with pose waypoints           |
-| `/planning/mission_planning/set_route`           | autoware_planning_msgs/srv/SetRoute       | route request with lanelet waypoints        |
+| `/planning/mission_planning/set_route`           | autoware_adapi_v1_msgs/srv/SetRoute       | route request with lanelet waypoints        |
 | `/planning/mission_planning/change_route_points` | autoware_adapi_v1_msgs/srv/SetRoutePoints | route change request with pose waypoints    |
-| `/planning/mission_planning/change_route`        | autoware_planning_msgs/srv/SetRoute       | route change request with lanelet waypoints |
+| `/planning/mission_planning/change_route`        | autoware_adapi_v1_msgs/srv/SetRoute       | route change request with lanelet waypoints |
 
 ### Subscriptions
 

--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -24,26 +24,29 @@
 namespace
 {
 
+using autoware_adapi_v1_msgs::msg::RoutePrimitive;
+using autoware_adapi_v1_msgs::msg::RouteSegment;
 using autoware_planning_msgs::msg::LaneletPrimitive;
 using autoware_planning_msgs::msg::LaneletSegment;
 
-LaneletPrimitive convert(const LaneletPrimitive & p)
+LaneletPrimitive convert(const RoutePrimitive & in)
 {
-  LaneletPrimitive primitive;
-  primitive.id = p.id;
-  primitive.primitive_type = p.primitive_type;
-  return primitive;
+  LaneletPrimitive out;
+  out.id = in.id;
+  out.primitive_type = in.type;
+  return out;
 }
 
-LaneletSegment convert(const LaneletSegment & s)
+LaneletSegment convert(const RouteSegment & in)
 {
-  LaneletSegment segment;
-  segment.preferred_primitive.id = s.preferred_primitive.id;
-  segment.primitives.push_back(convert(s.preferred_primitive));
-  for (const auto & p : s.primitives) {
-    segment.primitives.push_back(convert(p));
+  LaneletSegment out;
+  out.primitives.reserve(in.alternatives.size() + 1);
+  out.primitives.push_back(convert(in.preferred));
+  for (const auto & primitive : in.alternatives) {
+    out.primitives.push_back(convert(primitive));
   }
-  return segment;
+  out.preferred_primitive = convert(in.preferred);
+  return out;
 }
 
 std::array<uint8_t, 16> generate_random_id()

--- a/system/default_ad_api/src/routing.cpp
+++ b/system/default_ad_api/src/routing.cpp
@@ -31,8 +31,7 @@ RoutingNode::RoutingNode(const rclcpp::NodeOptions & options) : Node("routing", 
   adaptor.init_sub(sub_route_, this, &RoutingNode::on_route);
   adaptor.init_cli(cli_clear_route_, group_cli_);
   adaptor.init_srv(srv_clear_route_, this, &RoutingNode::on_clear_route);
-  adaptor.init_cli(cli_set_route_, group_cli_);
-  adaptor.init_srv(srv_set_route_, this, &RoutingNode::on_set_route);
+  adaptor.relay_service(cli_set_route_, srv_set_route_, group_cli_);
   adaptor.relay_service(cli_set_route_points_, srv_set_route_points_, group_cli_);
 
   adaptor.init_cli(cli_operation_mode_, group_cli_);
@@ -80,17 +79,6 @@ void RoutingNode::on_clear_route(
 {
   change_stop_mode();
   *res = *cli_clear_route_->call(req);
-}
-
-void RoutingNode::on_set_route(
-  const autoware_ad_api::routing::SetRoute::Service::Request::SharedPtr req,
-  const autoware_ad_api::routing::SetRoute::Service::Response::SharedPtr res)
-{
-  const auto inner_req = std::make_shared<planning_interface::SetRoute::Service::Request>();
-  *inner_req = conversion::convert_set_route(*req);
-
-  const auto inner_res = cli_set_route_->call(inner_req);
-  component_interface_utils::status::copy(inner_res, res);  // NOLINT cpplint false positive
 }
 
 }  // namespace default_ad_api

--- a/system/default_ad_api/src/routing.hpp
+++ b/system/default_ad_api/src/routing.hpp
@@ -58,9 +58,6 @@ private:
   void on_clear_route(
     const autoware_ad_api::routing::ClearRoute::Service::Request::SharedPtr req,
     const autoware_ad_api::routing::ClearRoute::Service::Response::SharedPtr res);
-  void on_set_route(
-    const autoware_ad_api::routing::SetRoute::Service::Request::SharedPtr req,
-    const autoware_ad_api::routing::SetRoute::Service::Response::SharedPtr res);
 };
 
 }  // namespace default_ad_api

--- a/system/default_ad_api/src/utils/route_conversion.hpp
+++ b/system/default_ad_api/src/utils/route_conversion.hpp
@@ -20,19 +20,15 @@
 #include <autoware_adapi_v1_msgs/msg/route.hpp>
 #include <autoware_adapi_v1_msgs/srv/set_route.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <autoware_planning_msgs/srv/set_route.hpp>
 
 namespace default_ad_api::conversion
 {
 
-using ExternalSetRoute = autoware_adapi_v1_msgs::srv::SetRoute::Request;
-using InternalSetRoute = autoware_planning_msgs::srv::SetRoute::Request;
 using ExternalRoute = autoware_adapi_v1_msgs::msg::Route;
 using InternalRoute = autoware_planning_msgs::msg::LaneletRoute;
 
 ExternalRoute create_empty_route(const rclcpp::Time & stamp);
 ExternalRoute convert_route(const InternalRoute & internal);
-InternalSetRoute convert_set_route(const ExternalSetRoute & external);
 
 }  // namespace default_ad_api::conversion
 


### PR DESCRIPTION
## Description

From this comment: https://github.com/autowarefoundation/autoware.universe/pull/3396#issuecomment-1506993820. When we were using HADMapRoute, there was a type conversion problem, but now it is unified with LaneletRoute. So remove unnecessary services.

## Tests performed

Check if the route can be set in the simple planning simulator.

## Effects on system behavior

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
