### PR TITLE
feat(avoidance): output avoidance target marker that are always shown in rviz

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/marker_util/avoidance/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/marker_util/avoidance/debug.hpp
@@ -58,17 +58,11 @@ MarkerArray createAvoidLineMarkerArray(
 
 MarkerArray createPredictedVehiclePositions(const PathWithLaneId & path, std::string && ns);
 
-MarkerArray createAvoidableTargetObjectsMarkerArray(
-  const ObjectDataArray & objects, std::string && ns);
-
-MarkerArray createUnavoidableTargetObjectsMarkerArray(
-  const ObjectDataArray & objects, std::string && ns);
+MarkerArray createTargetObjectsMarkerArray(const ObjectDataArray & objects, const std::string & ns);
 
 MarkerArray createOtherObjectsMarkerArray(const ObjectDataArray & objects, const std::string & ns);
 
 MarkerArray createUnsafeObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);
-
-MarkerArray createUnavoidableObjectsMarkerArray(const ObjectDataArray & objects, std::string && ns);
 
 MarkerArray makeOverhangToRoadShoulderMarkerArray(
   const behavior_path_planner::ObjectDataArray & objects, std::string && ns);

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -271,11 +271,24 @@ private:
   // debug
   mutable DebugData debug_data_;
   mutable std::shared_ptr<AvoidanceDebugMsgArray> debug_msg_ptr_;
-  void setDebugData(
-    const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug) const;
-  void updateAvoidanceDebugData(std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const;
   mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_line_;
   mutable rclcpp::Time debug_avoidance_initializer_for_shift_line_time_;
+
+  /**
+   * @brief fill debug markers.
+   */
+  void updateDebugMarker(
+    const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug) const;
+
+  /**
+   * @brief fill information markers that are shown in Rviz by default.
+   */
+  void updateInfoMarker(const AvoidancePlanningData & data) const;
+
+  /**
+   * @brief fill debug msg that are published as a topic.
+   */
+  void updateAvoidanceDebugData(std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const;
 
   double getLateralMarginFromVelocity(const double velocity) const;
 


### PR DESCRIPTION
## Description

- add another markers that contains important information about the avoidance module.
- the avoidance module outputs `avoidable_target_objects` and `unavoidable_target_objects` marker as important information.
- these markers are always shown in Rviz by default.
- https://github.com/autowarefoundation/autoware_launch/pull/339

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

- RED Cube -> Target objects that is **NOT** avoidable.
- YELLOW Cube -> Target objects that is avoidable.

![rviz_screenshot_2023_05_03-10_57_40](https://user-images.githubusercontent.com/44889564/235820008-f072e334-ca9c-48dc-acb2-6093d67cb3d7.png)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
