### PR TITLE
refactor(autoware_auto_control_msgs): replace autoware_auto_control_msgs with autoware_control_msgs

### DIFF
--- a/common/tier4_control_rviz_plugin/README.md
+++ b/common/tier4_control_rviz_plugin/README.md
@@ -18,7 +18,7 @@ This package is to mimic external control for simulation.
 | Name                             | Type                                                       | Description             |
 | -------------------------------- | ---------------------------------------------------------- | ----------------------- |
 | `/control/gate_mode_cmd`         | `tier4_control_msgs::msg::GateMode`                        | GATE mode               |
-| `/external/selected/control_cmd` | `autoware_auto_control_msgs::msg::AckermannControlCommand` | AckermannControlCommand |
+| `/external/selected/control_cmd` | `autoware_control_msgs::msg::Control` | Control |
 | `/external/selected/gear_cmd`    | `autoware_auto_vehicle_msgs::msg::GearCommand`             | GEAR                    |
 
 ## Usage

--- a/common/tier4_control_rviz_plugin/README.md
+++ b/common/tier4_control_rviz_plugin/README.md
@@ -15,11 +15,11 @@ This package is to mimic external control for simulation.
 
 ### Output
 
-| Name                             | Type                                                       | Description             |
-| -------------------------------- | ---------------------------------------------------------- | ----------------------- |
-| `/control/gate_mode_cmd`         | `tier4_control_msgs::msg::GateMode`                        | GATE mode               |
-| `/external/selected/control_cmd` | `autoware_control_msgs::msg::Control` | Control |
-| `/external/selected/gear_cmd`    | `autoware_auto_vehicle_msgs::msg::GearCommand`             | GEAR                    |
+| Name                             | Type                                           | Description |
+| -------------------------------- | ---------------------------------------------- | ----------- |
+| `/control/gate_mode_cmd`         | `tier4_control_msgs::msg::GateMode`            | GATE mode   |
+| `/external/selected/control_cmd` | `autoware_control_msgs::msg::Control`          | Control     |
+| `/external/selected/gear_cmd`    | `autoware_auto_vehicle_msgs::msg::GearCommand` | GEAR        |
 
 ## Usage
 

