### PR TITLE
feat(mpc): calc predicted trajectory in world coordinate

### DIFF
--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc.hpp
@@ -261,6 +261,13 @@ private:
     const double u_filtered, const float current_steer, const double predict_dt) const;
 
   /**
+   * @brief calculate predicted trajectory
+   */
+  Trajectory calcualtePredictedTrajectory(
+    const MPCMatrix & mpc_matrix, const Eigen::MatrixXd & x0, const Eigen::MatrixXd & Uex,
+    const MPCTrajectory & mpc_resampled_ref_traj, const double dt);
+
+  /**
    * @brief check if the matrix has invalid value
    */
   bool isValid(const MPCMatrix & m) const;

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_utils.hpp
@@ -75,11 +75,10 @@ bool convertToMPCTrajectory(
 /**
  * @brief convert the given MPCTrajectory to a Trajectory msg
  * @param [in] input MPCTrajectory to convert
- * @param [out] output resulting Trajectory msg
- * @return true if the conversion was successful
+ * @return resulting Trajectory msg
  */
-bool convertToAutowareTrajectory(
-  const MPCTrajectory & input, autoware_auto_planning_msgs::msg::Trajectory & output);
+autoware_auto_planning_msgs::msg::Trajectory convertToAutowareTrajectory(
+  const MPCTrajectory & input);
 /**
  * @brief calculate the arc length at each point of the given trajectory
  * @param [in] trajectory trajectory for which to calculate the arc length

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics.hpp
@@ -87,6 +87,9 @@ public:
    */
   void calculateReferenceInput(Eigen::MatrixXd & u_ref) override;
 
+  Eigen::MatrixXd updateStateInWorldCoordinate(
+    const Eigen::MatrixXd & input, const double dt) override;
+
 private:
   double m_steer_lim;  //!< @brief steering angle limit [rad]
   double m_steer_tau;  //!< @brief steering time constant for 1d-model [s]

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp
@@ -102,6 +102,22 @@ public:
    * @param [out] u_ref input
    */
   virtual void calculateReferenceInput(Eigen::MatrixXd & u_ref) = 0;
+
+  // --------------- for debug purpose ---------------------
+
+  //!< @brief state in world coordinate to predict future state
+  Eigen::MatrixXd x_in_world_coordinate;
+
+  /**
+   * @brief set state in world coordinate. Its dimension could differ from the error dynamics
+   */
+  void setStateInWorldCoordinate(const Eigen::MatrixXd & state);
+
+  /**
+   * @brief calculate predicted state in world coordinate from the input and dt.
+   */
+  virtual Eigen::MatrixXd updateStateInWorldCoordinate(
+    const Eigen::MatrixXd & input, const double dt);
 };
 }  // namespace autoware::motion::control::mpc_lateral_controller
 #endif  // MPC_LATERAL_CONTROLLER__VEHICLE_MODEL__VEHICLE_MODEL_INTERFACE_HPP_

--- a/control/mpc_lateral_controller/src/mpc.cpp
+++ b/control/mpc_lateral_controller/src/mpc.cpp
@@ -171,9 +171,7 @@ Trajectory MPC::calcualtePredictedTrajectory(
         x, y, traj.z.at(i), yaw, traj.vx.at(i), traj.k.at(i), traj.smooth_k.at(i),
         traj.relative_time.at(i));
     }
-    Trajectory predicted_traj;
-    MPCUtils::convertToAutowareTrajectory(mpc_predicted_traj, predicted_traj);
-    return predicted_traj;
+    return MPCUtils::convertToAutowareTrajectory(mpc_predicted_traj);
   };
 
   if (m_vehicle_model_type == "kinematics") {
@@ -198,9 +196,7 @@ Trajectory MPC::calcualtePredictedTrajectory(
         X_next(0), X_next(1), traj.z.at(i), X_next(2), traj.vx.at(i), traj.k.at(i),
         traj.smooth_k.at(i), traj.relative_time.at(i));
     }
