### PR TITLE
feat(behavior_path_planner): add dynamic obstacle avoidance module

### DIFF
--- a/launch/tier4_planning_launch/launch/planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/planning.launch.xml
@@ -21,6 +21,7 @@
   <!-- behavior path planner -->
   <arg name="side_shift_param_path"/>
   <arg name="avoidance_param_path"/>
+  <arg name="dynamic_avoidance_param_path"/>
   <arg name="lane_change_param_path"/>
   <arg name="goal_planner_param_path"/>
   <arg name="pull_out_param_path"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -49,6 +49,8 @@ def launch_setup(context, *args, **kwargs):
         avoidance_param = yaml.safe_load(f)["/**"]["ros__parameters"]
     with open(LaunchConfiguration("avoidance_by_lc_param_path").perform(context), "r") as f:
         avoidance_by_lc_param = yaml.safe_load(f)["/**"]["ros__parameters"]
+    with open(LaunchConfiguration("dynamic_avoidance_param_path").perform(context), "r") as f:
+        dynamic_avoidance_param = yaml.safe_load(f)["/**"]["ros__parameters"]
     with open(LaunchConfiguration("lane_change_param_path").perform(context), "r") as f:
         lane_change_param = yaml.safe_load(f)["/**"]["ros__parameters"]
     with open(LaunchConfiguration("goal_planner_param_path").perform(context), "r") as f:
@@ -90,6 +92,7 @@ def launch_setup(context, *args, **kwargs):
             side_shift_param,
             avoidance_param,
             avoidance_by_lc_param,
