### PR TITLE
fix(obstacle_stop_planner): fix the issues when use_predicted_objects true

### DIFF
--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/adaptive_cruise_control.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/adaptive_cruise_control.hpp
@@ -16,6 +16,7 @@
 #define OBSTACLE_STOP_PLANNER__ADAPTIVE_CRUISE_CONTROL_HPP_
 
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
@@ -32,6 +33,7 @@ namespace motion_planning
 {
 using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
+using autoware_auto_perception_msgs::msg::PredictedObject;
 class AdaptiveCruiseController
 {
 public:
@@ -46,6 +48,14 @@ public:
     const autoware_auto_perception_msgs::msg::PredictedObjects::ConstSharedPtr object_ptr,
     const nav_msgs::msg::Odometry::ConstSharedPtr current_velocity_ptr, bool * need_to_stop,
     TrajectoryPoints * output_trajectory, const std_msgs::msg::Header trajectory_header);
+
+  void insertAdaptiveCruiseVelocity(
+    const TrajectoryPoints & trajectory, const int nearest_collision_point_idx,
+    const geometry_msgs::msg::Pose self_pose, const pcl::PointXYZ & nearest_collision_point,
+    const rclcpp::Time nearest_collision_point_time,
+    const nav_msgs::msg::Odometry::ConstSharedPtr current_velocity_ptr, bool * need_to_stop,
+    TrajectoryPoints * output_trajectory, const std_msgs::msg::Header trajectory_header,
+    const PredictedObject & target_object);
 
 private:
   rclcpp::Publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr pub_debug_;
@@ -187,6 +197,8 @@ private:
   bool estimatePointVelocityFromPcl(
     const double traj_yaw, const pcl::PointXYZ & nearest_collision_point,
     const rclcpp::Time & nearest_collision_point_time, double * velocity);
+  void calculateProjectedVelocityFromObject(
+    const PredictedObject & object, const double traj_yaw, double * velocity);
   double estimateRoughPointVelocity(double current_vel);
   bool isObstacleVelocityHigh(const double obj_vel);
   double calcUpperVelocity(const double dist_to_col, const double obj_vel, const double self_vel);

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -88,7 +88,7 @@ using vehicle_info_util::VehicleInfo;
 
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
-
+using autoware_auto_perception_msgs::msg::PredictedObject;
 struct ObstacleWithDetectionTime
 {
   explicit ObstacleWithDetectionTime(const rclcpp::Time & t, pcl::PointXYZ & p)
@@ -102,13 +102,15 @@ struct ObstacleWithDetectionTime
 
 struct PredictedObjectWithDetectionTime
 {
-  explicit PredictedObjectWithDetectionTime(const rclcpp::Time & t, Pose & p)
-  : detection_time(t), point(p)
+  explicit PredictedObjectWithDetectionTime(
+    const rclcpp::Time & t, geometry_msgs::msg::Point & p, PredictedObject obj)
+  : detection_time(t), point(p), object(std::move(obj))
   {
   }
 
   rclcpp::Time detection_time;
-  Pose point;
+  geometry_msgs::msg::Point point;
+  PredictedObject object;
 };
 
 class ObstacleStopPlannerNode : public rclcpp::Node
@@ -173,8 +175,9 @@ private:
     const StopParam & stop_param, const PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr);
 
   void searchPredictedObject(
-    const TrajectoryPoints & decimate_trajectory, PlannerData & planner_data,
-    const VehicleInfo & vehicle_info, const StopParam & stop_param);
+    const TrajectoryPoints & decimate_trajectory, TrajectoryPoints & output,
+    PlannerData & planner_data, const Header & trajectory_header, const VehicleInfo & vehicle_info,
+    const StopParam & stop_param);
 
   void insertVelocity(
     TrajectoryPoints & trajectory, PlannerData & planner_data, const Header & trajectory_header,

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
@@ -17,6 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_auto_perception_msgs/msg/predicted_object.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/pose.hpp>
@@ -248,6 +249,8 @@ struct PlannerData
   pcl::PointXYZ nearest_slow_down_point;
 
   pcl::PointXYZ lateral_nearest_slow_down_point;
+
+  autoware_auto_perception_msgs::msg::Shape slow_down_object_shape{};
 
   Pose nearest_collision_point_pose{};
 

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_utils.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_utils.hpp
@@ -21,6 +21,7 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
+#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/point.hpp>
@@ -28,6 +29,7 @@
 #include <geometry_msgs/msg/pose_array.hpp>
 
 #include <boost/optional.hpp>
+#include <boost/variant.hpp>
 
 #include <map>
 #include <string>
@@ -54,6 +56,9 @@ using vehicle_info_util::VehicleInfo;
 
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
+using autoware_auto_perception_msgs::msg::PredictedObject;
+using autoware_auto_perception_msgs::msg::PredictedObjects;
+using PointVariant = boost::variant<float, double>;
 
 boost::optional<std::pair<double, double>> calcFeasibleMarginAndVelocity(
   const SlowDownParam & slow_down_param, const double dist_baselink_to_obstacle,
@@ -101,12 +106,12 @@ void getLateralNearestPoint(
   const PointCloud & pointcloud, const Pose & base_pose, pcl::PointXYZ * lateral_nearest_point,
   double * deviation);
 
-void getNearestPointForPredictedObject(
-  const PoseArray & object, const Pose & base_pose, Pose * nearest_collision_point,
-  rclcpp::Time * nearest_collision_point_time);
+double getNearestPointAndDistanceForPredictedObject(
+  const geometry_msgs::msg::PoseArray & points, const Pose & base_pose,
+  geometry_msgs::msg::Point * nearest_collision_point);
 
 void getLateralNearestPointForPredictedObject(
-  const PoseArray & object, const Pose & base_pose, Pose * lateral_nearest_point,
+  const PoseArray & object, const Pose & base_pose, pcl::PointXYZ * lateral_nearest_point,
   double * deviation);
 
 Pose getVehicleCenterFromBase(const Pose & base_pose, const VehicleInfo & vehicle_info);
@@ -136,6 +141,13 @@ TrajectoryPoints extendTrajectory(const TrajectoryPoints & input, const double e
 
 TrajectoryPoint getExtendTrajectoryPoint(
   double extend_distance, const TrajectoryPoint & goal_point);
+
+bool intersectsInZAxis(const PredictedObject & object, const double z_min, const double z_max);
+
+pcl::PointXYZ pointToPcl(const double x, const double y, const double z);
+
+boost::optional<PredictedObject> getObstacleFromUuid(
+  const PredictedObjects & obstacles, const unique_identifier_msgs::msg::UUID & target_object_id);
 
 rclcpp::SubscriptionOptions createSubscriptionOptions(rclcpp::Node * node_ptr);
 

--- a/planning/obstacle_stop_planner/src/planner_utils.cpp
+++ b/planning/obstacle_stop_planner/src/planner_utils.cpp
@@ -27,6 +27,8 @@
 namespace motion_planning
 {
 
+using autoware_auto_perception_msgs::msg::PredictedObject;
+using autoware_auto_perception_msgs::msg::PredictedObjects;
 using motion_utils::calcDecelDistWithJerkAndAccConstraints;
 using motion_utils::findFirstNearestIndexWithSoftConstraints;
 using motion_utils::findFirstNearestSegmentIndexWithSoftConstraints;
@@ -467,6 +469,31 @@ TrajectoryPoints extendTrajectory(const TrajectoryPoints & input, const double e
   return output;
 }
 
+bool intersectsInZAxis(const PredictedObject & object, const double z_min, const double z_max)
+{
+  const auto & obj_pose = object.kinematics.initial_pose_with_covariance;
+  const auto & obj_height = object.shape.dimensions.z;
+  return obj_pose.pose.position.z - obj_height / 2.0 <= z_max &&
+         obj_pose.pose.position.z + obj_height / 2.0 >= z_min;
+}
+
+pcl::PointXYZ pointToPcl(const double x, const double y, const double z)
+{
+  // Store the point components in a variant
+  PointVariant x_variant = x;
+  PointVariant y_variant = y;
+  PointVariant z_variant = z;
+
+  // Extract the corresponding components from the variant
+  auto extract_float = [](const auto & variant) { return boost::get<float>(variant); };
+  float pcl_x = boost::apply_visitor(extract_float, x_variant);
+  float pcl_y = boost::apply_visitor(extract_float, y_variant);
+  float pcl_z = boost::apply_visitor(extract_float, z_variant);
+
+  // Create a new pcl::PointXYZ object
+  return {pcl_x, pcl_y, pcl_z};
+}
+
 bool getSelfPose(const Header & header, const tf2_ros::Buffer & tf_buffer, Pose & self_pose)
 {
   try {
@@ -527,34 +554,34 @@ void getLateralNearestPoint(
   *deviation = min_norm;
 }
 
-void getNearestPointForPredictedObject(
-  const PoseArray & object, const Pose & base_pose, Pose * nearest_collision_point,
-  rclcpp::Time * nearest_collision_point_time)
+double getNearestPointAndDistanceForPredictedObject(
+  const geometry_msgs::msg::PoseArray & points, const Pose & base_pose,
+  geometry_msgs::msg::Point * nearest_collision_point)
 {
   double min_norm = 0.0;
   bool is_init = false;
 
-  for (const auto & p : object.poses) {
-    double norm = calcDistance2d(p, base_pose);
+  for (const auto & p : points.poses) {
+    double norm = tier4_autoware_utils::calcDistance2d(p, base_pose);
     if (norm < min_norm || !is_init) {
       min_norm = norm;
-      *nearest_collision_point = p;
-      *nearest_collision_point_time = (object.header).stamp;
+      *nearest_collision_point = p.position;
       is_init = true;
     }
   }
+  return min_norm;
 }
 
 void getLateralNearestPointForPredictedObject(
-  const PoseArray & object, const Pose & base_pose, Pose * lateral_nearest_point,
+  const PoseArray & object, const Pose & base_pose, pcl::PointXYZ * lateral_nearest_point,
   double * deviation)
 {
   double min_norm = std::numeric_limits<double>::max();
-  for (size_t i = 0; i < object.poses.size(); ++i) {
-    double norm = calcDistance2d(object.poses.at(i), base_pose);
+  for (const auto & pose : object.poses) {
+    double norm = calcDistance2d(pose, base_pose);
     if (norm < min_norm) {
       min_norm = norm;
-      *lateral_nearest_point = object.poses.at(i);
+      *lateral_nearest_point = pointToPcl(pose.position.x, pose.position.y, base_pose.position.z);
     }
   }
   *deviation = min_norm;
@@ -658,4 +685,19 @@ Polygon2d convertPolygonObjectToGeometryPolygon(
                      : tier4_autoware_utils::inverseClockwise(object_polygon);
   return object_polygon;
 }
+
+boost::optional<PredictedObject> getObstacleFromUuid(
+  const PredictedObjects & obstacles, const unique_identifier_msgs::msg::UUID & target_object_id)
+{
+  const auto itr = std::find_if(
+    obstacles.objects.begin(), obstacles.objects.end(), [&](PredictedObject predicted_object) {
+      return predicted_object.object_id == target_object_id;
+    });
+
+  if (itr == obstacles.objects.end()) {
+    return boost::none;
+  }
+  return boost::make_optional(*itr);
+}
+
 }  // namespace motion_planning


### PR DESCRIPTION

## Description

<!-- Write a brief description of this PR. -->

In obstacle_stop_planner, use_predicted_object option was added but it does not work as we wanted. Firstly, there are some bugs while checking the obstacle. For example, it uses the last collision footprint to set collision point.

![Screenshot from 2023-04-26 23-54-30](https://user-images.githubusercontent.com/45468306/234700083-1a57548b-9047-40a5-a2f8-c2a7e873b1bf.png)

Also, it checks only intersected points while checking collision, however, corner points also need to be checked.

![Screenshot from 2023-04-15 18-01-36](https://user-images.githubusercontent.com/45468306/234700154-0657c8d3-914f-47c9-9acc-c9148fc9e7d1.png)

Also I needed make some changes in adaptive_cruise_planner while using predicted objects, because perception side is estimating obstacle velocity, adaptive_cruise_control does not need to estimate the velocity.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

For Z-Axis-Filtering: 

![Screenshot from 2023-04-26 09-38-13](https://user-images.githubusercontent.com/45468306/234703728-4d421563-9447-4174-8fc2-fc4a9148fea2.png)

Stop test: 


https://user-images.githubusercontent.com/45468306/234703822-f77bb994-44c5-4cea-91b1-fb4b973e74b0.mp4

Vehicle following:


https://user-images.githubusercontent.com/45468306/234703863-45086564-16a7-4bf9-82fb-0c5840198111.mp4

Slow-down:


https://user-images.githubusercontent.com/45468306/234703885-1a831ab6-36a1-434f-bb34-e3e90ddc2538.mp4



<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

There is no effect for system behavior, all things working as we wanted.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
