### PR TITLE
feat(intersection): switch default/occlusion_first_stop when occlusion appeared/disappeared or approved/disapproved

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -152,6 +152,7 @@ public:
   double getOcclusionDistance() const { return occlusion_stop_distance_; }
   void setOcclusionActivation(const bool activation) { occlusion_activated_ = activation; }
   bool isOccluded() const { return is_actually_occluded_ || is_forcefully_occluded_; }
+  bool isOcclusionFirstStopRequired() { return occlusion_first_stop_required_; }
 
 private:
   rclcpp::Node & node_;
@@ -179,7 +180,7 @@ private:
   bool occlusion_activated_ = true;
   // for first stop in two-phase stop
   const UUID occlusion_first_stop_uuid_;
-  bool occlusion_first_stop_safety_ = true;
+  bool occlusion_first_stop_required_ = false;
 
   StateMachine collision_state_machine_;     //! for stable collision checking
   StateMachine before_creep_state_machine_;  //! for two phase stop

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -150,14 +150,7 @@ public:
   UUID getOcclusionUUID() const { return occlusion_uuid_; }
   bool getOcclusionSafety() const { return occlusion_safety_; }
   double getOcclusionDistance() const { return occlusion_stop_distance_; }
-  UUID getOcclusionFirstStopUUID() const { return occlusion_first_stop_uuid_; }
-  bool getOcclusionFirstStopSafety() const { return occlusion_first_stop_safety_; }
-  double getOcclusionFirstStopDistance() const { return occlusion_first_stop_distance_; }
   void setOcclusionActivation(const bool activation) { occlusion_activated_ = activation; }
-  void setOcclusionFirstStopActivation(const bool activation)
-  {
-    occlusion_first_stop_activated_ = activation;
-  }
   bool isOccluded() const { return is_actually_occluded_ || is_forcefully_occluded_; }
 
 private:
@@ -187,8 +180,6 @@ private:
   // for first stop in two-phase stop
   const UUID occlusion_first_stop_uuid_;
   bool occlusion_first_stop_safety_ = true;
-  double occlusion_first_stop_distance_;
-  bool occlusion_first_stop_activated_ = true;
 
   StateMachine collision_state_machine_;     //! for stable collision checking
   StateMachine before_creep_state_machine_;  //! for two phase stop

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -210,10 +210,10 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createVirtualWallMarker
         {debug_data_.collision_stop_wall_pose}, "intersection", now),
       &wall_marker, now);
   }
-  if (!occlusion_first_stop_safety_) {
+  if (!activated_ && occlusion_first_stop_required_) {
     appendMarkerArray(
       virtual_wall_marker_creator_->createStopVirtualWallMarker(
-        {debug_data_.occlusion_first_stop_wall_pose}, "intersection(temporal)", now),
+        {debug_data_.occlusion_first_stop_wall_pose}, "intersection", now),
       &wall_marker, now);
   }
   if (!occlusion_activated_) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -213,7 +213,7 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createVirtualWallMarker
   if (!occlusion_first_stop_safety_) {
     appendMarkerArray(
       virtual_wall_marker_creator_->createStopVirtualWallMarker(
-        {debug_data_.occlusion_first_stop_wall_pose}, "intersection", now),
+        {debug_data_.occlusion_first_stop_wall_pose}, "intersection(temporal)", now),
       &wall_marker, now);
   }
   if (!occlusion_activated_) {

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -210,7 +210,7 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createVirtualWallMarker
         {debug_data_.collision_stop_wall_pose}, "intersection", now),
       &wall_marker, now);
   }
