### PR TITLE
fix(behavior_path_planner): fix goal planner backward parking

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -345,7 +345,11 @@ bool GoalPlannerModule::isExecutionRequested() const
     route_handler->isAllowedGoalModification() || checkOriginalGoalIsInShoulder();
   const double request_length =
     allow_goal_modification ? calcModuleRequestLength() : parameters_->minimum_request_length;
-  if (self_to_goal_arc_length < 0.0 || self_to_goal_arc_length > request_length) {
+  const double backward_goal_search_length =
+    allow_goal_modification ? parameters_->backward_goal_search_length : 0.0;
+  if (
+    self_to_goal_arc_length < -backward_goal_search_length ||
+    self_to_goal_arc_length > request_length) {
     return false;
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Fix the bug that `goal_planner` canceled when backward parking.
This bug was caused by https://github.com/autowarefoundation/autoware.universe/pull/3541

[Screencast from 2023年04月27日 14時51分24秒.webm](https://user-images.githubusercontent.com/39142679/235457412-7e5ef23d-6423-4533-bfe9-94aa893aa99b.webm)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

[tier4 internal slack](https://star4.slack.com/archives/CEV8XMJBV/p1682574760315699?thread_ts=1682493975.605229&cid=CEV8XMJBV)
[tier4 internal ticket](https://tier4.atlassian.net/browse/RT1-2277)

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

- backward pull over can be done

https://user-images.githubusercontent.com/39142679/235457653-bd5caced-54b4-4b8b-b5df-79fb46ba037d.mp4

- the goal can be put before the ego in the previous lane 
- can not put in the same lane (this is current planning limitation not just for goal_planner)

https://user-images.githubusercontent.com/39142679/235457671-ab985a4d-39cb-4963-bac9-cc9011648b4d.mp4




## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

no

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

can execute backward pull over

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
