### PR TITLE
feat(behavior): add interface in order to publish marker that is always shown in rviz

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -97,12 +97,12 @@ public:
   }
 
   /**
-   * @brief publish all registered modules' debug markers.
+   * @brief publish all registered modules' markers.
    */
-  void publishDebugMarker() const
+  void publishMarker() const
   {
     std::for_each(
-      manager_ptrs_.begin(), manager_ptrs_.end(), [](const auto & m) { m->publishDebugMarker(); });
+      manager_ptrs_.begin(), manager_ptrs_.end(), [](const auto & m) { m->publishMarker(); });
   }
 
   /**

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -80,6 +80,11 @@ public:
     }
 
     {
+      const auto ns = std::string("~/info/") + utils::convertToSnakeCase(name);
+      pub_info_marker_ = node.create_publisher<MarkerArray>(ns, 20);
+    }
+
+    {
       const auto ns = std::string("~/virtual_wall/") + utils::convertToSnakeCase(name);
       pub_virtual_wall_ = node.create_publisher<MarkerArray>(ns, 20);
     }
@@ -277,6 +282,8 @@ public:
   virtual void setData(const std::shared_ptr<const PlannerData> & data) { planner_data_ = data; }
 
 #ifdef USE_OLD_ARCHITECTURE
+  void publishInfoMarker() { pub_info_marker_->publish(info_marker_); }
+
   void publishDebugMarker() { pub_debug_marker_->publish(debug_marker_); }
 
   void publishVirtualWall()
@@ -322,7 +329,9 @@ public:
 
   PlanResult getPathReference() const { return path_reference_; }
 
-  MarkerArray getDebugMarkers() { return debug_marker_; }
+  MarkerArray getInfoMarkers() const { return info_marker_; }
+
+  MarkerArray getDebugMarkers() const { return debug_marker_; }
 
   ModuleStatus getCurrentStatus() const { return current_state_; }
 
@@ -375,6 +384,7 @@ private:
   rclcpp::Logger logger_;
 
 #ifdef USE_OLD_ARCHITECTURE
+  rclcpp::Publisher<MarkerArray>::SharedPtr pub_info_marker_;
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_debug_marker_;
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_virtual_wall_;
 #endif
@@ -476,6 +486,8 @@ protected:
   mutable boost::optional<Pose> slow_pose_{boost::none};
 
   mutable boost::optional<Pose> dead_pose_{boost::none};
+
+  mutable MarkerArray info_marker_;
 
   mutable MarkerArray debug_marker_;
 };

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1162,7 +1162,7 @@ void BehaviorPathPlannerNode::run()
 
 #ifndef USE_OLD_ARCHITECTURE
   planner_manager_->print();
-  planner_manager_->publishDebugMarker();
+  planner_manager_->publishMarker();
   planner_manager_->publishVirtualWall();
   lk_manager.unlock();  // release planner_manager_
 #endif

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -101,6 +101,7 @@ BehaviorModuleOutput BehaviorTreeManager::run(const std::shared_ptr<PlannerData>
   resetNotRunningModulePathCandidate();
 
   std::for_each(scene_modules_.begin(), scene_modules_.end(), [](const auto & m) {
+    m->publishInfoMarker();
     m->publishDebugMarker();
     m->publishVirtualWall();
     if (!m->isExecutionRequested()) {


### PR DESCRIPTION
## Description

show module's important markers as default. 
add anothre publisher.

(I'm working on implementation so that avoidance module outputs info markers.)

- https://github.com/autowarefoundation/autoware_launch/pull/333

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

![rviz_screenshot_2023_04_28-23_25_20](https://user-images.githubusercontent.com/44889564/235176509-ef590515-de7d-402f-83db-751c33477e0c.png)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
