### PR TITLE
build: mark autoware_cmake as <buildtool_depend>

### DIFF
--- a/common/autoware_ad_api_specs/package.xml
+++ b/common/autoware_ad_api_specs/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/autoware_ad_api_specs/package.xml
+++ b/common/autoware_ad_api_specs/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/autoware_ad_api_specs/package.xml
+++ b/common/autoware_ad_api_specs/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/common/autoware_auto_common/package.xml
+++ b/common/autoware_auto_common/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>builtin_interfaces</depend>
   <depend>eigen</depend>
 

--- a/common/autoware_auto_common/package.xml
+++ b/common/autoware_auto_common/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>builtin_interfaces</depend>
   <depend>eigen</depend>

--- a/common/autoware_auto_common/package.xml
+++ b/common/autoware_auto_common/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
   <depend>eigen</depend>

--- a/common/autoware_auto_geometry/package.xml
+++ b/common/autoware_auto_geometry/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_common</depend>
   <depend>autoware_auto_geometry_msgs</depend>

--- a/common/autoware_auto_geometry/package.xml
+++ b/common/autoware_auto_geometry/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_common</depend>
   <depend>autoware_auto_geometry_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/common/autoware_auto_geometry/package.xml
+++ b/common/autoware_auto_geometry/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_common</depend>
   <depend>autoware_auto_geometry_msgs</depend>

--- a/common/autoware_auto_perception_rviz_plugin/package.xml
+++ b/common/autoware_auto_perception_rviz_plugin/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>libboost-dev</build_depend>
   <build_depend>qtbase5-dev</build_depend>
 

--- a/common/autoware_auto_perception_rviz_plugin/package.xml
+++ b/common/autoware_auto_perception_rviz_plugin/package.xml
@@ -12,8 +12,8 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>libboost-dev</build_depend>
   <build_depend>qtbase5-dev</build_depend>
 

--- a/common/autoware_auto_tf2/package.xml
+++ b/common/autoware_auto_tf2/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_common</depend>
   <depend>autoware_auto_geometry_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/common/autoware_auto_tf2/package.xml
+++ b/common/autoware_auto_tf2/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_common</depend>
   <depend>autoware_auto_geometry_msgs</depend>

--- a/common/autoware_auto_tf2/package.xml
+++ b/common/autoware_auto_tf2/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_common</depend>
   <depend>autoware_auto_geometry_msgs</depend>

--- a/common/autoware_point_types/package.xml
+++ b/common/autoware_point_types/package.xml
@@ -14,7 +14,7 @@
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_cmake_copyright</depend>
   <depend>ament_cmake_cppcheck</depend>

--- a/common/autoware_point_types/package.xml
+++ b/common/autoware_point_types/package.xml
@@ -15,7 +15,6 @@
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
 
-
   <depend>ament_cmake_copyright</depend>
   <depend>ament_cmake_cppcheck</depend>
   <depend>ament_cmake_lint_cmake</depend>

--- a/common/autoware_point_types/package.xml
+++ b/common/autoware_point_types/package.xml
@@ -10,11 +10,11 @@
   <buildtool_depend>ament_cmake_core</buildtool_depend>
   <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
   <buildtool_depend>ament_cmake_test</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_cmake_copyright</depend>
   <depend>ament_cmake_cppcheck</depend>

--- a/common/autoware_testing/package.xml
+++ b/common/autoware_testing/package.xml
@@ -9,8 +9,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>ament_cmake_lint_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <buildtool_export_depend>ros_testing</buildtool_export_depend>
 

--- a/common/autoware_testing/package.xml
+++ b/common/autoware_testing/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_lint_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <buildtool_export_depend>ros_testing</buildtool_export_depend>
 
   <test_depend>ament_cmake_core</test_depend>

--- a/common/autoware_testing/package.xml
+++ b/common/autoware_testing/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>ament_cmake_lint_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <buildtool_export_depend>ros_testing</buildtool_export_depend>
 

--- a/common/bag_time_manager_rviz_plugin/package.xml
+++ b/common/bag_time_manager_rviz_plugin/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/component_interface_specs/package.xml
+++ b/common/component_interface_specs/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
 

--- a/common/component_interface_specs/package.xml
+++ b/common/component_interface_specs/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/common/component_interface_specs/package.xml
+++ b/common/component_interface_specs/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
 

--- a/common/component_interface_tools/package.xml
+++ b/common/component_interface_tools/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>

--- a/common/component_interface_tools/package.xml
+++ b/common/component_interface_tools/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>
   <depend>rclcpp</depend>

--- a/common/component_interface_tools/package.xml
+++ b/common/component_interface_tools/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>

--- a/common/component_interface_utils/package.xml
+++ b/common/component_interface_utils/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>tier4_system_msgs</build_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>

--- a/common/component_interface_utils/package.xml
+++ b/common/component_interface_utils/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>tier4_system_msgs</build_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>

--- a/common/cuda_utils/package.xml
+++ b/common/cuda_utils/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/cuda_utils/package.xml
+++ b/common/cuda_utils/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/cuda_utils/package.xml
+++ b/common/cuda_utils/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/common/fake_test_node/package.xml
+++ b/common/fake_test_node/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_cmake_ros</depend>
   <depend>autoware_auto_common</depend>

--- a/common/fake_test_node/package.xml
+++ b/common/fake_test_node/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>ament_cmake_ros</depend>
   <depend>autoware_auto_common</depend>
   <depend>rclcpp</depend>

--- a/common/fake_test_node/package.xml
+++ b/common/fake_test_node/package.xml
@@ -8,8 +8,8 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>ament_cmake_ros</depend>
   <depend>autoware_auto_common</depend>

--- a/common/global_parameter_loader/package.xml
+++ b/common/global_parameter_loader/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>vehicle_info_util</exec_depend>
 

--- a/common/global_parameter_loader/package.xml
+++ b/common/global_parameter_loader/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>vehicle_info_util</exec_depend>
 

--- a/common/global_parameter_loader/package.xml
+++ b/common/global_parameter_loader/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>vehicle_info_util</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/common/goal_distance_calculator/package.xml
+++ b/common/goal_distance_calculator/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/common/goal_distance_calculator/package.xml
+++ b/common/goal_distance_calculator/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/common/goal_distance_calculator/package.xml
+++ b/common/goal_distance_calculator/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/common/interpolation/package.xml
+++ b/common/interpolation/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>tier4_autoware_utils</depend>
 

--- a/common/interpolation/package.xml
+++ b/common/interpolation/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>tier4_autoware_utils</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/common/interpolation/package.xml
+++ b/common/interpolation/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>tier4_autoware_utils</depend>
 

--- a/common/kalman_filter/package.xml
+++ b/common/kalman_filter/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>eigen</build_depend>
   <build_depend>eigen3_cmake_module</build_depend>
 

--- a/common/kalman_filter/package.xml
+++ b/common/kalman_filter/package.xml
@@ -12,8 +12,8 @@
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>eigen</build_depend>
   <build_depend>eigen3_cmake_module</build_depend>
 

--- a/common/motion_utils/package.xml
+++ b/common/motion_utils/package.xml
@@ -22,7 +22,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>builtin_interfaces</depend>

--- a/common/motion_utils/package.xml
+++ b/common/motion_utils/package.xml
@@ -20,8 +20,8 @@
   <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/common/motion_utils/package.xml
+++ b/common/motion_utils/package.xml
@@ -21,7 +21,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/common/osqp_interface/package.xml
+++ b/common/osqp_interface/package.xml
@@ -11,8 +11,8 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>eigen</depend>
   <depend>osqp_vendor</depend>

--- a/common/osqp_interface/package.xml
+++ b/common/osqp_interface/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>eigen</depend>
   <depend>osqp_vendor</depend>

--- a/common/osqp_interface/package.xml
+++ b/common/osqp_interface/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>eigen</depend>
   <depend>osqp_vendor</depend>
   <depend>rclcpp</depend>

--- a/common/path_distance_calculator/package.xml
+++ b/common/path_distance_calculator/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>motion_utils</depend>

--- a/common/path_distance_calculator/package.xml
+++ b/common/path_distance_calculator/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_planning_msgs</depend>
   <depend>motion_utils</depend>
   <depend>rclcpp</depend>

--- a/common/path_distance_calculator/package.xml
+++ b/common/path_distance_calculator/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>motion_utils</depend>

--- a/common/perception_utils/package.xml
+++ b/common/perception_utils/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>interpolation</depend>

