### PR TITLE
feat(behavior_path_planner): support dynamic reconfigure on new manager

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1490,12 +1490,17 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
     return result;
   }
 
+#ifndef USE_OLD_ARCHITECTURE
+  {
+    const std::lock_guard<std::mutex> lock(mutex_manager_);  // for planner_manager_
+    planner_manager_->updateModuleParams(parameters);
+  }
+#endif
+
   result.successful = true;
   result.reason = "success";
 
   try {
-    updateParam(
-      parameters, "avoidance.publish_debug_marker", avoidance_param_ptr_->publish_debug_marker);
     updateParam(
       parameters, "lane_change.publish_debug_marker", lane_change_param_ptr_->publish_debug_marker);
     // Drivable area expansion parameters


### PR DESCRIPTION
## Description

the planner manager supports dynamic reconfigure. (+ add some params in updateModuleParams in avoidance manager.)

https://user-images.githubusercontent.com/44889564/235178747-d94ca960-49b9-45e8-8116-6a93a71acded.mp4

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
