### PR TITLE
feat(traffic_light_ssd_fine_detector): add support of ssd trained by mmdetection

### DIFF
--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -6,7 +6,6 @@
   <arg name="input/camera_info" default="/sensing/camera/traffic_light/camera_info" description="camera info topic name for traffic light"/>
   <arg name="fine_detector_label_path" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/voc_labels_tl.txt" description="fine detector label path"/>
   <arg name="fine_detector_model_path" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/mb2-ssd-lite-tlr.onnx" description="fine detector onnx model path"/>
-  <arg name="fine_detector_is_box_first" default="false"/>
   <arg name="classifier_label_path" default="$(find-pkg-share traffic_light_classifier)/data/lamp_labels.txt" description="classifier label path"/>
   <arg name="classifier_model_path" default="$(find-pkg-share traffic_light_classifier)/data/traffic_light_classifier_mobilenetv2.onnx" description="classifier onnx model path"/>
   <arg name="use_crosswalk_traffic_light_estimator" default="true" description="output pedestrian's traffic light signals"/>
@@ -36,7 +35,6 @@
       <arg name="use_multithread" value="true"/>
       <arg name="label_file" value="$(var fine_detector_label_path)"/>
       <arg name="onnx_file" value="$(var fine_detector_model_path)"/>
-      <arg name="is_box_first" value="$(var fine_detector_is_box_first)"/>
       <arg name="label_file_path" value="$(var classifier_label_path)"/>
       <arg name="model_file_path" value="$(var classifier_model_path)"/>
     </include>

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -8,7 +8,7 @@
   <arg name="fine_detector_model_path" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/mb2-ssd-lite-tlr.onnx" description="fine detector onnx model path"/>
   <arg name="fine_detector_head1_name" default="scores"/>
   <arg name="fine_detector_head2_name" default="boxes"/>
-  <arg name="fine_detector_boxes_first" default="false"/>
+  <arg name="fine_detector_is_box_first" default="false"/>
   <arg name="classifier_label_path" default="$(find-pkg-share traffic_light_classifier)/data/lamp_labels.txt" description="classifier label path"/>
   <arg name="classifier_model_path" default="$(find-pkg-share traffic_light_classifier)/data/traffic_light_classifier_mobilenetv2.onnx" description="classifier onnx model path"/>
   <arg name="use_crosswalk_traffic_light_estimator" default="true" description="output pedestrian's traffic light signals"/>
@@ -40,7 +40,7 @@
       <arg name="onnx_file" value="$(var fine_detector_model_path)"/>
       <arg name="head1_name" value="$(var fine_detector_head1_name)"/>
       <arg name="head2_name" value="$(var fine_detector_head2_name)"/>
-      <arg name="boxes_first" value="$(var fine_detector_boxes_first)"/>
+      <arg name="is_box_first" value="$(var fine_detector_is_box_first)"/>
       <arg name="label_file_path" value="$(var classifier_label_path)"/>
       <arg name="model_file_path" value="$(var classifier_model_path)"/>
     </include>

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -6,8 +6,6 @@
   <arg name="input/camera_info" default="/sensing/camera/traffic_light/camera_info" description="camera info topic name for traffic light"/>
   <arg name="fine_detector_label_path" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/voc_labels_tl.txt" description="fine detector label path"/>
   <arg name="fine_detector_model_path" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/mb2-ssd-lite-tlr.onnx" description="fine detector onnx model path"/>
-  <arg name="fine_detector_head1_name" default="scores"/>
-  <arg name="fine_detector_head2_name" default="boxes"/>
   <arg name="fine_detector_is_box_first" default="false"/>
   <arg name="classifier_label_path" default="$(find-pkg-share traffic_light_classifier)/data/lamp_labels.txt" description="classifier label path"/>
   <arg name="classifier_model_path" default="$(find-pkg-share traffic_light_classifier)/data/traffic_light_classifier_mobilenetv2.onnx" description="classifier onnx model path"/>
@@ -38,8 +36,6 @@
       <arg name="use_multithread" value="true"/>
       <arg name="label_file" value="$(var fine_detector_label_path)"/>
       <arg name="onnx_file" value="$(var fine_detector_model_path)"/>
-      <arg name="head1_name" value="$(var fine_detector_head1_name)"/>
-      <arg name="head2_name" value="$(var fine_detector_head2_name)"/>
       <arg name="is_box_first" value="$(var fine_detector_is_box_first)"/>
       <arg name="label_file_path" value="$(var classifier_label_path)"/>
       <arg name="model_file_path" value="$(var classifier_model_path)"/>

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -6,6 +6,9 @@
   <arg name="input/camera_info" default="/sensing/camera/traffic_light/camera_info" description="camera info topic name for traffic light"/>
   <arg name="fine_detector_label_path" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/voc_labels_tl.txt" description="fine detector label path"/>
   <arg name="fine_detector_model_path" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/mb2-ssd-lite-tlr.onnx" description="fine detector onnx model path"/>
+  <arg name="fine_detector_head1_name" default="scores"/>
+  <arg name="fine_detector_head2_name" default="boxes"/>
+  <arg name="fine_detector_boxes_first" default="false"/>
   <arg name="classifier_label_path" default="$(find-pkg-share traffic_light_classifier)/data/lamp_labels.txt" description="classifier label path"/>
   <arg name="classifier_model_path" default="$(find-pkg-share traffic_light_classifier)/data/traffic_light_classifier_mobilenetv2.onnx" description="classifier onnx model path"/>
   <arg name="use_crosswalk_traffic_light_estimator" default="true" description="output pedestrian's traffic light signals"/>
@@ -35,6 +38,9 @@
       <arg name="use_multithread" value="true"/>
       <arg name="label_file" value="$(var fine_detector_label_path)"/>
       <arg name="onnx_file" value="$(var fine_detector_model_path)"/>
+      <arg name="head1_name" value="$(var fine_detector_head1_name)"/>
+      <arg name="head2_name" value="$(var fine_detector_head2_name)"/>
+      <arg name="boxes_first" value="$(var fine_detector_boxes_first)"/>
       <arg name="label_file_path" value="$(var classifier_label_path)"/>
       <arg name="model_file_path" value="$(var classifier_model_path)"/>
     </include>

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
@@ -48,8 +48,7 @@ def generate_launch_description():
     add_launch_arg(
         "label_file", os.path.join(ssd_fine_detector_share_dir, "data", "voc_labels_tl.txt")
     )
-    add_launch_arg("is_box_first", "False")
-    add_launch_arg("is_box_normalized", "True")
+    add_launch_arg("dnn_header_type", "pytorch")
     add_launch_arg("fine_detector_precision", "FP32")
     add_launch_arg("score_thresh", "0.7")
     add_launch_arg("max_batch_size", "8")
@@ -199,8 +198,7 @@ def generate_launch_description():
     ssd_fine_detector_param = create_parameter_dict(
         "onnx_file",
         "label_file",
-        "is_box_first",
-        "is_box_normalized",
+        "dnn_header_type",
         "score_thresh",
         "max_batch_size",
         "approximate_sync",

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
@@ -50,9 +50,8 @@ def generate_launch_description():
     )
     add_launch_arg("head1_name", "scores")
     add_launch_arg("head2_name", "boxes")
-    add_launch_arg("boxes_first", "False")
-    add_launch_arg("use_softmax", "False")
-    add_launch_arg("denormalize_boxes", "True")
+    add_launch_arg("is_box_first", "False")
+    add_launch_arg("is_box_normalized", "True")
     add_launch_arg("fine_detector_precision", "FP32")
     add_launch_arg("score_thresh", "0.7")
     add_launch_arg("max_batch_size", "8")
@@ -204,9 +203,8 @@ def generate_launch_description():
         "label_file",
         "head1_name",
         "head2_name",
-        "boxes_first",
-        "use_softmax",
-        "denormalize_boxes",
+        "is_box_first",
+        "is_box_normalized",
         "score_thresh",
         "max_batch_size",
         "approximate_sync",

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
@@ -48,6 +48,11 @@ def generate_launch_description():
     add_launch_arg(
         "label_file", os.path.join(ssd_fine_detector_share_dir, "data", "voc_labels_tl.txt")
     )
+    add_launch_arg("head1_name", "scores")
+    add_launch_arg("head2_name", "boxes")
+    add_launch_arg("boxes_first", "False")
+    add_launch_arg("use_softmax", "False")
+    add_launch_arg("denormalize_boxes", "True")
     add_launch_arg("fine_detector_precision", "FP32")
     add_launch_arg("score_thresh", "0.7")
     add_launch_arg("max_batch_size", "8")
@@ -197,6 +202,11 @@ def generate_launch_description():
     ssd_fine_detector_param = create_parameter_dict(
         "onnx_file",
         "label_file",
+        "head1_name",
+        "head2_name",
+        "boxes_first",
+        "use_softmax",
+        "denormalize_boxes",
         "score_thresh",
         "max_batch_size",
         "approximate_sync",

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light_node_container.launch.py
@@ -48,8 +48,6 @@ def generate_launch_description():
     add_launch_arg(
         "label_file", os.path.join(ssd_fine_detector_share_dir, "data", "voc_labels_tl.txt")
     )
-    add_launch_arg("head1_name", "scores")
-    add_launch_arg("head2_name", "boxes")
     add_launch_arg("is_box_first", "False")
     add_launch_arg("is_box_normalized", "True")
     add_launch_arg("fine_detector_precision", "FP32")
@@ -201,8 +199,6 @@ def generate_launch_description():
     ssd_fine_detector_param = create_parameter_dict(
         "onnx_file",
         "label_file",
-        "head1_name",
-        "head2_name",
         "is_box_first",
         "is_box_normalized",
         "score_thresh",

--- a/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
@@ -119,11 +119,20 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
   )
 
   ### ssd ###
+  cuda_add_library(gather_topk_plugin SHARED
+    lib/src/plugins/gather_topk_kernel.cu
+    lib/src/plugins/gather_topk.cpp
+  )
+
   ament_auto_add_library(ssd SHARED
     lib/src/trt_ssd.cpp
   )
 
   target_include_directories(ssd PUBLIC
+    lib/include
+  )
+
+  target_include_directories(gather_topk_plugin PUBLIC
     lib/include
   )
 
@@ -134,6 +143,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     ${CUDA_LIBRARIES}
     ${CUBLAS_LIBRARIES}
     ${CUDNN_LIBRARY}
+    gather_topk_plugin
   )
 
   ament_auto_add_library(traffic_light_ssd_fine_detector_nodelet SHARED
@@ -144,6 +154,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     ${OpenCV_LIB}
     stdc++fs
     ssd
+    gather_topk_plugin
   )
 
   rclcpp_components_register_node(traffic_light_ssd_fine_detector_nodelet
@@ -154,6 +165,14 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
   ament_auto_package(INSTALL_TO_SHARE
     data
     launch
+  )
+
+  install(
+    TARGETS
+      gather_topk_plugin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
   )
 
 else()

--- a/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
+++ b/perception/traffic_light_ssd_fine_detector/CMakeLists.txt
@@ -124,6 +124,11 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     lib/src/plugins/gather_topk.cpp
   )
 
