### PR TITLE
chore(lane_change): use BehaviorModuleOuput as output of generatePlannedPath

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -66,9 +66,9 @@ public:
 
   virtual std::pair<bool, bool> getSafePath(LaneChangePath & safe_path) const = 0;
 
-  virtual PathWithLaneId generatePlannedPath() = 0;
+  virtual BehaviorModuleOutput generatePlannedPath() = 0;
 
-  virtual void generateExtendedDrivableArea(PathWithLaneId & path) = 0;
+  virtual void generateExtendedDrivableArea(BehaviorModuleOutput & output) = 0;
 
   virtual bool hasFinishedLaneChange() const = 0;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -66,9 +66,9 @@ public:
 
   virtual std::pair<bool, bool> getSafePath(LaneChangePath & safe_path) const = 0;
 
-  virtual BehaviorModuleOutput generatePlannedPath() = 0;
+  virtual BehaviorModuleOutput generateOutput() = 0;
 
-  virtual void generateExtendedDrivableArea(BehaviorModuleOutput & output) = 0;
+  virtual void extendOutputDrivableArea(BehaviorModuleOutput & output) = 0;
 
   virtual bool hasFinishedLaneChange() const = 0;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
@@ -110,7 +110,7 @@ protected:
     LaneChangePath & safe_path) const;
 
   void updateLaneChangeStatus();
-  void generateExtendedDrivableArea(PathWithLaneId & path);
+  void generateExtendedDrivableArea(BehaviorModuleOutput & output);
   void updateOutputTurnSignal(BehaviorModuleOutput & output);
   void updateSteeringFactorPtr(const BehaviorModuleOutput & output);
   void updateSteeringFactorPtr(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/external_request_lane_change_module.hpp
@@ -110,7 +110,7 @@ protected:
     LaneChangePath & safe_path) const;
 
   void updateLaneChangeStatus();
-  void generateExtendedDrivableArea(BehaviorModuleOutput & output);
+  void extendOutputDrivableArea(BehaviorModuleOutput & output);
   void updateOutputTurnSignal(BehaviorModuleOutput & output);
   void updateSteeringFactorPtr(const BehaviorModuleOutput & output);
   void updateSteeringFactorPtr(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -43,9 +43,9 @@ public:
 
   std::pair<bool, bool> getSafePath(LaneChangePath & safe_path) const override;
 
-  PathWithLaneId generatePlannedPath() override;
+  BehaviorModuleOutput generatePlannedPath() override;
 
-  void generateExtendedDrivableArea(PathWithLaneId & path) override;
+  void generateExtendedDrivableArea(BehaviorModuleOutput & output) override;
 
   bool hasFinishedLaneChange() const override;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -43,9 +43,9 @@ public:
 
   std::pair<bool, bool> getSafePath(LaneChangePath & safe_path) const override;
 
-  BehaviorModuleOutput generatePlannedPath() override;
+  BehaviorModuleOutput generateOutput() override;
 
-  void generateExtendedDrivableArea(BehaviorModuleOutput & output) override;
+  void extendOutputDrivableArea(BehaviorModuleOutput & output) override;
 
   bool hasFinishedLaneChange() const override;
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -141,12 +141,13 @@ BehaviorModuleOutput ExternalRequestLaneChangeModule::plan()
     }
   }
 
-  generateExtendedDrivableArea(path);
-
   prev_approved_path_ = path;
 
   BehaviorModuleOutput output;
   output.path = std::make_shared<PathWithLaneId>(path);
+
+  generateExtendedDrivableArea(output);
+
   updateOutputTurnSignal(output);
 
   updateSteeringFactorPtr(output);
@@ -619,7 +620,7 @@ std_msgs::msg::Header ExternalRequestLaneChangeModule::getRouteHeader() const
 {
   return planner_data_->route_handler->getRouteHeader();
 }
