### PR TITLE
test(motion_velocity_smoother): add off-track test

### DIFF
--- a/planning/motion_velocity_smoother/test/test_motion_velocity_smoother_node_interface.cpp
+++ b/planning/motion_velocity_smoother/test/test_motion_velocity_smoother_node_interface.cpp
@@ -21,12 +21,20 @@
 
 #include <vector>
 
-TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInput)
+using motion_velocity_smoother::MotionVelocitySmootherNode;
+using planning_test_utils::PlanningInterfaceTestManager;
+
+std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
 {
-  rclcpp::init(0, nullptr);
+  auto test_manager = std::make_shared<PlanningInterfaceTestManager>();
+  test_manager->setTrajectorySubscriber("motion_velocity_smoother/output/trajectory");
+  test_manager->setTrajectoryInputTopicName("motion_velocity_smoother/input/trajectory");
+  test_manager->setOdometryTopicName("/localization/kinematic_state");
+  return test_manager;
+}
 
-  auto test_manager = std::make_shared<planning_test_utils::PlanningInterfaceTestManager>();
-
+std::shared_ptr<MotionVelocitySmootherNode> generateNode()
+{
   auto node_options = rclcpp::NodeOptions{};
   node_options.append_parameter_override("algorithm_type", "JerkFiltered");
   node_options.append_parameter_override("publish_debug_trajs", false);
@@ -43,19 +51,26 @@ TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInpu
      "--params-file", motion_velocity_smoother_dir + "/config/default_common.param.yaml",
      "--params-file", motion_velocity_smoother_dir + "/config/JerkFiltered.param.yaml"});
 
-  auto test_target_node =
-    std::make_shared<motion_velocity_smoother::MotionVelocitySmootherNode>(node_options);
+  return std::make_shared<MotionVelocitySmootherNode>(node_options);
+}
 
+void publishMandatoryTopics(
+  std::shared_ptr<PlanningInterfaceTestManager> test_manager,
+  rclcpp::Node::SharedPtr test_target_node)
+{
   // publish necessary topics from test_manager
   test_manager->publishOdometry(test_target_node, "/localization/kinematic_state");
   test_manager->publishMaxVelocity(
     test_target_node, "motion_velocity_smoother/input/external_velocity_limit_mps");
+}
 
-  // set subscriber for test_target_node
-  test_manager->setTrajectorySubscriber("motion_velocity_smoother/output/trajectory");
+TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInput)
+{
+  rclcpp::init(0, nullptr);
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
 
-  // setting topic name of subscribing topic
-  test_manager->setTrajectoryInputTopicName("motion_velocity_smoother/input/trajectory");
+  publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
   ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
@@ -63,4 +78,23 @@ TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInpu
 
   // test for trajectory with empty/one point/overlapping point
   ASSERT_NO_THROW(test_manager->testWithAbnormalTrajectory(test_target_node));
+
+  rclcpp::shutdown();
+}
+
+TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+{
+  rclcpp::init(0, nullptr);
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
+
+  publishMandatoryTopics(test_manager, test_target_node);
+
+  // test for normal trajectory
+  ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
+  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+
+  ASSERT_NO_THROW(test_manager->testTrajectoryWithInvalidEgoPose(test_target_node));
+
+  rclcpp::shutdown();
 }


### PR DESCRIPTION
## Description

Add a test to check the node will not die when the ego-vehicle pose is located far from the target trajectory.

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/3587 needs to be merged before.

## Tests performed

run colcon test.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
