### PR TITLE
refactor(behavior_path_planner): rename some variables

### DIFF
--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -497,7 +497,7 @@ bool isLaneChangePathSafe(
     path.points, current_pose, common_parameter.ego_nearest_dist_threshold,
     common_parameter.ego_nearest_yaw_threshold);
 
-  const auto vehicle_predicted_path = utils::convertToPredictedPath(
+  const auto ego_predicted_path = utils::convertToPredictedPath(
     path, current_twist, current_pose, current_seg_idx, check_end_time, time_resolution,
     prepare_duration, acceleration);
   const auto & vehicle_info = common_parameter.vehicle_info;
@@ -541,7 +541,7 @@ bool isLaneChangePathSafe(
   for (double t = check_start_time; t < check_end_time; t += time_resolution) {
     tier4_autoware_utils::Polygon2d ego_polygon;
     const auto result =
-      utils::getEgoExpectedPoseAndConvertToPolygon(vehicle_predicted_path, t, vehicle_info);
+      utils::getEgoExpectedPoseAndConvertToPolygon(ego_predicted_path, t, vehicle_info);
     if (!result) {
       continue;
     }
@@ -552,9 +552,9 @@ bool isLaneChangePathSafe(
   for (const auto & i : in_lane_object_indices) {
     const auto & obj = dynamic_objects->objects.at(i);
     auto current_debug_data = assignDebugData(obj);
-    const auto predicted_paths =
+    const auto obj_predicted_paths =
       utils::getPredictedPathFromObj(obj, lane_change_parameter.use_all_predicted_path);
-    for (const auto & obj_path : predicted_paths) {
+    for (const auto & obj_path : obj_predicted_paths) {
       if (!utils::safety_check::isSafeInLaneletCollisionCheck(
             interpolated_ego, current_twist, check_durations, lane_change_path.duration.prepare,
             obj, obj_path, common_parameter,
@@ -574,7 +574,7 @@ bool isLaneChangePathSafe(
   for (const auto & i : dynamic_objects_indices.other_lane) {
     const auto & obj = dynamic_objects->objects.at(i);
     auto current_debug_data = assignDebugData(obj);
-    current_debug_data.second.ego_predicted_path.push_back(vehicle_predicted_path);
+    current_debug_data.second.ego_predicted_path.push_back(ego_predicted_path);
 
     const auto predicted_paths =
       utils::getPredictedPathFromObj(obj, lane_change_parameter.use_all_predicted_path);

--- a/planning/behavior_path_planner/src/utils/safety_check.cpp
+++ b/planning/behavior_path_planner/src/utils/safety_check.cpp
@@ -199,16 +199,15 @@ bool isSafeInLaneletCollisionCheck(
       continue;
     }
 
-    const auto found_expected_obj_pose =
+    auto expected_obj_pose =
       perception_utils::calcInterpolatedPose(target_object_path, current_time);
 
-    if (!found_expected_obj_pose) {
+    if (!expected_obj_pose) {
       continue;
     }
 
-    auto expected_obj_pose = *found_expected_obj_pose;
     const auto & obj_polygon =
-      tier4_autoware_utils::toPolygon2d(expected_obj_pose, target_object.shape);
+      tier4_autoware_utils::toPolygon2d(*expected_obj_pose, target_object.shape);
     const auto & ego_info = interpolated_ego.at(i);
     auto expected_ego_pose = ego_info.first;
     const auto & ego_polygon = ego_info.second;
@@ -223,12 +222,12 @@ bool isSafeInLaneletCollisionCheck(
     debug.lerped_path.push_back(expected_ego_pose);
 
     getProjectedDistancePointFromPolygons(
-      ego_polygon, obj_polygon, expected_ego_pose, expected_obj_pose);
+      ego_polygon, obj_polygon, expected_ego_pose, *expected_obj_pose);
     debug.expected_ego_pose = expected_ego_pose;
-    debug.expected_obj_pose = expected_obj_pose;
+    debug.expected_obj_pose = *expected_obj_pose;
 
     if (!hasEnoughDistance(
-          expected_ego_pose, ego_current_twist, expected_obj_pose, object_twist, common_parameters,
+          expected_ego_pose, ego_current_twist, *expected_obj_pose, object_twist, common_parameters,
           front_decel, rear_decel, debug)) {
       debug.failed_reason = "not_enough_longitudinal";
       return false;


### PR DESCRIPTION
## Description
Rename some variables in the lane change module

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 887753b</samp>

Refactored some code in the behavior path planner to improve readability and consistency, and to migrate from `boost::optional` to `std::optional`. Affected files are `utils.cpp` and `safety_check.cpp`.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
