### PR TITLE
build: proper eigen deps and include

### DIFF
--- a/common/kalman_filter/include/kalman_filter/kalman_filter.hpp
+++ b/common/kalman_filter/include/kalman_filter/kalman_filter.hpp
@@ -15,8 +15,8 @@
 #ifndef KALMAN_FILTER__KALMAN_FILTER_HPP_
 #define KALMAN_FILTER__KALMAN_FILTER_HPP_
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Core>
+#include <Eigen/LU>
 
 /**
  * @file kalman_filter.h

--- a/common/kalman_filter/include/kalman_filter/time_delay_kalman_filter.hpp
+++ b/common/kalman_filter/include/kalman_filter/time_delay_kalman_filter.hpp
@@ -17,8 +17,8 @@
 
 #include "kalman_filter/kalman_filter.hpp"
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Core>
+#include <Eigen/LU>
 
 #include <iostream>
 

--- a/common/osqp_interface/include/osqp_interface/csc_matrix_conv.hpp
+++ b/common/osqp_interface/include/osqp_interface/csc_matrix_conv.hpp
@@ -15,9 +15,10 @@
 #ifndef OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_
 #define OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_
 
-#include <Eigen/Core>
 #include "osqp/glob_opts.h"  // for 'c_int' type ('long' or 'long long')
 #include "osqp_interface/visibility_control.hpp"
+
+#include <Eigen/Core>
 
 #include <vector>
 

--- a/common/osqp_interface/include/osqp_interface/csc_matrix_conv.hpp
+++ b/common/osqp_interface/include/osqp_interface/csc_matrix_conv.hpp
@@ -15,7 +15,7 @@
 #ifndef OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_
 #define OSQP_INTERFACE__CSC_MATRIX_CONV_HPP_
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "osqp/glob_opts.h"  // for 'c_int' type ('long' or 'long long')
 #include "osqp_interface/visibility_control.hpp"
 

--- a/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
+++ b/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
@@ -15,7 +15,7 @@
 #ifndef OSQP_INTERFACE__OSQP_INTERFACE_HPP_
 #define OSQP_INTERFACE__OSQP_INTERFACE_HPP_
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "osqp/osqp.h"
 #include "osqp_interface/csc_matrix_conv.hpp"
 #include "osqp_interface/visibility_control.hpp"

--- a/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
+++ b/common/osqp_interface/include/osqp_interface/osqp_interface.hpp
@@ -15,11 +15,11 @@
 #ifndef OSQP_INTERFACE__OSQP_INTERFACE_HPP_
 #define OSQP_INTERFACE__OSQP_INTERFACE_HPP_
 
-#include <Eigen/Core>
 #include "osqp/osqp.h"
 #include "osqp_interface/csc_matrix_conv.hpp"
 #include "osqp_interface/visibility_control.hpp"
 
+#include <Eigen/Core>
 #include <rclcpp/rclcpp.hpp>
 
 #include <limits>

--- a/common/osqp_interface/src/csc_matrix_conv.cpp
+++ b/common/osqp_interface/src/csc_matrix_conv.cpp
@@ -14,8 +14,8 @@
 
 #include "osqp_interface/csc_matrix_conv.hpp"
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/SparseCore"
+#include <Eigen/Core>
+#include <Eigen/SparseCore>
 
 #include <exception>
 #include <iostream>

--- a/common/osqp_interface/test/test_csc_matrix_conv.cpp
+++ b/common/osqp_interface/test/test_csc_matrix_conv.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "gtest/gtest.h"
 #include "osqp_interface/csc_matrix_conv.hpp"
 

--- a/common/osqp_interface/test/test_csc_matrix_conv.cpp
+++ b/common/osqp_interface/test/test_csc_matrix_conv.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Eigen/Core>
 #include "gtest/gtest.h"
 #include "osqp_interface/csc_matrix_conv.hpp"
+
+#include <Eigen/Core>
 
 #include <string>
 #include <tuple>

--- a/common/osqp_interface/test/test_osqp_interface.cpp
+++ b/common/osqp_interface/test/test_osqp_interface.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Eigen/Core>
 #include "gtest/gtest.h"
 #include "osqp_interface/osqp_interface.hpp"
+
+#include <Eigen/Core>
 
 #include <tuple>
 #include <vector>

--- a/common/osqp_interface/test/test_osqp_interface.cpp
+++ b/common/osqp_interface/test/test_osqp_interface.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "gtest/gtest.h"
 #include "osqp_interface/osqp_interface.hpp"
 

--- a/common/tier4_debug_tools/include/tier4_debug_tools/lateral_error_publisher.hpp
+++ b/common/tier4_debug_tools/include/tier4_debug_tools/lateral_error_publisher.hpp
@@ -17,8 +17,8 @@
 
 #define EIGEN_MPL2_ONLY
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <motion_utils/trajectory/trajectory.hpp>
 #include <rclcpp/rclcpp.hpp>
 

--- a/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp
+++ b/common/tier4_localization_rviz_plugin/src/pose_history_footprint/display.cpp
@@ -23,8 +23,8 @@
 #include <rviz_rendering/objects/billboard_line.hpp>
 
 #define EIGEN_MPL2_ONLY
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include <OgreBillboardSet.h>
 #include <OgreManualObject.h>

--- a/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
@@ -40,8 +40,8 @@
 #include <vector>
 
 #define EIGEN_MPL2_ONLY
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <utils.hpp>
 
 namespace

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
@@ -21,7 +21,7 @@
 #include "control_performance_analysis/msg/float_stamped.hpp"
 #include "motion_utils/trajectory/trajectory.hpp"
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <rclcpp/time.hpp>
 
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
@@ -15,8 +15,8 @@
 #ifndef CONTROL_PERFORMANCE_ANALYSIS__CONTROL_PERFORMANCE_ANALYSIS_UTILS_HPP_
 #define CONTROL_PERFORMANCE_ANALYSIS__CONTROL_PERFORMANCE_ANALYSIS_UTILS_HPP_
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/quaternion.hpp>

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_utils.hpp
@@ -15,7 +15,7 @@
 #ifndef MPC_LATERAL_CONTROLLER__MPC_UTILS_HPP_
 #define MPC_LATERAL_CONTROLLER__MPC_UTILS_HPP_
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_utils.hpp
@@ -15,11 +15,12 @@
 #ifndef MPC_LATERAL_CONTROLLER__MPC_UTILS_HPP_
 #define MPC_LATERAL_CONTROLLER__MPC_UTILS_HPP_
 
-#include <Eigen/Core>
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
+
+#include <Eigen/Core>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_interface.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_interface.hpp
@@ -15,9 +15,9 @@
 #ifndef MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_INTERFACE_HPP_
 #define MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_INTERFACE_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/Dense"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/LU>
 
 namespace autoware::motion::control::mpc_lateral_controller
 {

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_osqp.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_osqp.hpp
@@ -15,10 +15,11 @@
 #ifndef MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_OSQP_HPP_
 #define MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_OSQP_HPP_
 
-#include <Eigen/Dense>
 #include "mpc_lateral_controller/qp_solver/qp_solver_interface.hpp"
 #include "osqp_interface/osqp_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+#include <Eigen/Dense>
 
 namespace autoware::motion::control::mpc_lateral_controller
 {

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_osqp.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_osqp.hpp
@@ -15,7 +15,7 @@
 #ifndef MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_OSQP_HPP_
 #define MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_OSQP_HPP_
 
-#include "eigen3/Eigen/Dense"
+#include <Eigen/Dense>
 #include "mpc_lateral_controller/qp_solver/qp_solver_interface.hpp"
 #include "osqp_interface/osqp_interface.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_unconstr_fast.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_unconstr_fast.hpp
@@ -15,10 +15,11 @@
 #ifndef MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_UNCONSTR_FAST_HPP_
 #define MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_UNCONSTR_FAST_HPP_
 
+#include "mpc_lateral_controller/qp_solver/qp_solver_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <Eigen/LU>
-#include "mpc_lateral_controller/qp_solver/qp_solver_interface.hpp"
 
 #include <cmath>
 

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_unconstr_fast.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/qp_solver/qp_solver_unconstr_fast.hpp
@@ -15,9 +15,9 @@
 #ifndef MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_UNCONSTR_FAST_HPP_
 #define MPC_LATERAL_CONTROLLER__QP_SOLVER__QP_SOLVER_UNCONSTR_FAST_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/Dense"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/LU>
 #include "mpc_lateral_controller/qp_solver/qp_solver_interface.hpp"
 
 #include <cmath>

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_dynamics.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_dynamics.hpp
@@ -47,8 +47,8 @@
 #ifndef MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_DYNAMICS_HPP_
 #define MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_DYNAMICS_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
 
 namespace autoware::motion::control::mpc_lateral_controller

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_dynamics.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_dynamics.hpp
@@ -47,9 +47,10 @@
 #ifndef MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_DYNAMICS_HPP_
 #define MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_DYNAMICS_HPP_
 
+#include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
 
 namespace autoware::motion::control::mpc_lateral_controller
 {

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics.hpp
@@ -41,9 +41,10 @@
 #ifndef MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 #define MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 
+#include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
 
 namespace autoware::motion::control::mpc_lateral_controller
 {

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics.hpp
@@ -41,8 +41,8 @@
 #ifndef MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 #define MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
 
 namespace autoware::motion::control::mpc_lateral_controller

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp
@@ -38,8 +38,8 @@
 #ifndef MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_NO_DELAY_HPP_
 #define MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_NO_DELAY_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
 
 namespace autoware::motion::control::mpc_lateral_controller

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp
@@ -38,9 +38,10 @@
 #ifndef MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_NO_DELAY_HPP_
 #define MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_NO_DELAY_HPP_
 
+#include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
 
 namespace autoware::motion::control::mpc_lateral_controller
 {

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp
@@ -15,7 +15,7 @@
 #ifndef MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_INTERFACE_HPP_
 #define MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_INTERFACE_HPP_
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 
 namespace autoware::motion::control::mpc_lateral_controller
 {

--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -15,12 +15,12 @@
 #ifndef PID_LONGITUDINAL_CONTROLLER__LONGITUDINAL_CONTROLLER_UTILS_HPP_
 #define PID_LONGITUDINAL_CONTROLLER__LONGITUDINAL_CONTROLLER_UTILS_HPP_
 
-#include <Eigen/Core>
-#include <Eigen/Geometry>
 #include "interpolation/linear_interpolation.hpp"
 #include "motion_utils/trajectory/trajectory.hpp"
 #include "tf2/utils.h"
 
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <experimental/optional>  // NOLINT
 
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"

--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -15,8 +15,8 @@
 #ifndef PID_LONGITUDINAL_CONTROLLER__LONGITUDINAL_CONTROLLER_UTILS_HPP_
 #define PID_LONGITUDINAL_CONTROLLER__LONGITUDINAL_CONTROLLER_UTILS_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/Geometry"
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include "interpolation/linear_interpolation.hpp"
 #include "motion_utils/trajectory/trajectory.hpp"
 #include "tf2/utils.h"

--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -16,8 +16,6 @@
 #define PID_LONGITUDINAL_CONTROLLER__PID_LONGITUDINAL_CONTROLLER_HPP_
 
 #include "diagnostic_updater/diagnostic_updater.hpp"
-#include <Eigen/Core>
-#include <Eigen/Geometry>
 #include "pid_longitudinal_controller/debug_values.hpp"
 #include "pid_longitudinal_controller/longitudinal_controller_utils.hpp"
 #include "pid_longitudinal_controller/lowpass_filter.hpp"
@@ -29,6 +27,9 @@
 #include "tf2_ros/transform_listener.h"
 #include "trajectory_follower_base/longitudinal_controller_base.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
 #include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"

--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -16,8 +16,8 @@
 #define PID_LONGITUDINAL_CONTROLLER__PID_LONGITUDINAL_CONTROLLER_HPP_
 
 #include "diagnostic_updater/diagnostic_updater.hpp"
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/Geometry"
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include "pid_longitudinal_controller/debug_values.hpp"
 #include "pid_longitudinal_controller/longitudinal_controller_utils.hpp"
 #include "pid_longitudinal_controller/lowpass_filter.hpp"

--- a/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
+++ b/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
@@ -15,8 +15,6 @@
 #ifndef TRAJECTORY_FOLLOWER_NODE__CONTROLLER_NODE_HPP_
 #define TRAJECTORY_FOLLOWER_NODE__CONTROLLER_NODE_HPP_
 
-#include <Eigen/Core>
-#include <Eigen/Geometry>
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tf2_ros/buffer.h"
@@ -25,6 +23,9 @@
 #include "trajectory_follower_base/longitudinal_controller_base.hpp"
 #include "trajectory_follower_node/visibility_control.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
 #include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"

--- a/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
+++ b/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
@@ -15,8 +15,8 @@
 #ifndef TRAJECTORY_FOLLOWER_NODE__CONTROLLER_NODE_HPP_
 #define TRAJECTORY_FOLLOWER_NODE__CONTROLLER_NODE_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/Geometry"
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tf2_ros/buffer.h"

--- a/evaluator/planning_evaluator/src/metrics/obstacle_metrics.cpp
+++ b/evaluator/planning_evaluator/src/metrics/obstacle_metrics.cpp
@@ -14,8 +14,9 @@
 
 #include "planning_evaluator/metrics/obstacle_metrics.hpp"
 
-#include <Eigen/Core>
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+
+#include <Eigen/Core>
 
 #include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
 

--- a/evaluator/planning_evaluator/src/metrics/obstacle_metrics.cpp
+++ b/evaluator/planning_evaluator/src/metrics/obstacle_metrics.cpp
@@ -14,7 +14,7 @@
 
 #include "planning_evaluator/metrics/obstacle_metrics.hpp"
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 
 #include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"

--- a/evaluator/planning_evaluator/src/metrics/stability_metrics.cpp
+++ b/evaluator/planning_evaluator/src/metrics/stability_metrics.cpp
@@ -14,7 +14,7 @@
 
 #include "planning_evaluator/metrics/stability_metrics.hpp"
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "motion_utils/trajectory/trajectory.hpp"
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 

--- a/evaluator/planning_evaluator/src/metrics/stability_metrics.cpp
+++ b/evaluator/planning_evaluator/src/metrics/stability_metrics.cpp
@@ -14,9 +14,10 @@
 
 #include "planning_evaluator/metrics/stability_metrics.hpp"
 
-#include <Eigen/Core>
 #include "motion_utils/trajectory/trajectory.hpp"
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+
+#include <Eigen/Core>
 
 #include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
 

--- a/localization/ekf_localizer/test/src/test_ekf_localizer.cpp
+++ b/localization/ekf_localizer/test/src/test_ekf_localizer.cpp
@@ -14,8 +14,8 @@
 
 #include "ekf_localizer/ekf_localizer.hpp"
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/matrix_type.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/matrix_type.hpp
@@ -15,7 +15,7 @@
 #ifndef NDT_SCAN_MATCHER__MATRIX_TYPE_HPP_
 #define NDT_SCAN_MATCHER__MATRIX_TYPE_HPP_
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 using Matrix6d = Eigen::Matrix<double, 6, 6>;
 using RowMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;

--- a/perception/bytetrack/CMakeLists.txt
+++ b/perception/bytetrack/CMakeLists.txt
@@ -29,6 +29,7 @@ target_include_directories(bytetrack_lib
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/include>
   $<INSTALL_INTERFACE:include>
 )
+target_link_libraries(bytetrack_lib Eigen3::Eigen)
 
 #
 # ROS node

--- a/perception/bytetrack/lib/include/data_type.h
+++ b/perception/bytetrack/lib/include/data_type.h
@@ -38,8 +38,8 @@
 
 #pragma once
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Core>
+#include <Eigen/Dense>
 
 #include <cstddef>
 #include <utility>

--- a/perception/bytetrack/lib/src/kalman_filter.cpp
+++ b/perception/bytetrack/lib/src/kalman_filter.cpp
@@ -38,7 +38,7 @@
 
 #include "kalman_filter.h"
 
-#include <eigen3/Eigen/Cholesky>
+#include <Eigen/Cholesky>
 
 namespace byte_kalman
 {

--- a/perception/probabilistic_occupancy_grid_map/include/updater/occupancy_grid_map_binary_bayes_filter_updater.hpp
+++ b/perception/probabilistic_occupancy_grid_map/include/updater/occupancy_grid_map_binary_bayes_filter_updater.hpp
@@ -17,8 +17,8 @@
 
 #include "updater/occupancy_grid_map_updater_interface.hpp"
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 namespace costmap_2d
 {

--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -14,7 +14,7 @@
 
 #include "motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp"
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "motion_velocity_smoother/trajectory_utils.hpp"
 
 #include <algorithm>

--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -14,8 +14,9 @@
 
 #include "motion_velocity_smoother/smoother/jerk_filtered_smoother.hpp"
 
-#include <Eigen/Core>
 #include "motion_velocity_smoother/trajectory_utils.hpp"
+
+#include <Eigen/Core>
 
 #include <algorithm>
 #include <chrono>

--- a/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -14,8 +14,9 @@
 
 #include "motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
 
-#include <Eigen/Core>
 #include "motion_velocity_smoother/trajectory_utils.hpp"
+
+#include <Eigen/Core>
 
 #include <algorithm>
 #include <chrono>

--- a/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -14,7 +14,7 @@
 
 #include "motion_velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "motion_velocity_smoother/trajectory_utils.hpp"
 
 #include <algorithm>

--- a/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -14,8 +14,9 @@
 
 #include "motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
 
-#include <Eigen/Core>
 #include "motion_velocity_smoother/trajectory_utils.hpp"
+
+#include <Eigen/Core>
 
 #include <algorithm>
 #include <chrono>

--- a/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -14,7 +14,7 @@
 
 #include "motion_velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "motion_velocity_smoother/trajectory_utils.hpp"
 
 #include <algorithm>

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/eb_path_smoother.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/eb_path_smoother.hpp
@@ -15,10 +15,11 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__EB_PATH_SMOOTHER_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__EB_PATH_SMOOTHER_HPP_
 
-#include <Eigen/Core>
 #include "obstacle_avoidance_planner/common_structs.hpp"
 #include "obstacle_avoidance_planner/type_alias.hpp"
 #include "osqp_interface/osqp_interface.hpp"
+
+#include <Eigen/Core>
 
 #include <memory>
 #include <optional>

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/eb_path_smoother.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/eb_path_smoother.hpp
@@ -15,7 +15,7 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__EB_PATH_SMOOTHER_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__EB_PATH_SMOOTHER_HPP_
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "obstacle_avoidance_planner/common_structs.hpp"
 #include "obstacle_avoidance_planner/type_alias.hpp"
 #include "osqp_interface/osqp_interface.hpp"

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -15,8 +15,8 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__MPT_OPTIMIZER_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__MPT_OPTIMIZER_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/Sparse"
+#include <Eigen/Core>
+#include <Eigen/Sparse>
 #include "gtest/gtest.h"
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation_points_2d.hpp"

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -15,8 +15,6 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__MPT_OPTIMIZER_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__MPT_OPTIMIZER_HPP_
 
-#include <Eigen/Core>
-#include <Eigen/Sparse>
 #include "gtest/gtest.h"
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation_points_2d.hpp"
@@ -26,6 +24,9 @@
 #include "osqp_interface/osqp_interface.hpp"
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/Sparse>
 
 #include <memory>
 #include <optional>

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/geometry_utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/geometry_utils.hpp
@@ -15,7 +15,6 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__UTILS__GEOMETRY_UTILS_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__UTILS__GEOMETRY_UTILS_HPP_
 
-#include <Eigen/Core>
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation.hpp"
 #include "interpolation/spline_interpolation_points_2d.hpp"
@@ -23,6 +22,8 @@
 #include "obstacle_avoidance_planner/common_structs.hpp"
 #include "obstacle_avoidance_planner/type_alias.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
+
+#include <Eigen/Core>
 
 #include "autoware_auto_planning_msgs/msg/path_point.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/geometry_utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/geometry_utils.hpp
@@ -15,7 +15,7 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__UTILS__GEOMETRY_UTILS_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__UTILS__GEOMETRY_UTILS_HPP_
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation.hpp"
 #include "interpolation/spline_interpolation_points_2d.hpp"

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/trajectory_utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/trajectory_utils.hpp
@@ -15,7 +15,7 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__UTILS__TRAJECTORY_UTILS_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__UTILS__TRAJECTORY_UTILS_HPP_
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation.hpp"
 #include "interpolation/spline_interpolation_points_2d.hpp"

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/trajectory_utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/trajectory_utils.hpp
@@ -15,13 +15,14 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__UTILS__TRAJECTORY_UTILS_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__UTILS__TRAJECTORY_UTILS_HPP_
 
-#include <Eigen/Core>
 #include "interpolation/linear_interpolation.hpp"
 #include "interpolation/spline_interpolation.hpp"
 #include "interpolation/spline_interpolation_points_2d.hpp"
 #include "motion_utils/trajectory/trajectory.hpp"
 #include "obstacle_avoidance_planner/common_structs.hpp"
 #include "obstacle_avoidance_planner/type_alias.hpp"
+
+#include <Eigen/Core>
 
 #include "autoware_auto_planning_msgs/msg/path_point.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/vehicle_model/vehicle_model_bicycle_kinematics.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/vehicle_model/vehicle_model_bicycle_kinematics.hpp
@@ -15,8 +15,8 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "obstacle_avoidance_planner/vehicle_model/vehicle_model_interface.hpp"
 
 #include <vector>

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/vehicle_model/vehicle_model_bicycle_kinematics.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/vehicle_model/vehicle_model_bicycle_kinematics.hpp
@@ -15,9 +15,10 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__VEHICLE_MODEL__VEHICLE_MODEL_BICYCLE_KINEMATICS_HPP_
 
+#include "obstacle_avoidance_planner/vehicle_model/vehicle_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "obstacle_avoidance_planner/vehicle_model/vehicle_model_interface.hpp"
 
 #include <vector>
 

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/vehicle_model/vehicle_model_interface.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/vehicle_model/vehicle_model_interface.hpp
@@ -15,8 +15,8 @@
 #ifndef OBSTACLE_AVOIDANCE_PLANNER__VEHICLE_MODEL__VEHICLE_MODEL_INTERFACE_HPP_
 #define OBSTACLE_AVOIDANCE_PLANNER__VEHICLE_MODEL__VEHICLE_MODEL_INTERFACE_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/Sparse"
+#include <Eigen/Core>
+#include <Eigen/Sparse>
 
 #include <vector>
 

--- a/planning/obstacle_cruise_planner/src/optimization_based_planner/velocity_optimizer.cpp
+++ b/planning/obstacle_cruise_planner/src/optimization_based_planner/velocity_optimizer.cpp
@@ -14,7 +14,7 @@
 
 #include "obstacle_cruise_planner/optimization_based_planner/velocity_optimizer.hpp"
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <iostream>
 

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/debug_marker.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/debug_marker.hpp
@@ -30,8 +30,8 @@
 #include <string>
 #include <vector>
 #define EIGEN_MPL2_ONLY
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <tier4_autoware_utils/geometry/boost_geometry.hpp>
 namespace motion_planning
 {

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -24,8 +24,8 @@
 #include "obstacle_stop_planner/node.hpp"
 #include "obstacle_stop_planner/planner_utils.hpp"
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include <pcl/filters/voxel_grid.h>
 #include <tf2/utils.h>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc.hpp
@@ -15,8 +15,8 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <deque>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc.hpp
@@ -15,9 +15,10 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_HPP_
 
+#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <deque>
 #include <iostream>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
@@ -15,8 +15,8 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_GEARED_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_GEARED_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <deque>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp
@@ -15,9 +15,10 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_GEARED_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_GEARED_HPP_
 
+#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <deque>
 #include <iostream>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_vel.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_vel.hpp
@@ -15,8 +15,8 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_VEL_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_VEL_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <deque>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_vel.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_delay_steer_vel.hpp
@@ -15,9 +15,10 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_VEL_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_VEL_HPP_
 
+#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <deque>
 #include <iostream>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc.hpp
@@ -15,9 +15,10 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_ACC_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_ACC_HPP_
 
+#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <iostream>
 

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc.hpp
@@ -15,8 +15,8 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_ACC_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_ACC_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <iostream>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
@@ -15,9 +15,10 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_ACC_GEARED_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_ACC_GEARED_HPP_
 
+#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <iostream>
 

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_acc_geared.hpp
@@ -15,8 +15,8 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_ACC_GEARED_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_ACC_GEARED_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <iostream>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_vel.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_vel.hpp
@@ -15,9 +15,10 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_VEL_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_VEL_HPP_
 
+#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/LU>
-#include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <iostream>
 /**

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_vel.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_ideal_steer_vel.hpp
@@ -15,8 +15,8 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_VEL_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_IDEAL_STEER_VEL_HPP_
 
-#include "eigen3/Eigen/Core"
-#include "eigen3/Eigen/LU"
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include "simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
 
 #include <iostream>

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_interface.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/vehicle_model/sim_model_interface.hpp
@@ -15,7 +15,7 @@
 #ifndef SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_INTERFACE_HPP_
 #define SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_INTERFACE_HPP_
 
-#include "eigen3/Eigen/Core"
+#include <Eigen/Core>
 
 #include "autoware_auto_vehicle_msgs/msg/gear_command.hpp"
 


### PR DESCRIPTION
## Description

As mentioned [here](https://github.com/autowarefoundation/autoware.universe/pull/3606#discussion_r1182365444), including eigen headers with `#include <eigen3/Eigen/*>` is not "correct". For example, if someone downloads and 
installs eigen library from source manually, `<depend>eigen</depend>` and `find_package(Eigen3)` will work fine but the header may not be found, or the system eigen library header will be used instead if installed on the system (mixing Eigen version within the same compilation unit is most likely UB).

This PR replaces all `#include <eigen3/Eigen/XXX>` and `#include "eigen3/Eigen/XXX"` by the appropriate equivalent. Eigen dependency is added when necessary.

## Tests performed

If it compiles, it should be Ok

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
