### PR TITLE
[WIP] chore(obstacle_avoidance_planner):  rename camera6&7 in RViz

### DIFF
--- a/planning/obstacle_avoidance_planner/rviz/obstacle_avoidance_planner.rviz
+++ b/planning/obstacle_avoidance_planner/rviz/obstacle_avoidance_planner.rviz
@@ -246,21 +246,21 @@ Visualization Manager:
                   Show Axes: false
                   Show Trail: false
                   Value: true
-                traffic_light_left_camera/camera_link:
+                camera6/camera_link:
                   Alpha: 1
                   Show Axes: false
                   Show Trail: false
                   Value: true
-                traffic_light_left_camera/camera_optical_link:
+                camera6/camera_optical_link:
                   Alpha: 1
                   Show Axes: false
                   Show Trail: false
-                traffic_light_right_camera/camera_link:
+                camera7/camera_link:
                   Alpha: 1
                   Show Axes: false
                   Show Trail: false
                   Value: true
-                traffic_light_right_camera/camera_optical_link:
+                camera7/camera_optical_link:
                   Alpha: 1
                   Show Axes: false
                   Show Trail: false


### PR DESCRIPTION
[WIP until all AWF products agree with the rename]

## Description

<!-- Write a brief description of this PR. -->
Rename camera by https://github.com/tier4/autoware_individual_params.jpntaxi/pull/71
- traffic light left should be camera 6.
- traffic light right should be camera 7

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
