### PR TITLE
test(obstacle_cruise_planner): add off-track test

### DIFF
--- a/planning/obstacle_cruise_planner/test/test_obstacle_cruise_planner_node_interface.cpp
+++ b/planning/obstacle_cruise_planner/test/test_obstacle_cruise_planner_node_interface.cpp
@@ -21,12 +21,26 @@
 
 #include <vector>
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+using motion_planning::ObstacleCruisePlannerNode;
+using planning_test_utils::PlanningInterfaceTestManager;
+
+std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
 {
-  rclcpp::init(0, nullptr);
+  auto test_manager = std::make_shared<PlanningInterfaceTestManager>();
 
-  auto test_manager = std::make_shared<planning_test_utils::PlanningInterfaceTestManager>();
+  // set subscriber with topic name: obstacle_cruise_planner → test_node_
+  test_manager->setTrajectorySubscriber("obstacle_cruise_planner/output/trajectory");
 
+  // set obstacle_cruise_planners input topic name(this topic is changed to test node):
+  test_manager->setTrajectoryInputTopicName("obstacle_cruise_planner/input/trajectory");
+
+  test_manager->setOdometryTopicName("obstacle_cruise_planner/input/odometry");
+
+  return test_manager;
+}
+
+std::shared_ptr<ObstacleCruisePlannerNode> generateNode()
+{
   auto node_options = rclcpp::NodeOptions{};
   const auto obstacle_cruise_planner_dir =
     ament_index_cpp::get_package_share_directory("obstacle_cruise_planner");
@@ -38,19 +52,27 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
      "--params-file", planning_test_utils_dir + "/config/test_vehicle_info.param.yaml",
      "--params-file", obstacle_cruise_planner_dir + "/config/default_common.param.yaml",
      "--params-file", obstacle_cruise_planner_dir + "/config/obstacle_cruise_planner.param.yaml"});
-  auto test_target_node =
-    std::make_shared<motion_planning::ObstacleCruisePlannerNode>(node_options);
 
+  return std::make_shared<motion_planning::ObstacleCruisePlannerNode>(node_options);
+}
+
+void publishMandatoryTopics(
+  std::shared_ptr<PlanningInterfaceTestManager> test_manager,
+  std::shared_ptr<ObstacleCruisePlannerNode> test_target_node)
+{
   // publish necessary topics from test_manager
   test_manager->publishOdometry(test_target_node, "obstacle_cruise_planner/input/odometry");
   test_manager->publishPredictedObjects(test_target_node, "obstacle_cruise_planner/input/objects");
   test_manager->publishAcceleration(test_target_node, "obstacle_cruise_planner/input/acceleration");
+}
 
-  // set subscriber with topic name: obstacle_cruise_planner → test_node_
-  test_manager->setTrajectorySubscriber("obstacle_cruise_planner/output/trajectory");
+TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+{
+  rclcpp::init(0, nullptr);
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
 
-  // set obstacle_cruise_planners input topic name(this topic is changed to test node):
-  test_manager->setTrajectoryInputTopicName("obstacle_cruise_planner/input/trajectory");
+  publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
   ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
@@ -58,4 +80,24 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
 
   // test for trajectory with empty/one point/overlapping point
   ASSERT_NO_THROW(test_manager->testWithAbnormalTrajectory(test_target_node));
+
+  rclcpp::shutdown();
+}
+
+TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+{
+  rclcpp::init(0, nullptr);
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
+
+  publishMandatoryTopics(test_manager, test_target_node);
+
+  // test for normal trajectory
+  ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
+  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+
+  // test for trajectory with empty/one point/overlapping point
+  ASSERT_NO_THROW(test_manager->testTrajectoryWithInvalidEgoPose(test_target_node));
+
+  rclcpp::shutdown();
 }


### PR DESCRIPTION
## Description

Add a test to check the node will not die when the ego-vehicle pose is located far from the target trajectory.

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/3587 needs to be merged before.

## Tests performed

run colcon test.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
