### PR TITLE
feat(map_loader): visualize hatched road markings

### DIFF
--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
@@ -121,12 +121,14 @@ void Lanelet2MapVisualizationNode::onMapBin(
   lanelet::ConstPolygons3d no_obstacle_segmentation_area_for_run_out =
     lanelet::utils::query::getAllPolygonsByType(
       viz_lanelet_map, "no_obstacle_segmentation_area_for_run_out");
+  lanelet::ConstPolygons3d hatched_road_markings_area =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "hatched_road_markings");
 
   std_msgs::msg::ColorRGBA cl_road, cl_shoulder, cl_cross, cl_partitions, cl_pedestrian_markings,
     cl_ll_borders, cl_shoulder_borders, cl_stoplines, cl_trafficlights, cl_detection_areas,
     cl_speed_bumps, cl_parking_lots, cl_parking_spaces, cl_lanelet_id, cl_obstacle_polygons,
     cl_no_stopping_areas, cl_no_obstacle_segmentation_area,
-    cl_no_obstacle_segmentation_area_for_run_out;
+    cl_no_obstacle_segmentation_area_for_run_out, cl_hatched_road_markings_area;
   setColor(&cl_road, 0.27, 0.27, 0.27, 0.999);
   setColor(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   setColor(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -145,6 +147,7 @@ void Lanelet2MapVisualizationNode::onMapBin(
   setColor(&cl_lanelet_id, 0.5, 0.5, 0.5, 0.999);
   setColor(&cl_no_obstacle_segmentation_area, 0.37, 0.37, 0.27, 0.5);
   setColor(&cl_no_obstacle_segmentation_area_for_run_out, 0.37, 0.7, 0.27, 0.5);
+  setColor(&cl_hatched_road_markings_area, 0.3, 0.3, 0.3, 0.5);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -218,6 +221,10 @@ void Lanelet2MapVisualizationNode::onMapBin(
     &map_marker_array,
     lanelet::visualization::noObstacleSegmentationAreaForRunOutAsMarkerArray(
       no_obstacle_segmentation_area_for_run_out, cl_no_obstacle_segmentation_area_for_run_out));
+
+  insertMarkerArray(
+    &map_marker_array, lanelet::visualization::hatchedRoadMarkingsAreaAsMarkerArray(
+                         hatched_road_markings_area, cl_hatched_road_markings_area));
 
   pub_marker_->publish(map_marker_array);
 }

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
@@ -128,7 +128,8 @@ void Lanelet2MapVisualizationNode::onMapBin(
     cl_ll_borders, cl_shoulder_borders, cl_stoplines, cl_trafficlights, cl_detection_areas,
     cl_speed_bumps, cl_parking_lots, cl_parking_spaces, cl_lanelet_id, cl_obstacle_polygons,
     cl_no_stopping_areas, cl_no_obstacle_segmentation_area,
-    cl_no_obstacle_segmentation_area_for_run_out, cl_hatched_road_markings_area;
+    cl_no_obstacle_segmentation_area_for_run_out, cl_hatched_road_markings_area,
+    cl_hatched_road_markings_line;
   setColor(&cl_road, 0.27, 0.27, 0.27, 0.999);
   setColor(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   setColor(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -148,6 +149,7 @@ void Lanelet2MapVisualizationNode::onMapBin(
   setColor(&cl_no_obstacle_segmentation_area, 0.37, 0.37, 0.27, 0.5);
   setColor(&cl_no_obstacle_segmentation_area_for_run_out, 0.37, 0.7, 0.27, 0.5);
   setColor(&cl_hatched_road_markings_area, 0.3, 0.3, 0.3, 0.5);
+  setColor(&cl_hatched_road_markings_line, 0.5, 0.5, 0.5, 0.999);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -223,8 +225,9 @@ void Lanelet2MapVisualizationNode::onMapBin(
       no_obstacle_segmentation_area_for_run_out, cl_no_obstacle_segmentation_area_for_run_out));
 
   insertMarkerArray(
-    &map_marker_array, lanelet::visualization::hatchedRoadMarkingsAreaAsMarkerArray(
-                         hatched_road_markings_area, cl_hatched_road_markings_area));
+    &map_marker_array,
+    lanelet::visualization::hatchedRoadMarkingsAreaAsMarkerArray(
+      hatched_road_markings_area, cl_hatched_road_markings_area, cl_hatched_road_markings_line));
 
   pub_marker_->publish(map_marker_array);
 }


### PR DESCRIPTION
## Description

visualize hatched road markings area in LL2.
![image](https://user-images.githubusercontent.com/20228327/236818245-4c162344-2e19-457f-a924-b85d03e2f6ae.png)

Discussion for introducing hatched road markings area.
https://github.com/orgs/autowarefoundation/discussions/3414
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

can visualize the area with planning simulator
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/