--- a/common/tier4_control_rviz_plugin/package.xml
+++ b/common/tier4_control_rviz_plugin/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_control_rviz_plugin/package.xml
+++ b/common/tier4_control_rviz_plugin/package.xml
@@ -10,8 +10,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
@@ -110,11 +110,11 @@ ManualController::ManualController(QWidget * parent) : rviz_common::Panel(parent
 void ManualController::update()
 {
   if (!raw_node_) return;
-  AckermannControlCommand ackermann;
+  Control ackermann;
   {
     ackermann.stamp = raw_node_->get_clock()->now();
     ackermann.lateral.steering_tire_angle = steering_angle_;
-    ackermann.longitudinal.speed = cruise_velocity_;
+    ackermann.longitudinal.velocity = cruise_velocity_;
     if (current_acceleration_) {
       /**
        * @brief Calculate desired acceleration by simple BackSteppingControl
@@ -133,9 +133,9 @@ void ManualController::update()
   GearCommand gear_cmd;
   {
     const double eps = 0.001;
-    if (ackermann.longitudinal.speed > eps) {
+    if (ackermann.longitudinal.velocity > eps) {
       gear_cmd.command = GearCommand::DRIVE;
-    } else if (ackermann.longitudinal.speed < -eps && current_velocity_ < eps) {
+    } else if (ackermann.longitudinal.velocity < -eps && current_velocity_ < eps) {
       gear_cmd.command = GearCommand::REVERSE;
       ackermann.longitudinal.acceleration *= -1.0;
     } else {
@@ -180,7 +180,7 @@ void ManualController::onInitialize()
 
   pub_gate_mode_ = raw_node_->create_publisher<GateMode>("/control/gate_mode_cmd", rclcpp::QoS(1));
 
-  pub_control_command_ = raw_node_->create_publisher<AckermannControlCommand>(
+  pub_control_command_ = raw_node_->create_publisher<Control>(
     "/external/selected/control_cmd", rclcpp::QoS(1));
 
   pub_gear_cmd_ = raw_node_->create_publisher<GearCommand>("/external/selected/gear_cmd", 1);

--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
@@ -180,8 +180,8 @@ void ManualController::onInitialize()
 
   pub_gate_mode_ = raw_node_->create_publisher<GateMode>("/control/gate_mode_cmd", rclcpp::QoS(1));
 
-  pub_control_command_ = raw_node_->create_publisher<Control>(
-    "/external/selected/control_cmd", rclcpp::QoS(1));
+  pub_control_command_ =
+    raw_node_->create_publisher<Control>("/external/selected/control_cmd", rclcpp::QoS(1));
 
   pub_gear_cmd_ = raw_node_->create_publisher<GearCommand>("/external/selected/gear_cmd", 1);
 }

--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
@@ -26,10 +26,10 @@
 
 #include "autoware_auto_vehicle_msgs/msg/velocity_report.hpp"
 #include "geometry_msgs/msg/twist.hpp"
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
 
@@ -37,9 +37,9 @@
 
 namespace rviz_plugins
 {
-using autoware_control_msgs::msg::Control;
 using autoware_auto_vehicle_msgs::msg::GearCommand;
 using autoware_auto_vehicle_msgs::msg::VelocityReport;
+using autoware_control_msgs::msg::Control;
 using geometry_msgs::msg::Twist;
 using tier4_control_msgs::msg::GateMode;
 using EngageSrv = tier4_external_api_msgs::srv::Engage;

--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
@@ -26,7 +26,7 @@
 
 #include "autoware_auto_vehicle_msgs/msg/velocity_report.hpp"
 #include "geometry_msgs/msg/twist.hpp"
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
@@ -37,7 +37,7 @@
 
 namespace rviz_plugins
 {
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using autoware_auto_vehicle_msgs::msg::GearCommand;
 using autoware_auto_vehicle_msgs::msg::VelocityReport;
 using geometry_msgs::msg::Twist;
@@ -74,7 +74,7 @@ protected:
   rclcpp::Subscription<VelocityReport>::SharedPtr sub_velocity_;
   rclcpp::Subscription<Engage>::SharedPtr sub_engage_;
   rclcpp::Publisher<tier4_control_msgs::msg::GateMode>::SharedPtr pub_gate_mode_;
-  rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_control_command_;
+  rclcpp::Publisher<Control>::SharedPtr pub_control_command_;
   rclcpp::Publisher<GearCommand>::SharedPtr pub_gear_cmd_;
   rclcpp::Client<EngageSrv>::SharedPtr client_engage_;
   rclcpp::Subscription<GearReport>::SharedPtr sub_gear_;

--- a/control/autonomous_emergency_braking/package.xml
+++ b/control/autonomous_emergency_braking/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/control/autonomous_emergency_braking/package.xml
+++ b/control/autonomous_emergency_braking/package.xml
@@ -11,9 +11,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
   <depend>motion_utils</depend>

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -25,13 +25,13 @@ Error acceleration calculations are made based on the velocity calculations abov
 
 ### Input topics
 
-| Name                                     | Type                                                     | Description                                 |
-| ---------------------------------------- | -------------------------------------------------------- | ------------------------------------------- |
-| `/planning/scenario_planning/trajectory` | autoware_auto_planning_msgs::msg::Trajectory             | Output trajectory from planning module.     |
-| `/control/command/control_cmd`           | autoware_control_msgs::msg::Control | Output control command from control module. |
-| `/vehicle/status/steering_status`        | autoware_auto_vehicle_msgs::msg::SteeringReport          | Steering information from vehicle.          |
-| `/localization/kinematic_state`          | nav_msgs::msg::Odometry                                  | Use twist from odometry.                    |
-| `/tf`                                    | tf2_msgs::msg::TFMessage                                 | Extract ego pose from tf.                   |
+| Name                                     | Type                                            | Description                                 |
+| ---------------------------------------- | ----------------------------------------------- | ------------------------------------------- |
+| `/planning/scenario_planning/trajectory` | autoware_auto_planning_msgs::msg::Trajectory    | Output trajectory from planning module.     |
+| `/control/command/control_cmd`           | autoware_control_msgs::msg::Control             | Output control command from control module. |
+| `/vehicle/status/steering_status`        | autoware_auto_vehicle_msgs::msg::SteeringReport | Steering information from vehicle.          |
+| `/localization/kinematic_state`          | nav_msgs::msg::Odometry                         | Use twist from odometry.                    |
+| `/tf`                                    | tf2_msgs::msg::TFMessage                        | Extract ego pose from tf.                   |
 
 ### Output topics
 

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -28,7 +28,7 @@ Error acceleration calculations are made based on the velocity calculations abov
 | Name                                     | Type                                                     | Description                                 |
 | ---------------------------------------- | -------------------------------------------------------- | ------------------------------------------- |
 | `/planning/scenario_planning/trajectory` | autoware_auto_planning_msgs::msg::Trajectory             | Output trajectory from planning module.     |
-| `/control/command/control_cmd`           | autoware_auto_control_msgs::msg::AckermannControlCommand | Output control command from control module. |
+| `/control/command/control_cmd`           | autoware_control_msgs::msg::Control | Output control command from control module. |
 | `/vehicle/status/steering_status`        | autoware_auto_vehicle_msgs::msg::SteeringReport          | Steering information from vehicle.          |
 | `/localization/kinematic_state`          | nav_msgs::msg::Odometry                                  | Use twist from odometry.                    |
 | `/tf`                                    | tf2_msgs::msg::TFMessage                                 | Extract ego pose from tf.                   |

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
@@ -24,9 +24,9 @@
 #include <Eigen/Core>
 #include <rclcpp/time.hpp>
 
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/twist.hpp>
@@ -38,9 +38,9 @@
 
 namespace control_performance_analysis
 {
-using autoware_control_msgs::msg::Control;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
+using autoware_control_msgs::msg::Control;
 using control_performance_analysis::msg::DrivingMonitorStamped;
 using control_performance_analysis::msg::Error;
 using control_performance_analysis::msg::ErrorStamped;

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
@@ -24,7 +24,7 @@
 #include <Eigen/Core>
 #include <rclcpp/time.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
 #include <geometry_msgs/msg/pose.hpp>
@@ -38,7 +38,7 @@
 
 namespace control_performance_analysis
 {
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
 using control_performance_analysis::msg::DrivingMonitorStamped;
@@ -72,7 +72,7 @@ public:
   // Setters
   void setCurrentPose(const Pose & msg);
   void setCurrentWaypoints(const Trajectory & trajectory);
-  void setCurrentControlValue(const AckermannControlCommand & msg);
+  void setCurrentControlValue(const Control & msg);
   void setInterpolatedVars(
     const Pose & interpolated_pose, const double & interpolated_velocity,
     const double & interpolated_acceleration, const double & interpolated_steering_angle);
@@ -102,7 +102,7 @@ private:
   std::shared_ptr<autoware_auto_planning_msgs::msg::Trajectory> current_trajectory_ptr_;
   std::shared_ptr<Pose> current_vec_pose_ptr_;
   std::shared_ptr<std::vector<Odometry>> odom_history_ptr_;  // velocities at k-2, k-1, k, k+1
-  std::shared_ptr<AckermannControlCommand> current_control_ptr_;
+  std::shared_ptr<Control> current_control_ptr_;
   std::shared_ptr<SteeringReport> current_vec_steering_msg_ptr_;
 
   // State holder

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_node.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_node.hpp
@@ -23,9 +23,9 @@
 #include <signal_processing/lowpass_filter_1d.hpp>
 #include <tier4_autoware_utils/ros/self_pose_listener.hpp>
 
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
@@ -36,9 +36,9 @@
 
 namespace control_performance_analysis
 {
-using autoware_control_msgs::msg::Control;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
+using autoware_control_msgs::msg::Control;
 using control_performance_analysis::msg::DrivingMonitorStamped;
 using control_performance_analysis::msg::ErrorStamped;
 using geometry_msgs::msg::PoseStamped;
@@ -52,9 +52,8 @@ public:
 private:
   // Subscribers and Local Variable Assignment
   rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;  // subscribe to trajectory
-  rclcpp::Subscription<Control>::SharedPtr
-    sub_control_cmd_;                                       // subscribe to steering control value
-  rclcpp::Subscription<Odometry>::SharedPtr sub_velocity_;  // subscribe to velocity
+  rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;  // subscribe to steering control value
+  rclcpp::Subscription<Odometry>::SharedPtr sub_velocity_;    // subscribe to velocity
   rclcpp::Subscription<SteeringReport>::SharedPtr sub_vehicle_steering_;
 
   // Publishers

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_node.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_node.hpp
@@ -23,7 +23,7 @@
 #include <signal_processing/lowpass_filter_1d.hpp>
 #include <tier4_autoware_utils/ros/self_pose_listener.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -36,7 +36,7 @@
 
 namespace control_performance_analysis
 {
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
 using control_performance_analysis::msg::DrivingMonitorStamped;
@@ -52,7 +52,7 @@ public:
 private:
   // Subscribers and Local Variable Assignment
   rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;  // subscribe to trajectory
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr
+  rclcpp::Subscription<Control>::SharedPtr
     sub_control_cmd_;                                       // subscribe to steering control value
   rclcpp::Subscription<Odometry>::SharedPtr sub_velocity_;  // subscribe to velocity
   rclcpp::Subscription<SteeringReport>::SharedPtr sub_vehicle_steering_;
@@ -68,26 +68,26 @@ private:
 
   // Callback Methods
   void onTrajectory(const Trajectory::ConstSharedPtr msg);
-  void onControlRaw(const AckermannControlCommand::ConstSharedPtr control_msg);
+  void onControlRaw(const Control::ConstSharedPtr control_msg);
   void onVecSteeringMeasured(const SteeringReport::ConstSharedPtr meas_steer_msg);
   void onVelocity(const Odometry::ConstSharedPtr msg);
 
   // Parameters
   Params param_{};  // wheelbase, control period and feedback coefficients.
   // State holder
-  AckermannControlCommand::ConstSharedPtr last_control_cmd_;
+  Control::ConstSharedPtr last_control_cmd_;
   double d_control_cmd_{0};
 
   // Subscriber Parameters
   Trajectory::ConstSharedPtr current_trajectory_ptr_;  // ConstPtr to local traj.
-  AckermannControlCommand::ConstSharedPtr current_control_msg_ptr_;
+  Control::ConstSharedPtr current_control_msg_ptr_;
   SteeringReport::ConstSharedPtr current_vec_steering_msg_ptr_;
   Odometry::ConstSharedPtr current_odom_ptr_;
   PoseStamped::ConstSharedPtr current_pose_;  // pose of the vehicle, x, y, heading
 
   // prev states
   Trajectory prev_traj;
-  AckermannControlCommand prev_cmd;
+  Control prev_cmd;
   SteeringReport prev_steering;
 
   // Algorithm

--- a/control/control_performance_analysis/package.xml
+++ b/control/control_performance_analysis/package.xml
@@ -24,9 +24,9 @@
 
   <build_depend>builtin_interfaces</build_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>motion_utils</depend>

--- a/control/control_performance_analysis/package.xml
+++ b/control/control_performance_analysis/package.xml
@@ -24,7 +24,7 @@
 
   <build_depend>builtin_interfaces</build_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/control/control_performance_analysis/src/control_performance_analysis_core.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_core.cpp
@@ -74,9 +74,9 @@ void ControlPerformanceAnalysisCore::setCurrentPose(const Pose & msg)
   current_vec_pose_ptr_ = std::make_shared<Pose>(msg);
 }
 
-void ControlPerformanceAnalysisCore::setCurrentControlValue(const AckermannControlCommand & msg)
+void ControlPerformanceAnalysisCore::setCurrentControlValue(const Control & msg)
 {
-  current_control_ptr_ = std::make_shared<AckermannControlCommand>(msg);
+  current_control_ptr_ = std::make_shared<Control>(msg);
 }
 
 std::pair<bool, int32_t> ControlPerformanceAnalysisCore::findClosestPrevWayPointIdx_path_direction()

--- a/control/control_performance_analysis/src/control_performance_analysis_node.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_node.cpp
@@ -24,7 +24,7 @@
 
 namespace
 {
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using control_performance_analysis::msg::DrivingMonitorStamped;
 using control_performance_analysis::msg::ErrorStamped;
 
@@ -62,7 +62,7 @@ ControlPerformanceAnalysisNode::ControlPerformanceAnalysisNode(
     "~/input/reference_trajectory", 1,
     std::bind(&ControlPerformanceAnalysisNode::onTrajectory, this, _1));
 
-  sub_control_cmd_ = create_subscription<AckermannControlCommand>(
+  sub_control_cmd_ = create_subscription<Control>(
     "~/input/control_raw", 1, std::bind(&ControlPerformanceAnalysisNode::onControlRaw, this, _1));
 
   sub_vehicle_steering_ = create_subscription<SteeringReport>(
@@ -94,7 +94,7 @@ void ControlPerformanceAnalysisNode::onTrajectory(const Trajectory::ConstSharedP
 }
 
 void ControlPerformanceAnalysisNode::onControlRaw(
-  const AckermannControlCommand::ConstSharedPtr control_msg)
+  const Control::ConstSharedPtr control_msg)
 {
   if (last_control_cmd_) {
     const rclcpp::Duration & duration =

--- a/control/control_performance_analysis/src/control_performance_analysis_node.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_node.cpp
@@ -93,8 +93,7 @@ void ControlPerformanceAnalysisNode::onTrajectory(const Trajectory::ConstSharedP
   current_trajectory_ptr_ = msg;
 }
 
-void ControlPerformanceAnalysisNode::onControlRaw(
-  const Control::ConstSharedPtr control_msg)
+void ControlPerformanceAnalysisNode::onControlRaw(const Control::ConstSharedPtr control_msg)
 {
   if (last_control_cmd_) {
     const rclcpp::Duration & duration =

--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -17,7 +17,7 @@
 
 | Name                                | Type                                                     | Description                              |
 | ----------------------------------- | -------------------------------------------------------- | ---------------------------------------- |
-| `~/output/control_command`          | autoware_auto_control_msgs::msg::AckermannControlCommand | lateral and longitudinal control command |
+| `~/output/control_command`          | autoware_control_msgs::msg::Control | lateral and longitudinal control command |
 | `~/output/external_control_command` | tier4_external_api_msgs::msg::ControlCommandStamped      | lateral and longitudinal control command |
 | `~/output/shift`                    | tier4_external_api_msgs::msg::GearShiftStamped           | gear command                             |
 | `~/output/turn_signal`              | tier4_external_api_msgs::msg::TurnSignalStamped          | turn signal command                      |

--- a/control/joy_controller/README.md
+++ b/control/joy_controller/README.md
@@ -15,15 +15,15 @@
 
 ### Output topics
 
-| Name                                | Type                                                     | Description                              |
-| ----------------------------------- | -------------------------------------------------------- | ---------------------------------------- |
-| `~/output/control_command`          | autoware_control_msgs::msg::Control | lateral and longitudinal control command |
-| `~/output/external_control_command` | tier4_external_api_msgs::msg::ControlCommandStamped      | lateral and longitudinal control command |
-| `~/output/shift`                    | tier4_external_api_msgs::msg::GearShiftStamped           | gear command                             |
-| `~/output/turn_signal`              | tier4_external_api_msgs::msg::TurnSignalStamped          | turn signal command                      |
-| `~/output/gate_mode`                | tier4_control_msgs::msg::GateMode                        | gate mode (Auto or External)             |
-| `~/output/heartbeat`                | tier4_external_api_msgs::msg::Heartbeat                  | heartbeat                                |
-| `~/output/vehicle_engage`           | autoware_auto_vehicle_msgs::msg::Engage                  | vehicle engage                           |
+| Name                                | Type                                                | Description                              |
+| ----------------------------------- | --------------------------------------------------- | ---------------------------------------- |
+| `~/output/control_command`          | autoware_control_msgs::msg::Control                 | lateral and longitudinal control command |
+| `~/output/external_control_command` | tier4_external_api_msgs::msg::ControlCommandStamped | lateral and longitudinal control command |
+| `~/output/shift`                    | tier4_external_api_msgs::msg::GearShiftStamped      | gear command                             |
+| `~/output/turn_signal`              | tier4_external_api_msgs::msg::TurnSignalStamped     | turn signal command                      |
+| `~/output/gate_mode`                | tier4_control_msgs::msg::GateMode                   | gate mode (Auto or External)             |
+| `~/output/heartbeat`                | tier4_external_api_msgs::msg::Heartbeat             | heartbeat                                |
+| `~/output/vehicle_engage`           | autoware_auto_vehicle_msgs::msg::Engage             | vehicle engage                           |
 
 ## Parameters
 

--- a/control/joy_controller/include/joy_controller/joy_controller.hpp
+++ b/control/joy_controller/include/joy_controller/joy_controller.hpp
@@ -19,8 +19,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/joy.hpp>
@@ -80,8 +80,7 @@ private:
   void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
 
   // Publisher
-  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr
-    pub_control_command_;
+  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr pub_control_command_;
   rclcpp::Publisher<tier4_external_api_msgs::msg::ControlCommandStamped>::SharedPtr
     pub_external_control_command_;
   rclcpp::Publisher<tier4_external_api_msgs::msg::GearShiftStamped>::SharedPtr pub_shift_;

--- a/control/joy_controller/include/joy_controller/joy_controller.hpp
+++ b/control/joy_controller/include/joy_controller/joy_controller.hpp
@@ -19,7 +19,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -80,7 +80,7 @@ private:
   void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
 
   // Publisher
-  rclcpp::Publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
+  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr
     pub_control_command_;
   rclcpp::Publisher<tier4_external_api_msgs::msg::ControlCommandStamped>::SharedPtr
     pub_external_control_command_;
@@ -105,7 +105,7 @@ private:
   rclcpp::Client<tier4_external_api_msgs::srv::Engage>::SharedPtr client_autoware_engage_;
 
   // Previous State
-  autoware_auto_control_msgs::msg::AckermannControlCommand prev_control_command_;
+  autoware_control_msgs::msg::Control prev_control_command_;
   tier4_external_api_msgs::msg::ControlCommand prev_external_control_command_;
   GearShiftType prev_shift_ = tier4_external_api_msgs::msg::GearShift::NONE;
   TurnSignalType prev_turn_signal_ = tier4_external_api_msgs::msg::TurnSignal::NONE;

--- a/control/joy_controller/package.xml
+++ b/control/joy_controller/package.xml
@@ -16,7 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>joy</depend>

--- a/control/joy_controller/package.xml
+++ b/control/joy_controller/package.xml
@@ -16,8 +16,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>joy</depend>
   <depend>nav_msgs</depend>

--- a/control/joy_controller/src/joy_controller/joy_controller_node.cpp
+++ b/control/joy_controller/src/joy_controller/joy_controller_node.cpp
@@ -484,8 +484,7 @@ AutowareJoyControllerNode::AutowareJoyControllerNode(const rclcpp::NodeOptions &
 
   // Publisher
   pub_control_command_ =
-    this->create_publisher<autoware_control_msgs::msg::Control>(
-      "output/control_command", 1);
+    this->create_publisher<autoware_control_msgs::msg::Control>("output/control_command", 1);
   pub_external_control_command_ =
     this->create_publisher<tier4_external_api_msgs::msg::ControlCommandStamped>(
       "output/external_control_command", 1);

--- a/control/joy_controller/src/joy_controller/joy_controller_node.cpp
+++ b/control/joy_controller/src/joy_controller/joy_controller_node.cpp
@@ -251,7 +251,7 @@ void AutowareJoyControllerNode::onTimer()
 
 void AutowareJoyControllerNode::publishControlCommand()
 {
-  autoware_auto_control_msgs::msg::AckermannControlCommand cmd;
+  autoware_control_msgs::msg::Control cmd;
   cmd.stamp = this->now();
   {
     cmd.lateral.steering_tire_angle = steer_ratio_ * joy_->steer();
@@ -259,24 +259,24 @@ void AutowareJoyControllerNode::publishControlCommand()
 
     if (joy_->accel()) {
       cmd.longitudinal.acceleration = accel_ratio_ * joy_->accel();
-      cmd.longitudinal.speed =
+      cmd.longitudinal.velocity =
         twist_->twist.linear.x + velocity_gain_ * cmd.longitudinal.acceleration;
-      cmd.longitudinal.speed =
-        std::min(cmd.longitudinal.speed, static_cast<float>(max_forward_velocity_));
+      cmd.longitudinal.velocity =
+        std::min(cmd.longitudinal.velocity, static_cast<float>(max_forward_velocity_));
     }
 
     if (joy_->brake()) {
-      cmd.longitudinal.speed = 0.0;
+      cmd.longitudinal.velocity = 0.0;
       cmd.longitudinal.acceleration = -brake_ratio_ * joy_->brake();
     }
 
     // Backward
     if (joy_->accel() && joy_->brake()) {
       cmd.longitudinal.acceleration = backward_accel_ratio_ * joy_->accel();
-      cmd.longitudinal.speed =
+      cmd.longitudinal.velocity =
         twist_->twist.linear.x - velocity_gain_ * cmd.longitudinal.acceleration;
-      cmd.longitudinal.speed =
-        std::max(cmd.longitudinal.speed, static_cast<float>(-max_backward_velocity_));
+      cmd.longitudinal.velocity =
+        std::max(cmd.longitudinal.velocity, static_cast<float>(-max_backward_velocity_));
     }
   }
 
@@ -484,7 +484,7 @@ AutowareJoyControllerNode::AutowareJoyControllerNode(const rclcpp::NodeOptions &
 
   // Publisher
   pub_control_command_ =
-    this->create_publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>(
+    this->create_publisher<autoware_control_msgs::msg::Control>(
       "output/control_command", 1);
   pub_external_control_command_ =
     this->create_publisher<tier4_external_api_msgs::msg::ControlCommandStamped>(

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc.hpp
@@ -22,9 +22,9 @@
 #include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
@@ -38,9 +38,9 @@
 namespace autoware::motion::control::mpc_lateral_controller
 {
 
-using autoware_control_msgs::msg::Lateral;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
+using autoware_control_msgs::msg::Lateral;
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::Odometry;
 using tier4_debug_msgs::msg::Float32MultiArrayStamped;
@@ -429,9 +429,8 @@ public:
    * @return True if the MPC calculation is successful, false otherwise.
    */
   bool calculateMPC(
-    const SteeringReport & current_steer, const Odometry & current_kinematics,
-    Lateral & ctrl_cmd, Trajectory & predicted_trajectory,
-    Float32MultiArrayStamped & diagnostic);
+    const SteeringReport & current_steer, const Odometry & current_kinematics, Lateral & ctrl_cmd,
+    Trajectory & predicted_trajectory, Float32MultiArrayStamped & diagnostic);
 
   /**
    * @brief Set the reference trajectory to be followed.

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc.hpp
@@ -22,7 +22,7 @@
 #include "mpc_lateral_controller/vehicle_model/vehicle_model_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/pose.hpp"
@@ -38,7 +38,7 @@
 namespace autoware::motion::control::mpc_lateral_controller
 {
 
-using autoware_auto_control_msgs::msg::AckermannLateralCommand;
+using autoware_control_msgs::msg::Lateral;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
 using geometry_msgs::msg::Pose;
@@ -376,7 +376,7 @@ private:
    */
   Float32MultiArrayStamped generateDiagData(
     const MPCTrajectory & reference_trajectory, const MPCData & mpc_data,
-    const MPCMatrix & mpc_matrix, const AckermannLateralCommand & ctrl_cmd, const VectorXd & Uex,
+    const MPCMatrix & mpc_matrix, const Lateral & ctrl_cmd, const VectorXd & Uex,
     const Odometry & current_kinematics) const;
 
   //!< @brief logging with warn and return false
@@ -430,7 +430,7 @@ public:
    */
   bool calculateMPC(
     const SteeringReport & current_steer, const Odometry & current_kinematics,
-    AckermannLateralCommand & ctrl_cmd, Trajectory & predicted_trajectory,
+    Lateral & ctrl_cmd, Trajectory & predicted_trajectory,
     Float32MultiArrayStamped & diagnostic);
 
   /**

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
@@ -22,10 +22,10 @@
 #include "rclcpp/rclcpp.hpp"
 #include "trajectory_follower_base/lateral_controller_base.hpp"
 
-#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -42,9 +42,9 @@ namespace autoware::motion::control::mpc_lateral_controller
 {
 
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
-using autoware_control_msgs::msg::Lateral;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
+using autoware_control_msgs::msg::Lateral;
 using nav_msgs::msg::Odometry;
 using tier4_debug_msgs::msg::Float32MultiArrayStamped;
 using tier4_debug_msgs::msg::Float32Stamped;

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
@@ -22,7 +22,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "trajectory_follower_base/lateral_controller_base.hpp"
 
-#include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
@@ -42,7 +42,7 @@ namespace autoware::motion::control::mpc_lateral_controller
 {
 
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
-using autoware_auto_control_msgs::msg::AckermannLateralCommand;
+using autoware_control_msgs::msg::Lateral;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
 using nav_msgs::msg::Odometry;
@@ -95,10 +95,10 @@ private:
   bool m_is_mpc_history_filled{false};
 
   // store the last mpc outputs for 1 sec
-  std::vector<std::pair<AckermannLateralCommand, rclcpp::Time>> m_mpc_steering_history{};
+  std::vector<std::pair<Lateral, rclcpp::Time>> m_mpc_steering_history{};
 
   // set the mpc steering output to history
-  void setSteeringToHistory(const AckermannLateralCommand & steering);
+  void setSteeringToHistory(const Lateral & steering);
 
   // check if the mpc steering output is converged
   bool isMpcConverged();
@@ -116,7 +116,7 @@ private:
   bool m_is_ctrl_cmd_prev_initialized = false;
 
   // Previous control command for path following.
-  AckermannLateralCommand m_ctrl_cmd_prev;
+  Lateral m_ctrl_cmd_prev;
 
   //  Flag indicating whether the first trajectory has been received.
   bool m_has_received_first_trajectory = false;
@@ -194,7 +194,7 @@ private:
    * @param ctrl_cmd Control command to be created.
    * @return Created control command.
    */
-  AckermannLateralCommand createCtrlCmdMsg(const AckermannLateralCommand & ctrl_cmd);
+  Lateral createCtrlCmdMsg(const Lateral & ctrl_cmd);
 
   /**
    * @brief Publish the predicted future trajectory.
@@ -212,13 +212,13 @@ private:
    * @brief Get the stop control command.
    * @return Stop control command.
    */
-  AckermannLateralCommand getStopControlCommand() const;
+  Lateral getStopControlCommand() const;
 
   /**
    * @brief Get the control command applied before initialization.
    * @return Initial control command.
    */
-  AckermannLateralCommand getInitialControlCommand() const;
+  Lateral getInitialControlCommand() const;
 
   /**
    * @brief Check if the ego car is in a stopped state.
@@ -244,7 +244,7 @@ private:
    * @param cmd Steering control command to be checked.
    * @return True if the steering control is converged and stable, false otherwise.
    */
-  bool isSteerConverged(const AckermannLateralCommand & cmd) const;
+  bool isSteerConverged(const Lateral & cmd) const;
 
   rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr m_set_param_res;
 

--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/steering_predictor.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/steering_predictor.hpp
@@ -17,14 +17,14 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 
 #include <memory>
 #include <vector>
 
 namespace autoware::motion::control::mpc_lateral_controller
 {
-using autoware_auto_control_msgs::msg::AckermannLateralCommand;
+using autoware_control_msgs::msg::Lateral;
 
 class SteeringPredictor
 {
@@ -61,7 +61,7 @@ private:
   double m_input_delay;
 
   // Buffer of sent control commands.
-  std::vector<AckermannLateralCommand> m_ctrl_cmd_vec;
+  std::vector<Lateral> m_ctrl_cmd_vec;
 
   /**
    * @brief Get the sum of all steering commands over the given time range.

--- a/control/mpc_lateral_controller/package.xml
+++ b/control/mpc_lateral_controller/package.xml
@@ -17,9 +17,9 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>

--- a/control/mpc_lateral_controller/package.xml
+++ b/control/mpc_lateral_controller/package.xml
@@ -17,7 +17,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/control/mpc_lateral_controller/src/mpc.cpp
+++ b/control/mpc_lateral_controller/src/mpc.cpp
@@ -27,9 +27,8 @@ using tier4_autoware_utils::normalizeRadian;
 using tier4_autoware_utils::rad2deg;
 
 bool MPC::calculateMPC(
-  const SteeringReport & current_steer, const Odometry & current_kinematics,
-  Lateral & ctrl_cmd, Trajectory & predicted_trajectory,
-  Float32MultiArrayStamped & diagnostic)
+  const SteeringReport & current_steer, const Odometry & current_kinematics, Lateral & ctrl_cmd,
+  Trajectory & predicted_trajectory, Float32MultiArrayStamped & diagnostic)
 {
   // since the reference trajectory does not take into account the current velocity of the ego
   // vehicle, it needs to calculate the trajectory velocity considering the longitudinal dynamics.

--- a/control/mpc_lateral_controller/src/mpc.cpp
+++ b/control/mpc_lateral_controller/src/mpc.cpp
@@ -28,7 +28,7 @@ using tier4_autoware_utils::rad2deg;
 
 bool MPC::calculateMPC(
   const SteeringReport & current_steer, const Odometry & current_kinematics,
-  AckermannLateralCommand & ctrl_cmd, Trajectory & predicted_trajectory,
+  Lateral & ctrl_cmd, Trajectory & predicted_trajectory,
   Float32MultiArrayStamped & diagnostic)
 {
   // since the reference trajectory does not take into account the current velocity of the ego
@@ -132,7 +132,7 @@ Trajectory MPC::calcPredictedTrajectory(
 
 Float32MultiArrayStamped MPC::generateDiagData(
   const MPCTrajectory & reference_trajectory, const MPCData & mpc_data,
-  const MPCMatrix & mpc_matrix, const AckermannLateralCommand & ctrl_cmd, const VectorXd & Uex,
+  const MPCMatrix & mpc_matrix, const Lateral & ctrl_cmd, const VectorXd & Uex,
   const Odometry & current_kinematics) const
 {
   Float32MultiArrayStamped diagnostic;

--- a/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -235,7 +235,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
     m_current_steering.steering_tire_angle -= steering_offset_->getOffset();
   }
 
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory predicted_traj;
   Float32MultiArrayStamped debug_values;
 
@@ -301,7 +301,7 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   return createLateralOutput(ctrl_cmd, is_mpc_solved);
 }
 
-bool MpcLateralController::isSteerConverged(const AckermannLateralCommand & cmd) const
+bool MpcLateralController::isSteerConverged(const Lateral & cmd) const
 {
   // wait for a while to propagate the trajectory shape to the output command when the trajectory
   // shape is changed.
@@ -372,17 +372,17 @@ void MpcLateralController::setTrajectory(const Trajectory & msg)
   }
 }
 
-AckermannLateralCommand MpcLateralController::getStopControlCommand() const
+Lateral MpcLateralController::getStopControlCommand() const
 {
-  AckermannLateralCommand cmd;
+  Lateral cmd;
   cmd.steering_tire_angle = static_cast<decltype(cmd.steering_tire_angle)>(m_steer_cmd_prev);
   cmd.steering_tire_rotation_rate = 0.0;
   return cmd;
 }
 
-AckermannLateralCommand MpcLateralController::getInitialControlCommand() const
+Lateral MpcLateralController::getInitialControlCommand() const
 {
-  AckermannLateralCommand cmd;
+  Lateral cmd;
   cmd.steering_tire_angle = m_current_steering.steering_tire_angle;
   cmd.steering_tire_rotation_rate = 0.0;
   return cmd;
@@ -420,8 +420,8 @@ bool MpcLateralController::isStoppedState() const
   }
 }
 
-AckermannLateralCommand MpcLateralController::createCtrlCmdMsg(
-  const AckermannLateralCommand & ctrl_cmd)
+Lateral MpcLateralController::createCtrlCmdMsg(
+  const Lateral & ctrl_cmd)
 {
   auto out = ctrl_cmd;
   out.stamp = node_->now();
@@ -447,7 +447,7 @@ void MpcLateralController::publishDebugValues(Float32MultiArrayStamped & debug_v
   m_pub_steer_offset->publish(offset);
 }
 
-void MpcLateralController::setSteeringToHistory(const AckermannLateralCommand & steering)
+void MpcLateralController::setSteeringToHistory(const Lateral & steering)
 {
   const auto time = node_->now();
   if (m_mpc_steering_history.empty()) {

--- a/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -420,8 +420,7 @@ bool MpcLateralController::isStoppedState() const
   }
 }
 
-Lateral MpcLateralController::createCtrlCmdMsg(
-  const Lateral & ctrl_cmd)
+Lateral MpcLateralController::createCtrlCmdMsg(const Lateral & ctrl_cmd)
 {
   auto out = ctrl_cmd;
   out.stamp = node_->now();

--- a/control/mpc_lateral_controller/src/steering_predictor.cpp
+++ b/control/mpc_lateral_controller/src/steering_predictor.cpp
@@ -47,7 +47,7 @@ double SteeringPredictor::calcSteerPrediction()
 void SteeringPredictor::storeSteerCmd(const double steer)
 {
   const auto time_delayed = m_clock->now() + rclcpp::Duration::from_seconds(m_input_delay);
-  AckermannLateralCommand cmd;
+  Lateral cmd;
   cmd.stamp = time_delayed;
   cmd.steering_tire_angle = static_cast<float>(steer);
 

--- a/control/mpc_lateral_controller/test/test_mpc.cpp
+++ b/control/mpc_lateral_controller/test/test_mpc.cpp
@@ -20,10 +20,10 @@
 #include "mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics.hpp"
 #include "mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp"
 
-#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
 
@@ -40,10 +40,10 @@
 namespace autoware::motion::control::mpc_lateral_controller
 {
 
-using autoware_control_msgs::msg::Lateral;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
+using autoware_control_msgs::msg::Lateral;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
 using tier4_debug_msgs::msg::Float32MultiArrayStamped;

--- a/control/mpc_lateral_controller/test/test_mpc.cpp
+++ b/control/mpc_lateral_controller/test/test_mpc.cpp
@@ -20,7 +20,7 @@
 #include "mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics.hpp"
 #include "mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp"
 
-#include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
@@ -40,7 +40,7 @@
 namespace autoware::motion::control::mpc_lateral_controller
 {
 
-using autoware_auto_control_msgs::msg::AckermannLateralCommand;
+using autoware_control_msgs::msg::Lateral;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
@@ -195,7 +195,7 @@ TEST_F(MPCTest, InitializeAndCalculate)
   initializeMPC(mpc);
 
   // Calculate MPC
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
   const auto odom = makeOdometry(pose_zero, default_velocity);
@@ -224,7 +224,7 @@ TEST_F(MPCTest, InitializeAndCalculateRightTurn)
   mpc.setReferenceTrajectory(dummy_right_turn_trajectory, trajectory_param);
 
   // Calculate MPC
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
   const auto odom = makeOdometry(pose_zero, default_velocity);
@@ -249,7 +249,7 @@ TEST_F(MPCTest, OsqpCalculate)
   ASSERT_TRUE(mpc.hasQPSolver());
 
   // Calculate MPC
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
   // with OSQP this function returns false despite finding correct solutions
@@ -275,7 +275,7 @@ TEST_F(MPCTest, OsqpCalculateRightTurn)
   ASSERT_TRUE(mpc.hasQPSolver());
 
   // Calculate MPC
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
   const auto odom = makeOdometry(pose_zero, default_velocity);
@@ -303,7 +303,7 @@ TEST_F(MPCTest, KinematicsNoDelayCalculate)
   // Init trajectory
   mpc.setReferenceTrajectory(dummy_straight_trajectory, trajectory_param);
   // Calculate MPC
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
   const auto odom = makeOdometry(pose_zero, default_velocity);
@@ -331,7 +331,7 @@ TEST_F(MPCTest, KinematicsNoDelayCalculateRightTurn)
   mpc.initializeLowPassFilters(steering_lpf_cutoff_hz, error_deriv_lpf_cutoff_hz);
 
   // Calculate MPC
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
   const auto odom = makeOdometry(pose_zero, default_velocity);
@@ -355,7 +355,7 @@ TEST_F(MPCTest, DynamicCalculate)
   ASSERT_TRUE(mpc.hasQPSolver());
 
   // Calculate MPC
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
   const auto odom = makeOdometry(pose_zero, default_velocity);
@@ -378,7 +378,7 @@ TEST_F(MPCTest, MultiSolveWithBuffer)
 
   mpc.m_input_buffer = {0.0, 0.0, 0.0};
   // Calculate MPC
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
   const auto odom = makeOdometry(pose_zero, default_velocity);
@@ -417,7 +417,7 @@ TEST_F(MPCTest, FailureCases)
   Pose pose_far;
   pose_far.position.x = pose_zero.position.x - admissible_position_error - 1.0;
   pose_far.position.y = pose_zero.position.y - admissible_position_error - 1.0;
-  AckermannLateralCommand ctrl_cmd;
+  Lateral ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
   const auto odom = makeOdometry(pose_far, default_velocity);

--- a/control/operation_mode_transition_manager/README.md
+++ b/control/operation_mode_transition_manager/README.md
@@ -38,7 +38,7 @@ For the mode transition:
 
 For the transition availability/completion check:
 
-- /control/command/control_cmd [`autoware_auto_control_msgs/msg/AckermannControlCommand`]: vehicle control signal
+- /control/command/control_cmd [`autoware_control_msgs/msg/Control`]: vehicle control signal
 - /localization/kinematic_state [`nav_msgs/msg/Odometry`]: ego vehicle state
 - /planning/scenario_planning/trajectory [`autoware_auto_planning_msgs/msg/Trajectory`]: planning trajectory
 - /vehicle/status/control_mode [`autoware_auto_vehicle_msgs/msg/ControlModeReport`]: vehicle control mode (autonomous/manual)

--- a/control/operation_mode_transition_manager/package.xml
+++ b/control/operation_mode_transition_manager/package.xml
@@ -11,9 +11,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>component_interface_specs</depend>
   <depend>component_interface_utils</depend>
   <depend>geometry_msgs</depend>

--- a/control/operation_mode_transition_manager/package.xml
+++ b/control/operation_mode_transition_manager/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>component_interface_specs</depend>

--- a/control/operation_mode_transition_manager/src/state.cpp
+++ b/control/operation_mode_transition_manager/src/state.cpp
@@ -35,8 +35,7 @@ AutonomousMode::AutonomousMode(rclcpp::Node * node)
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*node).getVehicleInfo();
 
   sub_control_cmd_ = node->create_subscription<Control>(
-    "control_cmd", 1,
-    [this](const Control::SharedPtr msg) { control_cmd_ = *msg; });
+    "control_cmd", 1, [this](const Control::SharedPtr msg) { control_cmd_ = *msg; });
 
   sub_kinematics_ = node->create_subscription<Odometry>(
     "kinematics", 1, [this](const Odometry::SharedPtr msg) { kinematics_ = *msg; });

--- a/control/operation_mode_transition_manager/src/state.cpp
+++ b/control/operation_mode_transition_manager/src/state.cpp
@@ -34,9 +34,9 @@ AutonomousMode::AutonomousMode(rclcpp::Node * node)
 {
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*node).getVehicleInfo();
 
-  sub_control_cmd_ = node->create_subscription<AckermannControlCommand>(
+  sub_control_cmd_ = node->create_subscription<Control>(
     "control_cmd", 1,
-    [this](const AckermannControlCommand::SharedPtr msg) { control_cmd_ = *msg; });
+    [this](const Control::SharedPtr msg) { control_cmd_ = *msg; });
 
   sub_kinematics_ = node->create_subscription<Odometry>(
     "kinematics", 1, [this](const Odometry::SharedPtr msg) { kinematics_ = *msg; });
@@ -204,7 +204,7 @@ bool AutonomousMode::isModeChangeAvailable()
   }
 
   const auto current_speed = kinematics_.twist.twist.linear.x;
-  const auto target_control_speed = control_cmd_.longitudinal.speed;
+  const auto target_control_speed = control_cmd_.longitudinal.velocity;
   const auto & param = engage_acceptable_param_;
 
   if (trajectory_.points.size() < 2) {

--- a/control/operation_mode_transition_manager/src/state.hpp
+++ b/control/operation_mode_transition_manager/src/state.hpp
@@ -21,8 +21,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <memory>

--- a/control/operation_mode_transition_manager/src/state.hpp
+++ b/control/operation_mode_transition_manager/src/state.hpp
@@ -21,7 +21,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
@@ -63,10 +63,10 @@ private:
   bool hasDangerAcceleration();
   std::pair<bool, bool> hasDangerLateralAcceleration();
 
-  using AckermannControlCommand = autoware_auto_control_msgs::msg::AckermannControlCommand;
+  using Control = autoware_control_msgs::msg::Control;
   using Odometry = nav_msgs::msg::Odometry;
   using Trajectory = autoware_auto_planning_msgs::msg::Trajectory;
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_control_cmd_;
+  rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;
   rclcpp::Subscription<Odometry>::SharedPtr sub_kinematics_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
   rclcpp::Logger logger_;
@@ -77,7 +77,7 @@ private:
   double nearest_yaw_deviation_threshold_;   // [rad] for finding nearest index
   EngageAcceptableParam engage_acceptable_param_;
   StableCheckParam stable_check_param_;
-  AckermannControlCommand control_cmd_;
+  Control control_cmd_;
   Odometry kinematics_;
   Trajectory trajectory_;
   vehicle_info_util::VehicleInfo vehicle_info_;

--- a/control/pid_longitudinal_controller/README.md
+++ b/control/pid_longitudinal_controller/README.md
@@ -141,7 +141,7 @@ Set the following from the [controller_node](../trajectory_follower_node/README.
 
 Return LongitudinalOutput which contains the following to the controller node
 
-- `autoware_auto_control_msgs/LongitudinalCommand`: command to control the longitudinal motion of the vehicle. It contains the target velocity and target acceleration.
+- `autoware_control_msgs/msg/Longitudinal`: command to control the longitudinal motion of the vehicle. It contains the target velocity and target acceleration.
 - LongitudinalSyncData
   - velocity convergence(currently not used)
 

--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -32,9 +32,9 @@
 #include <Eigen/Geometry>
 
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
-#include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
+#include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"

--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -32,7 +32,7 @@
 #include <Eigen/Geometry>
 
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
-#include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"
+#include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -186,7 +186,7 @@ private:
   double m_ego_nearest_yaw_threshold;
 
   // buffer of send command
-  std::vector<autoware_auto_control_msgs::msg::LongitudinalCommand> m_ctrl_cmd_vec;
+  std::vector<autoware_control_msgs::msg::Longitudinal> m_ctrl_cmd_vec;
 
   // for calculating dt
   std::shared_ptr<rclcpp::Time> m_prev_control_time{nullptr};
@@ -279,7 +279,7 @@ private:
    * @param [in] ctrl_cmd calculated control command to control velocity
    * @param [in] current_vel current velocity of the vehicle
    */
-  autoware_auto_control_msgs::msg::LongitudinalCommand createCtrlCmdMsg(
+  autoware_control_msgs::msg::Longitudinal createCtrlCmdMsg(
     const Motion & ctrl_cmd, const double & current_vel);
 
   /**

--- a/control/pid_longitudinal_controller/package.xml
+++ b/control/pid_longitudinal_controller/package.xml
@@ -18,9 +18,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>

--- a/control/pid_longitudinal_controller/package.xml
+++ b/control/pid_longitudinal_controller/package.xml
@@ -18,7 +18,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -681,13 +681,13 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
 }
 
 // Do not use nearest_idx here
-autoware_auto_control_msgs::msg::LongitudinalCommand PidLongitudinalController::createCtrlCmdMsg(
+autoware_control_msgs::msg::Longitudinal PidLongitudinalController::createCtrlCmdMsg(
   const Motion & ctrl_cmd, const double & current_vel)
 {
   // publish control command
-  autoware_auto_control_msgs::msg::LongitudinalCommand cmd{};
+  autoware_control_msgs::msg::Longitudinal cmd{};
   cmd.stamp = node_->now();
-  cmd.speed = static_cast<decltype(cmd.speed)>(ctrl_cmd.vel);
+  cmd.velocity = static_cast<decltype(cmd.velocity)>(ctrl_cmd.vel);
   cmd.acceleration = static_cast<decltype(cmd.acceleration)>(ctrl_cmd.acc);
 
   // store current velocity history
@@ -784,7 +784,7 @@ void PidLongitudinalController::storeAccelCmd(const double accel)
 {
   if (m_control_state == ControlState::DRIVE) {
     // convert format
-    autoware_auto_control_msgs::msg::LongitudinalCommand cmd;
+    autoware_control_msgs::msg::Longitudinal cmd;
     cmd.stamp = node_->now();
     cmd.acceleration = static_cast<decltype(cmd.acceleration)>(accel);
 

--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -41,7 +41,7 @@
 #include <motion_utils/trajectory/tmp_conversion.hpp>
 #include <motion_utils/trajectory/trajectory.hpp>
 
-#include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
@@ -56,7 +56,7 @@
 using autoware::motion::control::trajectory_follower::InputData;
 using autoware::motion::control::trajectory_follower::LateralControllerBase;
 using autoware::motion::control::trajectory_follower::LateralOutput;
-using autoware_auto_control_msgs::msg::AckermannLateralCommand;
+using autoware_control_msgs::msg::Lateral;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 
@@ -109,7 +109,7 @@ private:
   autoware_auto_planning_msgs::msg::Trajectory trajectory_;
   nav_msgs::msg::Odometry current_odometry_;
   autoware_auto_vehicle_msgs::msg::SteeringReport current_steering_;
-  boost::optional<AckermannLateralCommand> prev_cmd_;
+  boost::optional<Lateral> prev_cmd_;
 
   // Debug Publisher
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_debug_marker_;
@@ -137,7 +137,7 @@ private:
   bool isReady([[maybe_unused]] const InputData & input_data) override;
   LateralOutput run(const InputData & input_data) override;
 
-  AckermannLateralCommand generateCtrlCmdMsg(const double target_curvature);
+  Lateral generateCtrlCmdMsg(const double target_curvature);
 
   // Parameter
   Param param_{};
@@ -154,13 +154,13 @@ private:
    */
 
   TrajectoryPoint calcNextPose(
-    const double ds, TrajectoryPoint & point, AckermannLateralCommand cmd) const;
+    const double ds, TrajectoryPoint & point, Lateral cmd) const;
 
   boost::optional<Trajectory> generatePredictedTrajectory();
 
-  AckermannLateralCommand generateOutputControlCmd();
+  Lateral generateOutputControlCmd();
 
-  bool calcIsSteerConverged(const AckermannLateralCommand & cmd);
+  bool calcIsSteerConverged(const Lateral & cmd);
 
   double calcLookaheadDistance(
     const double lateral_error, const double curvature, const double velocity, const double min_ld,

--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_lateral_controller.hpp
@@ -41,8 +41,8 @@
 #include <motion_utils/trajectory/tmp_conversion.hpp>
 #include <motion_utils/trajectory/trajectory.hpp>
 
-#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -56,9 +56,9 @@
 using autoware::motion::control::trajectory_follower::InputData;
 using autoware::motion::control::trajectory_follower::LateralControllerBase;
 using autoware::motion::control::trajectory_follower::LateralOutput;
-using autoware_control_msgs::msg::Lateral;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_control_msgs::msg::Lateral;
 
 namespace pure_pursuit
 {
@@ -153,8 +153,7 @@ private:
    * of vehicle.
    */
 
-  TrajectoryPoint calcNextPose(
-    const double ds, TrajectoryPoint & point, Lateral cmd) const;
+  TrajectoryPoint calcNextPose(const double ds, TrajectoryPoint & point, Lateral cmd) const;
 
   boost::optional<Trajectory> generatePredictedTrajectory();
 

--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_node.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_node.hpp
@@ -36,7 +36,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/ros/self_pose_listener.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp>
+#include <autoware_control_msgs/msg/lateral.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -96,7 +96,7 @@ private:
   geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
 
   // Publisher
-  rclcpp::Publisher<autoware_auto_control_msgs::msg::AckermannLateralCommand>::SharedPtr
+  rclcpp::Publisher<autoware_control_msgs::msg::Lateral>::SharedPtr
     pub_ctrl_cmd_;
 
   void publishCommand(const double target_curvature);

--- a/control/pure_pursuit/include/pure_pursuit/pure_pursuit_node.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/pure_pursuit_node.hpp
@@ -36,8 +36,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/ros/self_pose_listener.hpp>
 
-#include <autoware_control_msgs/msg/lateral.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
+#include <autoware_control_msgs/msg/lateral.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -96,8 +96,7 @@ private:
   geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
 
   // Publisher
-  rclcpp::Publisher<autoware_control_msgs::msg::Lateral>::SharedPtr
-    pub_ctrl_cmd_;
+  rclcpp::Publisher<autoware_control_msgs::msg::Lateral>::SharedPtr pub_ctrl_cmd_;
 
   void publishCommand(const double target_curvature);
 

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -13,7 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>boost</depend>
   <depend>geometry_msgs</depend>

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -13,8 +13,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>boost</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_lateral_controller.cpp
@@ -400,8 +400,7 @@ Lateral PurePursuitLateralController::generateOutputControlCmd()
   return output_cmd;
 }
 
-Lateral PurePursuitLateralController::generateCtrlCmdMsg(
-  const double target_curvature)
+Lateral PurePursuitLateralController::generateCtrlCmdMsg(const double target_curvature)
 {
   const double tmp_steering =
     planning_utils::convertCurvatureToSteeringAngle(param_.wheel_base, target_curvature);

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_node.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_node.cpp
@@ -79,7 +79,7 @@ PurePursuitNode::PurePursuitNode(const rclcpp::NodeOptions & node_options)
     "input/current_odometry", 1, std::bind(&PurePursuitNode::onCurrentOdometry, this, _1));
 
   // Publishers
-  pub_ctrl_cmd_ = this->create_publisher<autoware_auto_control_msgs::msg::AckermannLateralCommand>(
+  pub_ctrl_cmd_ = this->create_publisher<autoware_control_msgs::msg::Lateral>(
     "output/control_raw", 1);
 
   // Debug Publishers
@@ -150,7 +150,7 @@ void PurePursuitNode::onTimer()
 
 void PurePursuitNode::publishCommand(const double target_curvature)
 {
-  autoware_auto_control_msgs::msg::AckermannLateralCommand cmd;
+  autoware_control_msgs::msg::Lateral cmd;
   cmd.stamp = get_clock()->now();
   cmd.steering_tire_angle =
     planning_utils::convertCurvatureToSteeringAngle(param_.wheel_base, target_curvature);

--- a/control/pure_pursuit/src/pure_pursuit/pure_pursuit_node.cpp
+++ b/control/pure_pursuit/src/pure_pursuit/pure_pursuit_node.cpp
@@ -79,8 +79,8 @@ PurePursuitNode::PurePursuitNode(const rclcpp::NodeOptions & node_options)
     "input/current_odometry", 1, std::bind(&PurePursuitNode::onCurrentOdometry, this, _1));
 
   // Publishers
-  pub_ctrl_cmd_ = this->create_publisher<autoware_control_msgs::msg::Lateral>(
-    "output/control_raw", 1);
+  pub_ctrl_cmd_ =
+    this->create_publisher<autoware_control_msgs::msg::Lateral>("output/control_raw", 1);
 
   // Debug Publishers
   pub_debug_marker_ =

--- a/control/shift_decider/README.md
+++ b/control/shift_decider/README.md
@@ -39,7 +39,7 @@ stop
 
 | Name                  | Type                                                       | Description                  |
 | --------------------- | ---------------------------------------------------------- | ---------------------------- |
-| `~/input/control_cmd` | `autoware_auto_control_msgs::msg::AckermannControlCommand` | Control command for vehicle. |
+| `~/input/control_cmd` | `autoware_control_msgs::msg::Control` | Control command for vehicle. |
 
 ### Output
 

--- a/control/shift_decider/README.md
+++ b/control/shift_decider/README.md
@@ -37,8 +37,8 @@ stop
 
 ### Input
 
-| Name                  | Type                                                       | Description                  |
-| --------------------- | ---------------------------------------------------------- | ---------------------------- |
+| Name                  | Type                                  | Description                  |
+| --------------------- | ------------------------------------- | ---------------------------- |
 | `~/input/control_cmd` | `autoware_control_msgs::msg::Control` | Control command for vehicle. |
 
 ### Output

--- a/control/shift_decider/include/shift_decider/shift_decider.hpp
+++ b/control/shift_decider/include/shift_decider/shift_decider.hpp
@@ -17,10 +17,10 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 
 #include <memory>
 
@@ -38,8 +38,7 @@ private:
   void initTimer(double period_s);
 
   rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr pub_shift_cmd_;
-  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr
-    sub_control_cmd_;
+  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr sub_control_cmd_;
   rclcpp::Subscription<autoware_auto_system_msgs::msg::AutowareState>::SharedPtr
     sub_autoware_state_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::GearReport>::SharedPtr sub_current_gear_;

--- a/control/shift_decider/include/shift_decider/shift_decider.hpp
+++ b/control/shift_decider/include/shift_decider/shift_decider.hpp
@@ -17,7 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
@@ -31,14 +31,14 @@ public:
 
 private:
   void onTimer();
-  void onControlCmd(autoware_auto_control_msgs::msg::AckermannControlCommand::SharedPtr msg);
+  void onControlCmd(autoware_control_msgs::msg::Control::SharedPtr msg);
   void onAutowareState(autoware_auto_system_msgs::msg::AutowareState::SharedPtr msg);
   void onCurrentGear(autoware_auto_vehicle_msgs::msg::GearReport::SharedPtr msg);
   void updateCurrentShiftCmd();
   void initTimer(double period_s);
 
   rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr pub_shift_cmd_;
-  rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
+  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr
     sub_control_cmd_;
   rclcpp::Subscription<autoware_auto_system_msgs::msg::AutowareState>::SharedPtr
     sub_autoware_state_;
@@ -46,7 +46,7 @@ private:
 
   rclcpp::TimerBase::SharedPtr timer_;
 
-  autoware_auto_control_msgs::msg::AckermannControlCommand::SharedPtr control_cmd_;
+  autoware_control_msgs::msg::Control::SharedPtr control_cmd_;
   autoware_auto_system_msgs::msg::AutowareState::SharedPtr autoware_state_;
   autoware_auto_vehicle_msgs::msg::GearCommand shift_cmd_;
   autoware_auto_vehicle_msgs::msg::GearReport::SharedPtr current_gear_ptr_;

--- a/control/shift_decider/package.xml
+++ b/control/shift_decider/package.xml
@@ -12,9 +12,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/control/shift_decider/package.xml
+++ b/control/shift_decider/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>rclcpp</depend>

--- a/control/shift_decider/src/shift_decider.cpp
+++ b/control/shift_decider/src/shift_decider.cpp
@@ -44,8 +44,7 @@ ShiftDecider::ShiftDecider(const rclcpp::NodeOptions & node_options)
   initTimer(0.1);
 }
 
-void ShiftDecider::onControlCmd(
-  autoware_control_msgs::msg::Control::SharedPtr msg)
+void ShiftDecider::onControlCmd(autoware_control_msgs::msg::Control::SharedPtr msg)
 {
   control_cmd_ = msg;
 }

--- a/control/shift_decider/src/shift_decider.cpp
+++ b/control/shift_decider/src/shift_decider.cpp
@@ -34,7 +34,7 @@ ShiftDecider::ShiftDecider(const rclcpp::NodeOptions & node_options)
 
   pub_shift_cmd_ =
     create_publisher<autoware_auto_vehicle_msgs::msg::GearCommand>("output/gear_cmd", durable_qos);
-  sub_control_cmd_ = create_subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>(
+  sub_control_cmd_ = create_subscription<autoware_control_msgs::msg::Control>(
     "input/control_cmd", queue_size, std::bind(&ShiftDecider::onControlCmd, this, _1));
   sub_autoware_state_ = create_subscription<autoware_auto_system_msgs::msg::AutowareState>(
     "input/state", queue_size, std::bind(&ShiftDecider::onAutowareState, this, _1));
@@ -45,7 +45,7 @@ ShiftDecider::ShiftDecider(const rclcpp::NodeOptions & node_options)
 }
 
 void ShiftDecider::onControlCmd(
-  autoware_auto_control_msgs::msg::AckermannControlCommand::SharedPtr msg)
+  autoware_control_msgs::msg::Control::SharedPtr msg)
 {
   control_cmd_ = msg;
 }
@@ -78,9 +78,9 @@ void ShiftDecider::updateCurrentShiftCmd()
   shift_cmd_.stamp = now();
   static constexpr double vel_threshold = 0.01;  // to prevent chattering
   if (autoware_state_->state == AutowareState::DRIVING) {
-    if (control_cmd_->longitudinal.speed > vel_threshold) {
+    if (control_cmd_->longitudinal.velocity > vel_threshold) {
       shift_cmd_.command = GearCommand::DRIVE;
-    } else if (control_cmd_->longitudinal.speed < -vel_threshold) {
+    } else if (control_cmd_->longitudinal.velocity < -vel_threshold) {
       shift_cmd_.command = GearCommand::REVERSE;
     } else {
       shift_cmd_.command = current_gear_ptr_->report;

--- a/control/trajectory_follower_base/include/trajectory_follower_base/lateral_controller_base.hpp
+++ b/control/trajectory_follower_base/include/trajectory_follower_base/lateral_controller_base.hpp
@@ -19,7 +19,7 @@
 #include "trajectory_follower_base/input_data.hpp"
 #include "trajectory_follower_base/sync_data.hpp"
 
-#include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 
 #include <boost/optional.hpp>
 
@@ -27,7 +27,7 @@ namespace autoware::motion::control::trajectory_follower
 {
 struct LateralOutput
 {
-  autoware_auto_control_msgs::msg::AckermannLateralCommand control_cmd;
+  autoware_control_msgs::msg::Lateral control_cmd;
   LateralSyncData sync_data;
 };
 

--- a/control/trajectory_follower_base/include/trajectory_follower_base/longitudinal_controller_base.hpp
+++ b/control/trajectory_follower_base/include/trajectory_follower_base/longitudinal_controller_base.hpp
@@ -19,7 +19,7 @@
 #include "trajectory_follower_base/input_data.hpp"
 #include "trajectory_follower_base/sync_data.hpp"
 
-#include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"
+#include "autoware_control_msgs/msg/longitudinal.hpp"
 
 #include <boost/optional.hpp>
 
@@ -27,7 +27,7 @@ namespace autoware::motion::control::trajectory_follower
 {
 struct LongitudinalOutput
 {
-  autoware_auto_control_msgs::msg::LongitudinalCommand control_cmd;
+  autoware_control_msgs::msg::Longitudinal control_cmd;
   LongitudinalSyncData sync_data;
 };
 class LongitudinalControllerBase

--- a/control/trajectory_follower_base/package.xml
+++ b/control/trajectory_follower_base/package.xml
@@ -20,7 +20,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/control/trajectory_follower_base/package.xml
+++ b/control/trajectory_follower_base/package.xml
@@ -20,9 +20,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>

--- a/control/trajectory_follower_node/design/simple_trajectory_follower-design.md
+++ b/control/trajectory_follower_node/design/simple_trajectory_follower-design.md
@@ -13,7 +13,7 @@ Inputs
 - `input/reference_trajectory` [autoware_auto_planning_msgs::msg::Trajectory] : reference trajectory to follow.
 - `input/current_kinematic_state` [nav_msgs::msg::Odometry] : current state of the vehicle (position, velocity, etc).
 - Output
-- `output/control_cmd` [autoware_auto_control_msgs::msg::AckermannControlCommand] : generated control command.
+- `output/control_cmd` [autoware_control_msgs::msg::Control] : generated control command.
 
 ### Parameters
 

--- a/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
+++ b/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
@@ -27,8 +27,8 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
-#include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"
+#include "autoware_control_msgs/msg/control.hpp"
+#include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
 #include "geometry_msgs/msg/accel_stamped.hpp"
@@ -74,7 +74,7 @@ private:
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::SteeringReport>::SharedPtr sub_steering_;
   rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr sub_accel_;
   rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_;
-  rclcpp::Publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
+  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr
     control_cmd_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_marker_pub_;
 

--- a/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
+++ b/control/trajectory_follower_node/include/trajectory_follower_node/controller_node.hpp
@@ -27,10 +27,10 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include "autoware_control_msgs/msg/control.hpp"
-#include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
+#include "autoware_control_msgs/msg/control.hpp"
+#include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "geometry_msgs/msg/accel_stamped.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -74,8 +74,7 @@ private:
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::SteeringReport>::SharedPtr sub_steering_;
   rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr sub_accel_;
   rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_;
-  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr
-    control_cmd_pub_;
+  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr control_cmd_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_marker_pub_;
 
   autoware_auto_planning_msgs::msg::Trajectory::SharedPtr current_trajectory_ptr_;

--- a/control/trajectory_follower_node/include/trajectory_follower_node/simple_trajectory_follower.hpp
+++ b/control/trajectory_follower_node/include/trajectory_follower_node/simple_trajectory_follower.hpp
@@ -17,9 +17,9 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory_point.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -28,9 +28,9 @@
 
 namespace simple_trajectory_follower
 {
-using autoware_control_msgs::msg::Control;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+using autoware_control_msgs::msg::Control;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
 using nav_msgs::msg::Odometry;

--- a/control/trajectory_follower_node/include/trajectory_follower_node/simple_trajectory_follower.hpp
+++ b/control/trajectory_follower_node/include/trajectory_follower_node/simple_trajectory_follower.hpp
@@ -17,7 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory_point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
@@ -28,7 +28,7 @@
 
 namespace simple_trajectory_follower
 {
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Pose;
@@ -44,7 +44,7 @@ public:
 private:
   rclcpp::Subscription<Odometry>::SharedPtr sub_kinematics_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
-  rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_cmd_;
+  rclcpp::Publisher<Control>::SharedPtr pub_cmd_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   Trajectory::SharedPtr trajectory_;

--- a/control/trajectory_follower_node/package.xml
+++ b/control/trajectory_follower_node/package.xml
@@ -20,7 +20,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/control/trajectory_follower_node/package.xml
+++ b/control/trajectory_follower_node/package.xml
@@ -20,10 +20,10 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>motion_utils</depend>
   <depend>mpc_lateral_controller</depend>
   <depend>pid_longitudinal_controller</depend>

--- a/control/trajectory_follower_node/src/controller_node.cpp
+++ b/control/trajectory_follower_node/src/controller_node.cpp
@@ -72,7 +72,7 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
   sub_operation_mode_ = create_subscription<OperationModeState>(
     "~/input/current_operation_mode", rclcpp::QoS{1},
     [this](const OperationModeState::SharedPtr msg) { current_operation_mode_ptr_ = msg; });
-  control_cmd_pub_ = create_publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>(
+  control_cmd_pub_ = create_publisher<autoware_control_msgs::msg::Control>(
     "~/output/control_cmd", rclcpp::QoS{1}.transient_local());
   debug_marker_pub_ =
     create_publisher<visualization_msgs::msg::MarkerArray>("~/output/debug_marker", rclcpp::QoS{1});
@@ -213,7 +213,7 @@ void Controller::callbackTimerControl()
   if (isTimeOut(lon_out, lat_out)) return;
 
   // 5. publish control command
-  autoware_auto_control_msgs::msg::AckermannControlCommand out;
+  autoware_control_msgs::msg::Control out;
   out.stamp = this->now();
   out.lateral = lat_out.control_cmd;
   out.longitudinal = lon_out.control_cmd;

--- a/control/trajectory_follower_node/src/simple_trajectory_follower.cpp
+++ b/control/trajectory_follower_node/src/simple_trajectory_follower.cpp
@@ -29,7 +29,7 @@ using tier4_autoware_utils::calcYawDeviation;
 SimpleTrajectoryFollower::SimpleTrajectoryFollower(const rclcpp::NodeOptions & options)
 : Node("simple_trajectory_follower", options)
 {
-  pub_cmd_ = create_publisher<AckermannControlCommand>("output/control_cmd", 1);
+  pub_cmd_ = create_publisher<Control>("output/control_cmd", 1);
 
   sub_kinematics_ = create_subscription<Odometry>(
     "input/kinematics", 1, [this](const Odometry::SharedPtr msg) { odometry_ = msg; });
@@ -54,10 +54,10 @@ void SimpleTrajectoryFollower::onTimer()
 
   updateClosest();
 
-  AckermannControlCommand cmd;
+  Control cmd;
   cmd.stamp = cmd.lateral.stamp = cmd.longitudinal.stamp = get_clock()->now();
   cmd.lateral.steering_tire_angle = static_cast<float>(calcSteerCmd());
-  cmd.longitudinal.speed = use_external_target_vel_ ? static_cast<float>(external_target_vel_)
+  cmd.longitudinal.velocity = use_external_target_vel_ ? static_cast<float>(external_target_vel_)
                                                     : closest_traj_point_.longitudinal_velocity_mps;
   cmd.longitudinal.acceleration = static_cast<float>(calcAccCmd());
   pub_cmd_->publish(cmd);

--- a/control/trajectory_follower_node/src/simple_trajectory_follower.cpp
+++ b/control/trajectory_follower_node/src/simple_trajectory_follower.cpp
@@ -57,8 +57,9 @@ void SimpleTrajectoryFollower::onTimer()
   Control cmd;
   cmd.stamp = cmd.lateral.stamp = cmd.longitudinal.stamp = get_clock()->now();
   cmd.lateral.steering_tire_angle = static_cast<float>(calcSteerCmd());
-  cmd.longitudinal.velocity = use_external_target_vel_ ? static_cast<float>(external_target_vel_)
-                                                    : closest_traj_point_.longitudinal_velocity_mps;
+  cmd.longitudinal.velocity = use_external_target_vel_
+                                ? static_cast<float>(external_target_vel_)
+                                : closest_traj_point_.longitudinal_velocity_mps;
   cmd.longitudinal.acceleration = static_cast<float>(calcAccCmd());
   pub_cmd_->publish(cmd);
 }

--- a/control/trajectory_follower_node/test/test_controller_node.cpp
+++ b/control/trajectory_follower_node/test/test_controller_node.cpp
@@ -21,7 +21,7 @@
 #include "trajectory_follower_test_utils.hpp"
 
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
-#include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
@@ -35,7 +35,7 @@
 #include <vector>
 
 using Controller = autoware::motion::control::trajectory_follower_node::Controller;
-using AckermannControlCommand = autoware_auto_control_msgs::msg::AckermannControlCommand;
+using Control = autoware_control_msgs::msg::Control;
 using Trajectory = autoware_auto_planning_msgs::msg::Trajectory;
 using TrajectoryPoint = autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using VehicleOdometry = nav_msgs::msg::Odometry;
@@ -98,7 +98,7 @@ public:
   FakeNodeFixture * fnf;
   std::shared_ptr<Controller> node;
 
-  AckermannControlCommand::SharedPtr cmd_msg;
+  Control::SharedPtr cmd_msg;
   bool received_control_command = false;
 
   void publish_default_odom()
@@ -180,10 +180,10 @@ public:
   rclcpp::Publisher<OperationModeState>::SharedPtr operation_mode_pub =
     fnf->create_publisher<OperationModeState>("controller/input/current_operation_mode");
 
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr cmd_sub =
-    fnf->create_subscription<AckermannControlCommand>(
+  rclcpp::Subscription<Control>::SharedPtr cmd_sub =
+    fnf->create_subscription<Control>(
       "controller/output/control_cmd", *fnf->get_fake_node(),
-      [this](const AckermannControlCommand::SharedPtr msg) {
+      [this](const Control::SharedPtr msg) {
         cmd_msg = msg;
         received_control_command = true;
       });
@@ -369,14 +369,14 @@ TEST_F(FakeNodeFixture, longitudinal_keep_velocity)
   test_utils::waitForMessage(tester.node, this, tester.received_control_command);
 
   ASSERT_TRUE(tester.received_control_command);
-  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.speed, 1.0);
+  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.velocity, 1.0);
   EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.acceleration, 0.0);
 
   // Generate another control message
   tester.traj_pub->publish(traj_msg);
   test_utils::waitForMessage(tester.node, this, tester.received_control_command);
   ASSERT_TRUE(tester.received_control_command);
-  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.speed, 1.0);
+  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.velocity, 1.0);
   EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.acceleration, 0.0);
 }
 
@@ -406,14 +406,14 @@ TEST_F(FakeNodeFixture, longitudinal_slow_down)
   test_utils::waitForMessage(tester.node, this, tester.received_control_command);
 
   ASSERT_TRUE(tester.received_control_command);
-  EXPECT_LT(tester.cmd_msg->longitudinal.speed, static_cast<float>(odom_vx));
+  EXPECT_LT(tester.cmd_msg->longitudinal.velocity, static_cast<float>(odom_vx));
   EXPECT_LT(tester.cmd_msg->longitudinal.acceleration, 0.0f);
 
   // Generate another control message
   tester.traj_pub->publish(traj);
   test_utils::waitForMessage(tester.node, this, tester.received_control_command);
   ASSERT_TRUE(tester.received_control_command);
-  EXPECT_LT(tester.cmd_msg->longitudinal.speed, static_cast<float>(odom_vx));
+  EXPECT_LT(tester.cmd_msg->longitudinal.velocity, static_cast<float>(odom_vx));
   EXPECT_LT(tester.cmd_msg->longitudinal.acceleration, 0.0f);
 }
 
@@ -443,14 +443,14 @@ TEST_F(FakeNodeFixture, longitudinal_accelerate)
   test_utils::waitForMessage(tester.node, this, tester.received_control_command);
 
   ASSERT_TRUE(tester.received_control_command);
-  EXPECT_GT(tester.cmd_msg->longitudinal.speed, static_cast<float>(odom_vx));
+  EXPECT_GT(tester.cmd_msg->longitudinal.velocity, static_cast<float>(odom_vx));
   EXPECT_GT(tester.cmd_msg->longitudinal.acceleration, 0.0f);
 
   // Generate another control message
   tester.traj_pub->publish(traj);
   test_utils::waitForMessage(tester.node, this, tester.received_control_command);
   ASSERT_TRUE(tester.received_control_command);
-  EXPECT_GT(tester.cmd_msg->longitudinal.speed, static_cast<float>(odom_vx));
+  EXPECT_GT(tester.cmd_msg->longitudinal.velocity, static_cast<float>(odom_vx));
   EXPECT_GT(tester.cmd_msg->longitudinal.acceleration, 0.0f);
 }
 
@@ -477,7 +477,7 @@ TEST_F(FakeNodeFixture, longitudinal_stopped)
   test_utils::waitForMessage(tester.node, this, tester.received_control_command);
 
   ASSERT_TRUE(tester.received_control_command);
-  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.speed, 0.0f);
+  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.velocity, 0.0f);
   EXPECT_LT(
     tester.cmd_msg->longitudinal.acceleration,
     0.0f);  // when stopped negative acceleration to brake
@@ -507,7 +507,7 @@ TEST_F(FakeNodeFixture, longitudinal_reverse)
   test_utils::waitForMessage(tester.node, this, tester.received_control_command);
 
   ASSERT_TRUE(tester.received_control_command);
-  EXPECT_LT(tester.cmd_msg->longitudinal.speed, 0.0f);
+  EXPECT_LT(tester.cmd_msg->longitudinal.velocity, 0.0f);
   EXPECT_GT(tester.cmd_msg->longitudinal.acceleration, 0.0f);
 }
 
@@ -535,7 +535,7 @@ TEST_F(FakeNodeFixture, longitudinal_emergency)
 
   ASSERT_TRUE(tester.received_control_command);
   // Emergencies (e.g., far from trajectory) produces braking command (0 vel, negative accel)
-  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.speed, 0.0f);
+  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.velocity, 0.0f);
   EXPECT_LT(tester.cmd_msg->longitudinal.acceleration, 0.0f);
 }
 
