### PR TITLE
fix(dummy_perception_publisher): add parameter to configure z pose of dummy object

### DIFF
--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -15,6 +15,7 @@
   <arg name="perception/enable_object_recognition" default="false" description="enable object recognition"/>
   <arg name="perception/enable_elevation_map" default="false" description="enable elevation map loader"/>
   <arg name="perception/enable_traffic_light" default="false" description="enable traffic light"/>
+  <arg name="perception/use_base_link_z" default="true" description="dummy perception uses base_link z axis coordinate if it is true"/>
   <arg name="sensing/visible_range" default="300.0" description="visible range when using dummy perception"/>
 
   <arg name="vehicle_model" description="vehicle model name"/>
@@ -33,6 +34,7 @@
     <include file="$(find-pkg-share dummy_perception_publisher)/launch/dummy_perception_publisher.launch.xml">
       <arg name="real" value="$(var perception/enable_detection_failure)"/>
       <arg name="use_object_recognition" value="$(var perception/enable_object_recognition)"/>
+      <arg name="use_base_link_z" value="$(var perception/use_base_link_z)"/>
       <arg name="visible_range" value="$(var sensing/visible_range)"/>
     </include>
   </group>

--- a/simulator/dummy_perception_publisher/README.md
+++ b/simulator/dummy_perception_publisher/README.md
@@ -24,12 +24,13 @@ This node publishes the result of the dummy detection with the type of perceptio
 
 ## Parameters
 
-| Name                        | Type   | Default Value | Explanation                                 |
-| --------------------------- | ------ | ------------- | ------------------------------------------- |
-| `visible_range`             | double | 100.0         | sensor visible range [m]                    |
-| `detection_successful_rate` | double | 0.8           | sensor detection rate. (min) 0.0 - 1.0(max) |
-| `enable_ray_tracing`        | bool   | true          | if True, use ray tracking                   |
-| `use_object_recognition`    | bool   | true          | if True, publish objects topic              |
+| Name                        | Type   | Default Value | Explanation                                      |
+| --------------------------- | ------ | ------------- | ------------------------------------------------ |
+| `visible_range`             | double | 100.0         | sensor visible range [m]                         |
+| `detection_successful_rate` | double | 0.8           | sensor detection rate. (min) 0.0 - 1.0(max)      |
+| `enable_ray_tracing`        | bool   | true          | if True, use ray tracking                        |
+| `use_object_recognition`    | bool   | true          | if True, publish objects topic                   |
+| `use_base_link_z`           | bool   | true          | if True, node uses z coordinate of ego base_link |
 
 ### Node Parameters
 

--- a/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
+++ b/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
@@ -116,6 +116,7 @@ private:
   bool enable_ray_tracing_;
   bool use_object_recognition_;
   bool use_real_param_;
+  bool use_base_link_z_;
   std::unique_ptr<PointCloudCreator> pointcloud_creator_;
 
   double angle_increment_;

--- a/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -4,6 +4,7 @@
   <arg name="visible_range" default="300.0"/>
   <arg name="real" default="true"/>
   <arg name="use_object_recognition" default="true"/>
+  <arg name="use_base_link_z" default="true"/>
 
   <group>
     <push-ros-namespace namespace="simulation"/>
@@ -19,6 +20,7 @@
         <param name="enable_ray_tracing" value="false"/>
         <param name="use_object_recognition" value="$(var use_object_recognition)"/>
         <param name="object_centric_pointcloud" value="false"/>
+        <param name="use_base_link_z" value="$(var use_base_link_z)"/>
       </node>
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
         <arg name="input/objects" value="/perception/object_recognition/detection/labeled_clusters"/>
@@ -36,6 +38,7 @@
         <param name="detection_successful_rate" value="1.0"/>
         <param name="enable_ray_tracing" value="false"/>
         <param name="use_object_recognition" value="$(var use_object_recognition)"/>
+        <param name="use_base_link_z" value="$(var use_base_link_z)"/>
       </node>
     </group>
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
In current implementation of autoware, dummy_perception_publisher always uses the baselink z position while publishing dummy object. Object's Z position can not be arranged from rviz plugin. I added a parameter to make it configurable. Default value of the parameter is true.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
![Screenshot from 2023-04-18 23-59-14](https://user-images.githubusercontent.com/45468306/233508366-29f06ed8-9e22-4fe0-b16c-06776b0bbf7d.png)

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
