### PR TITLE
refactor(obstacle_stop_planner): remove unnecessary variables and functions, improve code performance

### DIFF
--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_data.hpp
@@ -258,12 +258,6 @@ struct PlannerData
 
   autoware_auto_perception_msgs::msg::Shape slow_down_object_shape{};
 
-  Pose nearest_collision_point_pose{};
-
-  Pose nearest_slow_down_point_pose{};
-
-  Pose lateral_nearest_slow_down_point_pose{};
-
   rclcpp::Time nearest_collision_point_time{};
 
   double lateral_deviation{0.0};

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_utils.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/planner_utils.hpp
@@ -96,8 +96,6 @@ void createOneStepPolygon(
   const Pose & base_step_pose, const Pose & next_step_pose, Polygon2d & hull_polygon,
   const VehicleInfo & vehicle_info, const double expand_width = 0.0);
 
-bool getSelfPose(const Header & header, const tf2_ros::Buffer & tf_buffer, Pose & self_pose);
-
 void getNearestPoint(
   const PointCloud & pointcloud, const Pose & base_pose, pcl::PointXYZ * nearest_collision_point,
   rclcpp::Time * nearest_collision_point_time);

--- a/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -341,7 +341,7 @@ void AdaptiveCruiseController::calcDistanceToNearestPointOnPath(
   const rclcpp::Time & nearest_collision_point_time, double * distance,
   const std_msgs::msg::Header & trajectory_header)
 {
-  if (trajectory.size() == 0) {
+  if (trajectory.empty()) {
     RCLCPP_DEBUG_THROTTLE(
       node_->get_logger(), *node_->get_clock(), std::chrono::milliseconds(1000).count(),
       "input path is too short(size=0)");

--- a/planning/obstacle_stop_planner/src/planner_utils.cpp
+++ b/planning/obstacle_stop_planner/src/planner_utils.cpp
@@ -494,25 +494,6 @@ pcl::PointXYZ pointToPcl(const double x, const double y, const double z)
   return {pcl_x, pcl_y, pcl_z};
 }
 
-bool getSelfPose(const Header & header, const tf2_ros::Buffer & tf_buffer, Pose & self_pose)
-{
-  try {
-    TransformStamped transform;
-    transform = tf_buffer.lookupTransform(
-      header.frame_id, "base_link", header.stamp, rclcpp::Duration::from_seconds(0.1));
-    self_pose.position.x = transform.transform.translation.x;
-    self_pose.position.y = transform.transform.translation.y;
-    self_pose.position.z = transform.transform.translation.z;
-    self_pose.orientation.x = transform.transform.rotation.x;
-    self_pose.orientation.y = transform.transform.rotation.y;
-    self_pose.orientation.z = transform.transform.rotation.z;
-    self_pose.orientation.w = transform.transform.rotation.w;
-    return true;
-  } catch (tf2::TransformException & ex) {
-    return false;
-  }
-}
-
 void getNearestPoint(
   const PointCloud & pointcloud, const Pose & base_pose, pcl::PointXYZ * nearest_collision_point,
   rclcpp::Time * nearest_collision_point_time)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
In obstacle_stop_planner, I removed the unused function and variables. Also in some parts, pushPolygon function is called unnecessarily. Also to increase code efficiency, some changes made.

This should be merged after following PRs merged.

https://github.com/autowarefoundation/autoware.universe/pull/3556
https://github.com/autowarefoundation/autoware.universe/pull/3558

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Tested in planning simulator and worked well.
Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
