### PR TITLE
fix(behavior_path_planner): use object pose when extracting drivable area

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -81,8 +81,13 @@ struct DrivableLanes
 // quite messy. Needs to be refactored.
 struct DrivableAreaInfo
 {
+  struct Obstacle
+  {
+    geometry_msgs::msg::Pose pose;
+    tier4_autoware_utils::Polygon2d poly;
+  };
   std::vector<DrivableLanes> drivable_lanes;
-  std::vector<tier4_autoware_utils::Polygon2d> obstacle_polys;
+  std::vector<Obstacle> obstacles;  // obstacles to extract from the drivable area
 
   // temporary only for pull over's freespace planning
   double drivable_margin{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -65,7 +65,7 @@ void setStartData(
 Polygon2d createEnvelopePolygon(
   const ObjectData & object_data, const Pose & closest_pose, const double envelope_buffer);
 
-std::vector<tier4_autoware_utils::Polygon2d> generateObstaclePolygonsForDrivableArea(
+std::vector<DrivableAreaInfo::Obstacle> generateObstaclePolygonsForDrivableArea(
   const ObjectDataArray & objects, const std::shared_ptr<AvoidanceParameters> & parameters,
   const double vehicle_width);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -377,7 +377,7 @@ std::vector<DrivableLanes> combineDrivableLanes(
   const std::vector<DrivableLanes> & new_drivable_lanes_vec);
 
 void extractObstaclesFromDrivableArea(
-  PathWithLaneId & path, const std::vector<tier4_autoware_utils::Polygon2d> & obj_polys);
+  PathWithLaneId & path, const std::vector<DrivableAreaInfo::Obstacle> & obstacles);
 }  // namespace behavior_path_planner::utils
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__UTILS_HPP_

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -136,7 +136,7 @@ void PlannerManager::generateCombinedDrivableArea(
   }
 
   // extract obstacles from drivable area
-  utils::extractObstaclesFromDrivableArea(*output.path, output.drivable_area_info.obstacle_polys);
+  utils::extractObstaclesFromDrivableArea(*output.path, output.drivable_area_info.obstacles);
 }
 
 std::vector<SceneModulePtr> PlannerManager::getRequestModules(

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2532,9 +2532,8 @@ void AvoidanceModule::generateExtendedDrivableArea(BehaviorModuleOutput & output
     output.drivable_area_info.drivable_lanes = utils::combineDrivableLanes(
       getPreviousModuleOutput().drivable_area_info.drivable_lanes, drivable_lanes);
     // generate obstacle polygons
-    output.drivable_area_info.obstacle_polys =
-      utils::avoidance::generateObstaclePolygonsForDrivableArea(
-        avoidance_data_.target_objects, parameters_, planner_data_->parameters.vehicle_width / 2.0);
+    output.drivable_area_info.obstacles = utils::avoidance::generateObstaclePolygonsForDrivableArea(
+      avoidance_data_.target_objects, parameters_, planner_data_->parameters.vehicle_width / 2.0);
   }
 
   {  // for old architecture

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -168,12 +168,12 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
   // 2. get drivable lanes from previous module
   const auto drivable_lanes = getPreviousModuleOutput().drivable_area_info.drivable_lanes;
 
-  // 3. create obstacle polygons to avoid
-  std::vector<tier4_autoware_utils::Polygon2d> obstacle_polys;
+  // 3. create obstacles to avoid (= extract from the drivable area)
+  std::vector<DrivableAreaInfo::Obstacle> obstacles_for_drivable_area;
   for (const auto & object : target_objects_) {
     const auto obstacle_poly = calcDynamicObstaclePolygon(*prev_module_path, object);
     if (obstacle_poly) {
-      obstacle_polys.push_back(obstacle_poly.value());
+      obstacles_for_drivable_area.push_back({object.pose, obstacle_poly.value()});
     }
   }
 
@@ -182,7 +182,7 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
   output.reference_path = getPreviousModuleOutput().reference_path;
   // for new architecture
   output.drivable_area_info.drivable_lanes = drivable_lanes;
-  output.drivable_area_info.obstacle_polys = obstacle_polys;
+  output.drivable_area_info.obstacles = obstacles_for_drivable_area;
   output.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
 
   return output;
@@ -291,6 +291,8 @@ std::optional<tier4_autoware_utils::Polygon2d> DynamicAvoidanceModule::calcDynam
     }
     return getMinMaxValues(obj_lat_abs_offset_vec);
   }();
+  std::cerr << is_left << " " << min_obj_lat_abs_offset << " " << max_obj_lat_abs_offset
+            << std::endl;
   const double min_obj_lat_offset = min_obj_lat_abs_offset * (is_left ? 1.0 : -1.0);
   const double max_obj_lat_offset = max_obj_lat_abs_offset * (is_left ? 1.0 : -1.0);
 

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -291,8 +291,6 @@ std::optional<tier4_autoware_utils::Polygon2d> DynamicAvoidanceModule::calcDynam
     }
     return getMinMaxValues(obj_lat_abs_offset_vec);
   }();
