### PR TITLE
feat(behavior_path_planner): make drivable area expansion parameters common

### DIFF
--- a/planning/behavior_path_planner/config/drivable_area_expansion.param.yaml
+++ b/planning/behavior_path_planner/config/drivable_area_expansion.param.yaml
@@ -1,26 +1,9 @@
 /**:
   ros__parameters:
     # Static expansion
-    avoidance:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
-    lane_change:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
-    pull_out:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
-    pull_over:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
-    side_shift:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
+    drivable_area_right_bound_offset: 0.0
+    drivable_area_left_bound_offset: 0.0
+    drivable_area_types_to_skip: [road_border]
 
     # Dynamic expansion by projecting the ego footprint along the path
     dynamic_expansion:

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -107,11 +107,6 @@ struct BehaviorPathPlannerParameters
   double rear_vehicle_reaction_time;
   double rear_vehicle_safety_time_margin;
 
-  // lane following
-  double drivable_area_right_bound_offset;
-  double drivable_area_left_bound_offset;
-  std::vector<std::string> drivable_area_types_to_skip;
-
   // lane change
   double lane_change_prepare_duration;
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -354,7 +354,7 @@ protected:
     return std::abs(planner_data_->self_odometry->twist.twist.linear.x);
   }
 
-  std::vector<DrivableLanes> getNonoverlappingExpandedLanes(
+  std::vector<DrivableLanes> getNonOverlappingExpandedLanes(
     PathWithLaneId & path, const std::vector<DrivableLanes> & lanes) const
   {
     const auto & dp = planner_data_->drivable_area_expansion_parameters;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -354,6 +354,18 @@ protected:
     return std::abs(planner_data_->self_odometry->twist.twist.linear.x);
   }
 
+  std::vector<DrivableLanes> getNonoverlappingExpandedLanes(
+    PathWithLaneId & path, const std::vector<DrivableLanes> & lanes) const
+  {
+    const auto & dp = planner_data_->drivable_area_expansion_parameters;
+
+    const auto shorten_lanes = utils::cutOverlappedLanes(path, lanes);
+    const auto expanded_lanes = utils::expandLanelets(
+      shorten_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
+      dp.drivable_area_types_to_skip);
+    return expanded_lanes;
+  }
+
   rclcpp::Clock::SharedPtr clock_;
 
   std::shared_ptr<const PlannerData> planner_data_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -247,11 +247,6 @@ struct AvoidanceParameters
   // parameters depend on object class
   std::unordered_map<uint8_t, ObjectParameter> object_parameters;
 
-  // drivable area expansion
-  double drivable_area_right_bound_offset{};
-  double drivable_area_left_bound_offset{};
-  std::vector<std::string> drivable_area_types_to_skip{};
-
   // clip left and right bounds for objects
   bool enable_bound_clipping{false};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
@@ -28,6 +28,9 @@ namespace drivable_area_expansion
 
 struct DrivableAreaExpansionParameters
 {
+  static constexpr auto drivable_area_right_bound_offset_PARAM = "drivable_area_right_bound_offset";
+  static constexpr auto drivable_area_left_bound_offset_PARAM = "drivable_area_left_bound_offset";
+  static constexpr auto drivable_area_types_to_skip_PARAM = "drivable_area_types_to_skip";
   static constexpr auto ENABLED_PARAM = "dynamic_expansion.enabled";
   static constexpr auto EGO_EXTRA_OFFSET_FRONT =
     "dynamic_expansion.ego.extra_footprint_offset.front";
@@ -55,6 +58,9 @@ struct DrivableAreaExpansionParameters
   static constexpr auto EXTRA_COMPENSATE_PARAM =
     "dynamic_expansion.avoid_linestring.compensate.extra_distance";
 
+  double drivable_area_right_bound_offset;
+  double drivable_area_left_bound_offset;
+  std::vector<std::string> drivable_area_types_to_skip;
   bool enabled = false;
   std::string expansion_method{};
   double avoid_linestring_dist{};
@@ -83,6 +89,12 @@ struct DrivableAreaExpansionParameters
 
   void init(rclcpp::Node & node)
   {
+    drivable_area_right_bound_offset =
+      node.declare_parameter<double>(drivable_area_right_bound_offset_PARAM);
+    drivable_area_left_bound_offset =
+      node.declare_parameter<double>(drivable_area_left_bound_offset_PARAM);
+    drivable_area_types_to_skip =
+      node.declare_parameter<std::vector<std::string>>(drivable_area_types_to_skip_PARAM);
     enabled = node.declare_parameter<bool>(ENABLED_PARAM);
     max_expansion_distance = node.declare_parameter<double>(MAX_EXP_DIST_PARAM);
     max_path_arc_length = node.declare_parameter<double>(MAX_PATH_ARC_LENGTH_PARAM);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
@@ -28,9 +28,9 @@ namespace drivable_area_expansion
 
 struct DrivableAreaExpansionParameters
 {
-  static constexpr auto drivable_area_right_bound_offset_PARAM = "drivable_area_right_bound_offset";
-  static constexpr auto drivable_area_left_bound_offset_PARAM = "drivable_area_left_bound_offset";
-  static constexpr auto drivable_area_types_to_skip_PARAM = "drivable_area_types_to_skip";
+  static constexpr auto DRIVABLE_AREA_RIGHT_BOUND_OFFSET_PARAM = "drivable_area_right_bound_offset";
+  static constexpr auto DRIVABLE_AREA_LEFT_BOUND_OFFSET_PARAM = "drivable_area_left_bound_offset";
+  static constexpr auto DRIVABLE_AREA_TYPES_TO_SKIP_PARAM = "drivable_area_types_to_skip";
   static constexpr auto ENABLED_PARAM = "dynamic_expansion.enabled";
   static constexpr auto EGO_EXTRA_OFFSET_FRONT =
     "dynamic_expansion.ego.extra_footprint_offset.front";
@@ -90,11 +90,11 @@ struct DrivableAreaExpansionParameters
   void init(rclcpp::Node & node)
   {
     drivable_area_right_bound_offset =
-      node.declare_parameter<double>(drivable_area_right_bound_offset_PARAM);
+      node.declare_parameter<double>(DRIVABLE_AREA_RIGHT_BOUND_OFFSET_PARAM);
     drivable_area_left_bound_offset =
-      node.declare_parameter<double>(drivable_area_left_bound_offset_PARAM);
+      node.declare_parameter<double>(DRIVABLE_AREA_LEFT_BOUND_OFFSET_PARAM);
     drivable_area_types_to_skip =
-      node.declare_parameter<std::vector<std::string>>(drivable_area_types_to_skip_PARAM);
+      node.declare_parameter<std::vector<std::string>>(DRIVABLE_AREA_TYPES_TO_SKIP_PARAM);
     enabled = node.declare_parameter<bool>(ENABLED_PARAM);
     max_expansion_distance = node.declare_parameter<double>(MAX_EXP_DIST_PARAM);
     max_path_arc_length = node.declare_parameter<double>(MAX_PATH_ARC_LENGTH_PARAM);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -55,11 +55,6 @@ struct LaneChangeParameters
   double abort_delta_time{3.0};
   double abort_max_lateral_jerk{10.0};
 
-  // drivable area expansion
-  double drivable_area_right_bound_offset{0.0};
-  double drivable_area_left_bound_offset{0.0};
-  std::vector<std::string> drivable_area_types_to_skip{};
-
   // debug marker
   bool publish_debug_marker{false};
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_following/module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_following/module_data.hpp
@@ -24,10 +24,6 @@ namespace behavior_path_planner
 struct LaneFollowingParameters
 {
   double lane_change_prepare_duration;
-  // drivable area expansion
-  double drivable_area_right_bound_offset;
-  double drivable_area_left_bound_offset;
-  std::vector<std::string> drivable_area_types_to_skip{};
 
   // finding closest lanelet
   double distance_threshold;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/pull_out/pull_out_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/pull_out/pull_out_parameters.hpp
@@ -51,10 +51,6 @@ struct PullOutParameters
   double backward_search_resolution;
   double backward_path_update_duration;
   double ignore_distance_from_lane_end;
-  // drivable area expansion
-  double drivable_area_right_bound_offset;
-  double drivable_area_left_bound_offset;
-  std::vector<std::string> drivable_area_types_to_skip;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/pull_over/pull_over_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/pull_over/pull_over_parameters.hpp
@@ -99,10 +99,6 @@ struct PullOverParameters
   bool enable_collision_check_at_prepare_phase;
   bool use_predicted_path_outside_lanelet;
   bool use_all_predicted_path;
-  // drivable area expansion
-  double drivable_area_right_bound_offset;
-  double drivable_area_left_bound_offset;
-  std::vector<std::string> drivable_area_types_to_skip;
   // debug
   bool print_debug_info;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/side_shift/side_shift_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/side_shift/side_shift_parameters.hpp
@@ -37,10 +37,6 @@ struct SideShiftParameters
   double drivable_area_width;
   double drivable_area_height;
   double shift_request_time_limit;
-  // drivable area expansion
-  double drivable_area_right_bound_offset;
-  double drivable_area_left_bound_offset;
-  std::vector<std::string> drivable_area_types_to_skip;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -432,14 +432,6 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.rear_vehicle_reaction_time = declare_parameter<double>("rear_vehicle_reaction_time");
   p.rear_vehicle_safety_time_margin = declare_parameter<double>("rear_vehicle_safety_time_margin");
 
-  // lane following
-  p.drivable_area_right_bound_offset =
-    declare_parameter<double>("lane_following.drivable_area_right_bound_offset");
-  p.drivable_area_left_bound_offset =
-    declare_parameter<double>("lane_following.drivable_area_left_bound_offset");
-  p.drivable_area_types_to_skip =
-    declare_parameter<std::vector<std::string>>("lane_following.drivable_area_types_to_skip");
-
   // lane change
   p.lane_change_prepare_duration =
     declare_parameter<double>("lane_change.lane_change_prepare_duration");
@@ -463,13 +455,7 @@ SideShiftParameters BehaviorPathPlannerNode::getSideShiftParam()
   p.shifting_lateral_jerk = declare_parameter<double>(ns + "shifting_lateral_jerk");
   p.min_shifting_distance = declare_parameter<double>(ns + "min_shifting_distance");
   p.min_shifting_speed = declare_parameter<double>(ns + "min_shifting_speed");
-  p.drivable_area_right_bound_offset =
-    declare_parameter<double>(ns + "drivable_area_right_bound_offset");
   p.shift_request_time_limit = declare_parameter<double>(ns + "shift_request_time_limit");
-  p.drivable_area_left_bound_offset =
-    declare_parameter<double>(ns + "drivable_area_left_bound_offset");
-  p.drivable_area_types_to_skip =
-    declare_parameter<std::vector<std::string>>(ns + "drivable_area_types_to_skip");
 
   return p;
 }
@@ -509,12 +495,6 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
       declare_parameter<double>(ns + "detection_area_right_expand_dist");
     p.detection_area_left_expand_dist =
       declare_parameter<double>(ns + "detection_area_left_expand_dist");
-    p.drivable_area_right_bound_offset =
-      declare_parameter<double>(ns + "drivable_area_right_bound_offset");
-    p.drivable_area_left_bound_offset =
-      declare_parameter<double>(ns + "drivable_area_left_bound_offset");
-    p.drivable_area_types_to_skip =
-      declare_parameter<std::vector<std::string>>(ns + "drivable_area_types_to_skip");
     p.enable_bound_clipping = declare_parameter<bool>(ns + "enable_bound_clipping");
     p.enable_avoidance_over_same_direction =
       declare_parameter<bool>(ns + "enable_avoidance_over_same_direction");
@@ -704,14 +684,6 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.abort_delta_time = declare_parameter<double>(parameter("abort_delta_time"));
   p.abort_max_lateral_jerk = declare_parameter<double>(parameter("abort_max_lateral_jerk"));
 
-  // drivable area expansion
-  p.drivable_area_right_bound_offset =
-    declare_parameter<double>(parameter("drivable_area_right_bound_offset"));
-  p.drivable_area_left_bound_offset =
-    declare_parameter<double>(parameter("drivable_area_left_bound_offset"));
-  p.drivable_area_types_to_skip =
-    declare_parameter<std::vector<std::string>>(parameter("drivable_area_types_to_skip"));
-
   // debug marker
   p.publish_debug_marker = declare_parameter<bool>(parameter("publish_debug_marker"));
 
@@ -829,13 +801,6 @@ PullOverParameters BehaviorPathPlannerNode::getPullOverParam()
     p.use_predicted_path_outside_lanelet =
       declare_parameter<bool>(ns + "use_predicted_path_outside_lanelet");
     p.use_all_predicted_path = declare_parameter<bool>(ns + "use_all_predicted_path");
-    // drivable area
-    p.drivable_area_right_bound_offset =
-      declare_parameter<double>(ns + "drivable_area_right_bound_offset");
-    p.drivable_area_left_bound_offset =
-      declare_parameter<double>(ns + "drivable_area_left_bound_offset");
-    p.drivable_area_types_to_skip =
-      declare_parameter<std::vector<std::string>>(ns + "drivable_area_types_to_skip");
     // debug
     p.print_debug_info = declare_parameter<bool>(ns + "print_debug_info");
 
@@ -955,13 +920,6 @@ PullOutParameters BehaviorPathPlannerNode::getPullOutParam()
   p.backward_search_resolution = declare_parameter<double>(ns + "backward_search_resolution");
   p.backward_path_update_duration = declare_parameter<double>(ns + "backward_path_update_duration");
   p.ignore_distance_from_lane_end = declare_parameter<double>(ns + "ignore_distance_from_lane_end");
-  // drivable area
-  p.drivable_area_right_bound_offset =
-    declare_parameter<double>(ns + "drivable_area_right_bound_offset");
-  p.drivable_area_left_bound_offset =
-    declare_parameter<double>(ns + "drivable_area_left_bound_offset");
-  p.drivable_area_types_to_skip =
-    declare_parameter<std::vector<std::string>>(ns + "drivable_area_types_to_skip");
 
   // validation of parameters
   if (p.pull_out_sampling_num < 1) {
@@ -1536,6 +1494,15 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
     // Drivable area expansion parameters
     using drivable_area_expansion::DrivableAreaExpansionParameters;
     const std::lock_guard<std::mutex> lock(mutex_pd_);  // for planner_data_
+    updateParam(
+      parameters, DrivableAreaExpansionParameters::drivable_area_right_bound_offset_PARAM,
+      planner_data_->drivable_area_expansion_parameters.drivable_area_right_bound_offset);
+    updateParam(
+      parameters, DrivableAreaExpansionParameters::drivable_area_left_bound_offset_PARAM,
+      planner_data_->drivable_area_expansion_parameters.drivable_area_left_bound_offset);
+    updateParam(
+      parameters, DrivableAreaExpansionParameters::drivable_area_types_to_skip_PARAM,
+      planner_data_->drivable_area_expansion_parameters.drivable_area_types_to_skip);
     updateParam(
       parameters, DrivableAreaExpansionParameters::ENABLED_PARAM,
       planner_data_->drivable_area_expansion_parameters.enabled);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1495,13 +1495,13 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
     using drivable_area_expansion::DrivableAreaExpansionParameters;
     const std::lock_guard<std::mutex> lock(mutex_pd_);  // for planner_data_
     updateParam(
-      parameters, DrivableAreaExpansionParameters::drivable_area_right_bound_offset_PARAM,
+      parameters, DrivableAreaExpansionParameters::DRIVABLE_AREA_RIGHT_BOUND_OFFSET_PARAM,
       planner_data_->drivable_area_expansion_parameters.drivable_area_right_bound_offset);
     updateParam(
-      parameters, DrivableAreaExpansionParameters::drivable_area_left_bound_offset_PARAM,
+      parameters, DrivableAreaExpansionParameters::DRIVABLE_AREA_LEFT_BOUND_OFFSET_PARAM,
       planner_data_->drivable_area_expansion_parameters.drivable_area_left_bound_offset);
     updateParam(
-      parameters, DrivableAreaExpansionParameters::drivable_area_types_to_skip_PARAM,
+      parameters, DrivableAreaExpansionParameters::DRIVABLE_AREA_TYPES_TO_SKIP_PARAM,
       planner_data_->drivable_area_expansion_parameters.drivable_area_types_to_skip);
     updateParam(
       parameters, DrivableAreaExpansionParameters::ENABLED_PARAM,

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2525,12 +2525,6 @@ void AvoidanceModule::generateExtendedDrivableArea(BehaviorModuleOutput & output
     output.drivable_lanes.push_back(current_drivable_lanes);
   }
 
-  const auto shorten_lanes = utils::cutOverlappedLanes(path, output.drivable_lanes);
-
-  const auto extended_lanes = utils::expandLanelets(
-    shorten_lanes, parameters_->drivable_area_left_bound_offset,
-    parameters_->drivable_area_right_bound_offset, parameters_->drivable_area_types_to_skip);
-
   {
     const auto & p = planner_data_->parameters;
     generateDrivableArea(

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -552,7 +552,7 @@ PathWithLaneId AvoidanceByLCModule::getReferencePath() const
     lane_change_buffer);
 
   const auto drivable_lanes = utils::generateDrivableLanes(current_lanes);
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(reference_path, drivable_lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(reference_path, drivable_lanes);
   utils::generateDrivableArea(
     reference_path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 
@@ -934,7 +934,7 @@ void AvoidanceByLCModule::generateExtendedDrivableArea(PathWithLaneId & path)
   const auto & route_handler = planner_data_->route_handler;
   const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
     *route_handler, status_.current_lanes, status_.lane_change_lanes);
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, drivable_lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(path, drivable_lanes);
   utils::generateDrivableArea(
     path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 }

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -552,13 +552,9 @@ PathWithLaneId AvoidanceByLCModule::getReferencePath() const
     lane_change_buffer);
 
   const auto drivable_lanes = utils::generateDrivableLanes(current_lanes);
-  const auto shorten_lanes = utils::cutOverlappedLanes(reference_path, drivable_lanes);
-  const auto expanded_lanes = utils::expandLanelets(
-    shorten_lanes, parameters_->lane_change->drivable_area_left_bound_offset,
-    parameters_->lane_change->drivable_area_right_bound_offset,
-    parameters_->lane_change->drivable_area_types_to_skip);
+  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(reference_path, drivable_lanes);
   utils::generateDrivableArea(
-    reference_path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
+    reference_path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 
   return reference_path;
 }
@@ -695,9 +691,10 @@ bool AvoidanceByLCModule::isValidPath(const PathWithLaneId & path) const
   const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
     *route_handler, utils::extendLanes(route_handler, status_.current_lanes),
     utils::extendLanes(route_handler, status_.lane_change_lanes));
+  const auto & dp = planner_data_->drivable_area_expansion_parameters;
   const auto expanded_lanes = utils::expandLanelets(
-    drivable_lanes, parameters_->lane_change->drivable_area_left_bound_offset,
-    parameters_->lane_change->drivable_area_right_bound_offset);
+    drivable_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
+    dp.drivable_area_types_to_skip);
   const auto lanelets = utils::transformToLanelets(expanded_lanes);
 
   // check path points are in any lanelets
@@ -937,12 +934,9 @@ void AvoidanceByLCModule::generateExtendedDrivableArea(PathWithLaneId & path)
   const auto & route_handler = planner_data_->route_handler;
   const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
     *route_handler, status_.current_lanes, status_.lane_change_lanes);
-  const auto shorten_lanes = utils::cutOverlappedLanes(path, drivable_lanes);
-  const auto expanded_lanes = utils::expandLanelets(
-    shorten_lanes, parameters_->lane_change->drivable_area_left_bound_offset,
-    parameters_->lane_change->drivable_area_right_bound_offset);
+  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, drivable_lanes);
   utils::generateDrivableArea(
-    path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
+    path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 }
 
 bool AvoidanceByLCModule::isApprovedPathSafe(Pose & ego_pose_before_collision) const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/bt_normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/bt_normal.cpp
@@ -68,11 +68,13 @@ PathWithLaneId NormalLaneChangeBT::getReferencePath() const
     *route_handler, reference_path, current_lanes, parameters_->prepare_duration,
     lane_change_buffer);
 
+  const auto & dp = planner_data_->drivable_area_expansion_parameters;
+
   const auto drivable_lanes = utils::generateDrivableLanes(current_lanes);
   const auto shorten_lanes = utils::cutOverlappedLanes(reference_path, drivable_lanes);
   const auto expanded_lanes = utils::expandLanelets(
-    shorten_lanes, parameters_->drivable_area_left_bound_offset,
-    parameters_->drivable_area_right_bound_offset, parameters_->drivable_area_types_to_skip);
+    shorten_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
+    dp.drivable_area_types_to_skip);
   utils::generateDrivableArea(
     reference_path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -295,12 +295,9 @@ PathWithLaneId ExternalRequestLaneChangeModule::getReferencePath() const
     lane_change_buffer);
 
   const auto drivable_lanes = utils::generateDrivableLanes(current_lanes);
-  const auto shorten_lanes = utils::cutOverlappedLanes(reference_path, drivable_lanes);
-  const auto expanded_lanes = utils::expandLanelets(
-    drivable_lanes, parameters_->drivable_area_left_bound_offset,
-    parameters_->drivable_area_right_bound_offset);
+  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(reference_path, drivable_lanes);
   utils::generateDrivableArea(
-    reference_path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
+    reference_path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 
   return reference_path;
 }
@@ -402,10 +399,8 @@ bool ExternalRequestLaneChangeModule::isValidPath(const PathWithLaneId & path) c
   const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
     *route_handler, utils::extendLanes(route_handler, status_.current_lanes),
     utils::extendLanes(route_handler, status_.lane_change_lanes));
-  const auto expanded_lanes = utils::expandLanelets(
-    drivable_lanes, parameters_->drivable_area_left_bound_offset,
-    parameters_->drivable_area_right_bound_offset);
-  const auto lanelets = utils::transformToLanelets(expanded_lanes);
+  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, drivable_lanes);
+  const auto lanelets = utils::transformToLanelets(target_drivable_lanes);
 
   // check path points are in any lanelets
   for (const auto & point : path.points) {
@@ -627,12 +622,9 @@ void ExternalRequestLaneChangeModule::generateExtendedDrivableArea(PathWithLaneI
   const auto & route_handler = planner_data_->route_handler;
   const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
     *route_handler, status_.current_lanes, status_.lane_change_lanes);
-  const auto expanded_lanes = utils::expandLanelets(
-    drivable_lanes, parameters_->drivable_area_left_bound_offset,
-    parameters_->drivable_area_right_bound_offset);
-
+  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, drivable_lanes);
   utils::generateDrivableArea(
-    path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
+    path, drivable_lanes, common_parameters.vehicle_length, planner_data_);
 }
 
 bool ExternalRequestLaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -295,7 +295,7 @@ PathWithLaneId ExternalRequestLaneChangeModule::getReferencePath() const
     lane_change_buffer);
 
   const auto drivable_lanes = utils::generateDrivableLanes(current_lanes);
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(reference_path, drivable_lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(reference_path, drivable_lanes);
   utils::generateDrivableArea(
     reference_path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 
@@ -399,7 +399,7 @@ bool ExternalRequestLaneChangeModule::isValidPath(const PathWithLaneId & path) c
   const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
     *route_handler, utils::extendLanes(route_handler, status_.current_lanes),
     utils::extendLanes(route_handler, status_.lane_change_lanes));
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, drivable_lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(path, drivable_lanes);
   const auto lanelets = utils::transformToLanelets(target_drivable_lanes);
 
   // check path points are in any lanelets
@@ -622,7 +622,7 @@ void ExternalRequestLaneChangeModule::generateExtendedDrivableArea(PathWithLaneI
   const auto & route_handler = planner_data_->route_handler;
   const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
     *route_handler, status_.current_lanes, status_.lane_change_lanes);
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, drivable_lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(path, drivable_lanes);
   utils::generateDrivableArea(
     path, drivable_lanes, common_parameters.vehicle_length, planner_data_);
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -103,13 +103,14 @@ PathWithLaneId NormalLaneChange::generatePlannedPath()
 
 void NormalLaneChange::generateExtendedDrivableArea(PathWithLaneId & path)
 {
+  const auto & common_parameters = planner_data_->parameters;
+  const auto & dp = planner_data_->drivable_area_expansion_parameters;
+
   const auto drivable_lanes = getDrivableLanes();
   const auto shorten_lanes = utils::cutOverlappedLanes(path, drivable_lanes);
-
-  const auto & common_parameters = planner_data_->parameters;
   const auto expanded_lanes = utils::expandLanelets(
-    shorten_lanes, parameters_->drivable_area_left_bound_offset,
-    parameters_->drivable_area_right_bound_offset, parameters_->drivable_area_types_to_skip);
+    shorten_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
+    dp.drivable_area_types_to_skip);
   utils::generateDrivableArea(
     path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
 }
@@ -575,14 +576,16 @@ void NormalLaneChange::calcTurnSignalInfo()
 bool NormalLaneChange::isValidPath(const PathWithLaneId & path) const
 {
   const auto & route_handler = planner_data_->route_handler;
+  const auto & dp = planner_data_->drivable_area_expansion_parameters;
 
   // check lane departure
   const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
     *route_handler, utils::extendLanes(route_handler, status_.current_lanes),
     utils::extendLanes(route_handler, status_.lane_change_lanes));
   const auto expanded_lanes = utils::expandLanelets(
-    drivable_lanes, parameters_->drivable_area_left_bound_offset,
-    parameters_->drivable_area_right_bound_offset);
+    drivable_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
+    dp.drivable_area_types_to_skip);
+
   const auto lanelets = utils::transformToLanelets(expanded_lanes);
 
   // check path points are in any lanelets

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -198,7 +198,7 @@ BehaviorModuleOutput PullOutModule::plan()
     path = status_.backward_path;
   }
 
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, status_.lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(path, status_.lanes);
   utils::generateDrivableArea(
     path, target_drivable_lanes, planner_data_->parameters.vehicle_length, planner_data_);
 
@@ -310,7 +310,7 @@ BehaviorModuleOutput PullOutModule::planWaitingApproval()
   auto stop_path = status_.back_finished ? getCurrentPath() : status_.backward_path;
   const auto drivable_lanes =
     utils::generateDrivableLanesWithShoulderLanes(current_lanes, pull_out_lanes);
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(stop_path, status_.lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(stop_path, status_.lanes);
   utils::generateDrivableArea(
     stop_path, target_drivable_lanes, planner_data_->parameters.vehicle_length, planner_data_);
   for (auto & p : stop_path.points) {
@@ -518,7 +518,7 @@ PathWithLaneId PullOutModule::generateStopPath() const
   path.points.push_back(toPathPointWithLaneId(moved_pose));
 
   // generate drivable area
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, status_.lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(path, status_.lanes);
   utils::generateDrivableArea(
     path, target_drivable_lanes, planner_data_->parameters.vehicle_length, planner_data_);
 

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -310,9 +310,12 @@ BehaviorModuleOutput PullOutModule::planWaitingApproval()
   auto stop_path = status_.back_finished ? getCurrentPath() : status_.backward_path;
   const auto drivable_lanes =
     utils::generateDrivableLanesWithShoulderLanes(current_lanes, pull_out_lanes);
-  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(stop_path, status_.lanes);
+  const auto & dp = planner_data_->drivable_area_expansion_parameters;
+  const auto expanded_lanes = utils::expandLanelets(
+    drivable_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
+    dp.drivable_area_types_to_skip);
   utils::generateDrivableArea(
-    stop_path, target_drivable_lanes, planner_data_->parameters.vehicle_length, planner_data_);
+    stop_path, expanded_lanes, planner_data_->parameters.vehicle_length, planner_data_);
   for (auto & p : stop_path.points) {
     p.point.longitudinal_velocity_mps = 0.0;
   }

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -618,12 +618,9 @@ BehaviorModuleOutput PullOverModule::plan()
     for (auto & path : status_.pull_over_path->partial_paths) {
       const size_t ego_idx = planner_data_->findEgoIndex(path.points);
       utils::clipPathLength(path, ego_idx, planner_data_->parameters);
-      const auto shorten_lanes = utils::cutOverlappedLanes(path, status_.lanes);
-      const auto expanded_lanes = utils::expandLanelets(
-        shorten_lanes, parameters_->drivable_area_left_bound_offset,
-        parameters_->drivable_area_right_bound_offset, parameters_->drivable_area_types_to_skip);
+      const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, status_.lanes);
       utils::generateDrivableArea(
-        path, expanded_lanes, planner_data_->parameters.vehicle_length, planner_data_);
+        path, target_drivable_lanes, planner_data_->parameters.vehicle_length, planner_data_);
     }
   }
 
@@ -857,12 +854,9 @@ PathWithLaneId PullOverModule::generateStopPath()
 
   // generate drivable area
   const auto drivable_lanes = utils::generateDrivableLanes(status_.current_lanes);
-  const auto shorten_lanes = utils::cutOverlappedLanes(reference_path, drivable_lanes);
-  const auto expanded_lanes = utils::expandLanelets(
-    shorten_lanes, parameters_->drivable_area_left_bound_offset,
-    parameters_->drivable_area_right_bound_offset, parameters_->drivable_area_types_to_skip);
+  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(reference_path, drivable_lanes);
   utils::generateDrivableArea(
-    reference_path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
+    reference_path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 
   return reference_path;
 }
@@ -895,12 +889,9 @@ PathWithLaneId PullOverModule::generateFeasibleStopPath()
 
   // generate drivable area
   const auto drivable_lanes = utils::generateDrivableLanes(status_.current_lanes);
-  const auto shorten_lanes = utils::cutOverlappedLanes(stop_path, drivable_lanes);
-  const auto expanded_lanes = utils::expandLanelets(
-    shorten_lanes, parameters_->drivable_area_left_bound_offset,
-    parameters_->drivable_area_right_bound_offset, parameters_->drivable_area_types_to_skip);
+  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(stop_path, drivable_lanes);
   utils::generateDrivableArea(
-    stop_path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
+    stop_path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 
   return stop_path;
 }

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -618,7 +618,7 @@ BehaviorModuleOutput PullOverModule::plan()
     for (auto & path : status_.pull_over_path->partial_paths) {
       const size_t ego_idx = planner_data_->findEgoIndex(path.points);
       utils::clipPathLength(path, ego_idx, planner_data_->parameters);
-      const auto target_drivable_lanes = getNonoverlappingExpandedLanes(path, status_.lanes);
+      const auto target_drivable_lanes = getNonOverlappingExpandedLanes(path, status_.lanes);
       utils::generateDrivableArea(
         path, target_drivable_lanes, planner_data_->parameters.vehicle_length, planner_data_);
     }
@@ -854,7 +854,7 @@ PathWithLaneId PullOverModule::generateStopPath()
 
   // generate drivable area
   const auto drivable_lanes = utils::generateDrivableLanes(status_.current_lanes);
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(reference_path, drivable_lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(reference_path, drivable_lanes);
   utils::generateDrivableArea(
     reference_path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 
@@ -889,7 +889,7 @@ PathWithLaneId PullOverModule::generateFeasibleStopPath()
 
   // generate drivable area
   const auto drivable_lanes = utils::generateDrivableLanes(status_.current_lanes);
-  const auto target_drivable_lanes = getNonoverlappingExpandedLanes(stop_path, drivable_lanes);
+  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(stop_path, drivable_lanes);
   utils::generateDrivableArea(
     stop_path, target_drivable_lanes, common_parameters.vehicle_length, planner_data_);
 

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -416,21 +416,20 @@ double SideShiftModule::getClosestShiftLength() const
 
 void SideShiftModule::adjustDrivableArea(ShiftedPath * path) const
 {
+  const auto & dp = planner_data_->drivable_area_expansion_parameters;
   const auto itr = std::minmax_element(path->shift_length.begin(), path->shift_length.end());
 
   constexpr double threshold = 0.1;
   constexpr double margin = 0.5;
   const double left_offset = std::max(
-    *itr.second + (*itr.first > threshold ? margin : 0.0),
-    parameters_->drivable_area_left_bound_offset);
+    *itr.second + (*itr.first > threshold ? margin : 0.0), dp.drivable_area_left_bound_offset);
   const double right_offset = -std::min(
-    *itr.first - (*itr.first < -threshold ? margin : 0.0),
-    -parameters_->drivable_area_right_bound_offset);
+    *itr.first - (*itr.first < -threshold ? margin : 0.0), -dp.drivable_area_right_bound_offset);
 
   const auto drivable_lanes = utils::generateDrivableLanes(current_lanelets_);
   const auto shorten_lanes = utils::cutOverlappedLanes(path->path, drivable_lanes);
-  const auto expanded_lanes = utils::expandLanelets(
-    shorten_lanes, left_offset, right_offset, parameters_->drivable_area_types_to_skip);
+  const auto expanded_lanes =
+    utils::expandLanelets(shorten_lanes, left_offset, right_offset, dp.drivable_area_types_to_skip);
 
   {
     const auto & p = planner_data_->parameters;

--- a/planning/behavior_path_planner/src/utils/pull_out/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/pull_out/shift_pull_out.cpp
@@ -92,9 +92,10 @@ boost::optional<PullOutPath> ShiftPullOut::plan(Pose start_pose, Pose goal_pose)
     // check lane departure
     const auto drivable_lanes =
       utils::generateDrivableLanesWithShoulderLanes(road_lanes, shoulder_lanes);
+    const auto & dp = planner_data_->drivable_area_expansion_parameters;
     const auto expanded_lanes = utils::expandLanelets(
-      drivable_lanes, parameters_.drivable_area_left_bound_offset,
-      parameters_.drivable_area_right_bound_offset);
+      drivable_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
+      dp.drivable_area_types_to_skip);
     if (lane_departure_checker_->checkPathWillLeaveLane(
           utils::transformToLanelets(expanded_lanes), path_start_to_end)) {
       continue;

--- a/planning/behavior_path_planner/src/utils/pull_over/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/pull_over/shift_pull_over.cpp
@@ -207,9 +207,10 @@ boost::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
   // check if the parking path will leave lanes
   const auto drivable_lanes =
     utils::generateDrivableLanesWithShoulderLanes(road_lanes, shoulder_lanes);
+  const auto & dp = planner_data_->drivable_area_expansion_parameters;
   const auto expanded_lanes = utils::expandLanelets(
-    drivable_lanes, parameters_.drivable_area_left_bound_offset,
-    parameters_.drivable_area_right_bound_offset);
+    drivable_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
+    dp.drivable_area_types_to_skip);
   if (lane_departure_checker_.checkPathWillLeaveLane(
         utils::transformToLanelets(expanded_lanes), pull_over_path.getParkingPath())) {
     return {};

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1799,11 +1799,12 @@ BehaviorModuleOutput getReferencePath(
   const auto drivable_lanelets = getLaneletsFromPath(reference_path, route_handler);
   const auto drivable_lanes = generateDrivableLanes(drivable_lanelets);
 
-  const auto shorten_lanes = cutOverlappedLanes(reference_path, drivable_lanes);
+  const auto & dp = planner_data->drivable_area_expansion_parameters;
 
+  const auto shorten_lanes = cutOverlappedLanes(reference_path, drivable_lanes);
   const auto expanded_lanes = expandLanelets(
-    shorten_lanes, p.drivable_area_left_bound_offset, p.drivable_area_right_bound_offset,
-    p.drivable_area_types_to_skip);
+    shorten_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
+    dp.drivable_area_types_to_skip);
 
   generateDrivableArea(reference_path, expanded_lanes, p.vehicle_length, planner_data);
 


### PR DESCRIPTION
## Description

Currently, we have different drivable area expansion parameters for each module (lane change, avoidance, ...).

However, since with a new behavior_path_planner architecture, multiple modules are launched simultaneously, it's hard to expand the drivable area with different module's expansion parameters when multiple modules are launched.

Therefore, I changed the logic to have ONE set of parameters for all modules so that drivable area expansion future works well when multiple modules are launched.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator worked well.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing. (With this PR, we cannot expand the drivable area statically with each module's different parameters)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