+            dynamic_avoidance_param,
             lane_change_param,
             goal_planner_param,
             pull_out_param,

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -15,6 +15,7 @@ set(common_src
   src/scene_module/scene_module_visitor.cpp
   src/scene_module/avoidance/avoidance_module.cpp
   src/scene_module/avoidance_by_lc/module.cpp
+  src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
   src/scene_module/pull_out/pull_out_module.cpp
   src/scene_module/goal_planner/goal_planner_module.cpp
   src/scene_module/side_shift/side_shift_module.cpp
@@ -68,6 +69,7 @@ else()
     src/planner_manager.cpp
     src/scene_module/avoidance/manager.cpp
     src/scene_module/avoidance_by_lc/manager.cpp
+    src/scene_module/dynamic_avoidance/manager.cpp
     src/scene_module/pull_out/manager.cpp
     src/scene_module/goal_planner/manager.cpp
     src/scene_module/side_shift/manager.cpp

--- a/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -1,0 +1,20 @@
+/**:
+  ros__parameters:
+    dynamic_avoidance:
+      # avoidance is performed for the object type with true
+      target_object:
+        car: true
+        truck: true
+        bus: true
+        trailer: true
+        unknown: false
+        bicycle: false
+        motorcycle: true
+        pedestrian: false
+
+        min_obstacle_vel: 1.0 # [m/s]
+
+      drivable_area_generation:
+        lat_offset_from_obstacle: 0.8 # [m]
+        time_to_avoid: 5.0 # [s]
+        max_lat_offset_to_avoid: 1.0 # [m]

--- a/planning/behavior_path_planner/config/scene_module_manager.param.yaml
+++ b/planning/behavior_path_planner/config/scene_module_manager.param.yaml
@@ -65,3 +65,10 @@
       enable_simultaneous_execution_as_candidate_module: false
       priority: 3
       max_module_size: 1
+
+    dynamic_avoidance:
+      enable_module: false
+      enable_simultaneous_execution_as_approved_module: true
+      enable_simultaneous_execution_as_candidate_module: true
+      priority: 7
+      max_module_size: 1

--- a/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
@@ -7,7 +7,7 @@ Static obstacles such as parked vehicles are dealt with by the avoidance module.
 
 This module is under development.
 In the current implementation, the dynamic obstacles to avoid is extracted from the drivable area.
-Then the motion planner, in detail obstacle_avoidance_planner, will generate an avoiging trajectory.
+Then the motion planner, in detail obstacle_avoidance_planner, will generate an avoiding trajectory.
 
 ### Parameters
 

--- a/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
@@ -19,4 +19,4 @@ This module is under development.
 | target_object.min_obstacle_vel                    | [m/s] | double | Minimum obstacle velocity to avoid      | 1.0           |
 | drivable_area_generation.lat_offset_from_obstacle | [m]   | double | Lateral offset to avoid from obstacles  | 0.8           |
 | drivable_area_generation.time_to_avoid            | [s]   | double | Elapsed time for avoiding an obstacle   | 5.0           |
-| drivable_area_generation.max_lat_offset_to_avoi   | [m]   | double | Maximum lateral offset to avoid         | 0.5           |
+| drivable_area_generation.max_lat_offset_to_avoid  | [m]   | double | Maximum lateral offset to avoid         | 0.5           |

--- a/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
@@ -1,13 +1,13 @@
 # Dynamic avoidance design
 
+## Purpose / Role
+
 This is a module designed for avoiding obstacles which are running.
 Static obstacles such as parked vehicles are dealt with by the avoidance module.
 
-## Purpose / Role
-
-This module is designed for rule-based avoidance that is easy for developers to design its behavior. It generates avoidance path parameterized by intuitive parameters such as lateral jerk and avoidance distance margin. This makes it possible to pre-define avoidance behavior.
-
 This module is under development.
+In the current implementation, the dynamic obstacles to avoid is extracted from the drivable area.
+Then the motion planner, in detail obstacle_avoidance_planner, will generate an avoiging trajectory.
 
 ### Parameters
 

--- a/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
@@ -1,0 +1,22 @@
+# Dynamic avoidance design
+
+This is a module designed for avoiding obstacles which are running.
+Static obstacles such as parked vehicles are dealt with by the avoidance module.
+
+## Purpose / Role
+
+This module is designed for rule-based avoidance that is easy for developers to design its behavior. It generates avoidance path parameterized by intuitive parameters such as lateral jerk and avoidance distance margin. This makes it possible to pre-define avoidance behavior.
+
+This module is under development.
+
+### Parameters
+
+| Name                                              | Unit  | Type   | Description                             | Default value |
+| :------------------------------------------------ | :---- | :----- | :-------------------------------------- | :------------ |
+| target_object.car                                 | [-]   | bool   | The flag whether to avoid cars or not   | true          |
+| target_object.truck                               | [-]   | bool   | The flag whether to avoid trucks or not | true          |
+| ...                                               | [-]   | bool   | ...                                     | ...           |
+| target_object.min_obstacle_vel                    | [m/s] | double | Minimum obstacle velocity to avoid      | 1.0           |
+| drivable_area_generation.lat_offset_from_obstacle | [m]   | double | Lateral offset to avoid from obstacles  | 0.8           |
+| drivable_area_generation.time_to_avoid            | [s]   | double | Elapsed time for avoiding an obstacle   | 5.0           |
+| drivable_area_generation.max_lat_offset_to_avoi   | [m]   | double | Maximum lateral offset to avoid         | 0.5           |

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -21,6 +21,7 @@
 #ifdef USE_OLD_ARCHITECTURE
 #include "behavior_path_planner/behavior_tree_manager.hpp"
 #include "behavior_path_planner/scene_module/avoidance/avoidance_module.hpp"
+#include "behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp"
 #include "behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp"
 #include "behavior_path_planner/scene_module/lane_change/lane_change_module.hpp"
 #include "behavior_path_planner/scene_module/lane_following/lane_following_module.hpp"
@@ -30,6 +31,7 @@
 #include "behavior_path_planner/planner_manager.hpp"
 #include "behavior_path_planner/scene_module/avoidance/manager.hpp"
 #include "behavior_path_planner/scene_module/avoidance_by_lc/manager.hpp"
+#include "behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp"
 #include "behavior_path_planner/scene_module/goal_planner/manager.hpp"
 #include "behavior_path_planner/scene_module/lane_change/manager.hpp"
 #include "behavior_path_planner/scene_module/pull_out/manager.hpp"
@@ -75,6 +77,7 @@ namespace behavior_path_planner
 {
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_auto_mapping_msgs::msg::HADMapBin;
+using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::Path;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
@@ -149,6 +152,7 @@ private:
   // parameters
   std::shared_ptr<AvoidanceParameters> avoidance_param_ptr_;
   std::shared_ptr<AvoidanceByLCParameters> avoidance_by_lc_param_ptr_;
+  std::shared_ptr<DynamicAvoidanceParameters> dynamic_avoidance_param_ptr_;
   std::shared_ptr<SideShiftParameters> side_shift_param_ptr_;
   std::shared_ptr<LaneChangeParameters> lane_change_param_ptr_;
   std::shared_ptr<PullOutParameters> pull_out_param_ptr_;
@@ -161,6 +165,7 @@ private:
 #endif
 
   AvoidanceParameters getAvoidanceParam();
+  DynamicAvoidanceParameters getDynamicAvoidanceParam();
   LaneChangeParameters getLaneChangeParam();
   SideShiftParameters getSideShiftParam();
   GoalPlannerParameters getGoalPlannerParam();

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -43,6 +43,7 @@
 namespace behavior_path_planner
 {
 using autoware_adapi_v1_msgs::msg::OperationModeState;
+using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -35,6 +35,7 @@ struct BehaviorPathPlannerParameters
 
   ModuleConfigParameters config_avoidance;
   ModuleConfigParameters config_avoidance_by_lc;
+  ModuleConfigParameters config_dynamic_avoidance;
   ModuleConfigParameters config_pull_out;
   ModuleConfigParameters config_goal_planner;
   ModuleConfigParameters config_side_shift;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -1,0 +1,100 @@
+// Copyright 2021 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__DYNAMIC_AVOIDANCE_MODULE_HPP_
+#define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__DYNAMIC_AVOIDANCE_MODULE_HPP_
+
+#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_auto_perception_msgs/msg/predicted_object.hpp>
+#include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace behavior_path_planner
+{
+struct DynamicAvoidanceParameters
+{
+  bool avoid_car{true};
+  bool avoid_truck{true};
+  bool avoid_bus{true};
+  bool avoid_trailer{true};
+  bool avoid_unknown{false};
+  bool avoid_bicycle{false};
+  bool avoid_motorcycle{false};
+  bool avoid_pedestrian{false};
+};
+
+class DynamicAvoidanceModule : public SceneModuleInterface
+{
+public:
+  struct DynamicAvoidanceObject
+  {
+    explicit DynamicAvoidanceObject(const PredictedObject & predicted_object)
+    : pose(predicted_object.kinematics.initial_pose_with_covariance.pose),
+      shape(predicted_object.shape)
+    {
+    }
+
+    geometry_msgs::msg::Pose pose;
+    autoware_auto_perception_msgs::msg::Shape shape;
+  };
+
+#ifdef USE_OLD_ARCHITECTURE
+  DynamicAvoidanceModule(
+    const std::string & name, rclcpp::Node & node,
+    std::shared_ptr<DynamicAvoidanceParameters> parameters);
+#else
+  DynamicAvoidanceModule(
+    const std::string & name, rclcpp::Node & node,
+    std::shared_ptr<DynamicAvoidanceParameters> parameters,
+    const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map);
+#endif
+
+  bool isExecutionRequested() const override;
+  bool isExecutionReady() const override;
+  ModuleStatus updateState() override;
+  ModuleStatus getNodeStatusWhileWaitingApproval() const override { return ModuleStatus::SUCCESS; }
+  BehaviorModuleOutput plan() override;
+  CandidateOutput planCandidate() const override;
+  BehaviorModuleOutput planWaitingApproval() override;
+  void updateData() override;
+  void acceptVisitor(
+    [[maybe_unused]] const std::shared_ptr<SceneModuleVisitor> & visitor) const override
+  {
+  }
+
+private:
+  std::vector<DynamicAvoidanceObject> calcTargetObjects() const;
+  lanelet::ConstLanelets getAdjacentLanes(
+    const double forward_distance, const double backward_distance) const;
+  tier4_autoware_utils::Polygon2d calcDynamicObstaclesPolygon(
+    const PathWithLaneId & path, const DynamicAvoidanceObject & object);
+
+  std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject> target_objects_;
+  std::shared_ptr<DynamicAvoidanceParameters> parameters_;
+};
+}  // namespace behavior_path_planner
+
+#endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__DYNAMIC_AVOIDANCE_MODULE_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -50,6 +51,7 @@ struct DynamicAvoidanceParameters
   // drivable area generation
   double lat_offset_from_obstacle{0.0};
   double time_to_avoid{0.0};
+  double max_lat_offset_to_avoid{0.0};
 };
 
 class DynamicAvoidanceModule : public SceneModuleInterface
@@ -103,7 +105,7 @@ private:
   std::vector<DynamicAvoidanceObject> calcTargetObjects() const;
   lanelet::ConstLanelets getAdjacentLanes(
     const double forward_distance, const double backward_distance) const;
-  tier4_autoware_utils::Polygon2d calcDynamicObstaclePolygon(
+  std::optional<tier4_autoware_utils::Polygon2d> calcDynamicObstaclePolygon(
     const PathWithLaneId & path, const DynamicAvoidanceObject & object) const;
 
   std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject> target_objects_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
@@ -1,0 +1,53 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__MANAGER_HPP_
+#define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__MANAGER_HPP_
+
+#include "behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp"
+#include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace behavior_path_planner
+{
+
+class DynamicAvoidanceModuleManager : public SceneModuleManagerInterface
+{
+public:
+  DynamicAvoidanceModuleManager(
+    rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
+    const std::shared_ptr<DynamicAvoidanceParameters> & parameters);
+
+  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  {
+    return std::make_shared<DynamicAvoidanceModule>(
+      name_, *node_, parameters_, rtc_interface_ptr_map_);
+  }
+
+  void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
+
+private:
+  std::shared_ptr<DynamicAvoidanceParameters> parameters_;
+  std::vector<std::shared_ptr<DynamicAvoidanceModule>> registered_modules_;
+};
+
+}  // namespace behavior_path_planner
+
+#endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__MANAGER_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -85,10 +85,8 @@ public:
   {
     module_ptr->setData(planner_data_);
     module_ptr->setPreviousModuleOutput(previous_module_output);
-    std::cerr << "PO2" << std::endl;
     module_ptr->updateData();
 
-    std::cerr << "PO1" << std::endl;
     return module_ptr->isExecutionRequested();
   }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -85,8 +85,10 @@ public:
   {
     module_ptr->setData(planner_data_);
     module_ptr->setPreviousModuleOutput(previous_module_output);
+    std::cerr << "PO2" << std::endl;
     module_ptr->updateData();
 
+    std::cerr << "PO1" << std::endl;
     return module_ptr->isExecutionRequested();
   }
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -674,6 +674,13 @@ DynamicAvoidanceParameters BehaviorPathPlannerNode::getDynamicAvoidanceParam()
     p.avoid_bicycle = declare_parameter<bool>(ns + "bicycle");
     p.avoid_motorcycle = declare_parameter<bool>(ns + "motorcycle");
     p.avoid_pedestrian = declare_parameter<bool>(ns + "pedestrian");
+    p.min_obstacle_vel = declare_parameter<double>(ns + "min_obstacle_vel");
+  }
+
+  {  // drivable_area_generation
+    std::string ns = "dynamic_avoidance.drivable_area_generation.";
+    p.lat_offset_from_obstacle = declare_parameter<double>(ns + "lat_offset_from_obstacle");
+    p.time_to_avoid = declare_parameter<double>(ns + "time_to_avoid");
   }
 
   return p;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -154,10 +154,6 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       "Avoidance", create_publisher<Path>(path_candidate_name_space + "avoidance", 1));
     bt_manager_->registerSceneModule(avoidance_module);
 
-    auto dynamic_avoidance_module = std::make_shared<DynamicAvoidanceModule>(
-      "DynamicAvoidance", *this, dynamic_avoidance_param_ptr_);
-    bt_manager_->registerSceneModule(dynamic_avoidance_module);
-
     auto lane_following_module = std::make_shared<LaneFollowingModule>("LaneFollowing", *this);
     bt_manager_->registerSceneModule(lane_following_module);
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -681,6 +681,7 @@ DynamicAvoidanceParameters BehaviorPathPlannerNode::getDynamicAvoidanceParam()
     std::string ns = "dynamic_avoidance.drivable_area_generation.";
     p.lat_offset_from_obstacle = declare_parameter<double>(ns + "lat_offset_from_obstacle");
     p.time_to_avoid = declare_parameter<double>(ns + "time_to_avoid");
+    p.max_lat_offset_to_avoid = declare_parameter<double>(ns + "max_lat_offset_to_avoid");
   }
 
   return p;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -114,7 +114,7 @@ DynamicAvoidanceModule::DynamicAvoidanceModule(
 
 bool DynamicAvoidanceModule::isExecutionRequested() const
 {
-  RCLCPP_INFO(getLogger(), "DYNAMIC AVOIDANCE isExecutionRequested.");
+  RCLCPP_DEBUG(getLogger(), "DYNAMIC AVOIDANCE isExecutionRequested.");
 
   // check if the ego is driving forward
   const auto is_driving_forward = [&]() {
@@ -140,7 +140,7 @@ bool DynamicAvoidanceModule::isExecutionRequested() const
 
 bool DynamicAvoidanceModule::isExecutionReady() const
 {
-  RCLCPP_INFO(getLogger(), "DYNAMIC AVOIDANCE isExecutionReady.");
+  RCLCPP_DEBUG(getLogger(), "DYNAMIC AVOIDANCE isExecutionReady.");
   return true;
 }
 
@@ -175,7 +175,7 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
   const auto target_drivable_lanes =
     getNonOverlappingExpandedLanes(*reference_path, drivable_lanes);
 
-  // for old arhictecture
+  // for old architecture
   utils::generateDrivableArea(
     *reference_path, target_drivable_lanes, p.vehicle_length, planner_data_);
 
@@ -192,7 +192,7 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
   output.path = reference_path;
   output.reference_path = reference_path;
 
-  // for new arhictecture
+  // for new architecture
   output.drivable_area_info.drivable_lanes = utils::combineDrivableLanes(
     getPreviousModuleOutput().drivable_area_info.drivable_lanes, target_drivable_lanes);
 

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -1,0 +1,341 @@
+// Copyright 2021 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp"
+
+#include "behavior_path_planner/utils/path_utils.hpp"
+#include "behavior_path_planner/utils/utils.hpp"
+
+#include <lanelet2_extension/utility/message_conversion.hpp>
+#include <lanelet2_extension/utility/utilities.hpp>
+#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace behavior_path_planner
+{
+namespace
+{
+bool isCentroidWithinLanelets(
+  const PredictedObject & object, const lanelet::ConstLanelets & target_lanelets)
+{
+  if (target_lanelets.empty()) {
+    return false;
+  }
+
+  const auto & object_pos = object.kinematics.initial_pose_with_covariance.pose.position;
+  lanelet::BasicPoint2d object_centroid(object_pos.x, object_pos.y);
+
+  for (const auto & llt : target_lanelets) {
+    if (boost::geometry::within(object_centroid, llt.polygon2d().basicPolygon())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+std::vector<PredictedObject> getObjectsInLanes(
+  const std::vector<PredictedObject> & objects, const lanelet::ConstLanelets & target_lanes)
+{
+  std::vector<PredictedObject> target_objects;
+  for (const auto & object : objects) {
+    if (isCentroidWithinLanelets(object, target_lanes)) {
+      target_objects.push_back(object);
+    }
+  }
+
+  return target_objects;
+}
+
+geometry_msgs::msg::Point toGeometryPoint(const tier4_autoware_utils::Point2d & point)
+{
+  geometry_msgs::msg::Point geom_obj_point;
+  geom_obj_point.x = point.x();
+  geom_obj_point.y = point.y();
+  return geom_obj_point;
+}
+}  // namespace
+
+#ifdef USE_OLD_ARCHITECTURE
+DynamicAvoidanceModule::DynamicAvoidanceModule(
+  const std::string & name, rclcpp::Node & node,
+  std::shared_ptr<DynamicAvoidanceParameters> parameters)
+: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {""})},
+  parameters_{std::move(parameters)}
+#else
+DynamicAvoidanceModule::DynamicAvoidanceModule(
+  const std::string & name, rclcpp::Node & node,
+  std::shared_ptr<DynamicAvoidanceParameters> parameters,
+  const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map)
+: SceneModuleInterface{name, node, rtc_interface_ptr_map}, parameters_{std::move(parameters)}
+#endif
+{
+}
+
+bool DynamicAvoidanceModule::isExecutionRequested() const
+{
+  RCLCPP_INFO(getLogger(), "DYNAMIC AVOIDANCE isExecutionRequested.");
+
+  // check if the ego is driving forward
+  const auto is_driving_forward = [&]() {
+    if (!getPreviousModuleOutput().path || getPreviousModuleOutput().path->points.size() < 2) {
+      return false;
+    }
+    const auto is_driving_forward =
+      motion_utils::isDrivingForward(getPreviousModuleOutput().path->points);
+    if (!is_driving_forward) {
+      return false;
+    }
+    return *is_driving_forward;
+  }();
+
+  // check if the planner is already running
+  if (current_state_ == ModuleStatus::RUNNING) {
+    return true;
+  }
+
+  // check if there is target objects to avoid
+  return !target_objects_.empty();
+}
+
+bool DynamicAvoidanceModule::isExecutionReady() const
+{
+  RCLCPP_INFO(getLogger(), "DYNAMIC AVOIDANCE isExecutionReady.");
+  return true;
+}
+
+void DynamicAvoidanceModule::updateData()
+{
+  std::cerr << "updateData" << std::endl;
+  target_objects_ = calcTargetObjects();
+}
+
+ModuleStatus DynamicAvoidanceModule::updateState()
+{
+  const bool has_avoidance_target = !target_objects_.empty();
+
+  if (!has_avoidance_target) {
+    current_state_ = ModuleStatus::SUCCESS;
+  } else {
+    current_state_ = ModuleStatus::RUNNING;
+  }
+
+  return current_state_;
+}
+
+BehaviorModuleOutput DynamicAvoidanceModule::plan()
+{
+  // generate reference path
+  auto reference_path = utils::generateCenterLinePath(planner_data_);
+
+  // TODO(murooka) implement here
+  // generate drivable area
+  const auto & p = planner_data_->parameters;
+
+  const auto current_lanes = utils::getCurrentLanes(planner_data_);
+  const auto drivable_lanes = utils::generateDrivableLanes(current_lanes);
+  const auto target_drivable_lanes =
+    getNonOverlappingExpandedLanes(*reference_path, drivable_lanes);
+
+  // for old arhictecture
+  utils::generateDrivableArea(
+    *reference_path, target_drivable_lanes, p.vehicle_length, planner_data_);
+
+  std::vector<tier4_autoware_utils::Polygon2d> obstacle_polys;
+  for (const auto & object : target_objects_) {
+    const auto obstacle_poly = calcDynamicObstaclesPolygon(*reference_path, object);
+    obstacle_polys.push_back(obstacle_poly);
+  }
+
+  BehaviorModuleOutput output;
+  output.path = reference_path;
+  output.reference_path = reference_path;
+
+  // for new arhictecture
+  output.drivable_area_info.drivable_lanes = target_drivable_lanes;
+  output.drivable_area_info.obstacle_polys = obstacle_polys;
+
+  return output;
+}
+
+CandidateOutput DynamicAvoidanceModule::planCandidate() const
+{
+  auto candidate_path = utils::generateCenterLinePath(planner_data_);
+  return CandidateOutput(*candidate_path);
+}
+
+BehaviorModuleOutput DynamicAvoidanceModule::planWaitingApproval()
+{
+  BehaviorModuleOutput out = plan();
+  return out;
+}
+
+std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject>
+DynamicAvoidanceModule::calcTargetObjects() const
+{
+  // calculate target lanes to filter obstacles
+  const auto target_lanes = getAdjacentLanes(100.0, 5.0);
+
+  // calculate obstacles for dynamic avoidance
+  const auto & predicted_objects = planner_data_->dynamic_object->objects;
+  const auto target_predicted_objects = getObjectsInLanes(predicted_objects, target_lanes);
+  std::cerr << target_predicted_objects.size() << std::endl;
+
+  // convert predicted objects to dynamic avoidance objects
+  std::vector<DynamicAvoidanceObject> target_avoidance_objects;
+  for (const auto & predicted_object : target_predicted_objects) {
+    target_avoidance_objects.push_back(DynamicAvoidanceObject(predicted_object));
+  }
+
+  return target_avoidance_objects;
+}
+
+lanelet::ConstLanelets DynamicAvoidanceModule::getAdjacentLanes(
+  const double forward_distance, const double backward_distance) const
+{
+  const auto & rh = planner_data_->route_handler;
+
+  lanelet::ConstLanelet current_lane;
+  if (!rh->getClosestLaneletWithinRoute(getEgoPose(), &current_lane)) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
+      "failed to find closest lanelet within route!!!");
+    return {};
+  }
+
+  const auto ego_succeeding_lanes =
+    rh->getLaneletSequence(current_lane, getEgoPose(), backward_distance, forward_distance);
+
+  lanelet::ConstLanelets target_lanes;
+  for (const auto & lane : ego_succeeding_lanes) {
+    const auto opt_left_lane = rh->getLeftLanelet(lane);
+    if (opt_left_lane) {
+      target_lanes.push_back(opt_left_lane.get());
+    }
+
+    const auto opt_right_lane = rh->getRightLanelet(lane);
+    if (opt_right_lane) {
+      target_lanes.push_back(opt_right_lane.get());
+    }
+
+    const auto right_opposite_lanes = rh->getRightOppositeLanelets(lane);
+    if (!right_opposite_lanes.empty()) {
+      target_lanes.push_back(right_opposite_lanes.front());
+    }
+  }
+
+  return target_lanes;
+}
+
+/*
+void boundDynamicObstacles(PathWithLaneId & path, const DynamicAvoidanceObject & object)
+{
+  // calculate lat offset
+  const double lat_offset = motion_utils::calcLateralOffset(reference_path, object.pose.position);
+  const bool is_left = 0.0 < lat_offset;
+
+  auto & target_bound = is_left ? reference_path.left_bound : reference_path.right_bound;
+  const size_t obj_seg_idx = motion_utils::findNearsetSegmentIndex(target_bound,
+object.pose.position);
+
+  // calculate front and back point
+  const auto obj_points = tier4_autoware_utils::toPolygon2d(object.shape);
+  std::vector<double> obj_lon_offset_vec;
+  for (const auto & obj_point : obj_points.outer()) {
+    const lon_offset = motion_utils::calcLongitudinalOffsetToSement(target_bound, obj_seg_idx,
+obj_point); obj_lon_offset_vec.push_back(lon_offset);
+  }
+  const auto itr = std::minmax_element(obj_lon_offset_vec.begin(), obj_lon_offset_vec.end());
+  const size_t front_idx = std::distance(obj_lon_offset_vec.begin(), itr.first);
+  const size_t back_idx = std::distance(obj_lon_offset_vec.begin(), itr.second);
+  const auto obj_front_pos = obj_points.outer().at(front_idx);
+  const auto obj_back_pos = obj_points.outer().at(back_idx);
+
+  const size_t front_seg_idx = motion_utils::insertTargetPoint(-3.0, obj_front_pos, target_bound);
+  const size_t back_seg_idx = motion_utils::insertTargetPoint(3.0, obj_back_pos, target_bound);
+
+  for (size_t i = front_seg_idx; i < back_seg_idx) {
+    target_bound.at(i) =
+  }
+}
+*/
+
+tier4_autoware_utils::Polygon2d DynamicAvoidanceModule::calcDynamicObstaclesPolygon(
+  const PathWithLaneId & path, const DynamicAvoidanceObject & object)
+{
+  // calculate lat offset
+  const size_t obj_seg_idx =
+    motion_utils::findNearestSegmentIndex(path.points, object.pose.position);
+  const double obj_lat_offset =
+    motion_utils::calcLateralOffset(path.points, object.pose.position, obj_seg_idx);
+  const bool is_left = 0.0 < obj_lat_offset;
+
+  const auto [min_obj_lat_offset, min_obj_lat_offset_point] = [&]() {
+    const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
+    std::vector<double> obj_lat_offset_vec;
+    for (size_t i = 0; i < obj_points.outer().size(); ++i) {
+      const auto geom_obj_point = toGeometryPoint(obj_points.outer().at(i));
+      const size_t obj_point_seg_idx =
+        motion_utils::findNearestSegmentIndex(path.points, geom_obj_point);
+      const double obj_point_lat_offset =
+        motion_utils::calcLateralOffset(path.points, geom_obj_point, obj_point_seg_idx);
+      obj_lat_offset_vec.push_back(obj_point_lat_offset);
+    }
+    const size_t min_obj_lat_offset_idx = std::distance(
+      obj_lat_offset_vec.begin(),
+      std::min_element(obj_lat_offset_vec.begin(), obj_lat_offset_vec.end()));
+
+    return std::make_pair(
+      obj_lat_offset_vec.at(min_obj_lat_offset_idx),
+      toGeometryPoint(obj_points.outer().at(min_obj_lat_offset_idx)));
+  }();
+
+  // calculate object bound
+  const size_t obj_front_seg_idx =
+    motion_utils::findNearestSegmentIndex(path.points, min_obj_lat_offset_point);
+  std::vector<geometry_msgs::msg::Point> obj_bound_points;
+  for (size_t i = obj_front_seg_idx; i < obj_front_seg_idx; ++i) {
+    obj_bound_points.push_back(tier4_autoware_utils::calcOffsetPose(
+                                 path.points.at(i).point.pose, 0.0, min_obj_lat_offset, 0.0)
+                                 .position);
+  }
+
+  // convert obj_bound_points to obj_polygon
+  tier4_autoware_utils::Polygon2d obj_poly;
+  for (size_t i = 0; i < obj_bound_points.size(); ++i) {
+    const auto obj_poly_point =
+      tier4_autoware_utils::Point2d(obj_bound_points.at(i).x, obj_bound_points.at(i).y);
+    obj_poly.outer().push_back(obj_poly_point);
+  }
+
+  /*
+  auto & target_bound = is_left ? path.left_bound : path.right_bound;
+  const size_t obj_seg_idx = motion_utils::findNearsetSegmentIndex(target_bound,
+  object.pose.position);
+
+  // calculate front and back point
+  std::vector<double> obj_lon_offset_vec;
+  for (const auto & obj_point : obj_points.outer()) {
+    const lon_offset = motion_utils::calcLongitudinalOffsetToSement(target_bound, obj_seg_idx,
+  obj_point); obj_lon_offset_vec.push_back(lon_offset);
+  }
+  */
+}
+}  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -1,0 +1,47 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace behavior_path_planner
+{
+
+DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
+  rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
+  const std::shared_ptr<DynamicAvoidanceParameters> & parameters)
+: SceneModuleManagerInterface(node, name, config), parameters_{parameters}
+{
+  rtc_interface_ = std::make_shared<RTCInterface>(node, name);
+}
+
+void DynamicAvoidanceModuleManager::updateModuleParams(
+  [[maybe_unused]] const std::vector<rclcpp::Parameter> & parameters)
+{
+  using tier4_autoware_utils::updateParam;
+
+  auto & p = parameters_;
+
+  [[maybe_unused]] std::string ns = name_ + ".";
+
+  std::for_each(registered_modules_.begin(), registered_modules_.end(), [&p](const auto & m) {
+    m->updateModuleParams(p);
+  });
+}
+}  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -26,9 +26,8 @@ namespace behavior_path_planner
 DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
   rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
   const std::shared_ptr<DynamicAvoidanceParameters> & parameters)