--- a/common/perception_utils/package.xml
+++ b/common/perception_utils/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/common/perception_utils/package.xml
+++ b/common/perception_utils/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/common/polar_grid/package.xml
+++ b/common/polar_grid/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/polar_grid/package.xml
+++ b/common/polar_grid/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/polar_grid/package.xml
+++ b/common/polar_grid/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/rtc_manager_rviz_plugin/package.xml
+++ b/common/rtc_manager_rviz_plugin/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/rtc_manager_rviz_plugin/package.xml
+++ b/common/rtc_manager_rviz_plugin/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/rtc_manager_rviz_plugin/package.xml
+++ b/common/rtc_manager_rviz_plugin/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/signal_processing/package.xml
+++ b/common/signal_processing/package.xml
@@ -11,7 +11,7 @@
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
   <author email="ali.boyali@tier4.jp">Ali BOYALI</author>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>libboost-dev</build_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <depend>geometry_msgs</depend>

--- a/common/signal_processing/package.xml
+++ b/common/signal_processing/package.xml
@@ -11,9 +11,9 @@
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
   <author email="ali.boyali@tier4.jp">Ali BOYALI</author>
 
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>libboost-dev</build_depend>
-  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <build_export_depend>libboost-dev</build_export_depend>

--- a/common/tier4_adapi_rviz_plugin/package.xml
+++ b/common/tier4_adapi_rviz_plugin/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_adapi_rviz_plugin/package.xml
+++ b/common/tier4_adapi_rviz_plugin/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_adapi_rviz_plugin/package.xml
+++ b/common/tier4_adapi_rviz_plugin/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/tier4_api_utils/package.xml
+++ b/common/tier4_api_utils/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>tier4_external_api_msgs</depend>

--- a/common/tier4_api_utils/package.xml
+++ b/common/tier4_api_utils/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>rclcpp</depend>
   <depend>tier4_external_api_msgs</depend>

--- a/common/tier4_api_utils/package.xml
+++ b/common/tier4_api_utils/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>rclcpp</depend>
   <depend>tier4_external_api_msgs</depend>
 

--- a/common/tier4_automatic_goal_rviz_plugin/package.xml
+++ b/common/tier4_automatic_goal_rviz_plugin/package.xml
@@ -10,7 +10,7 @@
   <author email="dawid.moszynski@robotec.ai">Dawid Moszyński</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_autoware_utils/package.xml
+++ b/common/tier4_autoware_utils/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/common/tier4_autoware_utils/package.xml
+++ b/common/tier4_autoware_utils/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/common/tier4_autoware_utils/package.xml
+++ b/common/tier4_autoware_utils/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/common/tier4_calibration_rviz_plugin/package.xml
+++ b/common/tier4_calibration_rviz_plugin/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libqt5-core</depend>
   <depend>libqt5-widgets</depend>

--- a/common/tier4_calibration_rviz_plugin/package.xml
+++ b/common/tier4_calibration_rviz_plugin/package.xml
@@ -10,8 +10,8 @@
   <author email="tomoya.kimura@tier4.jp">Tomoya Kimura</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libqt5-core</depend>
   <depend>libqt5-widgets</depend>

--- a/common/tier4_calibration_rviz_plugin/package.xml
+++ b/common/tier4_calibration_rviz_plugin/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libqt5-core</depend>
   <depend>libqt5-widgets</depend>
   <depend>qtbase5-dev</depend>

--- a/common/tier4_control_rviz_plugin/package.xml
+++ b/common/tier4_control_rviz_plugin/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_control_rviz_plugin/package.xml
+++ b/common/tier4_control_rviz_plugin/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/common/tier4_control_rviz_plugin/package.xml
+++ b/common/tier4_control_rviz_plugin/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/common/tier4_datetime_rviz_plugin/package.xml
+++ b/common/tier4_datetime_rviz_plugin/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_datetime_rviz_plugin/package.xml
+++ b/common/tier4_datetime_rviz_plugin/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_datetime_rviz_plugin/package.xml
+++ b/common/tier4_datetime_rviz_plugin/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/tier4_debug_rviz_plugin/package.xml
+++ b/common/tier4_debug_rviz_plugin/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_debug_rviz_plugin/package.xml
+++ b/common/tier4_debug_rviz_plugin/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/tier4_debug_rviz_plugin/package.xml
+++ b/common/tier4_debug_rviz_plugin/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_debug_tools/package.xml
+++ b/common/tier4_debug_tools/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/common/tier4_debug_tools/package.xml
+++ b/common/tier4_debug_tools/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>motion_utils</depend>

--- a/common/tier4_debug_tools/package.xml
+++ b/common/tier4_debug_tools/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/common/tier4_localization_rviz_plugin/package.xml
+++ b/common/tier4_localization_rviz_plugin/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_localization_rviz_plugin/package.xml
+++ b/common/tier4_localization_rviz_plugin/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_localization_rviz_plugin/package.xml
+++ b/common/tier4_localization_rviz_plugin/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_perception_rviz_plugin/package.xml
+++ b/common/tier4_perception_rviz_plugin/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>dummy_perception_publisher</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_perception_rviz_plugin/package.xml
+++ b/common/tier4_perception_rviz_plugin/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>dummy_perception_publisher</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_perception_rviz_plugin/package.xml
+++ b/common/tier4_perception_rviz_plugin/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>dummy_perception_publisher</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_planning_rviz_plugin/package.xml
+++ b/common/tier4_planning_rviz_plugin/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/common/tier4_planning_rviz_plugin/package.xml
+++ b/common/tier4_planning_rviz_plugin/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_planning_rviz_plugin/package.xml
+++ b/common/tier4_planning_rviz_plugin/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/common/tier4_screen_capture_rviz_plugin/package.xml
+++ b/common/tier4_screen_capture_rviz_plugin/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libopencv-dev</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_screen_capture_rviz_plugin/package.xml
+++ b/common/tier4_screen_capture_rviz_plugin/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libopencv-dev</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_screen_capture_rviz_plugin/package.xml
+++ b/common/tier4_screen_capture_rviz_plugin/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libopencv-dev</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_simulated_clock_rviz_plugin/package.xml
+++ b/common/tier4_simulated_clock_rviz_plugin/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_simulated_clock_rviz_plugin/package.xml
+++ b/common/tier4_simulated_clock_rviz_plugin/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_simulated_clock_rviz_plugin/package.xml
+++ b/common/tier4_simulated_clock_rviz_plugin/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/tier4_state_rviz_plugin/package.xml
+++ b/common/tier4_state_rviz_plugin/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/common/tier4_state_rviz_plugin/package.xml
+++ b/common/tier4_state_rviz_plugin/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/common/tier4_state_rviz_plugin/package.xml
+++ b/common/tier4_state_rviz_plugin/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/common/tier4_traffic_light_rviz_plugin/package.xml
+++ b/common/tier4_traffic_light_rviz_plugin/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/common/tier4_traffic_light_rviz_plugin/package.xml
+++ b/common/tier4_traffic_light_rviz_plugin/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/common/tier4_traffic_light_rviz_plugin/package.xml
+++ b/common/tier4_traffic_light_rviz_plugin/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>lanelet2_extension</depend>

--- a/common/tier4_vehicle_rviz_plugin/package.xml
+++ b/common/tier4_vehicle_rviz_plugin/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>libqt5-core</depend>

--- a/common/tier4_vehicle_rviz_plugin/package.xml
+++ b/common/tier4_vehicle_rviz_plugin/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_vehicle_rviz_plugin/package.xml
+++ b/common/tier4_vehicle_rviz_plugin/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>libqt5-core</depend>

--- a/common/time_utils/package.xml
+++ b/common/time_utils/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>builtin_interfaces</build_depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/common/time_utils/package.xml
+++ b/common/time_utils/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>builtin_interfaces</build_depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/common/tvm_utility/package.xml
+++ b/common/tvm_utility/package.xml
@@ -27,7 +27,7 @@
   <maintainer email="xinyu.wang@tier4.jp">Xinyu Wang</maintainer>
   <license>Apache License 2.0</license>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>libopenblas-dev</depend>

--- a/control/autonomous_emergency_braking/package.xml
+++ b/control/autonomous_emergency_braking/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/control/autonomous_emergency_braking/package.xml
+++ b/control/autonomous_emergency_braking/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/control/autonomous_emergency_braking/package.xml
+++ b/control/autonomous_emergency_braking/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/control/control_performance_analysis/package.xml
+++ b/control/control_performance_analysis/package.xml
@@ -21,7 +21,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>builtin_interfaces</build_depend>
 
   <depend>autoware_auto_control_msgs</depend>

--- a/control/control_performance_analysis/package.xml
+++ b/control/control_performance_analysis/package.xml
@@ -19,9 +19,9 @@
   <author email="berkay@leodrive.ai">Berkay Karaman</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>builtin_interfaces</build_depend>
 
   <depend>autoware_auto_control_msgs</depend>

