### PR TITLE
fix(rviz_plugin): fx traffic light and velocity factor rviz plugin

### DIFF
--- a/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
@@ -202,6 +202,7 @@ void VelocitySteeringFactorsPanel::onVelocityFactors(const VelocityFactorArray::
       velocity_factors_table_->setCellWidget(i, 3, label);
     }
   }
+  velocity_factors_table_->update();
 }
 
 void VelocitySteeringFactorsPanel::onSteeringFactors(const SteeringFactorArray::ConstSharedPtr msg)
@@ -317,6 +318,7 @@ void VelocitySteeringFactorsPanel::onSteeringFactors(const SteeringFactorArray::
       steering_factors_table_->setCellWidget(i, 5, label);
     }
   }
+  steering_factors_table_->update();
 }
 }  // namespace rviz_plugins
 

--- a/common/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.cpp
+++ b/common/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.cpp
@@ -360,6 +360,7 @@ void TrafficLightPublishPanel::onTimer()
     traffic_table_->setCellWidget(i, 3, status_label);
     traffic_table_->setCellWidget(i, 4, confidence_label);
   }
+  traffic_table_->update();
 }
 
 void TrafficLightPublishPanel::onVectorMap(const HADMapBin::ConstSharedPtr msg)


### PR DESCRIPTION
## Description

resolve https://github.com/autowarefoundation/autoware.universe/issues/2923

fix panel view of table widgets

## Tests performed

by psim

![image](https://user-images.githubusercontent.com/65527974/235395779-130784e5-dcca-4a62-a087-4216db7f3e61.png)

Add velocity and steering factor panel and traffic light publish panel

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
