### PR TITLE
fix(behavior_path_planner): return FALSE when the uuid is not found

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -235,14 +235,16 @@ public:
    */
   bool isActivated()
   {
+    if (rtc_interface_ptr_map_.empty()) {
+      return true;
+    }
+
     for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
       if (itr->second->isRegistered(uuid_map_.at(itr->first))) {
         return itr->second->isActivated(uuid_map_.at(itr->first));
-      } else {
-        return false;
       }
     }
-    return true;
+    return false;
   }
 
   void publishSteeringFactor()

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -238,6 +238,8 @@ public:
     for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
       if (itr->second->isRegistered(uuid_map_.at(itr->first))) {
         return itr->second->isActivated(uuid_map_.at(itr->first));
+      } else {
+        return false;
       }
     }
     return true;

--- a/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_following/lane_following_module.cpp
@@ -26,7 +26,7 @@ namespace behavior_path_planner
 {
 LaneFollowingModule::LaneFollowingModule(const std::string & name, rclcpp::Node & node)
 // RTCInterface is temporarily registered, but not used.
-: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {""})}
+: SceneModuleInterface{name, node, {}}
 {
   initParam();
 }

--- a/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
@@ -26,7 +26,7 @@ namespace behavior_path_planner
 SideShiftModuleManager::SideShiftModuleManager(
   rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
   const std::shared_ptr<SideShiftParameters> & parameters)
-: SceneModuleManagerInterface(node, name, config, {""}), parameters_{parameters}
+: SceneModuleManagerInterface(node, name, config, {}), parameters_{parameters}
 {
 }
 

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -38,7 +38,7 @@ using tier4_autoware_utils::getPoint;
 SideShiftModule::SideShiftModule(
   const std::string & name, rclcpp::Node & node,
   const std::shared_ptr<SideShiftParameters> & parameters)
-: SceneModuleInterface{name, node, createRTCInterfaceMap(node, name, {""})}, parameters_{parameters}
+: SceneModuleInterface{name, node, {}}, parameters_{parameters}
 {
   using std::placeholders::_1;
   lateral_offset_subscriber_ = node.create_subscription<LateralOffset>(


### PR DESCRIPTION
## Description

return FALSE when the uuid is not found.

```c++
  bool isActivated()
  {
    for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
      if (itr->second->isRegistered(uuid_map_.at(itr->first))) {
        return itr->second->isActivated(uuid_map_.at(itr->first));
      } else {
        return false;
      }
    }
    return true;
  }
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

https://github.com/autowarefoundation/autoware.universe/assets/44889564/517ae0af-e813-4140-b5f2-6111fb680d7d

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
