### PR TITLE
feat(lane_change): extend lane change path

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -21,6 +21,7 @@
 #include "behavior_path_planner/utils/lane_change/lane_change_path.hpp"
 #include "behavior_path_planner/utils/lane_change/utils.hpp"
 #include "behavior_path_planner/utils/path_shifter/path_shifter.hpp"
+#include "behavior_path_planner/utils/path_utils.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -45,7 +46,10 @@ using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
 using marker_utils::CollisionCheckDebugMap;
+using motion_utils::calcSignedArcLength;
+using motion_utils::findFirstNearestSegmentIndexWithSoftConstraints;
 using route_handler::Direction;
+using tier4_autoware_utils::getPose;
 using tier4_planning_msgs::msg::LaneChangeDebugMsg;
 using tier4_planning_msgs::msg::LaneChangeDebugMsgArray;
 
@@ -179,6 +183,8 @@ protected:
   virtual lanelet::ConstLanelets getCurrentLanes() const = 0;
 
   virtual int getNumToPreferredLane(const lanelet::ConstLanelet & lane) const = 0;
+
+  virtual PathWithLaneId getExtendPath(const PathWithLaneId & path) const = 0;
 
   virtual PathWithLaneId getPrepareSegment(
     const lanelet::ConstLanelets & current_lanes, const double arc_length_from_current,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -72,6 +72,8 @@ protected:
 
   int getNumToPreferredLane(const lanelet::ConstLanelet & lane) const override;
 
+  PathWithLaneId getExtendPath(const PathWithLaneId & path) const override;
+
   PathWithLaneId getPrepareSegment(
     const lanelet::ConstLanelets & current_lanes, const double arc_length_from_current,
     const double backward_path_length, const double prepare_length,


### PR DESCRIPTION
## Description

Current lane change module decides lane change path and never update until the LC behavior finishing. Therefore, output lane change path is shorter than `forward_path_length`.

![rviz_screenshot_2023_04_24-09_25_23](https://user-images.githubusercontent.com/44889564/234511202-ec182352-6694-4b49-a6f4-89d43106e99c.png)

In this PR, I fixed path generation logic so that the module keeps generating same length (backward: `backward_path_length`, forward: `forward_path_length`) output path.

https://user-images.githubusercontent.com/44889564/234509546-fef10c5e-d8cb-49b9-a4f6-3bd31dd7a8b9.mp4

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
