### PR TITLE
refactor(lane_change): change prev info to non pointer

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -57,10 +57,6 @@ public:
     Direction direction)
   : lane_change_parameters_{std::move(parameters)}, direction_{direction}, type_{type}
   {
-    prev_module_reference_path_ = std::make_shared<PathWithLaneId>();
-    prev_module_path_ = std::make_shared<PathWithLaneId>();
-    prev_drivable_area_info_ = std::make_shared<DrivableAreaInfo>();
-    prev_turn_signal_info_ = std::make_shared<TurnSignalInfo>();
   }
 
   LaneChangeBase(const LaneChangeBase &) = delete;
@@ -94,23 +90,21 @@ public:
     const std::shared_ptr<PathWithLaneId> & prev_module_path)
   {
     if (prev_module_reference_path) {
-      *prev_module_reference_path_ = *prev_module_reference_path;
+      prev_module_reference_path_ = *prev_module_reference_path;
     }
     if (prev_module_path) {
-      *prev_module_path_ = *prev_module_path;
+      prev_module_path_ = *prev_module_path;
     }
   };
 
   virtual void setPreviousDrivableAreaInfo(const DrivableAreaInfo & prev_drivable_area_info)
   {
-    if (prev_drivable_area_info_) {
-      *prev_drivable_area_info_ = prev_drivable_area_info;
-    }
+    prev_drivable_area_info_ = prev_drivable_area_info;
   }
 
   virtual void setPreviousTurnSignalInfo(const TurnSignalInfo & prev_turn_signal_info)
   {
-    *prev_turn_signal_info_ = prev_turn_signal_info;
+    prev_turn_signal_info_ = prev_turn_signal_info;
   }
 
   virtual void updateSpecialData() {}
@@ -235,10 +229,10 @@ protected:
   std::shared_ptr<LaneChangeParameters> lane_change_parameters_{};
   std::shared_ptr<LaneChangePath> abort_path_{};
   std::shared_ptr<const PlannerData> planner_data_{};
-  std::shared_ptr<PathWithLaneId> prev_module_reference_path_{};
-  std::shared_ptr<PathWithLaneId> prev_module_path_{};
-  std::shared_ptr<DrivableAreaInfo> prev_drivable_area_info_{};
-  std::shared_ptr<TurnSignalInfo> prev_turn_signal_info_{};
+  PathWithLaneId prev_module_reference_path_{};
+  PathWithLaneId prev_module_path_{};
+  DrivableAreaInfo prev_drivable_area_info_{};
+  TurnSignalInfo prev_turn_signal_info_{};
 
   PathWithLaneId prev_approved_path_{};
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
@@ -115,7 +115,7 @@ AvoidancePlanningData AvoidanceByLaneChange::calcAvoidancePlanningData(
   // reference pose
   data.reference_pose = getEgoPose();
 
-  data.reference_path_rough = *prev_module_path_;
+  data.reference_path_rough = prev_module_path_;
 
   const auto resample_interval =
     avoidance_by_lane_change_parameters_->avoidance->resample_interval_for_planning;


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1193734</samp>

This pull request refactors the lane change scene module classes in the behavior path planner to avoid using shared pointers for some member variables. This reduces memory overhead and improves performance. The files affected are `base_class.hpp`, `normal.cpp`, and `avoidance_by_lane_change.cpp`.

## Related links

None

## Tests performed

Compile in both new and old architecture.
Test using PSIM.

## Notes for reviewers

None.

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
