### PR TITLE
refactor(pid_longitudinal_controller): set stopped state if ego is not in autonomous mode

### DIFF
--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -526,6 +526,11 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
     RCLCPP_INFO_SKIPFIRST_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000, "%s", s);
   };
 
+  // if current operation mode is not autonomous mode, then change state to stopped
+  if (m_current_operation_mode.mode != OperationModeState::AUTONOMOUS) {
+    return changeState(ControlState::STOPPED);
+  }
+
   // transit state
   // in DRIVE state
   if (m_control_state == ControlState::DRIVE) {


### PR DESCRIPTION


## Description

<!-- Write a brief description of this PR. -->

In the current implementation of `pid_longitudinal_controller`, if the operation mode is changed, the state will be the same. In this situation, if the goal is set, controller enters into `DRIVE` state until the vehicle reaches the goal. However, if the operation mode is changed while driving and set autonomous again, controller state stays in `DRIVE` and the controller does not check the `keep_stopped_condition`. So vehicle starts to driving without checking steering converged or not.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Tested in planning simulator, worked well.
Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
