### PR TITLE
feat(behavior_velocity_planner::intersection): add parameter for occlusion peeking offset

### DIFF
--- a/planning/behavior_velocity_planner/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/config/intersection.param.yaml
@@ -29,10 +29,11 @@
         keep_detection_vel_thr: 0.833 # == 3.0km/h. keep detection if ego is ego.vel < keep_detection_vel_thr
 
       occlusion:
-        enable: true
+        enable: false
         occlusion_detection_area_length: 70.0 # [m]
         enable_creeping: false # flag to use the creep velocity when reaching occlusion limit stop line
         occlusion_creep_velocity: 0.8333 # the creep velocity to occlusion limit stop line
+        peeking_offset: -0.1 # [m] offset for peeking into detection area
         free_space_max: 43
         occupied_min: 58
         do_dp: true

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -112,6 +112,7 @@ public:
       double occlusion_detection_area_length;  //! used for occlusion detection
       bool enable_creeping;
       double occlusion_creep_velocity;  //! the creep velocity to occlusion limit stop lline
+      double peeking_offset;
       int free_space_max;
       int occupied_min;
       bool do_dp;

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -318,11 +318,11 @@ private:
     const Polygon2d & stuck_vehicle_detect_area,
     const autoware_auto_perception_msgs::msg::PredictedObject & object) const;
 
