### PR TITLE
feat(tier4_perception_rviz_plugin): use negative z pose and positive dimension values

### DIFF
--- a/common/tier4_perception_rviz_plugin/src/tools/car_pose.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/car_pose.cpp
@@ -100,7 +100,9 @@ CarInitialPoseTool::CarInitialPoseTool()
   std_dev_y_->setMin(0);
   std_dev_z_->setMin(0);
   std_dev_theta_->setMin(0);
-  position_z_->setMin(0);
+  width_->setMin(0);
+  length_->setMin(0);
+  height_->setMin(0);
 }
 
 void CarInitialPoseTool::onInitialize()
@@ -191,7 +193,9 @@ BusInitialPoseTool::BusInitialPoseTool()
   std_dev_y_->setMin(0);
   std_dev_z_->setMin(0);
   std_dev_theta_->setMin(0);
-  position_z_->setMin(0);
+  width_->setMin(0);
+  length_->setMin(0);
+  height_->setMin(0);
 }
 
 void BusInitialPoseTool::onInitialize()
@@ -284,7 +288,9 @@ BikeInitialPoseTool::BikeInitialPoseTool()
   std_dev_y_->setMin(0);
   std_dev_z_->setMin(0);
   std_dev_theta_->setMin(0);
-  position_z_->setMin(0);
+  width_->setMin(0);
+  length_->setMin(0);
+  height_->setMin(0);
   label_->addOption("BICYCLE", ObjectClassification::BICYCLE);
   label_->addOption("MOTORCYCLE", ObjectClassification::MOTORCYCLE);
 }

--- a/common/tier4_perception_rviz_plugin/src/tools/pedestrian_pose.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/pedestrian_pose.cpp
@@ -94,7 +94,6 @@ PedestrianInitialPoseTool::PedestrianInitialPoseTool()
   std_dev_y_->setMin(0);
   std_dev_z_->setMin(0);
   std_dev_theta_->setMin(0);
-  position_z_->setMin(0);
 }
 
 void PedestrianInitialPoseTool::onInitialize()

--- a/common/tier4_perception_rviz_plugin/src/tools/unknown_pose.cpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/unknown_pose.cpp
@@ -89,7 +89,6 @@ UnknownInitialPoseTool::UnknownInitialPoseTool()
   std_dev_y_->setMin(0);
   std_dev_z_->setMin(0);
   std_dev_theta_->setMin(0);
-  position_z_->setMin(0);
 }
 
 void UnknownInitialPoseTool::onInitialize()


### PR DESCRIPTION


## Description

<!-- Write a brief description of this PR. -->
While testing in planning simulator, we sometimes need to set obstacle in negative side of z axis. Also, dummy vehicle's dimensions can not be negative.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