@@ -566,7 +566,7 @@ TEST_F(FakeNodeFixture, longitudinal_not_check_steer_converged)
 
   ASSERT_TRUE(tester.received_control_command);
   // Not keep stopped state when the lateral control is not converged.
-  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.speed, 1.0f);
+  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.velocity, 1.0f);
 }
 
 TEST_F(FakeNodeFixture, longitudinal_check_steer_converged)
@@ -597,5 +597,5 @@ TEST_F(FakeNodeFixture, longitudinal_check_steer_converged)
 
   ASSERT_TRUE(tester.received_control_command);
   // Keep stopped state when the lateral control is not converged.
-  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.speed, 0.0f);
+  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.velocity, 0.0f);
 }

--- a/control/trajectory_follower_node/test/test_controller_node.cpp
+++ b/control/trajectory_follower_node/test/test_controller_node.cpp
@@ -21,10 +21,10 @@
 #include "trajectory_follower_test_utils.hpp"
 
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
-#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -180,13 +180,11 @@ public:
   rclcpp::Publisher<OperationModeState>::SharedPtr operation_mode_pub =
     fnf->create_publisher<OperationModeState>("controller/input/current_operation_mode");
 
-  rclcpp::Subscription<Control>::SharedPtr cmd_sub =
-    fnf->create_subscription<Control>(
-      "controller/output/control_cmd", *fnf->get_fake_node(),
-      [this](const Control::SharedPtr msg) {
-        cmd_msg = msg;
-        received_control_command = true;
-      });
+  rclcpp::Subscription<Control>::SharedPtr cmd_sub = fnf->create_subscription<Control>(
+    "controller/output/control_cmd", *fnf->get_fake_node(), [this](const Control::SharedPtr msg) {
+      cmd_msg = msg;
+      received_control_command = true;
+    });
 
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> br =
     std::make_shared<tf2_ros::StaticTransformBroadcaster>(fnf->get_fake_node());

