### PR TITLE
feat(dynamic_avoidance): avoid oncoming vehicles

### DIFF
--- a/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -15,6 +15,7 @@
         min_obstacle_vel: 1.0 # [m/s]
 
       drivable_area_generation:
-        lat_offset_from_obstacle: 0.8 # [m]
-        time_to_avoid: 5.0 # [s]
-        max_lat_offset_to_avoid: 1.0 # [m]
+        lat_offset_from_obstacle: 2.0 # [m]
+        time_to_avoid_same_directional_object: 5.0 # [s]
+        time_to_avoid_opposite_directional_object: 6.0 # [s]
+        max_lat_offset_to_avoid: 2.0 # [m]

--- a/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_dynamic_avoidance_design.md
@@ -11,12 +11,13 @@ Then the motion planner, in detail obstacle_avoidance_planner, will generate an 
 
 ### Parameters
 
-| Name                                              | Unit  | Type   | Description                             | Default value |
-| :------------------------------------------------ | :---- | :----- | :-------------------------------------- | :------------ |
-| target_object.car                                 | [-]   | bool   | The flag whether to avoid cars or not   | true          |
-| target_object.truck                               | [-]   | bool   | The flag whether to avoid trucks or not | true          |
-| ...                                               | [-]   | bool   | ...                                     | ...           |
-| target_object.min_obstacle_vel                    | [m/s] | double | Minimum obstacle velocity to avoid      | 1.0           |
-| drivable_area_generation.lat_offset_from_obstacle | [m]   | double | Lateral offset to avoid from obstacles  | 0.8           |
-| drivable_area_generation.time_to_avoid            | [s]   | double | Elapsed time for avoiding an obstacle   | 5.0           |
-| drivable_area_generation.max_lat_offset_to_avoid  | [m]   | double | Maximum lateral offset to avoid         | 0.5           |
+| Name                                                               | Unit  | Type   | Description                                                 | Default value |
+| :----------------------------------------------------------------- | :---- | :----- | :---------------------------------------------------------- | :------------ |
+| target_object.car                                                  | [-]   | bool   | The flag whether to avoid cars or not                       | true          |
+| target_object.truck                                                | [-]   | bool   | The flag whether to avoid trucks or not                     | true          |
+| ...                                                                | [-]   | bool   | ...                                                         | ...           |
+| target_object.min_obstacle_vel                                     | [m/s] | double | Minimum obstacle velocity to avoid                          | 1.0           |
+| drivable_area_generation.lat_offset_from_obstacle                  | [m]   | double | Lateral offset to avoid from obstacles                      | 0.8           |
+| drivable_area_generation.time_to_avoid_same_directional_object     | [s]   | double | Elapsed time for avoiding the same directional obstacle     | 5.0           |
+| drivable_area_generation.time_to_avoid_opposite_directional_object | [s]   | double | Elapsed time for avoiding the opposite directional obstacle | 6.0           |
+| drivable_area_generation.max_lat_offset_to_avoid                   | [m]   | double | Maximum lateral offset to avoid                             | 0.5           |

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -50,7 +50,8 @@ struct DynamicAvoidanceParameters
 
   // drivable area generation
   double lat_offset_from_obstacle{0.0};
-  double time_to_avoid{0.0};
+  double time_to_avoid_same_directional_object{0.0};
+  double time_to_avoid_opposite_directional_object{0.0};
   double max_lat_offset_to_avoid{0.0};
 };
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -676,7 +676,10 @@ DynamicAvoidanceParameters BehaviorPathPlannerNode::getDynamicAvoidanceParam()
   {  // drivable_area_generation
     std::string ns = "dynamic_avoidance.drivable_area_generation.";
     p.lat_offset_from_obstacle = declare_parameter<double>(ns + "lat_offset_from_obstacle");
-    p.time_to_avoid = declare_parameter<double>(ns + "time_to_avoid");
+    p.time_to_avoid_same_directional_object =
+      declare_parameter<double>(ns + "time_to_avoid_same_directional_object");
+    p.time_to_avoid_opposite_directional_object =
+      declare_parameter<double>(ns + "time_to_avoid_opposite_directional_object");
     p.max_lat_offset_to_avoid = declare_parameter<double>(ns + "max_lat_offset_to_avoid");
   }
 


### PR DESCRIPTION
## Description

