### PR TITLE
refactor(behavior_path_planner): move ego data getters to abstract class

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -334,11 +334,6 @@ private:
 
   // ========= helper functions ==========
 
-  double getEgoSpeed() const
-  {
-    return std::abs(planner_data_->self_odometry->twist.twist.linear.x);
-  }
-
   double getNominalAvoidanceEgoSpeed() const
   {
     return std::max(getEgoSpeed(), parameters_->min_nominal_avoidance_speed);
@@ -417,10 +412,6 @@ private:
   }
 
   double getCurrentBaseShift() const { return path_shifter_.getBaseOffset(); }
-
-  Point getEgoPosition() const { return planner_data_->self_odometry->pose.pose.position; }
-
-  Pose getEgoPose() const { return planner_data_->self_odometry->pose.pose; }
 
   Pose getUnshiftedEgoPose(const ShiftedPath & prev_path) const;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance_by_lc/module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance_by_lc/module.hpp
@@ -203,9 +203,6 @@ private:
   bool isAbortState() const;
 
   // getter
-  Point getEgoPosition() const { return planner_data_->self_odometry->pose.pose.position; }
-  Pose getEgoPose() const { return planner_data_->self_odometry->pose.pose; }
-  Twist getEgoTwist() const;
   std_msgs::msg::Header getRouteHeader() const;
   void resetPathIfAbort();
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
@@ -126,11 +126,6 @@ protected:
   bool hasFinishedLaneChange() const;
   bool isAbortState() const;
 
-  // getter
-  Pose getEgoPose() const;
-  Twist getEgoTwist() const;
-  std_msgs::msg::Header getRouteHeader() const;
-
   // debug
   mutable std::unordered_map<std::string, CollisionCheckDebug> object_debug_;
   mutable std::vector<LaneChangePath> debug_valid_path_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
@@ -125,6 +125,7 @@ protected:
   bool isAbortConditionSatisfied();
   bool hasFinishedLaneChange() const;
   bool isAbortState() const;
+  std_msgs::msg::Header getRouteHeader() const;
 
   // debug
   mutable std::unordered_map<std::string, CollisionCheckDebug> object_debug_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -189,9 +189,6 @@ private:
   bool isAbortState() const;
 
   // getter
-  Pose getEgoPose() const;
-  Twist getEgoTwist() const;
-  std_msgs::msg::Header getRouteHeader() const;
   void resetPathIfAbort();
 
   // debug

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/lane_change_module.hpp
@@ -189,6 +189,7 @@ private:
   bool isAbortState() const;
 
   // getter
+  std_msgs::msg::Header getRouteHeader() const;
   void resetPathIfAbort();
 
   // debug

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -343,7 +343,10 @@ protected:
     return planner_data_->self_odometry->pose.pose.position;
   }
   geometry_msgs::msg::Pose getEgoPose() const { return planner_data_->self_odometry->pose.pose; }
-  geometry_msgs::msg::Twist getEgoTwist() const { planner_data_->self_odometry->twist.twist; }
+  geometry_msgs::msg::Twist getEgoTwist() const
+  {
+    return planner_data_->self_odometry->twist.twist;
+  }
   double getEgoSpeed() const
   {
     return std::abs(planner_data_->self_odometry->twist.twist.linear.x);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -338,9 +338,12 @@ protected:
 
   void clearWaitingApproval() { is_waiting_approval_ = false; }
 
-  Point getEgoPosition() const { return planner_data_->self_odometry->pose.pose.position; }
-  Pose getEgoPose() const { return planner_data_->self_odometry->pose.pose; }
-  Twist getEgoTwist() const { planner_data_->self_odometry->twist.twist; }
+  geometry_msgs::msg::Point getEgoPosition() const
+  {
+    return planner_data_->self_odometry->pose.pose.position;
+  }
+  geometry_msgs::msg::Pose getEgoPose() const { return planner_data_->self_odometry->pose.pose; }
+  geometry_msgs::msg::Twist getEgoTwist() const { planner_data_->self_odometry->twist.twist; }
   double getEgoSpeed() const
   {
     return std::abs(planner_data_->self_odometry->twist.twist.linear.x);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -338,6 +338,14 @@ protected:
 
   void clearWaitingApproval() { is_waiting_approval_ = false; }
 
+  Point getEgoPosition() const { return planner_data_->self_odometry->pose.pose.position; }
+  Pose getEgoPose() const { return planner_data_->self_odometry->pose.pose; }
+  Twist getEgoTwist() const { planner_data_->self_odometry->twist.twist; }
+  double getEgoSpeed() const
+  {
+    return std::abs(planner_data_->self_odometry->twist.twist.linear.x);
+  }
+
   rclcpp::Clock::SharedPtr clock_;
 
   std::shared_ptr<const PlannerData> planner_data_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -128,7 +128,6 @@ private:
 
   // NOTE: this function is ported from avoidance.
   Pose getUnshiftedEgoPose(const ShiftedPath & prev_path) const;
-  inline Pose getEgoPose() const { return planner_data_->self_odometry->pose.pose; }
   PathWithLaneId extendBackwardLength(const PathWithLaneId & original_path) const;
   PathWithLaneId calcCenterLinePath(
     const std::shared_ptr<const PlannerData> & planner_data, const Pose & pose) const;

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -923,11 +923,6 @@ void AvoidanceByLCModule::updateSteeringFactorPtr(
     SteeringFactor::LANE_CHANGE, steering_factor_direction, SteeringFactor::APPROACHING, "");
 }
 
-Twist AvoidanceByLCModule::getEgoTwist() const
-{
-  return planner_data_->self_odometry->twist.twist;
-}
-
 std_msgs::msg::Header AvoidanceByLCModule::getRouteHeader() const
 {
   return planner_data_->route_handler->getRouteHeader();

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -619,14 +619,6 @@ void ExternalRequestLaneChangeModule::updateSteeringFactorPtr(
     {output.start_distance_to_path_change, output.finish_distance_to_path_change},
     SteeringFactor::LANE_CHANGE, steering_factor_direction, SteeringFactor::APPROACHING, "");
 }
-Pose ExternalRequestLaneChangeModule::getEgoPose() const
-{
-  return planner_data_->self_odometry->pose.pose;
-}
-Twist ExternalRequestLaneChangeModule::getEgoTwist() const
-{
-  return planner_data_->self_odometry->twist.twist;
-}
 std_msgs::msg::Header ExternalRequestLaneChangeModule::getRouteHeader() const
 {
   return planner_data_->route_handler->getRouteHeader();

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -742,14 +742,6 @@ void LaneChangeModule::updateSteeringFactorPtr(
     {output.start_distance_to_path_change, output.finish_distance_to_path_change},
     SteeringFactor::LANE_CHANGE, steering_factor_direction, SteeringFactor::APPROACHING, "");
 }
-Pose LaneChangeModule::getEgoPose() const
-{
-  return planner_data_->self_odometry->pose.pose;
-}
-Twist LaneChangeModule::getEgoTwist() const
-{
-  return planner_data_->self_odometry->twist.twist;
-}
 std_msgs::msg::Header LaneChangeModule::getRouteHeader() const
 {
   return planner_data_->route_handler->getRouteHeader();


### PR DESCRIPTION
## Description

move getter functions of ego's data (pose, position, twist, speed) to abstract class.
<!-- Write a brief description of this PR. -->

## Tests performed

Confirmed that build just passed since this is not a big change.

## Effects on system behavior

No behavior change.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
