### PR TITLE
fix(avoidance): fix visualization bug

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -34,6 +34,8 @@ bool isTargetObjectType(
 double calcShiftLength(
   const bool & is_object_on_right, const double & overhang_dist, const double & avoid_margin);
 
+bool isShiftNecessary(const bool & is_object_on_right, const double & shift_length);
+
 bool isSameDirectionShift(const bool & is_object_on_right, const double & shift_length);
 
 size_t findPathIndexFromArclength(

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3323,6 +3323,7 @@ void AvoidanceModule::setDebugData(
   add(createOtherObjectsMarkerArray(data.other_objects, AvoidanceDebugFactor::NOT_PARKING_OBJECT));
   add(createOtherObjectsMarkerArray(data.other_objects, std::string("MovingObject")));
   add(createOtherObjectsMarkerArray(data.other_objects, std::string("OutOfTargetArea")));
+  add(createOtherObjectsMarkerArray(data.other_objects, std::string("NotNeedAvoidance")));
 
   add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
   add(createOverhangFurthestLineStringMarkerArray(

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -96,6 +96,32 @@ double calcShiftLength(
   return std::fabs(shift_length) > 1e-3 ? shift_length : 0.0;
 }
 
+bool isShiftNecessary(const bool & is_object_on_right, const double & shift_length)
+{
+  /**
+   *   ^
+   *   |
+   * --+----x-------------------------------x--->
+   *   |                 x     x
+   *   |                 ==obj==
+   */
+  if (is_object_on_right && shift_length < 0.0) {
+    return false;
+  }
+
+  /**
+   *   ^                 ==obj==
+   *   |                 x     x
+   * --+----x-------------------------------x--->
+   *   |
+   */
+  if (!is_object_on_right && shift_length > 0.0) {
+    return false;
+  }
+
+  return true;
+}
+
 bool isSameDirectionShift(const bool & is_object_on_right, const double & shift_length)
 {
   return (is_object_on_right == std::signbit(shift_length));
@@ -681,6 +707,15 @@ void filterTargetObjects(
       }
       return std::min(max_allowable_lateral_distance, max_avoid_margin);
     }();
+
+    if (!!avoid_margin) {
+      const auto shift_length = calcShiftLength(isOnRight(o), o.overhang_dist, avoid_margin.get());
+      if (!isShiftNecessary(isOnRight(o), shift_length)) {
+        o.reason = "NotNeedAvoidance";
+        data.other_objects.push_back(o);
+        continue;
+      }
+    }
 
     // force avoidance for stopped vehicle
     {


### PR DESCRIPTION
## Description

In following two patern, the ego doesn't need to shift any more.

- the object is on **RIGHT** of the ego' path, and the shift length is **LESS** than zero.
- the object is on **LEFT** of the ego' path, and the shift length is **MORE** than zero.

Currently, since avoidance module doesn't check these condition explicitly, those objects are shown as `IsSameDirectionShift`.

![rviz_screenshot_2023_04_29-14_56_47](https://user-images.githubusercontent.com/44889564/235286736-6de044c9-ad00-4c2c-8bd5-26b9b6135a5b.png)

In this PR, I added a funciton to check above condition and push back those objects in other objects (not target objects) as `NotNeedAvoidance`.

![rviz_screenshot_2023_04_29-14_51_20](https://user-images.githubusercontent.com/44889564/235286806-435ee430-066b-4786-b9da-c78472bf91c3.png)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS avoidance scenarios](https://evaluation.tier4.jp/evaluation/reports/6dba3116-8292-5195-bf35-fcd90087adcc?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
