### PR TITLE
fix(behavior_path_planner): deal with empty drivable_lanes with old archi

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -87,8 +87,8 @@ struct DrivableAreaInfo
     geometry_msgs::msg::Pose pose;
     tier4_autoware_utils::Polygon2d poly;
   };
-  std::vector<DrivableLanes> drivable_lanes;
-  std::vector<Obstacle> obstacles;  // obstacles to extract from the drivable area
+  std::vector<DrivableLanes> drivable_lanes{};
+  std::vector<Obstacle> obstacles{};  // obstacles to extract from the drivable area
   bool enable_expanding_hatched_road_markings{false};
 
   // temporary only for pull over's freespace planning

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2768,8 +2768,10 @@ DrivableAreaInfo combineDrivableAreaInfo(
   DrivableAreaInfo combined_drivable_area_info;
 
   // drivable lanes
+#ifndef USE_OLD_ARCHITECTURE
   combined_drivable_area_info.drivable_lanes =
     combineDrivableLanes(drivable_area_info1.drivable_lanes, drivable_area_info2.drivable_lanes);
+#endif
 
   // obstacles
   for (const auto & obstacle : drivable_area_info1.obstacles) {


### PR DESCRIPTION
## Description

With old architecture, the drivable_lanes is empty for some reason.
We do not have to consider drivable_lanes with old architecture, so I commented out.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Planning simulator worked well locally.

Ran scenario test.
https://evaluation.tier4.jp/evaluation/reports/82f6a97b-f2fc-5a7c-aa51-0be7518eb5f3?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No behavior change.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
