### PR TITLE
feat(behavior_path_planner): use dynamic minimum lane changing length

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -459,7 +459,10 @@ BehaviorModuleOutput AvoidanceByLCModule::planWaitingApproval()
 
   if (!avoidance_data_.target_objects.empty()) {
     const auto to_front_object_distance = avoidance_data_.target_objects.front().longitudinal;
-    const auto lane_change_buffer = planner_data_->parameters.minimum_lane_changing_length;
+    const double shift_length = status_.lane_change_path.shift_line.end_shift_length -
+                                status_.lane_change_path.shift_line.start_shift_length;
+    const double lane_change_buffer =
+      utils::calcMinimumLaneChangeLength(planner_data_->parameters, {shift_length});
 
     boost::optional<Pose> p_insert{};
     insertDecelPoint(


### PR DESCRIPTION
## Description
Use minimum lane changing length computed from shift length and lateral jerk and acceleration.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Lane change buffer will be larger when using avoidance by lane change module

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
