### PR TITLE
refactor(behavior_path_planner): move steering_factor_interface to abstract class

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -64,7 +64,9 @@ public:
     is_waiting_approval_{false},
     is_locked_new_module_launch_{false},
     current_state_{ModuleStatus::SUCCESS},
-    rtc_interface_ptr_map_(rtc_interface_ptr_map)
+    rtc_interface_ptr_map_(rtc_interface_ptr_map),
+    steering_factor_interface_ptr_(
+      std::make_unique<SteeringFactorInterface>(&node, util::convertToSnakeCase(name)))
   {
 #ifdef USE_OLD_ARCHITECTURE
     const auto ns = std::string("~/debug/") + utils::convertToSnakeCase(name);
@@ -342,8 +344,6 @@ protected:
 
   std::shared_ptr<const PlannerData> planner_data_;
 
-  std::unique_ptr<SteeringFactorInterface> steering_factor_interface_ptr_;
-
   bool is_waiting_approval_;
   bool is_locked_new_module_launch_;
 
@@ -355,6 +355,8 @@ protected:
   ModuleStatus current_state_;
 
   std::unordered_map<std::string, std::shared_ptr<RTCInterface>> rtc_interface_ptr_map_;
+
+  std::unique_ptr<SteeringFactorInterface> steering_factor_interface_ptr_;
 
   mutable MarkerArray debug_marker_;
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -66,7 +66,7 @@ public:
     current_state_{ModuleStatus::SUCCESS},
     rtc_interface_ptr_map_(rtc_interface_ptr_map),
     steering_factor_interface_ptr_(
-      std::make_unique<SteeringFactorInterface>(&node, util::convertToSnakeCase(name)))
+      std::make_unique<SteeringFactorInterface>(&node, utils::convertToSnakeCase(name)))
   {
 #ifdef USE_OLD_ARCHITECTURE
     const auto ns = std::string("~/debug/") + utils::convertToSnakeCase(name);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -84,20 +84,14 @@ AvoidanceModule::AvoidanceModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters)
 : SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {"left", "right"})},
   parameters_{std::move(parameters)}
-{
-  using std::placeholders::_1;
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "avoidance");
-}
 #else
 AvoidanceModule::AvoidanceModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters,
   const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map)
 : SceneModuleInterface{name, node, rtc_interface_ptr_map}, parameters_{std::move(parameters)}
-{
-  using std::placeholders::_1;
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "avoidance");
-}
 #endif
+{
+}
 
 bool AvoidanceModule::isExecutionRequested() const
 {

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -54,8 +54,6 @@ AvoidanceByLCModule::AvoidanceByLCModule(
   const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map)
 : SceneModuleInterface{name, node, rtc_interface_ptr_map}, parameters_{parameters}
 {
-  steering_factor_interface_ptr_ =
-    std::make_unique<SteeringFactorInterface>(&node, "avoidance_by_lane_change");
 }
 
 void AvoidanceByLCModule::processOnEntry()

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -40,8 +40,6 @@ ExternalRequestLaneChangeModule::ExternalRequestLaneChangeModule(
   parameters_{std::move(parameters)},
   direction_{direction}
 {
-  steering_factor_interface_ptr_ =
-    std::make_unique<SteeringFactorInterface>(&node, utils::convertToSnakeCase(name));
 }
 
 void ExternalRequestLaneChangeModule::processOnEntry()

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -41,9 +41,6 @@ LaneChangeModule::LaneChangeModule(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<LaneChangeParameters> parameters)
 : SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {"left", "right"})},
   parameters_{std::move(parameters)}
-{
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "lane_change");
-}
 #else
 LaneChangeModule::LaneChangeModule(
   const std::string & name, rclcpp::Node & node,
@@ -54,10 +51,9 @@ LaneChangeModule::LaneChangeModule(
   parameters_{parameters},
   direction_{direction},
   type_{type}
-{
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, name);
-}
 #endif
+{
+}
 
 void LaneChangeModule::processOnEntry()
 {

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -31,9 +31,6 @@ LaneFollowingModule::LaneFollowingModule(
 : SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {""})}, parameters_{parameters}
 {
   initParam();
-  // TODO(murooka) The following is temporary implementation for new architecture's refactoring
-  steering_factor_interface_ptr_ =
-    std::make_unique<SteeringFactorInterface>(&node, "lane_following");
 }
 
 void LaneFollowingModule::initParam()

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -42,7 +42,6 @@ PullOutModule::PullOutModule(
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "pull_out");
   lane_departure_checker_ = std::make_shared<LaneDepartureChecker>();
   lane_departure_checker_->setVehicleInfo(vehicle_info_);
 
@@ -68,7 +67,6 @@ PullOutModule::PullOutModule(
   parameters_{parameters},
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "pull_out");
   lane_departure_checker_ = std::make_shared<LaneDepartureChecker>();
   lane_departure_checker_->setVehicleInfo(vehicle_info_);
 

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -65,8 +65,6 @@ PullOverModule::PullOverModule(
   vehicle_info_{vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo()}
 {
 #endif
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "pull_over");
-
   LaneDepartureChecker lane_departure_checker{};
   lane_departure_checker.setVehicleInfo(vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo());
 

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -51,10 +51,6 @@ SideShiftModule::SideShiftModule(
 : SceneModuleInterface{name, node, rtc_interface_ptr_map}, parameters_{parameters}
 {
 #endif
-
-  // TODO(murooka) The following is temporary implementation for new architecture's refactoring
-  steering_factor_interface_ptr_ = std::make_unique<SteeringFactorInterface>(&node, "side_shift");
-
   // If lateral offset is subscribed, it approves side shift module automatically
   clearWaitingApproval();
 }


### PR DESCRIPTION
## Description

Removed redundant implementation of steering_factor_interface definition by moving it to the abstract class.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator worked well with
- [x] old architecture
- [x] new architecture

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No behavior change

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
