### PR TITLE
chore(behavior_path_planner): remove open cv dependency

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -23,7 +23,6 @@
 #include "motion_utils/motion_utils.hpp"
 #include "perception_utils/predicted_path_utils.hpp"
 
-#include <opencv2/opencv.hpp>
 #include <route_handler/route_handler.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -54,7 +54,6 @@
   <depend>lane_departure_checker</depend>
   <depend>lanelet2_extension</depend>
   <depend>libboost-dev</depend>
-  <depend>libopencv-dev</depend>
   <depend>magic_enum</depend>
   <depend>motion_utils</depend>
   <depend>perception_utils</depend>

--- a/planning/behavior_path_planner/test/input.cpp
+++ b/planning/behavior_path_planner/test/input.cpp
@@ -32,7 +32,7 @@ PathWithLaneId generateStraightSamplePathWithLaneId(
 
     PathPointWithLaneId path_point_with_lane_id;
     path_point_with_lane_id.point = point;
-    path_point_with_lane_id.lane_ids = std::vector<int64>();
+    path_point_with_lane_id.lane_ids = std::vector<int64_t>();
 
     path.header.frame_id = "map";
     path.points.push_back(path_point_with_lane_id);
@@ -56,7 +56,7 @@ PathWithLaneId generateDiagonalSamplePathWithLaneId(
 
     PathPointWithLaneId path_point_with_lane_id;
     path_point_with_lane_id.point = point;
-    path_point_with_lane_id.lane_ids = std::vector<int64>();
+    path_point_with_lane_id.lane_ids = std::vector<int64_t>();
 
     path.header.frame_id = "map";
     path.points.push_back(path_point_with_lane_id);


### PR DESCRIPTION
## Description

Currently, the behavior path planner does not depend on OpenCV.
I removed the dependency from the code.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator works well

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
