### PR TITLE
feat(rtc_auto_mode_manager): add new module

### DIFF
--- a/planning/rtc_auto_mode_manager/src/rtc_auto_mode_manager_interface.cpp
+++ b/planning/rtc_auto_mode_manager/src/rtc_auto_mode_manager_interface.cpp
@@ -43,6 +43,10 @@ Module getModuleType(const std::string & module_name)
     module.type = Module::LANE_CHANGE_LEFT;
   } else if (module_name == "lane_change_right") {
     module.type = Module::LANE_CHANGE_RIGHT;
+  } else if (module_name == "avoidance_by_lane_change_left") {
+    module.type = Module::AVOIDANCE_BY_LC_LEFT;
+  } else if (module_name == "avoidance_by_lane_change_right") {
+    module.type = Module::AVOIDANCE_BY_LC_RIGHT;
   } else if (module_name == "avoidance_left") {
     module.type = Module::AVOIDANCE_LEFT;
   } else if (module_name == "avoidance_right") {


### PR DESCRIPTION
## Description

Register new module `avoidance_by_lane_change_right/left` to rtc auto mode manager.

Related PR: https://github.com/tier4/tier4_autoware_msgs/pull/71

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I can change rtc mode via rtc manager rviz plugin.

![rviz_screenshot_2023_04_20-10_49_49](https://user-images.githubusercontent.com/44889564/233237636-b42c0fe1-a714-438e-8e5b-8d91d28f1a0c.png)
![rviz_screenshot_2023_04_20-10_50_11](https://user-images.githubusercontent.com/44889564/233237643-bffb218a-0846-4f12-9339-5d7daa15b1a4.png)

## Effects on system behavior

This PR make it possible to change `avoidance_by_lane_change` module rtc mode.

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
