### PR TITLE
refactor(behavior_path_planner): remove dupliated lane change parameters

### DIFF
--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -46,9 +46,6 @@
       drivable_area_left_bound_offset: 0.0
       drivable_area_types_to_skip: [road_border]
 
-    lane_change:
-      lane_change_prepare_duration: 4.0
-
     closest_lanelet:
       distance_threshold: 5.0 # [m]
       yaw_threshold: 0.79 # [rad]

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -59,6 +59,7 @@ struct BehaviorPathPlannerParameters
   double lane_changing_lateral_acc_at_low_velocity{0.15};
   double lateral_acc_switching_velocity{0.4};
   double minimum_lane_changing_velocity{5.6};
+  double lane_change_prepare_duration{4.0};
   double minimum_prepare_length;
 
   double minimum_pull_over_length;
@@ -110,9 +111,6 @@ struct BehaviorPathPlannerParameters
 
   double rear_vehicle_reaction_time;
   double rear_vehicle_safety_time_margin;
-
-  // lane change
-  double lane_change_prepare_duration;
 };
 
 #endif  // BEHAVIOR_PATH_PLANNER__PARAMETERS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -26,7 +26,6 @@ namespace behavior_path_planner
 struct LaneChangeParameters
 {
   // trajectory generation
-  double prepare_duration{2.0};
   double lane_change_finish_judge_buffer{3.0};
   double prediction_time_resolution{0.5};
   int lane_change_sampling_num{10};

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -394,8 +394,7 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
     declare_parameter<double>("lane_change.lateral_acc_switching_velocity");
   p.minimum_lane_changing_velocity =
     declare_parameter<double>("lane_change.minimum_lane_changing_velocity");
-  p.lane_change_prepare_duration =
-    declare_parameter<double>("lane_change.lane_change_prepare_duration");
+  p.lane_change_prepare_duration = declare_parameter<double>("lane_change.prepare_duration");
   p.minimum_prepare_length =
     0.5 * p.max_acc * p.lane_change_prepare_duration * p.lane_change_prepare_duration;
 
@@ -652,7 +651,6 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   const auto parameter = [](std::string && name) { return "lane_change." + name; };
 
   // trajectory generation
-  p.prepare_duration = declare_parameter<double>(parameter("prepare_duration"));
   p.lane_change_finish_judge_buffer =
     declare_parameter<double>(parameter("lane_change_finish_judge_buffer"));
   p.prediction_time_resolution = declare_parameter<double>(parameter("prediction_time_resolution"));

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -535,7 +535,7 @@ PathWithLaneId AvoidanceByLCModule::getReferencePath() const
     utils::calcMinimumLaneChangeLength(common_parameters, shift_intervals);
 
   reference_path = utils::setDecelerationVelocity(
-    *route_handler, reference_path, current_lanes, parameters_->lane_change->prepare_duration,
+    *route_handler, reference_path, current_lanes, common_parameters.lane_change_prepare_duration,
     lane_change_buffer);
 
   const auto drivable_lanes = utils::generateDrivableLanes(current_lanes);
@@ -552,7 +552,7 @@ lanelet::ConstLanelets AvoidanceByLCModule::getLaneChangeLanes(
   lanelet::ConstLanelets lane_change_lanes;
   const auto & route_handler = planner_data_->route_handler;
   const auto minimum_prepare_length = planner_data_->parameters.minimum_prepare_length;
-  const auto prepare_duration = parameters_->lane_change->prepare_duration;
+  const auto prepare_duration = planner_data_->parameters.lane_change_prepare_duration;
   const auto current_pose = getEgoPose();
   const auto current_twist = getEgoTwist();
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/bt_normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/bt_normal.cpp
@@ -66,7 +66,7 @@ PathWithLaneId NormalLaneChangeBT::getReferencePath() const
     utils::calcMinimumLaneChangeLength(common_parameters, shift_intervals);
 
   reference_path = utils::setDecelerationVelocity(
-    *route_handler, reference_path, current_lanes, parameters_->prepare_duration,
+    *route_handler, reference_path, current_lanes, common_parameters.lane_change_prepare_duration,
     lane_change_buffer);
 
   const auto & dp = planner_data_->drivable_area_expansion_parameters;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -240,8 +240,9 @@ lanelet::ConstLanelets NormalLaneChange::getLaneChangeLanes(
 
   const auto minimum_prepare_length = planner_data_->parameters.minimum_prepare_length;
 
-  const auto lane_change_prepare_length =
-    std::max(getEgoVelocity() * parameters_->prepare_duration, minimum_prepare_length);
+  const auto lane_change_prepare_length = std::max(
+    getEgoVelocity() * planner_data_->parameters.lane_change_prepare_duration,
+    minimum_prepare_length);
 
   const auto & route_handler = getRouteHandler();
 
@@ -304,7 +305,7 @@ bool NormalLaneChange::getLaneChangePaths(
 
   const auto backward_path_length = common_parameter.backward_path_length;
   const auto forward_path_length = common_parameter.forward_path_length;
-  const auto prepare_duration = parameters_->prepare_duration;
+  const auto prepare_duration = common_parameter.lane_change_prepare_duration;
   const auto minimum_prepare_length = common_parameter.minimum_prepare_length;
   const auto minimum_lane_changing_velocity = common_parameter.minimum_lane_changing_velocity;
   const auto lane_change_sampling_num = parameters_->lane_change_sampling_num;
@@ -315,8 +316,8 @@ bool NormalLaneChange::getLaneChangePaths(
   // compute maximum_deceleration
   const auto maximum_deceleration =
     std::invoke([&minimum_lane_changing_velocity, &current_velocity, &common_parameter, this]() {
-      const double min_a =
-        (minimum_lane_changing_velocity - current_velocity) / parameters_->prepare_duration;
+      const double min_a = (minimum_lane_changing_velocity - current_velocity) /
+                           common_parameter.lane_change_prepare_duration;
       return std::clamp(
         min_a, -std::abs(common_parameter.min_acc), -std::numeric_limits<double>::epsilon());
     });
@@ -561,7 +562,7 @@ void NormalLaneChange::calcTurnSignalInfo()
 
   turn_signal_info.desired_start_point = std::invoke([&]() {
     const auto blinker_start_duration = planner_data_->parameters.turn_signal_search_time;
-    const auto prepare_duration = parameters_->prepare_duration;
+    const auto prepare_duration = planner_data_->parameters.lane_change_prepare_duration;
     const auto diff_time = prepare_duration - blinker_start_duration;
     if (diff_time < 1e-5) {
       return path.path.points.front().point.pose;

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -136,7 +136,7 @@ std::optional<LaneChangePath> constructCandidatePath(
   candidate_path.length.lane_changing = lane_changing_length;
   candidate_path.duration.prepare = std::invoke([&]() {
     const auto duration = prepare_length / lane_change_velocity.prepare;
-    return std::min(duration, lane_change_param.prepare_duration);
+    return std::min(duration, common_parameter.lane_change_prepare_duration);
   });
   candidate_path.duration.lane_changing = std::invoke([&]() {
     const auto rounding_multiplier = 1.0 / lane_change_param.prediction_time_resolution;
@@ -222,7 +222,7 @@ bool getLaneChangePaths(
   // rename parameter
   const auto backward_path_length = common_parameter.backward_path_length;
   const auto forward_path_length = common_parameter.forward_path_length;
-  const auto prepare_duration = parameter.prepare_duration;
+  const auto prepare_duration = common_parameter.lane_change_prepare_duration;
   const auto minimum_lane_changing_velocity = common_parameter.minimum_lane_changing_velocity;
   const auto lane_change_sampling_num = parameter.lane_change_sampling_num;
 
@@ -232,8 +232,8 @@ bool getLaneChangePaths(
   // compute maximum_deceleration
   const auto maximum_deceleration = std::invoke(
     [&minimum_lane_changing_velocity, &current_velocity, &common_parameter, &parameter]() {
-      const double min_a =
-        (minimum_lane_changing_velocity - current_velocity) / parameter.prepare_duration;
+      const double min_a = (minimum_lane_changing_velocity - current_velocity) /
+                           common_parameter.lane_change_prepare_duration;
       return std::clamp(
         min_a, -std::abs(common_parameter.min_acc), -std::numeric_limits<double>::epsilon());
     });
@@ -491,7 +491,7 @@ bool isLaneChangePathSafe(
 
   const double check_start_time = check_at_prepare_phase ? 0.0 : lane_change_path.duration.prepare;
   const double check_end_time = lane_change_path.duration.sum();
-  const double & prepare_duration = lane_change_parameter.prepare_duration;
+  const double & prepare_duration = common_parameter.lane_change_prepare_duration;
 
   const auto current_seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
     path.points, current_pose, common_parameter.ego_nearest_dist_threshold,


### PR DESCRIPTION
## Description
Remove duplicated lane change parameter. i.e. `lane_change_prepare_duration`.

[Related PR](https://github.com/autowarefoundation/autoware_launch/pull/328)
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
