### PR TITLE
fix(side_shift): fix drivable area generation

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -85,7 +85,7 @@ private:
 #endif
 
   // non-const methods
-  BehaviorModuleOutput SideShiftModule::adjustDrivableArea(const ShiftedPath & path, DrivableAreaInfo & out) const;
+  BehaviorModuleOutput adjustDrivableArea(const ShiftedPath & path) const;
 
   ShiftLine calcShiftLine() const;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -85,7 +85,7 @@ private:
 #endif
 
   // non-const methods
-  void adjustDrivableArea(ShiftedPath * path, DrivableAreaInfo & out) const;
+  BehaviorModuleOutput SideShiftModule::adjustDrivableArea(const ShiftedPath & path, DrivableAreaInfo & out) const;
 
   ShiftLine calcShiftLine() const;
 

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -297,10 +297,10 @@ BehaviorModuleOutput SideShiftModule::plan()
   // Reset orientation
   setOrientation(&shifted_path.path);
 
-  BehaviorModuleOutput output;
-  output.path = std::make_shared<PathWithLaneId>(shifted_path.path);
+  auto output = adjustDrivableArea(shifted_path);
+
+  output.path = std::make_shared<PathWithLaneId>(output_path);
   output.reference_path = getPreviousModuleOutput().reference_path;
-  adjustDrivableArea(&shifted_path, output.drivable_area_info);
 
   prev_output_ = shifted_path;
   path_reference_ = getPreviousModuleOutput().reference_path;
@@ -333,10 +333,10 @@ BehaviorModuleOutput SideShiftModule::planWaitingApproval()
   // Reset orientation
   setOrientation(&shifted_path.path);
 
-  BehaviorModuleOutput output;
-  output.path = std::make_shared<PathWithLaneId>(shifted_path.path);
+  auto output = adjustDrivableArea(shifted_path);
+
+  output.path = std::make_shared<PathWithLaneId>(output_path);
   output.reference_path = getPreviousModuleOutput().reference_path;
-  adjustDrivableArea(&shifted_path, output.drivable_area_info);
 
   path_candidate_ = std::make_shared<PathWithLaneId>(planCandidate().path_candidate);
   path_reference_ = getPreviousModuleOutput().reference_path;
@@ -416,8 +416,10 @@ double SideShiftModule::getClosestShiftLength() const
   return prev_output_.shift_length.at(closest);
 }
 
-void SideShiftModule::adjustDrivableArea(ShiftedPath * path, DrivableAreaInfo & out) const
+BehaviorModuleOutput SideShiftModule::adjustDrivableArea(const ShiftedPath & path, DrivableAreaInfo & out) const
 {
+  BehaviorModuleOutput out;
+
   const auto & dp = planner_data_->drivable_area_expansion_parameters;
   const auto itr = std::minmax_element(path->shift_length.begin(), path->shift_length.end());
 
@@ -434,16 +436,26 @@ void SideShiftModule::adjustDrivableArea(ShiftedPath * path, DrivableAreaInfo & 
     utils::expandLanelets(shorten_lanes, left_offset, right_offset, dp.drivable_area_types_to_skip);
 
   {  // for old architecture
+  auto output_path = path->path;
+  const auto & p = planner_data_->parameters;
+  const size_t current_seg_idx = planner_data_->findEgoSegmentIndex(output_path.points);
+  const auto & current_pose = planner_data_->self_odometry->pose.pose;
+  output_path.points = motion_utils::cropPoints(
+    output_path.points, current_pose.position, current_seg_idx, p.forward_path_length,
+    p.backward_path_length + p.input_path_interval);
+
     const auto & p = planner_data_->parameters;
-    utils::generateDrivableArea(path->path, expanded_lanes, p.vehicle_length, planner_data_);
+    utils::generateDrivableArea(output_path, expanded_lanes, p.vehicle_length, planner_data_);
   }
 
   {  // for new architecture
     // NOTE: side shift module is not launched with other modules. Therefore, drivable_lanes can be
     // assigned without combining.
-    out.drivable_lanes = expanded_lanes;
-    out.is_already_expanded = true;
+    out.drivable_area_info.drivable_lanes = expanded_lanes;
+    out.drivable_area_info.is_already_expanded = true;
   }
+
+  return out;
 }
 
 PathWithLaneId SideShiftModule::extendBackwardLength(const PathWithLaneId & original_path) const


### PR DESCRIPTION
## Description

Without this PR, in some cases which I'm not sure, the generated drivable area is weird as follows.
![image](https://user-images.githubusercontent.com/20228327/234443851-d7bf9e16-4d9b-4533-b8ed-e2587fbb6c66.png)

This is because during side shift calculation, the path front point is not close to the ego but far away from the ego, and the result of the nearest search from the path front point to something for drivable area calculation is wrong.

In this PR, I crop the path close to the ego before drivable area generation and after the path calculation.


<!-- Write a brief description of this PR. -->



## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