--- a/control/external_cmd_selector/package.xml
+++ b/control/external_cmd_selector/package.xml
@@ -18,7 +18,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/control/external_cmd_selector/package.xml
+++ b/control/external_cmd_selector/package.xml
@@ -17,8 +17,8 @@
   <author email="kenji.miyake@tier4.jp">Kenji Miyake</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/control/external_cmd_selector/package.xml
+++ b/control/external_cmd_selector/package.xml
@@ -19,7 +19,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>

--- a/control/joy_controller/package.xml
+++ b/control/joy_controller/package.xml
@@ -17,8 +17,8 @@
   <author email="kenji.miyake@tier4.jp">Kenji Miyake</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/control/joy_controller/package.xml
+++ b/control/joy_controller/package.xml
@@ -18,7 +18,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/control/joy_controller/package.xml
+++ b/control/joy_controller/package.xml
@@ -19,7 +19,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/control/lane_departure_checker/package.xml
+++ b/control/lane_departure_checker/package.xml
@@ -10,8 +10,8 @@
   <author email="kenji.miyake@tier4.jp">Kenji Miyake</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/lane_departure_checker/package.xml
+++ b/control/lane_departure_checker/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/lane_departure_checker/package.xml
+++ b/control/lane_departure_checker/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/control/mpc_lateral_controller/package.xml
+++ b/control/mpc_lateral_controller/package.xml
@@ -15,8 +15,8 @@
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/mpc_lateral_controller/package.xml
+++ b/control/mpc_lateral_controller/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/control/mpc_lateral_controller/package.xml
+++ b/control/mpc_lateral_controller/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/obstacle_collision_checker/package.xml
+++ b/control/obstacle_collision_checker/package.xml
@@ -20,7 +20,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_planning_msgs</depend>
   <depend>boost</depend>
   <depend>diagnostic_updater</depend>

--- a/control/obstacle_collision_checker/package.xml
+++ b/control/obstacle_collision_checker/package.xml
@@ -19,7 +19,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>boost</depend>

--- a/control/obstacle_collision_checker/package.xml
+++ b/control/obstacle_collision_checker/package.xml
@@ -18,8 +18,8 @@
   <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>boost</depend>

--- a/control/operation_mode_transition_manager/package.xml
+++ b/control/operation_mode_transition_manager/package.xml
@@ -8,7 +8,7 @@
 
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_auto_control_msgs</depend>

--- a/control/pid_longitudinal_controller/package.xml
+++ b/control/pid_longitudinal_controller/package.xml
@@ -15,8 +15,8 @@
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/control/pid_longitudinal_controller/package.xml
+++ b/control/pid_longitudinal_controller/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/pid_longitudinal_controller/package.xml
+++ b/control/pid_longitudinal_controller/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -12,8 +12,8 @@
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>boost</depend>

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>boost</depend>

--- a/control/shift_decider/package.xml
+++ b/control/shift_decider/package.xml
@@ -10,8 +10,8 @@
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/control/shift_decider/package.xml
+++ b/control/shift_decider/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/control/shift_decider/package.xml
+++ b/control/shift_decider/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/control/trajectory_follower_base/package.xml
+++ b/control/trajectory_follower_base/package.xml
@@ -17,8 +17,8 @@
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/control/trajectory_follower_base/package.xml
+++ b/control/trajectory_follower_base/package.xml
@@ -18,7 +18,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/control/trajectory_follower_base/package.xml
+++ b/control/trajectory_follower_base/package.xml
@@ -19,7 +19,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/trajectory_follower_node/package.xml
+++ b/control/trajectory_follower_node/package.xml
@@ -17,8 +17,8 @@
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/control/trajectory_follower_node/package.xml
+++ b/control/trajectory_follower_node/package.xml
@@ -18,7 +18,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/control/trajectory_follower_node/package.xml
+++ b/control/trajectory_follower_node/package.xml
@@ -19,7 +19,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/control/vehicle_cmd_gate/package.xml
+++ b/control/vehicle_cmd_gate/package.xml
@@ -11,8 +11,8 @@
   <author email="hiroki.ota@tier4.jp">Hiroki OTA</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/control/vehicle_cmd_gate/package.xml
+++ b/control/vehicle_cmd_gate/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/control/vehicle_cmd_gate/package.xml
+++ b/control/vehicle_cmd_gate/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/evaluator/diagnostic_converter/package.xml
+++ b/evaluator/diagnostic_converter/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>diagnostic_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/evaluator/diagnostic_converter/package.xml
+++ b/evaluator/diagnostic_converter/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>diagnostic_msgs</depend>
   <depend>pluginlib</depend>

--- a/evaluator/diagnostic_converter/package.xml
+++ b/evaluator/diagnostic_converter/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>diagnostic_msgs</depend>
   <depend>pluginlib</depend>

--- a/evaluator/kinematic_evaluator/package.xml
+++ b/evaluator/kinematic_evaluator/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/evaluator/kinematic_evaluator/package.xml
+++ b/evaluator/kinematic_evaluator/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/evaluator/kinematic_evaluator/package.xml
+++ b/evaluator/kinematic_evaluator/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/evaluator/localization_evaluator/package.xml
+++ b/evaluator/localization_evaluator/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/evaluator/localization_evaluator/package.xml
+++ b/evaluator/localization_evaluator/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/evaluator/localization_evaluator/package.xml
+++ b/evaluator/localization_evaluator/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/evaluator/planning_evaluator/package.xml
+++ b/evaluator/planning_evaluator/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/evaluator/planning_evaluator/package.xml
+++ b/evaluator/planning_evaluator/package.xml
@@ -11,8 +11,8 @@
   <author email="maxime.clement@tier4.jp">Maxime CLEMENT</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/evaluator/planning_evaluator/package.xml
+++ b/evaluator/planning_evaluator/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/launch/map4_localization_launch/package.xml
+++ b/launch/map4_localization_launch/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>automatic_pose_initializer</exec_depend>
   <exec_depend>eagleye_fix2pose</exec_depend>
   <exec_depend>eagleye_gnss_converter</exec_depend>

--- a/launch/map4_localization_launch/package.xml
+++ b/launch/map4_localization_launch/package.xml
@@ -13,8 +13,8 @@
   <author email="ryohei.sasaki@map.jp">Ryohei Sasaki</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>automatic_pose_initializer</exec_depend>
   <exec_depend>eagleye_fix2pose</exec_depend>

--- a/launch/map4_localization_launch/package.xml
+++ b/launch/map4_localization_launch/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>automatic_pose_initializer</exec_depend>
   <exec_depend>eagleye_fix2pose</exec_depend>

--- a/launch/tier4_autoware_api_launch/package.xml
+++ b/launch/tier4_autoware_api_launch/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>ad_api_adaptors</exec_depend>
   <exec_depend>autoware_iv_external_api_adaptor</exec_depend>

--- a/launch/tier4_autoware_api_launch/package.xml
+++ b/launch/tier4_autoware_api_launch/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>ad_api_adaptors</exec_depend>
   <exec_depend>autoware_iv_external_api_adaptor</exec_depend>
   <exec_depend>autoware_iv_internal_api_adaptor</exec_depend>

--- a/launch/tier4_autoware_api_launch/package.xml
+++ b/launch/tier4_autoware_api_launch/package.xml
@@ -12,8 +12,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>ad_api_adaptors</exec_depend>
   <exec_depend>autoware_iv_external_api_adaptor</exec_depend>

--- a/launch/tier4_control_launch/package.xml
+++ b/launch/tier4_control_launch/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>external_cmd_converter</exec_depend>
   <exec_depend>external_cmd_selector</exec_depend>

--- a/launch/tier4_control_launch/package.xml
+++ b/launch/tier4_control_launch/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>external_cmd_converter</exec_depend>
   <exec_depend>external_cmd_selector</exec_depend>

--- a/launch/tier4_control_launch/package.xml
+++ b/launch/tier4_control_launch/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>external_cmd_converter</exec_depend>
   <exec_depend>external_cmd_selector</exec_depend>
   <exec_depend>lane_departure_checker</exec_depend>

--- a/launch/tier4_localization_launch/package.xml
+++ b/launch/tier4_localization_launch/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>automatic_pose_initializer</exec_depend>
   <exec_depend>ekf_localizer</exec_depend>

--- a/launch/tier4_localization_launch/package.xml
+++ b/launch/tier4_localization_launch/package.xml
@@ -12,8 +12,8 @@
   <author email="yamato.ando@tier4.jp">Yamato Ando</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>automatic_pose_initializer</exec_depend>
   <exec_depend>ekf_localizer</exec_depend>

