### PR TITLE
feat(behavior_path_planner): remove minimum lane changing length

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -48,6 +48,13 @@ struct BehaviorPathPlannerParameters
   double backward_length_buffer_for_end_of_lane;
   double backward_length_buffer_for_end_of_pull_over;
   double backward_length_buffer_for_end_of_pull_out;
+
+  // lane change parameters
+  double lane_changing_lateral_jerk{0.5};
+  double lane_changing_lateral_acc{0.315};
+  double lane_changing_lateral_acc_at_low_velocity{0.15};
+  double lateral_acc_switching_velocity{0.4};
+  double minimum_lane_changing_velocity{5.6};
   double minimum_lane_changing_length;
   double minimum_prepare_length;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -27,12 +27,7 @@ struct LaneChangeParameters
 {
   // trajectory generation
   double prepare_duration{2.0};
-  double lane_changing_lateral_jerk{0.5};
-  double lane_changing_lateral_acc{0.315};
-  double lane_changing_lateral_acc_at_low_velocity{0.15};
-  double lateral_acc_switching_velocity{0.4};
   double lane_change_finish_judge_buffer{3.0};
-  double minimum_lane_changing_velocity{5.6};
   double prediction_time_resolution{0.5};
   double maximum_deceleration{1.0};
   int lane_change_sampling_num{10};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -67,7 +67,7 @@ bool isPathInLanelets(
 
 double calcLaneChangingLength(
   const double lane_changing_velocity, const double shift_length,
-  const BehaviorPathPlannerParameters & com_param, const LaneChangeParameters & lc_param);
+  const BehaviorPathPlannerParameters & common_parameter);
 
 std::optional<LaneChangePath> constructCandidatePath(
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_segment,
@@ -75,6 +75,7 @@ std::optional<LaneChangePath> constructCandidatePath(
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
   const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double acceleration,
   const LaneChangePhaseInfo lane_change_length, const LaneChangePhaseInfo lane_change_velocity,
+  const BehaviorPathPlannerParameters & common_parameter,
   const LaneChangeParameters & lane_change_param);
 
 bool getLaneChangePaths(
@@ -105,7 +106,8 @@ bool isLaneChangePathSafe(
 bool hasEnoughLength(
   const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes, const Pose & current_pose,
-  const RouteHandler & route_handler, const double minimum_lane_change_length,
+  const RouteHandler & route_handler, const double minimum_lane_changing_velocity,
+  const BehaviorPathPlannerParameters & common_parameters,
   const Direction direction = Direction::NONE);
 
 ShiftLine getLaneChangingShiftLine(

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -339,8 +339,16 @@ bool checkPathRelativeAngle(const PathWithLaneId & path, const double angle_thre
 double calcTotalLaneChangeLength(
   const BehaviorPathPlannerParameters & common_param, const bool include_buffer = true);
 
+double calcLaneChangingTime(
+  const double lane_changing_velocity, const double shift_length,
+  const BehaviorPathPlannerParameters & common_parameter);
+
 double calcLaneChangeBuffer(
   const BehaviorPathPlannerParameters & common_param, const int num_lane_change,
+  const double length_to_intersection = 0.0);
+
+double calcMinimumLaneChangeLength(
+  const BehaviorPathPlannerParameters & common_param, const std::vector<double> & shift_intervals,
   const double length_to_intersection = 0.0);
 
 lanelet::ConstLanelets getLaneletsFromPath(

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -376,14 +376,26 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   // ROS parameters
   p.backward_path_length = declare_parameter<double>("backward_path_length") + backward_offset;
   p.forward_path_length = declare_parameter<double>("forward_path_length");
+
+  // lane change parameters
   p.backward_length_buffer_for_end_of_lane =
     declare_parameter<double>("lane_change.backward_length_buffer_for_end_of_lane");
+  p.minimum_lane_changing_length =
+    declare_parameter<double>("lane_change.minimum_lane_changing_length");
+  p.lane_changing_lateral_jerk =
+    declare_parameter<double>("lane_change.lane_changing_lateral_jerk");
+  p.lane_changing_lateral_acc = declare_parameter<double>("lane_change.lane_changing_lateral_acc");
+  p.lane_changing_lateral_acc_at_low_velocity =
+    declare_parameter<double>("lane_change.lane_changing_lateral_acc_at_low_velocity");
+  p.lateral_acc_switching_velocity =
+    declare_parameter<double>("lane_change.lateral_acc_switching_velocity");
+  p.minimum_lane_changing_velocity =
+    declare_parameter<double>("lane_change.minimum_lane_changing_velocity");
+
   p.backward_length_buffer_for_end_of_pull_over =
     declare_parameter<double>("backward_length_buffer_for_end_of_pull_over");
   p.backward_length_buffer_for_end_of_pull_out =
     declare_parameter<double>("backward_length_buffer_for_end_of_pull_out");
-  p.minimum_lane_changing_length =
-    declare_parameter<double>("lane_change.minimum_lane_changing_length");
   p.minimum_prepare_length = declare_parameter<double>("lane_change.minimum_prepare_length");
 
   p.minimum_pull_over_length = declare_parameter<double>("minimum_pull_over_length");
@@ -659,16 +671,8 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
 
   // trajectory generation
   p.prepare_duration = declare_parameter<double>(parameter("prepare_duration"));
-  p.lane_changing_lateral_jerk = declare_parameter<double>(parameter("lane_changing_lateral_jerk"));
-  p.lane_changing_lateral_acc = declare_parameter<double>(parameter("lane_changing_lateral_acc"));
-  p.lane_changing_lateral_acc_at_low_velocity =
-    declare_parameter<double>(parameter("lane_changing_lateral_acc_at_low_velocity"));
-  p.lateral_acc_switching_velocity =
-    declare_parameter<double>(parameter("lateral_acc_switching_velocity"));
   p.lane_change_finish_judge_buffer =
     declare_parameter<double>(parameter("lane_change_finish_judge_buffer"));
-  p.minimum_lane_changing_velocity =
-    declare_parameter<double>(parameter("minimum_lane_changing_velocity"));
   p.prediction_time_resolution = declare_parameter<double>(parameter("prediction_time_resolution"));
   p.maximum_deceleration = declare_parameter<double>(parameter("maximum_deceleration"));
   p.lane_change_sampling_num = declare_parameter<int>(parameter("lane_change_sampling_num"));

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -566,7 +566,7 @@ lanelet::ConstLanelets AvoidanceByLCModule::getLaneChangeLanes(
 {
   lanelet::ConstLanelets lane_change_lanes;
   const auto & route_handler = planner_data_->route_handler;
-  const auto minimum_lane_changing_length = planner_data_->parameters.minimum_lane_changing_length;
+  const auto minimum_prepare_length = planner_data_->parameters.minimum_prepare_length;
   const auto prepare_duration = parameters_->lane_change->prepare_duration;
   const auto current_pose = getEgoPose();
   const auto current_twist = getEgoTwist();
@@ -586,7 +586,7 @@ lanelet::ConstLanelets AvoidanceByLCModule::getLaneChangeLanes(
   lanelet::ConstLanelet current_lane;
   lanelet::utils::query::getClosestLanelet(current_lanes, current_pose, &current_lane);
   const double lane_change_prepare_length =
-    std::max(current_twist.linear.x * prepare_duration, minimum_lane_changing_length);
+    std::max(current_twist.linear.x * prepare_duration, minimum_prepare_length);
   lanelet::ConstLanelets current_check_lanes =
     route_handler->getLaneletSequence(current_lane, current_pose, 0.0, lane_change_prepare_length);
   lanelet::ConstLanelet lane_change_lane;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -310,7 +310,7 @@ lanelet::ConstLanelets ExternalRequestLaneChangeModule::getLaneChangeLanes(
 {
   lanelet::ConstLanelets lane_change_lanes;
   const auto & route_handler = planner_data_->route_handler;
-  const auto minimum_lane_changing_length = planner_data_->parameters.minimum_lane_changing_length;
+  const auto minimum_prepare_length = planner_data_->parameters.minimum_prepare_length;
   const auto prepare_duration = parameters_->prepare_duration;
   const auto current_pose = getEgoPose();
   const auto current_twist = getEgoTwist();
@@ -323,7 +323,7 @@ lanelet::ConstLanelets ExternalRequestLaneChangeModule::getLaneChangeLanes(
   lanelet::ConstLanelet current_lane;
   lanelet::utils::query::getClosestLanelet(current_lanes, current_pose, &current_lane);
   const double lane_change_prepare_length =
-    std::max(current_twist.linear.x * prepare_duration, minimum_lane_changing_length);
+    std::max(current_twist.linear.x * prepare_duration, minimum_prepare_length);
   lanelet::ConstLanelets current_check_lanes =
     route_handler->getLaneletSequence(current_lane, current_pose, 0.0, lane_change_prepare_length);
   lanelet::ConstLanelet lane_change_lane;

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -102,6 +102,7 @@ std::optional<LaneChangePath> constructCandidatePath(
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
   const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double acceleration,
   const LaneChangePhaseInfo lane_change_length, const LaneChangePhaseInfo lane_change_velocity,
+  const BehaviorPathPlannerParameters & common_parameter,
   const LaneChangeParameters & lane_change_param)
 {
   PathShifter path_shifter;
@@ -113,9 +114,12 @@ std::optional<LaneChangePath> constructCandidatePath(
   bool offset_back = false;
 
   const auto lane_changing_velocity = lane_change_velocity.lane_changing;
+  const auto lateral_acc = lane_changing_velocity < common_parameter.lateral_acc_switching_velocity
+                             ? common_parameter.lane_changing_lateral_acc_at_low_velocity
+                             : common_parameter.lane_changing_lateral_acc;
 
   path_shifter.setVelocity(lane_changing_velocity);
-  path_shifter.setLateralAccelerationLimit(std::abs(lane_change_param.lane_changing_lateral_acc));
+  path_shifter.setLateralAccelerationLimit(std::abs(lateral_acc));
 
   if (!path_shifter.generate(&shifted_path, offset_back)) {
     RCLCPP_DEBUG(
@@ -220,7 +224,7 @@ bool getLaneChangePaths(
   const auto forward_path_length = common_parameter.forward_path_length;
   const auto prepare_duration = parameter.prepare_duration;
   const auto minimum_prepare_length = common_parameter.minimum_prepare_length;
-  const auto minimum_lane_changing_velocity = parameter.minimum_lane_changing_velocity;
+  const auto minimum_lane_changing_velocity = common_parameter.minimum_lane_changing_velocity;
   const auto lane_change_sampling_num = parameter.lane_change_sampling_num;
 
   // get velocity
@@ -322,13 +326,14 @@ bool getLaneChangePaths(
       break;
     }
 
+    // calculate shift length
     const auto shift_length =
       lanelet::utils::getLateralDistanceToClosestLanelet(target_lanelets, lane_changing_start_pose);
 
     // we assume constant velocity during lane change
     const auto lane_changing_velocity = prepare_velocity;
     const auto lane_changing_length =
-      calcLaneChangingLength(lane_changing_velocity, shift_length, common_parameter, parameter);
+      calcLaneChangingLength(lane_changing_velocity, shift_length, common_parameter);
 
     if (lane_changing_length + prepare_length > dist_to_end_of_current_lanes) {
       RCLCPP_DEBUG(
@@ -386,7 +391,8 @@ bool getLaneChangePaths(
 
     const auto candidate_path = constructCandidatePath(
       prepare_segment, target_segment, target_lane_reference_path, shift_line, original_lanelets,
-      target_lanelets, sorted_lane_ids, acceleration, lc_length, lc_velocity, parameter);
+      target_lanelets, sorted_lane_ids, acceleration, lc_length, lc_velocity, common_parameter,
+      parameter);
 
     if (!candidate_path) {
       RCLCPP_DEBUG(
@@ -398,11 +404,11 @@ bool getLaneChangePaths(
 #ifdef USE_OLD_ARCHITECTURE
     const auto is_valid = hasEnoughLength(
       *candidate_path, original_lanelets, target_lanelets, pose, route_handler,
-      common_parameter.minimum_lane_changing_length);
+      minimum_lane_changing_velocity, common_parameter);
 #else
     const auto is_valid = hasEnoughLength(
       *candidate_path, original_lanelets, target_lanelets, pose, route_handler,
-      common_parameter.minimum_lane_changing_length, direction);
+      minimum_lane_changing_velocity, common_parameter, direction);
 #endif
 
     if (!is_valid) {
@@ -439,23 +445,29 @@ bool getLaneChangePaths(
 bool hasEnoughLength(
   const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,
   [[maybe_unused]] const lanelet::ConstLanelets & target_lanes, const Pose & current_pose,
-  const RouteHandler & route_handler, const double minimum_lane_change_length,
-  const Direction direction)
+  const RouteHandler & route_handler, const double minimum_lane_changing_velocity,
+  const BehaviorPathPlannerParameters & common_parameter, const Direction direction)
 {
-  const double lane_change_total_length = path.length.sum();
-  const int num = std::abs(route_handler.getNumLaneToPreferredLane(target_lanes.back(), direction));
-  const auto overall_graphs = route_handler.getOverallGraphPtr();
+  const double lane_change_length = path.length.sum();
+  const auto shift_intervals =
+    route_handler.getLateralIntervalsToPreferredLane(target_lanes.back(), direction);
 
-  const double lane_change_required_length = static_cast<double>(num) * minimum_lane_change_length;
+  double minimum_lane_change_length_to_preferred_lane = 0.0;
+  for (const auto & shift_length : shift_intervals) {
+    const auto lane_changing_time =
+      utils::calcLaneChangingTime(minimum_lane_changing_velocity, shift_length, common_parameter);
+    minimum_lane_change_length_to_preferred_lane +=
+      minimum_lane_changing_velocity * lane_changing_time + common_parameter.minimum_prepare_length;
+  }
 
-  if (lane_change_total_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
+  if (lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
     return false;
   }
 
   const auto goal_pose = route_handler.getGoalPose();
   if (
     route_handler.isInGoalRouteSection(current_lanes.back()) &&
-    lane_change_total_length + lane_change_required_length >
+    lane_change_length + minimum_lane_change_length_to_preferred_lane >
       utils::getSignedDistance(current_pose, goal_pose, current_lanes)) {
     return false;
   }
@@ -466,7 +478,7 @@ bool hasEnoughLength(
   }
 
   if (
-    lane_change_total_length + lane_change_required_length >
+    lane_change_length + minimum_lane_change_length_to_preferred_lane >
     utils::getDistanceToEndOfLane(current_pose, target_lanes)) {
     return false;
   }
@@ -649,17 +661,11 @@ PathWithLaneId getPrepareSegment(
 
 double calcLaneChangingLength(
   const double lane_changing_velocity, const double shift_length,
-  const BehaviorPathPlannerParameters & com_param, const LaneChangeParameters & lc_param)
+  const BehaviorPathPlannerParameters & common_parameter)
 {
-  const double lateral_acc = lane_changing_velocity < lc_param.lateral_acc_switching_velocity
-                               ? lc_param.lane_changing_lateral_acc_at_low_velocity
-                               : lc_param.lane_changing_lateral_acc;
-  const auto required_time = PathShifter::calcShiftTimeFromJerk(
-    shift_length, lc_param.lane_changing_lateral_jerk, lateral_acc);
-
-  const double & min_lane_change_length = com_param.minimum_lane_changing_length;
-  const double lane_changing_length =
-    std::max(lane_changing_velocity * required_time, min_lane_change_length);
+  const auto required_time =
+    utils::calcLaneChangingTime(lane_changing_velocity, shift_length, common_parameter);
+  const auto lane_changing_length = lane_changing_velocity * required_time;
 
   RCLCPP_DEBUG(
     rclcpp::get_logger("behavior_path_planner")
@@ -1126,7 +1132,7 @@ std::optional<LaneChangePath> getAbortPaths(
     PathWithLaneId ref = route_handler->getCenterLinePath(reference_lanelets, s_start, s_end);
     ref.points.back().point.longitudinal_velocity_mps = std::min(
       ref.points.back().point.longitudinal_velocity_mps,
-      static_cast<float>(lane_change_param.minimum_lane_changing_velocity));
+      static_cast<float>(common_param.minimum_lane_changing_velocity));
     return ref;
   });
 

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -223,7 +223,6 @@ bool getLaneChangePaths(
   const auto backward_path_length = common_parameter.backward_path_length;
   const auto forward_path_length = common_parameter.forward_path_length;
   const auto prepare_duration = parameter.prepare_duration;
-  const auto minimum_prepare_length = common_parameter.minimum_prepare_length;
   const auto minimum_lane_changing_velocity = common_parameter.minimum_lane_changing_velocity;
   const auto lane_change_sampling_num = parameter.lane_change_sampling_num;
 
@@ -283,9 +282,8 @@ bool getLaneChangePaths(
     const double acceleration = (prepare_velocity - current_velocity) / prepare_duration;
 
     // get path on original lanes
-    const double prepare_length = std::max(
-      current_velocity * prepare_duration + 0.5 * acceleration * std::pow(prepare_duration, 2),
-      minimum_prepare_length);
+    const double prepare_length =
+      current_velocity * prepare_duration + 0.5 * acceleration * std::pow(prepare_duration, 2);
 
     if (prepare_length < target_length) {
       RCLCPP_DEBUG(
@@ -340,22 +338,6 @@ bool getLaneChangePaths(
         rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
         "lane changing path too long");
       continue;
-    }
-
-    if (is_goal_in_route) {
-      const double s_start =
-        lanelet::utils::getArcCoordinates(target_lanelets, lane_changing_start_pose).length;
-      const double s_goal =
-        lanelet::utils::getArcCoordinates(target_lanelets, route_handler.getGoalPose()).length;
-      if (
-        s_start + lane_changing_length + parameter.lane_change_finish_judge_buffer +
-          required_total_min_length >
-        s_goal) {
-        RCLCPP_DEBUG(
-          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-          "length of lane changing path is longer than length to goal!!");
-        continue;
-      }
     }
 
     const auto target_segment = getTargetSegment(


### PR DESCRIPTION
## Description
Since minimum lane changing length can be determined by minimum lane changing velocity, shift length, lateral acceleration and lateral jerk, we can remove minimum lane changing length from the parameter. 

Note that in this PR, I did not remove all of the minimum lane changing length as the change would be too large. I'll remove other minimum lane changing length in other PRS.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6cc2a61</samp>

This pull request refactors and improves the lane changing feature in the `behavior_path_planner` package. It introduces a new struct `BehaviorPathPlannerParameters` to store and access the lane changing parameters, and simplifies the function interface and calls related to lane changing logic. It also adds some utility functions to calculate the lane change buffer length and time, and updates the scene modules to use the new parameters and functions.
<!-- Write a brief description of this PR. -->

## Related links
[Scenario Test Results (TIER IV Internal)](https://evaluation.tier4.jp/evaluation/reports/8160ed34-5375-5dfc-b3fe-79c313b1d372?project_id=prd_jt)
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Scenario Test
1326/1330
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
There are no interface changes.
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
Some parts of the lane change module do not use minimum lane change length, and it is decided by minimum lane changing velocity and lateral shift length
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
