### PR TITLE
feat(pull_over): minor change with drivable area expansion

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -217,7 +217,7 @@ void generateDrivableArea(
 
 void generateDrivableArea(
   PathWithLaneId & path, const double vehicle_length, const double right_offset,
-  const double left_offset, const double margin, const bool is_driving_forward = true);
+  const double left_offset, const bool is_driving_forward = true);
 
 lanelet::ConstLineStrings3d getMaximumDrivableArea(
   const std::shared_ptr<const PlannerData> & planner_data);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -216,8 +216,8 @@ void generateDrivableArea(
   const std::shared_ptr<const PlannerData> planner_data, const bool is_driving_forward = true);
 
 void generateDrivableArea(
-  PathWithLaneId & path, const double vehicle_length, const double right_offset,
-  const double left_offset, const bool is_driving_forward = true);
+  PathWithLaneId & path, const double vehicle_length, const double offset,
+  const bool is_driving_forward = true);
 
 lanelet::ConstLineStrings3d getMaximumDrivableArea(
   const std::shared_ptr<const PlannerData> & planner_data);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -216,8 +216,8 @@ void generateDrivableArea(
   const std::shared_ptr<const PlannerData> planner_data, const bool is_driving_forward = true);
 
 void generateDrivableArea(
-  PathWithLaneId & path, const double vehicle_length, const double vehicle_width,
-  const double margin, const bool is_driving_forward = true);
+  PathWithLaneId & path, const double vehicle_length, const double right_offset,
+  const double left_offset, const double margin, const bool is_driving_forward = true);
 
 lanelet::ConstLineStrings3d getMaximumDrivableArea(
   const std::shared_ptr<const PlannerData> & planner_data);

--- a/planning/behavior_path_planner/src/utils/pull_over/freespace_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/pull_over/freespace_pull_over.cpp
@@ -110,12 +110,9 @@ boost::optional<PullOverPath> FreespacePullOver::plan(const Pose & goal_pose)
       return {};
     }
 
-    const double right_offset =
-      planner_data_->parameters.vehicle_width / 2.0 + drivable_area_margin;
-    const double left_offset = planner_data_->parameters.vehicle_width / 2.0 + drivable_area_margin;
+    const double offset = planner_data_->parameters.vehicle_width / 2.0 + drivable_area_margin;
     utils::generateDrivableArea(
-      path, planner_data_->parameters.vehicle_length, right_offset, left_offset,
-      *is_driving_forward);
+      path, planner_data_->parameters.vehicle_length, offset, *is_driving_forward);
   }
 
   PullOverPath pull_over_path{};

--- a/planning/behavior_path_planner/src/utils/pull_over/freespace_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/pull_over/freespace_pull_over.cpp
@@ -110,11 +110,12 @@ boost::optional<PullOverPath> FreespacePullOver::plan(const Pose & goal_pose)
       return {};
     }
 
-    const double right_offset = planner_data_->parameters.vehicle_width / 2.0;
-    const double left_offset = planner_data_->parameters.vehicle_width / 2.0;
+    const double right_offset =
+      planner_data_->parameters.vehicle_width / 2.0 + drivable_area_margin;
+    const double left_offset = planner_data_->parameters.vehicle_width / 2.0 + drivable_area_margin;
     utils::generateDrivableArea(
       path, planner_data_->parameters.vehicle_length, right_offset, left_offset,
-      drivable_area_margin, *is_driving_forward);
+      *is_driving_forward);
   }
 
   PullOverPath pull_over_path{};

--- a/planning/behavior_path_planner/src/utils/pull_over/freespace_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/pull_over/freespace_pull_over.cpp
@@ -109,8 +109,11 @@ boost::optional<PullOverPath> FreespacePullOver::plan(const Pose & goal_pose)
       // path points is less than 2
       return {};
     }