--- a/launch/tier4_localization_launch/package.xml
+++ b/launch/tier4_localization_launch/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>automatic_pose_initializer</exec_depend>
   <exec_depend>ekf_localizer</exec_depend>
   <exec_depend>gyro_odometer</exec_depend>

--- a/launch/tier4_map_launch/package.xml
+++ b/launch/tier4_map_launch/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>map_loader</exec_depend>
   <exec_depend>map_tf_generator</exec_depend>
 

--- a/launch/tier4_map_launch/package.xml
+++ b/launch/tier4_map_launch/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>map_loader</exec_depend>
   <exec_depend>map_tf_generator</exec_depend>

--- a/launch/tier4_map_launch/package.xml
+++ b/launch/tier4_map_launch/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>map_loader</exec_depend>
   <exec_depend>map_tf_generator</exec_depend>

--- a/launch/tier4_perception_launch/package.xml
+++ b/launch/tier4_perception_launch/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>compare_map_segmentation</exec_depend>
   <exec_depend>crosswalk_traffic_light_estimator</exec_depend>

--- a/launch/tier4_perception_launch/package.xml
+++ b/launch/tier4_perception_launch/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>compare_map_segmentation</exec_depend>
   <exec_depend>crosswalk_traffic_light_estimator</exec_depend>

--- a/launch/tier4_perception_launch/package.xml
+++ b/launch/tier4_perception_launch/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>compare_map_segmentation</exec_depend>
   <exec_depend>crosswalk_traffic_light_estimator</exec_depend>
   <exec_depend>detected_object_feature_remover</exec_depend>

--- a/launch/tier4_planning_launch/package.xml
+++ b/launch/tier4_planning_launch/package.xml
@@ -54,7 +54,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>behavior_path_planner</exec_depend>
   <exec_depend>behavior_velocity_planner</exec_depend>
   <exec_depend>costmap_generator</exec_depend>

--- a/launch/tier4_planning_launch/package.xml
+++ b/launch/tier4_planning_launch/package.xml
@@ -53,7 +53,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>behavior_path_planner</exec_depend>
   <exec_depend>behavior_velocity_planner</exec_depend>

--- a/launch/tier4_planning_launch/package.xml
+++ b/launch/tier4_planning_launch/package.xml
@@ -52,8 +52,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>behavior_path_planner</exec_depend>
   <exec_depend>behavior_velocity_planner</exec_depend>

--- a/launch/tier4_sensing_launch/package.xml
+++ b/launch/tier4_sensing_launch/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>vehicle_info_util</exec_depend>
 

--- a/launch/tier4_sensing_launch/package.xml
+++ b/launch/tier4_sensing_launch/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>vehicle_info_util</exec_depend>
 

--- a/launch/tier4_sensing_launch/package.xml
+++ b/launch/tier4_sensing_launch/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>vehicle_info_util</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/launch/tier4_simulator_launch/package.xml
+++ b/launch/tier4_simulator_launch/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>dummy_perception_publisher</exec_depend>
   <exec_depend>fault_injection</exec_depend>
   <exec_depend>simple_planning_simulator</exec_depend>

--- a/launch/tier4_simulator_launch/package.xml
+++ b/launch/tier4_simulator_launch/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>dummy_perception_publisher</exec_depend>
   <exec_depend>fault_injection</exec_depend>

--- a/launch/tier4_simulator_launch/package.xml
+++ b/launch/tier4_simulator_launch/package.xml
@@ -12,8 +12,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>dummy_perception_publisher</exec_depend>
   <exec_depend>fault_injection</exec_depend>

--- a/launch/tier4_system_launch/package.xml
+++ b/launch/tier4_system_launch/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>component_state_monitor</exec_depend>
   <exec_depend>emergency_handler</exec_depend>
   <exec_depend>system_error_monitor</exec_depend>

--- a/launch/tier4_system_launch/package.xml
+++ b/launch/tier4_system_launch/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>component_state_monitor</exec_depend>
   <exec_depend>emergency_handler</exec_depend>

--- a/launch/tier4_system_launch/package.xml
+++ b/launch/tier4_system_launch/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>component_state_monitor</exec_depend>
   <exec_depend>emergency_handler</exec_depend>

--- a/launch/tier4_vehicle_launch/package.xml
+++ b/launch/tier4_vehicle_launch/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/launch/tier4_vehicle_launch/package.xml
+++ b/launch/tier4_vehicle_launch/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/launch/tier4_vehicle_launch/package.xml
+++ b/launch/tier4_vehicle_launch/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/localization/ekf_localizer/package.xml
+++ b/localization/ekf_localizer/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>eigen</build_depend>
 
   <depend>fmt</depend>

--- a/localization/ekf_localizer/package.xml
+++ b/localization/ekf_localizer/package.xml
@@ -12,9 +12,9 @@
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>eigen</build_depend>
 
   <depend>fmt</depend>

--- a/localization/gyro_odometer/package.xml
+++ b/localization/gyro_odometer/package.xml
@@ -9,8 +9,8 @@
   <author email="yamato.ando@tier4.jp">Yamato Ando</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>

--- a/localization/gyro_odometer/package.xml
+++ b/localization/gyro_odometer/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>

--- a/localization/gyro_odometer/package.xml
+++ b/localization/gyro_odometer/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/localization/initial_pose_button_panel/package.xml
+++ b/localization/initial_pose_button_panel/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>

--- a/localization/initial_pose_button_panel/package.xml
+++ b/localization/initial_pose_button_panel/package.xml
@@ -10,8 +10,8 @@
   <author email="yamato.ando@tier4.jp">Yamato ANDO</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>

--- a/localization/initial_pose_button_panel/package.xml
+++ b/localization/initial_pose_button_panel/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-widgets</depend>

--- a/localization/localization_error_monitor/package.xml
+++ b/localization/localization_error_monitor/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>

--- a/localization/localization_error_monitor/package.xml
+++ b/localization/localization_error_monitor/package.xml
@@ -10,8 +10,8 @@
   <author email="taichi.higashide@tier4.jp">Taichi Higashide</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/localization/localization_error_monitor/package.xml
+++ b/localization/localization_error_monitor/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/localization/ndt_scan_matcher/package.xml
+++ b/localization/ndt_scan_matcher/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_map_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/localization/ndt_scan_matcher/package.xml
+++ b/localization/ndt_scan_matcher/package.xml
@@ -11,8 +11,8 @@
   <author email="yamato.ando@tier4.jp">Yamato Ando</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_map_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/localization/ndt_scan_matcher/package.xml
+++ b/localization/ndt_scan_matcher/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_map_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>fmt</depend>

--- a/localization/pose2twist/package.xml
+++ b/localization/pose2twist/package.xml
@@ -9,8 +9,8 @@
   <author email="yamato.ando@tier4.jp">Yamato Ando</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/localization/pose2twist/package.xml
+++ b/localization/pose2twist/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/localization/pose2twist/package.xml
+++ b/localization/pose2twist/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/localization/pose_initializer/package.xml
+++ b/localization/pose_initializer/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>component_interface_specs</depend>
   <depend>component_interface_utils</depend>
   <depend>geometry_msgs</depend>

--- a/localization/pose_initializer/package.xml
+++ b/localization/pose_initializer/package.xml
@@ -11,8 +11,8 @@
   <author email="isamu.takagi@tier4.jp">Takagi, Isamu</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>component_interface_specs</depend>
   <depend>component_interface_utils</depend>

--- a/localization/pose_initializer/package.xml
+++ b/localization/pose_initializer/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>component_interface_specs</depend>
   <depend>component_interface_utils</depend>

--- a/localization/stop_filter/package.xml
+++ b/localization/stop_filter/package.xml
@@ -10,8 +10,8 @@
   <author email="koji.minoda@tier4.jp">Koji Minoda</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/localization/stop_filter/package.xml
+++ b/localization/stop_filter/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/localization/stop_filter/package.xml
+++ b/localization/stop_filter/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/localization/twist2accel/package.xml
+++ b/localization/twist2accel/package.xml
@@ -10,8 +10,8 @@
   <author email="koji.minoda@tier4.jp">Koji Minoda</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/localization/twist2accel/package.xml
+++ b/localization/twist2accel/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/localization/twist2accel/package.xml
+++ b/localization/twist2accel/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/map/map_height_fitter/package.xml
+++ b/map/map_height_fitter/package.xml
@@ -10,8 +10,8 @@
   <author email="isamu.takagi@tier4.jp">Takagi, Isamu</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_map_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/map/map_height_fitter/package.xml