+  cuda_add_library(grid_priors_plugin SHARED
+    lib/src/plugins/grid_priors_kernel.cu
+    lib/src/plugins/grid_priors.cpp
+  )
+
   ament_auto_add_library(ssd SHARED
     lib/src/trt_ssd.cpp
   )
@@ -136,6 +141,10 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     lib/include
   )
 
+  target_include_directories(grid_priors_plugin PUBLIC
+    lib/include
+  )
+
   target_link_libraries(ssd
     ${NVINFER}
     ${NVONNXPARSER}
@@ -144,6 +153,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     ${CUBLAS_LIBRARIES}
     ${CUDNN_LIBRARY}
     gather_topk_plugin
+    grid_priors_plugin
   )
 
   ament_auto_add_library(traffic_light_ssd_fine_detector_nodelet SHARED
@@ -155,6 +165,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     stdc++fs
     ssd
     gather_topk_plugin
+    grid_priors_plugin
   )
 
   rclcpp_components_register_node(traffic_light_ssd_fine_detector_nodelet
@@ -170,6 +181,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
   install(
     TARGETS
       gather_topk_plugin
+      grid_priors_plugin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin

--- a/perception/traffic_light_ssd_fine_detector/README.md
+++ b/perception/traffic_light_ssd_fine_detector/README.md
@@ -50,16 +50,15 @@ Based on the camera image and the global ROI array detected by `map_based_detect
 
 ### Node Parameters
 
-| Name                | Type   | Default Value                  | Description                                                          |
-| ------------------- | ------ | ------------------------------ | -------------------------------------------------------------------- |
-| `onnx_file`         | string | "./data/mb2-ssd-lite-tlr.onnx" | The onnx file name for yolo model                                    |
-| `label_file`        | string | "./data/voc_labels_tl.txt"     | The label file with label names for detected objects written on it   |
-| `is_box_first`      | bool   | false                          | Indicates whether first output head is for boxes                     |
-| `is_box_normalized` | bool   | true                           | Indicates whether output boxes have been normalized into `[0, 1]`    |
-| `mode`              | string | "FP32"                         | The inference mode: "FP32", "FP16", "INT8"                           |
-| `max_batch_size`    | int    | 8                              | The size of the batch processed at one time by inference by TensorRT |
-| `approximate_sync`  | bool   | false                          | Flag for whether to ues approximate sync policy                      |
-| `build_only`        | bool   | false                          | shutdown node after TensorRT engine file is built                    |
+| Name               | Type   | Default Value                  | Description                                                          |
+| ------------------ | ------ | ------------------------------ | -------------------------------------------------------------------- |
+| `onnx_file`        | string | "./data/mb2-ssd-lite-tlr.onnx" | The onnx file name for yolo model                                    |
+| `label_file`       | string | "./data/voc_labels_tl.txt"     | The label file with label names for detected objects written on it   |
+| `dnn_header_type`  | string | "pytorch"                      | Name of DNN trained toolbox: "pytorch" or "mmdetection"              |
+| `mode`             | string | "FP32"                         | The inference mode: "FP32", "FP16", "INT8"                           |
+| `max_batch_size`   | int    | 8                              | The size of the batch processed at one time by inference by TensorRT |
+| `approximate_sync` | bool   | false                          | Flag for whether to ues approximate sync policy                      |
+| `build_only`       | bool   | false                          | shutdown node after TensorRT engine file is built                    |
 
 ## Assumptions / Known limits
 

--- a/perception/traffic_light_ssd_fine_detector/README.md
+++ b/perception/traffic_light_ssd_fine_detector/README.md
@@ -50,14 +50,19 @@ Based on the camera image and the global ROI array detected by `map_based_detect
 
 ### Node Parameters
 
-| Name               | Type   | Default Value                  | Description                                                          |
-| ------------------ | ------ | ------------------------------ | -------------------------------------------------------------------- |
-| `onnx_file`        | string | "./data/mb2-ssd-lite-tlr.onnx" | The onnx file name for yolo model                                    |
-| `label_file`       | string | "./data/voc_labels_tl.txt"     | The label file with label names for detected objects written on it   |
-| `mode`             | string | "FP32"                         | The inference mode: "FP32", "FP16", "INT8"                           |
-| `max_batch_size`   | int    | 8                              | The size of the batch processed at one time by inference by TensorRT |
-| `approximate_sync` | bool   | false                          | Flag for whether to ues approximate sync policy                      |
-| `build_only`       | bool   | false                          | shutdown node after TensorRT engine file is built                    |
+| Name                | Type   | Default Value                  | Description                                                          |
+| ------------------- | ------ | ------------------------------ | -------------------------------------------------------------------- |
+| `onnx_file`         | string | "./data/mb2-ssd-lite-tlr.onnx" | The onnx file name for yolo model                                    |
+| `label_file`        | string | "./data/voc_labels_tl.txt"     | The label file with label names for detected objects written on it   |
+| `head1_name`        | string | "scores"                       | The name of first output head                                        |
+| `head2_name`        | string | "boxes"                        | The name of second output head                                       |
+| `boxes_first`       | bool   | false                          | Indicates whether first output head is for boxes                     |
+| `use_softmax`       | bool   | false                          | Indicates whether use sofrmax for output scores                      |
+| `denormalize_boxes` | bool   | true                           | Indicates whether should denormalize output boxes with image size    |
+| `mode`              | string | "FP32"                         | The inference mode: "FP32", "FP16", "INT8"                           |
+| `max_batch_size`    | int    | 8                              | The size of the batch processed at one time by inference by TensorRT |
+| `approximate_sync`  | bool   | false                          | Flag for whether to ues approximate sync policy                      |
+| `build_only`        | bool   | false                          | shutdown node after TensorRT engine file is built                    |
 
 ## Assumptions / Known limits
 

--- a/perception/traffic_light_ssd_fine_detector/README.md
+++ b/perception/traffic_light_ssd_fine_detector/README.md
@@ -56,9 +56,8 @@ Based on the camera image and the global ROI array detected by `map_based_detect
 | `label_file`        | string | "./data/voc_labels_tl.txt"     | The label file with label names for detected objects written on it   |
 | `head1_name`        | string | "scores"                       | The name of first output head                                        |
 | `head2_name`        | string | "boxes"                        | The name of second output head                                       |
-| `boxes_first`       | bool   | false                          | Indicates whether first output head is for boxes                     |
-| `use_softmax`       | bool   | false                          | Indicates whether use sofrmax for output scores                      |
-| `denormalize_boxes` | bool   | true                           | Indicates whether should denormalize output boxes with image size    |
+| `is_box_first`      | bool   | false                          | Indicates whether first output head is for boxes                     |
+| `is_box_normalized` | bool   | true                           | Indicates whether output boxes have been normalized into `[0, 1]`    |
 | `mode`              | string | "FP32"                         | The inference mode: "FP32", "FP16", "INT8"                           |
 | `max_batch_size`    | int    | 8                              | The size of the batch processed at one time by inference by TensorRT |
 | `approximate_sync`  | bool   | false                          | Flag for whether to ues approximate sync policy                      |

--- a/perception/traffic_light_ssd_fine_detector/README.md
+++ b/perception/traffic_light_ssd_fine_detector/README.md
@@ -54,8 +54,6 @@ Based on the camera image and the global ROI array detected by `map_based_detect
 | ------------------- | ------ | ------------------------------ | -------------------------------------------------------------------- |
 | `onnx_file`         | string | "./data/mb2-ssd-lite-tlr.onnx" | The onnx file name for yolo model                                    |
 | `label_file`        | string | "./data/voc_labels_tl.txt"     | The label file with label names for detected objects written on it   |
-| `head1_name`        | string | "scores"                       | The name of first output head                                        |
-| `head2_name`        | string | "boxes"                        | The name of second output head                                       |
 | `is_box_first`      | bool   | false                          | Indicates whether first output head is for boxes                     |
 | `is_box_normalized` | bool   | true                           | Indicates whether output boxes have been normalized into `[0, 1]`    |
 | `mode`              | string | "FP32"                         | The inference mode: "FP32", "FP16", "INT8"                           |

--- a/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
+++ b/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
+++ b/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
@@ -100,10 +100,8 @@ private:
   ssd::Shape input_shape_;
   int class_num_;
   int detection_per_class_;
-  std::string head1_name_;
-  std::string head2_name_;
-  std::optional<ssd::Dims2> head1_dims_;
-  std::optional<ssd::Dims2> head2_dims_;
+  std::optional<ssd::Dims2> box_dims_;
+  std::optional<ssd::Dims2> score_dims_;
   bool is_box_first_;
   bool is_box_normalized_;
 

--- a/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
+++ b/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
@@ -63,7 +63,6 @@ private:
   bool cnnOutput2BoxDetection(
     const float * scores, const float * boxes, const int tlr_id,
     const std::vector<cv::Mat> & in_imgs, const int num_rois, std::vector<Detection> & detections);
-  void calculateSoftmax(std::vector<float> & scores) const;
   bool rosMsg2CvMat(const sensor_msgs::msg::Image::ConstSharedPtr image_msg, cv::Mat & image);
   bool fitInFrame(cv::Point & lt, cv::Point & rb, const cv::Size & size);
   void cvRect2TlRoiMsg(
@@ -105,9 +104,8 @@ private:
   std::string head2_name_;
   std::optional<ssd::Dims2> head1_dims_;
   std::optional<ssd::Dims2> head2_dims_;
-  bool boxes_first_;
-  bool use_softmax_;
-  bool denormalize_boxes_;
+  bool is_box_first_;
+  bool is_box_normalized_;
 
   std::vector<float> mean_;
   std::vector<float> std_;

--- a/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
+++ b/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
@@ -102,8 +102,7 @@ private:
   int detection_per_class_;
   std::optional<ssd::Dims2> box_dims_;
   std::optional<ssd::Dims2> score_dims_;
-  bool is_box_first_;
-  bool is_box_normalized_;
+  std::string dnn_header_type_;
 
   std::vector<float> mean_;
   std::vector<float> std_;

--- a/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
+++ b/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
@@ -63,6 +63,7 @@ private:
   bool cnnOutput2BoxDetection(
     const float * scores, const float * boxes, const int tlr_id,
     const std::vector<cv::Mat> & in_imgs, const int num_rois, std::vector<Detection> & detections);
+  void calculateSoftmax(std::vector<float> & scores) const;
   bool rosMsg2CvMat(const sensor_msgs::msg::Image::ConstSharedPtr image_msg, cv::Mat & image);
   bool fitInFrame(cv::Point & lt, cv::Point & rb, const cv::Size & size);
   void cvRect2TlRoiMsg(
@@ -97,14 +98,16 @@ private:
   double score_thresh_;
 
   int tlr_id_;
-  ssd::Size size_;
+  ssd::Shape input_shape_;
   int class_num_;
   int detection_per_class_;
   std::string head1_name_;
   std::string head2_name_;
-  ssd::Dims head1_dims_;
-  ssd::Dims head2_dims_;
-  bool score_first_{true};
+  std::optional<ssd::Dims2> head1_dims_;
+  std::optional<ssd::Dims2> head2_dims_;
+  bool boxes_first_;
+  bool use_softmax_;
+  bool denormalize_boxes_;
 
   std::vector<float> mean_;
   std::vector<float> std_;

--- a/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
+++ b/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
@@ -97,11 +97,14 @@ private:
   double score_thresh_;
 
   int tlr_id_;
-  int channel_;
-  int width_;
-  int height_;
+  ssd::Size size_;
   int class_num_;
   int detection_per_class_;
+  std::string head1_name_;
+  std::string head2_name_;
+  ssd::Dims head1_dims_;
+  ssd::Dims head2_dims_;
+  bool score_first_{true};
 
   std::vector<float> mean_;
   std::vector<float> std_;

--- a/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
+++ b/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
@@ -2,6 +2,8 @@
   <arg name="onnx_file" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/mb2-ssd-lite-tlr.onnx"/>
   <arg name="label_file" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/voc_labels_tl.txt"/>
   <arg name="mode" default="FP32"/>
+  <arg name="head1_name" default="scores"/>
+  <arg name="head2_name" default="boxes"/>
   <arg name="input/image" default="/image_raw"/>
   <arg name="input/rois" default="/traffic_light_map_based_detector/output/rois"/>
   <arg name="output/rois" default="~/output/rois"/>

--- a/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
+++ b/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
@@ -21,9 +21,8 @@
     <remap from="~/output/rois" to="$(var output/rois)"/>
     <param name="onnx_file" type="str" value="$(var onnx_file)"/>
     <param name="label_file" type="str" value="$(var label_file)"/>
+    <param name="dnn_header_type" type="str" value="$(var dnn_header_type)"/>
     <param name="mode" type="str" value="$(var mode)"/>
-    <param name="is_box_first" value="$(var is_box_first)"/>
-    <param name="is_box_normalized" value="$(var is_box_normalized)"/>
     <param name="score_thresh" value="$(var score_thresh)"/>
     <param name="max_batch_size" value="$(var max_batch_size)"/>
     <param name="approximate_sync" value="$(var approximate_sync)"/>

--- a/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
+++ b/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
@@ -4,8 +4,8 @@
   <arg name="mode" default="FP32"/>
   <arg name="head1_name" default="scores"/>
   <arg name="head2_name" default="boxes"/>
-  <arg name="boxes_first" default="false"/>
-  <arg name="denormalize_boxes" default="true"/>
+  <arg name="is_box_first" default="false"/>
+  <arg name="is_box_normalized" default="true"/>
   <arg name="input/image" default="/image_raw"/>
   <arg name="input/rois" default="/traffic_light_map_based_detector/output/rois"/>
   <arg name="output/rois" default="~/output/rois"/>
@@ -27,8 +27,8 @@
     <param name="mode" type="str" value="$(var mode)"/>
     <param name="head1_name" value="$(var head1_name)"/>
     <param name="head2_name" value="$(var head2_name)"/>
-    <param name="boxes_first" value="$(var boxes_first)"/>
-    <param name="denormalize_boxes" value="$(var denormalize_boxes)"/>
+    <param name="is_box_first" value="$(var is_box_first)"/>
+    <param name="is_box_normalized" value="$(var is_box_normalized)"/>
     <param name="score_thresh" value="$(var score_thresh)"/>
     <param name="max_batch_size" value="$(var max_batch_size)"/>
     <param name="approximate_sync" value="$(var approximate_sync)"/>

--- a/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
+++ b/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
@@ -4,6 +4,8 @@
   <arg name="mode" default="FP32"/>
   <arg name="head1_name" default="scores"/>
   <arg name="head2_name" default="boxes"/>
+  <arg name="boxes_first" default="false"/>
+  <arg name="denormalize_boxes" default="true"/>
   <arg name="input/image" default="/image_raw"/>
   <arg name="input/rois" default="/traffic_light_map_based_detector/output/rois"/>
   <arg name="output/rois" default="~/output/rois"/>
@@ -23,6 +25,10 @@
     <param name="onnx_file" type="str" value="$(var onnx_file)"/>
     <param name="label_file" type="str" value="$(var label_file)"/>
     <param name="mode" type="str" value="$(var mode)"/>
+    <param name="head1_name" value="$(var head1_name)"/>
+    <param name="head2_name" value="$(var head2_name)"/>
+    <param name="boxes_first" value="$(var boxes_first)"/>
+    <param name="denormalize_boxes" value="$(var denormalize_boxes)"/>
     <param name="score_thresh" value="$(var score_thresh)"/>
     <param name="max_batch_size" value="$(var max_batch_size)"/>
     <param name="approximate_sync" value="$(var approximate_sync)"/>

--- a/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
+++ b/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
@@ -2,8 +2,7 @@
   <arg name="onnx_file" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/mb2-ssd-lite-tlr.onnx"/>
   <arg name="label_file" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/voc_labels_tl.txt"/>
   <arg name="mode" default="FP32"/>
-  <arg name="is_box_first" default="false"/>
-  <arg name="is_box_normalized" default="true"/>
+  <arg name="dnn_header_type" default="pytorch" description="pytorch or mmdetection"/>
   <arg name="input/image" default="/image_raw"/>
   <arg name="input/rois" default="/traffic_light_map_based_detector/output/rois"/>
   <arg name="output/rois" default="~/output/rois"/>

--- a/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
+++ b/perception/traffic_light_ssd_fine_detector/launch/traffic_light_ssd_fine_detector.launch.xml
@@ -2,8 +2,6 @@
   <arg name="onnx_file" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/mb2-ssd-lite-tlr.onnx"/>
   <arg name="label_file" default="$(find-pkg-share traffic_light_ssd_fine_detector)/data/voc_labels_tl.txt"/>
   <arg name="mode" default="FP32"/>
-  <arg name="head1_name" default="scores"/>
-  <arg name="head2_name" default="boxes"/>
   <arg name="is_box_first" default="false"/>
   <arg name="is_box_normalized" default="true"/>
   <arg name="input/image" default="/image_raw"/>
@@ -25,8 +23,6 @@
     <param name="onnx_file" type="str" value="$(var onnx_file)"/>
     <param name="label_file" type="str" value="$(var label_file)"/>
     <param name="mode" type="str" value="$(var mode)"/>
-    <param name="head1_name" value="$(var head1_name)"/>
-    <param name="head2_name" value="$(var head2_name)"/>
     <param name="is_box_first" value="$(var is_box_first)"/>
     <param name="is_box_normalized" value="$(var is_box_normalized)"/>
     <param name="score_thresh" value="$(var score_thresh)"/>

--- a/perception/traffic_light_ssd_fine_detector/lib/include/cuda_utils.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/cuda_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/include/cuda_utils.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/cuda_utils.hpp
@@ -22,6 +22,8 @@
 #define CUDA_UTILS_HPP_
 
 #include <./cuda_runtime_api.h>
+#include <cublas_v2.h>
+#include <cuda.h>
 
 #include <memory>
 #include <sstream>
@@ -29,6 +31,13 @@
 #include <type_traits>
 
 #define CHECK_CUDA_ERROR(e) (cuda::check_error(e, __FILE__, __LINE__))
+
+#define CUDA_1D_KERNEL_LOOP(i, n) \
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); i += blockDim.x * gridDim.x)
+
+#define THREADS_PER_BLOCK 512
+
+#define DIVUP(m, n) ((m) / (n) + ((m) % (n) > 0))
 
 namespace cuda
 {
@@ -50,7 +59,8 @@ template <typename T>
 using unique_ptr = std::unique_ptr<T, deleter>;
 
 // auto array = cuda::make_unique<float[]>(n);
-// ::cudaMemcpy(array.get(), src_array, sizeof(float)*n, ::cudaMemcpyHostToDevice);
+// ::cudaMemcpy(array.get(), src_array, sizeof(float)*n,
+// ::cudaMemcpyHostToDevice);
 template <typename T>
 typename std::enable_if<std::is_array<T>::value, cuda::unique_ptr<T>>::type make_unique(
   const std::size_t n)
@@ -62,7 +72,8 @@ typename std::enable_if<std::is_array<T>::value, cuda::unique_ptr<T>>::type make
 }
 
 // auto value = cuda::make_unique<my_class>();
-// ::cudaMemcpy(value.get(), src_value, sizeof(my_class), ::cudaMemcpyHostToDevice);
+// ::cudaMemcpy(value.get(), src_value, sizeof(my_class),
+// ::cudaMemcpyHostToDevice);
 template <typename T>
 cuda::unique_ptr<T> make_unique()
 {

--- a/perception/traffic_light_ssd_fine_detector/lib/include/cuda_utils.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/cuda_utils.hpp
@@ -25,6 +25,7 @@
 #include <cublas_v2.h>
 #include <cuda.h>
 
+#include <algorithm>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
@@ -38,6 +39,13 @@
 #define THREADS_PER_BLOCK 512
 
 #define DIVUP(m, n) ((m) / (n) + ((m) % (n) > 0))
+
+inline int GET_BLOCKS(const int N)
+{
+  int optimal_block_num = DIVUP(N, THREADS_PER_BLOCK);
+  constexpr int max_block_num = 4096;
+  return std::min(optimal_block_num, max_block_num);
+}
 
 namespace cuda
 {

--- a/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk.hpp
@@ -1,0 +1,99 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#ifndef GATHER_TOPK_HPP_
+#define GATHER_TOPK_HPP_
+
+#include "trt_plugin_helper.hpp"
+
+#include <NvInferRuntime.h>
+#include <NvInferVersion.h>
+#include <cublas_v2.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ssd
+{
+class GatherTopk : public nvinfer1::IPluginV2DynamicExt
+{
+private:
+  const std::string mLayerName;
+  std::string mNamespace;
+
+public:
+  explicit GatherTopk(const std::string & name);
+  GatherTopk(const std::string & name, const void * data, size_t length);
+  GatherTopk() = delete;
+
+  // IPluginV2 methods
+  const char * getPluginVersion() const noexcept override;
+  const char * getPluginType() const noexcept override;
+  int initialize() noexcept override;
+  void terminate() noexcept override;
+  void destroy() noexcept override;
+  void setPluginNamespace(const char * pluginNamespace) noexcept override;
+  const char * getPluginNamespace() const noexcept override;
+  int getNbOutputs() const noexcept override;
+  size_t getSerializationSize() const noexcept override;
+  void serialize(void * buffer) const noexcept override;
+
+  // IPluginV2Ext methods
+  nvinfer1::DataType getOutputDataType(
+    int index, const nvinfer1::DataType * inputTypes, int nbInputs) const noexcept override;
+
+  // IPluginV2DynamicExt methods
+  nvinfer1::IPluginV2DynamicExt * clone() const noexcept override;
+  nvinfer1::DimsExprs getOutputDimensions(
+    int outputIndex, const nvinfer1::DimsExprs * inputs, int nbInputs,
+    nvinfer1::IExprBuilder & exprBuilder) noexcept override;
+  bool supportsFormatCombination(
+    int pos, const nvinfer1::PluginTensorDesc * ioDesc, int nbInputs,
+    int nbOutputs) noexcept override;
+  void configurePlugin(
+    const nvinfer1::DynamicPluginTensorDesc * inputs, int nbInputs,
+    const nvinfer1::DynamicPluginTensorDesc * outputs, int nbOutputs) noexcept override;
+  size_t getWorkspaceSize(
+    const nvinfer1::PluginTensorDesc *, int, const nvinfer1::PluginTensorDesc *,
+    int) const noexcept override;
+  int enqueue(
+    const nvinfer1::PluginTensorDesc *, const nvinfer1::PluginTensorDesc *, const void * const *,
+    void * const *, void *, cudaStream_t) noexcept override;
+};  // class GatherTopk
+
+class GatherTopkCreator : public nvinfer1::IPluginCreator
+{
+private:
+  nvinfer1::PluginFieldCollection mFC;
+  std::vector<nvinfer1::PluginField> mPluginAttributes;
+  std::string mNamespace;
+
+public:
+  GatherTopkCreator();
+  const char * getPluginVersion() const noexcept override;
+  const nvinfer1::PluginFieldCollection * getFieldNames() noexcept override;
+  void setPluginNamespace(const char * pluginNamespace) noexcept override;
+  const char * getPluginNamespace() const noexcept override;
+  const char * getPluginName() const noexcept override;
+  nvinfer1::IPluginV2 * createPlugin(
+    const char * name, const nvinfer1::PluginFieldCollection * fc) noexcept override;
+  nvinfer1::IPluginV2 * deserializePlugin(
+    const char * name, const void * serialData, size_t serialLength) noexcept override;
+};  // class GatherTopkCreator
+}  // namespace ssd
+
+#endif  // GATHER_TOPK_HPP_

--- a/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk.hpp
@@ -94,6 +94,9 @@ public:
   nvinfer1::IPluginV2 * deserializePlugin(
     const char * name, const void * serialData, size_t serialLength) noexcept override;
 };  // class GatherTopkCreator
+
+REGISTER_TENSORRT_PLUGIN(GatherTopkCreator);
+
 }  // namespace ssd
 
 #endif  // GATHER_TOPK_HPP_

--- a/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk_kernel.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk_kernel.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk_kernel.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/gather_topk_kernel.hpp
@@ -1,0 +1,30 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#ifndef GATHER_TOPK_KERNEL_HPP_
+#define GATHER_TOPK_KERNEL_HPP_
+
+#include <cuda_runtime.h>
+
+namespace ssd
+{
+template <typename scalar_t>
+void gather_topk_impl(
+  const scalar_t * input, const int * indices, const int * dims, int nbDims,
+  const int * indices_dims, int indices_nbDims, scalar_t * output, cudaStream_t stream);
+}  // namespace ssd
+
+#endif  // GATHER_TOPK_KERNEL_HPP_

--- a/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors.hpp
@@ -96,6 +96,9 @@ public:
   nvinfer1::IPluginV2 * deserializePlugin(
     const char * name, const void * serialData, size_t serialLength) noexcept override;
 };  // class GridPriorsCreator
+
+REGISTER_TENSORRT_PLUGIN(GridPriorsCreator);
+
 }  // namespace ssd
 
 #endif  // GRID_PRIORS_HPP_

