### PR TITLE
refactor(behavior_path_planner): move common functions of side_shift and avoidance to utils

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -413,7 +413,6 @@ private:
 
   double getCurrentBaseShift() const { return path_shifter_.getBaseOffset(); }
 
-
   PathWithLaneId extendBackwardLength(const PathWithLaneId & original_path) const;
 
   // TODO(Horibe): think later.

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -413,12 +413,8 @@ private:
 
   double getCurrentBaseShift() const { return path_shifter_.getBaseOffset(); }
 
-  Pose getUnshiftedEgoPose(const ShiftedPath & prev_path) const;
 
   PathWithLaneId extendBackwardLength(const PathWithLaneId & original_path) const;
-
-  PathWithLaneId calcCenterLinePath(
-    const std::shared_ptr<const PlannerData> & planner_data, const Pose & pose) const;
 
   // TODO(Horibe): think later.
   // for unique ID

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -126,11 +126,7 @@ private:
   ShiftedPath prev_output_;
   ShiftLine prev_shift_line_;
 
-  // NOTE: this function is ported from avoidance.
-  Pose getUnshiftedEgoPose(const ShiftedPath & prev_path) const;
   PathWithLaneId extendBackwardLength(const PathWithLaneId & original_path) const;
-  PathWithLaneId calcCenterLinePath(
-    const std::shared_ptr<const PlannerData> & planner_data, const Pose & pose) const;
 
   mutable rclcpp::Time last_requested_shift_change_time_{clock_->now()};
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
@@ -99,7 +99,8 @@ geometry_msgs::msg::Pose getUnshiftedEgoPose(
 
 PathWithLaneId calcCenterLinePath(
   const std::shared_ptr<const PlannerData> & planner_data, const Pose & ref_pose,
-  const double longest_dist_to_shift_line, const std::optional<PathWithLaneId> & prev_module_path);
+  const double longest_dist_to_shift_line,
+  const std::optional<PathWithLaneId> & prev_module_path = std::nullopt);
 }  // namespace behavior_path_planner::utils
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__PATH_UTILS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_utils.hpp
@@ -17,6 +17,7 @@
 
 #include "behavior_path_planner/utils/path_shifter/path_shifter.hpp"
 
+#include <behavior_path_planner/data_manager.hpp>
 #include <behavior_path_planner/parameters.hpp>
 #include <freespace_planning_algorithms/abstract_algorithm.hpp>
 
@@ -28,6 +29,7 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 
 #include <limits>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -92,6 +94,12 @@ std::vector<double> splineTwoPoints(
 std::vector<Pose> interpolatePose(
   const Pose & start_pose, const Pose & end_pose, const double resample_interval);
 
+geometry_msgs::msg::Pose getUnshiftedEgoPose(
+  const geometry_msgs::msg::Pose & ego_pose, const ShiftedPath & prev_path);
+
+PathWithLaneId calcCenterLinePath(
+  const std::shared_ptr<const PlannerData> & planner_data, const Pose & ref_pose,
+  const double longest_dist_to_shift_line, const std::optional<PathWithLaneId> & prev_module_path);
 }  // namespace behavior_path_planner::utils
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__PATH_UTILS_HPP_

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -193,11 +193,31 @@ AvoidancePlanningData AvoidanceModule::calcAvoidancePlanningData(DebugData & deb
   AvoidancePlanningData data;
 
   // reference pose
-  const auto reference_pose = getUnshiftedEgoPose(prev_output_);
+  const auto reference_pose = util::getUnshiftedEgoPose(getEgoPose(), prev_output_);
   data.reference_pose = reference_pose;
 
+  // special for avoidance: take behind distance upt ot shift-start-point if it exist.
+  const auto longest_dist_to_shift_line = [&]() {
+    double max_dist = 0.0;
+    for (const auto & pnt : path_shifter_.getShiftLines()) {
+      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), pnt.start));
+    }
+    for (const auto & sl : registered_raw_shift_lines_) {
+      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), sl.start));
+    }
+    return max_dist;
+  }();
+
   // center line path (output of this function must have size > 1)
