### PR TITLE
fix(behavior_path_planner): fix invalid access in goal_planner module

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -176,8 +176,8 @@ void GoalPlannerModule::onTimer()
                                     const GoalCandidate & goal_candidate) {
     planner->setPlannerData(planner_data_);
     auto pull_over_path = planner->plan(goal_candidate.goal_pose);
-    pull_over_path->goal_id = goal_candidate.id;
     if (pull_over_path && isCrossingPossible(*pull_over_path)) {
+      pull_over_path->goal_id = goal_candidate.id;
       path_candidates.push_back(*pull_over_path);
       // calculate closest pull over start pose for stop path
       const double start_arc_length =


### PR DESCRIPTION
## Description
In goal_planner_module, when planner->plan() failes and it returns a null object, the invalid access for ```pull_over_path``` causes with the next line. 

```
    auto pull_over_path = planner->plan(goal_candidate.goal_pose);
    pull_over_path->goal_id = goal_candidate.id;
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/d05e2acd-d9fb-4d9a-b727-cea007827665)

This issue can be easily reproduced by moving the vehicle near the goal after setting the goal in the planning simulator.

![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/06550472-10be-48d0-ba2f-2c7ea444910a)
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/1d65d2f6-2407-4f6f-9722-b6444bf759fb)

I fixed it 



<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
I confirmed that the issue no longer reproduces.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
None
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
None
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
