### PR TITLE
fix(motion_velocity_smoother): insert the point when applying external velocity limit

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -826,7 +826,7 @@ void MotionVelocitySmootherNode::applyExternalVelocityLimit(TrajectoryPoints & t
   trajectory_utils::applyMaximumVelocityLimit(
     0, traj.size(), max_velocity_with_deceleration_, traj);
 
-  // insert the point that has external limited velocity
+  // insert the point at the distance of external velocity limit
   const auto & current_pose = current_odometry_ptr_->pose.pose;
   const size_t closest_seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
     traj, current_pose, node_param_.ego_nearest_dist_threshold,
@@ -834,26 +834,15 @@ void MotionVelocitySmootherNode::applyExternalVelocityLimit(TrajectoryPoints & t
   const auto inserted_index =
     motion_utils::insertTargetPoint(closest_seg_idx, external_velocity_limit_.dist, traj);
   if (!inserted_index) {
+    traj.back().longitudinal_velocity_mps = std::min(
+      traj.back().longitudinal_velocity_mps, static_cast<float>(external_velocity_limit_.velocity));
     return;
   }
-  const double original_vel = traj.at(*inserted_index).longitudinal_velocity_mps;
-  traj.at(*inserted_index).longitudinal_velocity_mps =
-    std::min(external_velocity_limit_.velocity, original_vel);
 
-  // distance from base link to the closest trajectory point ahead of ego vehicle
-  double dist = tier4_autoware_utils::calcLongitudinalDeviation(
-    current_pose, traj.at(closest_seg_idx + 1).pose.position);
-  for (size_t idx = closest_seg_idx + 1; idx < traj.size() - 1; ++idx) {
-    if (dist > external_velocity_limit_.dist) {
-      trajectory_utils::applyMaximumVelocityLimit(
-        idx, traj.size(), external_velocity_limit_.velocity, traj);
-      return;
-    }
+  // apply external velocity limit from the inserted point
+  trajectory_utils::applyMaximumVelocityLimit(
+    *inserted_index, traj.size(), external_velocity_limit_.velocity, traj);
 
-    dist += tier4_autoware_utils::calcDistance2d(traj.at(idx), traj.at(idx + 1));
-  }
-  traj.back().longitudinal_velocity_mps = std::min(
-    traj.back().longitudinal_velocity_mps, static_cast<float>(external_velocity_limit_.velocity));
   RCLCPP_DEBUG(
     get_logger(), "externalVelocityLimit : limit_vel = %.3f", external_velocity_limit_.velocity);
 }


### PR DESCRIPTION
## Description

In the current implementation, when applying the external velocity limit, the velocity of the points on the trajectory are being overwritten. However, this implementation has an issue where the inserting position of the external velocity limit is further away than expected and ego vehicle sometimes can't stop at the desired position (see the video below).
In this PR, I have resolved this problem by inserting the point of the external velocity limit.


https://user-images.githubusercontent.com/11865769/233629346-72330fa1-61b0-4bc8-91a6-513f12e440f9.mp4



### Before
![image](https://user-images.githubusercontent.com/11865769/233627410-902aa127-1c86-4494-92c4-932d364361ea.png)


### After
![image](https://user-images.githubusercontent.com/11865769/233627314-73e5c95f-81f4-41da-987a-c13ac652b994.png)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed this works with simple planning simulator.

https://user-images.githubusercontent.com/11865769/233630064-8d7fbd16-4cd8-4257-9bb3-7d38d27f1176.mp4

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
