### PR TITLE
fix(planner_manager): delete subsequent approved modules

### DIFF
--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -446,6 +446,9 @@ BehaviorModuleOutput PlannerManager::runApprovedModules(const std::shared_ptr<Pl
     if (itr != approved_module_ptrs_.end()) {
       clearCandidateModules();
       candidate_module_ptrs_.push_back(*itr);
+
+      std::for_each(
+        std::next(itr), approved_module_ptrs_.end(), [this](auto & m) { deleteExpiredModules(m); });
     }
 
     approved_module_ptrs_.erase(itr, approved_module_ptrs_.end());


### PR DESCRIPTION
## Description

When one of the module in approved modules stack is back to WAITING APPROVAL, the subsequent approved modules should be removed.

In current implementation, the subsequent modules is just removed from approved modules stack and is **NOT** unregisterd from its manager.

In this PR, it do not only erase waiting approved module from `approved_modules_ptrs_` but also unregister the subsequet modules from its manager.

```c++
std::for_each(
        std::next(itr), approved_module_ptrs_.end(), [this](auto & m) { deleteExpiredModules(m); });
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [ ] PASS TIER IV INTERNAL SCENAIROS (LC+Avoidance)
- [x] [PASS TIER IV INTERNAL SCENAIROS (others)
](https://evaluation.tier4.jp/evaluation/reports/6ca23166-cc0d-5e22-b46c-08ecf3c70713?project_id=prd_jt)
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Improve simultaneous execution on new manager.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
