### PR TITLE
test(scenario_selector): add off-track test

### DIFF
--- a/planning/scenario_selector/test/test_scenario_selector_node_interface.cpp
+++ b/planning/scenario_selector/test/test_scenario_selector_node_interface.cpp
@@ -31,6 +31,8 @@ std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
   // set subscriber with topic name: scenario_selector → test_node_
   test_manager->setScenarioSubscriber("output/scenario");
 
+  test_manager->setOdometryTopicName("input/odometry");
+
   return test_manager;
 }
 
@@ -97,5 +99,24 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectoryParkingMode)
 
   // test for trajectory with empty/one point/overlapping point
   ASSERT_NO_THROW(test_manager->testWithAbnormalTrajectory(test_target_node));
+  rclcpp::shutdown();
+}
+
+TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+{
+  rclcpp::init(0, nullptr);
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
+
+  publishMandatoryTopics(test_manager, test_target_node);
+
+  // set scenario_selector's input topic name(this topic is changed to test node)
+  test_manager->setTrajectoryInputTopicName("input/lane_driving/trajectory");
+
+  // test for normal trajectory
+  ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
+  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+
+  ASSERT_NO_THROW(test_manager->testTrajectoryWithInvalidEgoPose(test_target_node));
   rclcpp::shutdown();
 }


### PR DESCRIPTION
## Description

Add a test to check the node will not die when the ego-vehicle pose is located far from the target trajectory.

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/3587 needs to be merged before.

## Tests performed

run colcon test.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