-    Trajectory predicted_traj;
-    MPCUtils::convertToAutowareTrajectory(mpc_predicted_traj, predicted_traj);
-    return predicted_traj;
+    return MPCUtils::convertToAutowareTrajectory(mpc_predicted_traj);
   } else {
     // TODO(Horibe): implement for "kinematics_no_delay" and "dynamics"
     return calcPredictedTrajectoryInFrenetCoordinate();
@@ -516,8 +512,7 @@ bool MPC::updateStateForDelayCompensation(
 MPCTrajectory MPC::applyVelocityDynamicsFilter(
   const MPCTrajectory & input, const Pose & current_pose, const double v0) const
 {
-  Trajectory autoware_traj;
-  MPCUtils::convertToAutowareTrajectory(input, autoware_traj);
+  auto autoware_traj = MPCUtils::convertToAutowareTrajectory(input);
   if (autoware_traj.points.empty()) {
     return input;
   }
@@ -811,8 +806,7 @@ double MPC::getPredictionDeltaTime(
   const double start_time, const MPCTrajectory & input, const Pose & current_pose) const
 {
   // Calculate the time min_prediction_length ahead from current_pose
-  Trajectory autoware_traj;
-  MPCUtils::convertToAutowareTrajectory(input, autoware_traj);
+  auto autoware_traj = MPCUtils::convertToAutowareTrajectory(input);
   const size_t nearest_idx = motion_utils::findFirstNearestIndexWithSoftConstraints(
     autoware_traj.points, current_pose, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
   double sum_dist = 0;

--- a/control/mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/mpc_lateral_controller/src/mpc_utils.cpp
@@ -236,10 +236,10 @@ bool convertToMPCTrajectory(
   return true;
 }
 
-bool convertToAutowareTrajectory(
-  const MPCTrajectory & input, autoware_auto_planning_msgs::msg::Trajectory & output)
+autoware_auto_planning_msgs::msg::Trajectory convertToAutowareTrajectory(
+  const MPCTrajectory & input)
 {
-  output.points.clear();
+  autoware_auto_planning_msgs::msg::Trajectory output;
   autoware_auto_planning_msgs::msg::TrajectoryPoint p;
   using Real = decltype(p.pose.position.x);
   for (size_t i = 0; i < input.size(); ++i) {
@@ -254,7 +254,7 @@ bool convertToAutowareTrajectory(
       break;
     }
   }
-  return true;
+  return output;
 }
 
 bool calcMPCTrajectoryTime(MPCTrajectory & traj)
@@ -301,8 +301,7 @@ bool calcNearestPoseInterp(
     return false;
   }
 
-  autoware_auto_planning_msgs::msg::Trajectory autoware_traj;
-  convertToAutowareTrajectory(traj, autoware_traj);
+  auto autoware_traj = convertToAutowareTrajectory(traj);
   if (autoware_traj.points.empty()) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       logger, clock, 5000, "[calcNearestPoseInterp] input trajectory is empty");
@@ -407,8 +406,7 @@ void extendTrajectoryInYawDirection(
   traj.yaw.back() = yaw;
 
   // get terminal pose
-  autoware_auto_planning_msgs::msg::Trajectory autoware_traj;
-  MPCUtils::convertToAutowareTrajectory(traj, autoware_traj);
+  auto autoware_traj = MPCUtils::convertToAutowareTrajectory(traj);
   auto extended_pose = autoware_traj.points.back().pose;
 
   constexpr double extend_dist = 10.0;

--- a/control/mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
+++ b/control/mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
@@ -68,4 +68,22 @@ void KinematicsBicycleModel::calculateReferenceInput(Eigen::MatrixXd & u_ref)
 {
   u_ref(0, 0) = std::atan(m_wheelbase * m_curvature);
 }
+
+Eigen::MatrixXd KinematicsBicycleModel::updateStateInWorldCoordinate(
+  const Eigen::MatrixXd & input, const double dt)
+{
+  const auto yaw = x_in_world_coordinate(2);
+  const auto steer = x_in_world_coordinate(3);
+  const auto desired_steer = input(0);
+
+  Eigen::MatrixXd dxdt = Eigen::MatrixXd::Zero(4, 1);
+  dxdt(0) = m_velocity * std::cos(yaw);
+  dxdt(1) = m_velocity * std::sin(yaw);
+  dxdt(2) = m_velocity * std::tan(steer) / m_wheelbase;
+  dxdt(3) = -(steer - desired_steer) / m_steer_tau;
+
+  x_in_world_coordinate += dxdt * dt;
+  return x_in_world_coordinate;
+}
+
 }  // namespace autoware::motion::control::mpc_lateral_controller

--- a/control/mpc_lateral_controller/src/vehicle_model/vehicle_model_interface.cpp
+++ b/control/mpc_lateral_controller/src/vehicle_model/vehicle_model_interface.cpp
@@ -44,4 +44,16 @@ void VehicleModelInterface::setCurvature(const double curvature)
 {
   m_curvature = curvature;
 }
+void VehicleModelInterface::setStateInWorldCoordinate(const Eigen::MatrixXd & state)
+{
+  x_in_world_coordinate = state;
+}
+Eigen::MatrixXd VehicleModelInterface::updateStateInWorldCoordinate(
+  const Eigen::MatrixXd & input, const double dt)
+{
+  (void)input;
+  (void)dt;
+  throw std::runtime_error("this function is not implemented.");
+  return x_in_world_coordinate;
+}
 }  // namespace autoware::motion::control::mpc_lateral_controller


### PR DESCRIPTION
## Description

Update the algorithm to calculate the predicted trajectory to improve the accuracy in MPC.

Before: the trajectory is calculated in Frenet (relative) coordinate.
After: the trajectory is calculated in the world-coordinate 

## Related links

None

## Tests performed

Run psim.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

Predicted path accuracy changes.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