+++ b/map/map_height_fitter/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_map_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/map/map_height_fitter/package.xml
+++ b/map/map_height_fitter/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_map_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libpcl-common</depend>

--- a/map/map_loader/package.xml
+++ b/map/map_loader/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_map_msgs</depend>

--- a/map/map_loader/package.xml
+++ b/map/map_loader/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>fmt</depend>

--- a/map/map_loader/package.xml
+++ b/map/map_loader/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_map_msgs</depend>

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>lanelet2_extension</depend>
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>lanelet2_extension</depend>
   <depend>libpcl-all-dev</depend>

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>lanelet2_extension</depend>
   <depend>libpcl-all-dev</depend>

--- a/map/util/lanelet2_map_preprocessor/package.xml
+++ b/map/util/lanelet2_map_preprocessor/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>lanelet2_extension</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>

--- a/map/util/lanelet2_map_preprocessor/package.xml
+++ b/map/util/lanelet2_map_preprocessor/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>lanelet2_extension</depend>
   <depend>pcl_ros</depend>

--- a/map/util/lanelet2_map_preprocessor/package.xml
+++ b/map/util/lanelet2_map_preprocessor/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>lanelet2_extension</depend>
   <depend>pcl_ros</depend>

--- a/perception/bytetrack/package.xml
+++ b/perception/bytetrack/package.xml
@@ -13,7 +13,7 @@
   <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cuda_utils</depend>

--- a/perception/bytetrack/package.xml
+++ b/perception/bytetrack/package.xml
@@ -14,7 +14,6 @@
   <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cuda_utils</depend>
   <depend>cv_bridge</depend>

--- a/perception/bytetrack/package.xml
+++ b/perception/bytetrack/package.xml
@@ -8,12 +8,12 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>cudnn_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cuda_utils</depend>

--- a/perception/compare_map_segmentation/package.xml
+++ b/perception/compare_map_segmentation/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_map_msgs</depend>
   <depend>component_interface_specs</depend>

--- a/perception/compare_map_segmentation/package.xml
+++ b/perception/compare_map_segmentation/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_map_msgs</depend>
   <depend>component_interface_specs</depend>
   <depend>component_interface_utils</depend>

--- a/perception/compare_map_segmentation/package.xml
+++ b/perception/compare_map_segmentation/package.xml
@@ -15,8 +15,8 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_map_msgs</depend>
   <depend>component_interface_specs</depend>

--- a/perception/crosswalk_traffic_light_estimator/package.xml
+++ b/perception/crosswalk_traffic_light_estimator/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/perception/crosswalk_traffic_light_estimator/package.xml
+++ b/perception/crosswalk_traffic_light_estimator/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/perception/crosswalk_traffic_light_estimator/package.xml
+++ b/perception/crosswalk_traffic_light_estimator/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/perception/detected_object_feature_remover/package.xml
+++ b/perception/detected_object_feature_remover/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/detected_object_feature_remover/package.xml
+++ b/perception/detected_object_feature_remover/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>rclcpp</depend>

--- a/perception/detected_object_feature_remover/package.xml
+++ b/perception/detected_object_feature_remover/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>rclcpp</depend>

--- a/perception/detected_object_validation/package.xml
+++ b/perception/detected_object_validation/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>libopencv-dev</build_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>

--- a/perception/detected_object_validation/package.xml
+++ b/perception/detected_object_validation/package.xml
@@ -9,9 +9,9 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>libopencv-dev</build_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>

--- a/perception/detection_by_tracker/package.xml
+++ b/perception/detection_by_tracker/package.xml
@@ -9,9 +9,9 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>eigen</depend>
   <depend>euclidean_cluster</depend>

--- a/perception/detection_by_tracker/package.xml
+++ b/perception/detection_by_tracker/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>eigen</depend>
   <depend>euclidean_cluster</depend>

--- a/perception/detection_by_tracker/package.xml
+++ b/perception/detection_by_tracker/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-
   <depend>eigen</depend>
   <depend>euclidean_cluster</depend>
   <depend>libpcl-all-dev</depend>

--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_map_msgs</depend>

--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_map_msgs</depend>

--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>grid_map_cv</depend>

--- a/perception/euclidean_cluster/package.xml
+++ b/perception/euclidean_cluster/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>compare_map_segmentation</depend>

--- a/perception/euclidean_cluster/package.xml
+++ b/perception/euclidean_cluster/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>compare_map_segmentation</depend>

--- a/perception/euclidean_cluster/package.xml
+++ b/perception/euclidean_cluster/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>compare_map_segmentation</depend>
   <depend>geometry_msgs</depend>

--- a/perception/front_vehicle_velocity_estimator/package.xml
+++ b/perception/front_vehicle_velocity_estimator/package.xml
@@ -10,6 +10,7 @@
   <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -22,7 +23,6 @@
   <depend>sensor_msgs</depend>
   <depend>tier4_autoware_utils</depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/perception/front_vehicle_velocity_estimator/package.xml
+++ b/perception/front_vehicle_velocity_estimator/package.xml
@@ -22,7 +22,7 @@
   <depend>sensor_msgs</depend>
   <depend>tier4_autoware_utils</depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/perception/ground_segmentation/package.xml
+++ b/perception/ground_segmentation/package.xml
@@ -18,7 +18,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libopencv-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>

--- a/perception/ground_segmentation/package.xml
+++ b/perception/ground_segmentation/package.xml
@@ -17,7 +17,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libopencv-dev</depend>
   <depend>pcl_conversions</depend>

--- a/perception/ground_segmentation/package.xml
+++ b/perception/ground_segmentation/package.xml
@@ -16,8 +16,8 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libopencv-dev</depend>
   <depend>pcl_conversions</depend>

--- a/perception/heatmap_visualizer/package.xml
+++ b/perception/heatmap_visualizer/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/perception/heatmap_visualizer/package.xml
+++ b/perception/heatmap_visualizer/package.xml
@@ -9,8 +9,8 @@
   <author email="kotaro.uetake@tier4.jp">Kotaro Uetake</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/perception/heatmap_visualizer/package.xml
+++ b/perception/heatmap_visualizer/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/perception/image_projection_based_fusion/package.xml
+++ b/perception/image_projection_based_fusion/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>

--- a/perception/image_projection_based_fusion/package.xml
+++ b/perception/image_projection_based_fusion/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/image_projection_based_fusion/package.xml
+++ b/perception/image_projection_based_fusion/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/lidar_apollo_segmentation_tvm/package.xml
+++ b/perception/lidar_apollo_segmentation_tvm/package.xml
@@ -9,8 +9,8 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>libpcl-all-dev</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>

--- a/perception/lidar_apollo_segmentation_tvm/package.xml
+++ b/perception/lidar_apollo_segmentation_tvm/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>libpcl-all-dev</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>

--- a/perception/lidar_apollo_segmentation_tvm_nodes/package.xml
+++ b/perception/lidar_apollo_segmentation_tvm_nodes/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>lidar_apollo_segmentation_tvm</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/lidar_apollo_segmentation_tvm_nodes/package.xml
+++ b/perception/lidar_apollo_segmentation_tvm_nodes/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>lidar_apollo_segmentation_tvm</depend>
   <depend>rclcpp</depend>

--- a/perception/lidar_apollo_segmentation_tvm_nodes/package.xml
+++ b/perception/lidar_apollo_segmentation_tvm_nodes/package.xml
@@ -10,8 +10,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>lidar_apollo_segmentation_tvm</depend>
   <depend>rclcpp</depend>

--- a/perception/lidar_centerpoint/package.xml
+++ b/perception/lidar_centerpoint/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>pcl_ros</depend>

--- a/perception/lidar_centerpoint/package.xml
+++ b/perception/lidar_centerpoint/package.xml
@@ -10,8 +10,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>pcl_ros</depend>

--- a/perception/lidar_centerpoint/package.xml
+++ b/perception/lidar_centerpoint/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>perception_utils</depend>

--- a/perception/lidar_centerpoint_tvm/package.xml
+++ b/perception/lidar_centerpoint_tvm/package.xml
@@ -9,8 +9,8 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>pcl_ros</depend>

--- a/perception/lidar_centerpoint_tvm/package.xml
+++ b/perception/lidar_centerpoint_tvm/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>

--- a/perception/lidar_centerpoint_tvm/package.xml
+++ b/perception/lidar_centerpoint_tvm/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>pcl_ros</depend>

--- a/perception/map_based_prediction/package.xml
+++ b/perception/map_based_prediction/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>interpolation</depend>

--- a/perception/map_based_prediction/package.xml
+++ b/perception/map_based_prediction/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>

