### PR TITLE
fix(planning_test_utils): delete duplicated publisher and spinsomenode

### DIFF
--- a/planning/planning_test_utils/src/planning_interface_test_manager.cpp
+++ b/planning/planning_test_utils/src/planning_interface_test_manager.cpp
@@ -383,12 +383,9 @@ void PlanningInterfaceTestManager::testTrajectoryWithInvalidEgoPose(
 
 void PlanningInterfaceTestManager::testOffTrackFromRoute(rclcpp::Node::SharedPtr target_node)
 {
-  publishBehaviorNominalRoute(target_node, input_route_name_);
-
   const std::vector<double> deviation_from_route = {0.0, 1.0, 10.0, 100.0};
   for (const auto & deviation : deviation_from_route) {
     publishInitialPose(target_node, input_initial_pose_name_, deviation);
-    test_utils::spinSomeNodes(test_node_, target_node, 5);
   }
 }
 


### PR DESCRIPTION
## Description

fix duplicated publisher of route and spinsomenode function

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