-  std::cerr << is_left << " " << min_obj_lat_abs_offset << " " << max_obj_lat_abs_offset
-            << std::endl;
   const double min_obj_lat_offset = min_obj_lat_abs_offset * (is_left ? 1.0 : -1.0);
   const double max_obj_lat_offset = max_obj_lat_abs_offset * (is_left ? 1.0 : -1.0);
 

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -270,14 +270,14 @@ Polygon2d createEnvelopePolygon(
   return expanded_polygon;
 }
 
-std::vector<tier4_autoware_utils::Polygon2d> generateObstaclePolygonsForDrivableArea(
+std::vector<DrivableAreaInfo::Obstacle> generateObstaclePolygonsForDrivableArea(
   const ObjectDataArray & objects, const std::shared_ptr<AvoidanceParameters> & parameters,
   const double vehicle_width)
 {
-  std::vector<tier4_autoware_utils::Polygon2d> obj_polys;
+  std::vector<DrivableAreaInfo::Obstacle> obstacles_for_drivable_area;
 
   if (objects.empty() || !parameters->enable_bound_clipping) {
-    return obj_polys;
+    return obstacles_for_drivable_area;
   }
 
   for (const auto & object : objects) {
@@ -302,9 +302,10 @@ std::vector<tier4_autoware_utils::Polygon2d> generateObstaclePolygonsForDrivable
       object.avoid_margin.get() - object_parameter.envelope_buffer_margin - vehicle_width / 2.0;
     const auto obj_poly =
       tier4_autoware_utils::expandPolygon(object.envelope_poly, diff_poly_buffer);
-    obj_polys.push_back(obj_poly);
+    obstacles_for_drivable_area.push_back(
+      {object.object.kinematics.initial_pose_with_covariance.pose, obj_poly});
   }
-  return obj_polys;
+  return obstacles_for_drivable_area;
 }
 
 double getLongitudinalVelocity(const Pose & p_ref, const Pose & p_target, const double v)

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -427,7 +427,7 @@ std::vector<Point> updateBoundary(
   return updated_bound;
 }
 
-geometry_msgs::msg::Point calcCenterOfGeometry(const Polygon2d & obj_poly)
+[[maybe_unused]] geometry_msgs::msg::Point calcCenterOfGeometry(const Polygon2d & obj_poly)
 {
   geometry_msgs::msg::Point center_pos;
   for (const auto & point : obj_poly.outer()) {
@@ -2466,25 +2466,25 @@ std::vector<DrivableLanes> combineDrivableLanes(
 
 // NOTE: Assuming that path.right/left_bound is already created.
 void extractObstaclesFromDrivableArea(
-  PathWithLaneId & path, const std::vector<tier4_autoware_utils::Polygon2d> & obj_polys)
+  PathWithLaneId & path, const std::vector<DrivableAreaInfo::Obstacle> & obstacles)
 {
-  if (obj_polys.empty()) {
+  if (obstacles.empty()) {
     return;
   }
 
   std::vector<std::vector<PolygonPoint>> right_polygons;
   std::vector<std::vector<PolygonPoint>> left_polygons;
-  for (const auto & obj_poly : obj_polys) {
-    const auto obj_pos = drivable_area_processing::calcCenterOfGeometry(obj_poly);
+  for (const auto & obstacle : obstacles) {
+    const auto & obj_pos = obstacle.pose.position;
 
     // get edge points of the object
     const size_t nearest_path_idx =
       motion_utils::findNearestIndex(path.points, obj_pos);  // to get z for object polygon
     std::vector<Point> edge_points;
-    for (size_t i = 0; i < obj_poly.outer().size() - 1;
+    for (size_t i = 0; i < obstacle.poly.outer().size() - 1;
          ++i) {  // NOTE: There is a duplicated points
       edge_points.push_back(tier4_autoware_utils::createPoint(
-        obj_poly.outer().at(i).x(), obj_poly.outer().at(i).y(),
+        obstacle.poly.outer().at(i).x(), obstacle.poly.outer().at(i).y(),
         path.points.at(nearest_path_idx).point.pose.position.z));
     }
 


### PR DESCRIPTION
## Description

When extracting the object's polygon from the drivable area, left or right drivable area's line string is selected for extraction according to the CoM (center of mass) of the polygon.
However, this logic cannot deal with the case on a curve.

Therefore,  I changed the logic of selecting left or right drivable area's line string by using the object pose instead of CoM as follows.

![image](https://user-images.githubusercontent.com/20228327/235340779-5098fd08-31b6-47c4-8b16-daeeb16fe995.png)


**without this PR**
The object is extracted from the left drivable line string by mistake.
![image](https://user-images.githubusercontent.com/20228327/235333917-f3c5df82-0af0-418f-bfa2-6a040b5fa5ec.png)


**with this PR**
The object is extracted from the right drivable line string correctly.
![image](https://user-images.githubusercontent.com/20228327/235333390-cb4caa23-4da0-401f-8833-b85542e3a1ce.png)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
