### PR TITLE
fix(tier4_planning_rviz_plugin): update vehicle info by global parameters

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/path/display.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display.hpp
@@ -161,9 +161,10 @@ public:
   ~AutowarePathWithLaneIdDisplay();
 
 private:
-  void preprocessMessageDetail(
+  void preProcessMessageDetail() override;
+  void preVisualizePathFootprintDetail(
     const autoware_auto_planning_msgs::msg::PathWithLaneId::ConstSharedPtr msg_ptr) override;
-  void processMessageDetail(
+  void visualizePathFootprintDetail(
     const autoware_auto_planning_msgs::msg::PathWithLaneId::ConstSharedPtr msg_ptr,
     const size_t p_idx) override;
 
@@ -179,12 +180,16 @@ class AutowarePathDisplay
 : public AutowarePathWithDrivableAreaDisplay<autoware_auto_planning_msgs::msg::Path>
 {
   Q_OBJECT
+private:
+  void preProcessMessageDetail() override;
 };
 
 class AutowareTrajectoryDisplay
 : public AutowarePathBaseDisplay<autoware_auto_planning_msgs::msg::Trajectory>
 {
   Q_OBJECT
+private:
+  void preProcessMessageDetail() override;
 };
 }  // namespace rviz_plugins
 

--- a/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
@@ -211,8 +211,12 @@ public:
 
 protected:
   virtual void visualizeDrivableArea([[maybe_unused]] const typename T::ConstSharedPtr msg_ptr) {}
-  virtual void preprocessMessageDetail([[maybe_unused]] const typename T::ConstSharedPtr msg_ptr) {}
-  virtual void processMessageDetail(
+  virtual void preProcessMessageDetail() {}
+  virtual void preVisualizePathFootprintDetail(
+    [[maybe_unused]] const typename T::ConstSharedPtr msg_ptr)
+  {
+  }
+  virtual void visualizePathFootprintDetail(
     [[maybe_unused]] const typename T::ConstSharedPtr msg_ptr, [[maybe_unused]] const size_t p_idx)
   {
   }
@@ -230,6 +234,8 @@ protected:
         "Message contained invalid floating point values (nans or infs)");
       return;
     }
+
+    preProcessMessageDetail();
 
     Ogre::Vector3 position;
     Ogre::Quaternion orientation;
@@ -406,7 +412,7 @@ protected:
 
     const float offset_from_baselink = property_offset_.getFloat();
 
-    preprocessMessageDetail(msg_ptr);
+    preVisualizePathFootprintDetail(msg_ptr);
 
     for (size_t p_idx = 0; p_idx < msg_ptr->points.size(); p_idx++) {
       const auto & point = msg_ptr->points.at(p_idx);
@@ -481,7 +487,7 @@ protected:
         }
       }
 
-      processMessageDetail(msg_ptr, p_idx);
+      visualizePathFootprintDetail(msg_ptr, p_idx);
     }
 
     footprint_manual_object_->end();

--- a/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
@@ -494,6 +494,22 @@ protected:
     point_manual_object_->end();
   }
 
+  void updateVehicleInfo()
+  {
+    if (vehicle_info_) {
+      vehicle_footprint_info_ = std::make_shared<VehicleFootprintInfo>(
+        vehicle_info_->vehicle_length_m, vehicle_info_->vehicle_width_m,
+        vehicle_info_->rear_overhang_m);
+    } else {
+      const float length{property_vehicle_length_.getFloat()};
+      const float width{property_vehicle_width_.getFloat()};
+      const float rear_overhang{property_rear_overhang_.getFloat()};
+
+      vehicle_footprint_info_ =
+        std::make_shared<VehicleFootprintInfo>(length, width, rear_overhang);
+    }
+  }
+
   Ogre::ManualObject * path_manual_object_{nullptr};
   Ogre::ManualObject * velocity_manual_object_{nullptr};
   Ogre::ManualObject * footprint_manual_object_{nullptr};
@@ -529,6 +545,8 @@ protected:
   rviz_common::properties::FloatProperty property_point_radius_;
   rviz_common::properties::FloatProperty property_point_offset_;
 
+  std::shared_ptr<VehicleInfo> vehicle_info_;
+
 private:
   typename T::ConstSharedPtr last_msg_ptr_;
 
@@ -541,24 +559,7 @@ private:
     float length, width, rear_overhang;
   };
 
-  std::shared_ptr<VehicleInfo> vehicle_info_;
   std::shared_ptr<VehicleFootprintInfo> vehicle_footprint_info_;
-
-  void updateVehicleInfo()
-  {
-    if (vehicle_info_) {
-      vehicle_footprint_info_ = std::make_shared<VehicleFootprintInfo>(
-        vehicle_info_->vehicle_length_m, vehicle_info_->vehicle_width_m,
-        vehicle_info_->rear_overhang_m);
-    } else {
-      const float length{property_vehicle_length_.getFloat()};
-      const float width{property_vehicle_width_.getFloat()};
-      const float rear_overhang{property_rear_overhang_.getFloat()};
-
-      vehicle_footprint_info_ =
-        std::make_shared<VehicleFootprintInfo>(length, width, rear_overhang);
-    }
-  }
 };
 }  // namespace rviz_plugins
 