-  std::optional<size_t> findNearestOcclusionProjectedPosition(
+  bool isOcclusionCleared(
     const nav_msgs::msg::OccupancyGrid & occ_grid,
     const std::vector<lanelet::CompoundPolygon3d> & detection_areas,
     const lanelet::CompoundPolygon3d & first_detection_area,
-    const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip, const double interval,
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip,
     const std::pair<size_t, size_t> & lane_interval,
     const std::vector<util::DetectionLaneDivision> & lane_divisions,
     const double occlusion_dist_thr) const;

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -112,9 +112,9 @@ std::optional<size_t> generateStaticPassJudgeLine(
 std::optional<size_t> generatePeekingLimitLine(
   const lanelet::CompoundPolygon3d & first_detection_area,
   autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip, const double ip_interval,
   const std::pair<size_t, size_t> lane_interval,
-  const std::shared_ptr<const PlannerData> & planner_data);
+  const std::shared_ptr<const PlannerData> & planner_data, const double offset);
 
 std::optional<size_t> getFirstPointInsidePolygon(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -109,6 +109,13 @@ std::optional<size_t> generateStaticPassJudgeLine(
   const std::pair<size_t, size_t> lane_interval,
   const std::shared_ptr<const PlannerData> & planner_data);
 
+std::optional<size_t> generatePeekingLimitLine(
+  const lanelet::CompoundPolygon3d & first_detection_area,
+  autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip,
+  const std::pair<size_t, size_t> lane_interval,
+  const std::shared_ptr<const PlannerData> & planner_data);
+
 std::optional<size_t> getFirstPointInsidePolygon(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const std::pair<size_t, size_t> lane_interval, const lanelet::CompoundPolygon3d & polygon);

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -84,6 +84,7 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   ip.occlusion.enable_creeping = node.declare_parameter<bool>(ns + ".occlusion.enable_creeping");
   ip.occlusion.occlusion_creep_velocity =
     node.declare_parameter<double>(ns + ".occlusion.occlusion_creep_velocity");
+  ip.occlusion.peeking_offset = node.declare_parameter<double>(ns + ".occlusion.peeking_offset");
   ip.occlusion.free_space_max = node.declare_parameter<int>(ns + ".occlusion.free_space_max");
   ip.occlusion.occupied_min = node.declare_parameter<int>(ns + ".occlusion.occupied_min");
   ip.occlusion.do_dp = node.declare_parameter<bool>(ns + ".occlusion.do_dp");

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -265,7 +265,8 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   const auto occlusion_peeking_line_idx_opt =
     first_detection_area
       ? util::generatePeekingLimitLine(
-          first_detection_area.value(), path, path_ip, lane_interval_ip, planner_data_)
+          first_detection_area.value(), path, path_ip, interval, lane_interval_ip, planner_data_,
+          planner_param_.occlusion.peeking_offset)
       : std::nullopt;
 
   /* a flag if front stop line is not occlusion */

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -256,17 +256,16 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   const double occlusion_dist_thr = std::fabs(
     std::pow(planner_param_.occlusion.max_vehicle_velocity_for_rss, 2) /
     (2 * planner_param_.occlusion.min_vehicle_brake_for_rss));
-  const auto occlusion_stop_line_idx_ip_opt =
+  const bool is_occlusion_cleared =
     (enable_occlusion_detection_ && first_detection_area && !occlusion_attention_lanelets.empty())
-      ? findNearestOcclusionProjectedPosition(
+      ? isOcclusionCleared(
           *planner_data_->occupancy_grid, occlusion_attention_area, first_detection_area.value(),
-          path_ip, interval, lane_detection_interval_ip, detection_divisions_.value(),
-          occlusion_dist_thr)
-      : std::nullopt;
-  const std::optional<size_t> occlusion_stop_line_idx_opt =
-    occlusion_stop_line_idx_ip_opt
-      ? util::insertPoint(
-          path_ip.points.at(occlusion_stop_line_idx_ip_opt.value()).point.pose, path)
+          path_ip, lane_detection_interval_ip, detection_divisions_.value(), occlusion_dist_thr)
+      : true;
+  const auto occlusion_peeking_line_idx_opt =
+    first_detection_area
+      ? util::generatePeekingLimitLine(
+          first_detection_area.value(), path, path_ip, lane_interval_ip, planner_data_)
       : std::nullopt;
 
   /* a flag if front stop line is not occlusion */
@@ -277,25 +276,25 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 
   /* calculate final stop lines */
   std::optional<size_t> stop_line_idx = default_stop_line_idx_opt;
-  std::optional<size_t> occlusion_stop_line_idx =
+  std::optional<size_t> occlusion_peeking_line_idx =
     default_stop_line_idx_opt;  // TODO(Mamoru Sobue): maybe different position depending on the
                                 // flag
   std::optional<size_t> occlusion_first_stop_line_idx = default_stop_line_idx_opt;
   std::optional<std::pair<size_t, size_t>> insert_creep_during_occlusion = std::nullopt;
-  if (occlusion_stop_line_idx_opt) {
+  if (!is_occlusion_cleared) {
     if (!default_stop_line_idx_opt) {
       occlusion_stop_required = true;
-      stop_line_idx = occlusion_stop_line_idx = occlusion_stop_line_idx_opt;
+      stop_line_idx = occlusion_peeking_line_idx = occlusion_peeking_line_idx_opt;
       is_occluded_ = true;
       occlusion_state_ = OcclusionState::CREEP_SECOND_STOP_LINE;
       RCLCPP_WARN(logger_, "directly stop at occlusion stop line because collision line not found");
     } else if (before_creep_state_machine_.getState() == StateMachine::State::GO) {
       occlusion_stop_required = true;
-      stop_line_idx = occlusion_stop_line_idx = occlusion_stop_line_idx_opt;
+      stop_line_idx = occlusion_peeking_line_idx = occlusion_peeking_line_idx_opt;
       // clear first stop line
       // insert creep velocity [closest_idx, occlusion_stop_line)
       insert_creep_during_occlusion =
-        std::make_pair(closest_idx, occlusion_stop_line_idx_opt.value());
+        std::make_pair(closest_idx, occlusion_peeking_line_idx_opt.value());
       is_occluded_ = true;
       occlusion_state_ = OcclusionState::CREEP_SECOND_STOP_LINE;
     } else {
@@ -310,11 +309,11 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
       }
       first_phase_stop_required = true;
       occlusion_stop_required = true;
-      occlusion_stop_line_idx = occlusion_stop_line_idx_opt;
+      occlusion_peeking_line_idx = occlusion_peeking_line_idx_opt;
       stop_line_idx = occlusion_first_stop_line_idx;
       // insert creep velocity [default_stop_line, occlusion_stop_line)
       insert_creep_during_occlusion =
-        std::make_pair(default_stop_line_idx_opt.value(), occlusion_stop_line_idx_opt.value());
+        std::make_pair(default_stop_line_idx_opt.value(), occlusion_peeking_line_idx_opt.value());
       is_occluded_ = true;
       occlusion_state_ = OcclusionState::BEFORE_FIRST_STOP_LINE;
     }
@@ -386,7 +385,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     occlusion_safety_ = false;
     occlusion_stop_distance_ = motion_utils::calcSignedArcLength(
       path->points, planner_data_->current_odometry->pose.position,
-      path->points.at(occlusion_stop_line_idx.value()).point.pose.position);
+      path->points.at(occlusion_peeking_line_idx.value()).point.pose.position);
   } else {
     /* collision */
     setSafe(collision_state_machine_.getState() == StateMachine::State::GO);
@@ -415,13 +414,14 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
         planning_utils::getAheadPose(occlusion_first_stop_line_idx.value(), baselink2front, *path);
     }
 
