### PR TITLE
feat(obstacle_avoidance_planner): replan when forward path shape changes

### DIFF
--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -23,8 +23,8 @@
     # replanning & trimming trajectory param outside algorithm
     replan:
       max_path_shape_around_ego_lat_dist: 2.0  # threshold of path shape change around ego [m]
-      max_path_shape_forward_lon_dist: 50.0    # forward point to check lateral distance difference [m]
-      max_path_shape_forward_lat_dist: 0.1    # threshold of path shape change around forward point [m]
+      max_path_shape_forward_lon_dist: 100.0   # forward point to check lateral distance difference [m]
+      max_path_shape_forward_lat_dist: 0.1     # threshold of path shape change around forward point [m]
       max_ego_moving_dist: 5.0                 # threshold of ego's moving distance for replan [m]
       # make max_goal_moving_dist long to keep start point fixed for pull over
       max_goal_moving_dist: 15.0               # threshold of goal's moving distance for replan [m]

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -23,6 +23,8 @@
     # replanning & trimming trajectory param outside algorithm
     replan:
       max_path_shape_around_ego_lat_dist: 2.0  # threshold of path shape change around ego [m]
+      max_path_shape_forward_lon_dist: 50.0    # forward point to check lateral distance difference [m]
+      max_path_shape_forward_lat_dist: 0.1    # threshold of path shape change around forward point [m]
       max_ego_moving_dist: 5.0                 # threshold of ego's moving distance for replan [m]
       # make max_goal_moving_dist long to keep start point fixed for pull over
       max_goal_moving_dist: 15.0               # threshold of goal's moving distance for replan [m]

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/replan_checker.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/replan_checker.hpp
@@ -32,9 +32,13 @@ public:
   explicit ReplanChecker(rclcpp::Node * node, const EgoNearestParam & ego_nearest_param);
   void onParam(const std::vector<rclcpp::Parameter> & parameters);
 
-  bool isResetRequired(const PlannerData & planner_data);
+  bool isResetRequired(const PlannerData & planner_data) const;
 
-  bool isReplanRequired(const rclcpp::Time & current_time);
+  bool isReplanRequired(const PlannerData & planner_data, const rclcpp::Time & current_time) const;
+
+  void updateData(
+    const PlannerData & planner_data, const bool is_replan_required,
+    const rclcpp::Time & current_time);
 
 private:
   EgoNearestParam ego_nearest_param_;
@@ -49,11 +53,15 @@ private:
 
   // algorithm parameters
   double max_path_shape_around_ego_lat_dist_;
+  double max_path_shape_forward_lat_dist_;
+  double max_path_shape_forward_lon_dist_;
   double max_ego_moving_dist_;
   double max_goal_moving_dist_;
   double max_delta_time_sec_;
 
   bool isPathAroundEgoChanged(
+    const PlannerData & planner_data, const std::vector<TrajectoryPoint> & prev_traj_points) const;
+  bool isPathForwardChanged(
     const PlannerData & planner_data, const std::vector<TrajectoryPoint> & prev_traj_points) const;
   bool isPathGoalChanged(
     const PlannerData & planner_data, const std::vector<TrajectoryPoint> & prev_traj_points) const;

--- a/planning/obstacle_avoidance_planner/src/replan_checker.cpp
+++ b/planning/obstacle_avoidance_planner/src/replan_checker.cpp
@@ -27,6 +27,10 @@ ReplanChecker::ReplanChecker(rclcpp::Node * node, const EgoNearestParam & ego_ne
 {
   max_path_shape_around_ego_lat_dist_ =
     node->declare_parameter<double>("replan.max_path_shape_around_ego_lat_dist");
+  max_path_shape_forward_lat_dist_ =
+    node->declare_parameter<double>("replan.max_path_shape_forward_lat_dist");
+  max_path_shape_forward_lon_dist_ =
+    node->declare_parameter<double>("replan.max_path_shape_forward_lon_dist");
   max_ego_moving_dist_ = node->declare_parameter<double>("replan.max_ego_moving_dist");
   max_goal_moving_dist_ = node->declare_parameter<double>("replan.max_goal_moving_dist");
   max_delta_time_sec_ = node->declare_parameter<double>("replan.max_delta_time_sec");
@@ -38,12 +42,16 @@ void ReplanChecker::onParam(const std::vector<rclcpp::Parameter> & parameters)
 
   updateParam<double>(
     parameters, "replan.max_path_shape_around_ego_lat_dist", max_path_shape_around_ego_lat_dist_);
+  updateParam<double>(
+    parameters, "replan.max_path_shape_forward_lat_dist", max_path_shape_forward_lat_dist_);
+  updateParam<double>(
+    parameters, "replan.max_path_shape_forward_lon_dist", max_path_shape_forward_lon_dist_);
   updateParam<double>(parameters, "replan.max_ego_moving_dist", max_ego_moving_dist_);
   updateParam<double>(parameters, "replan.max_goal_moving_dist", max_goal_moving_dist_);
   updateParam<double>(parameters, "replan.max_delta_time_sec", max_delta_time_sec_);
 }
 
-bool ReplanChecker::isResetRequired(const PlannerData & planner_data)
+bool ReplanChecker::isResetRequired(const PlannerData & planner_data) const
 {
   const auto & p = planner_data;
 
@@ -56,7 +64,8 @@ bool ReplanChecker::isResetRequired(const PlannerData & planner_data)
 
     // path shape changes
     if (isPathAroundEgoChanged(planner_data, prev_traj_points)) {
-      RCLCPP_INFO(logger_, "Replan with resetting optimization since path shape changed.");
+      RCLCPP_INFO(
+        logger_, "Replan with resetting optimization since path shape around ego changed.");
       return true;
     }
 
@@ -79,20 +88,18 @@ bool ReplanChecker::isResetRequired(const PlannerData & planner_data)
     return false;
   }();
 
-  // update previous information required in this function
-  prev_traj_points_ptr_ = std::make_shared<std::vector<TrajectoryPoint>>(p.traj_points);
-  prev_ego_pose_ptr_ = std::make_shared<geometry_msgs::msg::Pose>(p.ego_pose);
-
   return reset_required;
 }
 
