### PR TITLE
feat(behavior_path_planner): use lanelets for getting backward lanelets

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -165,8 +165,8 @@ bool hasEnoughLengthToLaneChangeAfterAbort(
   const Pose & curent_pose, const double abort_return_dist,
   const BehaviorPathPlannerParameters & common_param);
 
-lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
-  const RouteHandler & route_handler, const lanelet::ConstLanelet & target_lanes,
+lanelet::ConstLanelets getBackwardLanelets(
+  const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & current_pose, const double backward_length);
 
 LaneChangeTargetObjectIndices filterObjectIndices(

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -948,15 +948,15 @@ bool AvoidanceByLCModule::isApprovedPathSafe(Pose & ego_pose_before_collision) c
   const auto & path = status_.lane_change_path;
 
   // get lanes used for detection
-  const auto check_lanes = utils::lane_change::getBackwardLanelets(
+  const auto backward_target_lanes_for_object_filtering = utils::lane_change::getBackwardLanelets(
     *route_handler, path.target_lanelets, current_pose, check_distance_);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
   const auto lateral_buffer =
     utils::lane_change::calcLateralBufferForFiltering(common_parameters.vehicle_width);
   const auto dynamic_object_indices = utils::lane_change::filterObjectIndices(
-    {path}, *dynamic_objects, check_lanes, current_pose, common_parameters.forward_path_length,
-    *lane_change_parameters, lateral_buffer);
+    {path}, *dynamic_objects, backward_target_lanes_for_object_filtering, current_pose,
+    common_parameters.forward_path_length, *lane_change_parameters, lateral_buffer);
 
   return utils::lane_change::isLaneChangePathSafe(
     path, dynamic_objects, dynamic_object_indices, current_pose, current_twist, common_parameters,

--- a/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance_by_lc/module.cpp
@@ -948,8 +948,8 @@ bool AvoidanceByLCModule::isApprovedPathSafe(Pose & ego_pose_before_collision) c
   const auto & path = status_.lane_change_path;
 
   // get lanes used for detection
-  const auto check_lanes = utils::lane_change::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, path.target_lanelets.front(), current_pose, check_distance_);
+  const auto check_lanes = utils::lane_change::getBackwardLanelets(
+    *route_handler, path.target_lanelets, current_pose, check_distance_);
 
   std::unordered_map<std::string, CollisionCheckDebug> debug_data;
   const auto lateral_buffer =

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -492,8 +492,8 @@ bool NormalLaneChange::getLaneChangePaths(
 
     if (candidate_paths->empty()) {
       // only compute dynamic object indices once
-      const auto backward_lanes = utils::lane_change::getExtendedTargetLanesForCollisionCheck(
-        route_handler, target_lanelets.front(), getEgoPose(), check_length_);
+      const auto backward_lanes = utils::lane_change::getBackwardLanelets(
+        route_handler, target_lanelets, getEgoPose(), check_length_);
       dynamic_object_indices = utils::lane_change::filterObjectIndices(
         {*candidate_path}, *dynamic_objects, backward_lanes, getEgoPose(),
         common_parameter.forward_path_length, *parameters_, lateral_buffer);
@@ -532,8 +532,8 @@ bool NormalLaneChange::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
   const auto & path = status_.lane_change_path;
 
   // get lanes used for detection
-  const auto check_lanes = utils::lane_change::getExtendedTargetLanesForCollisionCheck(
-    *route_handler, path.target_lanelets.front(), current_pose, check_length_);
+  const auto check_lanes = utils::lane_change::getBackwardLanelets(
+    *route_handler, path.target_lanelets, current_pose, check_length_);
 
   CollisionCheckDebugMap debug_data;
   const auto lateral_buffer =

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -492,11 +492,12 @@ bool NormalLaneChange::getLaneChangePaths(
 
     if (candidate_paths->empty()) {
       // only compute dynamic object indices once
-      const auto backward_lanes = utils::lane_change::getBackwardLanelets(
-        route_handler, target_lanelets, getEgoPose(), check_length_);
+      const auto backward_target_lanes_for_object_filtering =
+        utils::lane_change::getBackwardLanelets(
+          route_handler, target_lanelets, getEgoPose(), check_length_);
       dynamic_object_indices = utils::lane_change::filterObjectIndices(
-        {*candidate_path}, *dynamic_objects, backward_lanes, getEgoPose(),
-        common_parameter.forward_path_length, *parameters_, lateral_buffer);
+        {*candidate_path}, *dynamic_objects, backward_target_lanes_for_object_filtering,
+        getEgoPose(), common_parameter.forward_path_length, *parameters_, lateral_buffer);
     }
     candidate_paths->push_back(*candidate_path);
 
@@ -532,15 +533,15 @@ bool NormalLaneChange::isApprovedPathSafe(Pose & ego_pose_before_collision) cons
   const auto & path = status_.lane_change_path;
 
   // get lanes used for detection
-  const auto check_lanes = utils::lane_change::getBackwardLanelets(
+  const auto backward_target_lanes_for_object_filtering = utils::lane_change::getBackwardLanelets(
     *route_handler, path.target_lanelets, current_pose, check_length_);
 
   CollisionCheckDebugMap debug_data;
   const auto lateral_buffer =
     utils::lane_change::calcLateralBufferForFiltering(common_parameters.vehicle_width);
   const auto dynamic_object_indices = utils::lane_change::filterObjectIndices(
-    {path}, *dynamic_objects, check_lanes, current_pose, common_parameters.forward_path_length,
-    lane_change_parameters, lateral_buffer);
+    {path}, *dynamic_objects, backward_target_lanes_for_object_filtering, current_pose,
+    common_parameters.forward_path_length, lane_change_parameters, lateral_buffer);
 
   return utils::lane_change::isLaneChangePathSafe(
     path, dynamic_objects, dynamic_object_indices, current_pose, current_twist, common_parameters,

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -402,8 +402,8 @@ bool getLaneChangePaths(
 
     if (candidate_paths->empty()) {
       // only compute dynamic object indices once
-      const auto backward_lanes = utils::lane_change::getExtendedTargetLanesForCollisionCheck(
-        route_handler, target_lanelets.front(), pose, check_length);
+      const auto backward_lanes =
+        utils::lane_change::getBackwardLanelets(route_handler, target_lanelets, pose, check_length);
       dynamic_object_indices = filterObjectIndices(
         {*candidate_path}, *dynamic_objects, backward_lanes, pose,
         common_parameter.forward_path_length, parameter, lateral_buffer);
@@ -1115,18 +1115,23 @@ bool hasEnoughLengthToLaneChangeAfterAbort(
 }
 
 // TODO(Azu): In the future, get back lanelet within `to_back_dist` [m] from queried lane
-lanelet::ConstLanelets getExtendedTargetLanesForCollisionCheck(
-  const RouteHandler & route_handler, const lanelet::ConstLanelet & target_lane,
+lanelet::ConstLanelets getBackwardLanelets(
+  const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & current_pose, const double backward_length)
 {
-  const auto arc_length = lanelet::utils::getArcCoordinates({target_lane}, current_pose);
+  if (target_lanes.empty()) {
+    return {};
+  }
+
+  const auto arc_length = lanelet::utils::getArcCoordinates(target_lanes, current_pose);
 
   if (arc_length.length >= backward_length) {
     return {};
   }
 
+  const auto & front_lane = target_lanes.front();
   const auto preceding_lanes = route_handler.getPrecedingLaneletSequence(
-    target_lane, std::abs(backward_length - arc_length.length), {target_lane});
+    front_lane, std::abs(backward_length - arc_length.length), {front_lane});
 
   lanelet::ConstLanelets backward_lanes{};
   const auto num_of_lanes = std::invoke([&preceding_lanes]() {

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -402,10 +402,10 @@ bool getLaneChangePaths(
 
     if (candidate_paths->empty()) {
       // only compute dynamic object indices once
-      const auto backward_lanes =
+      const auto backward_target_lanes_for_object_filtering =
         utils::lane_change::getBackwardLanelets(route_handler, target_lanelets, pose, check_length);
       dynamic_object_indices = filterObjectIndices(
-        {*candidate_path}, *dynamic_objects, backward_lanes, pose,
+        {*candidate_path}, *dynamic_objects, backward_target_lanes_for_object_filtering, pose,
         common_parameter.forward_path_length, parameter, lateral_buffer);
     }
     candidate_paths->push_back(*candidate_path);


### PR DESCRIPTION
## Description
Use lanelets instead of lanelet to get backward lanelets for collision check of the lane change module. I also changed the function name to `getBackwardLanelets` to make it easy to understand.


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Scenario Result 1326/1330
[TIER IV Internal Link](https://evaluation.tier4.jp/evaluation/reports/d9a08f72-9553-5fcc-a67a-db9d538fc87f?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

When there are several lanes adjacent to current lanelets, the computation can be much more accurate than before.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
