### PR TITLE
refactor(behavior_path_planner): remove unnecessary modifyPathForSmoothGoalConnection

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -185,12 +185,6 @@ private:
   void onLateralOffset(const LateralOffset::ConstSharedPtr msg);
   SetParametersResult onSetParam(const std::vector<rclcpp::Parameter> & parameters);
 
-  /**
-   * @brief Modify the path points near the goal to smoothly connect the lanelet and the goal point.
-   */
-  PathWithLaneId modifyPathForSmoothGoalConnection(
-    const PathWithLaneId & path,
-    const std::shared_ptr<PlannerData> & planner_data) const;  // (TODO) move to util
   OnSetParametersCallbackHandle::SharedPtr m_set_param_res;
 
   /**

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1580,31 +1580,6 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
 
   return result;
 }
-
-PathWithLaneId BehaviorPathPlannerNode::modifyPathForSmoothGoalConnection(
-  const PathWithLaneId & path, const std::shared_ptr<PlannerData> & planner_data) const
-{
-  const auto goal = planner_data->route_handler->getGoalPose();
-  const auto goal_lane_id = planner_data->route_handler->getGoalLaneId();
-
-  Pose refined_goal{};
-  {
-    lanelet::ConstLanelet goal_lanelet;
-    if (planner_data->route_handler->getGoalLanelet(&goal_lanelet)) {
-      refined_goal = utils::refineGoal(goal, goal_lanelet);
-    } else {
-      refined_goal = goal;
-    }
-  }
-
-  auto refined_path = utils::refinePathForGoal(
-    planner_data->parameters.refine_goal_search_radius_range, M_PI * 0.5, path, refined_goal,
-    goal_lane_id);
-  refined_path.header.frame_id = "map";
-  refined_path.header.stamp = this->now();
-
-  return refined_path;
-}
 }  // namespace behavior_path_planner
 
 #include <rclcpp_components/register_node_macro.hpp>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

moved `modifyPathForSmoothGoalConnection` to `goal_planner` in https://github.com/autowarefoundation/autoware.universe/pull/3454, so `behavior_path_planner_node`'s one is not used now.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware.universe/pull/3454

## Tests performed

<!-- Describe how you have tested this PR. -->

build

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

no

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

no

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
