### PR TITLE
fix(intersection): always send finite distance to occlusion peeking stop line in RTC

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -189,17 +189,16 @@ void IntersectionModuleManager::sendRTC(const Time & stamp)
     const bool is_occluded = intersection_module->isOccluded();
     const UUID uuid = getUUID(scene_module->getModuleId());
     const auto occlusion_uuid = intersection_module->getOcclusionUUID();
+    const auto occlusion_distance = intersection_module->getOcclusionDistance();
     const auto occlusion_first_stop_uuid = intersection_module->getOcclusionFirstStopUUID();
     if (!is_occluded) {
       // default
       updateRTCStatus(uuid, scene_module->isSafe(), scene_module->getDistance(), stamp);
       occlusion_rtc_interface_.updateCooperateStatus(
-        occlusion_uuid, true, std::numeric_limits<double>::lowest(),
-        std::numeric_limits<double>::lowest(), stamp);
+        occlusion_uuid, true, occlusion_distance, occlusion_distance, stamp);
     } else {
       // occlusion
       const auto occlusion_safety = intersection_module->getOcclusionSafety();
-      const auto occlusion_distance = intersection_module->getOcclusionDistance();
       occlusion_rtc_interface_.updateCooperateStatus(
         occlusion_uuid, occlusion_safety, occlusion_distance, occlusion_distance, stamp);
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -385,17 +385,17 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     logger_.get_child("collision state_machine"), *clock_);
 
   /* set RTC safety respectively */
+  occlusion_first_stop_distance_ = dist_1st_stopline;
+  occlusion_stop_distance_ = dist_2nd_stopline;
+  setDistance(dist_1st_stopline);
   if (occlusion_stop_required) {
     if (first_phase_stop_required) {
       occlusion_first_stop_safety_ = false;
-      occlusion_first_stop_distance_ = dist_1st_stopline;
     }
     occlusion_safety_ = is_occlusion_cleared;
-    occlusion_stop_distance_ = dist_2nd_stopline;
   } else {
     /* collision */
     setSafe(collision_state_machine_.getState() == StateMachine::State::GO);
-    setDistance(dist_1st_stopline);
   }
 
   /* make decision */


### PR DESCRIPTION
## Description

always set the distance to default occlusion peeking stop line for RTC

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

The distance is finite when not occluded or approved.

### When auto mode
![image](https://user-images.githubusercontent.com/28677420/235088552-9f4691ed-b28e-472a-887d-da930128cca1.png)

### When manual mode
![image](https://user-images.githubusercontent.com/28677420/235091144-e845840d-7ba2-45f9-af17-064601943eb2.png)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

approval process of `intersection_occlusion` in RTC

## Effects on system behavior

approval process of `intersection_occlusion` in RTC

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
