### PR TITLE
fix(avoidance): use infinity to show that next traffic light doesn't exist explicitly

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -313,7 +313,7 @@ struct ObjectData  // avoidance target
   double to_road_shoulder_distance{0.0};
 
   // to intersection
-  double to_stop_factor_distance{std::numeric_limits<double>::max()};
+  double to_stop_factor_distance{std::numeric_limits<double>::infinity()};
 
   // if lateral margin is NOT enough, the ego must avoid the object.
   bool avoid_required{false};

--- a/planning/behavior_path_planner/src/marker_util/avoidance/debug.cpp
+++ b/planning/behavior_path_planner/src/marker_util/avoidance/debug.cpp
@@ -78,14 +78,13 @@ MarkerArray createObjectInfoMarkerArray(const ObjectDataArray & objects, std::st
 
   for (const auto & object : objects) {
     {
-      const auto to_stop_factor_distance = std::min(object.to_stop_factor_distance, 1000.0);
       marker.id = uuidToInt32(object.object.object_id);
       marker.pose = object.object.kinematics.initial_pose_with_covariance.pose;
       std::ostringstream string_stream;
       string_stream << std::fixed << std::setprecision(2);
       string_stream << "ratio:" << object.shiftable_ratio << " [-]\n"
                     << "lateral: " << object.lateral << " [-]\n"
-                    << "stop_factor:" << to_stop_factor_distance << " [m]\n"
+                    << "stop_factor:" << object.to_stop_factor_distance << " [m]\n"
                     << "move_time:" << object.move_time << " [s]\n"
                     << "stop_time:" << object.stop_time << " [s]\n";
       marker.text = string_stream.str();

--- a/planning/behavior_path_planner/src/utils/avoidance/util.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/util.cpp
@@ -819,7 +819,7 @@ void fillObjectMovingTime(
   }
 
   if (is_new_object) {
-    object_data.move_time = std::numeric_limits<double>::max();
+    object_data.move_time = std::numeric_limits<double>::infinity();
     object_data.stop_time = 0.0;
     object_data.last_move = now;
     return;

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1118,7 +1118,7 @@ double getDistanceToNextTrafficLight(
 {
   lanelet::ConstLanelet current_lanelet;
   if (!lanelet::utils::query::getClosestLanelet(lanelets, current_pose, &current_lanelet)) {
-    return std::numeric_limits<double>::max();
+    return std::numeric_limits<double>::infinity();
   }
 
   const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(current_pose.position);
@@ -1166,7 +1166,7 @@ double getDistanceToNextTrafficLight(
     distance += lanelet::utils::getLaneletLength3d(llt);
   }
 
-  return std::numeric_limits<double>::max();
+  return std::numeric_limits<double>::infinity();
 }
 
 double getDistanceToNextIntersection(


### PR DESCRIPTION
## Description

- use infinity instead of max to show that next traffic light doesn't exist explicitly

Before this PR, debug marker shows huge FINITE number even when there is no traffic light within route.

![rviz_screenshot_2023_04_24-08_57_18](https://user-images.githubusercontent.com/44889564/233873863-97ef0fa4-be4c-4e33-aac8-0d47b2c0cbd6.png)

After this PR, debug marker shows INF at such a situation.

![rviz_screenshot_2023_04_24-08_56_01](https://user-images.githubusercontent.com/44889564/233874041-5b7f5e74-bd41-4813-a627-eec1709870c4.png)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

System behavior doesn't change.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