--- a/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors.hpp
@@ -1,0 +1,101 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#ifndef GRID_PRIORS_HPP_
+#define GRID_PRIORS_HPP_
+
+#include "trt_plugin_helper.hpp"
+
+#include <NvInferRuntime.h>
+#include <NvInferVersion.h>
+#include <cublas_v2.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ssd
+{
+class GridPriors : public nvinfer1::IPluginV2DynamicExt
+{
+private:
+  const std::string mLayerName;
+  std::string mNamespace;
+  nvinfer1::Dims mStride;
+  cublasHandle_t m_cublas_handle;
+
+public:
+  explicit GridPriors(const std::string & name, const nvinfer1::Dims & stride);
+  GridPriors(const std::string & name, const void *, size_t length);
+  GridPriors() = delete;
+
+  // IPluginV2 methods
+  const char * getPluginVersion() const noexcept override;
+  const char * getPluginType() const noexcept override;
+  int initialize() noexcept override;
+  void terminate() noexcept override;
+  void destroy() noexcept override;
+  void setPluginNamespace(const char * pluginNamespace) noexcept override;
+  const char * getPluginNamespace() const noexcept override;
+  int getNbOutputs() const noexcept override;
+  size_t getSerializationSize() const noexcept override;
+  void serialize(void * buffer) const noexcept override;
+
+  // IPluginV2Ext methods
+  nvinfer1::DataType getOutputDataType(
+    int index, const nvinfer1::DataType * inputTypes, int nbInputs) const noexcept override;
+
+  // IPluginV2DynamicExt methods
+  nvinfer1::IPluginV2DynamicExt * clone() const noexcept override;
+  nvinfer1::DimsExprs getOutputDimensions(
+    int outputIndex, const nvinfer1::DimsExprs * inputs, int nbInputs,
+    nvinfer1::IExprBuilder & exprBuilder) noexcept override;
+  bool supportsFormatCombination(
+    int pos, const nvinfer1::PluginTensorDesc * ioDesc, int nbInputs,
+    int nbOutputs) noexcept override;
+  void configurePlugin(
+    const nvinfer1::DynamicPluginTensorDesc * inputs, int nbInputs,
+    const nvinfer1::DynamicPluginTensorDesc * outputs, int nbOutputs) noexcept override;
+  size_t getWorkspaceSize(
+    const nvinfer1::PluginTensorDesc *, int, const nvinfer1::PluginTensorDesc *,
+    int) const noexcept override;
+  int enqueue(
+    const nvinfer1::PluginTensorDesc *, const nvinfer1::PluginTensorDesc *, const void * const *,
+    void * const *, void *, cudaStream_t) noexcept override;
+};  // class GridPriors
+
+class GridPriorsCreator : public nvinfer1::IPluginCreator
+{
+private:
+  nvinfer1::PluginFieldCollection mFC;
+  std::vector<nvinfer1::PluginField> mPluginAttributes;
+  std::string mNamespace;
+
+public:
+  GridPriorsCreator();
+  const char * getPluginVersion() const noexcept override;
+  const nvinfer1::PluginFieldCollection * getFieldNames() noexcept override;
+  void setPluginNamespace(const char * pluginNamespace) noexcept override;
+  const char * getPluginNamespace() const noexcept override;
+  const char * getPluginName() const noexcept override;
+  nvinfer1::IPluginV2 * createPlugin(
+    const char * name, const nvinfer1::PluginFieldCollection * fc) noexcept override;
+  nvinfer1::IPluginV2 * deserializePlugin(
+    const char * name, const void * serialData, size_t serialLength) noexcept override;
+};  // class GridPriorsCreator
+}  // namespace ssd
+
+#endif  // GRID_PRIORS_HPP_

