### PR TITLE
feat(motion_velocity_smoother): suppress warning

### DIFF
--- a/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/motion_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -329,7 +329,7 @@ bool JerkFilteredSmoother::apply(
     const auto msg = status_polish == 0    ? "unperformed"
                      : status_polish == -1 ? "unsuccessful"
                                            : "unknown";
-    RCLCPP_WARN(logger_, "osqp polish process failed : %s. The result may be inaccurate", msg);
+    RCLCPP_DEBUG(logger_, "osqp polish process failed : %s. The result may be inaccurate", msg);
   }
 
   if (VERBOSE_TRAJECTORY_VELOCITY) {


### PR DESCRIPTION
## Description

suppress `[motion_velocity_smoother-26] [WARN 1683770836.671243586] [smoother.jerk_filtered_smoother]: osqp polish process failed : unsuccessful. The result may be inaccurate (apply():332)`


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simualtor
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No behavior change
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
