### PR TITLE
feat(vehicle_cmd_gate): add multiple pause source ability

### DIFF
--- a/control/vehicle_cmd_gate/src/pause_interface.hpp
+++ b/control/vehicle_cmd_gate/src/pause_interface.hpp
@@ -21,6 +21,9 @@
 
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 
+#include <string>
+#include <unordered_map>
+
 namespace vehicle_cmd_gate
 {
 
@@ -40,10 +43,11 @@ public:
   void update(const AckermannControlCommand & control);
 
 private:
-  bool is_paused_;
   bool is_start_requested_;
-  std::optional<bool> prev_is_paused_;
   std::optional<bool> prev_is_start_requested_;
+  IsPaused::Message pause_state_;
+  std::unordered_map<std::string, bool> pause_map_;
+  std::optional<std::unordered_map<std::string, bool>> prev_pause_map_;
 
   rclcpp::Node * node_;
   component_interface_utils::Service<SetPause>::SharedPtr srv_set_pause_;
@@ -53,6 +57,8 @@ private:
   void on_pause(
     const SetPause::Service::Request::SharedPtr req,
     const SetPause::Service::Response::SharedPtr res);
+
+  void update_pause_state();
 };
 
 }  // namespace vehicle_cmd_gate


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
<!--
copilot:all
-->

Before this be merged, msg file should be merged.
https://github.com/tier4/tier4_autoware_msgs/pull/82
### <samp>🤖 Generated by Copilot at 8030a11</samp>

### Summary
:sparkles::recycle::memo:

<!--
1.  :sparkles: This emoji represents the addition of new features or functionality to the code, such as the new method and the new message and container.
2.  :recycle: This emoji represents the refactoring or improvement of existing code, such as the modification of the `PauseInterface` class to support multiple pause sources and publish the pause state.
3.  :memo: This emoji represents the addition or update of documentation or comments, such as the docstrings for the new method and the class attributes.
-->
Improved the pause interface for the vehicle command gate by allowing multiple sources of pause requests and publishing the pause state. Refactored the `PauseInterface` class and added a new method `update_pause_state` to handle the pause logic. Modified `pause_interface.cpp` and `pause_interface.hpp` accordingly.

> _We are the masters of the pause interface_
> _We control the sources of the halt_
> _We update and publish the state of grace_
> _We defy the forces of default_

### Walkthrough
*  Add a feature that allows multiple sources to request a pause of the vehicle command gate, and shows which sources are requesting it ([link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-c6cb4d89b8200c23b9b1122c4fe09f7d632739fa755790bb015985d2ec4249b1L27-R40), [link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-c6cb4d89b8200c23b9b1122c4fe09f7d632739fa755790bb015985d2ec4249b1L64-R79), [link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-2e03f03d7c1b2b381a455d80ad899e13556a3bd1752e51964ba8bae589a11906R24-R25), [link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-2e03f03d7c1b2b381a455d80ad899e13556a3bd1752e51964ba8bae589a11906L43-R49), [link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-2e03f03d7c1b2b381a455d80ad899e13556a3bd1752e51964ba8bae589a11906R59-R60))
  * Modify the constructor of the `PauseInterface` class to initialize the `pause_state_` message and remove the `is_paused_` and `prev_is_paused_` variables ([link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-c6cb4d89b8200c23b9b1122c4fe09f7d632739fa755790bb015985d2ec4249b1L27-R40))
  * Modify the `publish` method to use the `pause_state_` and `pause_map_` variables, and call the `update_pause_state` method before publishing ([link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-c6cb4d89b8200c23b9b1122c4fe09f7d632739fa755790bb015985d2ec4249b1L27-R40))
  * Modify the `on_pause` callback to store the pause request and the source in the `pause_map_` variable, and call the `update_pause_state` method ([link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-c6cb4d89b8200c23b9b1122c4fe09f7d632739fa755790bb015985d2ec4249b1L64-R79))
  * Add the `update_pause_state` method that updates the `pause_state_` message based on the `pause_map_` variable ([link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-c6cb4d89b8200c23b9b1122c4fe09f7d632739fa755790bb015985d2ec4249b1L64-R79), [link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-2e03f03d7c1b2b381a455d80ad899e13556a3bd1752e51964ba8bae589a11906R59-R60))
  * Add the `pause_state_`, `pause_map_`, and `prev_pause_map_` variables to the `PauseInterface` class, and remove the `is_paused_` and `prev_is_paused_` variables ([link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-2e03f03d7c1b2b381a455d80ad899e13556a3bd1752e51964ba8bae589a11906L43-R49))
  * Include the header file for the `unordered_map` container in the `pause_interface.hpp` file ([link](https://github.com/autowarefoundation/autoware.universe/pull/3435/files?diff=unified&w=0#diff-2e03f03d7c1b2b381a455d80ad899e13556a3bd1752e51964ba8bae589a11906R24-R25))


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
After this PR, requests should include the node's name.
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
