### PR TITLE
fix(intersection): fixed to restart after occlusion is cleared

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -387,7 +387,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
       occlusion_first_stop_safety_ = false;
       occlusion_first_stop_distance_ = dist_1st_stopline;
     }
-    occlusion_safety_ = false;
+    occlusion_safety_ = is_occlusion_cleared;
     occlusion_stop_distance_ = dist_2nd_stopline;
   } else {
     /* collision */


### PR DESCRIPTION
## Description

Prior this PR, ego vehicle keeps stopping at the peeking stop line after occlusion gets cleared.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

RTC works as before.

### Before this PR

ego stucks

https://user-images.githubusercontent.com/28677420/234611335-7c5fa991-b2af-47cd-b375-c6c20f05c94b.mp4

### After this PR

https://user-images.githubusercontent.com/28677420/234610279-09d2bdf0-b587-45f5-8639-d392631b5557.mp4

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

ego restarts after occlusion is cleared.

## Effects on system behavior

ego restarts after occlusion is cleared.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
