### PR TITLE
refactor(lane_change): unify the functions for old/new architecture

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
+set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
+set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -55,20 +55,18 @@ public:
   LaneChangeBase(const std::shared_ptr<LaneChangeParameters> & parameters, Direction direction)
   : parameters_{parameters}, direction_{direction}
   {
+    prev_module_reference_path_ = std::make_shared<PathWithLaneId>();
+    prev_module_path_ = std::make_shared<PathWithLaneId>();
+    prev_drivable_lanes_ = std::make_shared<std::vector<DrivableLanes>>();
   }
 
   virtual ~LaneChangeBase() = default;
 
-  virtual void updateLaneChangeStatus(
-    const PathWithLaneId & prev_module_reference_path,
-    const PathWithLaneId & previous_module_path) = 0;
+  virtual void updateLaneChangeStatus() = 0;
 
-  virtual std::pair<bool, bool> getSafePath(
-    const PathWithLaneId & prev_module_reference_path, const PathWithLaneId & prev_module_path,
-    LaneChangePath & safe_path) const = 0;
+  virtual std::pair<bool, bool> getSafePath(LaneChangePath & safe_path) const = 0;
 
-  virtual PathWithLaneId generatePlannedPath(
-    const std::vector<DrivableLanes> & prev_drivable_lanes) = 0;
+  virtual PathWithLaneId generatePlannedPath() = 0;
 
   virtual void generateExtendedDrivableArea(
     const std::vector<DrivableLanes> & prev_drivable_lanes, PathWithLaneId & path) = 0;
@@ -84,6 +82,18 @@ public:
   virtual void resetParameters() = 0;
 
   virtual TurnSignalInfo updateOutputTurnSignal() = 0;
+
+  virtual void setPreviousModulePaths(
+    const PathWithLaneId & prev_module_reference_path, const PathWithLaneId & prev_module_path)
+  {
+    *prev_module_reference_path_ = prev_module_reference_path;
+    *prev_module_path_ = prev_module_path;
+  };
+
+  virtual void setPreviousDrivableLanes(const std::vector<DrivableLanes> & prev_drivable_lanes)
+  {
+    *prev_drivable_lanes_ = prev_drivable_lanes;
+  }
 
   const LaneChangeStatus & getLaneChangeStatus() const { return status_; }
 
@@ -178,6 +188,9 @@ protected:
   std::shared_ptr<LaneChangeParameters> parameters_{};
   std::shared_ptr<LaneChangePath> abort_path_{};
   std::shared_ptr<const PlannerData> planner_data_{};
+  std::shared_ptr<PathWithLaneId> prev_module_reference_path_{};
+  std::shared_ptr<PathWithLaneId> prev_module_path_{};
+  std::shared_ptr<std::vector<DrivableLanes>> prev_drivable_lanes_{};
 
   PathWithLaneId prev_approved_path_{};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -68,8 +68,7 @@ public:
 
   virtual PathWithLaneId generatePlannedPath() = 0;
 
-  virtual void generateExtendedDrivableArea(
-    const std::vector<DrivableLanes> & prev_drivable_lanes, PathWithLaneId & path) = 0;
+  virtual void generateExtendedDrivableArea(PathWithLaneId & path) = 0;
 
   virtual bool hasFinishedLaneChange() const = 0;
 
@@ -156,8 +155,16 @@ public:
   const Direction & getDirection() const { return direction_; }
 
 protected:
+  virtual lanelet::ConstLanelets getCurrentLanes() const = 0;
+
   virtual lanelet::ConstLanelets getLaneChangeLanes(
     const lanelet::ConstLanelets & current_lanes) const = 0;
+
+  virtual std::pair<LaneChangePaths, bool> getLaneChangePaths(
+    const lanelet::ConstLanelets & current_lanes,
+    const lanelet::ConstLanelets & target_lanes) const = 0;
+
+  virtual std::vector<DrivableLanes> getDrivableLanes() const = 0;
 
   virtual bool isApprovedPathSafe(Pose & ego_pose_before_collision) const = 0;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -160,9 +160,15 @@ protected:
   virtual lanelet::ConstLanelets getLaneChangeLanes(
     const lanelet::ConstLanelets & current_lanes) const = 0;
 
-  virtual std::pair<LaneChangePaths, bool> getLaneChangePaths(
-    const lanelet::ConstLanelets & current_lanes,
-    const lanelet::ConstLanelets & target_lanes) const = 0;
+  virtual int getNumToPreferredLane(const lanelet::ConstLanelet & lane) const = 0;
+
+  virtual PathWithLaneId getPrepareSegment(
+    const lanelet::ConstLanelets & current_lanes, const double backward_path_length,
+    const double prepare_length, const double prepare_velocity) const = 0;
+
+  virtual bool getLaneChangePaths(
+    const lanelet::ConstLanelets & original_lanelets,
+    const lanelet::ConstLanelets & target_lanelets, LaneChangePaths * candidate_paths) const = 0;
 
   virtual std::vector<DrivableLanes> getDrivableLanes() const = 0;
 
@@ -202,7 +208,7 @@ protected:
   PathWithLaneId prev_approved_path_{};
 
   double lane_change_lane_length_{200.0};
