### PR TITLE
feat(goal_planner): add no_parking_area for goal search

### DIFF
--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
@@ -125,13 +125,15 @@ void Lanelet2MapVisualizationNode::onMapBin(
       viz_lanelet_map, "no_obstacle_segmentation_area_for_run_out");
   lanelet::ConstPolygons3d hatched_road_markings_area =
     lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "hatched_road_markings");
+  std::vector<lanelet::NoParkingAreaConstPtr> no_parking_reg_elems =
+    lanelet::utils::query::noParkingAreas(all_lanelets);
 
   std_msgs::msg::ColorRGBA cl_road, cl_shoulder, cl_cross, cl_partitions, cl_pedestrian_markings,
     cl_ll_borders, cl_shoulder_borders, cl_stoplines, cl_trafficlights, cl_detection_areas,
     cl_speed_bumps, cl_crosswalks, cl_parking_lots, cl_parking_spaces, cl_lanelet_id,
     cl_obstacle_polygons, cl_no_stopping_areas, cl_no_obstacle_segmentation_area,
     cl_no_obstacle_segmentation_area_for_run_out, cl_hatched_road_markings_area,
-    cl_hatched_road_markings_line;
+    cl_hatched_road_markings_line, cl_no_parking_areas;
   setColor(&cl_road, 0.27, 0.27, 0.27, 0.999);
   setColor(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   setColor(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -153,6 +155,7 @@ void Lanelet2MapVisualizationNode::onMapBin(
   setColor(&cl_no_obstacle_segmentation_area_for_run_out, 0.37, 0.7, 0.27, 0.5);
   setColor(&cl_hatched_road_markings_area, 0.3, 0.3, 0.3, 0.5);
   setColor(&cl_hatched_road_markings_line, 0.5, 0.5, 0.5, 0.999);
+  setColor(&cl_no_parking_areas, 0.42, 0.42, 0.42, 0.5);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -234,6 +237,10 @@ void Lanelet2MapVisualizationNode::onMapBin(
     &map_marker_array,
     lanelet::visualization::hatchedRoadMarkingsAreaAsMarkerArray(
       hatched_road_markings_area, cl_hatched_road_markings_area, cl_hatched_road_markings_line));
+
+  insertMarkerArray(
+    &map_marker_array,
+    lanelet::visualization::noParkingAreasAsMarkerArray(no_parking_reg_elems, cl_no_parking_areas));
 
   pub_marker_->publish(map_marker_array);
 }

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_searcher.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_searcher.hpp
@@ -44,7 +44,7 @@ private:
   bool checkCollision(const Pose & pose) const;
   bool checkCollisionWithLongitudinalDistance(
     const Pose & ego_pose, const PredictedObjects & dynamic_objects) const;
-  BasicPolygons2d getNoStoppingAreaPolygons(const lanelet::ConstLanelets & lanes) const;
+  BasicPolygons2d getNoParkingAreaPolygons(const lanelet::ConstLanelets & lanes) const;
   bool isInAreas(const LinearRing2d & footprint, const BasicPolygons2d & areas) const;
 
   LinearRing2d vehicle_footprint_{};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_searcher.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_searcher.hpp
@@ -45,6 +45,7 @@ private:
   bool checkCollisionWithLongitudinalDistance(
     const Pose & ego_pose, const PredictedObjects & dynamic_objects) const;
   BasicPolygons2d getNoParkingAreaPolygons(const lanelet::ConstLanelets & lanes) const;
+  BasicPolygons2d getNoStoppingAreaPolygons(const lanelet::ConstLanelets & lanes) const;
   bool isInAreas(const LinearRing2d & footprint, const BasicPolygons2d & areas) const;
 
   LinearRing2d vehicle_footprint_{};

--- a/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
@@ -26,7 +26,7 @@
 namespace behavior_path_planner
 {
 using lane_departure_checker::LaneDepartureChecker;
-using lanelet::autoware::NoStoppingArea;
+using lanelet::autoware::NoParkingArea;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::inverseTransformPose;
 
@@ -104,7 +104,7 @@ GoalCandidates GoalSearcher::search(const Pose & original_goal_pose)
       const auto transformed_vehicle_footprint =
         transformVector(vehicle_footprint_, tier4_autoware_utils::pose2transform(search_pose));
 
-      if (isInAreas(transformed_vehicle_footprint, getNoStoppingAreaPolygons(pull_over_lanes))) {
+      if (isInAreas(transformed_vehicle_footprint, getNoParkingAreaPolygons(pull_over_lanes))) {
         continue;
       }
 
@@ -276,12 +276,12 @@ void GoalSearcher::createAreaPolygons(std::vector<Pose> original_search_poses)
   }
 }
 
-BasicPolygons2d GoalSearcher::getNoStoppingAreaPolygons(const lanelet::ConstLanelets & lanes) const
+BasicPolygons2d GoalSearcher::getNoParkingAreaPolygons(const lanelet::ConstLanelets & lanes) const
 {
   BasicPolygons2d area_polygons{};
   for (const auto & ll : lanes) {
-    for (const auto & reg_elem : ll.regulatoryElementsAs<NoStoppingArea>()) {
-      for (const auto & area : reg_elem->noStoppingAreas()) {
+    for (const auto & reg_elem : ll.regulatoryElementsAs<NoParkingArea>()) {
+      for (const auto & area : reg_elem->noParkingAreas()) {
         const auto & area_poly = lanelet::utils::to2D(area).basicPolygon();
         area_polygons.push_back(area_poly);
       }

--- a/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
@@ -27,6 +27,7 @@ namespace behavior_path_planner
 {
 using lane_departure_checker::LaneDepartureChecker;
 using lanelet::autoware::NoParkingArea;
+using lanelet::autoware::NoStoppingArea;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::inverseTransformPose;
 
@@ -105,6 +106,10 @@ GoalCandidates GoalSearcher::search(const Pose & original_goal_pose)
         transformVector(vehicle_footprint_, tier4_autoware_utils::pose2transform(search_pose));
 
       if (isInAreas(transformed_vehicle_footprint, getNoParkingAreaPolygons(pull_over_lanes))) {
+        continue;
+      }
+
+      if (isInAreas(transformed_vehicle_footprint, getNoStoppingAreaPolygons(pull_over_lanes))) {
         continue;
       }
 
@@ -282,6 +287,20 @@ BasicPolygons2d GoalSearcher::getNoParkingAreaPolygons(const lanelet::ConstLanel
   for (const auto & ll : lanes) {
     for (const auto & reg_elem : ll.regulatoryElementsAs<NoParkingArea>()) {
       for (const auto & area : reg_elem->noParkingAreas()) {
+        const auto & area_poly = lanelet::utils::to2D(area).basicPolygon();
+        area_polygons.push_back(area_poly);
+      }
+    }
+  }
+  return area_polygons;
+}
+
+BasicPolygons2d GoalSearcher::getNoStoppingAreaPolygons(const lanelet::ConstLanelets & lanes) const
+{
+  BasicPolygons2d area_polygons{};
+  for (const auto & ll : lanes) {
+    for (const auto & reg_elem : ll.regulatoryElementsAs<NoStoppingArea>()) {
+      for (const auto & area : reg_elem->noStoppingAreas()) {
         const auto & area_poly = lanelet::utils::to2D(area).basicPolygon();
         area_polygons.push_back(area_poly);
       }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->


Support no_parking_area not only no_stopping_area for goal search


Currently `no_stopping_area` is used for the area where the ego vehicle cannot arrive when pull over. 
related: https://github.com/autowarefoundation/autoware.universe/pull/2492
But it is different from the original use of `no_stopping_area`, so create new `no_parking_area` and will use it in pull_over

the difference between `no_stopping_area` and `no_parking_area`
- `no_stopping_area` is an area where stopping for even a few seconds is not allowed. Stopping due to traffic congestion or waiting at traffic lights is also prohibited. This area is used by `no_stopping_area` module.
- `no_parking_area` is an area where only parking is prohibited. Stopping due to traffic congestion or waiting at traffic lights is not included. This area is used by parking module like `pull_over` of `goal_planner`

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/5542cae2-80cd-43d3-9fd4-b2461d8f4d2f)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware_common/pull/172

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

[tier4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/64270cb9-8ccb-519a-8026-ae5e8846bc3f/?project_id=prd_jt) 1578/1588

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
