### PR TITLE
test(planning_test_utils, behavior_path_planner): add test for off-track ego pose

### DIFF
--- a/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
@@ -22,14 +22,27 @@
 #include <cmath>
 #include <vector>
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+using behavior_path_planner::BehaviorPathPlannerNode;
+using planning_test_utils::PlanningInterfaceTestManager;
+
+std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
 {
-  rclcpp::init(0, nullptr);
+  auto test_manager = std::make_shared<PlanningInterfaceTestManager>();
 
-  auto test_manager = std::make_shared<planning_test_utils::PlanningInterfaceTestManager>();
+  // set subscriber with topic name: behavior_path_planner → test_node_
+  test_manager->setPathWithLaneIdSubscriber("behavior_path_planner/output/path");
 
+  // set behavior_path_planner's input topic name(this topic is changed to test node)
+  test_manager->setRouteInputTopicName("behavior_path_planner/input/route");
+
+  test_manager->setInitialPoseTopicName("behavior_path_planner/input/odometry");
+
+  return test_manager;
+}
+
+std::shared_ptr<BehaviorPathPlannerNode> generateNode()
+{
   auto node_options = rclcpp::NodeOptions{};
-
   const auto planning_test_utils_dir =
     ament_index_cpp::get_package_share_directory("planning_test_utils");
   const auto behavior_path_planner_dir =
@@ -52,9 +65,13 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
                    behavior_path_planner_dir + "/config/avoidance_by_lc/avoidance_by_lc.param.yaml",
                    behavior_path_planner_dir + "/config/side_shift/side_shift.param.yaml"});
 
-  auto test_target_node =
-    std::make_shared<behavior_path_planner::BehaviorPathPlannerNode>(node_options);
+  return std::make_shared<BehaviorPathPlannerNode>(node_options);
+}
 
+void publishMandatoryTopics(
+  std::shared_ptr<PlanningInterfaceTestManager> test_manager,
+  std::shared_ptr<BehaviorPathPlannerNode> test_target_node)
+{
   // publish necessary topics from test_manager
   test_manager->publishInitialPose(test_target_node, "behavior_path_planner/input/odometry");
   test_manager->publishAcceleration(test_target_node, "behavior_path_planner/input/accel");
@@ -68,12 +85,15 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
   test_manager->publishOperationModeState(test_target_node, "system/operation_mode/state");
   test_manager->publishLateralOffset(
     test_target_node, "behavior_path_planner/input/lateral_offset");
+}
 
-  // set subscriber with topic name: behavior_path_planner → test_node_
-  test_manager->setPathWithLaneIdSubscriber("behavior_path_planner/output/path");
+TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+{
+  rclcpp::init(0, nullptr);
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
 
-  // set behavior_path_planner's input topic name(this topic is changed to test node)
-  test_manager->setRouteInputTopicName("behavior_path_planner/input/route");
+  publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
   ASSERT_NO_THROW(test_manager->testWithBehaviorNominalRoute(test_target_node));
@@ -81,5 +101,24 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
 
   // test with empty route
   test_manager->testWithAbnormalRoute(test_target_node);
+  rclcpp::shutdown();
+}
+
+TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
+  publishMandatoryTopics(test_manager, test_target_node);
+
+  // test for normal trajectory
+  ASSERT_NO_THROW(test_manager->testWithBehaviorNominalRoute(test_target_node));
+
+  // make sure behavior_path_planner is running
+  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+
+  ASSERT_NO_THROW(test_manager->testOffTrackFromRoute(test_target_node));
+
   rclcpp::shutdown();
 }

--- a/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
@@ -118,7 +118,7 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   // make sure behavior_path_planner is running
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
-  ASSERT_NO_THROW(test_manager->testOffTrackFromRoute(test_target_node));
+  ASSERT_NO_THROW(test_manager->testRouteWithInvalidEgoPose(test_target_node));
 
   rclcpp::shutdown();
 }

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
@@ -149,6 +149,12 @@ public:
   void testWithNominalPathWithLaneId(rclcpp::Node::SharedPtr target_node);
   void testWithAbnormalPathWithLaneId(rclcpp::Node::SharedPtr target_node);
 
+  // for invalid ego poses, contains some tests inside.
+  void testRouteWithInvalidEgoPose(rclcpp::Node::SharedPtr target_node);
+  void testPathWithInvalidEgoPose(rclcpp::Node::SharedPtr target_node);
+  void testPathWithLaneIdWithInvalidEgoPose(rclcpp::Node::SharedPtr target_node);
+  void testTrajectoryWithInvalidEgoPose(rclcpp::Node::SharedPtr target_node);
+
   // ego vehicle is located far from trajectory
   void testOffTrackFromRoute(rclcpp::Node::SharedPtr target_node);
   void testOffTrackFromPath(rclcpp::Node::SharedPtr target_node);

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
@@ -90,8 +90,12 @@ class PlanningInterfaceTestManager
 public:
   PlanningInterfaceTestManager();
 
