### PR TITLE
feat(behavior_path_planner): disable safety check

### DIFF
--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -183,8 +183,13 @@ std::optional<LaneChangePath> constructCandidatePath(
     point.lane_ids = target_segment.points.at(*nearest_idx).lane_ids;
   }
 
+  // TODO(Yutaka Shimizu): remove this flag after make the isPathInLanelets faster
+  const bool enable_path_check_in_lanelet = false;
+
   // check candidate path is in lanelet
-  if (!isPathInLanelets(shifted_path.path, original_lanelets, target_lanelets)) {
+  if (
+    enable_path_check_in_lanelet &&
+    !isPathInLanelets(shifted_path.path, original_lanelets, target_lanelets)) {
     return std::nullopt;
   }
 


### PR DESCRIPTION
## Description
Currently, the lane change module spends a lot of time to check if the generated candidate path is inside of the lanelets. Even though the generated path is usually in the designated lanelets, it unreasonably takes tons of time. In this PR, I made a flag and disable this safety check for the default setting.

copilot:summary
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