--- a/perception/map_based_prediction/package.xml
+++ b/perception/map_based_prediction/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>interpolation</depend>

--- a/perception/multi_object_tracker/package.xml
+++ b/perception/multi_object_tracker/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>
   <depend>kalman_filter</depend>

--- a/perception/multi_object_tracker/package.xml
+++ b/perception/multi_object_tracker/package.xml
@@ -9,9 +9,9 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>

--- a/perception/multi_object_tracker/package.xml
+++ b/perception/multi_object_tracker/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>

--- a/perception/object_merger/package.xml
+++ b/perception/object_merger/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>
   <depend>mussp</depend>

--- a/perception/object_merger/package.xml
+++ b/perception/object_merger/package.xml
@@ -9,9 +9,9 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>

--- a/perception/object_merger/package.xml
+++ b/perception/object_merger/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>

--- a/perception/object_range_splitter/package.xml
+++ b/perception/object_range_splitter/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>rclcpp</depend>

--- a/perception/object_range_splitter/package.xml
+++ b/perception/object_range_splitter/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/object_range_splitter/package.xml
+++ b/perception/object_range_splitter/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>rclcpp</depend>

--- a/perception/occupancy_grid_map_outlier_filter/package.xml
+++ b/perception/occupancy_grid_map_outlier_filter/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/perception/occupancy_grid_map_outlier_filter/package.xml
+++ b/perception/occupancy_grid_map_outlier_filter/package.xml
@@ -15,8 +15,8 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/perception/occupancy_grid_map_outlier_filter/package.xml
+++ b/perception/occupancy_grid_map_outlier_filter/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>image_transport</depend>

--- a/perception/probabilistic_occupancy_grid_map/package.xml
+++ b/perception/probabilistic_occupancy_grid_map/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>eigen3_cmake_module</depend>
   <depend>laser_geometry</depend>
   <depend>message_filters</depend>

--- a/perception/probabilistic_occupancy_grid_map/package.xml
+++ b/perception/probabilistic_occupancy_grid_map/package.xml
@@ -11,8 +11,8 @@
   <author email="yukihiro.saito@tier4.jp">Yukihiro Saito</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>eigen3_cmake_module</depend>
   <depend>laser_geometry</depend>

--- a/perception/probabilistic_occupancy_grid_map/package.xml
+++ b/perception/probabilistic_occupancy_grid_map/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>eigen3_cmake_module</depend>
   <depend>laser_geometry</depend>

--- a/perception/radar_fusion_to_detected_object/package.xml
+++ b/perception/radar_fusion_to_detected_object/package.xml
@@ -20,7 +20,7 @@
   <depend>std_msgs</depend>
   <depend>tier4_autoware_utils</depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/perception/radar_fusion_to_detected_object/package.xml
+++ b/perception/radar_fusion_to_detected_object/package.xml
@@ -10,6 +10,7 @@
   <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>eigen</depend>
@@ -20,7 +21,6 @@
   <depend>std_msgs</depend>
   <depend>tier4_autoware_utils</depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/perception/radar_tracks_msgs_converter/package.xml
+++ b/perception/radar_tracks_msgs_converter/package.xml
@@ -10,6 +10,7 @@
   <author email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -22,7 +23,6 @@
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/perception/radar_tracks_msgs_converter/package.xml
+++ b/perception/radar_tracks_msgs_converter/package.xml
@@ -22,7 +22,7 @@
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/perception/shape_estimation/package.xml
+++ b/perception/shape_estimation/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>builtin_interfaces</depend>

--- a/perception/shape_estimation/package.xml
+++ b/perception/shape_estimation/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>eigen</depend>

--- a/perception/shape_estimation/package.xml
+++ b/perception/shape_estimation/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>builtin_interfaces</depend>

--- a/perception/tensorrt_yolo/package.xml
+++ b/perception/tensorrt_yolo/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/tensorrt_yolo/package.xml
+++ b/perception/tensorrt_yolo/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/tensorrt_yolo/package.xml
+++ b/perception/tensorrt_yolo/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>

--- a/perception/tensorrt_yolox/package.xml
+++ b/perception/tensorrt_yolox/package.xml
@@ -17,7 +17,7 @@
   <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cuda_utils</depend>

--- a/perception/tensorrt_yolox/package.xml
+++ b/perception/tensorrt_yolox/package.xml
@@ -18,7 +18,6 @@
   <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cuda_utils</depend>
   <depend>cv_bridge</depend>

--- a/perception/tensorrt_yolox/package.xml
+++ b/perception/tensorrt_yolox/package.xml
@@ -11,13 +11,13 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>cudnn_cmake_module</buildtool_depend>
   <buildtool_depend>tensorrt_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cuda_utils</depend>

--- a/perception/traffic_light_classifier/package.xml
+++ b/perception/traffic_light_classifier/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>wget</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>

--- a/perception/traffic_light_classifier/package.xml
+++ b/perception/traffic_light_classifier/package.xml
@@ -9,9 +9,9 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>wget</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/traffic_light_classifier/package.xml
+++ b/perception/traffic_light_classifier/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>wget</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_map_based_detector/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/perception/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_map_based_detector/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/perception/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_map_based_detector/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/perception/traffic_light_selector/package.xml
+++ b/perception/traffic_light_selector/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/perception/traffic_light_selector/package.xml
+++ b/perception/traffic_light_selector/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_perception_msgs</depend>

--- a/perception/traffic_light_selector/package.xml
+++ b/perception/traffic_light_selector/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/perception/traffic_light_ssd_fine_detector/package.xml
+++ b/perception/traffic_light_ssd_fine_detector/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/traffic_light_ssd_fine_detector/package.xml
+++ b/perception/traffic_light_ssd_fine_detector/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/traffic_light_ssd_fine_detector/package.xml
+++ b/perception/traffic_light_ssd_fine_detector/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>

--- a/perception/traffic_light_visualization/package.xml
+++ b/perception/traffic_light_visualization/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/traffic_light_visualization/package.xml
+++ b/perception/traffic_light_visualization/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>

--- a/perception/traffic_light_visualization/package.xml
+++ b/perception/traffic_light_visualization/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_perception_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -40,7 +40,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -41,7 +41,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -39,8 +39,8 @@
   <author email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/package.xml
@@ -48,7 +48,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>

--- a/planning/behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/package.xml
@@ -46,9 +46,9 @@
   <author email="yukihiro.saito@tier4.jp">Yukihiro Saito</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>

--- a/planning/behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/package.xml
@@ -49,7 +49,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/costmap_generator/package.xml
+++ b/planning/costmap_generator/package.xml
@@ -14,8 +14,8 @@
   <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/costmap_generator/package.xml
+++ b/planning/costmap_generator/package.xml
@@ -15,7 +15,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/costmap_generator/package.xml
+++ b/planning/costmap_generator/package.xml
@@ -16,7 +16,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>grid_map_ros</depend>

--- a/planning/external_velocity_limit_selector/package.xml
+++ b/planning/external_velocity_limit_selector/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/external_velocity_limit_selector/package.xml
+++ b/planning/external_velocity_limit_selector/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_debug_msgs</depend>

--- a/planning/external_velocity_limit_selector/package.xml
+++ b/planning/external_velocity_limit_selector/package.xml
@@ -15,8 +15,8 @@
   <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/freespace_planner/package.xml
+++ b/planning/freespace_planner/package.xml
@@ -15,7 +15,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>freespace_planning_algorithms</depend>

--- a/planning/freespace_planner/package.xml
+++ b/planning/freespace_planner/package.xml
@@ -14,8 +14,8 @@
   <author email="tomohito.ando@tier4.jp">Tomohito ANDO</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>freespace_planning_algorithms</depend>

--- a/planning/freespace_planner/package.xml
+++ b/planning/freespace_planner/package.xml
@@ -16,7 +16,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_planning_msgs</depend>
   <depend>freespace_planning_algorithms</depend>
   <depend>geometry_msgs</depend>

--- a/planning/freespace_planning_algorithms/package.xml
+++ b/planning/freespace_planning_algorithms/package.xml
@@ -14,8 +14,8 @@
   <author email="h-ishida@jsk.imi.i.u-tokyo.ac.jp">Hirokazu Ishida</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/planning/freespace_planning_algorithms/package.xml
+++ b/planning/freespace_planning_algorithms/package.xml
@@ -15,7 +15,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/planning/freespace_planning_algorithms/package.xml
+++ b/planning/freespace_planning_algorithms/package.xml
@@ -16,7 +16,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>nlohmann-json-dev</depend>

