### PR TITLE
feat(tier4_planning_rviz_plugin): remove z offset from the bound

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/path/display.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display.hpp
@@ -63,13 +63,13 @@ void visualizeBound(
     auto target_lp = bound.at(i);
     target_lp.x = target_lp.x - x_offset;
     target_lp.y = target_lp.y + y_offset;
-    target_lp.z = target_lp.z + 0.5;
+    target_lp.z = target_lp.z;
     bound_object->position(target_lp.x, target_lp.y, target_lp.z);
     bound_object->colour(color);
     auto target_rp = bound.at(i);
     target_rp.x = target_rp.x + x_offset;
     target_rp.y = target_rp.y - y_offset;
-    target_rp.z = target_rp.z + 0.5;
+    target_rp.z = target_rp.z;
     bound_object->position(target_rp.x, target_rp.y, target_rp.z);
     bound_object->colour(color);
   }


### PR DESCRIPTION
## Description
Remove z offset from the left and right bound to clean the visualization.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
