### PR TITLE
feat(motion_velocity_smoother): add guard for duplicated points and enable tests

### DIFF
--- a/planning/motion_velocity_smoother/CMakeLists.txt
+++ b/planning/motion_velocity_smoother/CMakeLists.txt
@@ -52,12 +52,12 @@ if(BUILD_TESTING)
   target_link_libraries(test_smoother_functions
   smoother
   )
-  # ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
-  #   test/test_motion_velocity_smoother_node_interface.cpp
-  # )
-  # target_link_libraries(test_${PROJECT_NAME}
-  #   motion_velocity_smoother_node
-  # )
+  ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
+    test/test_motion_velocity_smoother_node_interface.cpp
+  )
+  target_link_libraries(test_${PROJECT_NAME}
+    motion_velocity_smoother_node
+  )
 endif()
 
 

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -402,6 +402,16 @@ void MotionVelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstShar
     return;
   }
 
+  // calculate trajectory velocity
+  auto input_points = motion_utils::convertToTrajectoryPointArray(*base_traj_raw_ptr_);
+
+  // guard for invalid trajectory
+  input_points = motion_utils::removeOverlapPoints(input_points);
+  if (input_points.size() < 2) {
+    RCLCPP_ERROR(get_logger(), "No enough points in trajectory after overlap points removal");
+    return;
+  }
+
   // calculate prev closest point
   if (!prev_output_.empty()) {
     current_closest_point_from_prev_output_ = calcProjectedTrajectoryPointFromEgo(prev_output_);
@@ -413,9 +423,6 @@ void MotionVelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstShar
 
   // ignore current external velocity limit next time
   external_velocity_limit_ptr_ = nullptr;
-
-  // calculate trajectory velocity
-  auto input_points = motion_utils::convertToTrajectoryPointArray(*base_traj_raw_ptr_);
 
   // For negative velocity handling, multiple -1 to velocity if it is for reverse.
   // NOTE: this process must be in the beginning of the process

--- a/planning/motion_velocity_smoother/test/test_motion_velocity_smoother_node_interface.cpp
+++ b/planning/motion_velocity_smoother/test/test_motion_velocity_smoother_node_interface.cpp
@@ -29,17 +29,21 @@ TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInpu
 
   auto node_options = rclcpp::NodeOptions{};
 
-  test_manager->declareVehicleInfoParams(node_options);
-  test_manager->declareNearestSearchDistanceParams(node_options);
   node_options.append_parameter_override("algorithm_type", "JerkFiltered");
   node_options.append_parameter_override("publish_debug_trajs", false);
 
   const auto motion_velocity_smoother_dir =
     ament_index_cpp::get_package_share_directory("motion_velocity_smoother");
 
+  const auto planning_test_utils_dir =
+    ament_index_cpp::get_package_share_directory("planning_test_utils");
+
   node_options.arguments(
-    {"--ros-args", "--params-file",
-     motion_velocity_smoother_dir + "/config/test_default_motion_velocity_smoother.param.yaml",
+    {"--ros-args", "--params-file", planning_test_utils_dir + "/config/test_common.param.yaml",
+     "--params-file", planning_test_utils_dir + "/config/test_nearest_search.param.yaml",
+     "--params-file", planning_test_utils_dir + "/config/test_vehicle_info.param.yaml",
+     "--params-file",
+     motion_velocity_smoother_dir + "/config/default_motion_velocity_smoother.param.yaml",
      "--params-file", motion_velocity_smoother_dir + "/config/default_common.param.yaml",
      "--params-file", motion_velocity_smoother_dir + "/config/JerkFiltered.param.yaml"});
 


### PR DESCRIPTION
## Description

Two updates:
- add remove-overlap-points function at the top of the process
- enable a test for the invalid trajectory checking if the node won't die when the invalid trajectory is published

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

- pass the unit test
- run psim (go and stop)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