--- a/planning/mission_planner/package.xml
+++ b/planning/mission_planner/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/mission_planner/package.xml
+++ b/planning/mission_planner/package.xml
@@ -15,8 +15,8 @@
   <author email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/mission_planner/package.xml
+++ b/planning/mission_planner/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/motion_velocity_smoother/package.xml
+++ b/planning/motion_velocity_smoother/package.xml
@@ -20,7 +20,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>interpolation</depend>

--- a/planning/motion_velocity_smoother/package.xml
+++ b/planning/motion_velocity_smoother/package.xml
@@ -17,9 +17,9 @@
   <author email="makoto.kurihara@tier4.jp">Makoto Kurihara</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/planning/motion_velocity_smoother/package.xml
+++ b/planning/motion_velocity_smoother/package.xml
@@ -19,7 +19,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/planning/obstacle_avoidance_planner/package.xml
+++ b/planning/obstacle_avoidance_planner/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>interpolation</depend>

--- a/planning/obstacle_avoidance_planner/package.xml
+++ b/planning/obstacle_avoidance_planner/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/planning/obstacle_avoidance_planner/package.xml
+++ b/planning/obstacle_avoidance_planner/package.xml
@@ -12,8 +12,8 @@
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/planning/obstacle_cruise_planner/package.xml
+++ b/planning/obstacle_cruise_planner/package.xml
@@ -13,8 +13,8 @@
   <author email="yutaka.shimizu@tier4.jp">Yutaka Shimizu</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/obstacle_cruise_planner/package.xml
+++ b/planning/obstacle_cruise_planner/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/obstacle_cruise_planner/package.xml
+++ b/planning/obstacle_cruise_planner/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/obstacle_stop_planner/package.xml
+++ b/planning/obstacle_stop_planner/package.xml
@@ -17,8 +17,8 @@
   <author email="yukihiro.saito@tier4.jp">Yukihiro Saito</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/obstacle_stop_planner/package.xml
+++ b/planning/obstacle_stop_planner/package.xml
@@ -19,7 +19,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/obstacle_stop_planner/package.xml
+++ b/planning/obstacle_stop_planner/package.xml
@@ -18,7 +18,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/planning_debug_tools/package.xml
+++ b/planning/planning_debug_tools/package.xml
@@ -13,7 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/planning_debug_tools/package.xml
+++ b/planning/planning_debug_tools/package.xml
@@ -11,9 +11,9 @@
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/planning_test_utils/package.xml
+++ b/planning/planning_test_utils/package.xml
@@ -11,8 +11,8 @@
   <author email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>

--- a/planning/planning_test_utils/package.xml
+++ b/planning/planning_test_utils/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/planning_test_utils/package.xml
+++ b/planning/planning_test_utils/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>

--- a/planning/planning_validator/package.xml
+++ b/planning/planning_validator/package.xml
@@ -12,7 +12,7 @@
   <author email="yutaka.shimizu@tier4.jp">Yutaka Shimizu</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/route_handler/package.xml
+++ b/planning/route_handler/package.xml
@@ -13,8 +13,8 @@
   <author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/route_handler/package.xml
+++ b/planning/route_handler/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/route_handler/package.xml
+++ b/planning/route_handler/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/planning/rtc_auto_mode_manager/package.xml
+++ b/planning/rtc_auto_mode_manager/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/rtc_auto_mode_manager/package.xml
+++ b/planning/rtc_auto_mode_manager/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_rtc_msgs</depend>

--- a/planning/rtc_auto_mode_manager/package.xml
+++ b/planning/rtc_auto_mode_manager/package.xml
@@ -13,8 +13,8 @@
   <author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/rtc_replayer/package.xml
+++ b/planning/rtc_replayer/package.xml
@@ -13,8 +13,8 @@
   <author email="taiki.tanaka@tier4.jp">Fumiya Watanabe</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/rtc_replayer/package.xml
+++ b/planning/rtc_replayer/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/rtc_replayer/package.xml
+++ b/planning/rtc_replayer/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_rtc_msgs</depend>

--- a/planning/scenario_selector/package.xml
+++ b/planning/scenario_selector/package.xml
@@ -17,8 +17,8 @@
   <author email="kenji.miyake@tier4.jp">Kenji Miyake</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/scenario_selector/package.xml
+++ b/planning/scenario_selector/package.xml
@@ -19,7 +19,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>lanelet2_extension</depend>

--- a/planning/scenario_selector/package.xml
+++ b/planning/scenario_selector/package.xml
@@ -18,7 +18,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/static_centerline_optimizer/package.xml
+++ b/planning/static_centerline_optimizer/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>

--- a/planning/static_centerline_optimizer/package.xml
+++ b/planning/static_centerline_optimizer/package.xml
@@ -11,8 +11,8 @@
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>

--- a/planning/surround_obstacle_checker/package.xml
+++ b/planning/surround_obstacle_checker/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/surround_obstacle_checker/package.xml
+++ b/planning/surround_obstacle_checker/package.xml
@@ -10,9 +10,9 @@
   <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/surround_obstacle_checker/package.xml
+++ b/planning/surround_obstacle_checker/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/sensing/geo_pos_conv/package.xml
+++ b/sensing/geo_pos_conv/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>rclcpp</depend>
 

--- a/sensing/geo_pos_conv/package.xml
+++ b/sensing/geo_pos_conv/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>rclcpp</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/sensing/geo_pos_conv/package.xml
+++ b/sensing/geo_pos_conv/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
 

--- a/sensing/gnss_poser/package.xml
+++ b/sensing/gnss_poser/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>libboost-dev</build_depend>
 
   <depend>autoware_sensing_msgs</depend>

--- a/sensing/gnss_poser/package.xml
+++ b/sensing/gnss_poser/package.xml
@@ -9,8 +9,8 @@
   <author email="ryo.watanabe@tier4.jp">Ryo Watanabe</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>libboost-dev</build_depend>
 
   <depend>autoware_sensing_msgs</depend>

--- a/sensing/image_transport_decompressor/package.xml
+++ b/sensing/image_transport_decompressor/package.xml
@@ -18,7 +18,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>cv_bridge</depend>
   <depend>rclcpp</depend>

--- a/sensing/image_transport_decompressor/package.xml
+++ b/sensing/image_transport_decompressor/package.xml
@@ -17,8 +17,8 @@
   <author>Julius Kammerl</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>cv_bridge</depend>
   <depend>rclcpp</depend>

--- a/sensing/image_transport_decompressor/package.xml
+++ b/sensing/image_transport_decompressor/package.xml
@@ -19,7 +19,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>cv_bridge</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/sensing/imu_corrector/package.xml
+++ b/sensing/imu_corrector/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/sensing/imu_corrector/package.xml
+++ b/sensing/imu_corrector/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/sensing/imu_corrector/package.xml
+++ b/sensing/imu_corrector/package.xml
@@ -9,8 +9,8 @@
   <author email="yamato.ando@tier4.jp">Yamato Ando</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/sensing/livox/livox_tag_filter/package.xml
+++ b/sensing/livox/livox_tag_filter/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>

--- a/sensing/livox/livox_tag_filter/package.xml
+++ b/sensing/livox/livox_tag_filter/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>

--- a/sensing/livox/livox_tag_filter/package.xml
+++ b/sensing/livox/livox_tag_filter/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>

--- a/sensing/pointcloud_preprocessor/package.xml
+++ b/sensing/pointcloud_preprocessor/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>cgal</depend>

--- a/sensing/pointcloud_preprocessor/package.xml
+++ b/sensing/pointcloud_preprocessor/package.xml
@@ -15,8 +15,8 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_point_types</depend>

--- a/sensing/pointcloud_preprocessor/package.xml
+++ b/sensing/pointcloud_preprocessor/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_point_types</depend>

--- a/sensing/radar_scan_to_pointcloud2/package.xml
+++ b/sensing/radar_scan_to_pointcloud2/package.xml
@@ -17,7 +17,7 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/sensing/radar_scan_to_pointcloud2/package.xml
+++ b/sensing/radar_scan_to_pointcloud2/package.xml
@@ -9,6 +9,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
@@ -17,7 +18,6 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/sensing/radar_static_pointcloud_filter/package.xml
+++ b/sensing/radar_static_pointcloud_filter/package.xml
@@ -20,7 +20,7 @@
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/sensing/radar_static_pointcloud_filter/package.xml
+++ b/sensing/radar_static_pointcloud_filter/package.xml
@@ -9,6 +9,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
@@ -20,7 +21,6 @@
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/sensing/radar_threshold_filter/package.xml
+++ b/sensing/radar_threshold_filter/package.xml
@@ -9,12 +9,12 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>radar_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/sensing/radar_threshold_filter/package.xml
+++ b/sensing/radar_threshold_filter/package.xml
@@ -14,7 +14,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/sensing/tier4_pcl_extensions/package.xml
+++ b/sensing/tier4_pcl_extensions/package.xml
@@ -8,11 +8,11 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 
-  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>eigen</build_depend>
   <build_depend>range-v3</build_depend>
 

