### PR TITLE
fix(behavior_path_planner): fix executing goal_planner when goal is before ego

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -345,7 +345,7 @@ bool GoalPlannerModule::isExecutionRequested() const
     route_handler->isAllowedGoalModification() || checkOriginalGoalIsInShoulder();
   const double request_length =
     allow_goal_modification ? calcModuleRequestLength() : parameters_->minimum_request_length;
-  if (self_to_goal_arc_length > request_length) {
+  if (self_to_goal_arc_length < 0.0 || self_to_goal_arc_length > request_length) {
     return false;
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

fix executing goal_planner when goal is before ego by considering negative `self_to_goal_arc_length`  value.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->



psim 

goal_planner is not executed and avoidance can be run.

![Screenshot from 2023-04-26 15-17-05](https://user-images.githubusercontent.com/39142679/234487112-dc6aed58-ab48-4a4b-87e1-1720f72f47bb.png)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

no

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

can set goal before ego

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
