### PR TITLE
feat(planning_test_utils): add off-track test for path and trajectory

### DIFF
--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
@@ -90,7 +90,8 @@ class PlanningInterfaceTestManager
 public:
   PlanningInterfaceTestManager();
 
-  void publishOdometry(rclcpp::Node::SharedPtr target_node, std::string topic_name);
+  void publishOdometry(
+    rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift = 0.0);
 
   void publishInitialPose(
     rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift = 0.0);

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
@@ -353,7 +353,7 @@ void spinSomeNodes(
 template <typename T>
 void publishToTargetNode(
   rclcpp::Node::SharedPtr test_node, rclcpp::Node::SharedPtr target_node, std::string topic_name,
-  typename rclcpp::Publisher<T>::SharedPtr publisher, T data, const int repeat_count = 1)
+  typename rclcpp::Publisher<T>::SharedPtr publisher, T data, const int repeat_count = 3)
 {
   if (topic_name.empty()) {
     throw std::runtime_error(std::string("Topic name for ") + typeid(data).name() + " is empty");

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
@@ -235,10 +235,10 @@ HADMapBin makeMapBinMsg()
   return map_bin_msg;
 }
 
-Odometry makeOdometry()
+Odometry makeOdometry(const double shift = 0.0)
 {
   Odometry odometry;
-  const std::array<double, 4> start_pose{5.5, 4., M_PI_2};
+  const std::array<double, 4> start_pose{0.0, shift, 0.0, 0.0};
   odometry.pose.pose = createPose(start_pose);
   odometry.header.frame_id = "map";
   return odometry;
@@ -355,12 +355,13 @@ void publishToTargetNode(
   rclcpp::Node::SharedPtr test_node, rclcpp::Node::SharedPtr target_node, std::string topic_name,
   typename rclcpp::Publisher<T>::SharedPtr publisher, T data, const int repeat_count = 1)
 {
+  if (topic_name.empty()) {
+    throw std::runtime_error(std::string("Topic name for ") + typeid(data).name() + " is empty");
+  }
+
   test_utils::setPublisher<T>(test_node, topic_name, publisher);
   publisher->publish(data);
-  if (topic_name.empty()) {
-    throw std::runtime_error(
-      std::string("Topic name for ") + typeid(*publisher).name() + " is empty");
-  }
+
   if (target_node->count_subscribers(topic_name) == 0) {
     throw std::runtime_error("No subscriber for " + topic_name);
   }

--- a/planning/planning_test_utils/src/planning_interface_test_manager.cpp
+++ b/planning/planning_test_utils/src/planning_interface_test_manager.cpp
@@ -388,7 +388,6 @@ void PlanningInterfaceTestManager::testOffTrackFromRoute(rclcpp::Node::SharedPtr
   const std::vector<double> deviation_from_route = {0.0, 1.0, 10.0, 100.0};
   for (const auto & deviation : deviation_from_route) {
     publishInitialPose(target_node, input_initial_pose_name_, deviation);
-    test_utils::spinSomeNodes(test_node_, target_node, 5);
   }
 }
 
@@ -406,7 +405,6 @@ void PlanningInterfaceTestManager::testOffTrackFromPathWithLaneId(
   const std::vector<double> deviation_from_path = {0.0, 1.0, 10.0, 100.0};
   for (const auto & deviation : deviation_from_path) {
     publishOdometry(target_node, input_odometry_name_, deviation);
-    test_utils::spinSomeNodes(test_node_, target_node, 5);
   }
 }
 
@@ -417,7 +415,6 @@ void PlanningInterfaceTestManager::testOffTrackFromTrajectory(rclcpp::Node::Shar
   const std::vector<double> deviation_from_traj = {0.0, 1.0, 10.0, 100.0};
   for (const auto & deviation : deviation_from_traj) {
     publishOdometry(target_node, input_odometry_name_, deviation);
-    test_utils::spinSomeNodes(test_node_, target_node, 5);
   }
 }
 

--- a/planning/planning_test_utils/src/planning_interface_test_manager.cpp
+++ b/planning/planning_test_utils/src/planning_interface_test_manager.cpp
@@ -26,10 +26,10 @@ PlanningInterfaceTestManager::PlanningInterfaceTestManager()
 }
 
 void PlanningInterfaceTestManager::publishOdometry(
-  rclcpp::Node::SharedPtr target_node, std::string topic_name)
+  rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift)
 {
   test_utils::publishToTargetNode(
-    test_node_, target_node, topic_name, odom_pub_, test_utils::makeOdometry());
+    test_node_, target_node, topic_name, odom_pub_, test_utils::makeOdometry(shift));
 }
 
 void PlanningInterfaceTestManager::publishMaxVelocity(
@@ -401,14 +401,24 @@ void PlanningInterfaceTestManager::testOffTrackFromPath(rclcpp::Node::SharedPtr 
 void PlanningInterfaceTestManager::testOffTrackFromPathWithLaneId(
   rclcpp::Node::SharedPtr target_node)
 {
-  // write me
-  (void)target_node;
+  publishNominalPathWithLaneId(target_node, input_path_with_lane_id_name_);
+
+  const std::vector<double> deviation_from_path = {0.0, 1.0, 10.0, 100.0};
+  for (const auto & deviation : deviation_from_path) {
+    publishOdometry(target_node, input_odometry_name_, deviation);
+    test_utils::spinSomeNodes(test_node_, target_node, 5);
+  }
 }
 
 void PlanningInterfaceTestManager::testOffTrackFromTrajectory(rclcpp::Node::SharedPtr target_node)
 {
-  // write me
-  (void)target_node;
+  publishNominalTrajectory(target_node, input_trajectory_name_);
+
+  const std::vector<double> deviation_from_traj = {0.0, 1.0, 10.0, 100.0};
+  for (const auto & deviation : deviation_from_traj) {
+    publishOdometry(target_node, input_odometry_name_, deviation);
+    test_utils::spinSomeNodes(test_node_, target_node, 5);
+  }
 }
 
 int PlanningInterfaceTestManager::getReceivedTopicNum()


### PR DESCRIPTION
## Description

Add util functions to check the node will not die when the ego-vehicle pose is located far from the target trajectory.

## Related links

None

## Tests performed

None. (tested in each package)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

None

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
