### PR TITLE
fix(lane_change): remove unnecessary if condition

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -103,14 +103,12 @@ public:
 
   virtual void setPreviousDrivableAreaInfo(const DrivableAreaInfo & prev_drivable_area_info)
   {
-    if (prev_drivable_area_info_) {
-      *prev_drivable_area_info_ = prev_drivable_area_info;
-    }
+    prev_drivable_area_info_ = std::make_shared<DrivableAreaInfo>(prev_drivable_area_info);
   }
 
   virtual void setPreviousTurnSignalInfo(const TurnSignalInfo & prev_turn_signal_info)
   {
-    *prev_turn_signal_info_ = prev_turn_signal_info;
+    prev_turn_signal_info_ = std::make_shared<TurnSignalInfo>(prev_turn_signal_info);
   }
 
   virtual void updateSpecialData() {}


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/3635

I guess that the if condition should be removed.

```c++
  virtual void setPreviousDrivableAreaInfo(const DrivableAreaInfo & prev_drivable_area_info)
  {
    if (prev_drivable_area_info_) {
      *prev_drivable_area_info_ = prev_drivable_area_info;
    }
  }
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
