### PR TITLE
feat(behavior_path_planner): remove minimum lane changing length from external lc

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request.cpp
@@ -45,10 +45,10 @@ lanelet::ConstLanelets ExternalRequestLaneChange::getLaneChangeLanes(
   lanelet::ConstLanelet current_lane;
   lanelet::utils::query::getClosestLanelet(current_lanes, getEgoPose(), &current_lane);
 
-  const auto minimum_lane_changing_length = planner_data_->parameters.minimum_lane_changing_length;
+  const auto minimum_prepare_length = planner_data_->parameters.minimum_prepare_length;
 
   const auto lane_change_prepare_length =
-    std::max(getEgoVelocity() * parameters_->prepare_duration, minimum_lane_changing_length);
+    std::max(getEgoVelocity() * parameters_->prepare_duration, minimum_prepare_length);
 
   const auto & route_handler = getRouteHandler();
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -434,9 +434,9 @@ bool ExternalRequestLaneChangeModule::isValidPath(const PathWithLaneId & path) c
 bool ExternalRequestLaneChangeModule::isNearEndOfLane() const
 {
   const auto & current_pose = getEgoPose();
-  const auto minimum_lane_changing_length = planner_data_->parameters.minimum_lane_changing_length;
-  const auto end_of_lane_buffer = planner_data_->parameters.backward_length_buffer_for_end_of_lane;
-  const double threshold = end_of_lane_buffer + minimum_lane_changing_length;
+  const auto & shift_length = status_.lane_change_path.shift_line.end_shift_length;
+  const auto threshold =
+    utils::calcMinimumLaneChangeLength(planner_data_->parameters, {shift_length});
 
   return std::max(0.0, utils::getDistanceToEndOfLane(current_pose, status_.current_lanes)) <
          threshold;


### PR DESCRIPTION
## Description
Remove minimum lane changing length parameter from external lane change module.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ef61b7</samp>

Improved the logic for determining when to start preparing for a lane change based on the actual lane change path length. Renamed a variable to avoid confusion with a function that calculates the lane change length. Modified `isNearEndOfLane` in `external_request_lane_change_module.cpp` and `minimum_lane_changing_length` in `external_request.cpp`.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Not Applicable
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
No interface changes
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
External lane change computes minimum lane changing length based on shift interval and lateral jerk and acceleration.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