-: SceneModuleManagerInterface(node, name, config), parameters_{parameters}
+: SceneModuleManagerInterface(node, name, config, {""}), parameters_{parameters}
 {
-  rtc_interface_ = std::make_shared<RTCInterface>(node, name);
 }
 
 void DynamicAvoidanceModuleManager::updateModuleParams(

--- a/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
@@ -52,18 +52,20 @@ std::shared_ptr<BehaviorPathPlannerNode> generateNode()
     "bt_tree_config_path", behavior_path_planner_dir + "/config/behavior_path_planner_tree.xml");
 
   test_utils::updateNodeOptions(
-    node_options, {planning_test_utils_dir + "/config/test_common.param.yaml",
-                   planning_test_utils_dir + "/config/test_nearest_search.param.yaml",
-                   planning_test_utils_dir + "/config/test_vehicle_info.param.yaml",
-                   behavior_path_planner_dir + "/config/behavior_path_planner.param.yaml",
-                   behavior_path_planner_dir + "/config/drivable_area_expansion.param.yaml",
-                   behavior_path_planner_dir + "/config/scene_module_manager.param.yaml",
-                   behavior_path_planner_dir + "/config/avoidance/avoidance.param.yaml",
-                   behavior_path_planner_dir + "/config/lane_change/lane_change.param.yaml",
-                   behavior_path_planner_dir + "/config/pull_out/pull_out.param.yaml",
-                   behavior_path_planner_dir + "/config/goal_planner/goal_planner.param.yaml",
-                   behavior_path_planner_dir + "/config/avoidance_by_lc/avoidance_by_lc.param.yaml",
-                   behavior_path_planner_dir + "/config/side_shift/side_shift.param.yaml"});
+    node_options,
+    {planning_test_utils_dir + "/config/test_common.param.yaml",
+     planning_test_utils_dir + "/config/test_nearest_search.param.yaml",
+     planning_test_utils_dir + "/config/test_vehicle_info.param.yaml",
+     behavior_path_planner_dir + "/config/behavior_path_planner.param.yaml",
+     behavior_path_planner_dir + "/config/drivable_area_expansion.param.yaml",
+     behavior_path_planner_dir + "/config/scene_module_manager.param.yaml",
+     behavior_path_planner_dir + "/config/avoidance/avoidance.param.yaml",
+     behavior_path_planner_dir + "/config/dynamic_avoidance/dynamic_avoidance.param.yaml",
+     behavior_path_planner_dir + "/config/lane_change/lane_change.param.yaml",
+     behavior_path_planner_dir + "/config/pull_out/pull_out.param.yaml",
+     behavior_path_planner_dir + "/config/goal_planner/goal_planner.param.yaml",
+     behavior_path_planner_dir + "/config/avoidance_by_lc/avoidance_by_lc.param.yaml",
+     behavior_path_planner_dir + "/config/side_shift/side_shift.param.yaml"});
 
   return std::make_shared<BehaviorPathPlannerNode>(node_options);
 }