--- a/common/tier4_planning_rviz_plugin/src/path/display.cpp
+++ b/common/tier4_planning_rviz_plugin/src/path/display.cpp
@@ -23,6 +23,24 @@ AutowarePathWithLaneIdDisplay::AutowarePathWithLaneIdDisplay()
 {
 }
 
+void AutowarePathWithLaneIdDisplay::preProcessMessageDetail()
+{
+  // NOTE: This doesn't work in the constructor.
+  // NOTE: This doesn't work in the abstract class since the class has to have a "Q_Object" type.
+  if (!vehicle_info_) {
+    try {
+      vehicle_info_ = std::make_shared<VehicleInfo>(
+        VehicleInfoUtil(*rviz_ros_node_.lock()->get_raw_node()).getVehicleInfo());
+      updateVehicleInfo();
+    } catch (const std::exception & e) {
+      RCLCPP_WARN_THROTTLE(
+        rviz_ros_node_.lock()->get_raw_node()->get_logger(),
+        *rviz_ros_node_.lock()->get_raw_node()->get_clock(), 5000, "Failed to get vehicle_info: %s",
+        e.what());
+    }
+  }
+}
+
 AutowarePathWithLaneIdDisplay::~AutowarePathWithLaneIdDisplay()
 {
   for (const auto & e : lane_id_obj_ptrs_) {
@@ -32,7 +50,7 @@ AutowarePathWithLaneIdDisplay::~AutowarePathWithLaneIdDisplay()
   lane_id_obj_ptrs_.shrink_to_fit();
 }
 
-void AutowarePathWithLaneIdDisplay::preprocessMessageDetail(
+void AutowarePathWithLaneIdDisplay::preVisualizePathFootprintDetail(
   const autoware_auto_planning_msgs::msg::PathWithLaneId::ConstSharedPtr msg_ptr)
 {
   const size_t size = msg_ptr->points.size();
@@ -56,7 +74,7 @@ void AutowarePathWithLaneIdDisplay::preprocessMessageDetail(
   }
 }
 
-void AutowarePathWithLaneIdDisplay::processMessageDetail(
+void AutowarePathWithLaneIdDisplay::visualizePathFootprintDetail(
   const autoware_auto_planning_msgs::msg::PathWithLaneId::ConstSharedPtr msg_ptr,
   const size_t p_idx)
 {
@@ -82,6 +100,42 @@ void AutowarePathWithLaneIdDisplay::processMessageDetail(
   } else {
     const auto & text_ptr = lane_id_obj_ptrs_.at(p_idx).second;
     text_ptr->setVisible(false);
+  }
+}
+
+void AutowarePathDisplay::preProcessMessageDetail()
+{
+  // NOTE: This doesn't work in the constructor.
+  // NOTE: This doesn't work in the abstract class since the class has to have a "Q_Object" type.
+  if (!vehicle_info_) {
+    try {
+      vehicle_info_ = std::make_shared<VehicleInfo>(
+        VehicleInfoUtil(*rviz_ros_node_.lock()->get_raw_node()).getVehicleInfo());
+      updateVehicleInfo();
+    } catch (const std::exception & e) {
+      RCLCPP_WARN_THROTTLE(
+        rviz_ros_node_.lock()->get_raw_node()->get_logger(),
+        *rviz_ros_node_.lock()->get_raw_node()->get_clock(), 5000, "Failed to get vehicle_info: %s",
+        e.what());
+    }
+  }
+}
+
+void AutowareTrajectoryDisplay::preProcessMessageDetail()
+{
+  // NOTE: This doesn't work in the constructor.
+  // NOTE: This doesn't work in the abstract class since the class has to have a "Q_Object" type.
+  if (!vehicle_info_) {
+    try {
+      vehicle_info_ = std::make_shared<VehicleInfo>(
+        VehicleInfoUtil(*rviz_ros_node_.lock()->get_raw_node()).getVehicleInfo());
+      updateVehicleInfo();
+    } catch (const std::exception & e) {
+      RCLCPP_WARN_THROTTLE(
+        rviz_ros_node_.lock()->get_raw_node()->get_logger(),
+        *rviz_ros_node_.lock()->get_raw_node()->get_clock(), 5000, "Failed to get vehicle_info: %s",
+        e.what());
+    }
   }
 }
 }  // namespace rviz_plugins


### PR DESCRIPTION
## Description

By the recent refactoring of tier4_planning_rviz_plugin, the following function that update the vehicle_info by global parameters are removed by mistake.
https://github.com/autowarefoundation/autoware.universe/blob/ecc577457c5b7c92eb46f2fe33d5183ab4b44bf0/common/tier4_planning_rviz_plugin/src/path_footprint/display.cpp#L91-L103

This function can be implemented in the class which has Q_Object class.
Therefore, it cannot be implemented the base class since it does not have Q_Object due to its template abstraction.

So I implemented this function in each derived class redundantly.

When visualizing footprint of the **small** robot,
**with this PR**
(correct vehicle size)
![image](https://user-images.githubusercontent.com/20228327/233835917-bf0bd8e6-a7d2-4df8-b40f-ad9cd8019272.png)
**without this PR**
(not correct vehicle size)
![image](https://user-images.githubusercontent.com/20228327/233835924-fdedc163-2e11-4799-a01a-81a62c69bcf3.png)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator works well

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

On rviz, vehicle's size is used for footprint visualization.
Without this PR, the default vehicle size is used.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
