### PR TITLE
fix(planner_manager): use LIFO policy in approved modules unregistering

### DIFF
--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -389,10 +389,7 @@ BehaviorModuleOutput PlannerManager::runApprovedModules(const std::shared_ptr<Pl
       candidate_module_ptrs_.push_back(*itr);
     }
 
-    approved_module_ptrs_.erase(
-      std::remove_if(
-        approved_module_ptrs_.begin(), approved_module_ptrs_.end(), waiting_approval_modules),
-      approved_module_ptrs_.end());
+    approved_module_ptrs_.erase(itr, approved_module_ptrs_.end());
   }
 
   /**
@@ -427,24 +424,55 @@ BehaviorModuleOutput PlannerManager::runApprovedModules(const std::shared_ptr<Pl
     return results.at(output_module_name);
   }();
 
+  const auto not_success_itr = std::find_if(
+    approved_module_ptrs_.rbegin(), approved_module_ptrs_.rend(),
+    [](const auto & m) { return m->getCurrentStatus() != ModuleStatus::SUCCESS; });
+
+  // convert reverse iterator -> iterator
+  const auto success_itr = std::prev(not_success_itr).base() - 1;
+
   /**
-   * 1.remove success modules. these modules' outputs are used as valid plan.
-   * 2.update root lanelet if lane change module succeeded path planning, and finished correctly.
+   * there is no succeeded module. return.
    */
-  {
-    const auto itr = std::find_if(
-      approved_module_ptrs_.begin(), approved_module_ptrs_.end(),
-      [](const auto & m) { return m->getCurrentStatus() == ModuleStatus::SUCCESS; });
+  if (success_itr == approved_module_ptrs_.end()) {
+    return approved_modules_output;
+  }
 
-    if (itr == approved_module_ptrs_.begin()) {
-      if ((*itr)->name().find("lane_change") != std::string::npos) {
-        root_lanelet_ = updateRootLanelet(data);
-      }
+  const auto lane_change_itr = std::find_if(
+    success_itr, approved_module_ptrs_.end(),
+    [](const auto & m) { return m->name().find("lane_change") != std::string::npos; });
 
-      clearCandidateModules();
-      deleteExpiredModules(*itr);
-      approved_module_ptrs_.erase(itr);
-    }
+  /**
+   * remove success modules according to Last In First Out(LIFO) policy. when the next module is in
+   * ModuleStatus::RUNNING, the previous module keeps running even if it is in
+   * ModuleStatus::SUCCESS.
+   */
+  if (lane_change_itr == approved_module_ptrs_.end()) {
+    std::for_each(
+      success_itr, approved_module_ptrs_.end(), [this](auto & m) { deleteExpiredModules(m); });
+
+    approved_module_ptrs_.erase(success_itr, approved_module_ptrs_.end());
+    clearCandidateModules();
+
+    return approved_modules_output;
+  }
+
+  /**
+   * as an exception, when there is lane change module is in succeeded modules, it doesn't remove
+   * any modules if module whose status is NOT ModuleStatus::SUCCESS exists. this is because the
+   * root lanelet is updated at the moment of lane change module's unregistering, and that causes
+   * change First In module's input.
+   */
+  if (not_success_itr == approved_module_ptrs_.rend()) {
+    std::for_each(
+      success_itr, approved_module_ptrs_.end(), [this](auto & m) { deleteExpiredModules(m); });
+
+    approved_module_ptrs_.erase(success_itr, approved_module_ptrs_.end());
+    clearCandidateModules();
+
+    root_lanelet_ = updateRootLanelet(data);
+
+    return approved_modules_output;
   }
 
   return approved_modules_output;


### PR DESCRIPTION
## Description

The planner manager doesn't control the order of removing expired modules from approved modules but I'm sure that it is better to define removing policy.

Since the last added module's output path is generated from first added module's output, perhaps the last added module's output changes greatly if it removes the first added module at first. And I think that it is safer to remove modules based on Last In First Out rule. 

![image](https://user-images.githubusercontent.com/44889564/232631738-b51bfbbc-21a6-4f2e-a595-f37e112d1afa.png)

In this PR, I use Last In First Out policy in unregistering logic.

![image](https://user-images.githubusercontent.com/44889564/232439742-5c558693-b45e-4eb4-acb4-21c47a569f9a.png)

On the other hand, when the lane change module finishes with `ModuleStatus::SUCCESS`, root lanelet and the input of first added module (module A in following fig) will be updated.

![image](https://user-images.githubusercontent.com/44889564/232633430-727340a9-c75a-4a9e-aa64-31b7fcf615c4.png)

This also causes large path change, so the manager waits for all module success, only when it removes lane change module.

![image](https://user-images.githubusercontent.com/44889564/232633607-4963b1ab-484a-4ad2-9d0a-693d9252bf6c.png)

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

[[LC+Avoidance scenarios]](https://evaluation.tier4.jp/evaluation/reports/f943eeaf-a08f-5c27-82a4-2cf9f4eefbad?project_id=prd_jt) All PASS

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Nothing

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Improve LC+Avoidance maneuver.

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