With this PR, oncoming vehicles can be avoided as follows.
NOTE: The parameters are tuned for the video to show how this works easily to understand.
[Screencast from 2023年04月29日 00時58分05秒.webm](https://user-images.githubusercontent.com/20228327/235197189-fba5f009-6eec-4b31-9e47-1dea4bd244f1.webm)

When testing like the above movie,
- incorpolate https://github.com/autowarefoundation/autoware.universe/pull/3583 and https://github.com/autowarefoundation/autoware.universe/pull/3579 (This has launcher's change)
- add change in autoware.universe
```bash
$ git diff
diff --git a/planning/behavior_path_planner/CMakeLists.txt b/planning/behavior_path_planner/CMakeLists.txt
index 78383f6146..710f287175 100644
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
+set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
 
 set(common_src
   src/steering_factor_interface.cpp
```
- add change in autoware_launch
```bash
$ git diff
diff --git a/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml b/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml
index 400bc926..0bd5f74f 100644
--- a/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml
@@ -19,12 +19,12 @@
     qp_solver_type: "osqp"                       # optimization solver option (unconstraint_fast or osqp)
     mpc_prediction_horizon: 50                   # prediction horizon step
     mpc_prediction_dt: 0.1                       # prediction horizon period [s]
-    mpc_weight_lat_error: 0.1                    # lateral error weight in matrix Q
+    mpc_weight_lat_error: 1.0                    # lateral error weight in matrix Q
     mpc_weight_heading_error: 0.0                # heading error weight in matrix Q
     mpc_weight_heading_error_squared_vel: 0.3    # heading error * velocity weight in matrix Q
     mpc_weight_steering_input: 1.0               # steering error weight in matrix R
     mpc_weight_steering_input_squared_vel: 0.25  # steering error * velocity weight in matrix R
-    mpc_weight_lat_jerk: 0.0                     # lateral jerk weight in matrix R
+    mpc_weight_lat_jerk: 0.1                     # lateral jerk weight in matrix R
     mpc_weight_steer_rate: 0.0                   # steering rate weight in matrix R
     mpc_weight_steer_acc: 0.000001               # steering angular acceleration weight in matrix R
     mpc_low_curvature_weight_lat_error: 0.1                    # lateral error weight in matrix Q in low curvature point
diff --git a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml
index 6d19b619..c26cfaa2 100644
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -15,7 +15,7 @@
         min_obstacle_vel: 1.0 # [m/s]
 
       drivable_area_generation:
-        lat_offset_from_obstacle: 0.8 # [m]
+        lat_offset_from_obstacle: 2.0 # [m]
         time_to_avoid_same_directional_object: 5.0 # [s]
         time_to_avoid_opposite_directional_object: 6.0 # [s]
-        max_lat_offset_to_avoid: 0.5 # [m]
+        max_lat_offset_to_avoid: 2.0 # [m]
diff --git a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
index 32da47b1..11aacd9e 100644
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -53,7 +53,7 @@
       max_module_size: 1
 
     avoidance:
-      enable_module: true
+      enable_module: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
       priority: 4
@@ -66,9 +66,8 @@
       enable_simultaneous_execution_as_candidate_module: false
       priority: 3
       max_module_size: 1
-
     dynamic_avoidance:
-      enable_module: false
+      enable_module: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 7
diff --git a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/rtc_auto_mode_manager/rtc_auto_mode_manager.param.yaml b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/rtc_auto_mode_manager/rtc_auto_mode_manager.param.yaml
index af82a346..c752f6cb 100644
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/rtc_auto_mode_manager/rtc_auto_mode_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/rtc_auto_mode_manager/rtc_auto_mode_manager.param.yaml
@@ -7,12 +7,10 @@
       - "intersection"
       - "no_stopping_area"
       - "traffic_light"
-      - "external_request_lane_change_left"
-      - "external_request_lane_change_right"
       - "lane_change_left"
       - "lane_change_right"
-      - "avoidance_left"
-      - "avoidance_right"
+      # - "avoidance_left"
+      # - "avoidance_right"
       - "goal_planner"
       - "pull_out"
       - "intersection_occlusion"
@@ -26,8 +24,8 @@
       - "traffic_light"
       - "lane_change_left"
       - "lane_change_right"
-      - "avoidance_left"
-      - "avoidance_right"
+      # - "avoidance_left"
+      # - "avoidance_right"
       - "goal_planner"
       - "pull_out"
       - "intersection_occlusion"
diff --git a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
index 01a8dfb4..420f3556 100644
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -4,7 +4,7 @@
       enable_smoothing: true                                       # enable path smoothing by elastic band
       enable_skip_optimization: false                              # skip elastic band and model predictive trajectory
       enable_reset_prev_optimization: false                        # If true, optimization has no fix constraint to the previous result.
-      enable_outside_drivable_area_stop: true                      # stop if the ego's trajectory footprint is outside the drivable area
+      enable_outside_drivable_area_stop: false                     # stop if the ego's trajectory footprint is outside the drivable area
       use_footprint_polygon_for_outside_drivable_area_check: false # If false, only the footprint's corner points are considered.
 
       debug:
diff --git a/autoware_launch/rviz/autoware.rviz b/autoware_launch/rviz/autoware.rviz
index cdc4da53..d7e76f6c 100644
```

launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/335

<!-- Write a brief description of this PR. -->

## Tests performed

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Can avoid oncoming vehicles when dynamic avoidance is set to True.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
