### PR TITLE
fix: do not use c++20 char8_t keyword

### DIFF
--- a/common/autoware_auto_common/include/autoware_auto_common/common/types.hpp
+++ b/common/autoware_auto_common/include/autoware_auto_common/common/types.hpp
@@ -37,7 +37,9 @@ namespace types
 // We don't currently require code to comply to MISRA, but we should try to where it is
 // easily possible.
 using bool8_t = bool;
+#if __cplusplus < 201811L || !__cpp_char8_t
 using char8_t = char;
+#endif
 using uchar8_t = unsigned char;
 // If we ever compile on a platform where this is not true, float32_t and float64_t definitions
 // need to be adjusted.


### PR DESCRIPTION
## Description

from C++ 20 char8_t is a restricted keyword:
https://en.cppreference.com/w/cpp/keyword/char8_t

## Tests performed

Not applicable.

## Effects on system behavior

Error when compiling with `-std=c++20`   

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
