### PR TITLE
fix(behavior_velocity_planner::intersection): strictly wait at 1st stop line when occlusion is detected

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -289,8 +289,13 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
       is_occluded_ = true;
       occlusion_state_ = OcclusionState::CREEP_SECOND_STOP_LINE;
     } else {
+      const bool approached_stop_line =
+        motion_utils::calcSignedArcLength(
+          path_ip.points, current_pose.position,
+          path->points.at(default_stop_line_idx_opt.value()).point.pose.position) <
+        planner_param_.common.stop_overshoot_margin;
       const bool is_stopped = planner_data_->isVehicleStopped();
-      if (is_stopped) {
+      if (is_stopped && approached_stop_line) {
         // start waiting at the first stop line
         before_creep_state_machine_.setStateWithMarginTime(
           StateMachine::State::GO, logger_.get_child("occlusion state_machine"), *clock_);

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -389,7 +389,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   }
 
   /* make decision */
-  const double baselink2front = planner_data_->vehicle_info_.vehicle_length_m;
+  const double baselink2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
   if (!occlusion_activated_) {
     is_go_out_ = false;
     /* in case of creeping */


### PR DESCRIPTION
## Description

Tighten the condition for first phase stop timeout by starting waiting when vehicle get stopped.

## Related links

https://tier4.atlassian.net/browse/RT1-2240

## Tests performed

### Before this PR

The vehicle does not wait for 1sec exaclty.

https://user-images.githubusercontent.com/28677420/234219918-82f93848-7866-41d0-b08f-920f0b4e7b23.mp4


### After this PR

The vehicle waits for 1sec.

https://user-images.githubusercontent.com/28677420/234218075-5c6a2e56-11e9-4e6c-802d-ef3c6bdd34c8.mp4


## Notes for reviewers

Not applicable

## Interface changes

Not applicable

## Effects on system behavior

The vehicle will wait for exactly specified time
 
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