-  const auto center_path = calcCenterLinePath(planner_data_, reference_pose);
+#ifdef USE_OLD_ARCHITECTURE
+  const auto center_path =
+    util::calcCenterLinePath(planner_data_, reference_pose, longest_dist_to_shift_line);
+#else
+  const auto center_path = util::calcCenterLinePath(
+    planner_data_, reference_pose, longest_dist_to_shift_line,
+    *getPreviousModuleOutput().reference_path);
+#endif
+
   debug.center_line = center_path;
   if (center_path.points.size() < 2) {
     RCLCPP_WARN_THROTTLE(
@@ -2626,61 +2646,6 @@ PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & orig
   return extended_path;
 }
 
-// TODO(Horibe) clean up functions: there is a similar code in util as well.
-PathWithLaneId AvoidanceModule::calcCenterLinePath(
-  const std::shared_ptr<const PlannerData> & planner_data, const Pose & pose) const
-{
-  const auto & p = planner_data->parameters;
-  const auto & route_handler = planner_data->route_handler;
-
-  PathWithLaneId centerline_path;
-
-  // special for avoidance: take behind distance upt ot shift-start-point if it exist.
-  const auto longest_dist_to_shift_line = [&]() {
-    double max_dist = 0.0;
-    for (const auto & pnt : path_shifter_.getShiftLines()) {
-      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), pnt.start));
-    }
-    for (const auto & sl : registered_raw_shift_lines_) {
-      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), sl.start));
-    }
-    return max_dist;
-  }();
-
-  printShiftLines(path_shifter_.getShiftLines(), "path_shifter_.getShiftLines()");
-  printShiftLines(registered_raw_shift_lines_, "registered_raw_shift_lines_");
-
-  const auto extra_margin = 10.0;  // Since distance does not consider arclength, but just line.
-  const auto backward_length =
-    std::max(p.backward_path_length, longest_dist_to_shift_line + extra_margin);
-
-  DEBUG_PRINT(
-    "p.backward_path_length = %f, longest_dist_to_shift_line = %f, backward_length = %f",
-    p.backward_path_length, longest_dist_to_shift_line, backward_length);
-
-#ifdef USE_OLD_ARCHITECTURE
-  const lanelet::ConstLanelets current_lanes =
-    utils::calcLaneAroundPose(route_handler, pose, p.forward_path_length, backward_length);
-#else
-  const lanelet::ConstLanelets current_lanes =
-    utils::getCurrentLanesFromPath(*getPreviousModuleOutput().reference_path, planner_data_);
-#endif
-  centerline_path = utils::getCenterLinePath(
-    *route_handler, current_lanes, pose, backward_length, p.forward_path_length, p);
-
-  // for debug: check if the path backward distance is same as the desired length.
-  // {
-  //   const auto back_to_ego = motion_utils::calcSignedArcLength(
-  //     centerline_path.points, centerline_path.points.front().point.pose.position,
-  //     getEgoPosition());
-  //   RCLCPP_INFO(getLogger(), "actual back_to_ego distance = %f", back_to_ego);
-  // }
-
-  centerline_path.header = route_handler->getRouteHeader();
-
-  return centerline_path;
-}
-
 boost::optional<AvoidLine> AvoidanceModule::calcIntersectionShiftLine(
   const AvoidancePlanningData & data) const
 {
@@ -3083,27 +3048,6 @@ AvoidLineArray AvoidanceModule::findNewShiftLine(
 
   DEBUG_PRINT("No new shift point exists.");
   return {};
-}
-
-Pose AvoidanceModule::getUnshiftedEgoPose(const ShiftedPath & prev_path) const
-{
-  const auto ego_pose = getEgoPose();
-
-  if (prev_path.path.points.empty()) {
-    return ego_pose;
-  }
-
-  // un-shifted fot current ideal pose
-  const auto closest = findNearestIndex(prev_path.path.points, ego_pose.position);
-
-  // NOTE: Considering avoidance by motion, we set unshifted_pose as previous path instead of
-  // ego_pose.
-  Pose unshifted_pose = motion_utils::calcInterpolatedPoint(prev_path.path, ego_pose).point.pose;
-
-  unshifted_pose = calcOffsetPose(unshifted_pose, 0.0, -prev_path.shift_length.at(closest), 0.0);
-  unshifted_pose.orientation = ego_pose.orientation;
-
-  return unshifted_pose;
 }
 
 ShiftedPath AvoidanceModule::generateAvoidancePath(PathShifter & path_shifter) const

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -193,7 +193,7 @@ AvoidancePlanningData AvoidanceModule::calcAvoidancePlanningData(DebugData & deb
   AvoidancePlanningData data;
 
   // reference pose
-  const auto reference_pose = util::getUnshiftedEgoPose(getEgoPose(), prev_output_);
+  const auto reference_pose = utils::getUnshiftedEgoPose(getEgoPose(), prev_output_);
   data.reference_pose = reference_pose;
 
   // special for avoidance: take behind distance upt ot shift-start-point if it exist.
@@ -211,9 +211,9 @@ AvoidancePlanningData AvoidanceModule::calcAvoidancePlanningData(DebugData & deb
   // center line path (output of this function must have size > 1)
 #ifdef USE_OLD_ARCHITECTURE
   const auto center_path =
-    util::calcCenterLinePath(planner_data_, reference_pose, longest_dist_to_shift_line);
+    utils::calcCenterLinePath(planner_data_, reference_pose, longest_dist_to_shift_line);
 #else
-  const auto center_path = util::calcCenterLinePath(
+  const auto center_path = utils::calcCenterLinePath(
     planner_data_, reference_pose, longest_dist_to_shift_line,
     *getPreviousModuleOutput().reference_path);
 #endif

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -201,12 +201,12 @@ void SideShiftModule::updateData()
 
   const auto reference_pose = prev_output_.shift_length.empty()
                                 ? planner_data_->self_odometry->pose.pose
-                                : util::getUnshiftedEgoPose(getEgoPose(), prev_output_);
+                                : utils::getUnshiftedEgoPose(getEgoPose(), prev_output_);
 #ifdef USE_OLD_ARCHITECTURE
   const auto centerline_path =
-    util::calcCenterLinePath(planner_data_, reference_pose, longest_dist_to_shift_line);
+    utils::calcCenterLinePath(planner_data_, reference_pose, longest_dist_to_shift_line);
 #else
-  const auto centerline_path = util::calcCenterLinePath(
+  const auto centerline_path = utils::calcCenterLinePath(
     planner_data_, reference_pose, longest_dist_to_shift_line,
     *getPreviousModuleOutput().reference_path);
 #endif

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -190,10 +190,26 @@ void SideShiftModule::updateData()
     prev_reference_ = *getPreviousModuleOutput().path;
   }
 
+  // special for avoidance: take behind distance upt ot shift-start-point if it exist.
+  const auto longest_dist_to_shift_line = [&]() {
+    double max_dist = 0.0;
+    for (const auto & pnt : path_shifter_.getShiftLines()) {
+      max_dist = std::max(max_dist, tier4_autoware_utils::calcDistance2d(getEgoPose(), pnt.start));
+    }
+    return max_dist;
+  }();
+
   const auto reference_pose = prev_output_.shift_length.empty()
                                 ? planner_data_->self_odometry->pose.pose
-                                : getUnshiftedEgoPose(prev_output_);
-  const auto centerline_path = calcCenterLinePath(planner_data_, reference_pose);
+                                : util::getUnshiftedEgoPose(getEgoPose(), prev_output_);
+#ifdef USE_OLD_ARCHITECTURE
+  const auto centerline_path =
+    util::calcCenterLinePath(planner_data_, reference_pose, longest_dist_to_shift_line);
+#else
+  const auto centerline_path = util::calcCenterLinePath(
+    planner_data_, reference_pose, longest_dist_to_shift_line,
+    *getPreviousModuleOutput().reference_path);
+#endif
 
   constexpr double resample_interval = 1.0;
 #ifdef USE_OLD_ARCHITECTURE
@@ -422,25 +438,6 @@ void SideShiftModule::adjustDrivableArea(ShiftedPath * path) const
   }
 }
 
-// NOTE: this function is ported from avoidance.
-Pose SideShiftModule::getUnshiftedEgoPose(const ShiftedPath & prev_path) const
-{
-  const auto ego_pose = getEgoPose();
-  if (prev_path.path.points.empty()) {
-    return ego_pose;
-  }
-
-  // un-shifted fot current ideal pose
-  const auto closest = motion_utils::findNearestIndex(prev_path.path.points, ego_pose.position);
-
-  Pose unshifted_pose = ego_pose;
-
-  unshifted_pose = calcOffsetPose(unshifted_pose, 0.0, -prev_path.shift_length.at(closest), 0.0);
-  unshifted_pose.orientation = ego_pose.orientation;
-
-  return unshifted_pose;
-}
-
 PathWithLaneId SideShiftModule::extendBackwardLength(const PathWithLaneId & original_path) const
 {
   // special for avoidance: take behind distance upt ot shift-start-point if it exist.
@@ -483,41 +480,4 @@ PathWithLaneId SideShiftModule::extendBackwardLength(const PathWithLaneId & orig
 
   return extended_path;
 }
-
-// NOTE: this function is ported from avoidance.
-PathWithLaneId SideShiftModule::calcCenterLinePath(
-  const std::shared_ptr<const PlannerData> & planner_data, const Pose & pose) const
-{
-  const auto & p = planner_data->parameters;
-  const auto & route_handler = planner_data->route_handler;
-
-  PathWithLaneId centerline_path;
-
-  // special for avoidance: take behind distance upt ot shift-start-point if it exist.
-  const auto longest_dist_to_shift_line = [&]() {
-    double max_dist = 0.0;
-    for (const auto & pnt : path_shifter_.getShiftLines()) {
-      max_dist = std::max(max_dist, tier4_autoware_utils::calcDistance2d(getEgoPose(), pnt.start));
-    }
-    return max_dist;
-  }();
-  const auto extra_margin = 10.0;  // Since distance does not consider arclength, but just line.
-  const auto backward_length =
-    std::max(p.backward_path_length, longest_dist_to_shift_line + extra_margin);
-
-  RCLCPP_DEBUG(
-    getLogger(),
-    "p.backward_path_length = %f, longest_dist_to_shift_line = %f, backward_length = %f",
-    p.backward_path_length, longest_dist_to_shift_line, backward_length);
-
-  const lanelet::ConstLanelets current_lanes =
-    utils::calcLaneAroundPose(route_handler, pose, p.forward_path_length, backward_length);
-  centerline_path = utils::getCenterLinePath(
-    *route_handler, current_lanes, pose, backward_length, p.forward_path_length, p);
-
-  centerline_path.header = route_handler->getRouteHeader();
-
-  return centerline_path;
-}
-
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/path_utils.cpp
@@ -469,4 +469,60 @@ std::vector<Pose> interpolatePose(
   return interpolated_poses;
 }
 
+Pose getUnshiftedEgoPose(const Pose & ego_pose, const ShiftedPath & prev_path)
+{
+  if (prev_path.path.points.empty()) {
+    return ego_pose;
+  }
+
+  // un-shifted for current ideal pose
+  const auto closest_idx = motion_utils::findNearestIndex(prev_path.path.points, ego_pose.position);
+
+  // NOTE: Considering avoidance by motion, we set unshifted_pose as previous path instead of
+  // ego_pose.
+  auto unshifted_pose = motion_utils::calcInterpolatedPoint(prev_path.path, ego_pose).point.pose;
+
+  unshifted_pose = tier4_autoware_utils::calcOffsetPose(
+    unshifted_pose, 0.0, -prev_path.shift_length.at(closest_idx), 0.0);
+  unshifted_pose.orientation = ego_pose.orientation;
+
+  return unshifted_pose;
+}
+
+// TODO(Horibe) clean up functions: there is a similar code in util as well.
+PathWithLaneId calcCenterLinePath(
+  const std::shared_ptr<const PlannerData> & planner_data, const Pose & ref_pose,
+  const double longest_dist_to_shift_line,
+  const std::optional<PathWithLaneId> & prev_module_path = std::nullopt)
+{
+  const auto & p = planner_data->parameters;
+  const auto & ego_pose = planner_data->self_odometry->pose.pose;
+  const auto & route_handler = planner_data->route_handler;
+
+  PathWithLaneId centerline_path;
+
+  const auto extra_margin = 10.0;  // Since distance does not consider arclength, but just line.
+  const auto backward_length =
+    std::max(p.backward_path_length, longest_dist_to_shift_line + extra_margin);
+
+  RCLCPP_DEBUG(
+    rclcpp::get_logger("path_utils"),
+    "p.backward_path_length = %f, longest_dist_to_shift_line = %f, backward_length = %f",
+    p.backward_path_length, longest_dist_to_shift_line, backward_length);
+
+  const lanelet::ConstLanelets current_lanes = [&]() {
+    if (!prev_module_path) {
+      return util::calcLaneAroundPose(
+        route_handler, ref_pose, p.forward_path_length, backward_length);
+    }
+    return util::getCurrentLanesFromPath(*prev_module_path, planner_data);
+  }();
+
+  centerline_path = util::getCenterLinePath(
+    *route_handler, current_lanes, ref_pose, backward_length, p.forward_path_length, p);
+
+  centerline_path.header = route_handler->getRouteHeader();
+
+  return centerline_path;
+}
 }  // namespace behavior_path_planner::utils

--- a/planning/behavior_path_planner/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/path_utils.cpp
@@ -512,13 +512,13 @@ PathWithLaneId calcCenterLinePath(
 
   const lanelet::ConstLanelets current_lanes = [&]() {
     if (!prev_module_path) {
-      return util::calcLaneAroundPose(
+      return utils::calcLaneAroundPose(
         route_handler, ref_pose, p.forward_path_length, backward_length);
     }
-    return util::getCurrentLanesFromPath(*prev_module_path, planner_data);
+    return utils::getCurrentLanesFromPath(*prev_module_path, planner_data);
   }();
 
-  centerline_path = util::getCenterLinePath(
+  centerline_path = utils::getCenterLinePath(
     *route_handler, current_lanes, ref_pose, backward_length, p.forward_path_length, p);
 
   centerline_path.header = route_handler->getRouteHeader();

--- a/planning/behavior_path_planner/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/path_utils.cpp
@@ -492,11 +492,9 @@ Pose getUnshiftedEgoPose(const Pose & ego_pose, const ShiftedPath & prev_path)
 // TODO(Horibe) clean up functions: there is a similar code in util as well.
 PathWithLaneId calcCenterLinePath(
   const std::shared_ptr<const PlannerData> & planner_data, const Pose & ref_pose,
-  const double longest_dist_to_shift_line,
-  const std::optional<PathWithLaneId> & prev_module_path = std::nullopt)
+  const double longest_dist_to_shift_line, const std::optional<PathWithLaneId> & prev_module_path)
 {
   const auto & p = planner_data->parameters;
-  const auto & ego_pose = planner_data->self_odometry->pose.pose;
   const auto & route_handler = planner_data->route_handler;
 
   PathWithLaneId centerline_path;


### PR DESCRIPTION
## Description

move `getUnshiftedEgoPose` and `calcCenterLinePath` defined in side_shift and avoidance to utils.
<!-- Write a brief description of this PR. -->

## Tests performed

Planning simulator works well with
- [x] old architecture
- [x] new architecture
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No behavior change.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