--- a/control/trajectory_follower_node/test/test_lateral_controller_node.cpp
+++ b/control/trajectory_follower_node/test/test_lateral_controller_node.cpp
@@ -21,7 +21,7 @@
 
 #include <trajectory_follower_node/lateral_controller_node.hpp>
 
-#include "autoware_auto_control_msgs/msg/ackermann_lateral_command.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
@@ -34,7 +34,7 @@
 #include <vector>
 
 using LateralController = autoware::motion::control::trajectory_follower_node::LateralController;
-using LateralCommand = autoware_auto_control_msgs::msg::AckermannLateralCommand;
+using LateralCommand = autoware_control_msgs::msg::Lateral;
 using Trajectory = autoware_auto_planning_msgs::msg::Trajectory;
 using TrajectoryPoint = autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using VehicleOdometry = nav_msgs::msg::Odometry;

--- a/control/trajectory_follower_node/test/test_lateral_controller_node.cpp
+++ b/control/trajectory_follower_node/test/test_lateral_controller_node.cpp
@@ -21,10 +21,10 @@
 
 #include <trajectory_follower_node/lateral_controller_node.hpp>
 
-#include "autoware_control_msgs/msg/lateral.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
+#include "autoware_control_msgs/msg/lateral.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"

--- a/control/trajectory_follower_node/test/test_longitudinal_controller_node.cpp
+++ b/control/trajectory_follower_node/test/test_longitudinal_controller_node.cpp
@@ -21,9 +21,9 @@
 
 #include <trajectory_follower_node/longitudinal_controller_node.hpp>
 
-#include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
+#include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
@@ -76,13 +76,12 @@ TEST_F(FakeNodeFixture, longitudinal_keep_velocity)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
-    this->create_subscription<Longitudinal>(
-      "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
-        cmd_msg = msg;
-        received_longitudinal_command = true;
-      });
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub = this->create_subscription<Longitudinal>(
+    "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
+    [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
+      cmd_msg = msg;
+      received_longitudinal_command = true;
+    });
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> br =
     std::make_shared<tf2_ros::StaticTransformBroadcaster>(this->get_fake_node());
 
@@ -148,13 +147,12 @@ TEST_F(FakeNodeFixture, longitudinal_slow_down)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
-    this->create_subscription<Longitudinal>(
-      "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
-        cmd_msg = msg;
-        received_longitudinal_command = true;
-      });
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub = this->create_subscription<Longitudinal>(
+    "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
+    [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
+      cmd_msg = msg;
+      received_longitudinal_command = true;
+    });
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> br =
     std::make_shared<tf2_ros::StaticTransformBroadcaster>(this->get_fake_node());
 
@@ -220,13 +218,12 @@ TEST_F(FakeNodeFixture, longitudinal_accelerate)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
-    this->create_subscription<Longitudinal>(
-      "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
-        cmd_msg = msg;
-        received_longitudinal_command = true;
-      });
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub = this->create_subscription<Longitudinal>(
+    "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
+    [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
+      cmd_msg = msg;
+      received_longitudinal_command = true;
+    });
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> br =
     std::make_shared<tf2_ros::StaticTransformBroadcaster>(this->get_fake_node());
 
@@ -292,13 +289,12 @@ TEST_F(FakeNodeFixture, longitudinal_stopped)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
-    this->create_subscription<Longitudinal>(
-      "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
-        cmd_msg = msg;
-        received_longitudinal_command = true;
-      });
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub = this->create_subscription<Longitudinal>(
+    "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
+    [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
+      cmd_msg = msg;
+      received_longitudinal_command = true;
+    });
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> br =
     std::make_shared<tf2_ros::StaticTransformBroadcaster>(this->get_fake_node());
 
@@ -356,13 +352,12 @@ TEST_F(FakeNodeFixture, longitudinal_reverse)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
-    this->create_subscription<Longitudinal>(
-      "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
-        cmd_msg = msg;
-        received_longitudinal_command = true;
-      });
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub = this->create_subscription<Longitudinal>(
+    "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
+    [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
+      cmd_msg = msg;
+      received_longitudinal_command = true;
+    });
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> br =
     std::make_shared<tf2_ros::StaticTransformBroadcaster>(this->get_fake_node());
 
@@ -420,13 +415,12 @@ TEST_F(FakeNodeFixture, longitudinal_emergency)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
-    this->create_subscription<Longitudinal>(
-      "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
-        cmd_msg = msg;
-        received_longitudinal_command = true;
-      });
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub = this->create_subscription<Longitudinal>(
+    "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
+    [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
+      cmd_msg = msg;
+      received_longitudinal_command = true;
+    });
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> br =
     std::make_shared<tf2_ros::StaticTransformBroadcaster>(this->get_fake_node());
 

--- a/control/trajectory_follower_node/test/test_longitudinal_controller_node.cpp
+++ b/control/trajectory_follower_node/test/test_longitudinal_controller_node.cpp
@@ -21,7 +21,7 @@
 
 #include <trajectory_follower_node/longitudinal_controller_node.hpp>
 
-#include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"
+#include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/vehicle_odometry.hpp"
 #include "geometry_msgs/msg/pose.hpp"
@@ -33,7 +33,7 @@
 
 using LongitudinalController =
   autoware::motion::control::trajectory_follower_node::LongitudinalController;
-using LongitudinalCommand = autoware_auto_control_msgs::msg::LongitudinalCommand;
+using Longitudinal = autoware_control_msgs::msg::Longitudinal;
 using Trajectory = autoware_auto_planning_msgs::msg::Trajectory;
 using TrajectoryPoint = autoware_auto_planning_msgs::msg::TrajectoryPoint;
 using VehicleOdometry = nav_msgs::msg::Odometry;