--- a/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors_kernel.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors_kernel.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors_kernel.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/grid_priors_kernel.hpp
@@ -1,0 +1,30 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#ifndef GRID_PRIORS_KERNEL_HPP_
+#define GRID_PRIORS_KERNEL_HPP_
+
+#include <cuda_runtime.h>
+
+namespace ssd
+{
+template <typename scalar_t>
+void grid_priors_impl(
+  const scalar_t * base_anchor, scalar_t * output, int num_base_anchors, int feat_w, int feat_h,
+  int stride_w, int stride_h, cudaStream_t stream);
+}  // namespace ssd
+
+#endif  // GRID_PRIORS_KERNEL_HPP_

--- a/perception/traffic_light_ssd_fine_detector/lib/include/trt_plugin_helper.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/trt_plugin_helper.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/include/trt_plugin_helper.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/trt_plugin_helper.hpp
@@ -1,0 +1,67 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#ifndef TRT_PLUGIN_HELPER_HPP_
+#define TRT_PLUGIN_HELPER_HPP_
+
+#include <NvInferRuntime.h>
+#include <cudnn.h>
+
+#include <iostream>
+#include <stdexcept>
+
+cudnnStatus_t convert_trt2cudnn_dtype(nvinfer1::DataType trt_dtype, cudnnDataType_t * cudnn_dtype);
+
+enum pluginStatus_t {
+  STATUS_SUCCESS = 0,
+  STATUS_FAILURE = 1,
+  STATUS_BAD_PARAM = 2,
+  STATUS_NOT_SUPPORTED = 3,
+  STATUS_NOT_INITIALIZED = 4
+};  // enum pluginStatus_t
+
+#define ASSERT(assertion)                                                     \
+  {                                                                           \
+    if (!assertion) {                                                         \
+      std::cerr << "#assertion" << __FILE__ << ", " << __LINE__ << std::endl; \
+      abort();                                                                \
+    }                                                                         \
+  }
+
+#define CUASSERT(status_)                                                                       \
+  {                                                                                             \
+    auto s_ = status;                                                                           \
+    if (s_ != cudaSuccess) {                                                                    \
+      std::cerr << __FILE__ << ", " << __LINE__ << ", " << s_ << ", " << cudaGetErrorString(s_) \
+                << std::endl;                                                                   \
+    }                                                                                           \
+  }
+
+#define CUBLASASSERT(status_)                                               \
+  {                                                                         \
+    auto s_ = status_;                                                      \
+    if (s_ != CUBLAS_STATUS_SUCCESS) {                                      \
+      std::cerr << __FILE__ << ", " << __LINE__ << ", " << s_ << std::endl; \
+    }                                                                       \
+  }
+
+#define CUERRORMSG(status_)                                                            \
+  {                                                                                    \
+    auto s_ = status_;                                                                 \
+    if (s_ != 0) std::cerr << __FILE__ << ", " << __LINE__ << ", " << s_ << std::endl; \
+  }
+
+#endif  // TRT_PLUGIN_HELPER_HPP_