-bool ReplanChecker::isReplanRequired(const rclcpp::Time & current_time)
+bool ReplanChecker::isReplanRequired(
+  const PlannerData & planner_data, const rclcpp::Time & current_time) const
 {
   const bool replan_required = [&]() {
     // guard for invalid variables
     if (!prev_replanned_time_ptr_ || !prev_traj_points_ptr_) {
       return true;
     }
+    const auto & prev_traj_points = *prev_traj_points_ptr_;
 
     // time elapses
     const double delta_time_sec = (current_time - *prev_replanned_time_ptr_).seconds();
@@ -100,15 +107,32 @@ bool ReplanChecker::isReplanRequired(const rclcpp::Time & current_time)
       return true;
     }
 
+    // path shape changes
+    if (isPathForwardChanged(planner_data, prev_traj_points)) {
+      RCLCPP_INFO(logger_, "Replan since path forward shape changed.");
+      return true;
+    }
+
     return false;
   }();
 
+  return replan_required;
+}
+
+void ReplanChecker::updateData(
+  const PlannerData & planner_data, const bool is_replan_required,
+  const rclcpp::Time & current_time)
+{
+  const auto & p = planner_data;
+
   // update previous information required in this function
-  if (replan_required) {
+  prev_traj_points_ptr_ = std::make_shared<std::vector<TrajectoryPoint>>(p.traj_points);
+  prev_ego_pose_ptr_ = std::make_shared<geometry_msgs::msg::Pose>(p.ego_pose);
+
+  // update previous information required in this function
+  if (is_replan_required) {
     prev_replanned_time_ptr_ = std::make_shared<rclcpp::Time>(current_time);
   }
-
-  return replan_required;
 }
 
 bool ReplanChecker::isPathAroundEgoChanged(
@@ -130,6 +154,33 @@ bool ReplanChecker::isPathAroundEgoChanged(
 
   const double diff_ego_lat_offset = prev_ego_lat_offset - ego_lat_offset;
   if (std::abs(diff_ego_lat_offset) < max_path_shape_around_ego_lat_dist_) {
+    return false;
+  }
+
+  return true;
+}
+
+bool ReplanChecker::isPathForwardChanged(
+  const PlannerData & planner_data, const std::vector<TrajectoryPoint> & prev_traj_points) const
+{
+  const auto & p = planner_data;
+
+  // calculate forward point of previous trajectory points
+  const auto prev_ego_seg_idx =
+    trajectory_utils::findEgoSegmentIndex(prev_traj_points, p.ego_pose, ego_nearest_param_);
+  const auto & prev_forward_point = motion_utils::calcLongitudinalOffsetPoint(
+    prev_traj_points, prev_ego_seg_idx, max_path_shape_forward_lon_dist_);
+  if (!prev_forward_point) {
+    return false;
+  }
+
+  // calculate lateral offset of current trajectory points to prev forward point
+  const auto forward_seg_idx =
+    motion_utils::findNearestSegmentIndex(p.traj_points, *prev_forward_point);
+  const double forward_lat_offset =
+    motion_utils::calcLateralOffset(p.traj_points, *prev_forward_point, forward_seg_idx);
+
+  if (std::abs(forward_lat_offset) < max_path_shape_forward_lat_dist_) {
     return false;
   }
 


### PR DESCRIPTION
## Description

When the behavior's path shape changes like lane_change or avoidance, in the worst cases it takes 1 second to plan a path with optimization by obstacle_avoidance_planner.
With this PR, if the behavior's path shape changes, the optimization will work in this planning cycle.

launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/309
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator works well.
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Optimization path planning will work right after the behavior's path shape changes.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
