### PR TITLE
feat(behavior_path_planner): remove calcTotalLaneChangeLength function

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -182,7 +182,10 @@ protected:
   bool isNearEndOfLane() const
   {
     const auto & current_pose = getEgoPose();
-    const double threshold = utils::calcTotalLaneChangeLength(planner_data_->parameters);
+    const auto shift_intervals = planner_data_->route_handler->getLateralIntervalsToPreferredLane(
+      status_.current_lanes.back());
+    const double threshold =
+      utils::calcMinimumLaneChangeLength(planner_data_->parameters, shift_intervals);
 
     return (std::max(0.0, utils::getDistanceToEndOfLane(current_pose, status_.current_lanes)) -
             threshold) < planner_data_->parameters.backward_length_buffer_for_end_of_lane;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -336,9 +336,6 @@ boost::optional<std::pair<Pose, Polygon2d>> getEgoExpectedPoseAndConvertToPolygo
 
 bool checkPathRelativeAngle(const PathWithLaneId & path, const double angle_threshold);
 
-double calcTotalLaneChangeLength(
-  const BehaviorPathPlannerParameters & common_param, const bool include_buffer = true);
-
 double calcLaneChangingTime(
   const double lane_changing_velocity, const double shift_length,
   const BehaviorPathPlannerParameters & common_parameter);

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -727,7 +727,10 @@ bool AvoidanceByLCModule::isValidPath(const PathWithLaneId & path) const
 bool AvoidanceByLCModule::isNearEndOfLane() const
 {
   const auto & current_pose = getEgoPose();
-  const double threshold = utils::calcTotalLaneChangeLength(planner_data_->parameters);
+  const auto shift_intervals =
+    planner_data_->route_handler->getLateralIntervalsToPreferredLane(status_.current_lanes.back());
+  const double threshold =
+    utils::calcMinimumLaneChangeLength(planner_data_->parameters, shift_intervals);
 
   return std::max(0.0, utils::getDistanceToEndOfLane(current_pose, status_.current_lanes)) <
          threshold;

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1973,15 +1973,6 @@ bool checkPathRelativeAngle(const PathWithLaneId & path, const double angle_thre
   return true;
 }
 
-double calcTotalLaneChangeLength(
-  const BehaviorPathPlannerParameters & common_param, const bool include_buffer)
-{
-  const double minimum_lane_change_distance =
-    common_param.minimum_prepare_length + common_param.minimum_lane_changing_length;
-  const double end_of_lane_buffer = common_param.backward_length_buffer_for_end_of_lane;
-  return minimum_lane_change_distance + end_of_lane_buffer * static_cast<double>(include_buffer);
-}
-
 double calcLaneChangingTime(
   const double lane_changing_velocity, const double shift_length,
   const BehaviorPathPlannerParameters & common_parameter)


### PR DESCRIPTION
## Description
Remove `calcTotalLaneChangeLength` function to dynamically calculate total lane change length.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19f34e4</samp>

Refactored the lane change and avoidance logic in the `behavior_path_planner` package to use a new utility function `calcMinimumLaneChangeLength` that considers the lateral intervals to the preferred lane. Removed the unused function `calcTotalLaneChangeLength` from the `utils.hpp` and `utils.cpp` files.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Scenario Test Result 1323/1330
[TIER4 Internal Link](https://evaluation.tier4.jp/evaluation/reports/10f4c49d-0b72-5b4c-833f-c17c2c7dee17?project_id=prd_jt)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Total lane change length will be computed dynamically.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
