### PR TITLE
test(freespace_planner): add off-track test

### DIFF
--- a/planning/freespace_planner/test/test_freespace_planner_node_interface.cpp
+++ b/planning/freespace_planner/test/test_freespace_planner_node_interface.cpp
@@ -30,6 +30,7 @@ std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
   test_manager->setRouteInputTopicName("freespace_planner/input/route");
   test_manager->setTrajectorySubscriber("freespace_planner/output/trajectory");
   test_manager->setOdometryTopicName("freespace_planner/input/odometry");
+  test_manager->setInitialPoseTopicName("freespace_planner/input/odometry");
   return test_manager;
 }
 

--- a/planning/freespace_planner/test/test_freespace_planner_node_interface.cpp
+++ b/planning/freespace_planner/test/test_freespace_planner_node_interface.cpp
@@ -21,12 +21,20 @@
 
 #include <vector>
 
-TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInput)
+using freespace_planner::FreespacePlannerNode;
+using planning_test_utils::PlanningInterfaceTestManager;
+
+std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
 {
-  rclcpp::init(0, nullptr);
+  auto test_manager = std::make_shared<PlanningInterfaceTestManager>();
+  test_manager->setRouteInputTopicName("freespace_planner/input/route");
+  test_manager->setTrajectorySubscriber("freespace_planner/output/trajectory");
+  test_manager->setOdometryTopicName("freespace_planner/input/odometry");
+  return test_manager;
+}
 
-  auto test_manager = std::make_shared<planning_test_utils::PlanningInterfaceTestManager>();
-
+std::shared_ptr<FreespacePlannerNode> generateNode()
+{
   auto node_options = rclcpp::NodeOptions{};
   const auto planning_test_utils_dir =
     ament_index_cpp::get_package_share_directory("planning_test_utils");
@@ -36,19 +44,27 @@ TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInpu
     {"--ros-args", "--params-file",
      planning_test_utils_dir + "/config/test_vehicle_info.param.yaml", "--params-file",
      freespace_planner_dir + "/config/freespace_planner.param.yaml"});
-  auto test_target_node = std::make_shared<freespace_planner::FreespacePlannerNode>(node_options);
+  return std::make_shared<FreespacePlannerNode>(node_options);
+}
 
+void publishMandatoryTopics(
+  std::shared_ptr<PlanningInterfaceTestManager> test_manager,
+  rclcpp::Node::SharedPtr test_target_node)
+{
   // publish necessary topics from test_manager
   test_manager->publishTF(test_target_node, "/tf");
   test_manager->publishOdometry(test_target_node, "freespace_planner/input/odometry");
   test_manager->publishOccupancyGrid(test_target_node, "freespace_planner/input/occupancy_grid");
   test_manager->publishParkingScenario(test_target_node, "freespace_planner/input/scenario");
+}
 
-  // set subscriber with topic name: freespace_planner → test_node_
-  test_manager->setRouteInputTopicName("freespace_planner/input/route");
+TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInput)
+{
+  rclcpp::init(0, nullptr);
 
-  // set freespace_planner's input topic name(this topic is changed to test node)
-  test_manager->setTrajectorySubscriber("freespace_planner/output/trajectory");
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
+  publishMandatoryTopics(test_manager, test_target_node);
 
   // test with normal route
   ASSERT_NO_THROW(test_manager->testWithBehaviorNominalRoute(test_target_node));
@@ -56,4 +72,22 @@ TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInpu
 
   // test with empty route
   ASSERT_NO_THROW(test_manager->testWithAbnormalRoute(test_target_node));
+  rclcpp::shutdown();
+}
+
+TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+{
+  rclcpp::init(0, nullptr);
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
+
+  publishMandatoryTopics(test_manager, test_target_node);
+
+  // test for normal route
+  ASSERT_NO_THROW(test_manager->testWithBehaviorNominalRoute(test_target_node));
+  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+
+  ASSERT_NO_THROW(test_manager->testRouteWithInvalidEgoPose(test_target_node));
+
+  rclcpp::shutdown();
 }


### PR DESCRIPTION
## Description

Add a test to check the node will not die when the ego-vehicle pose is located far from the target trajectory.

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/3587 needs to be merged before.

## Tests performed

run colcon test.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
