### PR TITLE
feat(behavior_path_planner): hold previous drivable area info in LC

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -59,7 +59,7 @@ public:
   {
     prev_module_reference_path_ = std::make_shared<PathWithLaneId>();
     prev_module_path_ = std::make_shared<PathWithLaneId>();
-    prev_drivable_lanes_ = std::make_shared<std::vector<DrivableLanes>>();
+    prev_drivable_area_info_ = std::make_shared<DrivableAreaInfo>();
   }
 
   LaneChangeBase(const LaneChangeBase &) = delete;
@@ -100,10 +100,10 @@ public:
     }
   };
 
-  virtual void setPreviousDrivableLanes(const std::vector<DrivableLanes> & prev_drivable_lanes)
+  virtual void setPreviousDrivableAreaInfo(const DrivableAreaInfo & prev_drivable_area_info)
   {
-    if (prev_drivable_lanes_) {
-      *prev_drivable_lanes_ = prev_drivable_lanes;
+    if (prev_drivable_area_info_) {
+      *prev_drivable_area_info_ = prev_drivable_area_info;
     }
   }
 
@@ -231,7 +231,7 @@ protected:
   std::shared_ptr<const PlannerData> planner_data_{};
   std::shared_ptr<PathWithLaneId> prev_module_reference_path_{};
   std::shared_ptr<PathWithLaneId> prev_module_path_{};
-  std::shared_ptr<std::vector<DrivableLanes>> prev_drivable_lanes_{};
+  std::shared_ptr<DrivableAreaInfo> prev_drivable_area_info_{};
 
   PathWithLaneId prev_approved_path_{};
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -130,8 +130,7 @@ BehaviorModuleOutput LaneChangeInterface::plan()
     resetPathIfAbort();
   }
 
-  module_type_->setPreviousDrivableLanes(
-    getPreviousModuleOutput().drivable_area_info.drivable_lanes);
+  module_type_->setPreviousDrivableAreaInfo(getPreviousModuleOutput().drivable_area_info);
   auto output = module_type_->generateOutput();
   path_reference_ = output.reference_path;
   *prev_approved_path_ = *getPreviousModuleOutput().path;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -521,7 +521,7 @@ std::vector<DrivableLanes> NormalLaneChange::getDrivableLanes() const
 {
   const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
     *getRouteHandler(), status_.current_lanes, status_.lane_change_lanes);
-  return utils::combineDrivableLanes(*prev_drivable_lanes_, drivable_lanes);
+  return utils::combineDrivableLanes(prev_drivable_area_info_->drivable_lanes, drivable_lanes);
 }
 
 bool NormalLaneChange::isApprovedPathSafe(Pose & ego_pose_before_collision) const


### PR DESCRIPTION
## Description

previous drivable_lanes is held in LC to keep the information when generating the current drivable_lanes.
Additionally, drivable_area_info itself has to be kept as well when generating the current drivable_area_info to keep other variables in DrivableAreaInfo other than drivable_lanes (e.g. obstacles to extract from the drivable area).

With this PR, previous drivable_area_info is held in LC.
<!-- Write a brief description of this PR. -->

## Tests performed

planning simulator
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