-  double check_distance_{100.0};
+  double check_length_{100.0};
 
   bool is_abort_path_approved_{false};
   bool is_abort_approval_requested_{false};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -65,9 +65,16 @@ protected:
   lanelet::ConstLanelets getLaneChangeLanes(
     const lanelet::ConstLanelets & current_lanes) const override;
 
-  std::pair<LaneChangePaths, bool> getLaneChangePaths(
-    const lanelet::ConstLanelets & current_lanes,
-    const lanelet::ConstLanelets & target_lanes) const override;
+  int getNumToPreferredLane(const lanelet::ConstLanelet & lane) const override;
+
+  PathWithLaneId getPrepareSegment(
+    const lanelet::ConstLanelets & current_lanes, const double backward_path_length,
+    const double prepare_length, const double prepare_velocity) const override;
+
+  bool getLaneChangePaths(
+    const lanelet::ConstLanelets & original_lanelets,
+    const lanelet::ConstLanelets & target_lanelets,
+    LaneChangePaths * candidate_paths) const override;
 
   std::vector<DrivableLanes> getDrivableLanes() const override;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -45,8 +45,7 @@ public:
 
   PathWithLaneId generatePlannedPath() override;
 
-  void generateExtendedDrivableArea(
-    const std::vector<DrivableLanes> & prev_drivable_lanes, PathWithLaneId & path) override;
+  void generateExtendedDrivableArea(PathWithLaneId & path) override;
 
   bool hasFinishedLaneChange() const override;
 
@@ -61,8 +60,16 @@ public:
   TurnSignalInfo updateOutputTurnSignal() override;
 
 protected:
+  lanelet::ConstLanelets getCurrentLanes() const override;
+
   lanelet::ConstLanelets getLaneChangeLanes(
     const lanelet::ConstLanelets & current_lanes) const override;
+
+  std::pair<LaneChangePaths, bool> getLaneChangePaths(
+    const lanelet::ConstLanelets & current_lanes,
+    const lanelet::ConstLanelets & target_lanes) const override;
+
+  std::vector<DrivableLanes> getDrivableLanes() const override;
 
   bool isApprovedPathSafe(Pose & ego_pose_before_collision) const override;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -39,16 +39,11 @@ public:
 
   ~NormalLaneChange() override = default;
 
-  void updateLaneChangeStatus(
-    const PathWithLaneId & prev_module_reference_path,
-    const PathWithLaneId & previous_module_path) override;
+  void updateLaneChangeStatus() override;
 
-  std::pair<bool, bool> getSafePath(
-    const PathWithLaneId & prev_module_reference_path, const PathWithLaneId & prev_module_path,
-    LaneChangePath & safe_path) const override;
+  std::pair<bool, bool> getSafePath(LaneChangePath & safe_path) const override;
 
-  PathWithLaneId generatePlannedPath(
-    const std::vector<DrivableLanes> & prev_drivable_lanes) override;
+  PathWithLaneId generatePlannedPath() override;
 
   void generateExtendedDrivableArea(
     const std::vector<DrivableLanes> & prev_drivable_lanes, PathWithLaneId & path) override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -48,6 +48,17 @@ using marker_utils::CollisionCheckDebug;
 using route_handler::Direction;
 using tier4_autoware_utils::Polygon2d;
 
+double calcLaneChangeResampleInterval(
+  const double lane_changing_length, const double lane_changing_velocity);
+
+std::vector<int64_t> replaceWithSortedIds(
+  const std::vector<int64_t> & original_lane_ids,
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids);
+
+std::vector<std::vector<int64_t>> getSortedLaneIds(
+  const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
+  const lanelet::ConstLanelets & target_lanes, const double rough_shift_length);
+
 PathWithLaneId combineReferencePath(const PathWithLaneId & path1, const PathWithLaneId & path2);
 
 bool isPathInLanelets(
@@ -174,6 +185,8 @@ LaneChangeTargetObjectIndices filterObjectIndices(
 bool isTargetObjectType(const PredictedObject & object, const LaneChangeParameters & parameter);
 
 double calcLateralBufferForFiltering(const double vehicle_width, const double lateral_buffer = 0.0);
+
+double calcLateralBufferForFiltering(const double vehicle_width, const double lateral_buffer);
 
 std::string getStrDirection(const std::string & name, const Direction direction);
 


### PR DESCRIPTION
## Description

In order to minimize the amount of changes when the base class in inherited by the codes in the OLD ARCHITECTURE, some function is moved from `utils::lane_change` to `normal.cpp`. For the codes that required to be compiled with `COMPILE_WITH_OLD_ARCHITECTURE`, it is extracted into a proxy function, and the proxy function will be used in the main function. This is so that the main function will not be override when they are inherited later.

## Related links

#3452 should be merged AFTER this PR.

## Tests performed

- [X] Build with `COMPILE_WITH_OLD_ARCHITECTURE = TRUE`
- [X] Build with `COMPILE_WITH_OLD_ARCHITECTURE = FALSE`
- [X] Degradation test in the CI [TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/c8a3f76a-dfd6-5b16-8b63-2718b3c81eab?project_id=prd_jt)

## Notes for reviewers

#3452 should be merged AFTER this PR.

## Interface changes

No changes to the main interface as this code only affect the module level.

## Effects on system behavior

No effects to the main system as this is refactoring PR.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
