### PR TITLE
fix(obstacle_avoidance_planner): fix node die

### DIFF
--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -887,7 +887,7 @@ void MPTOptimizer::avoidSuddenSteering(
   if (!prev_ref_points_ptr_) {
     return;
   }
-  const size_t prev_idx = trajectory_utils::findEgoIndex(
+  const size_t prev_ego_idx = trajectory_utils::findEgoIndex(
     *prev_ref_points_ptr_, tier4_autoware_utils::getPose(ref_points.front()), ego_nearest_param_);
 
   const double max_bound_fixing_length = ego_vel * mpt_param_.max_bound_fixing_time;
@@ -899,7 +899,9 @@ void MPTOptimizer::avoidSuddenSteering(
     std::min(ego_idx + static_cast<size_t>(max_bound_fixing_idx), ref_points.size());
 
   for (size_t i = 0; i < max_fixed_bound_idx; ++i) {
-    const auto & prev_bounds = prev_ref_points_ptr_->at(prev_idx + i).bounds;
+    const size_t prev_idx = std::min(
+      prev_ego_idx + i, static_cast<size_t>(static_cast<int>(prev_ref_points_ptr_->size()) - 1));
+    const auto & prev_bounds = prev_ref_points_ptr_->at(prev_idx).bounds;
 
     ref_points.at(i).bounds.upper_bound = prev_bounds.upper_bound;
     ref_points.at(i).bounds.lower_bound = prev_bounds.lower_bound;


### PR DESCRIPTION
## Description

Without this PR, the obstacle_avoidance_planner node will die due to the invalid access of the vector.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