--- a/sensing/tier4_pcl_extensions/package.xml
+++ b/sensing/tier4_pcl_extensions/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>eigen</build_depend>
   <build_depend>range-v3</build_depend>
 

--- a/sensing/vehicle_velocity_converter/package.xml
+++ b/sensing/vehicle_velocity_converter/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/sensing/vehicle_velocity_converter/package.xml
+++ b/sensing/vehicle_velocity_converter/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/sensing/vehicle_velocity_converter/package.xml
+++ b/sensing/vehicle_velocity_converter/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/simulator/dummy_perception_publisher/package.xml
+++ b/simulator/dummy_perception_publisher/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/simulator/dummy_perception_publisher/package.xml
+++ b/simulator/dummy_perception_publisher/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>rosidl_default_generators</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/simulator/fault_injection/package.xml
+++ b/simulator/fault_injection/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>diagnostic_aggregator</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/simulator/fault_injection/package.xml
+++ b/simulator/fault_injection/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>diagnostic_aggregator</depend>
   <depend>diagnostic_msgs</depend>

--- a/simulator/fault_injection/package.xml
+++ b/simulator/fault_injection/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>diagnostic_aggregator</depend>
   <depend>diagnostic_msgs</depend>

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_tf2</depend>

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/system/bluetooth_monitor/package.xml
+++ b/system/bluetooth_monitor/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>libboost-serialization-dev</build_depend>
 
   <depend>diagnostic_msgs</depend>

--- a/system/bluetooth_monitor/package.xml
+++ b/system/bluetooth_monitor/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>libboost-serialization-dev</build_depend>
 
   <depend>diagnostic_msgs</depend>

--- a/system/component_state_monitor/package.xml
+++ b/system/component_state_monitor/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>

--- a/system/component_state_monitor/package.xml
+++ b/system/component_state_monitor/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/component_state_monitor/package.xml
+++ b/system/component_state_monitor/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>

--- a/system/default_ad_api/package.xml
+++ b/system/default_ad_api/package.xml
@@ -12,8 +12,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>

--- a/system/default_ad_api/package.xml
+++ b/system/default_ad_api/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_adapi_version_msgs</depend>

--- a/system/default_ad_api/package.xml
+++ b/system/default_ad_api/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>

--- a/system/default_ad_api_helpers/ad_api_adaptors/package.xml
+++ b/system/default_ad_api_helpers/ad_api_adaptors/package.xml
@@ -12,8 +12,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>

--- a/system/default_ad_api_helpers/ad_api_adaptors/package.xml
+++ b/system/default_ad_api_helpers/ad_api_adaptors/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>component_interface_utils</depend>

--- a/system/default_ad_api_helpers/ad_api_adaptors/package.xml
+++ b/system/default_ad_api_helpers/ad_api_adaptors/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>

--- a/system/default_ad_api_helpers/automatic_pose_initializer/package.xml
+++ b/system/default_ad_api_helpers/automatic_pose_initializer/package.xml
@@ -12,8 +12,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>

--- a/system/default_ad_api_helpers/automatic_pose_initializer/package.xml
+++ b/system/default_ad_api_helpers/automatic_pose_initializer/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>component_interface_utils</depend>

--- a/system/default_ad_api_helpers/automatic_pose_initializer/package.xml
+++ b/system/default_ad_api_helpers/automatic_pose_initializer/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_ad_api_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>

--- a/system/dummy_diag_publisher/package.xml
+++ b/system/dummy_diag_publisher/package.xml
@@ -10,8 +10,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>

--- a/system/dummy_diag_publisher/package.xml
+++ b/system/dummy_diag_publisher/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>
   <depend>rclcpp</depend>

--- a/system/dummy_diag_publisher/package.xml
+++ b/system/dummy_diag_publisher/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>

--- a/system/dummy_infrastructure/package.xml
+++ b/system/dummy_infrastructure/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
   <build_depend>libboost-dev</build_depend>
 
   <depend>rclcpp</depend>

--- a/system/dummy_infrastructure/package.xml
+++ b/system/dummy_infrastructure/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>libboost-dev</build_depend>
 
   <depend>rclcpp</depend>

--- a/system/emergency_handler/package.xml
+++ b/system/emergency_handler/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/system/emergency_handler/package.xml
+++ b/system/emergency_handler/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>

--- a/system/emergency_handler/package.xml
+++ b/system/emergency_handler/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/system/mrm_comfortable_stop_operator/package.xml
+++ b/system/mrm_comfortable_stop_operator/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/mrm_comfortable_stop_operator/package.xml
+++ b/system/mrm_comfortable_stop_operator/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>rclcpp</depend>

--- a/system/mrm_comfortable_stop_operator/package.xml
+++ b/system/mrm_comfortable_stop_operator/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>rclcpp</depend>

--- a/system/mrm_emergency_stop_operator/package.xml
+++ b/system/mrm_emergency_stop_operator/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>rclcpp</depend>

--- a/system/mrm_emergency_stop_operator/package.xml
+++ b/system/mrm_emergency_stop_operator/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/system/mrm_emergency_stop_operator/package.xml
+++ b/system/mrm_emergency_stop_operator/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>

--- a/system/system_error_monitor/package.xml
+++ b/system/system_error_monitor/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/system/system_error_monitor/package.xml
+++ b/system/system_error_monitor/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/system/system_error_monitor/package.xml
+++ b/system/system_error_monitor/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/system/system_monitor/package.xml
+++ b/system/system_monitor/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/system/system_monitor/package.xml
+++ b/system/system_monitor/package.xml
@@ -9,8 +9,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/system/system_monitor/package.xml
+++ b/system/system_monitor/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>

--- a/system/topic_state_monitor/package.xml
+++ b/system/topic_state_monitor/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>ament_index_cpp</depend>
   <depend>diagnostic_updater</depend>

--- a/system/topic_state_monitor/package.xml
+++ b/system/topic_state_monitor/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>diagnostic_updater</depend>

--- a/system/topic_state_monitor/package.xml
+++ b/system/topic_state_monitor/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>ament_index_cpp</depend>
   <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>

--- a/system/velodyne_monitor/package.xml
+++ b/system/velodyne_monitor/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>crypto++</depend>
   <depend>diagnostic_msgs</depend>

--- a/system/velodyne_monitor/package.xml
+++ b/system/velodyne_monitor/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>crypto++</depend>
   <depend>diagnostic_msgs</depend>

--- a/system/velodyne_monitor/package.xml
+++ b/system/velodyne_monitor/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>crypto++</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
@@ -11,8 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
@@ -12,7 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>

--- a/vehicle/external_cmd_converter/package.xml
+++ b/vehicle/external_cmd_converter/package.xml
@@ -10,8 +10,8 @@
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/vehicle/external_cmd_converter/package.xml
+++ b/vehicle/external_cmd_converter/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/vehicle/external_cmd_converter/package.xml
+++ b/vehicle/external_cmd_converter/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/vehicle/raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/raw_vehicle_cmd_converter/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/vehicle/raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/raw_vehicle_cmd_converter/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/vehicle/raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/raw_vehicle_cmd_converter/package.xml
@@ -15,8 +15,8 @@
   <author email="taiki.tanaka@tier4.jp">Tanaka Taiki</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/vehicle/steer_offset_estimator/package.xml
+++ b/vehicle/steer_offset_estimator/package.xml
@@ -7,7 +7,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/vehicle/vehicle_info_util/package.xml
+++ b/vehicle/vehicle_info_util/package.xml
@@ -14,8 +14,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
   <buildtool_depend>autoware_cmake</buildtool_depend>
+
 
   <depend>rclcpp</depend>
   <depend>tier4_autoware_utils</depend>

--- a/vehicle/vehicle_info_util/package.xml
+++ b/vehicle/vehicle_info_util/package.xml
@@ -15,7 +15,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>tier4_autoware_utils</depend>

--- a/vehicle/vehicle_info_util/package.xml
+++ b/vehicle/vehicle_info_util/package.xml
@@ -16,7 +16,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-
   <depend>rclcpp</depend>
   <depend>tier4_autoware_utils</depend>
 


### PR DESCRIPTION
Since autoware_cmake only provide cmake macros only <buildtool_depend> is necessary.
With <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)

## Description

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