-void ExternalRequestLaneChangeModule::generateExtendedDrivableArea(PathWithLaneId & path)
+void ExternalRequestLaneChangeModule::generateExtendedDrivableArea(BehaviorModuleOutput & output)
 {
   const auto & common_parameters = planner_data_->parameters;
   const auto & route_handler = planner_data_->route_handler;
@@ -629,8 +630,9 @@ void ExternalRequestLaneChangeModule::generateExtendedDrivableArea(PathWithLaneI
   const auto expanded_lanes = utils::expandLanelets(
     drivable_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
     dp.drivable_area_types_to_skip);
+
   utils::generateDrivableArea(
-    path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
+    output.path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
 }
 
 bool ExternalRequestLaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -146,7 +146,7 @@ BehaviorModuleOutput ExternalRequestLaneChangeModule::plan()
   BehaviorModuleOutput output;
   output.path = std::make_shared<PathWithLaneId>(path);
 
-  generateExtendedDrivableArea(output);
+  extendOutputDrivableArea(output);
 
   updateOutputTurnSignal(output);
 
@@ -620,7 +620,7 @@ std_msgs::msg::Header ExternalRequestLaneChangeModule::getRouteHeader() const
 {
   return planner_data_->route_handler->getRouteHeader();
 }
-void ExternalRequestLaneChangeModule::generateExtendedDrivableArea(BehaviorModuleOutput & output)
+void ExternalRequestLaneChangeModule::extendOutputDrivableArea(BehaviorModuleOutput & output)
 {
   const auto & common_parameters = planner_data_->parameters;
   const auto & route_handler = planner_data_->route_handler;
@@ -632,7 +632,7 @@ void ExternalRequestLaneChangeModule::generateExtendedDrivableArea(BehaviorModul
     dp.drivable_area_types_to_skip);
 
   utils::generateDrivableArea(
-    output.path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
+    *output.path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
 }
 
 bool ExternalRequestLaneChangeModule::isApprovedPathSafe(Pose & ego_pose_before_collision) const

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -117,7 +117,7 @@ BehaviorModuleOutput LaneChangeInterface::plan()
   resetPathReference();
 
   module_type_->setPreviousDrivableLanes(getPreviousModuleOutput().drivable_lanes);
-  const auto path = module_type_->generatePlannedPath();
+  auto output = module_type_->generatePlannedPath();
 
   if (!module_type_->isValidPath()) {
     return {};
@@ -129,8 +129,6 @@ BehaviorModuleOutput LaneChangeInterface::plan()
 
   const auto reference_path = module_type_->getReferencePath();
 
-  BehaviorModuleOutput output;
-  output.path = std::make_shared<PathWithLaneId>(path);
   output.reference_path = std::make_shared<PathWithLaneId>(reference_path);
   output.turn_signal_info = module_type_->updateOutputTurnSignal();
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -116,9 +116,6 @@ BehaviorModuleOutput LaneChangeInterface::plan()
   resetPathCandidate();
   resetPathReference();
 
-  module_type_->setPreviousDrivableLanes(getPreviousModuleOutput().drivable_lanes);
-  auto output = module_type_->generateOutput();
-
   if (!module_type_->isValidPath()) {
     return {};
   }
@@ -127,12 +124,9 @@ BehaviorModuleOutput LaneChangeInterface::plan()
     resetPathIfAbort();
   }
 
-  const auto reference_path = module_type_->getReferencePath();
-
-  output.reference_path = std::make_shared<PathWithLaneId>(reference_path);
-  output.turn_signal_info = module_type_->updateOutputTurnSignal();
-
-  path_reference_ = std::make_shared<PathWithLaneId>(reference_path);
+  module_type_->setPreviousDrivableLanes(getPreviousModuleOutput().drivable_lanes);
+  const auto output = module_type_->generateOutput();
+  *path_reference_ = *output.reference_path;
   *prev_approved_path_ = *getPreviousModuleOutput().path;
 
   updateSteeringFactorPtr(output);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -125,8 +125,8 @@ BehaviorModuleOutput LaneChangeInterface::plan()
   }
 
   module_type_->setPreviousDrivableLanes(getPreviousModuleOutput().drivable_lanes);
-  const auto output = module_type_->generateOutput();
-  *path_reference_ = *output.reference_path;
+  auto output = module_type_->generateOutput();
+  path_reference_ = output.reference_path;
   *prev_approved_path_ = *getPreviousModuleOutput().path;
 
   updateSteeringFactorPtr(output);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -117,7 +117,7 @@ BehaviorModuleOutput LaneChangeInterface::plan()
   resetPathReference();
 
   module_type_->setPreviousDrivableLanes(getPreviousModuleOutput().drivable_lanes);
-  auto output = module_type_->generatePlannedPath();
+  auto output = module_type_->generateOutput();
 
   if (!module_type_->isValidPath()) {
     return {};

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -113,7 +113,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
   resetPathReference();
   is_activated_ = isActivated();
 
-  const auto path = module_type_->generatePlannedPath();
+  auto output = module_type_->generatePlannedPath();
 
   if (!module_type_->isValidPath()) {
     return {};
@@ -123,12 +123,10 @@ BehaviorModuleOutput LaneChangeModule::plan()
     resetPathIfAbort();
   }
 
-  BehaviorModuleOutput output;
-  output.path = std::make_shared<PathWithLaneId>(path);
   output.turn_signal_info = module_type_->updateOutputTurnSignal();
 
   path_reference_ = getPreviousModuleOutput().reference_path;
-  prev_approved_path_ = path;
+  prev_approved_path_ = *output.path;
 
   updateSteeringFactorPtr(output);
   clearWaitingApproval();

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -113,7 +113,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
   resetPathReference();
   is_activated_ = isActivated();
 
-  auto output = module_type_->generatePlannedPath();
+  auto output = module_type_->generateOutput();
 
   if (!module_type_->isValidPath()) {
     return {};

--- a/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/lane_change_module.cpp
@@ -113,8 +113,6 @@ BehaviorModuleOutput LaneChangeModule::plan()
   resetPathReference();
   is_activated_ = isActivated();
 
-  auto output = module_type_->generateOutput();
-
   if (!module_type_->isValidPath()) {
     return {};
   }
@@ -123,7 +121,7 @@ BehaviorModuleOutput LaneChangeModule::plan()
     resetPathIfAbort();
   }
 
-  output.turn_signal_info = module_type_->updateOutputTurnSignal();
+  auto output = module_type_->generateOutput();
 
   path_reference_ = getPreviousModuleOutput().reference_path;
   prev_approved_path_ = *output.path;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -85,34 +85,36 @@ std::pair<bool, bool> NormalLaneChange::getSafePath(LaneChangePath & safe_path) 
   return {true, found_safe_path};
 }
 
-PathWithLaneId NormalLaneChange::generatePlannedPath()
+BehaviorModuleOutput NormalLaneChange::generatePlannedPath()
 {
-  auto path = getLaneChangePath().path;
-  generateExtendedDrivableArea(path);
+  BehaviorModuleOutput output;
+  output.path = std::make_shared<PathWithLaneId>(getLaneChangePath().path);
+
+  generateExtendedDrivableArea(output);
 
   if (isAbortState()) {
-    return path;
+    return output;
   }
 
   if (isStopState()) {
-    const auto stop_point = utils::insertStopPoint(0.1, path);
+    const auto stop_point = utils::insertStopPoint(0.1, *output.path);
   }
 
-  return path;
+  return output;
 }
 
-void NormalLaneChange::generateExtendedDrivableArea(PathWithLaneId & path)
+void NormalLaneChange::generateExtendedDrivableArea(BehaviorModuleOutput & output)
 {
   const auto & common_parameters = planner_data_->parameters;
   const auto & dp = planner_data_->drivable_area_expansion_parameters;
 
   const auto drivable_lanes = getDrivableLanes();
-  const auto shorten_lanes = utils::cutOverlappedLanes(path, drivable_lanes);
+  const auto shorten_lanes = utils::cutOverlappedLanes(*output.path, drivable_lanes);
   const auto expanded_lanes = utils::expandLanelets(
     shorten_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
     dp.drivable_area_types_to_skip);
   utils::generateDrivableArea(
-    path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
+    *output.path, expanded_lanes, common_parameters.vehicle_length, planner_data_);
 }
 bool NormalLaneChange::hasFinishedLaneChange() const
 {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -85,12 +85,12 @@ std::pair<bool, bool> NormalLaneChange::getSafePath(LaneChangePath & safe_path) 
   return {true, found_safe_path};
 }
 
-BehaviorModuleOutput NormalLaneChange::generatePlannedPath()
+BehaviorModuleOutput NormalLaneChange::generateOutput()
 {
   BehaviorModuleOutput output;
   output.path = std::make_shared<PathWithLaneId>(getLaneChangePath().path);
 
-  generateExtendedDrivableArea(output);
+  extendOutputDrivableArea(output);
 
   if (isAbortState()) {
     return output;
@@ -103,7 +103,7 @@ BehaviorModuleOutput NormalLaneChange::generatePlannedPath()
   return output;
 }
 
-void NormalLaneChange::generateExtendedDrivableArea(BehaviorModuleOutput & output)
+void NormalLaneChange::extendOutputDrivableArea(BehaviorModuleOutput & output)
 {
   const auto & common_parameters = planner_data_->parameters;
   const auto & dp = planner_data_->drivable_area_expansion_parameters;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -100,6 +100,9 @@ BehaviorModuleOutput NormalLaneChange::generateOutput()
     const auto stop_point = utils::insertStopPoint(0.1, *output.path);
   }
 
+  output.reference_path = std::make_shared<PathWithLaneId>(getReferencePath());
+  output.turn_signal_info = updateOutputTurnSignal();
+
   return output;
 }
 


### PR DESCRIPTION
## Description

For the following PR with which each module's output for drivable area will be drivable area information like drivable_lanes instead of drivable area line strings, the lane change module's output (generatePlannedPath's output) was changed from `Path` to `BehavioModuleOutput`.
https://github.com/tier4/autoware.universe/pull/373

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator works well.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
