### PR TITLE
refactor(behavior_path_planner): use tier4_autoware_utils

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/safety_check.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/safety_check.hpp
@@ -20,6 +20,7 @@
 #include "behavior_path_planner/utils/lane_change/lane_change_module_data.hpp"
 
 #include <tier4_autoware_utils/geometry/boost_geometry.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_object.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_path.hpp>

--- a/planning/behavior_path_planner/src/utils/safety_check.cpp
+++ b/planning/behavior_path_planner/src/utils/safety_check.cpp
@@ -105,18 +105,7 @@ void getProjectedDistancePointFromPolygons(
 }
 Pose projectCurrentPoseToTarget(const Pose & desired_object, const Pose & target_object)
 {
-  tf2::Transform tf_map_desired_to_global{};
-  tf2::Transform tf_map_target_to_global{};
-
-  tf2::fromMsg(desired_object, tf_map_desired_to_global);
-  tf2::fromMsg(target_object, tf_map_target_to_global);
-
-  Pose desired_obj_pose_projected_to_target{};
-  tf2::toMsg(
-    tf_map_desired_to_global.inverse() * tf_map_target_to_global,
-    desired_obj_pose_projected_to_target);
-
-  return desired_obj_pose_projected_to_target;
+  return tier4_autoware_utils::inverseTransformPose(target_object, desired_object);
 }
 
 bool hasEnoughDistance(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Use `tier4_autoware_utils::inverseTransformPose` in `safety_check.cpp`.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Tested in TIER IV internal test (now running...)
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

Nothing.

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Nothing.

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Nothing.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
