### PR TITLE
refactor(vehicle_cmd_gate): use lateral command while creating stop cmd

### DIFF
--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -404,7 +404,7 @@ void VehicleCmdGate::publishControlCommands(const Commands & commands)
 
   // Check engage
   if (!is_engaged_) {
-    filtered_commands.control = createStopControlCmd();
+    filtered_commands.control = createStopControlCmd(filtered_commands.control.lateral);
   }
 
   // Check pause
@@ -537,15 +537,16 @@ AckermannControlCommand VehicleCmdGate::filterControlCommand(const AckermannCont
   return out;
 }
 
-AckermannControlCommand VehicleCmdGate::createStopControlCmd() const
+AckermannControlCommand VehicleCmdGate::createStopControlCmd(
+  const AckermannLateralCommand & current_lateral_cmd) const
 {
   AckermannControlCommand cmd;
   const auto t = this->now();
   cmd.stamp = t;
   cmd.lateral.stamp = t;
   cmd.longitudinal.stamp = t;
-  cmd.lateral.steering_tire_angle = current_steer_;
-  cmd.lateral.steering_tire_rotation_rate = 0.0;
+  cmd.lateral.steering_tire_angle = current_lateral_cmd.steering_tire_angle;
+  cmd.lateral.steering_tire_rotation_rate = current_lateral_cmd.steering_tire_rotation_rate;
   cmd.longitudinal.speed = 0.0;
   cmd.longitudinal.acceleration = stop_hold_acceleration_;
 

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
@@ -51,6 +51,7 @@ namespace vehicle_cmd_gate
 using autoware_adapi_v1_msgs::msg::MrmState;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_auto_control_msgs::msg::AckermannLateralCommand;
 using autoware_auto_vehicle_msgs::msg::GearCommand;
 using autoware_auto_vehicle_msgs::msg::GearReport;
 using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
@@ -205,7 +206,8 @@ private:
 
   // Algorithm
   AckermannControlCommand prev_control_cmd_;
-  AckermannControlCommand createStopControlCmd() const;
+  AckermannControlCommand createStopControlCmd(
+    const AckermannLateralCommand & current_lateral_cmd) const;
   AckermannControlCommand createEmergencyStopControlCmd() const;
 
   std::shared_ptr<rclcpp::Time> prev_time_;


### PR DESCRIPTION
## Description
In the vehicle_cmd_gate package, if the vehicle disengages, it creates a stop command. However, while creating a stop command, it inserts current steering as lateral command and it causes unwanted behavior like in the video:

https://github.com/autowarefoundation/autoware.universe/assets/45468306/6dd86034-de2a-43f5-b972-d860e3f6d568

After disengaging, the vehicle sends current steering so the vehicle moves outside of the road.

<!-- Write a brief description of this PR. -->

## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/45468306/d3bdf096-2b22-43f6-9a69-6890fae75baf


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