@@ -65,7 +65,7 @@ std::shared_ptr<LongitudinalController> makeLongitudinalNode()
 TEST_F(FakeNodeFixture, longitudinal_keep_velocity)
 {
   // Data to test
-  LongitudinalCommand::SharedPtr cmd_msg;
+  Longitudinal::SharedPtr cmd_msg;
   bool received_longitudinal_command = false;
 
   // Node
@@ -76,10 +76,10 @@ TEST_F(FakeNodeFixture, longitudinal_keep_velocity)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<LongitudinalCommand>::SharedPtr cmd_sub =
-    this->create_subscription<LongitudinalCommand>(
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
+    this->create_subscription<Longitudinal>(
       "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const LongitudinalCommand::SharedPtr msg) {
+      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
         cmd_msg = msg;
         received_longitudinal_command = true;
       });
@@ -122,7 +122,7 @@ TEST_F(FakeNodeFixture, longitudinal_keep_velocity)
   test_utils::waitForMessage(node, this, received_longitudinal_command);
 
   ASSERT_TRUE(received_longitudinal_command);
-  EXPECT_DOUBLE_EQ(cmd_msg->speed, 1.0);
+  EXPECT_DOUBLE_EQ(cmd_msg->velocity, 1.0);
   EXPECT_DOUBLE_EQ(cmd_msg->acceleration, 0.0);
 
   // Generate another control message
@@ -130,14 +130,14 @@ TEST_F(FakeNodeFixture, longitudinal_keep_velocity)
   traj_pub->publish(traj);
   test_utils::waitForMessage(node, this, received_longitudinal_command);
   ASSERT_TRUE(received_longitudinal_command);
-  EXPECT_DOUBLE_EQ(cmd_msg->speed, 1.0);
+  EXPECT_DOUBLE_EQ(cmd_msg->velocity, 1.0);
   EXPECT_DOUBLE_EQ(cmd_msg->acceleration, 0.0);
 }
 
 TEST_F(FakeNodeFixture, longitudinal_slow_down)
 {
   // Data to test
-  LongitudinalCommand::SharedPtr cmd_msg;
+  Longitudinal::SharedPtr cmd_msg;
   bool received_longitudinal_command = false;
 
   // Node
@@ -148,10 +148,10 @@ TEST_F(FakeNodeFixture, longitudinal_slow_down)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<LongitudinalCommand>::SharedPtr cmd_sub =
-    this->create_subscription<LongitudinalCommand>(
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
+    this->create_subscription<Longitudinal>(
       "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const LongitudinalCommand::SharedPtr msg) {
+      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
         cmd_msg = msg;
         received_longitudinal_command = true;
       });
@@ -194,7 +194,7 @@ TEST_F(FakeNodeFixture, longitudinal_slow_down)
   test_utils::waitForMessage(node, this, received_longitudinal_command);
 
   ASSERT_TRUE(received_longitudinal_command);
-  EXPECT_LT(cmd_msg->speed, static_cast<float>(odom_msg.twist.twist.linear.x));
+  EXPECT_LT(cmd_msg->velocity, static_cast<float>(odom_msg.twist.twist.linear.x));
   EXPECT_LT(cmd_msg->acceleration, 0.0f);
 
   // Generate another control message
@@ -202,14 +202,14 @@ TEST_F(FakeNodeFixture, longitudinal_slow_down)
   traj_pub->publish(traj);
   test_utils::waitForMessage(node, this, received_longitudinal_command);
   ASSERT_TRUE(received_longitudinal_command);
-  EXPECT_LT(cmd_msg->speed, static_cast<float>(odom_msg.twist.twist.linear.x));
+  EXPECT_LT(cmd_msg->velocity, static_cast<float>(odom_msg.twist.twist.linear.x));
   EXPECT_LT(cmd_msg->acceleration, 0.0f);
 }
 
 TEST_F(FakeNodeFixture, longitudinal_accelerate)
 {
   // Data to test
-  LongitudinalCommand::SharedPtr cmd_msg;
+  Longitudinal::SharedPtr cmd_msg;
   bool received_longitudinal_command = false;
 
   // Node
@@ -220,10 +220,10 @@ TEST_F(FakeNodeFixture, longitudinal_accelerate)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<LongitudinalCommand>::SharedPtr cmd_sub =
-    this->create_subscription<LongitudinalCommand>(
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
+    this->create_subscription<Longitudinal>(
       "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const LongitudinalCommand::SharedPtr msg) {
+      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
         cmd_msg = msg;
         received_longitudinal_command = true;
       });
@@ -266,7 +266,7 @@ TEST_F(FakeNodeFixture, longitudinal_accelerate)
   test_utils::waitForMessage(node, this, received_longitudinal_command);
 
   ASSERT_TRUE(received_longitudinal_command);
-  EXPECT_GT(cmd_msg->speed, static_cast<float>(odom_msg.twist.twist.linear.x));
+  EXPECT_GT(cmd_msg->velocity, static_cast<float>(odom_msg.twist.twist.linear.x));
   EXPECT_GT(cmd_msg->acceleration, 0.0f);
 
   // Generate another control message
@@ -274,14 +274,14 @@ TEST_F(FakeNodeFixture, longitudinal_accelerate)
   traj_pub->publish(traj);
   test_utils::waitForMessage(node, this, received_longitudinal_command);
   ASSERT_TRUE(received_longitudinal_command);
-  EXPECT_GT(cmd_msg->speed, static_cast<float>(odom_msg.twist.twist.linear.x));
+  EXPECT_GT(cmd_msg->velocity, static_cast<float>(odom_msg.twist.twist.linear.x));
   EXPECT_GT(cmd_msg->acceleration, 0.0f);
 }
 
 TEST_F(FakeNodeFixture, longitudinal_stopped)
 {
   // Data to test
-  LongitudinalCommand::SharedPtr cmd_msg;
+  Longitudinal::SharedPtr cmd_msg;
   bool received_longitudinal_command = false;
 
   // Node
@@ -292,10 +292,10 @@ TEST_F(FakeNodeFixture, longitudinal_stopped)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<LongitudinalCommand>::SharedPtr cmd_sub =
-    this->create_subscription<LongitudinalCommand>(
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
+    this->create_subscription<Longitudinal>(
       "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const LongitudinalCommand::SharedPtr msg) {
+      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
         cmd_msg = msg;
         received_longitudinal_command = true;
       });
@@ -338,14 +338,14 @@ TEST_F(FakeNodeFixture, longitudinal_stopped)
   test_utils::waitForMessage(node, this, received_longitudinal_command);
 
   ASSERT_TRUE(received_longitudinal_command);
-  EXPECT_DOUBLE_EQ(cmd_msg->speed, 0.0f);
+  EXPECT_DOUBLE_EQ(cmd_msg->velocity, 0.0f);
   EXPECT_LT(cmd_msg->acceleration, 0.0f);  // when stopped negative acceleration to brake
 }
 
 TEST_F(FakeNodeFixture, longitudinal_reverse)
 {
   // Data to test
-  LongitudinalCommand::SharedPtr cmd_msg;
+  Longitudinal::SharedPtr cmd_msg;
   bool received_longitudinal_command = false;
 
   // Node
@@ -356,10 +356,10 @@ TEST_F(FakeNodeFixture, longitudinal_reverse)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<LongitudinalCommand>::SharedPtr cmd_sub =
-    this->create_subscription<LongitudinalCommand>(
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
+    this->create_subscription<Longitudinal>(
       "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const LongitudinalCommand::SharedPtr msg) {
+      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
         cmd_msg = msg;
         received_longitudinal_command = true;
       });
@@ -402,14 +402,14 @@ TEST_F(FakeNodeFixture, longitudinal_reverse)
   test_utils::waitForMessage(node, this, received_longitudinal_command);
 
   ASSERT_TRUE(received_longitudinal_command);
-  EXPECT_LT(cmd_msg->speed, 0.0f);
+  EXPECT_LT(cmd_msg->velocity, 0.0f);
   EXPECT_GT(cmd_msg->acceleration, 0.0f);
 }
 
 TEST_F(FakeNodeFixture, longitudinal_emergency)
 {
   // Data to test
-  LongitudinalCommand::SharedPtr cmd_msg;
+  Longitudinal::SharedPtr cmd_msg;
   bool received_longitudinal_command = false;
 
   // Node
@@ -420,10 +420,10 @@ TEST_F(FakeNodeFixture, longitudinal_emergency)
     this->create_publisher<VehicleOdometry>("longitudinal_controller/input/current_odometry");
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub =
     this->create_publisher<Trajectory>("longitudinal_controller/input/current_trajectory");
-  rclcpp::Subscription<LongitudinalCommand>::SharedPtr cmd_sub =
-    this->create_subscription<LongitudinalCommand>(
+  rclcpp::Subscription<Longitudinal>::SharedPtr cmd_sub =
+    this->create_subscription<Longitudinal>(
       "longitudinal_controller/output/control_cmd", *this->get_fake_node(),
-      [&cmd_msg, &received_longitudinal_command](const LongitudinalCommand::SharedPtr msg) {
+      [&cmd_msg, &received_longitudinal_command](const Longitudinal::SharedPtr msg) {
         cmd_msg = msg;
         received_longitudinal_command = true;
       });
@@ -467,6 +467,6 @@ TEST_F(FakeNodeFixture, longitudinal_emergency)
 
   ASSERT_TRUE(received_longitudinal_command);
   // Emergencies (e.g., far from trajectory) produces braking command (0 vel, negative accel)
-  EXPECT_DOUBLE_EQ(cmd_msg->speed, 0.0f);
+  EXPECT_DOUBLE_EQ(cmd_msg->velocity, 0.0f);
   EXPECT_LT(cmd_msg->acceleration, 0.0f);
 }

--- a/control/vehicle_cmd_gate/README.md
+++ b/control/vehicle_cmd_gate/README.md
@@ -8,38 +8,38 @@
 
 ### Input
 
-| Name                                        | Type                                                       | Description                                                          |
-| ------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------- |
-| `~/input/steering`                          | `autoware_auto_vehicle_msgs::msg::SteeringReport`          | steering status                                                      |
-| `~/input/auto/control_cmd`                  | `autoware_control_msgs::msg::Control` | command for lateral and longitudinal velocity from planning module   |
-| `~/input/auto/turn_indicators_cmd`          | `autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand`   | turn indicators command from planning module                         |
-| `~/input/auto/hazard_lights_cmd`            | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`     | hazard lights command from planning module                           |
-| `~/input/auto/gear_cmd`                     | `autoware_auto_vehicle_msgs::msg::GearCommand`             | gear command from planning module                                    |
-| `~/input/external/control_cmd`              | `autoware_control_msgs::msg::Control` | command for lateral and longitudinal velocity from external          |
-| `~/input/external/turn_indicators_cmd`      | `autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand`   | turn indicators command from external                                |
-| `~/input/external/hazard_lights_cmd`        | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`     | hazard lights command from external                                  |
-| `~/input/external/gear_cmd`                 | `autoware_auto_vehicle_msgs::msg::GearCommand`             | gear command from external                                           |
-| `~/input/external_emergency_stop_heartbeat` | `tier4_external_api_msgs::msg::Heartbeat`                  | heartbeat                                                            |
-| `~/input/gate_mode`                         | `tier4_control_msgs::msg::GateMode`                        | gate mode (AUTO or EXTERNAL)                                         |
-| `~/input/emergency/control_cmd`             | `autoware_control_msgs::msg::Control` | command for lateral and longitudinal velocity from emergency handler |
-| `~/input/emergency/hazard_lights_cmd`       | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`     | hazard lights command from emergency handler                         |
-| `~/input/emergency/gear_cmd`                | `autoware_auto_vehicle_msgs::msg::GearCommand`             | gear command from emergency handler                                  |
-| `~/input/engage`                            | `autoware_auto_vehicle_msgs::msg::Engage`                  | engage signal                                                        |
-| `~/input/operation_mode`                    | `autoware_adapi_v1_msgs::msg::OperationModeState`          | operation mode of Autoware                                           |
+| Name                                        | Type                                                     | Description                                                          |
+| ------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------- |
+| `~/input/steering`                          | `autoware_auto_vehicle_msgs::msg::SteeringReport`        | steering status                                                      |
+| `~/input/auto/control_cmd`                  | `autoware_control_msgs::msg::Control`                    | command for lateral and longitudinal velocity from planning module   |
+| `~/input/auto/turn_indicators_cmd`          | `autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand` | turn indicators command from planning module                         |
+| `~/input/auto/hazard_lights_cmd`            | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`   | hazard lights command from planning module                           |
+| `~/input/auto/gear_cmd`                     | `autoware_auto_vehicle_msgs::msg::GearCommand`           | gear command from planning module                                    |
+| `~/input/external/control_cmd`              | `autoware_control_msgs::msg::Control`                    | command for lateral and longitudinal velocity from external          |
+| `~/input/external/turn_indicators_cmd`      | `autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand` | turn indicators command from external                                |
+| `~/input/external/hazard_lights_cmd`        | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`   | hazard lights command from external                                  |
+| `~/input/external/gear_cmd`                 | `autoware_auto_vehicle_msgs::msg::GearCommand`           | gear command from external                                           |
+| `~/input/external_emergency_stop_heartbeat` | `tier4_external_api_msgs::msg::Heartbeat`                | heartbeat                                                            |
+| `~/input/gate_mode`                         | `tier4_control_msgs::msg::GateMode`                      | gate mode (AUTO or EXTERNAL)                                         |
+| `~/input/emergency/control_cmd`             | `autoware_control_msgs::msg::Control`                    | command for lateral and longitudinal velocity from emergency handler |
+| `~/input/emergency/hazard_lights_cmd`       | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`   | hazard lights command from emergency handler                         |
+| `~/input/emergency/gear_cmd`                | `autoware_auto_vehicle_msgs::msg::GearCommand`           | gear command from emergency handler                                  |
+| `~/input/engage`                            | `autoware_auto_vehicle_msgs::msg::Engage`                | engage signal                                                        |
+| `~/input/operation_mode`                    | `autoware_adapi_v1_msgs::msg::OperationModeState`        | operation mode of Autoware                                           |
 
 ### Output
 
-| Name                                   | Type                                                       | Description                                              |
-| -------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------- |
-| `~/output/vehicle_cmd_emergency`       | `autoware_auto_system_msgs::msg::EmergencyState`           | emergency state which was originally in vehicle command  |
-| `~/output/command/control_cmd`         | `autoware_control_msgs::msg::Control` | command for lateral and longitudinal velocity to vehicle |
-| `~/output/command/turn_indicators_cmd` | `autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand`   | turn indicators command to vehicle                       |
-| `~/output/command/hazard_lights_cmd`   | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`     | hazard lights command to vehicle                         |
-| `~/output/command/gear_cmd`            | `autoware_auto_vehicle_msgs::msg::GearCommand`             | gear command to vehicle                                  |
-| `~/output/gate_mode`                   | `tier4_control_msgs::msg::GateMode`                        | gate mode (AUTO or EXTERNAL)                             |
-| `~/output/engage`                      | `autoware_auto_vehicle_msgs::msg::Engage`                  | engage signal                                            |
-| `~/output/external_emergency`          | `tier4_external_api_msgs::msg::Emergency`                  | external emergency signal                                |
-| `~/output/operation_mode`              | `tier4_system_msgs::msg::OperationMode`                    | current operation mode of the vehicle_cmd_gate           |
+| Name                                   | Type                                                     | Description                                              |
+| -------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+| `~/output/vehicle_cmd_emergency`       | `autoware_auto_system_msgs::msg::EmergencyState`         | emergency state which was originally in vehicle command  |
+| `~/output/command/control_cmd`         | `autoware_control_msgs::msg::Control`                    | command for lateral and longitudinal velocity to vehicle |
+| `~/output/command/turn_indicators_cmd` | `autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand` | turn indicators command to vehicle                       |
+| `~/output/command/hazard_lights_cmd`   | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`   | hazard lights command to vehicle                         |
+| `~/output/command/gear_cmd`            | `autoware_auto_vehicle_msgs::msg::GearCommand`           | gear command to vehicle                                  |
+| `~/output/gate_mode`                   | `tier4_control_msgs::msg::GateMode`                      | gate mode (AUTO or EXTERNAL)                             |
+| `~/output/engage`                      | `autoware_auto_vehicle_msgs::msg::Engage`                | engage signal                                            |
+| `~/output/external_emergency`          | `tier4_external_api_msgs::msg::Emergency`                | external emergency signal                                |
+| `~/output/operation_mode`              | `tier4_system_msgs::msg::OperationMode`                  | current operation mode of the vehicle_cmd_gate           |
 
 ## Parameters
 

--- a/control/vehicle_cmd_gate/README.md
+++ b/control/vehicle_cmd_gate/README.md
@@ -11,17 +11,17 @@
 | Name                                        | Type                                                       | Description                                                          |
 | ------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------- |
 | `~/input/steering`                          | `autoware_auto_vehicle_msgs::msg::SteeringReport`          | steering status                                                      |
-| `~/input/auto/control_cmd`                  | `autoware_auto_control_msgs::msg::AckermannControlCommand` | command for lateral and longitudinal velocity from planning module   |
+| `~/input/auto/control_cmd`                  | `autoware_control_msgs::msg::Control` | command for lateral and longitudinal velocity from planning module   |
 | `~/input/auto/turn_indicators_cmd`          | `autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand`   | turn indicators command from planning module                         |
 | `~/input/auto/hazard_lights_cmd`            | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`     | hazard lights command from planning module                           |
 | `~/input/auto/gear_cmd`                     | `autoware_auto_vehicle_msgs::msg::GearCommand`             | gear command from planning module                                    |
-| `~/input/external/control_cmd`              | `autoware_auto_control_msgs::msg::AckermannControlCommand` | command for lateral and longitudinal velocity from external          |
+| `~/input/external/control_cmd`              | `autoware_control_msgs::msg::Control` | command for lateral and longitudinal velocity from external          |
 | `~/input/external/turn_indicators_cmd`      | `autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand`   | turn indicators command from external                                |
 | `~/input/external/hazard_lights_cmd`        | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`     | hazard lights command from external                                  |
 | `~/input/external/gear_cmd`                 | `autoware_auto_vehicle_msgs::msg::GearCommand`             | gear command from external                                           |
 | `~/input/external_emergency_stop_heartbeat` | `tier4_external_api_msgs::msg::Heartbeat`                  | heartbeat                                                            |
 | `~/input/gate_mode`                         | `tier4_control_msgs::msg::GateMode`                        | gate mode (AUTO or EXTERNAL)                                         |
-| `~/input/emergency/control_cmd`             | `autoware_auto_control_msgs::msg::AckermannControlCommand` | command for lateral and longitudinal velocity from emergency handler |
+| `~/input/emergency/control_cmd`             | `autoware_control_msgs::msg::Control` | command for lateral and longitudinal velocity from emergency handler |
 | `~/input/emergency/hazard_lights_cmd`       | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`     | hazard lights command from emergency handler                         |
 | `~/input/emergency/gear_cmd`                | `autoware_auto_vehicle_msgs::msg::GearCommand`             | gear command from emergency handler                                  |
 | `~/input/engage`                            | `autoware_auto_vehicle_msgs::msg::Engage`                  | engage signal                                                        |
@@ -32,7 +32,7 @@
 | Name                                   | Type                                                       | Description                                              |
 | -------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------- |
 | `~/output/vehicle_cmd_emergency`       | `autoware_auto_system_msgs::msg::EmergencyState`           | emergency state which was originally in vehicle command  |
-| `~/output/command/control_cmd`         | `autoware_auto_control_msgs::msg::AckermannControlCommand` | command for lateral and longitudinal velocity to vehicle |
+| `~/output/command/control_cmd`         | `autoware_control_msgs::msg::Control` | command for lateral and longitudinal velocity to vehicle |
 | `~/output/command/turn_indicators_cmd` | `autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand`   | turn indicators command to vehicle                       |
 | `~/output/command/hazard_lights_cmd`   | `autoware_auto_vehicle_msgs::msg::HazardLightsCommand`     | hazard lights command to vehicle                         |
 | `~/output/command/gear_cmd`            | `autoware_auto_vehicle_msgs::msg::GearCommand`             | gear command to vehicle                                  |

--- a/control/vehicle_cmd_gate/package.xml
+++ b/control/vehicle_cmd_gate/package.xml
@@ -14,9 +14,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>component_interface_specs</depend>
   <depend>component_interface_utils</depend>
   <depend>diagnostic_updater</depend>

--- a/control/vehicle_cmd_gate/package.xml
+++ b/control/vehicle_cmd_gate/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>component_interface_specs</depend>

--- a/control/vehicle_cmd_gate/script/delays_checker.py
+++ b/control/vehicle_cmd_gate/script/delays_checker.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from autoware_auto_control_msgs.msg import AckermannControlCommand
+from autoware_control_msgs.msg import Control
 from autoware_auto_vehicle_msgs.msg import Engage
 from geometry_msgs.msg import AccelWithCovarianceStamped
 from nav_msgs.msg import Odometry
@@ -68,13 +68,13 @@ class DelaysChecker(Node):
         )
         self.sub_engage = self.create_subscription(Engage, engage_topic, self.CallBackEngage, 1)
         self.sub_in_gate_cmd = self.create_subscription(
-            AckermannControlCommand,
+            Control,
             in_gate_cmd_topic,
             self.CallBackInCmd,
             1,
         )
         self.sub_out_gate_cmd = self.create_subscription(
-            AckermannControlCommand,
+            Control,
             out_gate_cmd_topic,
             self.CallBackOutCmd,
             1,

--- a/control/vehicle_cmd_gate/script/delays_checker.py
+++ b/control/vehicle_cmd_gate/script/delays_checker.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from autoware_control_msgs.msg import Control
 from autoware_auto_vehicle_msgs.msg import Engage
+from autoware_control_msgs.msg import Control
 from geometry_msgs.msg import AccelWithCovarianceStamped
 from nav_msgs.msg import Odometry
 import rclpy

--- a/control/vehicle_cmd_gate/src/adapi_pause_interface.cpp
+++ b/control/vehicle_cmd_gate/src/adapi_pause_interface.cpp
@@ -53,9 +53,9 @@ void AdapiPauseInterface::publish()
   }
 }
 
-void AdapiPauseInterface::update(const AckermannControlCommand & control)
+void AdapiPauseInterface::update(const Control & control)
 {
-  is_start_requested_ = eps < std::abs(control.longitudinal.speed);
+  is_start_requested_ = eps < std::abs(control.longitudinal.velocity);
 }
 
 void AdapiPauseInterface::on_pause(

--- a/control/vehicle_cmd_gate/src/adapi_pause_interface.hpp
+++ b/control/vehicle_cmd_gate/src/adapi_pause_interface.hpp
@@ -19,7 +19,7 @@
 #include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 
 namespace vehicle_cmd_gate
 {
@@ -28,7 +28,7 @@ class AdapiPauseInterface
 {
 private:
   static constexpr double eps = 1e-3;
-  using AckermannControlCommand = autoware_auto_control_msgs::msg::AckermannControlCommand;
+  using Control = autoware_control_msgs::msg::Control;
   using SetPause = control_interface::SetPause;
   using IsPaused = control_interface::IsPaused;
   using IsStartRequested = control_interface::IsStartRequested;
@@ -37,7 +37,7 @@ public:
   explicit AdapiPauseInterface(rclcpp::Node * node);
   bool is_paused();
   void publish();
-  void update(const AckermannControlCommand & control);
+  void update(const Control & control);
 
 private:
   bool is_paused_;

--- a/control/vehicle_cmd_gate/src/moderate_stop_interface.hpp
+++ b/control/vehicle_cmd_gate/src/moderate_stop_interface.hpp
@@ -19,7 +19,7 @@
 #include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 
 #include <string>
 #include <unordered_map>

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_filter.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_filter.cpp
@@ -30,14 +30,13 @@ void VehicleCmdFilter::limitLongitudinalWithVel(Control & input) const
     std::min(static_cast<double>(input.longitudinal.velocity), param_.vel_lim), -param_.vel_lim);
 }
 
-void VehicleCmdFilter::limitLongitudinalWithAcc(
-  const double dt, Control & input) const
+void VehicleCmdFilter::limitLongitudinalWithAcc(const double dt, Control & input) const
 {
   input.longitudinal.acceleration = std::max(
     std::min(static_cast<double>(input.longitudinal.acceleration), param_.lon_acc_lim),
     -param_.lon_acc_lim);
-  input.longitudinal.velocity =
-    limitDiff(input.longitudinal.velocity, prev_cmd_.longitudinal.velocity, param_.lon_acc_lim * dt);
+  input.longitudinal.velocity = limitDiff(
+    input.longitudinal.velocity, prev_cmd_.longitudinal.velocity, param_.lon_acc_lim * dt);
 }
 
 void VehicleCmdFilter::VehicleCmdFilter::limitLongitudinalWithJerk(
@@ -52,15 +51,14 @@ void VehicleCmdFilter::limitLateralWithLatAcc(
 {
   double latacc = calcLatAcc(input);
   if (std::fabs(latacc) > param_.lat_acc_lim) {
-    double v_sq =
-      std::max(static_cast<double>(input.longitudinal.velocity * input.longitudinal.velocity), 0.001);
+    double v_sq = std::max(
+      static_cast<double>(input.longitudinal.velocity * input.longitudinal.velocity), 0.001);
     double steer_lim = std::atan(param_.lat_acc_lim * param_.wheel_base / v_sq);
     input.lateral.steering_tire_angle = latacc > 0.0 ? steer_lim : -steer_lim;
   }
 }
 
-void VehicleCmdFilter::limitLateralWithLatJerk(
-  const double dt, Control & input) const
+void VehicleCmdFilter::limitLateralWithLatJerk(const double dt, Control & input) const
 {
   double curr_latacc = calcLatAcc(input);
   double prev_latacc = calcLatAcc(prev_cmd_);
@@ -69,14 +67,15 @@ void VehicleCmdFilter::limitLateralWithLatJerk(
   const double latacc_min = prev_latacc - param_.lat_jerk_lim * dt;
 
   if (curr_latacc > latacc_max) {
-    input.lateral.steering_tire_angle = calcSteerFromLatacc(input.longitudinal.velocity, latacc_max);
+    input.lateral.steering_tire_angle =
+      calcSteerFromLatacc(input.longitudinal.velocity, latacc_max);
   } else if (curr_latacc < latacc_min) {
-    input.lateral.steering_tire_angle = calcSteerFromLatacc(input.longitudinal.velocity, latacc_min);
+    input.lateral.steering_tire_angle =
+      calcSteerFromLatacc(input.longitudinal.velocity, latacc_min);
   }
 }
 
-void VehicleCmdFilter::limitActualSteerDiff(
-  const double current_steer_angle, Control & input) const
+void VehicleCmdFilter::limitActualSteerDiff(const double current_steer_angle, Control & input) const
 {
   auto ds = input.lateral.steering_tire_angle - current_steer_angle;
   ds = std::clamp(ds, -param_.actual_steer_diff_lim, param_.actual_steer_diff_lim);

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
@@ -17,11 +17,11 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 
 namespace vehicle_cmd_gate
 {
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 
 struct VehicleCmdFilterParam
 {
@@ -47,23 +47,23 @@ public:
   void setLatJerkLim(double v) { param_.lat_jerk_lim = v; }
   void setActualSteerDiffLim(double v) { param_.actual_steer_diff_lim = v; }
   void setParam(const VehicleCmdFilterParam & p) { param_ = p; }
-  void setPrevCmd(const AckermannControlCommand & v) { prev_cmd_ = v; }
+  void setPrevCmd(const Control & v) { prev_cmd_ = v; }
 
-  void limitLongitudinalWithVel(AckermannControlCommand & input) const;
-  void limitLongitudinalWithAcc(const double dt, AckermannControlCommand & input) const;
-  void limitLongitudinalWithJerk(const double dt, AckermannControlCommand & input) const;
-  void limitLateralWithLatAcc(const double dt, AckermannControlCommand & input) const;
-  void limitLateralWithLatJerk(const double dt, AckermannControlCommand & input) const;
+  void limitLongitudinalWithVel(Control & input) const;
+  void limitLongitudinalWithAcc(const double dt, Control & input) const;
+  void limitLongitudinalWithJerk(const double dt, Control & input) const;
+  void limitLateralWithLatAcc(const double dt, Control & input) const;
+  void limitLateralWithLatJerk(const double dt, Control & input) const;
   void limitActualSteerDiff(
-    const double current_steer_angle, AckermannControlCommand & input) const;
+    const double current_steer_angle, Control & input) const;
   void filterAll(
-    const double dt, const double current_steer_angle, AckermannControlCommand & input) const;
+    const double dt, const double current_steer_angle, Control & input) const;
 
 private:
   VehicleCmdFilterParam param_;
-  AckermannControlCommand prev_cmd_;
+  Control prev_cmd_;
 
-  double calcLatAcc(const AckermannControlCommand & cmd) const;
+  double calcLatAcc(const Control & cmd) const;
   double calcSteerFromLatacc(const double v, const double latacc) const;
   double limitDiff(const double curr, const double prev, const double diff_lim) const;
 };

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
@@ -54,10 +54,8 @@ public:
   void limitLongitudinalWithJerk(const double dt, Control & input) const;
   void limitLateralWithLatAcc(const double dt, Control & input) const;
   void limitLateralWithLatJerk(const double dt, Control & input) const;
-  void limitActualSteerDiff(
-    const double current_steer_angle, Control & input) const;
-  void filterAll(
-    const double dt, const double current_steer_angle, Control & input) const;
+  void limitActualSteerDiff(const double current_steer_angle, Control & input) const;
+  void filterAll(const double dt, const double current_steer_angle, Control & input) const;
 
 private:
   VehicleCmdFilterParam param_;

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
@@ -26,12 +26,12 @@
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <std_srvs/srv/trigger.hpp>
@@ -51,11 +51,11 @@ namespace vehicle_cmd_gate
 
 using autoware_adapi_v1_msgs::msg::MrmState;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
-using autoware_control_msgs::msg::Control;
 using autoware_auto_vehicle_msgs::msg::GearCommand;
 using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
 using autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand;
+using autoware_control_msgs::msg::Control;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using std_srvs::srv::Trigger;
 using tier4_control_msgs::msg::GateMode;

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
@@ -26,7 +26,7 @@
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
@@ -51,7 +51,7 @@ namespace vehicle_cmd_gate
 
 using autoware_adapi_v1_msgs::msg::MrmState;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using autoware_auto_vehicle_msgs::msg::GearCommand;
 using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
@@ -74,7 +74,7 @@ using EngageSrv = tier4_external_api_msgs::srv::Engage;
 using motion_utils::VehicleStopChecker;
 struct Commands
 {
-  AckermannControlCommand control;
+  Control control;
   TurnIndicatorsCommand turn_indicator;
   HazardLightsCommand hazard_light;
   GearCommand gear;
@@ -92,7 +92,7 @@ public:
 private:
   // Publisher
   rclcpp::Publisher<VehicleEmergencyStamped>::SharedPtr vehicle_cmd_emergency_pub_;
-  rclcpp::Publisher<AckermannControlCommand>::SharedPtr control_cmd_pub_;
+  rclcpp::Publisher<Control>::SharedPtr control_cmd_pub_;
   rclcpp::Publisher<GearCommand>::SharedPtr gear_cmd_pub_;
   rclcpp::Publisher<TurnIndicatorsCommand>::SharedPtr turn_indicator_cmd_pub_;
   rclcpp::Publisher<HazardLightsCommand>::SharedPtr hazard_light_cmd_pub_;
@@ -135,26 +135,26 @@ private:
 
   // Subscriber for auto
   Commands auto_commands_;
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr auto_control_cmd_sub_;
+  rclcpp::Subscription<Control>::SharedPtr auto_control_cmd_sub_;
   rclcpp::Subscription<TurnIndicatorsCommand>::SharedPtr auto_turn_indicator_cmd_sub_;
   rclcpp::Subscription<HazardLightsCommand>::SharedPtr auto_hazard_light_cmd_sub_;
   rclcpp::Subscription<GearCommand>::SharedPtr auto_gear_cmd_sub_;
-  void onAutoCtrlCmd(AckermannControlCommand::ConstSharedPtr msg);
+  void onAutoCtrlCmd(Control::ConstSharedPtr msg);
 
   // Subscription for external
   Commands remote_commands_;
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr remote_control_cmd_sub_;
+  rclcpp::Subscription<Control>::SharedPtr remote_control_cmd_sub_;
   rclcpp::Subscription<TurnIndicatorsCommand>::SharedPtr remote_turn_indicator_cmd_sub_;
   rclcpp::Subscription<HazardLightsCommand>::SharedPtr remote_hazard_light_cmd_sub_;
   rclcpp::Subscription<GearCommand>::SharedPtr remote_gear_cmd_sub_;
-  void onRemoteCtrlCmd(AckermannControlCommand::ConstSharedPtr msg);
+  void onRemoteCtrlCmd(Control::ConstSharedPtr msg);
 
   // Subscription for emergency
   Commands emergency_commands_;
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr emergency_control_cmd_sub_;
+  rclcpp::Subscription<Control>::SharedPtr emergency_control_cmd_sub_;
   rclcpp::Subscription<HazardLightsCommand>::SharedPtr emergency_hazard_light_cmd_sub_;
   rclcpp::Subscription<GearCommand>::SharedPtr emergency_gear_cmd_sub_;
-  void onEmergencyCtrlCmd(AckermannControlCommand::ConstSharedPtr msg);
+  void onEmergencyCtrlCmd(Control::ConstSharedPtr msg);
 
   // Parameter
   bool use_emergency_handling_;
@@ -203,16 +203,16 @@ private:
   void checkExternalEmergencyStop(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
   // Algorithm
-  AckermannControlCommand prev_control_cmd_;
-  AckermannControlCommand createStopControlCmd() const;
-  AckermannControlCommand createEmergencyStopControlCmd() const;
+  Control prev_control_cmd_;
+  Control createStopControlCmd() const;
+  Control createEmergencyStopControlCmd() const;
 
   std::shared_ptr<rclcpp::Time> prev_time_;
   double getDt();
-  AckermannControlCommand getActualStatusAsCommand();
+  Control getActualStatusAsCommand();
 
   VehicleCmdFilter filter_;
-  AckermannControlCommand filterControlCommand(const AckermannControlCommand & msg);
+  Control filterControlCommand(const Control & msg);
 
   // filtering on transition
   OperationModeState current_operation_mode_;

--- a/planning/planning_debug_tools/scripts/closest_velocity_checker.py
+++ b/planning/planning_debug_tools/scripts/closest_velocity_checker.py
@@ -16,12 +16,12 @@
 
 import time
 
-from autoware_control_msgs.msg import Control
 from autoware_auto_planning_msgs.msg import Path
 from autoware_auto_planning_msgs.msg import PathWithLaneId
 from autoware_auto_planning_msgs.msg import Trajectory
 from autoware_auto_vehicle_msgs.msg import Engage
 from autoware_auto_vehicle_msgs.msg import VelocityReport
+from autoware_control_msgs.msg import Control
 from geometry_msgs.msg import Pose
 from nav_msgs.msg import Odometry
 import numpy as np

--- a/planning/planning_debug_tools/scripts/closest_velocity_checker.py
+++ b/planning/planning_debug_tools/scripts/closest_velocity_checker.py
@@ -16,7 +16,7 @@
 
 import time
 
-from autoware_auto_control_msgs.msg import AckermannControlCommand
+from autoware_control_msgs.msg import Control
 from autoware_auto_planning_msgs.msg import Path
 from autoware_auto_planning_msgs.msg import PathWithLaneId
 from autoware_auto_planning_msgs.msg import Trajectory
@@ -104,13 +104,13 @@ class VelocityChecker(Node):
 
         # control commands
         self.sub6 = self.create_subscription(
-            AckermannControlCommand,
+            Control,
             "/control/trajectory_follower/control_cmd",
             self.CallBackControlCmd,
             1,
         )
         self.sub7 = self.create_subscription(
-            AckermannControlCommand, "/control/command/control_cmd", self.CallBackVehicleCmd, 1
+            Control, "/control/command/control_cmd", self.CallBackVehicleCmd, 1
         )
 
         # others related to velocity
@@ -274,13 +274,13 @@ class VelocityChecker(Node):
 
     def CallBackControlCmd(self, msg):
         # self.get_logger().info('CONTROL_CMD called')
-        self.data_arr[CONTROL_CMD] = msg.longitudinal.speed
+        self.data_arr[CONTROL_CMD] = msg.longitudinal.velocity
         self.data_arr[CONTROL_CMD_ACC] = msg.longitudinal.acceleration
         return
 
     def CallBackVehicleCmd(self, msg):
         # self.get_logger().info('VEHICLE_CMD called')
-        self.data_arr[VEHICLE_CMD] = msg.longitudinal.speed
+        self.data_arr[VEHICLE_CMD] = msg.longitudinal.velocity
         self.data_arr[VEHICLE_CMD_ACC] = msg.longitudinal.acceleration
         return
 

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
@@ -35,7 +35,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_perception_msgs/msg/traffic_signal_array.hpp>

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
@@ -35,7 +35,6 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_perception_msgs/msg/traffic_signal_array.hpp>
@@ -43,6 +42,7 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/point.hpp>

--- a/planning/planning_test_utils/package.xml
+++ b/planning/planning_test_utils/package.xml
@@ -13,11 +13,11 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>component_interface_specs</depend>
   <depend>component_interface_utils</depend>

--- a/planning/planning_test_utils/package.xml
+++ b/planning/planning_test_utils/package.xml
@@ -13,7 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/simulator/simple_planning_simulator/design/simple_planning_simulator-design.md
+++ b/simulator/simple_planning_simulator/design/simple_planning_simulator-design.md
@@ -18,8 +18,8 @@ The purpose of this simulator is for the integration test of planning and contro
 ### input
 
 - input/initialpose [`geometry_msgs/msg/PoseWithCovarianceStamped`] : for initial pose
-- input/ackermann_control_command [`autoware_auto_msgs/msg/AckermannControlCommand`] : target command to drive a vehicle
-- input/manual_ackermann_control_command [`autoware_auto_msgs/msg/AckermannControlCommand`] : manual target command to drive a vehicle (used when control_mode_request = Manual)
+- input/ackermann_control_command [`autoware_control_msgs/msg/Control`] : target command to drive a vehicle
+- input/manual_ackermann_control_command [`autoware_control_msgs/msg/Control`] : manual target command to drive a vehicle (used when control_mode_request = Manual)
 - input/gear_command [`autoware_auto_vehicle_msgs/msg/GearCommand`] : target gear command.
 - input/manual_gear_command [`autoware_auto_vehicle_msgs/msg/GearCommand`] : target gear command (used when control_mode_request = Manual)
 - input/turn_indicators_command [`autoware_auto_vehicle_msgs/msg/TurnIndicatorsCommand`] : target turn indicator command

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -20,7 +20,7 @@
 #include "simple_planning_simulator/visibility_control.hpp"
 #include "tier4_api_utils/tier4_api_utils.hpp"
 
-#include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
+#include "autoware_control_msgs/msg/control.hpp"
 #include "autoware_auto_geometry_msgs/msg/complex32.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/control_mode_command.hpp"
@@ -60,7 +60,7 @@ namespace simulation
 namespace simple_planning_simulator
 {
 
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using autoware_auto_geometry_msgs::msg::Complex32;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::ControlModeReport;
@@ -141,8 +141,8 @@ private:
   rclcpp::Subscription<TurnIndicatorsCommand>::SharedPtr sub_turn_indicators_cmd_;
   rclcpp::Subscription<HazardLightsCommand>::SharedPtr sub_hazard_lights_cmd_;
   rclcpp::Subscription<VehicleControlCommand>::SharedPtr sub_vehicle_cmd_;
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_ackermann_cmd_;
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_manual_ackermann_cmd_;
+  rclcpp::Subscription<Control>::SharedPtr sub_ackermann_cmd_;
+  rclcpp::Subscription<Control>::SharedPtr sub_manual_ackermann_cmd_;
   rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_init_pose_;
   rclcpp::Subscription<TwistStamped>::SharedPtr sub_init_twist_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
@@ -170,8 +170,8 @@ private:
   VelocityReport current_velocity_;
   Odometry current_odometry_;
   SteeringReport current_steer_;
-  AckermannControlCommand current_ackermann_cmd_;
-  AckermannControlCommand current_manual_ackermann_cmd_;
+  Control current_ackermann_cmd_;
+  Control current_manual_ackermann_cmd_;
   GearCommand current_gear_cmd_;
   GearCommand current_manual_gear_cmd_;
   TurnIndicatorsCommand::ConstSharedPtr current_turn_indicators_cmd_ptr_;
@@ -214,7 +214,7 @@ private:
   /**
    * @brief set input steering, velocity, and acceleration of the vehicle model
    */
-  void set_input(const AckermannControlCommand & cmd);
+  void set_input(const Control & cmd);
 
   /**
    * @brief set current_vehicle_state_ with received message

--- a/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/simple_planning_simulator/include/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -20,7 +20,6 @@
 #include "simple_planning_simulator/visibility_control.hpp"
 #include "tier4_api_utils/tier4_api_utils.hpp"
 
-#include "autoware_control_msgs/msg/control.hpp"
 #include "autoware_auto_geometry_msgs/msg/complex32.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_vehicle_msgs/msg/control_mode_command.hpp"
@@ -36,6 +35,7 @@
 #include "autoware_auto_vehicle_msgs/msg/vehicle_control_command.hpp"
 #include "autoware_auto_vehicle_msgs/msg/velocity_report.hpp"
 #include "autoware_auto_vehicle_msgs/srv/control_mode_command.hpp"
+#include "autoware_control_msgs/msg/control.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -60,7 +60,6 @@ namespace simulation
 namespace simple_planning_simulator
 {
 
-using autoware_control_msgs::msg::Control;
 using autoware_auto_geometry_msgs::msg::Complex32;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::ControlModeReport;
@@ -75,6 +74,7 @@ using autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport;
 using autoware_auto_vehicle_msgs::msg::VehicleControlCommand;
 using autoware_auto_vehicle_msgs::msg::VelocityReport;
 using autoware_auto_vehicle_msgs::srv::ControlModeCommand;
+using autoware_control_msgs::msg::Control;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -11,10 +11,10 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_tf2</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_tf2</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -89,12 +89,12 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
     "input/initialpose", QoS{1}, std::bind(&SimplePlanningSimulator::on_initialpose, this, _1));
   sub_init_twist_ = create_subscription<TwistStamped>(
     "input/initialtwist", QoS{1}, std::bind(&SimplePlanningSimulator::on_initialtwist, this, _1));
-  sub_ackermann_cmd_ = create_subscription<AckermannControlCommand>(
+  sub_ackermann_cmd_ = create_subscription<Control>(
     "input/ackermann_control_command", QoS{1},
-    [this](const AckermannControlCommand::SharedPtr msg) { current_ackermann_cmd_ = *msg; });
-  sub_manual_ackermann_cmd_ = create_subscription<AckermannControlCommand>(
+    [this](const Control::SharedPtr msg) { current_ackermann_cmd_ = *msg; });
+  sub_manual_ackermann_cmd_ = create_subscription<Control>(
     "input/manual_ackermann_control_command", QoS{1},
-    [this](const AckermannControlCommand::SharedPtr msg) { current_manual_ackermann_cmd_ = *msg; });
+    [this](const Control::SharedPtr msg) { current_manual_ackermann_cmd_ = *msg; });
   sub_gear_cmd_ = create_subscription<GearCommand>(
     "input/gear_command", QoS{1},
     [this](const GearCommand::SharedPtr msg) { current_gear_cmd_ = *msg; });
@@ -344,10 +344,10 @@ void SimplePlanningSimulator::on_set_pose(
   response->status = tier4_api_utils::response_success();
 }
 
-void SimplePlanningSimulator::set_input(const AckermannControlCommand & cmd)
+void SimplePlanningSimulator::set_input(const Control & cmd)
 {
   const auto steer = cmd.lateral.steering_tire_angle;
-  const auto vel = cmd.longitudinal.speed;
+  const auto vel = cmd.longitudinal.velocity;
   const auto accel = cmd.longitudinal.acceleration;
 
   using autoware_auto_vehicle_msgs::msg::GearCommand;

--- a/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -24,8 +24,8 @@
 
 #include <memory>
 
-using autoware_control_msgs::msg::Control;
 using autoware_auto_vehicle_msgs::msg::GearCommand;
+using autoware_control_msgs::msg::Control;
 using geometry_msgs::msg::PoseWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 
@@ -125,8 +125,7 @@ void sendGear(
  * @param [in] pub_sub_node pointer to the node used for communication
  */
 void sendCommand(
-  const Control & cmd, rclcpp::Node::SharedPtr sim_node,
-  std::shared_ptr<PubSubNode> pub_sub_node)
+  const Control & cmd, rclcpp::Node::SharedPtr sim_node, std::shared_ptr<PubSubNode> pub_sub_node)
 {
   for (int i = 0; i < 150; ++i) {
     pub_sub_node->pub_ackermann_command_->publish(cmd);

--- a/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -24,7 +24,7 @@
 
 #include <memory>
 
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using autoware_auto_vehicle_msgs::msg::GearCommand;
 using geometry_msgs::msg::PoseWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
@@ -51,14 +51,14 @@ public:
       "output/odometry", rclcpp::QoS{1},
       [this](const Odometry::SharedPtr msg) { current_odom_ = msg; });
     pub_ackermann_command_ =
-      create_publisher<AckermannControlCommand>("input/ackermann_control_command", rclcpp::QoS{1});
+      create_publisher<Control>("input/ackermann_control_command", rclcpp::QoS{1});
     pub_initialpose_ =
       create_publisher<PoseWithCovarianceStamped>("input/initialpose", rclcpp::QoS{1});
     pub_gear_cmd_ = create_publisher<GearCommand>("input/gear_command", rclcpp::QoS{1});
   }
 
   rclcpp::Subscription<Odometry>::SharedPtr current_odom_sub_;
-  rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_ackermann_command_;
+  rclcpp::Publisher<Control>::SharedPtr pub_ackermann_command_;
   rclcpp::Publisher<GearCommand>::SharedPtr pub_gear_cmd_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_initialpose_;
 
@@ -66,7 +66,7 @@ public:
 };
 
 /**
- * @brief Generate an AckermannControlCommand message
+ * @brief Generate an Control message
  * @param [in] t timestamp
  * @param [in] steer [rad] steering
  * @param [in] steer_rate [rad/s] steering rotation rate
@@ -74,17 +74,17 @@ public:
  * @param [in] acc [m/s²] acceleration
  * @param [in] jerk [m/s3] jerk
  */
-AckermannControlCommand cmdGen(
+Control cmdGen(
   const builtin_interfaces::msg::Time & t, double steer, double steer_rate, double vel, double acc,
   double jerk)
 {
-  AckermannControlCommand cmd;
+  Control cmd;
   cmd.stamp = t;
   cmd.lateral.stamp = t;
   cmd.lateral.steering_tire_angle = steer;
   cmd.lateral.steering_tire_rotation_rate = steer_rate;
   cmd.longitudinal.stamp = t;
-  cmd.longitudinal.speed = vel;
+  cmd.longitudinal.velocity = vel;
   cmd.longitudinal.acceleration = acc;
   cmd.longitudinal.jerk = jerk;
   return cmd;
@@ -125,7 +125,7 @@ void sendGear(
  * @param [in] pub_sub_node pointer to the node used for communication
  */
 void sendCommand(
-  const AckermannControlCommand & cmd, rclcpp::Node::SharedPtr sim_node,
+  const Control & cmd, rclcpp::Node::SharedPtr sim_node,
   std::shared_ptr<PubSubNode> pub_sub_node)
 {
   for (int i = 0; i < 150; ++i) {

--- a/system/component_state_monitor/config/topics.yaml
+++ b/system/component_state_monitor/config/topics.yaml
@@ -108,7 +108,7 @@
   args:
     node_name_suffix: trajectory_follower_control_cmd
     topic: /control/trajectory_follower/control_cmd
-    topic_type: autoware_auto_control_msgs/msg/AckermannControlCommand
+    topic_type: autoware_control_msgs/msg/Control
     best_effort: false
     transient_local: false
     warn_rate: 5.0
@@ -121,7 +121,7 @@
   args:
     node_name_suffix: control_command_control_cmd
     topic: /control/command/control_cmd
-    topic_type: autoware_auto_control_msgs/msg/AckermannControlCommand
+    topic_type: autoware_control_msgs/msg/Control
     best_effort: false
     transient_local: false
     warn_rate: 5.0
@@ -160,7 +160,7 @@
   args:
     node_name_suffix: system_emergency_control_cmd
     topic: /system/emergency/control_cmd
-    topic_type: autoware_auto_control_msgs/msg/AckermannControlCommand
+    topic_type: autoware_control_msgs/msg/Control
     best_effort: false
     transient_local: false
     warn_rate: 5.0

--- a/system/emergency_handler/README.md
+++ b/system/emergency_handler/README.md
@@ -17,7 +17,7 @@ Emergency Handler is a node to select proper MRM from from system failure state 
 | Name                                      | Type                                                       | Description                                                                   |
 | ----------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `/system/emergency/hazard_status`         | `autoware_auto_system_msgs::msg::HazardStatusStamped`      | Used to select proper MRM from system failure state contained in HazardStatus |
-| `/control/vehicle_cmd`                    | `autoware_auto_control_msgs::msg::AckermannControlCommand` | Used as reference when generate Emergency Control Command                     |
+| `/control/vehicle_cmd`                    | `autoware_control_msgs::msg::Control` | Used as reference when generate Emergency Control Command                     |
 | `/localization/kinematic_state`           | `nav_msgs::msg::Odometry`                                  | Used to decide whether vehicle is stopped or not                              |
 | `/vehicle/status/control_mode`            | `autoware_auto_vehicle_msgs::msg::ControlModeReport`       | Used to check vehicle mode: autonomous or manual                              |
 | `/system/api/mrm/comfortable_stop/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`                | Used to check if MRM comfortable stop operation is available                  |

--- a/system/emergency_handler/README.md
+++ b/system/emergency_handler/README.md
@@ -14,14 +14,14 @@ Emergency Handler is a node to select proper MRM from from system failure state 
 
 ### Input
 
-| Name                                      | Type                                                       | Description                                                                   |
-| ----------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `/system/emergency/hazard_status`         | `autoware_auto_system_msgs::msg::HazardStatusStamped`      | Used to select proper MRM from system failure state contained in HazardStatus |
-| `/control/vehicle_cmd`                    | `autoware_control_msgs::msg::Control` | Used as reference when generate Emergency Control Command                     |
-| `/localization/kinematic_state`           | `nav_msgs::msg::Odometry`                                  | Used to decide whether vehicle is stopped or not                              |
-| `/vehicle/status/control_mode`            | `autoware_auto_vehicle_msgs::msg::ControlModeReport`       | Used to check vehicle mode: autonomous or manual                              |
-| `/system/api/mrm/comfortable_stop/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`                | Used to check if MRM comfortable stop operation is available                  |
-| `/system/api/mrm/emergency_stop/status`   | `tier4_system_msgs::msg::MrmBehaviorStatus`                | Used to check if MRM emergency stop operation is available                    |
+| Name                                      | Type                                                  | Description                                                                   |
+| ----------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `/system/emergency/hazard_status`         | `autoware_auto_system_msgs::msg::HazardStatusStamped` | Used to select proper MRM from system failure state contained in HazardStatus |
+| `/control/vehicle_cmd`                    | `autoware_control_msgs::msg::Control`                 | Used as reference when generate Emergency Control Command                     |
+| `/localization/kinematic_state`           | `nav_msgs::msg::Odometry`                             | Used to decide whether vehicle is stopped or not                              |
+| `/vehicle/status/control_mode`            | `autoware_auto_vehicle_msgs::msg::ControlModeReport`  | Used to check vehicle mode: autonomous or manual                              |
+| `/system/api/mrm/comfortable_stop/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`           | Used to check if MRM comfortable stop operation is available                  |
+| `/system/api/mrm/emergency_stop/status`   | `tier4_system_msgs::msg::MrmBehaviorStatus`           | Used to check if MRM emergency stop operation is available                    |
 
 ### Output
 

--- a/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
@@ -21,7 +21,7 @@
 
 // Autoware
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
 #include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
@@ -61,7 +61,7 @@ private:
   // Subscribers
   rclcpp::Subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>::SharedPtr
     sub_hazard_status_stamped_;
-  rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
+  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr
     sub_prev_control_command_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
@@ -72,7 +72,7 @@ private:
     sub_mrm_emergency_stop_status_;
 
   autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr hazard_status_stamped_;
-  autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr prev_control_command_;
+  autoware_control_msgs::msg::Control::ConstSharedPtr prev_control_command_;
   nav_msgs::msg::Odometry::ConstSharedPtr odom_;
   autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_;
   tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr mrm_comfortable_stop_status_;
@@ -81,7 +81,7 @@ private:
   void onHazardStatusStamped(
     const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
   void onPrevControlCommand(
-    const autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr msg);
+    const autoware_control_msgs::msg::Control::ConstSharedPtr msg);
   void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
   void onControlMode(const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
   void onMrmComfortableStopStatus(
@@ -90,7 +90,7 @@ private:
     const tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr msg);
 
   // Publisher
-  rclcpp::Publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
+  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr
     pub_control_command_;
 
   // rclcpp::Publisher<tier4_vehicle_msgs::msg::ShiftStamped>::SharedPtr pub_shift_;

--- a/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
+++ b/system/emergency_handler/include/emergency_handler/emergency_handler_core.hpp
@@ -21,11 +21,11 @@
 
 // Autoware
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
 #include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior_status.hpp>
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
 
@@ -61,8 +61,7 @@ private:
   // Subscribers
   rclcpp::Subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>::SharedPtr
     sub_hazard_status_stamped_;
-  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr
-    sub_prev_control_command_;
+  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr sub_prev_control_command_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
     sub_control_mode_;
@@ -80,8 +79,7 @@ private:
 
   void onHazardStatusStamped(
     const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
-  void onPrevControlCommand(
-    const autoware_control_msgs::msg::Control::ConstSharedPtr msg);
+  void onPrevControlCommand(const autoware_control_msgs::msg::Control::ConstSharedPtr msg);
   void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
   void onControlMode(const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg);
   void onMrmComfortableStopStatus(
@@ -90,8 +88,7 @@ private:
     const tier4_system_msgs::msg::MrmBehaviorStatus::ConstSharedPtr msg);
 
   // Publisher
-  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr
-    pub_control_command_;
+  rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr pub_control_command_;
 
   // rclcpp::Publisher<tier4_vehicle_msgs::msg::ShiftStamped>::SharedPtr pub_shift_;
   // rclcpp::Publisher<tier4_vehicle_msgs::msg::TurnSignal>::SharedPtr pub_turn_signal_;

--- a/system/emergency_handler/package.xml
+++ b/system/emergency_handler/package.xml
@@ -11,9 +11,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>

--- a/system/emergency_handler/package.xml
+++ b/system/emergency_handler/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>nav_msgs</depend>

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -36,10 +36,9 @@ EmergencyHandler::EmergencyHandler() : Node("emergency_handler")
     create_subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>(
       "~/input/hazard_status", rclcpp::QoS{1},
       std::bind(&EmergencyHandler::onHazardStatusStamped, this, _1));
-  sub_prev_control_command_ =
-    create_subscription<autoware_control_msgs::msg::Control>(
-      "~/input/prev_control_command", rclcpp::QoS{1},
-      std::bind(&EmergencyHandler::onPrevControlCommand, this, _1));
+  sub_prev_control_command_ = create_subscription<autoware_control_msgs::msg::Control>(
+    "~/input/prev_control_command", rclcpp::QoS{1},
+    std::bind(&EmergencyHandler::onPrevControlCommand, this, _1));
   sub_odom_ = create_subscription<nav_msgs::msg::Odometry>(
     "~/input/odometry", rclcpp::QoS{1}, std::bind(&EmergencyHandler::onOdometry, this, _1));
   // subscribe control mode
@@ -77,8 +76,8 @@ EmergencyHandler::EmergencyHandler() : Node("emergency_handler")
   // Initialize
   odom_ = std::make_shared<const nav_msgs::msg::Odometry>();
   control_mode_ = std::make_shared<const autoware_auto_vehicle_msgs::msg::ControlModeReport>();
-  prev_control_command_ = autoware_control_msgs::msg::Control::ConstSharedPtr(
-    new autoware_control_msgs::msg::Control);
+  prev_control_command_ =
+    autoware_control_msgs::msg::Control::ConstSharedPtr(new autoware_control_msgs::msg::Control);
   mrm_comfortable_stop_status_ =
     std::make_shared<const tier4_system_msgs::msg::MrmBehaviorStatus>();
   mrm_emergency_stop_status_ = std::make_shared<const tier4_system_msgs::msg::MrmBehaviorStatus>();
@@ -104,8 +103,7 @@ void EmergencyHandler::onPrevControlCommand(
 {
   auto control_command = new autoware_control_msgs::msg::Control(*msg);
   control_command->stamp = msg->stamp;
-  prev_control_command_ =
-    autoware_control_msgs::msg::Control::ConstSharedPtr(control_command);
+  prev_control_command_ = autoware_control_msgs::msg::Control::ConstSharedPtr(control_command);
 }
 
 void EmergencyHandler::onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg)

--- a/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler/emergency_handler_core.cpp
@@ -37,7 +37,7 @@ EmergencyHandler::EmergencyHandler() : Node("emergency_handler")
       "~/input/hazard_status", rclcpp::QoS{1},
       std::bind(&EmergencyHandler::onHazardStatusStamped, this, _1));
   sub_prev_control_command_ =
-    create_subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>(
+    create_subscription<autoware_control_msgs::msg::Control>(
       "~/input/prev_control_command", rclcpp::QoS{1},
       std::bind(&EmergencyHandler::onPrevControlCommand, this, _1));
   sub_odom_ = create_subscription<nav_msgs::msg::Odometry>(
@@ -53,7 +53,7 @@ EmergencyHandler::EmergencyHandler() : Node("emergency_handler")
     std::bind(&EmergencyHandler::onMrmEmergencyStopStatus, this, _1));
 
   // Publisher
-  pub_control_command_ = create_publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>(
+  pub_control_command_ = create_publisher<autoware_control_msgs::msg::Control>(
     "~/output/control_command", rclcpp::QoS{1});
   pub_hazard_cmd_ = create_publisher<autoware_auto_vehicle_msgs::msg::HazardLightsCommand>(
     "~/output/hazard", rclcpp::QoS{1});
@@ -77,8 +77,8 @@ EmergencyHandler::EmergencyHandler() : Node("emergency_handler")
   // Initialize
   odom_ = std::make_shared<const nav_msgs::msg::Odometry>();
   control_mode_ = std::make_shared<const autoware_auto_vehicle_msgs::msg::ControlModeReport>();
-  prev_control_command_ = autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr(
-    new autoware_auto_control_msgs::msg::AckermannControlCommand);
+  prev_control_command_ = autoware_control_msgs::msg::Control::ConstSharedPtr(
+    new autoware_control_msgs::msg::Control);
   mrm_comfortable_stop_status_ =
     std::make_shared<const tier4_system_msgs::msg::MrmBehaviorStatus>();
   mrm_emergency_stop_status_ = std::make_shared<const tier4_system_msgs::msg::MrmBehaviorStatus>();
@@ -100,12 +100,12 @@ void EmergencyHandler::onHazardStatusStamped(
 }
 
 void EmergencyHandler::onPrevControlCommand(
-  const autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr msg)
+  const autoware_control_msgs::msg::Control::ConstSharedPtr msg)
 {
-  auto control_command = new autoware_auto_control_msgs::msg::AckermannControlCommand(*msg);
+  auto control_command = new autoware_control_msgs::msg::Control(*msg);
   control_command->stamp = msg->stamp;
   prev_control_command_ =
-    autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr(control_command);
+    autoware_control_msgs::msg::Control::ConstSharedPtr(control_command);
 }
 
 void EmergencyHandler::onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg)

--- a/system/mrm_emergency_stop_operator/READEME.md
+++ b/system/mrm_emergency_stop_operator/READEME.md
@@ -10,18 +10,18 @@ MRM emergency stop operator is a node that generates emergency stop commands acc
 
 ### Input
 
-| Name                                 | Type                                                       | Description                                                                                                                   |
-| ------------------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `~/input/mrm/emergency_stop/operate` | `tier4_system_msgs::srv::OperateMrm`                       | MRM execution order                                                                                                           |
+| Name                                 | Type                                  | Description                                                                                                                   |
+| ------------------------------------ | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `~/input/mrm/emergency_stop/operate` | `tier4_system_msgs::srv::OperateMrm`  | MRM execution order                                                                                                           |
 | `~/input/control/control_cmd`        | `autoware_control_msgs::msg::Control` | Control command output from the last node of the control component. Used for the initial value of the emergency stop command. |
-|                                      |                                                            |                                                                                                                               |
+|                                      |                                       |                                                                                                                               |
 
 ### Output
 
-| Name                                      | Type                                                       | Description            |
-| ----------------------------------------- | ---------------------------------------------------------- | ---------------------- |
-| `~/output/mrm/emergency_stop/status`      | `tier4_system_msgs::msg::MrmBehaviorStatus`                | MRM execution status   |
-| `~/output/mrm/emergency_stop/control_cmd` | `autoware_control_msgs::msg::Control` | Emergency stop command |
+| Name                                      | Type                                        | Description            |
+| ----------------------------------------- | ------------------------------------------- | ---------------------- |
+| `~/output/mrm/emergency_stop/status`      | `tier4_system_msgs::msg::MrmBehaviorStatus` | MRM execution status   |
+| `~/output/mrm/emergency_stop/control_cmd` | `autoware_control_msgs::msg::Control`       | Emergency stop command |
 
 ## Parameters
 

--- a/system/mrm_emergency_stop_operator/READEME.md
+++ b/system/mrm_emergency_stop_operator/READEME.md
@@ -13,7 +13,7 @@ MRM emergency stop operator is a node that generates emergency stop commands acc
 | Name                                 | Type                                                       | Description                                                                                                                   |
 | ------------------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `~/input/mrm/emergency_stop/operate` | `tier4_system_msgs::srv::OperateMrm`                       | MRM execution order                                                                                                           |
-| `~/input/control/control_cmd`        | `autoware_auto_control_msgs::msg::AckermannControlCommand` | Control command output from the last node of the control component. Used for the initial value of the emergency stop command. |
+| `~/input/control/control_cmd`        | `autoware_control_msgs::msg::Control` | Control command output from the last node of the control component. Used for the initial value of the emergency stop command. |
 |                                      |                                                            |                                                                                                                               |
 
 ### Output
@@ -21,7 +21,7 @@ MRM emergency stop operator is a node that generates emergency stop commands acc
 | Name                                      | Type                                                       | Description            |
 | ----------------------------------------- | ---------------------------------------------------------- | ---------------------- |
 | `~/output/mrm/emergency_stop/status`      | `tier4_system_msgs::msg::MrmBehaviorStatus`                | MRM execution status   |
-| `~/output/mrm/emergency_stop/control_cmd` | `autoware_auto_control_msgs::msg::AckermannControlCommand` | Emergency stop command |
+| `~/output/mrm/emergency_stop/control_cmd` | `autoware_control_msgs::msg::Control` | Emergency stop command |
 
 ## Parameters
 

--- a/system/mrm_emergency_stop_operator/include/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
+++ b/system/mrm_emergency_stop_operator/include/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 
 // Autoware
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior_status.hpp>
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
 
@@ -29,7 +29,7 @@
 
 namespace mrm_emergency_stop_operator
 {
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using tier4_system_msgs::msg::MrmBehaviorStatus;
 using tier4_system_msgs::srv::OperateMrm;
 
@@ -50,9 +50,9 @@ private:
   Parameters params_;
 
   // Subscriber
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_control_cmd_;
+  rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;
 
-  void onControlCommand(AckermannControlCommand::ConstSharedPtr msg);
+  void onControlCommand(Control::ConstSharedPtr msg);
 
   // Server
   rclcpp::Service<OperateMrm>::SharedPtr service_operation_;
@@ -62,10 +62,10 @@ private:
 
   // Publisher
   rclcpp::Publisher<MrmBehaviorStatus>::SharedPtr pub_status_;
-  rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_control_cmd_;
+  rclcpp::Publisher<Control>::SharedPtr pub_control_cmd_;
 
   void publishStatus() const;
-  void publishControlCommand(const AckermannControlCommand & command) const;
+  void publishControlCommand(const Control & command) const;
 
   // Timer
   rclcpp::TimerBase::SharedPtr timer_;
@@ -74,12 +74,12 @@ private:
 
   // States
   MrmBehaviorStatus status_;
-  AckermannControlCommand prev_control_cmd_;
+  Control prev_control_cmd_;
   bool is_prev_control_cmd_subscribed_;
 
   // Algorithm
-  AckermannControlCommand calcTargetAcceleration(
-    const AckermannControlCommand & prev_control_cmd) const;
+  Control calcTargetAcceleration(
+    const Control & prev_control_cmd) const;
 };
 
 }  // namespace mrm_emergency_stop_operator

--- a/system/mrm_emergency_stop_operator/include/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
+++ b/system/mrm_emergency_stop_operator/include/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
@@ -78,8 +78,7 @@ private:
   bool is_prev_control_cmd_subscribed_;
 
   // Algorithm
-  Control calcTargetAcceleration(
-    const Control & prev_control_cmd) const;
+  Control calcTargetAcceleration(const Control & prev_control_cmd) const;
 };
 
 }  // namespace mrm_emergency_stop_operator

--- a/system/mrm_emergency_stop_operator/package.xml
+++ b/system/mrm_emergency_stop_operator/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/system/mrm_emergency_stop_operator/src/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.cpp
+++ b/system/mrm_emergency_stop_operator/src/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.cpp
@@ -38,8 +38,7 @@ MrmEmergencyStopOperator::MrmEmergencyStopOperator(const rclcpp::NodeOptions & n
 
   // Publisher
   pub_status_ = create_publisher<MrmBehaviorStatus>("~/output/mrm/emergency_stop/status", 1);
-  pub_control_cmd_ =
-    create_publisher<Control>("~/output/mrm/emergency_stop/control_cmd", 1);
+  pub_control_cmd_ = create_publisher<Control>("~/output/mrm/emergency_stop/control_cmd", 1);
 
   // Timer
   const auto update_period_ns = rclcpp::Rate(params_.update_rate).period();
@@ -95,8 +94,7 @@ void MrmEmergencyStopOperator::onTimer()
   publishStatus();
 }
 
-Control MrmEmergencyStopOperator::calcTargetAcceleration(
-  const Control & prev_control_cmd) const
+Control MrmEmergencyStopOperator::calcTargetAcceleration(const Control & prev_control_cmd) const
 {
   auto control_cmd = Control();
 

--- a/tools/simulator_test/simulator_compatibility_test/package.xml
+++ b/tools/simulator_test/simulator_compatibility_test/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="shpark@morai.ai">shpark</maintainer>
   <license>TODO: License declaration</license>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_geometry_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_msgs</depend>

--- a/tools/simulator_test/simulator_compatibility_test/package.xml
+++ b/tools/simulator_test/simulator_compatibility_test/package.xml
@@ -7,7 +7,6 @@
   <maintainer email="shpark@morai.ai">shpark</maintainer>
   <license>TODO: License declaration</license>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_geometry_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_msgs</depend>
@@ -15,6 +14,7 @@
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>rclpy</depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/tools/simulator_test/simulator_compatibility_test/simulator_compatibility_test/publishers/ackermann_control_command.py
+++ b/tools/simulator_test/simulator_compatibility_test/simulator_compatibility_test/publishers/ackermann_control_command.py
@@ -9,7 +9,7 @@ from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 
 
-class PublisherAckermannControlCommand(Node):
+class PublisherControl(Node):
     def __init__(self):
         super().__init__("ackermann_control_command_publisher")
 

--- a/tools/simulator_test/simulator_compatibility_test/simulator_compatibility_test/publishers/ackermann_control_command.py
+++ b/tools/simulator_test/simulator_compatibility_test/simulator_compatibility_test/publishers/ackermann_control_command.py
@@ -1,6 +1,6 @@
-from autoware_auto_control_msgs.msg import AckermannControlCommand
-from autoware_auto_control_msgs.msg import AckermannLateralCommand
-from autoware_auto_control_msgs.msg import LongitudinalCommand
+from autoware_control_msgs.msg import Control
+from autoware_control_msgs.msg import Lateral
+from autoware_control_msgs.msg import Longitudinal
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy
@@ -23,13 +23,13 @@ class PublisherAckermannControlCommand(Node):
             durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
         )
         self.topic = "/control/command/control_cmd"
-        self.publisher_ = self.create_publisher(AckermannControlCommand, self.topic, QOS_RKL10TL)
+        self.publisher_ = self.create_publisher(Control, self.topic, QOS_RKL10TL)
 
     def publish_msg(self, control_cmd):
         stamp = self.get_clock().now().to_msg()
-        msg = AckermannControlCommand()
-        lateral_cmd = AckermannLateralCommand()
-        longitudinal_cmd = LongitudinalCommand()
+        msg = Control()
+        lateral_cmd = Lateral()
+        longitudinal_cmd = Longitudinal()
         lateral_cmd.stamp.sec = stamp.sec
         lateral_cmd.stamp.nanosec = stamp.nanosec
         lateral_cmd.steering_tire_angle = control_cmd["lateral"]["steering_tire_angle"]
@@ -38,7 +38,7 @@ class PublisherAckermannControlCommand(Node):
         ]
         longitudinal_cmd.stamp.sec = stamp.sec
         longitudinal_cmd.stamp.nanosec = stamp.nanosec
-        longitudinal_cmd.speed = control_cmd["longitudinal"]["speed"]
+        longitudinal_cmd.velocity = control_cmd["longitudinal"]["speed"]
         longitudinal_cmd.acceleration = control_cmd["longitudinal"]["acceleration"]
         longitudinal_cmd.jerk = control_cmd["longitudinal"]["jerk"]
 
@@ -53,7 +53,7 @@ class PublisherAckermannControlCommand(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    node = PublisherAckermannControlCommand()
+    node = PublisherControl()
     try:
         rclpy.spin(node)
     except KeyboardInterrupt:

--- a/tools/simulator_test/simulator_compatibility_test/test_base/test_03_longitudinal_command_and_report.py
+++ b/tools/simulator_test/simulator_compatibility_test/test_base/test_03_longitudinal_command_and_report.py
@@ -1,8 +1,8 @@
 import time
 
-from autoware_auto_control_msgs.msg import AckermannControlCommand
-from autoware_auto_control_msgs.msg import AckermannLateralCommand
-from autoware_auto_control_msgs.msg import LongitudinalCommand
+from autoware_control_msgs.msg import Control
+from autoware_control_msgs.msg import Lateral
+from autoware_control_msgs.msg import Longitudinal
 import pytest
 import rclpy
 from rclpy.executors import MultiThreadedExecutor
@@ -39,13 +39,13 @@ class Test03LongitudinalCommandAndReportBase:
 
         cls.node = rclpy.create_node("test_03_longitudinal_command_and_report_base")
         cls.sub = cls.node.create_subscription(
-            AckermannControlCommand,
+            Control,
             "/control/command/control_cmd",
             lambda msg: cls.msgs_rx.append(msg),
             10,
         )
         cls.pub = cls.node.create_publisher(
-            AckermannControlCommand, "/control/command/control_cmd", QOS_RKL10TL
+            Control, "/control/command/control_cmd", QOS_RKL10TL
         )
         cls.sub_velocity_report = SubscriberVelocityReport()
         cls.executor = MultiThreadedExecutor()
@@ -71,9 +71,9 @@ class Test03LongitudinalCommandAndReportBase:
 
     def generate_control_msg(self, control_cmd):
         stamp = self.node.get_clock().now().to_msg()
-        msg = AckermannControlCommand()
-        lateral_cmd = AckermannLateralCommand()
-        longitudinal_cmd = LongitudinalCommand()
+        msg = Control()
+        lateral_cmd = Lateral()
+        longitudinal_cmd = Longitudinal()
         lateral_cmd.stamp.sec = stamp.sec
         lateral_cmd.stamp.nanosec = stamp.nanosec
         lateral_cmd.steering_tire_angle = control_cmd["lateral"]["steering_tire_angle"]
@@ -82,7 +82,7 @@ class Test03LongitudinalCommandAndReportBase:
         ]
         longitudinal_cmd.stamp.sec = stamp.sec
         longitudinal_cmd.stamp.nanosec = stamp.nanosec
-        longitudinal_cmd.speed = control_cmd["longitudinal"]["speed"]
+        longitudinal_cmd.velocity = control_cmd["longitudinal"]["speed"]
         longitudinal_cmd.acceleration = control_cmd["longitudinal"]["acceleration"]
         longitudinal_cmd.jerk = control_cmd["longitudinal"]["jerk"]
 
@@ -101,7 +101,7 @@ class Test03LongitudinalCommandAndReportBase:
             if len(self.msgs_rx) > 2:
                 break
         received = self.msgs_rx[-1]
-        assert received.longitudinal.speed == speed
+        assert received.longitudinal.velocity == speed
         self.msgs_rx.clear()
 
     def set_acceleration(self, acceleration):

--- a/tools/simulator_test/simulator_compatibility_test/test_base/test_03_longitudinal_command_and_report.py
+++ b/tools/simulator_test/simulator_compatibility_test/test_base/test_03_longitudinal_command_and_report.py
@@ -44,9 +44,7 @@ class Test03LongitudinalCommandAndReportBase:
             lambda msg: cls.msgs_rx.append(msg),
             10,
         )
-        cls.pub = cls.node.create_publisher(
-            Control, "/control/command/control_cmd", QOS_RKL10TL
-        )
+        cls.pub = cls.node.create_publisher(Control, "/control/command/control_cmd", QOS_RKL10TL)
         cls.sub_velocity_report = SubscriberVelocityReport()
         cls.executor = MultiThreadedExecutor()
         cls.executor.add_node(cls.sub_velocity_report)

--- a/tools/simulator_test/simulator_compatibility_test/test_base/test_04_lateral_command_and_report.py
+++ b/tools/simulator_test/simulator_compatibility_test/test_base/test_04_lateral_command_and_report.py
@@ -43,9 +43,7 @@ class Test04LateralCommandAndReportBase:
             lambda msg: cls.msgs_rx.append(msg),
             10,
         )
-        cls.pub = cls.node.create_publisher(
-            Control, "/control/command/control_cmd", QOS_RKL10TL
-        )
+        cls.pub = cls.node.create_publisher(Control, "/control/command/control_cmd", QOS_RKL10TL)
         cls.sub_steering_report = SubscriberSteeringReport()
         cls.executor = MultiThreadedExecutor()
         cls.executor.add_node(cls.sub_steering_report)

--- a/tools/simulator_test/simulator_compatibility_test/test_base/test_04_lateral_command_and_report.py
+++ b/tools/simulator_test/simulator_compatibility_test/test_base/test_04_lateral_command_and_report.py
@@ -1,8 +1,8 @@
 import time
 
-from autoware_auto_control_msgs.msg import AckermannControlCommand
-from autoware_auto_control_msgs.msg import AckermannLateralCommand
-from autoware_auto_control_msgs.msg import LongitudinalCommand
+from autoware_control_msgs.msg import Control
+from autoware_control_msgs.msg import Lateral
+from autoware_control_msgs.msg import Longitudinal
 import pytest
 import rclpy
 from rclpy.executors import MultiThreadedExecutor
@@ -38,13 +38,13 @@ class Test04LateralCommandAndReportBase:
         }
         cls.node = rclpy.create_node("test_04_lateral_command_and_report_base")
         cls.sub = cls.node.create_subscription(
-            AckermannControlCommand,
+            Control,
             "/control/command/control_cmd",
             lambda msg: cls.msgs_rx.append(msg),
             10,
         )
         cls.pub = cls.node.create_publisher(
-            AckermannControlCommand, "/control/command/control_cmd", QOS_RKL10TL
+            Control, "/control/command/control_cmd", QOS_RKL10TL
         )
         cls.sub_steering_report = SubscriberSteeringReport()
         cls.executor = MultiThreadedExecutor()
@@ -70,9 +70,9 @@ class Test04LateralCommandAndReportBase:
 
     def generate_control_msg(self, control_cmd):
         stamp = self.node.get_clock().now().to_msg()
-        msg = AckermannControlCommand()
-        lateral_cmd = AckermannLateralCommand()
-        longitudinal_cmd = LongitudinalCommand()
+        msg = Control()
+        lateral_cmd = Lateral()
+        longitudinal_cmd = Longitudinal()
         lateral_cmd.stamp.sec = stamp.sec
         lateral_cmd.stamp.nanosec = stamp.nanosec
         lateral_cmd.steering_tire_angle = control_cmd["lateral"]["steering_tire_angle"]
@@ -81,7 +81,7 @@ class Test04LateralCommandAndReportBase:
         ]
         longitudinal_cmd.stamp.sec = stamp.sec
         longitudinal_cmd.stamp.nanosec = stamp.nanosec
-        longitudinal_cmd.speed = control_cmd["longitudinal"]["speed"]
+        longitudinal_cmd.velocity = control_cmd["longitudinal"]["speed"]
         longitudinal_cmd.acceleration = control_cmd["longitudinal"]["acceleration"]
         longitudinal_cmd.jerk = control_cmd["longitudinal"]["jerk"]
 

--- a/vehicle/external_cmd_converter/README.md
+++ b/vehicle/external_cmd_converter/README.md
@@ -14,8 +14,8 @@
 
 ## Output topics
 
-| Name                | Type                                                     | Description                                                        |
-| ------------------- | -------------------------------------------------------- | ------------------------------------------------------------------ |
+| Name                | Type                                | Description                                                        |
+| ------------------- | ----------------------------------- | ------------------------------------------------------------------ |
 | `~/out/control_cmd` | autoware_control_msgs::msg::Control | ackermann control command converted from selected external command |
 
 ## Parameters

--- a/vehicle/external_cmd_converter/README.md
+++ b/vehicle/external_cmd_converter/README.md
@@ -16,7 +16,7 @@
 
 | Name                | Type                                                     | Description                                                        |
 | ------------------- | -------------------------------------------------------- | ------------------------------------------------------------------ |
-| `~/out/control_cmd` | autoware_auto_control_msgs::msg::AckermannControlCommand | ackermann control command converted from selected external command |
+| `~/out/control_cmd` | autoware_control_msgs::msg::Control | ackermann control command converted from selected external command |
 
 ## Parameters
 

--- a/vehicle/external_cmd_converter/include/external_cmd_converter/node.hpp
+++ b/vehicle/external_cmd_converter/include/external_cmd_converter/node.hpp
@@ -20,8 +20,8 @@
 #include <raw_vehicle_cmd_converter/brake_map.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_external_api_msgs/msg/control_command_stamped.hpp>

--- a/vehicle/external_cmd_converter/include/external_cmd_converter/node.hpp
+++ b/vehicle/external_cmd_converter/include/external_cmd_converter/node.hpp
@@ -20,7 +20,7 @@
 #include <raw_vehicle_cmd_converter/brake_map.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
@@ -33,12 +33,12 @@
 namespace external_cmd_converter
 {
 using GearCommand = autoware_auto_vehicle_msgs::msg::GearCommand;
-using AckermannControlCommand = autoware_auto_control_msgs::msg::AckermannControlCommand;
+using Control = autoware_control_msgs::msg::Control;
 using ExternalControlCommand = tier4_external_api_msgs::msg::ControlCommandStamped;
 using Odometry = nav_msgs::msg::Odometry;
 using raw_vehicle_cmd_converter::AccelMap;
 using raw_vehicle_cmd_converter::BrakeMap;
-using ControlCommandStamped = autoware_auto_control_msgs::msg::AckermannControlCommand;
+using ControlCommandStamped = autoware_control_msgs::msg::Control;
 using Odometry = nav_msgs::msg::Odometry;
 
 class ExternalCmdConverterNode : public rclcpp::Node
@@ -48,7 +48,7 @@ public:
 
 private:
   // Publisher
-  rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_cmd_;
+  rclcpp::Publisher<Control>::SharedPtr pub_cmd_;
   rclcpp::Publisher<tier4_external_api_msgs::msg::ControlCommandStamped>::SharedPtr
     pub_current_cmd_;
 

--- a/vehicle/external_cmd_converter/package.xml
+++ b/vehicle/external_cmd_converter/package.xml
@@ -12,8 +12,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/vehicle/external_cmd_converter/package.xml
+++ b/vehicle/external_cmd_converter/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>

--- a/vehicle/external_cmd_converter/src/node.cpp
+++ b/vehicle/external_cmd_converter/src/node.cpp
@@ -26,7 +26,7 @@ ExternalCmdConverterNode::ExternalCmdConverterNode(const rclcpp::NodeOptions & n
 {
   using std::placeholders::_1;
 
-  pub_cmd_ = create_publisher<AckermannControlCommand>("out/control_cmd", rclcpp::QoS{1});
+  pub_cmd_ = create_publisher<Control>("out/control_cmd", rclcpp::QoS{1});
   pub_current_cmd_ =
     create_publisher<ExternalControlCommand>("out/latest_external_control_cmd", rclcpp::QoS{1});
   sub_velocity_ = create_subscription<Odometry>(
@@ -142,11 +142,11 @@ void ExternalCmdConverterNode::onExternalCmd(const ExternalControlCommand::Const
   }
 
   // Publish ControlCommand
-  autoware_auto_control_msgs::msg::AckermannControlCommand output;
+  autoware_control_msgs::msg::Control output;
   output.stamp = cmd_ptr->stamp;
   output.lateral.steering_tire_angle = cmd_ptr->control.steering_angle;
   output.lateral.steering_tire_rotation_rate = cmd_ptr->control.steering_angle_velocity;
-  output.longitudinal.speed = ref_velocity;
+  output.longitudinal.velocity = ref_velocity;
   output.longitudinal.acceleration = ref_acceleration;
 
   pub_cmd_->publish(output);

--- a/vehicle/raw_vehicle_cmd_converter/README.md
+++ b/vehicle/raw_vehicle_cmd_converter/README.md
@@ -6,7 +6,7 @@
 
 | Name                  | Type                                                     | Description                                                                                                        |
 | --------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `~/input/control_cmd` | autoware_auto_control_msgs::msg::AckermannControlCommand | target `velocity/acceleration/steering_angle/steering_angle_velocity` is necessary to calculate actuation command. |
+| `~/input/control_cmd` | autoware_control_msgs::msg::Control | target `velocity/acceleration/steering_angle/steering_angle_velocity` is necessary to calculate actuation command. |
 | `~/input/steering"`   | autoware_auto_vehicle_msgs::SteeringReport               | current status of steering used for steering feed back control                                                     |
 | `~/input/twist`       | navigation_msgs::Odometry                                | twist topic in odometry is used.                                                                                   |
 

--- a/vehicle/raw_vehicle_cmd_converter/README.md
+++ b/vehicle/raw_vehicle_cmd_converter/README.md
@@ -4,11 +4,11 @@
 
 ## Input topics
 
-| Name                  | Type                                                     | Description                                                                                                        |
-| --------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `~/input/control_cmd` | autoware_control_msgs::msg::Control | target `velocity/acceleration/steering_angle/steering_angle_velocity` is necessary to calculate actuation command. |
-| `~/input/steering"`   | autoware_auto_vehicle_msgs::SteeringReport               | current status of steering used for steering feed back control                                                     |
-| `~/input/twist`       | navigation_msgs::Odometry                                | twist topic in odometry is used.                                                                                   |
+| Name                  | Type                                       | Description                                                                                                        |
+| --------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `~/input/control_cmd` | autoware_control_msgs::msg::Control        | target `velocity/acceleration/steering_angle/steering_angle_velocity` is necessary to calculate actuation command. |
+| `~/input/steering"`   | autoware_auto_vehicle_msgs::SteeringReport | current status of steering used for steering feed back control                                                     |
+| `~/input/twist`       | navigation_msgs::Odometry                  | twist topic in odometry is used.                                                                                   |
 
 ## Output topics
 

--- a/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/node.hpp
+++ b/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/node.hpp
@@ -22,7 +22,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -35,7 +35,7 @@
 
 namespace raw_vehicle_cmd_converter
 {
-using AckermannControlCommand = autoware_auto_control_msgs::msg::AckermannControlCommand;
+using Control = autoware_control_msgs::msg::Control;
 using tier4_debug_msgs::msg::Float32MultiArrayStamped;
 using tier4_vehicle_msgs::msg::ActuationCommandStamped;
 using TwistStamped = geometry_msgs::msg::TwistStamped;
@@ -76,7 +76,7 @@ public:
   //!< @brief subscriber for current velocity
   rclcpp::Subscription<Odometry>::SharedPtr sub_velocity_;
   //!< @brief subscriber for vehicle command
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_control_cmd_;
+  rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;
   //!< @brief subscriber for steering
   rclcpp::Subscription<Steering>::SharedPtr sub_steering_;
 
@@ -84,7 +84,7 @@ public:
 
   std::unique_ptr<TwistStamped> current_twist_ptr_;  // [m/s]
   std::unique_ptr<double> current_steer_ptr_;
-  AckermannControlCommand::ConstSharedPtr control_cmd_ptr_;
+  Control::ConstSharedPtr control_cmd_ptr_;
   AccelMap accel_map_;
   BrakeMap brake_map_;
   SteerMap steer_map_;
@@ -109,7 +109,7 @@ public:
   double calculateBrakeMap(const double current_velocity, const double desired_acc);
   double calculateSteer(const double vel, const double steering, const double steer_rate);
   void onSteering(const Steering::ConstSharedPtr msg);
-  void onControlCmd(const AckermannControlCommand::ConstSharedPtr msg);
+  void onControlCmd(const Control::ConstSharedPtr msg);
   void onVelocity(const Odometry::ConstSharedPtr msg);
   void publishActuationCmd();
   // for debugging

--- a/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/node.hpp
+++ b/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/node.hpp
@@ -22,8 +22,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_debug_msgs/msg/float32_multi_array_stamped.hpp>

--- a/vehicle/raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/raw_vehicle_cmd_converter/package.xml
@@ -17,8 +17,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>interpolation</depend>
   <depend>nav_msgs</depend>

--- a/vehicle/raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/raw_vehicle_cmd_converter/package.xml
@@ -17,7 +17,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>interpolation</depend>

--- a/vehicle/raw_vehicle_cmd_converter/src/node.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/node.cpp
@@ -76,7 +76,7 @@ RawVehicleCommandConverterNode::RawVehicleCommandConverterNode(
     steer_pid_.setInitialized();
   }
   pub_actuation_cmd_ = create_publisher<ActuationCommandStamped>("~/output/actuation_cmd", 1);
-  sub_control_cmd_ = create_subscription<AckermannControlCommand>(
+  sub_control_cmd_ = create_subscription<Control>(
     "~/input/control_cmd", 1, std::bind(&RawVehicleCommandConverterNode::onControlCmd, this, _1));
   sub_velocity_ = create_subscription<Odometry>(
     "~/input/odometry", 1, std::bind(&RawVehicleCommandConverterNode::onVelocity, this, _1));
@@ -214,7 +214,7 @@ void RawVehicleCommandConverterNode::onVelocity(const Odometry::ConstSharedPtr m
   current_twist_ptr_->twist = msg->twist.twist;
 }
 
-void RawVehicleCommandConverterNode::onControlCmd(const AckermannControlCommand::ConstSharedPtr msg)
+void RawVehicleCommandConverterNode::onControlCmd(const Control::ConstSharedPtr msg)
 {
   control_cmd_ptr_ = msg;
   publishActuationCmd();


### PR DESCRIPTION
## Description

Closes: https://github.com/autowarefoundation/autoware.universe/issues/3674

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fa17ed</samp>

This pull request replaces the use of `AckermannControlCommand` and `AckermannLateralCommand` messages from `autoware_auto_control_msgs` with the new generic `Control` and `Lateral` messages from `autoware_control_msgs` in various control modules and tools. This simplifies the control interface, avoids unnecessary conversions, and ensures compatibility with the latest control command definition. The changes affect the source code, header files, package dependencies, and documentation of the `tier4_control_rviz_plugin`, `control_performance_analysis`, `joy_controller`, `mpc_lateral_controller`, and `autonomous_emergency_braking` packages.

## Related links

- Needs to be merged with:
  - https://github.com/tier4/tier4_ad_api_adaptor/pull/106
  - https://github.com/tier4/pacmod_interface/pull/61
  - https://github.com/autowarefoundation/autoware_launch/pull/353
- Simulator PRs:
  - https://github.com/tier4/scenario_simulator_v2/pull/1020
  - https://github.com/tier4/AWSIM/pull/152

## Tests performed

- Compilation works and existing tests pass.
- [Planning simulation demo](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/) works.

## Notes for reviewers

- Because this is a very interconnected PR, I've had to make it all in a single PR.
- Needs to be merged with:
  - https://github.com/tier4/tier4_ad_api_adaptor/pull/106
  - https://github.com/tier4/pacmod_interface/pull/61
  - https://github.com/autowarefoundation/autoware_launch/pull/353

## Interface changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4fa17ed</samp>

*  Replace `autoware_auto_control_msgs` with `autoware_control_msgs` to unify the control message interface across different controllers ([link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-5b64a4bc696bc7711b9348d9610599ba2e6986447c080097ef916b35803f5499L13-R14), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-a5a8657b94b1105d141fe214352f1e45e517a74d62a1819bdfd9440517c7dab1L14-R16), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-0cc18a28606e9953bacccba90dfd5c377b5720fa1a1a0f9ce40d7f2076ed2094L27-R29), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-171cb7488d7ed1cf99749e4a77eb83ff52de843b6feb8e8cb8d2d202b581836eL22-R23), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-6eeea4c2cc2133f784a3f8d32eb1789e66fe92fdbe7a7589858fe54fa26035b9L20-R22))
*  Change the control command message type from `AckermannControlCommand` to `Control` and update the corresponding fields, namespaces, headers, publishers, subscribers, buffers, and functions in `tier4_control_rviz_plugin`, `control_performance_analysis`, and `joy_controller` ([link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-5fd28393490d860a54aa8f24adb07da1bea06c249de0013c16d3c74ad4a6e601L113-R117), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-5fd28393490d860a54aa8f24adb07da1bea06c249de0013c16d3c74ad4a6e601L136-R138), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-5fd28393490d860a54aa8f24adb07da1bea06c249de0013c16d3c74ad4a6e601L184-R185), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-190b681ca5dbb48ddcbf50741bc902cb1c9f0301bb41e7fe74818b5a5b75bd80L29-R32), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-190b681ca5dbb48ddcbf50741bc902cb1c9f0301bb41e7fe74818b5a5b75bd80L40-R42), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-190b681ca5dbb48ddcbf50741bc902cb1c9f0301bb41e7fe74818b5a5b75bd80L77-R77), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-e1660a2e3ebb958cfef455f5e14397dceccebc15fc618b1db42cb3dc7b646b2bL27-R29), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-e1660a2e3ebb958cfef455f5e14397dceccebc15fc618b1db42cb3dc7b646b2bL41-R43), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-e1660a2e3ebb958cfef455f5e14397dceccebc15fc618b1db42cb3dc7b646b2bL74-R74), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-e1660a2e3ebb958cfef455f5e14397dceccebc15fc618b1db42cb3dc7b646b2bL106-R106), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-a9a80896fda0b4e4012b8d5503832ae1d609a920bd14ee82177fab00799b2500L26-R28), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-a9a80896fda0b4e4012b8d5503832ae1d609a920bd14ee82177fab00799b2500L39-R41), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-a9a80896fda0b4e4012b8d5503832ae1d609a920bd14ee82177fab00799b2500L55-R56), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-a9a80896fda0b4e4012b8d5503832ae1d609a920bd14ee82177fab00799b2500L74-R73), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-a9a80896fda0b4e4012b8d5503832ae1d609a920bd14ee82177fab00799b2500L86-R85), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-a9a80896fda0b4e4012b8d5503832ae1d609a920bd14ee82177fab00799b2500L93-R92), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-15ac61f7cbbe7ac290018fd2509168cc4d2ff201c3a500ae3385364103bdb626L84-R86), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-73a4fb1691cb91096d60060ec20dbf49bc65b811fe7d29e2b1e3769ce8537f19L27-R27), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-73a4fb1691cb91096d60060ec20dbf49bc65b811fe7d29e2b1e3769ce8537f19L65-R65), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-73a4fb1691cb91096d60060ec20dbf49bc65b811fe7d29e2b1e3769ce8537f19L99-R99), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-bc205d5127fcdcda7bf5b0d8b14dfe99fe35996d3d6092b3fc3e42fe037048dfL22-R23), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-bc205d5127fcdcda7bf5b0d8b14dfe99fe35996d3d6092b3fc3e42fe037048dfL83-R83), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-bc205d5127fcdcda7bf5b0d8b14dfe99fe35996d3d6092b3fc3e42fe037048dfL108-R107), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-388110ee10c9684d1ec47329f192b4a749bf8b426bbd0268c526799997e3ca8aL254-R254), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-388110ee10c9684d1ec47329f192b4a749bf8b426bbd0268c526799997e3ca8aL262-R269), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-388110ee10c9684d1ec47329f192b4a749bf8b426bbd0268c526799997e3ca8aL276-R279), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-388110ee10c9684d1ec47329f192b4a749bf8b426bbd0268c526799997e3ca8aL487-R487))
*  Change the lateral control command message type from `AckermannLateralCommand` to `Lateral` and update the corresponding fields, namespaces, headers, publishers, subscribers, buffers, and functions in `mpc_lateral_controller` ([link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-030829d3b609275d79ffa6919606aee842cbe03df3984fae74a704cca0ef01c3L33-R35), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-030829d3b609275d79ffa6919606aee842cbe03df3984fae74a704cca0ef01c3L47-R49), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-030829d3b609275d79ffa6919606aee842cbe03df3984fae74a704cca0ef01c3L177-R177), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-030829d3b609275d79ffa6919606aee842cbe03df3984fae74a704cca0ef01c3L381-R381), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-8a89e4298b2125992eb5c99ef8f8d12caaf6d9d25646c2e63eee66052fe17a16L37-R40), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-8a89e4298b2125992eb5c99ef8f8d12caaf6d9d25646c2e63eee66052fe17a16L125-R125), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-8a89e4298b2125992eb5c99ef8f8d12caaf6d9d25646c2e63eee66052fe17a16L163-R164), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-8a89e4298b2125992eb5c99ef8f8d12caaf6d9d25646c2e63eee66052fe17a16L181-R186), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-8a89e4298b2125992eb5c99ef8f8d12caaf6d9d25646c2e63eee66052fe17a16L200-R200), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-3928795445dcd4b3ae03f4b6202b7170627811d40ff0246c8eb7917686cb9c4bL33-R33), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-3928795445dcd4b3ae03f4b6202b7170627811d40ff0246c8eb7917686cb9c4bL372-R371))
*  Update the README files for `tier4_control_rviz_plugin`, `control_performance_analysis`, `joy_controller`, and `mpc_lateral_controller` to reflect the new message types and fields for control command and lateral control ([link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-1cf606f792fcf0ba924b742a76c2dad5204d4bd17e1bfc3b376e326b80b4d280L18-R22), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-f3f59f78f0fc649f13fec38a8f923fabda3d6d257492d8db7c842ab9023b8b85L28-R34), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-c2b5931b2aa4a8f481961d2b96113bd6681624eccbb073b04a6e813cf2392ec7L18-R26), [link](https://github.com/autowarefoundation/autoware.universe/pull/3677/files?diff=unified&w=0#diff-14b7e76dd74fbb8acf66c33015394a2dd6119591c9280e2963e6a9021531f0a2L73-R73))

## Effects on system behavior

Shouldn't change the system behavior.

## Fun

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4fa17ed</samp>

> _`Control` replaces_
> _`AckermannControlCommand`_
> _Simpler interface_

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