--- a/perception/traffic_light_ssd_fine_detector/lib/include/trt_serialize.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/trt_serialize.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/include/trt_serialize.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/trt_serialize.hpp
@@ -40,7 +40,7 @@ struct Serializer<
   T, typename std::enable_if<
        std::is_arithmetic<T>::value || std::is_enum<T>::value || std::is_pod<T>::value>::type>
 {
-  static size_t serialized_size(T const & value) { return sizeof(T); }
+  static size_t serialized_size(T const &) { return sizeof(T); }
   static void serialize(void ** buffer, T const & value)
   {
     ::memcpy(*buffer, &value, sizeof(T));
@@ -105,6 +105,12 @@ struct Serializer<
 };  // struct Serializer
 
 }  // namespace
+
+template <typename T>
+inline size_t serialized_size(T const & value)
+{
+  return Serializer<T>::serialized_size(value);
+}
 
 template <typename T>
 inline void serialize_value(void ** buffer, T const & value)

--- a/perception/traffic_light_ssd_fine_detector/lib/include/trt_serialize.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/trt_serialize.hpp
@@ -1,0 +1,121 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#ifndef TRT_SERIALIZE_HPP_
+#define TRT_SERIALIZE_HPP_
+
+#include <cassert>
+#include <cstring>
+#include <type_traits>
+#include <vector>
+
+template <typename T>
+inline void serialize_value(void ** buffer, T const & value);
+
+template <typename T>
+inline void deserialize_value(void const ** buffer, size_t * buffer_size, T * value);
+
+namespace
+{
+template <typename T, class Enable = void>
+struct Serializer
+{
+};  // struct Serializer
+
+template <typename T>
+struct Serializer<
+  T, typename std::enable_if<
+       std::is_arithmetic<T>::value || std::is_enum<T>::value || std::is_pod<T>::value>::type>
+{
+  static size_t serialized_size(T const & value) { return sizeof(T); }
+  static void serialize(void ** buffer, T const & value)
+  {
+    ::memcpy(*buffer, &value, sizeof(T));
+    reinterpret_cast<char *&>(*buffer) += sizeof(T);
+  }
+  static void deserialize(void const ** buffer, size_t * buffer_size, T * value)
+  {
+    assert(sizeof(T) <= *buffer_size);
+    ::memcpy(value, *buffer, sizeof(T));
+    reinterpret_cast<char const *&>(*buffer) += sizeof(T);
+    *buffer_size -= sizeof(T);
+  }
+};  // struct Serializer
+
+template <>
+struct Serializer<const char *>
+{
+  static size_t serialized_size(const char * value) { return strlen(value) + 1; }
+  static void serialize(void ** buffer, const char * value)
+  {
+    ::memcpy(static_cast<char *>(*buffer), value, sizeof(char));
+    reinterpret_cast<char *&>(*buffer) += strlen(value) + 1;
+  }
+  static void deserialize(void const ** buffer, size_t * buffer_size, const char ** value)
+  {
+    *value = static_cast<char const *>(*buffer);
+    size_t data_size = strnlen(*value, *buffer_size) + 1;
+    assert(data_size <= *buffer_size);
+    reinterpret_cast<char const *&>(*buffer) += data_size;
+    *buffer_size -= data_size;
+  }
+};  // struct Serializer
+
+template <typename T>
+struct Serializer<
+  std::vector<T>,
+  typename std::enable_if<
+    std::is_arithmetic<T>::value || std::is_enum<T>::value || std::is_pod<T>::value>::type>
+{
+  static size_t serialized_size(std::vector<T> const & value)
+  {
+    return sizeof(value.size()) + value.size() * sizeof(T);
+  }
+  static void serialize(void ** buffer, std::vector<T> const & value)
+  {
+    serialize_value(buffer, value.size());
+    size_t nbyte = value.size() * sizeof(T);
+    ::memcpy(*buffer, value.data(), nbyte);
+    reinterpret_cast<char *&>(*buffer) += nbyte;
+  }
+  static void deserialize(void const ** buffer, size_t * buffer_size, std::vector<T> * value)
+  {
+    size_t size;
+    deserialize_value(buffer, buffer_size, &size);
+    value->resize(size);
+    size_t nbyte = value->size() * sizeof(T);
+    assert(nbyte <= *buffer_size);
+    ::memcpy(value->data(), *buffer, nbyte);
+    reinterpret_cast<char const *&>(*buffer) += nbyte;
+    *buffer_size -= nbyte;
+  }
+};  // struct Serializer
+
+}  // namespace
+
+template <typename T>
+inline void serialize_value(void ** buffer, T const & value)
+{
+  return Serializer<T>::serialize(buffer, value);
+}
+
+template <typename T>
+inline void deserialize_value(void const ** buffer, size_t * buffer_size, T * value)
+{
+  return Serializer<T>::deserialize(buffer, buffer_size, value);
+}
+
+#endif  // TRT_SERIALIZE_HPP_

--- a/perception/traffic_light_ssd_fine_detector/lib/include/trt_ssd.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/trt_ssd.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/include/trt_ssd.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/trt_ssd.hpp
@@ -92,8 +92,8 @@ public:
   // Get (c, h, w) size of the fixed input
   Shape getInputShape() const;
 
-  // Get output dimensions by name
-  std::optional<Dims2> getOutputDimensions(const std::string &) const;
+  // Get output dimensions by index
+  std::optional<Dims2> getOutputDimensions(const size_t index) const;
 
   // Get max allowed batch size
   inline int getMaxBatchSize() const

--- a/perception/traffic_light_ssd_fine_detector/lib/include/trt_ssd.hpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/include/trt_ssd.hpp
@@ -55,6 +55,19 @@ private:
   bool verbose_{false};
 };
 
