### PR TITLE
feat(intersection): add flag to enable creep towards intersection occlusion

### DIFF
--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -31,6 +31,7 @@
       occlusion:
         enable: true
         occlusion_detection_area_length: 70.0 # [m]
+        enable_creeping: false # flag to use the creep velocity when reaching occlusion limit stop line
         occlusion_creep_velocity: 0.8333 # the creep velocity to occlusion limit stop line
         free_space_max: 43
         occupied_min: 58

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -110,7 +110,8 @@ public:
     {
       bool enable;
       double occlusion_detection_area_length;  //! used for occlusion detection
-      double occlusion_creep_velocity;         //! the creep velocity to occlusion limit stop lline
+      bool enable_creeping;
+      double occlusion_creep_velocity;  //! the creep velocity to occlusion limit stop lline
       int free_space_max;
       int occupied_min;
       bool do_dp;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -81,7 +81,7 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   ip.occlusion.enable = node.declare_parameter<bool>(ns + ".occlusion.enable");
   ip.occlusion.occlusion_detection_area_length =
     node.declare_parameter<double>(ns + ".occlusion.occlusion_detection_area_length");
-  ip.occlusion.enble_creeping = node.declare_parameter<bool>(ns + ".occlusion.enable_creeping");
+  ip.occlusion.enable_creeping = node.declare_parameter<bool>(ns + ".occlusion.enable_creeping");
   ip.occlusion.occlusion_creep_velocity =
     node.declare_parameter<double>(ns + ".occlusion.occlusion_creep_velocity");
   ip.occlusion.free_space_max = node.declare_parameter<int>(ns + ".occlusion.free_space_max");

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -81,6 +81,7 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   ip.occlusion.enable = node.declare_parameter<bool>(ns + ".occlusion.enable");
   ip.occlusion.occlusion_detection_area_length =
     node.declare_parameter<double>(ns + ".occlusion.occlusion_detection_area_length");
+  ip.occlusion.enble_creeping = node.declare_parameter<bool>(ns + ".occlusion.enable_creeping");
   ip.occlusion.occlusion_creep_velocity =
     node.declare_parameter<double>(ns + ".occlusion.occlusion_creep_velocity");
   ip.occlusion.free_space_max = node.declare_parameter<int>(ns + ".occlusion.free_space_max");

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -405,7 +405,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   if (!occlusion_activated_) {
     is_go_out_ = false;
     /* in case of creeping */
-    if (insert_creep_during_occlusion) {
+    if (insert_creep_during_occlusion && planner_param_.occlusion.enable_creeping) {
       const auto [start, end] = insert_creep_during_occlusion.value();
       for (size_t i = start; i < end; ++i) {
         planning_utils::setVelocityFromIndex(


### PR DESCRIPTION
## Description
If intersection occlusion is enabled, the creep velocity for intersection occlusion will not be used.



<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator works well
## Effects on system behavior
If intersection occlusion is enabled, the creep velocity for intersection occlusion will not be used.



<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