-    const auto reconciled_occlusion_stop_line_idx =
+    const auto reconciled_occlusion_peeking_line_idx =
       occlusion_stop_required
-        ? occlusion_stop_line_idx.value()
+        ? occlusion_peeking_line_idx.value()
         : stop_line_idx.value();  // because intersection module may miss real occlusion
-    planning_utils::setVelocityFromIndex(reconciled_occlusion_stop_line_idx, 0.0 /* [m/s] */, path);
+    planning_utils::setVelocityFromIndex(
+      reconciled_occlusion_peeking_line_idx, 0.0 /* [m/s] */, path);
     debug_data_.occlusion_stop_wall_pose =
-      planning_utils::getAheadPose(reconciled_occlusion_stop_line_idx, baselink2front, *path);
+      planning_utils::getAheadPose(reconciled_occlusion_peeking_line_idx, baselink2front, *path);
 
     RCLCPP_DEBUG(logger_, "not activated. stop at the line.");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
@@ -947,11 +947,11 @@ bool IntersectionModule::checkFrontVehicleDeceleration(
   return false;
 }
 
-std::optional<size_t> IntersectionModule::findNearestOcclusionProjectedPosition(
+bool IntersectionModule::isOcclusionCleared(
   const nav_msgs::msg::OccupancyGrid & occ_grid,
   const std::vector<lanelet::CompoundPolygon3d> & detection_areas,
   const lanelet::CompoundPolygon3d & first_detection_area,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip, const double interval,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip,
   const std::pair<size_t, size_t> & lane_interval,
   const std::vector<util::DetectionLaneDivision> & lane_divisions,
   const double occlusion_dist_thr) const
@@ -959,11 +959,9 @@ std::optional<size_t> IntersectionModule::findNearestOcclusionProjectedPosition(
   const auto first_detection_area_idx =
     util::getFirstPointInsidePolygon(path_ip, lane_interval, first_detection_area);
   if (!first_detection_area_idx) {
-    return std::nullopt;
+    return false;
   }
 
-  const double baselink2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
-  const double vehicle_width = planner_data_->vehicle_info_.vehicle_width_m;
   const int width = occ_grid.info.width;
   const int height = occ_grid.info.height;
   const double reso = occ_grid.info.resolution;
@@ -1186,25 +1184,10 @@ std::optional<size_t> IntersectionModule::findNearestOcclusionProjectedPosition(
     distance_grid_heatmap, "color", occlusion_grid);
   occlusion_grid_pub_->publish(grid_map::GridMapRosConverter::toMessage(occlusion_grid));
   if (min_cost > min_cost_thr || !min_cost_projection_ind.has_value()) {
-    return std::nullopt;
+    return true;
+  } else {
+    return false;
   }
-
-  const auto nearest_occlusion_projection_pose =
-    path_ip.points.at(min_cost_projection_ind.value()).point.pose;
-  debug_data_.nearest_occlusion_projection_point = nearest_occlusion_projection_pose.position;
-  const double tan_wall_ang = std::tan(
-    tf2::getYaw(path_ip.points.at(min_cost_projection_ind.value()).point.pose.orientation) -
-    M_PI / 2.0);
-  const double tan_projection_ang = std::atan2(
-    nearest_occlusion_projection_pose.position.y - nearest_occlusion_point.y,
-    nearest_occlusion_projection_pose.position.x - nearest_occlusion_point.x);
-  const double tan_diff_ang =
-    std::fabs((tan_wall_ang - tan_projection_ang) / (1 + tan_wall_ang * tan_projection_ang));
-  const double footprint_offset = vehicle_width / 2.0 * tan_diff_ang;
-  const size_t baselink_max_entry_ind = static_cast<size_t>(std::max<int>(
-    0,
-    first_detection_area_idx.value() - std::ceil((baselink2front + footprint_offset) / interval)));
-  return std::make_optional<size_t>(baselink_max_entry_ind);
 }
 
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -21,6 +21,8 @@
 #include <utilization/path_utilization.hpp>
 #include <utilization/util.hpp>
 
+#include <boost/geometry/algorithms/intersects.hpp>
+
 #include <lanelet2_core/geometry/Polygon.h>
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
@@ -143,6 +145,43 @@ std::optional<size_t> generateStaticPassJudgeLine(
   if (idx < 0) {
     return std::nullopt;
   }
+  const auto & insert_point = path_ip.points.at(static_cast<size_t>(idx)).point.pose;
+  const auto duplicate_idx_opt = util::getDuplicatedPointIdx(*original_path, insert_point.position);
+  if (duplicate_idx_opt) {
+    return duplicate_idx_opt;
+  } else {
+    const auto insert_idx_opt = util::insertPoint(insert_point, original_path);
+    if (!insert_idx_opt) {
+      return std::nullopt;
+    }
+    return insert_idx_opt;
+  }
+}
+
+std::optional<size_t> generatePeekingLimitLine(
+  const lanelet::CompoundPolygon3d & first_detection_area,
+  autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip,
+  const std::pair<size_t, size_t> lane_interval,
+  const std::shared_ptr<const PlannerData> & planner_data)
+{
+  const auto local_footprint = planner_data->vehicle_info_.createFootprint(0.0, 0.0);
+  const auto area_2d = lanelet::utils::to2D(first_detection_area).basicPolygon();
+  std::optional<size_t> first_collision = std::nullopt;
+  for (size_t i = 0; i <= std::get<1>(lane_interval); ++i) {
+    const auto & base_pose = path_ip.points.at(i).point.pose;
+    const auto path_footprint = tier4_autoware_utils::transformVector(
+      local_footprint, tier4_autoware_utils::pose2transform(base_pose));
+    if (bg::intersects(path_footprint, area_2d)) {
+      first_collision = i;
+      break;
+    }
+  }
+  if (!first_collision || first_collision.value() == 0) {
+    return std::nullopt;
+  }
+
+  const int idx = first_collision.value() - 1;
   const auto & insert_point = path_ip.points.at(static_cast<size_t>(idx)).point.pose;
   const auto duplicate_idx_opt = util::getDuplicatedPointIdx(*original_path, insert_point.position);
   if (duplicate_idx_opt) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -161,9 +161,9 @@ std::optional<size_t> generateStaticPassJudgeLine(
 std::optional<size_t> generatePeekingLimitLine(
   const lanelet::CompoundPolygon3d & first_detection_area,
   autoware_auto_planning_msgs::msg::PathWithLaneId * original_path,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip,
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & path_ip, const double ip_interval,
   const std::pair<size_t, size_t> lane_interval,
-  const std::shared_ptr<const PlannerData> & planner_data)
+  const std::shared_ptr<const PlannerData> & planner_data, const double offset)
 {
   const auto local_footprint = planner_data->vehicle_info_.createFootprint(0.0, 0.0);
   const auto area_2d = lanelet::utils::to2D(first_detection_area).basicPolygon();
@@ -181,7 +181,11 @@ std::optional<size_t> generatePeekingLimitLine(
     return std::nullopt;
   }
 
-  const int idx = first_collision.value() - 1;
+  const int idx = first_collision.value() - 1 + std::ceil(offset / ip_interval);
+  if (idx < 0) {
+    return std::nullopt;
+  }
+
   const auto & insert_point = path_ip.points.at(static_cast<size_t>(idx)).point.pose;
   const auto duplicate_idx_opt = util::getDuplicatedPointIdx(*original_path, insert_point.position);
   if (duplicate_idx_opt) {


### PR DESCRIPTION
## Description

I fixed the peeking position calculation by checking the collision of each footprint position on the path and detection area.

## Related links

parameter PR: https://github.com/autowarefoundation/autoware_launch/pull/320

https://tier4.atlassian.net/browse/RT1-2238

## Tests performed

### Before this PR

![image](https://user-images.githubusercontent.com/28677420/234181779-a9f93e9a-c6f5-41e3-9861-d352ff3da55c.png)

### After this PR

The peeking position is just at beginning of detection area.

![image](https://user-images.githubusercontent.com/28677420/234180180-6e85f05f-6272-4264-bf01-4ba947a67079.png)

## Interface changes

Not applicable

## Effects on system behavior

Not applicable

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