+
+    const double right_offset = planner_data_->parameters.vehicle_width / 2.0;
+    const double left_offset = planner_data_->parameters.vehicle_width / 2.0;
     utils::generateDrivableArea(
-      path, planner_data_->parameters.vehicle_length, planner_data_->parameters.vehicle_width,
+      path, planner_data_->parameters.vehicle_length, right_offset, left_offset,
       drivable_area_margin, *is_driving_forward);
   }
 

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -971,8 +971,8 @@ void generateDrivableArea(
 
 // generate drivable area by expanding path for freespace
 void generateDrivableArea(
-  PathWithLaneId & path, const double vehicle_length, const double right_offset,
-  const double left_offset, const bool is_driving_forward)
+  PathWithLaneId & path, const double vehicle_length, const double offset,
+  const bool is_driving_forward)
 {
   using tier4_autoware_utils::calcOffsetPose;
 
@@ -1007,8 +1007,8 @@ void generateDrivableArea(
   for (const auto & point : resampled_path.points) {
     const auto & pose = point.point.pose;
 
-    const auto left_point = calcOffsetPose(pose, 0, left_offset, 0);
-    const auto right_point = calcOffsetPose(pose, 0, -right_offset, 0);
+    const auto left_point = calcOffsetPose(pose, 0, offset, 0);
+    const auto right_point = calcOffsetPose(pose, 0, -offset, 0);
 
     left_bound.push_back(left_point.position);
     right_bound.push_back(right_point.position);
@@ -1018,32 +1018,32 @@ void generateDrivableArea(
     // add backward offset point to bound
     const Pose first_point =
       calcOffsetPose(resampled_path.points.front().point.pose, -vehicle_length, 0, 0);
-    const Pose left_first_point = calcOffsetPose(first_point, 0, left_offset, 0);
-    const Pose right_first_point = calcOffsetPose(first_point, 0, -right_offset, 0);
+    const Pose left_first_point = calcOffsetPose(first_point, 0, offset, 0);
+    const Pose right_first_point = calcOffsetPose(first_point, 0, -offset, 0);
     left_bound.insert(left_bound.begin(), left_first_point.position);
     right_bound.insert(right_bound.begin(), right_first_point.position);
 
     // add forward offset point to bound
     const Pose last_point =
       calcOffsetPose(resampled_path.points.back().point.pose, vehicle_length, 0, 0);
-    const Pose left_last_point = calcOffsetPose(last_point, 0, left_offset, 0);
-    const Pose right_last_point = calcOffsetPose(last_point, 0, -right_offset, 0);
+    const Pose left_last_point = calcOffsetPose(last_point, 0, offset, 0);
+    const Pose right_last_point = calcOffsetPose(last_point, 0, -offset, 0);
     left_bound.push_back(left_last_point.position);
     right_bound.push_back(right_last_point.position);
   } else {
     // add forward offset point to bound
     const Pose first_point =
       calcOffsetPose(resampled_path.points.front().point.pose, vehicle_length, 0, 0);
-    const Pose left_first_point = calcOffsetPose(first_point, 0, left_offset, 0);
-    const Pose right_first_point = calcOffsetPose(first_point, 0, -right_offset, 0);
+    const Pose left_first_point = calcOffsetPose(first_point, 0, offset, 0);
+    const Pose right_first_point = calcOffsetPose(first_point, 0, -offset, 0);
     left_bound.insert(left_bound.begin(), left_first_point.position);
     right_bound.insert(right_bound.begin(), right_first_point.position);
 
     // add backward offset point to bound
     const Pose last_point =
       calcOffsetPose(resampled_path.points.back().point.pose, -vehicle_length, 0, 0);
-    const Pose left_last_point = calcOffsetPose(last_point, 0, left_offset, 0);
-    const Pose right_last_point = calcOffsetPose(last_point, 0, -right_offset, 0);
+    const Pose left_last_point = calcOffsetPose(last_point, 0, offset, 0);
+    const Pose right_last_point = calcOffsetPose(last_point, 0, -offset, 0);
     left_bound.push_back(left_last_point.position);
     right_bound.push_back(right_last_point.position);
   }

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -971,8 +971,8 @@ void generateDrivableArea(
 
 // generate drivable area by expanding path for freespace
 void generateDrivableArea(
-  PathWithLaneId & path, const double vehicle_length, const double vehicle_width,
-  const double margin, const bool is_driving_forward)
+  PathWithLaneId & path, const double vehicle_length, const double right_offset,
+  const double left_offset, const double margin, const bool is_driving_forward)
 {
   using tier4_autoware_utils::calcOffsetPose;
 
@@ -1007,8 +1007,8 @@ void generateDrivableArea(
   for (const auto & point : resampled_path.points) {
     const auto & pose = point.point.pose;
 
-    const auto left_point = calcOffsetPose(pose, 0, vehicle_width / 2.0 + margin, 0);
-    const auto right_point = calcOffsetPose(pose, 0, -vehicle_width / 2.0 - margin, 0);
+    const auto left_point = calcOffsetPose(pose, 0, left_offset + margin, 0);
+    const auto right_point = calcOffsetPose(pose, 0, -right_offset - margin, 0);
 
     left_bound.push_back(left_point.position);
     right_bound.push_back(right_point.position);
@@ -1018,32 +1018,32 @@ void generateDrivableArea(
     // add backward offset point to bound
     const Pose first_point =
       calcOffsetPose(resampled_path.points.front().point.pose, -vehicle_length, 0, 0);
-    const Pose left_first_point = calcOffsetPose(first_point, 0, vehicle_width / 2.0 + margin, 0);
-    const Pose right_first_point = calcOffsetPose(first_point, 0, -vehicle_width / 2.0 - margin, 0);
+    const Pose left_first_point = calcOffsetPose(first_point, 0, left_offset + margin, 0);
+    const Pose right_first_point = calcOffsetPose(first_point, 0, -right_offset - margin, 0);
     left_bound.insert(left_bound.begin(), left_first_point.position);
     right_bound.insert(right_bound.begin(), right_first_point.position);
 
     // add forward offset point to bound
     const Pose last_point =
       calcOffsetPose(resampled_path.points.back().point.pose, vehicle_length, 0, 0);
-    const Pose left_last_point = calcOffsetPose(last_point, 0, vehicle_width / 2.0 + margin, 0);
-    const Pose right_last_point = calcOffsetPose(last_point, 0, -vehicle_width / 2.0 - margin, 0);
+    const Pose left_last_point = calcOffsetPose(last_point, 0, left_offset + margin, 0);
+    const Pose right_last_point = calcOffsetPose(last_point, 0, -right_offset - margin, 0);
     left_bound.push_back(left_last_point.position);
     right_bound.push_back(right_last_point.position);
   } else {
     // add forward offset point to bound
     const Pose first_point =
       calcOffsetPose(resampled_path.points.front().point.pose, vehicle_length, 0, 0);
-    const Pose left_first_point = calcOffsetPose(first_point, 0, vehicle_width / 2.0 + margin, 0);
-    const Pose right_first_point = calcOffsetPose(first_point, 0, -vehicle_width / 2.0 - margin, 0);
+    const Pose left_first_point = calcOffsetPose(first_point, 0, left_offset + margin, 0);
+    const Pose right_first_point = calcOffsetPose(first_point, 0, -right_offset - margin, 0);
     left_bound.insert(left_bound.begin(), left_first_point.position);
     right_bound.insert(right_bound.begin(), right_first_point.position);
 
     // add backward offset point to bound
     const Pose last_point =
       calcOffsetPose(resampled_path.points.back().point.pose, -vehicle_length, 0, 0);
-    const Pose left_last_point = calcOffsetPose(last_point, 0, vehicle_width / 2.0 + margin, 0);
-    const Pose right_last_point = calcOffsetPose(last_point, 0, -vehicle_width / 2.0 - margin, 0);
+    const Pose left_last_point = calcOffsetPose(last_point, 0, left_offset + margin, 0);
+    const Pose right_last_point = calcOffsetPose(last_point, 0, -right_offset - margin, 0);
     left_bound.push_back(left_last_point.position);
     right_bound.push_back(right_last_point.position);
   }

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -972,7 +972,7 @@ void generateDrivableArea(
 // generate drivable area by expanding path for freespace
 void generateDrivableArea(
   PathWithLaneId & path, const double vehicle_length, const double right_offset,
-  const double left_offset, const double margin, const bool is_driving_forward)
+  const double left_offset, const bool is_driving_forward)
 {
   using tier4_autoware_utils::calcOffsetPose;
 
@@ -1007,8 +1007,8 @@ void generateDrivableArea(
   for (const auto & point : resampled_path.points) {
     const auto & pose = point.point.pose;
 
-    const auto left_point = calcOffsetPose(pose, 0, left_offset + margin, 0);
-    const auto right_point = calcOffsetPose(pose, 0, -right_offset - margin, 0);
+    const auto left_point = calcOffsetPose(pose, 0, left_offset, 0);
+    const auto right_point = calcOffsetPose(pose, 0, -right_offset, 0);
 
     left_bound.push_back(left_point.position);
     right_bound.push_back(right_point.position);
@@ -1018,32 +1018,32 @@ void generateDrivableArea(
     // add backward offset point to bound
     const Pose first_point =
       calcOffsetPose(resampled_path.points.front().point.pose, -vehicle_length, 0, 0);
-    const Pose left_first_point = calcOffsetPose(first_point, 0, left_offset + margin, 0);
-    const Pose right_first_point = calcOffsetPose(first_point, 0, -right_offset - margin, 0);
+    const Pose left_first_point = calcOffsetPose(first_point, 0, left_offset, 0);
+    const Pose right_first_point = calcOffsetPose(first_point, 0, -right_offset, 0);
     left_bound.insert(left_bound.begin(), left_first_point.position);
     right_bound.insert(right_bound.begin(), right_first_point.position);
 
     // add forward offset point to bound
     const Pose last_point =
       calcOffsetPose(resampled_path.points.back().point.pose, vehicle_length, 0, 0);
-    const Pose left_last_point = calcOffsetPose(last_point, 0, left_offset + margin, 0);
-    const Pose right_last_point = calcOffsetPose(last_point, 0, -right_offset - margin, 0);
+    const Pose left_last_point = calcOffsetPose(last_point, 0, left_offset, 0);
+    const Pose right_last_point = calcOffsetPose(last_point, 0, -right_offset, 0);
     left_bound.push_back(left_last_point.position);
     right_bound.push_back(right_last_point.position);
   } else {
     // add forward offset point to bound
     const Pose first_point =
       calcOffsetPose(resampled_path.points.front().point.pose, vehicle_length, 0, 0);
-    const Pose left_first_point = calcOffsetPose(first_point, 0, left_offset + margin, 0);
-    const Pose right_first_point = calcOffsetPose(first_point, 0, -right_offset - margin, 0);
+    const Pose left_first_point = calcOffsetPose(first_point, 0, left_offset, 0);
+    const Pose right_first_point = calcOffsetPose(first_point, 0, -right_offset, 0);
     left_bound.insert(left_bound.begin(), left_first_point.position);
     right_bound.insert(right_bound.begin(), right_first_point.position);
 
     // add backward offset point to bound
     const Pose last_point =
       calcOffsetPose(resampled_path.points.back().point.pose, -vehicle_length, 0, 0);
-    const Pose left_last_point = calcOffsetPose(last_point, 0, left_offset + margin, 0);
-    const Pose right_last_point = calcOffsetPose(last_point, 0, -right_offset - margin, 0);
+    const Pose left_last_point = calcOffsetPose(last_point, 0, left_offset, 0);
+    const Pose right_last_point = calcOffsetPose(last_point, 0, -right_offset, 0);
     left_bound.push_back(left_last_point.position);
     right_bound.push_back(right_last_point.position);
   }


### PR DESCRIPTION
## Description

In pull over's drivable area generation
- ~use different offsets for right and left offsets~
- margin is incorpolated into offset

working good
![image](https://user-images.githubusercontent.com/20228327/234036902-b87c67fe-e788-4462-89fa-94689ce2fe0b.png)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator works well

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