+struct Size
+{
+  int channel, width, height;
+  int dims() const { return channel * width * height; }
+  int area() const { return width * height; }
+};
+
+struct Dims
+{
+  int dim1, dim2;
+  int d() const { return dim1 * dim2; }
+};
+
 class Net
 {
 public:
@@ -75,9 +88,10 @@ public:
   void infer(std::vector<void *> & buffers, const int batch_size);
 
   // Get (c, h, w) size of the fixed input
-  std::vector<int> getInputSize();
+  Size getInputSize();
 
-  std::vector<int> getOutputScoreSize();
+  // Get output dimensions by name
+  Dims getOutputDimensions(const std::string &) const;
 
   // Get max allowed batch size
   int getMaxBatchSize();

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk.cpp
@@ -1,0 +1,237 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "gather_topk.hpp"
+
+#include "gather_topk_kernel.hpp"
+#include "trt_serialize.hpp"
+
+#include <assert.h>
+#include <stdio.h>
+
+#include <chrono>
+
+namespace ssd
+{
+namespace
+{
+static const char * PLUGIN_VERSION{"1"};
+static const char * PLUGIN_NAME{"GatherTopk"};
+}  // namespace
+
+GatherTopk::GatherTopk(const std::string & name) : mLayerName(name)
+{
+}
+GatherTopk::GatherTopk(const std::string & name, const void *, size_t) : mLayerName(name)
+{
+}
+
+// IPluginV2 methods
+const char * GatherTopk::getPluginVersion() const noexcept
+{
+  return PLUGIN_VERSION;
+}
+
+const char * GatherTopk::getPluginType() const noexcept
+{
+  return PLUGIN_NAME;
+}
+
+int GatherTopk::initialize() noexcept
+{
+  return STATUS_SUCCESS;
+}
+
+void GatherTopk::terminate() noexcept
+{
+}
+
+void GatherTopk::destroy() noexcept
+{
+  delete this;
+}
+
+void GatherTopk::setPluginNamespace(const char * pluginNamespace) noexcept
+{
+  mNamespace = pluginNamespace;
+}
+
+const char * GatherTopk::getPluginNamespace() const noexcept
+{
+  return mNamespace.c_str();
+}
+
+int GatherTopk::getNbOutputs() const noexcept
+{
+  return 1;
+}
+
+size_t GatherTopk::getSerializationSize() const noexcept
+{
+  return 0;
+}
+
+void GatherTopk::serialize(void *) const noexcept
+{
+}
+
+// IPluginV2Ext methods
+nvinfer1::DataType GatherTopk::getOutputDataType(
+  int, const nvinfer1::DataType * inputTypes, int) const noexcept
+{
+  return inputTypes[0];
+}
+
+// IPluginV2DynamicExt methods
+nvinfer1::IPluginV2DynamicExt * GatherTopk::clone() const noexcept
+{
+  GatherTopk * plugin = new GatherTopk(mLayerName);
+  plugin->setPluginNamespace(getPluginNamespace());
+  return plugin;
+}
+
+nvinfer1::DimsExprs GatherTopk::getOutputDimensions(
+  int, const nvinfer1::DimsExprs * inputs, int, nvinfer1::IExprBuilder &) noexcept
+{
+  assert(inputs[1].nbDims <= inputs[0].nbDims);
+  nvinfer1::DimsExprs ret;
+  ret.nbDims = inputs[0].nbDims;
+  for (int i = 0; i < inputs[1].nbDims; ++i) {
+    ret.d[i] = inputs[1].d[i];
+  }
+  for (int i = inputs[1].nbDims; i < inputs[0].nbDims; ++i) {
+    ret.d[i] = inputs[0].d[i];
+  }
+  return ret;
+}
+
+bool GatherTopk::supportsFormatCombination(
+  int pos, const nvinfer1::PluginTensorDesc * ioDesc, int, int) noexcept
+{
+  switch (pos) {
+    case 0:
+      // data
+      return (ioDesc[pos].type == nvinfer1::DataType::kFLOAT &&
+              ioDesc[pos].format == nvinfer1::TensorFormat::kLINEAR) ||
+             (ioDesc[pos].type == nvinfer1::DataType::kINT32 &&
+              ioDesc[pos].format == nvinfer1::TensorFormat::kLINEAR);
+    case 1:
+      // indices
+      return ioDesc[pos].type == nvinfer1::DataType::kINT32 &&
+             ioDesc[pos].format == nvinfer1::TensorFormat::kLINEAR;
+    case 2:
+      // output
+      return ioDesc[pos].type == ioDesc[0].type && ioDesc[pos].format == ioDesc[0].format;
+    default:
+      return true;
+  }
+}
+
+void GatherTopk::configurePlugin(
+  const nvinfer1::DynamicPluginTensorDesc *, int, const nvinfer1::DynamicPluginTensorDesc *,
+  int) noexcept
+{
+}
+
+size_t GatherTopk::getWorkspaceSize(
+  const nvinfer1::PluginTensorDesc *, int, const nvinfer1::PluginTensorDesc *, int) const noexcept
+{
+  return 0;
+}
+
+int GatherTopk::enqueue(
+  const nvinfer1::PluginTensorDesc * inputDesc, const nvinfer1::PluginTensorDesc *,
+  const void * const * inputs, void * const * outputs, void *, cudaStream_t stream) noexcept
+{
+  const int * dims = &(inputDesc[0].dims.d[0]);
+  const int * dims_indices = &(inputDesc[1].dims.d[0]);
+  int nbDims = inputDesc[0].dims.nbDims;
+  int nbDims_index = inputDesc[1].dims.nbDims;
+
+  const void * data = inputs[0];
+  const void * indices = inputs[1];
+  void * output = outputs[0];
+
+  auto data_type = inputDesc[0].type;
+
+  switch (data_type) {
+    case nvinfer1::DataType::kFLOAT:
+      gather_topk_impl<float>(
+        reinterpret_cast<const float *>(data), reinterpret_cast<const int *>(indices), dims, nbDims,
+        dims_indices, nbDims_index, reinterpret_cast<float *>(output), stream);
+      break;
+    case nvinfer1::DataType::kINT32:
+      gather_topk_impl<int>(
+        reinterpret_cast<const int *>(data), reinterpret_cast<const int *>(indices), dims, nbDims,
+        dims_indices, nbDims_index, reinterpret_cast<int *>(output), stream);
+      break;
+    default:
+      break;
+  }
+  return 0;
+}
+
+// PluginCreator
+GatherTopkCreator::GatherTopkCreator()
+{
+  mPluginAttributes.clear();
+  mFC.nbFields = mPluginAttributes.size();
+  mFC.fields = mPluginAttributes.data();
+}
+
+const char * GatherTopkCreator::getPluginName() const noexcept
+{
+  return PLUGIN_NAME;
+}
+
+const char * GatherTopkCreator::getPluginVersion() const noexcept
+{
+  return PLUGIN_VERSION;
+}
+
+const nvinfer1::PluginFieldCollection * GatherTopkCreator::getFieldNames() noexcept
+{
+  return &mFC;
+}
+
+void GatherTopkCreator::setPluginNamespace(const char * pluginNamespace) noexcept
+{
+  mNamespace = pluginNamespace;
+}
+
+const char * GatherTopkCreator::getPluginNamespace() const noexcept
+{
+  return mNamespace.c_str();
+}
+
+nvinfer1::IPluginV2 * GatherTopkCreator::createPlugin(
+  const char * name, const nvinfer1::PluginFieldCollection *) noexcept
+{
+  auto * plugin = new GatherTopk(name);
+  plugin->setPluginNamespace(getPluginNamespace());
+  return plugin;
+}
+
+nvinfer1::IPluginV2 * GatherTopkCreator::deserializePlugin(
+  const char * name, const void * serialData, size_t serialLength) noexcept
+{
+  auto plugin = new GatherTopk(name, serialData, serialLength);
+  plugin->setPluginNamespace(getPluginNamespace());
+  return plugin;
+}
+
+REGISTER_TENSORRT_PLUGIN(GatherTopkCreator);
+}  // namespace ssd

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk.cpp
@@ -233,5 +233,4 @@ nvinfer1::IPluginV2 * GatherTopkCreator::deserializePlugin(
   return plugin;
 }
 
-REGISTER_TENSORRT_PLUGIN(GatherTopkCreator);
 }  // namespace ssd

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk_kernel.cu
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk_kernel.cu
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk_kernel.cu
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/gather_topk_kernel.cu
@@ -1,0 +1,71 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "cuda_utils.hpp"
+#include "gather_topk_kernel.hpp"
+#include "trt_plugin_helper.hpp"
+
+#include <functional>
+#include <numeric>
+#include <vector>
+
+namespace ssd
+{
+template <typename scalar_t>
+__global__ void gather_topk_kernel(
+  const scalar_t * input, const int * indices, scalar_t * output, int batch, int num_input,
+  int num_indices, int channel)
+{
+  CUDA_1D_KERNEL_LOOP(index, batch * num_indices * channel)
+  {
+    const int b_id = index / (num_indices * channel);
+    const int n_id = (index / channel) % num_indices;
+    const int c_id = index % channel;
+
+    const int input_n_id = indices[b_id * num_indices + n_id];
+    const scalar_t value = input[b_id * num_input * channel + input_n_id * channel + c_id];
+    output[b_id * num_indices * channel + n_id * channel + c_id] = value;
+  }
+}
+
+template <typename scalar_t>
+void gather_topk_impl(
+  const scalar_t * input, const int * indices, const int * dims, int nbDims,
+  const int * dims_indices, int nbDims_index, scalar_t * output, cudaStream_t stream)
+{
+  int batch = 1;
+  for (int i = 0; i < nbDims_index - 1; ++i) {
+    batch *= dims[i];
+  }
+  int num_input = dims[nbDims_index - 1];
+  int num_indices = dims_indices[nbDims_index - 1];
+  int channel = 1;
+  for (int i = nbDims_index; i < nbDims; ++i) {
+    channel *= dims[i];
+  }
+  const int col_block = DIVUP(batch * num_indices * channel, THREADS_PER_BLOCK);
+  gather_topk_kernel<<<col_block, THREADS_PER_BLOCK, 0, stream>>>(
+    input, indices, output, batch, num_input, num_indices, channel);
+}
+
+template void gather_topk_impl<float>(
+  const float * input, const int * indices, const int * dims, int nbDims, const int * indices_dims,
+  int indices_nbDims, float * output, cudaStream_t stream);
+
+template void gather_topk_impl<int32_t>(
+  const int32_t * input, const int * indices, const int * dims, int nbDims,
+  const int * indices_dims, int indices_nbDims, int32_t * output, cudaStream_t stream);
+}  // namespace ssd

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors.cpp
@@ -1,0 +1,241 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "grid_priors.hpp"
+
+#include "grid_priors_kernel.hpp"
+#include "trt_serialize.hpp"
+
+#include <assert.h>
+
+namespace ssd
+{
+namespace
+{
+static const char * PLUGIN_VERSION{"1"};
+static const char * PLUGIN_NAME{"GridPriorsTRT"};
+}  // namespace
+
+GridPriors::GridPriors(const std::string & name, const nvinfer1::Dims & stride)
+: mLayerName(name), mStride(stride)
+{
+}
+
+GridPriors::GridPriors(const std::string & name, const void * data, size_t length)
+: mLayerName(name)
+{
+  deserialize_value(&data, &length, &mStride);
+}
+
+// IPluginV2 methods
+const char * GridPriors::getPluginVersion() const noexcept
+{
+  return PLUGIN_VERSION;
+}
+
+const char * GridPriors::getPluginType() const noexcept
+{
+  return PLUGIN_NAME;
+}
+
+int GridPriors::initialize() noexcept
+{
+  return STATUS_SUCCESS;
+}
+
+void GridPriors::terminate() noexcept
+{
+}
+
+void GridPriors::destroy() noexcept
+{
+  delete this;
+}
+
+void GridPriors::setPluginNamespace(const char * pluginNamespace) noexcept
+{
+  mNamespace = pluginNamespace;
+}
+
+const char * GridPriors::getPluginNamespace() const noexcept
+{
+  return mNamespace.c_str();
+}
+
+int GridPriors::getNbOutputs() const noexcept
+{
+  return 1;
+}
+
+size_t GridPriors::getSerializationSize() const noexcept
+{
+  return serialized_size(mStride);
+}
+
+void GridPriors::serialize(void * buffer) const noexcept
+{
+  serialize_value(&buffer, mStride);
+}
+
+// IPluginV2Ext methods
+nvinfer1::DataType GridPriors::getOutputDataType(
+  int, const nvinfer1::DataType * inputTypes, int) const noexcept
+{
+  return inputTypes[0];
+}
+
+// IPluginV2DynamicExt methods
+nvinfer1::IPluginV2DynamicExt * GridPriors::clone() const noexcept
+{
+  GridPriors * plugin = new GridPriors(mLayerName, mStride);
+  plugin->setPluginNamespace(getPluginNamespace());
+  return plugin;
+}
+
+nvinfer1::DimsExprs GridPriors::getOutputDimensions(
+  int, const nvinfer1::DimsExprs * inputs, int, nvinfer1::IExprBuilder & exprBuilder) noexcept
+{
+  nvinfer1::DimsExprs ret;
+  ret.nbDims = 2;
+  auto area =
+    exprBuilder.operation(nvinfer1::DimensionOperation::kPROD, *inputs[2].d[0], *inputs[1].d[0]);
+  ret.d[0] = exprBuilder.operation(nvinfer1::DimensionOperation::kPROD, *area, *(inputs[0].d[0]));
+  ret.d[1] = exprBuilder.constant(4);
+
+  return ret;
+}
+
+bool GridPriors::supportsFormatCombination(
+  int pos, const nvinfer1::PluginTensorDesc * ioDesc, int nbInputs, int) noexcept
+{
+  if (pos == 0) {
+    return (
+      ioDesc[pos].type == nvinfer1::DataType::kFLOAT &&
+      ioDesc[pos].format == nvinfer1::TensorFormat::kLINEAR);
+  } else if (pos == nbInputs) {
+    return ioDesc[pos].type == ioDesc[0].type && ioDesc[pos].format == ioDesc[0].format;
+  } else {
+    return true;
+  }
+}
+
+void GridPriors::configurePlugin(
+  const nvinfer1::DynamicPluginTensorDesc *, int, const nvinfer1::DynamicPluginTensorDesc *,
+  int) noexcept
+{
+}
+
+size_t GridPriors::getWorkspaceSize(
+  const nvinfer1::PluginTensorDesc *, int, const nvinfer1::PluginTensorDesc *, int) const noexcept
+{
+  return 0;
+}
+
+int GridPriors::enqueue(
+  const nvinfer1::PluginTensorDesc * inputDesc, const nvinfer1::PluginTensorDesc *,
+  const void * const * inputs, void * const * outputs, void *, cudaStream_t stream) noexcept
+{
+  int num_base_anchors = inputDesc[0].dims.d[0];
+  int feat_h = inputDesc[1].dims.d[0];
+  int feat_w = inputDesc[2].dims.d[0];
+
+  const void * base_anchor = inputs[0];
+  void * output = outputs[0];
+
+  auto data_type = inputDesc[0].type;
+  switch (data_type) {
+    case nvinfer1::DataType::kFLOAT:
+      grid_priors_impl<float>(
+        reinterpret_cast<const float *>(base_anchor), reinterpret_cast<float *>(output),
+        num_base_anchors, feat_w, feat_h, mStride.d[0], mStride.d[1], stream);
+      break;
+    default:
+      return 1;
+  }
+  return 0;
+}
+
+// PluginCreator
+GridPriorsCreator::GridPriorsCreator()
+{
+  mPluginAttributes.clear();
+  mPluginAttributes.emplace_back(nvinfer1::PluginField("stride_h"));
+  mPluginAttributes.emplace_back(nvinfer1::PluginField("stride_w"));
+  mFC.nbFields = mPluginAttributes.size();
+  mFC.fields = mPluginAttributes.data();
+}
+
+const char * GridPriorsCreator::getPluginName() const noexcept
+{
+  return PLUGIN_NAME;
+}
+
+const char * GridPriorsCreator::getPluginVersion() const noexcept
+{
+  return PLUGIN_VERSION;
+}
+
+const nvinfer1::PluginFieldCollection * GridPriorsCreator::getFieldNames() noexcept
+{
+  return &mFC;
+}
+
+void GridPriorsCreator::setPluginNamespace(const char * pluginNamespace) noexcept
+{
+  mNamespace = pluginNamespace;
+}
+
+const char * GridPriorsCreator::getPluginNamespace() const noexcept
+{
+  return mNamespace.c_str();
+}
+
+nvinfer1::IPluginV2 * GridPriorsCreator::createPlugin(
+  const char * name, const nvinfer1::PluginFieldCollection * fc) noexcept
+{
+  int stride_h = 1;
+  int stride_w = 1;
+
+  for (int i = 0; i < fc->nbFields; ++i) {
+    if (fc->fields[i].data == nullptr) {
+      continue;
+    }
+    std::string field_name(fc->fields[i].name);
+
+    if (field_name.compare("stride_w") == 0) {
+      stride_w = static_cast<const int *>(fc->fields[i].data)[0];
+    }
+    if (field_name.compare("stride_h") == 0) {
+      stride_h = static_cast<const int *>(fc->fields[i].data)[0];
+    }
+  }
+  nvinfer1::Dims stride{2, {stride_w, stride_h}};
+
+  GridPriors * plugin = new GridPriors(name, stride);
+  plugin->setPluginNamespace(getPluginNamespace());
+  return plugin;
+}
+
+nvinfer1::IPluginV2 * GridPriorsCreator::deserializePlugin(
+  const char * name, const void * serialData, size_t serialLength) noexcept
+{
+  auto plugin = new GridPriors(name, serialData, serialLength);
+  plugin->setPluginNamespace(getPluginNamespace());
+  return plugin;
+}
+
+REGISTER_TENSORRT_PLUGIN(GridPriorsCreator);
+}  // namespace ssd

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors.cpp
@@ -237,5 +237,4 @@ nvinfer1::IPluginV2 * GridPriorsCreator::deserializePlugin(
   return plugin;
 }
 
