### PR TITLE
feat(lane_change): consider previous module's turn signal

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -60,6 +60,7 @@ public:
     prev_module_reference_path_ = std::make_shared<PathWithLaneId>();
     prev_module_path_ = std::make_shared<PathWithLaneId>();
     prev_drivable_area_info_ = std::make_shared<DrivableAreaInfo>();
+    prev_turn_signal_info_ = std::make_shared<TurnSignalInfo>();
   }
 
   LaneChangeBase(const LaneChangeBase &) = delete;
@@ -105,6 +106,11 @@ public:
     if (prev_drivable_area_info_) {
       *prev_drivable_area_info_ = prev_drivable_area_info;
     }
+  }
+
+  virtual void setPreviousTurnSignalInfo(const TurnSignalInfo & prev_turn_signal_info)
+  {
+    *prev_turn_signal_info_ = prev_turn_signal_info;
   }
 
   virtual void updateSpecialData() {}
@@ -232,6 +238,7 @@ protected:
   std::shared_ptr<PathWithLaneId> prev_module_reference_path_{};
   std::shared_ptr<PathWithLaneId> prev_module_path_{};
   std::shared_ptr<DrivableAreaInfo> prev_drivable_area_info_{};
+  std::shared_ptr<TurnSignalInfo> prev_turn_signal_info_{};
 
   PathWithLaneId prev_approved_path_{};
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -131,6 +131,7 @@ BehaviorModuleOutput LaneChangeInterface::plan()
   }
 
   module_type_->setPreviousDrivableAreaInfo(getPreviousModuleOutput().drivable_area_info);
+  module_type_->setPreviousTurnSignalInfo(getPreviousModuleOutput().turn_signal_info);
   auto output = module_type_->generateOutput();
   path_reference_ = output.reference_path;
   *prev_approved_path_ = *getPreviousModuleOutput().path;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -105,6 +105,16 @@ BehaviorModuleOutput NormalLaneChange::generateOutput()
   output.reference_path = std::make_shared<PathWithLaneId>(getReferencePath());
   output.turn_signal_info = updateOutputTurnSignal();
 
+  if (!prev_turn_signal_info_) {
+    return output;
+  }
+
+  const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path->points);
+  output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
+    *output.path, getEgoPose(), current_seg_idx, *prev_turn_signal_info_, output.turn_signal_info,
+    planner_data_->parameters.ego_nearest_dist_threshold,
+    planner_data_->parameters.ego_nearest_yaw_threshold);
+
   return output;
 }
 


### PR DESCRIPTION
## Description

- consider previous module's turn signal in lane change module.
- https://github.com/autowarefoundation/autoware.universe/pull/3634

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/ba904c31-3bfd-5aed-87b1-4e572eaa18a4?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Improve turn signal behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
