### PR TITLE
fix(behavior_path_planner): fix lateral distance calculation

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -116,6 +116,14 @@ if(BUILD_TESTING)
     behavior_path_planner_node
   )
 
+  ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_safety_check
+    test/test_safety_check.cpp
+  )
+
+  target_link_libraries(test_${CMAKE_PROJECT_NAME}_safety_check
+    behavior_path_planner_node
+  )
+
   ament_add_ros_isolated_gmock(test_${CMAKE_PROJECT_NAME}_turn_signal
     test/test_turn_signal.cpp
   )

--- a/planning/behavior_path_planner/src/utils/safety_check.cpp
+++ b/planning/behavior_path_planner/src/utils/safety_check.cpp
@@ -129,9 +129,9 @@ void getTransformedPolygon(
 double calcLateralDistance(
   const Polygon2d & front_object_polygon, const Polygon2d & rear_object_polygon)
 {
-  double min_dist = 0.0;
+  double min_dist = std::numeric_limits<double>::max();
   for (const auto & rear_point : rear_object_polygon.outer()) {
-    double max_lateral_dist = std::numeric_limits<double>::min();
+    double max_lateral_dist = std::numeric_limits<double>::lowest();
     double min_lateral_dist = std::numeric_limits<double>::max();
     for (const auto & front_point : front_object_polygon.outer()) {
       const double lat_dist = front_point.y() - rear_point.y();

--- a/planning/behavior_path_planner/test/test_safety_check.cpp
+++ b/planning/behavior_path_planner/test/test_safety_check.cpp
@@ -1,0 +1,263 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "behavior_path_planner/utils/safety_check.hpp"
+#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+constexpr double epsilon = 1e-6;
+
+using autoware_auto_perception_msgs::msg::Shape;
+using geometry_msgs::msg::Point;
+using geometry_msgs::msg::Pose;
+using geometry_msgs::msg::Twist;
+using marker_utils::CollisionCheckDebug;
+using tier4_autoware_utils::Point2d;
+using tier4_autoware_utils::Polygon2d;
+
+namespace bg = boost::geometry;
+
+namespace
+{
+void appendPointToPolygon(Polygon2d & polygon, const Point & geom_point)
+{
+  Point2d point;
+  point.x() = geom_point.x;
+  point.y() = geom_point.y;
+
+  bg::append(polygon.outer(), point);
+}
+
+void appendPointToPolygon(Polygon2d & polygon, const Point2d & point)
+{
+  bg::append(polygon.outer(), point);
+}
+
+Polygon2d createPolygon(const std::vector<Point> & points)
+{
+  using tier4_autoware_utils::inverseClockwise;
+  using tier4_autoware_utils::isClockwise;
+
+  Polygon2d polygon;
+  for (const auto & point : points) {
+    appendPointToPolygon(polygon, point);
+  }
+
+  if (!polygon.outer().empty()) {
+    appendPointToPolygon(polygon, polygon.outer().front());
+  }
+  return isClockwise(polygon) ? polygon : inverseClockwise(polygon);
+}
+}  // namespace
+
+TEST(BehaviorPathPlanningLaneChangeUtilsTest, calcDistanceForRectangle)
+{
+  using behavior_path_planner::utils::safety_check::calcLateralDistance;
+  using behavior_path_planner::utils::safety_check::calcLongitudinalDistance;
+  using tier4_autoware_utils::createPoint;
+
+  // same position for lateral position
+  {
+    std::vector<Point> front_points;
+    front_points.emplace_back(createPoint(0.0, 0.0, 0.0));
+    front_points.emplace_back(createPoint(5.0, 0.0, 0.0));
+    front_points.emplace_back(createPoint(5.0, 2.0, 0.0));
+    front_points.emplace_back(createPoint(0.0, 2.0, 0.0));
+    const auto front_polygon = createPolygon(front_points);
+
+    std::vector<Point> rear_points;
+    rear_points.emplace_back(createPoint(0.0, 4.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 4.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 6.0, 0.0));
+    rear_points.emplace_back(createPoint(0.0, 6.0, 0.0));
+    const auto rear_polygon = createPolygon(rear_points);
+
+    // lateral distance
+    EXPECT_NEAR(calcLateralDistance(front_polygon, rear_polygon), 2.0, epsilon);
+    EXPECT_NEAR(calcLateralDistance(rear_polygon, front_polygon), 2.0, epsilon);
+
+    // longitudinal distance
+    EXPECT_NEAR(calcLongitudinalDistance(front_polygon, rear_polygon), 0.0, epsilon);
+    EXPECT_NEAR(calcLongitudinalDistance(rear_polygon, front_polygon), 0.0, epsilon);
+  }
+
+  {
+    std::vector<Point> rear_points;
+    rear_points.emplace_back(createPoint(0.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 2.0, 0.0));
+    rear_points.emplace_back(createPoint(0.0, 2.0, 0.0));
+    const auto rear_polygon = createPolygon(rear_points);
+
+    std::vector<Point> front_points;
+    front_points.emplace_back(createPoint(10.0, 4.0, 0.0));
+    front_points.emplace_back(createPoint(15.0, 4.0, 0.0));
+    front_points.emplace_back(createPoint(15.0, 6.0, 0.0));
+    front_points.emplace_back(createPoint(10.0, 6.0, 0.0));
+    const auto front_polygon = createPolygon(front_points);
+
+    // lateral distance
+    EXPECT_NEAR(calcLateralDistance(front_polygon, rear_polygon), 2.0, epsilon);
+
+    // longitudinal distance
+    EXPECT_NEAR(calcLongitudinalDistance(front_polygon, rear_polygon), 5.0, epsilon);
+  }
+
+  {
+    std::vector<Point> rear_points;
+    rear_points.emplace_back(createPoint(0.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 2.0, 0.0));
+    rear_points.emplace_back(createPoint(0.0, 2.0, 0.0));
+    const auto rear_polygon = createPolygon(rear_points);
+
+    std::vector<Point> front_points;
+    front_points.emplace_back(createPoint(4.0, 4.0, 0.0));
+    front_points.emplace_back(createPoint(9.0, 4.0, 0.0));
+    front_points.emplace_back(createPoint(9.0, 6.0, 0.0));
+    front_points.emplace_back(createPoint(4.0, 6.0, 0.0));
+    const auto front_polygon = createPolygon(front_points);
+
+    // lateral distance
+    EXPECT_NEAR(calcLateralDistance(front_polygon, rear_polygon), 2.0, epsilon);
+
+    // longitudinal distance
+    EXPECT_NEAR(calcLongitudinalDistance(front_polygon, rear_polygon), 0.0, epsilon);
+  }
+
+  {
+    std::vector<Point> rear_points;
+    rear_points.emplace_back(createPoint(0.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 2.0, 0.0));
+    rear_points.emplace_back(createPoint(0.0, 2.0, 0.0));
+    const auto rear_polygon = createPolygon(rear_points);
+
+    std::vector<Point> front_points;
+    front_points.emplace_back(createPoint(10.0, 0.0, 0.0));
+    front_points.emplace_back(createPoint(15.0, 0.0, 0.0));
+    front_points.emplace_back(createPoint(15.0, 2.0, 0.0));
+    front_points.emplace_back(createPoint(10.0, 2.0, 0.0));
+    const auto front_polygon = createPolygon(front_points);
+
+    // lateral distance
+    EXPECT_NEAR(calcLateralDistance(front_polygon, rear_polygon), 0.0, epsilon);
+
+    // longitudinal distance
+    EXPECT_NEAR(calcLongitudinalDistance(front_polygon, rear_polygon), 5.0, epsilon);
+  }
+
+  {
+    std::vector<Point> rear_points;
+    rear_points.emplace_back(createPoint(0.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0, 2.0, 0.0));
+    rear_points.emplace_back(createPoint(0.0, 2.0, 0.0));
+    const auto rear_polygon = createPolygon(rear_points);
+
+    std::vector<Point> front_points;
+    front_points.emplace_back(createPoint(5.0, 4.0, 0.0));
+    front_points.emplace_back(createPoint(10.0, 4.0, 0.0));
+    front_points.emplace_back(createPoint(10.0, 6.0, 0.0));
+    front_points.emplace_back(createPoint(5.0, 6.0, 0.0));
+    const auto front_polygon = createPolygon(front_points);
+
+    // lateral distance
+    EXPECT_NEAR(calcLateralDistance(front_polygon, rear_polygon), 2.0, epsilon);
+
+    // longitudinal distance
+    EXPECT_NEAR(calcLongitudinalDistance(front_polygon, rear_polygon), 0.0, epsilon);
+  }
+
+  // rotate rear to 30 degrees
+  {
+    std::vector<Point> rear_points;
+    rear_points.emplace_back(createPoint(0.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0 * std::sqrt(3) / 2.0, 2.5, 0.0));
+    rear_points.emplace_back(createPoint(5.0 * std::sqrt(3) / 2.0 - 1.0, 2.5 + std::sqrt(3), 0.0));
+    rear_points.emplace_back(createPoint(-1.0, std::sqrt(3), 0.0));
+    const auto rear_polygon = createPolygon(rear_points);
+
+    std::vector<Point> front_points;
+    front_points.emplace_back(createPoint(5.0, 4.0, 0.0));
+    front_points.emplace_back(createPoint(10.0, 4.0, 0.0));
+    front_points.emplace_back(createPoint(10.0, 6.0, 0.0));
+    front_points.emplace_back(createPoint(5.0, 6.0, 0.0));
+    const auto front_polygon = createPolygon(front_points);
+
+    // lateral distance
+    EXPECT_NEAR(calcLateralDistance(front_polygon, rear_polygon), 0.0, epsilon);
+
+    // longitudinal distance
+    EXPECT_NEAR(
+      calcLongitudinalDistance(front_polygon, rear_polygon), 5.0 - 5 * std::sqrt(3) / 2.0, epsilon);
+  }
+
+  // rotate rear to 30 degrees
+  {
+    std::vector<Point> rear_points;
+    rear_points.emplace_back(createPoint(0.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0 * std::sqrt(3) / 2.0, 2.5, 0.0));
+    rear_points.emplace_back(createPoint(5.0 * std::sqrt(3) / 2.0 - 1.0, 2.5 + std::sqrt(3), 0.0));
+    rear_points.emplace_back(createPoint(-1.0, std::sqrt(3), 0.0));
+    const auto rear_polygon = createPolygon(rear_points);
+
+    std::vector<Point> front_points;
+    front_points.emplace_back(createPoint(5.0, 5.0, 0.0));
+    front_points.emplace_back(createPoint(10.0, 5.0, 0.0));
+    front_points.emplace_back(createPoint(10.0, 7.0, 0.0));
+    front_points.emplace_back(createPoint(5.0, 7.0, 0.0));
+    const auto front_polygon = createPolygon(front_points);
+
+    // lateral distance
+    EXPECT_NEAR(
+      calcLateralDistance(front_polygon, rear_polygon), 5.0 - 2.5 - std::sqrt(3), epsilon);
+
+    // longitudinal distance
+    EXPECT_NEAR(
+      calcLongitudinalDistance(front_polygon, rear_polygon), 5.0 - 5 * std::sqrt(3) / 2.0, epsilon);
+  }
+
+  // rotate both rear and front to 30 degrees
+  {
+    std::vector<Point> rear_points;
+    rear_points.emplace_back(createPoint(0.0, 0.0, 0.0));
+    rear_points.emplace_back(createPoint(5.0 * std::sqrt(3) / 2.0, 2.5, 0.0));
+    rear_points.emplace_back(createPoint(5.0 * std::sqrt(3) / 2.0 - 1.0, 2.5 + std::sqrt(3), 0.0));
+    rear_points.emplace_back(createPoint(-1.0, std::sqrt(3), 0.0));
+    const auto rear_polygon = createPolygon(rear_points);
+
+    std::vector<Point> front_points;
+    front_points.emplace_back(createPoint(10.0, 5.0, 0.0));
+    front_points.emplace_back(createPoint(10 + 5.0 * std::sqrt(3) / 2.0, 5.0 + 2.5, 0.0));
+    front_points.emplace_back(
+      createPoint(10 + 5.0 * std::sqrt(3) / 2.0 - 1.0, 5.0 + 2.5 + std::sqrt(3), 0.0));
+    front_points.emplace_back(createPoint(10 - 1.0, 5.0 + std::sqrt(3), 0.0));
+    const auto front_polygon = createPolygon(front_points);
+
+    // lateral distance
+    EXPECT_NEAR(
+      calcLateralDistance(front_polygon, rear_polygon), 5.0 - 2.5 - std::sqrt(3), epsilon);
+
+    // longitudinal distance
+    EXPECT_NEAR(
+      calcLongitudinalDistance(front_polygon, rear_polygon), 9.0 - 5 * std::sqrt(3) / 2.0, epsilon);
+  }
+}


### PR DESCRIPTION
## Description
Use `std::numeric_limits<double>::lowest` instead of `std::numeric_limits<double>::min()` for the lateral cauclation. Also, I fixed the initial value for the minimum distance.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Add several unit tests to check the distance calculation function works properly.

Scenario Test 1324/1350
[TIER IV Internal](https://evaluation.tier4.jp/evaluation/reports/145fd6ea-c8b2-5507-b46c-d370afca0f31?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Safety check for the lane change path can be more strict.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
