### PR TITLE
fix(intersection): fixed virtual wall marker id duplication

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -223,7 +223,7 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createVirtualWallMarker
       &wall_marker, now);
   }
 
-  auto id = 0;
+  auto id = planning_utils::bitShift(module_id_);
   for (auto & marker : wall_marker.markers) {
     if (marker.action == visualization_msgs::msg::Marker::ADD) {
       marker.id = id;


### PR DESCRIPTION
## Description

When there are multiple intersection module running and each of them is publishing virtual walls, there ids were duplicate and some walls were not displayed.

## Related links

https://tier4.atlassian.net/browse/RT1-2283

## Tests performed

Psim

### Before this PR

only intersection walls farthest from ego are displayed.

![image](https://user-images.githubusercontent.com/28677420/235464316-542b414e-3a39-4a81-ab6e-ecd11e32a63d.png)

### After this PR

![image](https://user-images.githubusercontent.com/28677420/235462891-c7ba3ca6-f4af-4fae-9072-a8764fa6b761.png)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Multiple intersection wall marker appears properly when all modules are disapproved.

## Effects on system behavior

Multiple intersection wall marker appears properly when all modules are disapproved.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
