### PR TITLE
fix(avoidance): request avoidance manauver when there is object that should be avoid

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -124,6 +124,11 @@ bool AvoidanceModule::isExecutionRequested() const
 #else
   fillShiftLine(avoid_data, debug_data_);
 
+  // there is object that should be avoid. return true.
+  if (!!avoid_data.stop_target_object) {
+    return true;
+  }
+
   if (avoid_data.unapproved_new_sl.empty()) {
     return false;
   }


### PR DESCRIPTION
## Description

The avoidance module doesn't make a request to path modification when there is no new shift line.
On the other hand, sometimes shift lines are not generated for object that should be avoid, for example the ego speed is too high to avoid it.

Therefore, the avoidance module doesn't make a request and do anything for the object. However it is unexpected behavior. The avoidance module should make a request and insert decel point to path for object whose unavoidable reason is `TOO_LARGE_JERK`.

:arrow_down: The avoidance module do nothing, and the ego is stopped by obstacle stop planner. As a result, there isn't enough distance to avoid between ego and object.

https://user-images.githubusercontent.com/44889564/232629359-feccfe20-e96b-43ce-b880-9e7964eda3e8.mp4

In this PR, I fix request logic, and `isExecutionRequested` return `true` if there are object that should be avoid (=`stop_target_object`).

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

[[UC-A-04-00104_001_case03_cmn]](https://evaluation.tier4.jp/evaluation/reports/1d328b41-222f-5be8-ae88-3e4c1a90244a/tests/57d689b9-c0a0-5b87-9c7c-ce80165be41e/306036e5-15cf-59f5-9c2c-134eeead675f?project_id=prd_jt) FAIL
[[UC-A-04-00104_002_case03_cmn]](https://evaluation.tier4.jp/evaluation/reports/1d328b41-222f-5be8-ae88-3e4c1a90244a/tests/57d689b9-c0a0-5b87-9c7c-ce80165be41e/d95b7a89-c1f9-5844-af87-5037be4438fd?project_id=prd_jt) FAIL

After this PR...

[[UC-A-04-00104_001_case03_cmn]](https://evaluation.tier4.jp/evaluation/reports/fc626ea1-020b-5fa7-820b-701dbfebbacf/tests/4fb81e1c-2b5f-500b-a255-b3c46f523c10/27502966-0f8b-54ed-b683-e825af60ad15?project_id=prd_jt) PASS
[[UC-A-04-00104_002_case03_cmn]](https://evaluation.tier4.jp/evaluation/reports/fc626ea1-020b-5fa7-820b-701dbfebbacf/tests/4fb81e1c-2b5f-500b-a255-b3c46f523c10/1abde46e-1931-50c4-b012-558ec848c9a5?project_id=prd_jt) PASS

:arrow_down: The avoidance module inserts decel point to path, and the ego is stopped by avoidance module with ehough distance to avoid.

https://user-images.githubusercontent.com/44889564/232629719-808b1724-feb2-436a-9013-918e7cdd47f2.mp4

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Fix unexpected yield behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