+  void publishOdometry(rclcpp::Node::SharedPtr target_node);
   void publishOdometry(rclcpp::Node::SharedPtr target_node, std::string topic_name);
+
+  void publishInitialPose(rclcpp::Node::SharedPtr target_node);
   void publishInitialPose(rclcpp::Node::SharedPtr target_node, std::string topic_name);
+
   void publishMaxVelocity(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishPointCloud(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishAcceleration(rclcpp::Node::SharedPtr target_node, std::string topic_name);
@@ -115,7 +119,8 @@ public:
   void publishExternalCrosswalkStates(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishExternalIntersectionStates(
     rclcpp::Node::SharedPtr target_node, std::string topic_name);
-  void publishInitialPoseData(rclcpp::Node::SharedPtr target_node, std::string topic_name);
+  void publishInitialPoseData(
+    rclcpp::Node::SharedPtr target_node, std::string topic_name, double shift = 0.0);
 
   void setTrajectoryInputTopicName(std::string topic_name);
   void setParkingTrajectoryInputTopicName(std::string topic_name);
@@ -130,6 +135,9 @@ public:
   void setRouteSubscriber(std::string topic_name);
   void setPathSubscriber(std::string topic_name);
 
+  void setInitialPoseTopicName(std::string topic_name);
+  void setOdometryTopicName(std::string topic_name);
+
   void testWithNominalTrajectory(rclcpp::Node::SharedPtr target_node);
   void testWithAbnormalTrajectory(rclcpp::Node::SharedPtr target_node);
 
@@ -140,6 +148,12 @@ public:
 
   void testWithNominalPathWithLaneId(rclcpp::Node::SharedPtr target_node);
   void testWithAbnormalPathWithLaneId(rclcpp::Node::SharedPtr target_node);
+
+  // ego vehicle is located far from trajectory
+  void testOffTrackFromRoute(rclcpp::Node::SharedPtr target_node);
+  void testOffTrackFromPath(rclcpp::Node::SharedPtr target_node);
+  void testOffTrackFromPathWithLaneId(rclcpp::Node::SharedPtr target_node);
+  void testOffTrackFromTrajectory(rclcpp::Node::SharedPtr target_node);
 
   int getReceivedTopicNum();
 
@@ -193,12 +207,14 @@ private:
   rclcpp::Publisher<PathWithLaneId>::SharedPtr normal_path_with_lane_id_pub_;
   rclcpp::Publisher<PathWithLaneId>::SharedPtr abnormal_path_with_lane_id_pub_;
 
-  std::string input_trajectory_name_;
-  std::string input_parking_trajectory_name_;
-  std::string input_lane_driving_trajectory_name_;
-  std::string input_route_name_;
-  std::string input_path_name_;
-  std::string input_path_with_lane_id_name_;
+  std::string input_trajectory_name_ = "";
+  std::string input_parking_trajectory_name_ = "";
+  std::string input_lane_driving_trajectory_name_ = "";
+  std::string input_route_name_ = "";
+  std::string input_path_name_ = "";
+  std::string input_path_with_lane_id_name_ = "";
+  std::string input_initial_pose_name_ = "";  // for the map based pose
+  std::string input_odometry_name_ = "";
 
   // Node
   rclcpp::Node::SharedPtr test_node_;

--- a/planning/planning_test_utils/src/planning_interface_test_manager.cpp
+++ b/planning/planning_test_utils/src/planning_interface_test_manager.cpp
@@ -31,6 +31,11 @@ void PlanningInterfaceTestManager::publishOdometry(
   test_utils::publishData<Odometry>(test_node_, target_node, topic_name, odom_pub_);
 }
 
+void PlanningInterfaceTestManager::publishOdometry(rclcpp::Node::SharedPtr target_node)
+{
+  publishOdometry(target_node, input_odometry_name_);
+}
+
 void PlanningInterfaceTestManager::publishMaxVelocity(
   rclcpp::Node::SharedPtr target_node, std::string topic_name)
 {
@@ -100,6 +105,11 @@ void PlanningInterfaceTestManager::publishInitialPose(
   rclcpp::Node::SharedPtr target_node, std::string topic_name)
 {
   publishInitialPoseData(target_node, topic_name);
+}
+
+void PlanningInterfaceTestManager::publishInitialPose(rclcpp::Node::SharedPtr target_node)
+{
+  publishInitialPose(target_node, input_initial_pose_name_);
 }
 
 void PlanningInterfaceTestManager::publishParkingState(
@@ -172,11 +182,14 @@ void PlanningInterfaceTestManager::publishExternalIntersectionStates(
 }
 
 void PlanningInterfaceTestManager::publishInitialPoseData(
-  rclcpp::Node::SharedPtr target_node, std::string topic_name)
+  rclcpp::Node::SharedPtr target_node, std::string topic_name, double shift)
 {
   std::shared_ptr<Odometry> current_odometry = std::make_shared<Odometry>();
+  const auto yaw = 0.9724497591854532;
+  const auto shift_x = shift * std::sin(yaw);
+  const auto shift_y = shift * std::cos(yaw);
   const std::array<double, 4> start_pose{
-    3722.16015625, 73723.515625, 0.233112560494183, 0.9724497591854532};
+    3722.16015625 + shift_x, 73723.515625 + shift_y, 0.233112560494183, yaw};
   current_odometry->pose.pose = test_utils::createPose(start_pose);
   current_odometry->header.frame_id = "map";
 
@@ -234,6 +247,16 @@ void PlanningInterfaceTestManager::setRouteInputTopicName(std::string topic_name
 void PlanningInterfaceTestManager::setPathWithLaneIdTopicName(std::string topic_name)
 {
   input_path_with_lane_id_name_ = topic_name;
+}
+
+void PlanningInterfaceTestManager::setInitialPoseTopicName(std::string topic_name)
+{
+  input_initial_pose_name_ = topic_name;
+}
+
+void PlanningInterfaceTestManager::setOdometryTopicName(std::string topic_name)
+{
+  input_odometry_name_ = topic_name;
 }
 
 void PlanningInterfaceTestManager::publishNominalTrajectory(
@@ -369,6 +392,43 @@ void PlanningInterfaceTestManager::testWithAbnormalPathWithLaneId(
 {
   publishAbNominalPathWithLaneId(target_node, input_path_with_lane_id_name_);
   test_utils::spinSomeNodes(test_node_, target_node, 5);
+}
+
+void PlanningInterfaceTestManager::testOffTrackFromRoute(rclcpp::Node::SharedPtr target_node)
+{
+  if (input_route_name_.empty()) {
+    throw std::runtime_error("route topic name is not set");
+  }
+  if (input_initial_pose_name_.empty()) {
+    throw std::runtime_error("initial topic pose name is not set");
+  }
+
+  publishBehaviorNominalRoute(target_node, input_route_name_);
+
+  const std::vector<double> deviation_from_route = {0.0, 1.0, 10.0, 100.0};
+  for (const auto & deviation : deviation_from_route) {
+    publishInitialPoseData(target_node, input_initial_pose_name_, deviation);
+    test_utils::spinSomeNodes(test_node_, target_node, 5);
+  }
+}
+
+void PlanningInterfaceTestManager::testOffTrackFromPath(rclcpp::Node::SharedPtr target_node)
+{
+  // write me
+  (void)target_node;
+}
+
+void PlanningInterfaceTestManager::testOffTrackFromPathWithLaneId(
+  rclcpp::Node::SharedPtr target_node)
+{
+  // write me
+  (void)target_node;
+}
+
+void PlanningInterfaceTestManager::testOffTrackFromTrajectory(rclcpp::Node::SharedPtr target_node)
+{
+  // write me
+  (void)target_node;
 }
 
 int PlanningInterfaceTestManager::getReceivedTopicNum()

--- a/planning/planning_test_utils/src/planning_interface_test_manager.cpp
+++ b/planning/planning_test_utils/src/planning_interface_test_manager.cpp
@@ -394,6 +394,32 @@ void PlanningInterfaceTestManager::testWithAbnormalPathWithLaneId(
   test_utils::spinSomeNodes(test_node_, target_node, 5);
 }
 
+// put all abnormal ego pose related tests in this functions to run all tests with one line code
+void PlanningInterfaceTestManager::testRouteWithInvalidEgoPose(rclcpp::Node::SharedPtr target_node)
+{
+  testOffTrackFromRoute(target_node);
+}
+
+// put all abnormal ego pose related tests in this functions to run all tests with one line code
+void PlanningInterfaceTestManager::testPathWithInvalidEgoPose(rclcpp::Node::SharedPtr target_node)
+{
+  testOffTrackFromPath(target_node);
+}
+
+// put all abnormal ego pose related tests in this functions to run all tests with one line code
+void PlanningInterfaceTestManager::testPathWithLaneIdWithInvalidEgoPose(
+  rclcpp::Node::SharedPtr target_node)
+{
+  testOffTrackFromPathWithLaneId(target_node);
+}
+
+// put all abnormal ego pose related tests in this functions to run all tests with one line code
+void PlanningInterfaceTestManager::testTrajectoryWithInvalidEgoPose(
+  rclcpp::Node::SharedPtr target_node)
+{
+  testOffTrackFromTrajectory(target_node);
+}
+
 void PlanningInterfaceTestManager::testOffTrackFromRoute(rclcpp::Node::SharedPtr target_node)
 {
   if (input_route_name_.empty()) {


### PR DESCRIPTION
## Description

Add a test in the `behavior_path_planner` to check that the node will not die when the ego pose is located far from the target route

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

pass the unit test

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
