### PR TITLE
chore(intersection): add visualization dependency

### DIFF
--- a/planning/behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/package.xml
@@ -61,6 +61,7 @@
   <depend>geometry_msgs</depend>
   <depend>grid_map_cv</depend>
   <depend>grid_map_ros</depend>
+  <exec_depend>grid_map_rviz_plugin</exec_depend>
   <depend>grid_map_utils</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>


### PR DESCRIPTION
## Description

Add `exec_depend` on `grid_map_visualization`.

## Tests performed

After installation, `GridMap` rviz plugin is available.

Note: if specified as `depend` ament_cmake fails for some reason.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
