### PR TITLE
feat(behavior_velocity_planner::intersection): modify module deletion condition

### DIFF
--- a/planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -677,6 +677,7 @@ std::set<int> getAssociativeIntersectionLanelets(
     for (const auto & neighbor : neighbors) parent_neighbors.insert(neighbor.id());
   }
   std::set<int> assocs;
+  assocs.insert(lane.id());
   for (const auto & parent_neighbor_id : parent_neighbors) {
     const auto parent_neighbor = lanelet_map->laneletLayer.get(parent_neighbor_id);
     const auto followings = routing_graph->following(parent_neighbor);


### PR DESCRIPTION
## Description

Considering the new feature of `pull_over`,  `lane_ids` may contain the ids of `intersection && road_shoulder` lanes that are before/after the goal `road_shoulder`

![image](https://user-images.githubusercontent.com/28677420/235067352-2e2c70bb-7d4d-4bda-9aa7-9cb8549f2136.png)

## Related links

https://tier4.atlassian.net/browse/RT1-2267

## Tests performed

https://user-images.githubusercontent.com/28677420/235067850-fe153ab5-344a-4e91-99e8-95cdd1954078.mp4

Before this PR the intersection module for `lane 11` repeatedly registered and deleted in every iteration in the case shown in the above video. After this PR it does not happen.

The consideration for Lane change is still OK (the ID of active intersection modules does not change in the below video).

https://user-images.githubusercontent.com/28677420/235068539-67bb7ab9-ee61-44b6-a97d-fa71843f0be2.mp4

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

RTC/FOA for intersection does not chatter.

## Effects on system behavior

RTC/FOA for intersection does not chatter.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