-REGISTER_TENSORRT_PLUGIN(GridPriorsCreator);
 }  // namespace ssd

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors_kernel.cu
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors_kernel.cu
@@ -1,4 +1,4 @@
-// Copyright 2023 Tier IV, Inc.
+// Copyright 2023 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors_kernel.cu
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/plugins/grid_priors_kernel.cu
@@ -1,0 +1,61 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "cuda_utils.hpp"
+#include "grid_priors_kernel.hpp"
+#include "trt_plugin_helper.hpp"
+
+#include <cuda_fp16.h>
+
+template <typename scalar_t>
+__global__ void grid_priors_kernel(
+  const scalar_t * base_anchor, scalar_t * output, int num_base_anchors, int feat_w, int feat_h,
+  int stride_w, int stride_h)
+{
+  extern __shared__ scalar_t shared_base_anchor[];
+  for (int i = threadIdx.x; i < num_base_anchors * 4; i += blockDim.x) {
+    shared_base_anchor[i] = base_anchor[i];
+  }
+  __syncthreads();
+
+  CUDA_1D_KERNEL_LOOP(index, num_base_anchors * feat_w * feat_h)
+  {
+    const int a_offset = (index % num_base_anchors) << 2;
+    const scalar_t w = static_cast<scalar_t>(((index / num_base_anchors) % feat_w) * stride_w);
+    const scalar_t h = static_cast<scalar_t>((index / (feat_w * num_base_anchors)) * stride_h);
+
+    auto out_start = output + index * 4;
+    out_start[0] = shared_base_anchor[a_offset] + w;
+    out_start[1] = shared_base_anchor[a_offset + 1] + h;
+    out_start[2] = shared_base_anchor[a_offset + 2] + w;
+    out_start[3] = shared_base_anchor[a_offset + 3] + h;
+  }
+}
+
+template <typename scalar_t>
+void grid_priors_impl(
+  const scalar_t * base_anchor, scalar_t * output, int num_base_anchors, int feat_w, int feat_h,
+  int stride_w, int stride_h, cudaStream_t stream)
+{
+  grid_priors_kernel<<<
+    GET_BLOCKS(num_base_anchors * feat_w * feat_h), THREADS_PER_BLOCK,
+    DIVUP(num_base_anchors * 4, 32) * 32 * sizeof(scalar_t), stream>>>(
+    base_anchor, output, num_base_anchors, feat_w, feat_h, stride_w, stride_h);
+}
+
+template void grid_priors_impl<float>(
+  const float * base_anchor, float * output, int num_base_anchors, int feat_w, int feat_h,
+  int stride_w, int stride_h, cudaStream_t stream);

--- a/perception/traffic_light_ssd_fine_detector/lib/src/trt_ssd.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/trt_ssd.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/lib/src/trt_ssd.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/trt_ssd.cpp
@@ -172,26 +172,11 @@ void Net::infer(std::vector<void *> & buffers, const int batch_size)
   if (!context_) {
     throw std::runtime_error("Fail to create context");
   }
