### PR TITLE
docs: remove typos and add cspell ignore

### DIFF
--- a/localization/ndt_scan_matcher/README.md
+++ b/localization/ndt_scan_matcher/README.md
@@ -223,14 +223,14 @@ Note that the dynamic map loading may FAIL if the map is split into two or more 
 
 Here is a split PCD map for `sample-map-rosbag` from Autoware tutorial: [`sample-map-rosbag_split.zip`](https://github.com/autowarefoundation/autoware.universe/files/10349104/sample-map-rosbag_split.zip)
 
-|  PCD files  | `use_dynamic_map_loading` | `enable_differential_load` | How NDT loads map(s) |
-| :---------: | :-----------------------: | :------------------------: | :------------------: |
-| single file |           true            |            true            |  at once (standard)  |
-| single file |           true            |           false            |  **does NOT work**   |
-| single file |           false           |         true/false         |  at once (standard)  |
-| split files |           true            |            true            |     dynamically      |
-| split files |           true            |           false            |  **does NOT work**   |
-| split files |           false           |         true/false         |  at once (standard)  |
+|   PCD files    | `use_dynamic_map_loading` | `enable_differential_load` | How NDT loads map(s) |
+| :------------: | :-----------------------: | :------------------------: | :------------------: |
+|  single file   |           true            |            true            |  at once (standard)  |
+|  single file   |           true            |           false            |  **does NOT work**   |
+|  single file   |           false           |         true/false         |  at once (standard)  |
+| multiple files |           true            |            true            |     dynamically      |
+| multiple files |           true            |           false            |  **does NOT work**   |
+| multiple files |           false           |         true/false         |  at once (standard)  |
 
 ## Scan matching score based on de-grounded LiDAR scan
 

--- a/localization/ndt_scan_matcher/README.md
+++ b/localization/ndt_scan_matcher/README.md
@@ -228,9 +228,9 @@ Here is a split PCD map for `sample-map-rosbag` from Autoware tutorial: [`sample
 | single file |           true            |            true            |  at once (standard)  |
 | single file |           true            |           false            |  **does NOT work**   |
 | single file |           false           |         true/false         |  at once (standard)  |
-|  splitted   |           true            |            true            |     dynamically      |
-|  splitted   |           true            |           false            |  **does NOT work**   |
-|  splitted   |           false           |         true/false         |  at once (standard)  |
+| split files |           true            |            true            |     dynamically      |
+| split files |           true            |           false            |  **does NOT work**   |
+| split files |           false           |         true/false         |  at once (standard)  |
 
 ## Scan matching score based on de-grounded LiDAR scan
 

--- a/localization/pose_initializer/README.md
+++ b/localization/pose_initializer/README.md
@@ -15,7 +15,7 @@ This node depends on the map height fitter library.
 
 | Name                  | Type | Description                                                                              |
 | --------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `ekf_enabled`         | bool | If true, EKF localizar is activated.                                                     |
+| `ekf_enabled`         | bool | If true, EKF localizer is activated.                                                     |
 | `ndt_enabled`         | bool | If true, the pose will be estimated by NDT scan matcher, otherwise it is passed through. |
 | `stop_check_enabled`  | bool | If true, initialization is accepted only when the vehicle is stopped.                    |
 | `stop_check_duration` | bool | The duration used for the stop check above.                                              |

--- a/perception/bytetrack/README.md
+++ b/perception/bytetrack/README.md
@@ -12,6 +12,8 @@ the number of false negatives is expected to decrease by using it.
 
 ### Cite
 
+<!-- cspell: ignore Yifu Peize Jiang Dongdong Fucheng Weng Zehuan Xinggang -->
+
 - Yifu Zhang, Peize Sun, Yi Jiang, Dongdong Yu, Fucheng Weng, Zehuan Yuan, Ping Luo, Wenyu Liu, and Xinggang Wang,
   "ByteTrack: Multi-Object Tracking by Associating Every Detection Box", in the proc. of the ECCV
   2022, [[ref](https://arxiv.org/abs/2110.06864)]

--- a/perception/image_projection_based_fusion/README.md
+++ b/perception/image_projection_based_fusion/README.md
@@ -40,8 +40,8 @@ if the roi msgs can be matched, fuse them and cache the pointcloud.
 | :-----------------: | :--------: | :-------: | :-------: | :-------: |
 | subscription status | O | O | O | |
 
-If the roi msg 3 is subscribed before the next pointcloud messge coming or timeout, fuse it if matched, otherwise wait for the next roi msg 3.
-If the roi msg 3 is not subscribed before the next pointcloud messge coming or timeout, postprocess the pointcloud messege as it is.
+If the roi msg 3 is subscribed before the next pointcloud message coming or timeout, fuse it if matched, otherwise wait for the next roi msg 3.
+If the roi msg 3 is not subscribed before the next pointcloud message coming or timeout, postprocess the pointcloud message as it is.
 
 The timeout threshold should be set according to the postprocessing time.
 E.g, if the postprocessing time is around 50ms, the timeout threshold should be set smaller than 50ms, so that the whole processing time could be less than 100ms.

--- a/perception/lidar_centerpoint/launch/centerpoint_vs_centerpoint-tiny/README.md
+++ b/perception/lidar_centerpoint/launch/centerpoint_vs_centerpoint-tiny/README.md
@@ -130,7 +130,7 @@ Then you will see two rviz window show immediately. On the left is the result fo
 
 ### Bounding Box blink on rviz
 
-To avoid Bounding Boxs blinking on rviz, you can extend bbox marker lifetime.
+To avoid Bounding Boxes blinking on rviz, you can extend bbox marker lifetime.
 
 Set `marker_ptr->lifetime` and `marker.lifetime` to a longer lifetime.
 

--- a/perception/probabilistic_occupancy_grid_map/README.md
+++ b/perception/probabilistic_occupancy_grid_map/README.md
@@ -18,7 +18,7 @@ You may need to choose `scan_origin_frame` and `gridmap_origin_frame` which mean
 
 ![image_for_frame_parameter_visualization](./image/gridmap_frame_settings.drawio.svg)
 
-### Each config paramters
+### Each config parameters
 
 Config parameters are managed in `config/*.yaml` and here shows its outline.
 

--- a/planning/behavior_velocity_planner/out-of-lane-design.md
+++ b/planning/behavior_velocity_planner/out-of-lane-design.md
@@ -27,10 +27,10 @@ In this first step, the ego footprint is projected at each path point and are ev
 #### 2. Other lanes
 
 In the second step, the set of lanes to consider for overlaps is generated.
-This set is built by selecting all lanelets within some distance from the ego vehicle, and then removing non-relevent lanelets.
-The selection distance is choosen as the maximum between the `slowdown.distance_threshold` and the `stop.distance_threshold`.
+This set is built by selecting all lanelets within some distance from the ego vehicle, and then removing non-relevant lanelets.
+The selection distance is chosen as the maximum between the `slowdown.distance_threshold` and the `stop.distance_threshold`.
 
-A lanelet is deemed non-relevent if it meets one of the following conditions.
+A lanelet is deemed non-relevant if it meets one of the following conditions.
 
 - It is part of the lanelets followed by the ego path.
 - It contains the rear point of the ego footprint.

--- a/planning/freespace_planning_algorithms/README.md
+++ b/planning/freespace_planning_algorithms/README.md
@@ -50,6 +50,9 @@ colcon build --packages-select freespace_planning_algorithms
 colcon test --packages-select freespace_planning_algorithms
 ```
 
+<!-- cspell: ignore fpalgos -->
+<!-- "fpalgos" means Free space Planning ALGOrithmS -->
+
 Inside the test, simulation results are stored in `/tmp/fpalgos-{algorithm_type}-case{scenario_number}` as a rosbag.
 Loading these resulting files, by using [test/debug_plot.py](test/debug_plot.py),
 one can create plots visualizing the path and obstacles as shown

--- a/planning/obstacle_avoidance_planner/docs/debug.md
+++ b/planning/obstacle_avoidance_planner/docs/debug.md
@@ -28,7 +28,7 @@ The `vehicle_model` must be specified to make footprints with vehicle's size.
 
 ![path_footprint](../media/debug/path_footprint_visualization.png)
 
-- **Drivalbe Area**
+- **Drivable Area**
   - The Drivable area generated in the `behavior` planner.
   - The skyblue left and right line strings, that is visualized by default.
   - NOTE:
@@ -69,7 +69,7 @@ The `vehicle_model` must be specified to make footprints with vehicle's size.
 
 - **Vehicle Circles**
   - The vehicle's shape is represented by a set of circles.
-  - The `obstcle_avoidance_planner` will try to make the these circles inside the above boundaries' width.
+  - The `obstacle_avoidance_planner` will try to make the these circles inside the above boundaries' width.
 
 ![vehicle_circles](../media/debug/vehicle_circles_visualization.png)
 

--- a/planning/obstacle_avoidance_planner/docs/mpt.md
+++ b/planning/obstacle_avoidance_planner/docs/mpt.md
@@ -360,7 +360,7 @@ $$
 To realize collision-free trajectory planning, we have to formulate constraints that the vehicle is inside the road and also does not collide with obstacles in linear equations.
 For linearity, we implemented some methods to approximate the vehicle shape with a set of circles, that is reliable and easy to implement.
 
-- 1. Bibycle Model
+- 1. Bicycle Model
 - 2. Uniform Circles
 - 3. Fitting Uniform Circles
 

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/README.md
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/README.md
@@ -185,7 +185,7 @@ ros2 run accel_brake_map_calibrator actuation_cmd_publisher.py
 
 ## Calibration Method
 
-Two algorithms are selectable for the acceleration map update, [update_offset_four_cell_around](#update_offset_four_cell_around-1) and [update_offset_each_cell](#update_offset_each_cell). Please see the link for datails.
+Two algorithms are selectable for the acceleration map update, [update_offset_four_cell_around](#update_offset_four_cell_around-1) and [update_offset_each_cell](#update_offset_each_cell). Please see the link for details.
 
 ### Data Preprocessing
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- I checked autoware.universe by cspell and got the result below
```
/home/autoware.universe/localization/ndt_scan_matcher/README.md:231:4 - Unknown word (splitted)
/home/autoware.universe/localization/ndt_scan_matcher/README.md:232:4 - Unknown word (splitted)
/home/autoware.universe/localization/ndt_scan_matcher/README.md:233:4 - Unknown word (splitted)
/home/autoware.universe/localization/pose_initializer/README.md:18:47 - Unknown word (localizar)
/home/autoware.universe/perception/bytetrack/README.md:15:3 - Unknown word (Yifu)
/home/autoware.universe/perception/bytetrack/README.md:15:15 - Unknown word (Peize)
/home/autoware.universe/perception/bytetrack/README.md:15:29 - Unknown word (Jiang)
/home/autoware.universe/perception/bytetrack/README.md:15:36 - Unknown word (Dongdong)
/home/autoware.universe/perception/bytetrack/README.md:15:49 - Unknown word (Fucheng)
/home/autoware.universe/perception/bytetrack/README.md:15:57 - Unknown word (Weng)
/home/autoware.universe/perception/bytetrack/README.md:15:63 - Unknown word (Zehuan)
/home/autoware.universe/perception/bytetrack/README.md:15:101 - Unknown word (Xinggang)
/home/autoware.universe/perception/probabilistic_occupancy_grid_map/README.md:21:17 - Unknown word (paramters)
/home/autoware.universe/planning/behavior_velocity_planner/out-of-lane-design.md:30:110 - Unknown word (relevent) fix: (relevant)
/home/autoware.universe/planning/behavior_velocity_planner/out-of-lane-design.md:31:27 - Unknown word (choosen) fix: (chosen)
/home/autoware.universe/planning/behavior_velocity_planner/out-of-lane-design.md:33:25 - Unknown word (relevent) fix: (relevant)
/home/autoware.universe/planning/freespace_planning_algorithms/README.md:53:57 - Unknown word (fpalgos)
/home/autoware.universe/planning/obstacle_avoidance_planner/docs/debug.md:31:5 - Unknown word (Drivalbe)
/home/autoware.universe/planning/obstacle_avoidance_planner/docs/debug.md:72:10 - Unknown word (obstcle)
/home/autoware.universe/planning/obstacle_avoidance_planner/docs/mpt.md:363:6 - Unknown word (Bibycle)
/home/autoware.universe/perception/image_projection_based_fusion/README.md:43:59 - Unknown word (messge)
/home/autoware.universe/perception/image_projection_based_fusion/README.md:44:63 - Unknown word (messge)
/home/autoware.universe/perception/image_projection_based_fusion/README.md:44:116 - Unknown word (messege)
/home/autoware.universe/perception/lidar_centerpoint/launch/centerpoint_vs_centerpoint-tiny/README.md:133:19 - Unknown word (Boxs)
/home/autoware.universe/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/README.md:188:213 - Unknown word (datails)
```
(note that this is the part of result)
- So I remove typos from README.md and add cspell ignore in it.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