### PR DESCRIPTION
## Description

**This feature is under development, and disabled by default.**
NOTE:
- This module is supposed to be used with a new behavior_path_planner architecture
- The following parameter should be false since the trajectory may be outside the drivable area in some cases.
https://github.com/autowarefoundation/autoware_launch/blob/5910b08f7742d78ac5f1ade182d470032e40e398/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml#L7
- This module does not require RTC's approval to execute.

Added a dynamic avoidance module for avoiding dynamic obstacles which are running on the road.
In the current implementation, by extracting the dynamic obstacles to avoid from the drivable area, the motion planner plans the trajectory to avoid the obstacles.

[Screencast from 2023年04月27日 17時49分10秒.webm](https://user-images.githubusercontent.com/20228327/234811180-b429dcee-e766-4993-80e8-6d155be138b1.webm)

TODO
- The trajectory shape ahead of the ego is a little bit jerky.
    - Needs to improve the motion planner which generates the trajectory
    - Needs to improve the lateral controller not to be so sensitive to the trajectory shape.
- The dynamic avoidance module has to be assured to launch with the avoidance or lane_change modules simultaneously.
- Complicated cases cannot be dealt with by the current implementation
    - e.g. The case where there are obstacles on the left and right side very close to the ego's trajectory.

small TODOs
- Decision-making to avoid or not can be improved
    - not to avoid obstacles that have not been avoided.
    - not to conflict with the decision from the cruise and stop planner.
<!-- Write a brief description of this PR. -->

## Related links

launcher: https://github.com/autowarefoundation/autoware_launch/pull/299

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
In the planning simulator, in a simple case, it's working correctly.
Though the steering controller is a little bit unstable.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
Nothing

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Dynamic avoidance feature can be enabled.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
