### PR TITLE
feat(obstacle_avoidance_planner): deal with infeasible drivable area

### DIFF
--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -110,6 +110,7 @@
         avoidance_cost_margin: 0.0                       # [m]
         avoidance_cost_band_length: 5.0                  # [m]
         avoidance_cost_decrease_rate: 0.05               # decreased cost per point interval
+        min_drivable_width: 0.2 # [m] The vehicle width and this parameter is supposed to be kept in the optimization's constraint
 
         weight:
           lat_error_weight: 0.0     # weight for lateral error

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -110,7 +110,7 @@
         avoidance_cost_margin: 0.0                       # [m]
         avoidance_cost_band_length: 5.0                  # [m]
         avoidance_cost_decrease_rate: 0.05               # decreased cost per point interval
-        min_drivable_width: 0.2 # [m] The vehicle width and this parameter is supposed to be kept in the optimization's constraint
+        min_drivable_width: 0.2                          # [m] The vehicle width and this parameter is guaranteed to keep for collision free constraint.
 
         weight:
           lat_error_weight: 0.0     # weight for lateral error

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -184,6 +184,7 @@ private:
     double avoidance_cost_margin;
     double avoidance_cost_band_length;
     double avoidance_cost_decrease_rate;
+    double min_drivable_width;
     double avoidance_lat_error_weight;
     double avoidance_yaw_error_weight;
     double avoidance_steer_input_weight;

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -252,6 +252,7 @@ private:
     const std::vector<geometry_msgs::msg::Point> & left_bound,
     const std::vector<geometry_msgs::msg::Point> & right_bound,
     const geometry_msgs::msg::Pose & ego_pose, const double ego_vel) const;
+  void keepMinimumBoundsWidth(std::vector<ReferencePoint> & ref_points) const;
   std::vector<ReferencePoint> extendViolatedBounds(
     const std::vector<ReferencePoint> & ref_points) const;
   void avoidSuddenSteering(

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -808,7 +808,7 @@ void MPTOptimizer::updateBounds(
         ref_point_for_bound_search.pose, right_bound, soft_road_clearance, false);
 
       // NOTE: The drivable area's width is sometimes narrower than the vehicle width which means
-      // infeasible to run espcially when obsatcles are extracted from the drivable area.
+      // infeasible to run especially when obstacles are extracted from the drivable area.
       //       In this case, the drivable area's width is forced to be wider.
       const double drivable_width = raw_dist_to_left_bound - raw_dist_to_right_bound;
       if (drivable_width < mpt_param_.min_drivable_width) {

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -852,8 +852,10 @@ void MPTOptimizer::keepMinimumBoundsWidth(std::vector<ReferencePoint> & ref_poin
     // const double drivable_width = b.upper_bound - b.lower_bound;
     // const bool is_infeasible_to_drive = drivable_width < mpt_param_.min_drivable_width;
 
-    // Here, it is infeasible to drive inside the drivable area
-    if (/*is_infeasible_to_drive &&*/ b.upper_bound < 0.0) {  // out of upper bound
+    // NOTE: The following condition should be uncommented to see obstacles outside the path.
+    //       However, on a narrow road, the ego may go outside the road border with this condition.
+    //       Currently, we cannot distinguish obstacles and road border
+    if (/*is_infeasible_to_drive ||*/ b.upper_bound < 0.0) {  // out of upper bound
       if (!out_of_upper_bound_start_idx) {
         out_of_upper_bound_start_idx = i;
       }
@@ -863,7 +865,7 @@ void MPTOptimizer::keepMinimumBoundsWidth(std::vector<ReferencePoint> & ref_poin
         out_of_upper_bound_start_idx = std::nullopt;
       }
     }
-    if (/*is_infeasible_to_drive &&*/ 0.0 < b.lower_bound) {  // out of lower bound
+    if (/*is_infeasible_to_drive ||*/ 0.0 < b.lower_bound) {  // out of lower bound
       if (!out_of_lower_bound_start_idx) {
         out_of_lower_bound_start_idx = i;
       }


### PR DESCRIPTION
## Description

When obstacles are extracted from the drivable area for static avoidance or dynamic avoidance by the motion planner, in some cases, the drivable area width is too narrow and it's infeasible to drive inside the drivable area as shown in the following figures.

In this case, without the PR, the trajectory optimization failed due to infeasible drivability.
To deal with this case, the obstacle avoidance planner expands the drivable area if it's infeasible to drive.

This feature of keeping the feasible drivable area width should be considered when the drivable area is created in the behavior_path_planner.
The reason I put this feature into not the behavior_path_planner but the obstacle_avoidance_planner is to add less implementation for this feature.
The obstacle_avoidance_planner already calculates the drivable area's width, so it's quite easy to add this feature there.

NOTE:
This feature does not adversely affect driving on narrow roads. (e.g. The drivable area will not be expanded to the outside the road.)

**Without this PR**
Failed to optimize the avoiding trajectory.
The output on the terminal is `[osqp_interface]: [MPT] Optimization failed due to solved inaccurate`
![image](https://user-images.githubusercontent.com/20228327/235168388-be444ae9-813a-41ee-a278-b441b4c5f1c0.png)

**With this PR**
Succeeded in optimizing the avoiding trajectory by modifying the drivable area internally in obstacle_avoidance_planner.
![image](https://user-images.githubusercontent.com/20228327/235169113-f055c4f0-70ef-4e2a-8b34-d35c16ece1f9.png)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
