### PR TITLE
feat(behavior_path_planner): add dynamic avoidance debug marker

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -101,7 +101,7 @@ void appendObjectMarker(MarkerArray & marker_array, const geometry_msgs::msg::Po
     "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "dynamic_objects_to_avoid",
     marker_array.markers.size(), visualization_msgs::msg::Marker::CUBE,
     tier4_autoware_utils::createMarkerScale(3.0, 1.0, 1.0),
-    tier4_autoware_utils::createMarkerColor(0.5, 0.5, 0.5, 0.8));
+    tier4_autoware_utils::createMarkerColor(1.0, 0.5, 0.6, 0.8));
   marker.pose = obj_pose;
 
   marker_array.markers.push_back(marker);

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -174,7 +174,7 @@ ModuleStatus DynamicAvoidanceModule::updateState()
 
 BehaviorModuleOutput DynamicAvoidanceModule::plan()
 {
-  debug_marker_.markers.clear();
+  info_marker_.markers.clear();
 
   // 1. get reference path from previous module
   const auto prev_module_path = getPreviousModuleOutput().path;
@@ -189,7 +189,7 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
     if (obstacle_poly) {
       obstacles_for_drivable_area.push_back({object.pose, obstacle_poly.value()});
 
-      appendObjectMarker(debug_marker_, object.pose);
+      appendObjectMarker(info_marker_, object.pose);
     }
   }
 

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -94,6 +94,18 @@ std::pair<double, double> getMinMaxValues(const std::vector<double> & vec)
 
   return std::make_pair(vec.at(min_idx), vec.at(max_idx));
 }
+
+void appendObjectMarker(MarkerArray & marker_array, const geometry_msgs::msg::Pose & obj_pose)
+{
+  auto marker = tier4_autoware_utils::createDefaultMarker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "dynamic_objects_to_avoid",
+    marker_array.markers.size(), visualization_msgs::msg::Marker::CUBE,
+    tier4_autoware_utils::createMarkerScale(3.0, 1.0, 1.0),
+    tier4_autoware_utils::createMarkerColor(0.5, 0.5, 0.5, 0.8));
+  marker.pose = obj_pose;
+
+  marker_array.markers.push_back(marker);
+}
 }  // namespace
 
 #ifdef USE_OLD_ARCHITECTURE
@@ -162,6 +174,8 @@ ModuleStatus DynamicAvoidanceModule::updateState()
 
 BehaviorModuleOutput DynamicAvoidanceModule::plan()
 {
+  debug_marker_.markers.clear();
+
   // 1. get reference path from previous module
   const auto prev_module_path = getPreviousModuleOutput().path;
 
@@ -174,6 +188,8 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
     const auto obstacle_poly = calcDynamicObstaclePolygon(*prev_module_path, object);
     if (obstacle_poly) {
       obstacles_for_drivable_area.push_back({object.pose, obstacle_poly.value()});
+
+      appendObjectMarker(debug_marker_, object.pose);
     }
   }
 


### PR DESCRIPTION
## Description

This can be used by using new behavior_path_planner architecture and enabling dynamic_avoidance module.

Added a marker of objects to avoid in dynamic_avoidance module (pink rectangular)
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/e864e56f-e506-4fcd-9ed3-5bccf67f61eb)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Can visualize dynamic objects to avoid

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
