### PR TITLE
feat(behavior_path_planner): resolve multiple modules turn signal info

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -37,7 +37,6 @@
 #endif
 
 #include "behavior_path_planner/steering_factor_interface.hpp"
-#include "behavior_path_planner/turn_signal_decider.hpp"
 #include "behavior_path_planner/utils/avoidance/avoidance_module_data.hpp"
 #include "behavior_path_planner/utils/goal_planner/goal_planner_parameters.hpp"
 #include "behavior_path_planner/utils/lane_change/lane_change_module_data.hpp"
@@ -136,8 +135,6 @@ private:
   bool has_received_map_{false};
   bool has_received_route_{false};
 
-  TurnSignalDecider turn_signal_decider_;
-
   std::mutex mutex_pd_;       // mutex for planner_data_
   std::mutex mutex_manager_;  // mutex for bt_manager_ or planner_manager_
   std::mutex mutex_map_;      // mutex for has_received_map_ and map_ptr_
@@ -220,7 +217,8 @@ private:
   /**
    * @brief publish steering factor from intersection
    */
-  void publish_steering_factor(const TurnIndicatorsCommand & turn_signal);
+  void publish_steering_factor(
+    const std::shared_ptr<PlannerData> & planner_data, const TurnIndicatorsCommand & turn_signal);
 
   /**
    * @brief publish left and right bound

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -16,6 +16,7 @@
 #define BEHAVIOR_PATH_PLANNER__DATA_MANAGER_HPP_
 
 #include "behavior_path_planner/parameters.hpp"
+#include "behavior_path_planner/turn_signal_decider.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/parameters.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -96,24 +97,6 @@ struct DrivableAreaInfo
   bool is_already_expanded{false};
 };
 
-struct TurnSignalInfo
-{
-  TurnSignalInfo()
-  {
-    turn_signal.command = TurnIndicatorsCommand::NO_COMMAND;
-    hazard_signal.command = HazardLightsCommand::NO_COMMAND;
-  }
-
-  // desired turn signal
-  TurnIndicatorsCommand turn_signal;
-  HazardLightsCommand hazard_signal;
-
-  geometry_msgs::msg::Pose desired_start_point;
-  geometry_msgs::msg::Pose desired_end_point;
-  geometry_msgs::msg::Pose required_start_point;
-  geometry_msgs::msg::Pose required_end_point;
-};
-
 struct BehaviorModuleOutput
 {
   BehaviorModuleOutput() = default;
@@ -159,6 +142,17 @@ struct PlannerData
   std::shared_ptr<RouteHandler> route_handler{std::make_shared<RouteHandler>()};
   BehaviorPathPlannerParameters parameters{};
   drivable_area_expansion::DrivableAreaExpansionParameters drivable_area_expansion_parameters{};
+
+  mutable TurnSignalDecider turn_signal_decider;
+
+  TurnIndicatorsCommand getTurnSignal(
+    const PathWithLaneId & path, const TurnSignalInfo & turn_signal_info)
+  {
+    const auto & current_pose = self_odometry->pose.pose;
+    const auto & current_vel = self_odometry->twist.twist.linear.x;
+    return turn_signal_decider.getTurnSignal(
+      route_handler, path, turn_signal_info, current_pose, current_vel, parameters);
+  }
 
   template <class T>
   size_t findEgoIndex(const std::vector<T> & points) const

--- a/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
@@ -15,7 +15,7 @@
 #ifndef BEHAVIOR_PATH_PLANNER__TURN_SIGNAL_DECIDER_HPP_
 #define BEHAVIOR_PATH_PLANNER__TURN_SIGNAL_DECIDER_HPP_
 
-#include <behavior_path_planner/data_manager.hpp>
+#include <behavior_path_planner/parameters.hpp>
 #include <route_handler/route_handler.hpp>
 
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
@@ -45,16 +45,40 @@ const std::map<std::string, uint8_t> signal_map = {
   {"straight", TurnIndicatorsCommand::DISABLE},
   {"none", TurnIndicatorsCommand::DISABLE}};
 
+struct TurnSignalInfo
+{
+  TurnSignalInfo()
+  {
+    turn_signal.command = TurnIndicatorsCommand::NO_COMMAND;
+    hazard_signal.command = HazardLightsCommand::NO_COMMAND;
+  }
+
+  // desired turn signal
+  TurnIndicatorsCommand turn_signal;
+  HazardLightsCommand hazard_signal;
+
+  geometry_msgs::msg::Pose desired_start_point;
+  geometry_msgs::msg::Pose desired_end_point;
+  geometry_msgs::msg::Pose required_start_point;
+  geometry_msgs::msg::Pose required_end_point;
+};
+
 class TurnSignalDecider
 {
 public:
   TurnIndicatorsCommand getTurnSignal(
-    const std::shared_ptr<const PlannerData> & planner_data, const PathWithLaneId & path,
-    const TurnSignalInfo & turn_signal_info);
+    const std::shared_ptr<RouteHandler> & route_handler, const PathWithLaneId & path,
+    const TurnSignalInfo & turn_signal_info, const Pose & current_pose, const double current_vel,
+    const BehaviorPathPlannerParameters & parameters);
 
   TurnIndicatorsCommand resolve_turn_signal(
     const PathWithLaneId & path, const Pose & current_pose, const size_t current_seg_idx,
     const TurnSignalInfo & intersection_signal_info, const TurnSignalInfo & behavior_signal_info,
+    const double nearest_dist_threshold, const double nearest_yaw_threshold);
+
+  TurnSignalInfo use_prior_turn_signal(
+    const PathWithLaneId & path, const Pose & current_pose, const size_t current_seg_idx,
+    const TurnSignalInfo & original_signal, const TurnSignalInfo & new_signal,
     const double nearest_dist_threshold, const double nearest_yaw_threshold);
 
   void setParameters(


### PR DESCRIPTION
## Description

Currently, last added scene module over writes turn signal info, and previous module's signal is always ignored.

In this PR, I added new function to resolve multiple modules' turn signal info based on [**THIS**](https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/docs/behavior_path_planner_turn_signal_design.md) algorithm.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS
](https://evaluation.tier4.jp/evaluation/reports/4432f4e5-8ebd-5dad-bb21-518412f0d610?project_id=prd_jt)
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing. (Just adding new function.)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