-  if (!occlusion_first_stop_activated_) {
+  if (!occlusion_first_stop_safety_) {
     appendMarkerArray(
       virtual_wall_marker_creator_->createStopVirtualWallMarker(
         {debug_data_.occlusion_first_stop_wall_pose}, "intersection", now),

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -186,7 +186,9 @@ void IntersectionModuleManager::sendRTC(const Time & stamp)
   for (const auto & scene_module : scene_modules_) {
     const auto intersection_module = std::dynamic_pointer_cast<IntersectionModule>(scene_module);
     const UUID uuid = getUUID(scene_module->getModuleId());
-    updateRTCStatus(uuid, scene_module->isSafe(), scene_module->getDistance(), stamp);
+    const bool safety =
+      scene_module->isSafe() && (!intersection_module->isOcclusionFirstStopRequired());
+    updateRTCStatus(uuid, safety, scene_module->getDistance(), stamp);
     const auto occlusion_uuid = intersection_module->getOcclusionUUID();
     const auto occlusion_distance = intersection_module->getOcclusionDistance();
     const auto occlusion_safety = intersection_module->getOcclusionSafety();

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -185,19 +185,13 @@ void IntersectionModuleManager::sendRTC(const Time & stamp)
 {
   for (const auto & scene_module : scene_modules_) {
     const auto intersection_module = std::dynamic_pointer_cast<IntersectionModule>(scene_module);
-    const bool is_occluded = intersection_module->isOccluded();
     const UUID uuid = getUUID(scene_module->getModuleId());
+    updateRTCStatus(uuid, scene_module->isSafe(), scene_module->getDistance(), stamp);
     const auto occlusion_uuid = intersection_module->getOcclusionUUID();
     const auto occlusion_distance = intersection_module->getOcclusionDistance();
-    updateRTCStatus(uuid, scene_module->isSafe(), scene_module->getDistance(), stamp);
-    if (!is_occluded) {
-      occlusion_rtc_interface_.updateCooperateStatus(
-        occlusion_uuid, true, occlusion_distance, occlusion_distance, stamp);
-    } else {
-      const auto occlusion_safety = intersection_module->getOcclusionSafety();
-      occlusion_rtc_interface_.updateCooperateStatus(
-        occlusion_uuid, occlusion_safety, occlusion_distance, occlusion_distance, stamp);
-    }
+    const auto occlusion_safety = intersection_module->getOcclusionSafety();
+    occlusion_rtc_interface_.updateCooperateStatus(
+      occlusion_uuid, occlusion_safety, occlusion_distance, occlusion_distance, stamp);
   }
   rtc_interface_.publishCooperateStatus(stamp);  // publishRTCStatus()
   occlusion_rtc_interface_.publishCooperateStatus(stamp);

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -70,8 +70,7 @@ IntersectionModule::IntersectionModule(
   assoc_ids_(assoc_ids),
   enable_occlusion_detection_(enable_occlusion_detection),
   detection_divisions_(std::nullopt),
-  occlusion_uuid_(tier4_autoware_utils::generateUUID()),
-  occlusion_first_stop_uuid_(tier4_autoware_utils::generateUUID())
+  occlusion_uuid_(tier4_autoware_utils::generateUUID())
 {
   velocity_factor_.init(VelocityFactor::INTERSECTION);
   planner_param_ = planner_param;
@@ -105,7 +104,6 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   occlusion_safety_ = true;
   occlusion_stop_distance_ = std::numeric_limits<double>::lowest();
   occlusion_first_stop_safety_ = true;
-  occlusion_first_stop_distance_ = std::numeric_limits<double>::lowest();
 
   /* get current pose */
   const geometry_msgs::msg::Pose current_pose = planner_data_->current_odometry->pose;
@@ -387,7 +385,6 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     logger_.get_child("collision state_machine"), *clock_);
 
   /* set RTC safety respectively */
-  occlusion_first_stop_distance_ = dist_1st_stopline;
   occlusion_stop_distance_ = dist_2nd_stopline;
   setDistance(dist_1st_stopline);
   if (occlusion_stop_required) {
@@ -414,7 +411,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
       }
     }
 
-    if (!occlusion_first_stop_activated_ && occlusion_first_stop_line_idx) {
+    if (!occlusion_first_stop_safety_ && occlusion_first_stop_line_idx) {
       planning_utils::setVelocityFromIndex(
         occlusion_first_stop_line_idx.value(), 0.0 /* [m/s] */, path);
       debug_data_.occlusion_first_stop_wall_pose =


### PR DESCRIPTION
## Description

The temporal stop at the default stopline when occlusion is detected can be activated/deactivated by the RTC with this PR.
To simplify the logic, I removed the uuid for this temporal stop.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

### manual mode

If both intersection/intersection_occlusion is set to manual mode, there will be two intersection walls. One is "intersection" and the other is "intersection_occlusion". The "intersection" wall will disappear when deactivated.

https://github.com/autowarefoundation/autoware.universe/assets/28677420/a024ea7d-3f3c-4abe-aed0-bb49547b9b0e

### auto mode

intersection_occlusion works as before.

https://github.com/autowarefoundation/autoware.universe/assets/28677420/0cf4d071-06db-47e7-bd40-78fab6f1c233

The temporal "intersection" wall will disappear when deactivated.

https://github.com/autowarefoundation/autoware.universe/assets/28677420/3abe1570-7ee1-427f-9b7c-37e72d81b1db

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

when running intersection/intersection_occlusion in manual mode

## Effects on system behavior

when running intersection/intersection_occlusion in manual mode

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