-  auto input_dims = engine_->getBindingDimensions(0);
+  auto input_dims = getTensorShape("input");
   context_->setBindingDimensions(
     0, nvinfer1::Dims4(batch_size, input_dims.d[1], input_dims.d[2], input_dims.d[3]));
   context_->enqueueV2(buffers.data(), stream_, nullptr);
   cudaStreamSynchronize(stream_);
-}
-
-Shape Net::getInputShape() const
-{
-  auto dims = engine_->getBindingDimensions(0);
-  return {dims.d[1], dims.d[2], dims.d[3]};
-}
-
-std::optional<Dims2> Net::getOutputDimensions(const size_t index) const
-{
-  if (index == 1 || index == 2) {
-    auto dims = engine_->getBindingDimensions(index);
-    return Dims2(dims.d[1], dims.d[2]);
-  }
-  return std::nullopt;
 }
 
 }  // namespace ssd

--- a/perception/traffic_light_ssd_fine_detector/lib/src/trt_ssd.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/trt_ssd.cpp
@@ -185,14 +185,13 @@ Shape Net::getInputShape() const
   return {dims.d[1], dims.d[2], dims.d[3]};
 }
 
-std::optional<Dims2> Net::getOutputDimensions(const std::string & name) const
+std::optional<Dims2> Net::getOutputDimensions(const size_t index) const
 {
-  auto index = getBindingIndex(name);
-  if (index == -1) {
-    return std::nullopt;
+  if (index == 1 || index == 2) {
+    auto dims = engine_->getBindingDimensions(index);
+    return Dims2(dims.d[1], dims.d[2]);
   }
-  auto dims = engine_->getBindingDimensions(index);
-  return Dims2(dims.d[1], dims.d[2]);
+  return std::nullopt;
 }
 
 }  // namespace ssd

--- a/perception/traffic_light_ssd_fine_detector/lib/src/trt_ssd.cpp
+++ b/perception/traffic_light_ssd_fine_detector/lib/src/trt_ssd.cpp
@@ -176,15 +176,19 @@ void Net::infer(std::vector<void *> & buffers, const int batch_size)
   cudaStreamSynchronize(stream_);
 }
 
-std::vector<int> Net::getInputSize()
+Size Net::getInputSize()
 {
   auto dims = engine_->getBindingDimensions(0);
   return {dims.d[1], dims.d[2], dims.d[3]};
 }
 
-std::vector<int> Net::getOutputScoreSize()
+Dims Net::getOutputDimensions(const std::string & name) const
 {
-  auto dims = engine_->getBindingDimensions(1);
+  auto index = engine_->getBindingIndex(name.c_str());
+  if (index == -1) {
+    return {};
+  }
+  auto dims = engine_->getBindingDimensions(index);
   return {dims.d[1], dims.d[2]};
 }
 

--- a/perception/traffic_light_ssd_fine_detector/src/nodelet.cpp
+++ b/perception/traffic_light_ssd_fine_detector/src/nodelet.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2020 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/traffic_light_ssd_fine_detector/src/nodelet.cpp
+++ b/perception/traffic_light_ssd_fine_detector/src/nodelet.cpp
@@ -310,10 +310,12 @@ bool TrafficLightSSDFineDetectorNodelet::cnnOutput2BoxDetection(
       rb.x = boxes[box_index + 2] * in_imgs.at(i).cols;
       rb.y = boxes[box_index + 3] * in_imgs.at(i).rows;
     } else {
-      lt.x = boxes[box_index];
-      lt.y = boxes[box_index + 1];
-      rb.x = boxes[box_index + 2];
-      rb.y = boxes[box_index + 3];
+      const float dx = static_cast<float>(in_imgs.at(i).cols) / input_shape_.width;
+      const float dy = static_cast<float>(in_imgs.at(i).rows) / input_shape_.height;
+      lt.x = boxes[box_index] * dx;
+      lt.y = boxes[box_index + 1] * dy;
+      rb.x = boxes[box_index + 2] * dx;
+      rb.y = boxes[box_index + 3] * dy;
     }
     fitInFrame(lt, rb, cv::Size(in_imgs.at(i).cols, in_imgs.at(i).rows));
     det.x = lt.x;

--- a/perception/traffic_light_ssd_fine_detector/src/nodelet.cpp
+++ b/perception/traffic_light_ssd_fine_detector/src/nodelet.cpp
@@ -87,13 +87,8 @@ TrafficLightSSDFineDetectorNodelet::TrafficLightSSDFineDetectorNodelet(
   }
 
   input_shape_ = net_ptr_->getInputShape();
-  if (dnn_header_type_.compare("pytorch") == 0) {
-    score_dims_ = net_ptr_->getOutputDimensions(1);
-    box_dims_ = net_ptr_->getOutputDimensions(2);
-  } else {
-    box_dims_ = net_ptr_->getOutputDimensions(1);
-    score_dims_ = net_ptr_->getOutputDimensions(2);
-  }
+  box_dims_ = net_ptr_->getOutputDimensions("boxes");
+  score_dims_ = net_ptr_->getOutputDimensions("scores");
   detection_per_class_ = score_dims_->d[0];
   class_num_ = score_dims_->d[1];
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Add support of applying SSD trained by [open-mmlab/mmdetection](https://github.com/open-mmlab/mmdetection) to Autoware.
- Add support of output is no particular order.
  - ~~Get binding dimensions with the flag named `is_box_first`.~~
  - Detcides DNN output order (boxes, scores order or not) and operation (re-scalle with image size) by specifing DNN toolbox name pytorch or mmdetection
- Add TensorRT custom plugins defined in [open-mmlab/mmdeploy](https://github.com/open-mmlab/mmdeploy).
  - GatherTopK
  - GridPriors

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. --> 
I confirmed that both before and after PR got same score with current default model in [tier4/driving_log_replayer](https://github.com/tier4/driving_log_replayer).
- Before PR
```
[traffic_light_evaluator_node.py-68] Frame:
[traffic_light_evaluator_node.py-68]  Total Num: 6
[traffic_light_evaluator_node.py-68]  Skipped Frames: []
[traffic_light_evaluator_node.py-68]  Skipped Frames Count: 0
[traffic_light_evaluator_node.py-68] 
[traffic_light_evaluator_node.py-68] Ground Truth Num: 12
[traffic_light_evaluator_node.py-68] 
[traffic_light_evaluator_node.py-68] [TOTAL] Accuracy: 0.750, Precision: 1.000, Recall: 0.750, F1score: 0.857
[traffic_light_evaluator_node.py-68] |      Label | green |  red |  yellow |  unknown | 
[traffic_light_evaluator_node.py-68] | :--------: | :---: | :---: | :---: | :---: |
[traffic_light_evaluator_node.py-68] |    predict_num | 8 | 1 | 0 | 0 |
[traffic_light_evaluator_node.py-68] |    Accuracy | 0.800 | 1.000 | inf | 0.000 |
[traffic_light_evaluator_node.py-68] |   Precision | 1.000 | 1.000 | inf | inf |
[traffic_light_evaluator_node.py-68] |   Recall | 0.800 | 1.000 | inf | 0.000 |
[traffic_light_evaluator_node.py-68] |   F1score | 0.889 | 1.000 | inf | inf |
```
- After PR
```
[traffic_light_evaluator_node.py-68] Frame:
[traffic_light_evaluator_node.py-68]  Total Num: 6
[traffic_light_evaluator_node.py-68]  Skipped Frames: []
[traffic_light_evaluator_node.py-68]  Skipped Frames Count: 0
[traffic_light_evaluator_node.py-68] 
[traffic_light_evaluator_node.py-68] Ground Truth Num: 12
[traffic_light_evaluator_node.py-68] 
[traffic_light_evaluator_node.py-68] [TOTAL] Accuracy: 0.750, Precision: 1.000, Recall: 0.750, F1score: 0.857
[traffic_light_evaluator_node.py-68] |      Label | green |  red |  yellow |  unknown | 
[traffic_light_evaluator_node.py-68] | :--------: | :---: | :---: | :---: | :---: |
[traffic_light_evaluator_node.py-68] |    predict_num | 8 | 1 | 0 | 0 |
[traffic_light_evaluator_node.py-68] |    Accuracy | 0.800 | 1.000 | inf | 0.000 |
[traffic_light_evaluator_node.py-68] |   Precision | 1.000 | 1.000 | inf | inf |
[traffic_light_evaluator_node.py-68] |   Recall | 0.800 | 1.000 | inf | 0.000 |
[traffic_light_evaluator_node.py-68] |   F1score | 0.889 | 1.000 | inf | inf |
```

- mmdetection model

Also, I ran ssd fine detector trained by myself with mmdetection.

[sample-ssd.onnx](https://drive.google.com/file/d/1ULPvOJtKpxKrdFTxFXOunTrnqmn4BQlf/view?usp=sharing)

*Note that*, since this model is just for checking whether this change works well,  the performace of model is not so good.

https://user-images.githubusercontent.com/60615504/234191498-948b1cf6-da36-4a3d-9ca5-6f2ca4ea935b.mp4

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
The parameters for above model trained by myself are following.

| Name | Value |
|--------|--------|
|`onnx_file`|YOUR_ONNX_PATH|
|`max_batch_size`|1|
|~~`is_box_first`~~ |~~true~~ |
| ~~`is_box_normalized`~~ | ~~false~~ |
|`dnn_header_type`|mmdetection|

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
Add the following parameters. The default values are suited for current default model (`mb2-ssd-lite-tlr.onnx`).
|Name|Type|Default|Description|
|:--|:--|:--|:--|
|~~`is_box_first`~~|~~bool~~|~~false~~|~~Indicates whether first output head is for boxes~~|
|~~`is_box_normalized`~~|~~bool~~|~~true~~|~~Indicates whether output boxes have been normalized into [0, 1]~~|
|`dnn_header_type`|string|pytorch|Name of DNN toolbox type, pytorch or mmdetection|

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
