### PR TITLE
build(iron): add workaround for image common header

### DIFF
--- a/perception/bytetrack/include/bytetrack/bytetrack_node.hpp
+++ b/perception/bytetrack/include/bytetrack/bytetrack_node.hpp
@@ -21,7 +21,11 @@
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 #include <tier4_perception_msgs/msg/dynamic_object_array.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <chrono>
 #include <fstream>

--- a/perception/bytetrack/src/bytetrack_visualizer_node.cpp
+++ b/perception/bytetrack/src/bytetrack_visualizer_node.cpp
@@ -17,7 +17,11 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <chrono>
 #include <string>

--- a/perception/image_projection_based_fusion/src/debugger.cpp
+++ b/perception/image_projection_based_fusion/src/debugger.cpp
@@ -14,7 +14,11 @@
 
 #include "image_projection_based_fusion/debugger.hpp"
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 namespace
 {

--- a/perception/tensorrt_yolo/include/tensorrt_yolo/nodelet.hpp
+++ b/perception/tensorrt_yolo/include/tensorrt_yolo/nodelet.hpp
@@ -27,7 +27,11 @@
 #include <std_msgs/msg/header.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <chrono>
 #include <fstream>

--- a/perception/tensorrt_yolox/include/tensorrt_yolox/tensorrt_yolox_node.hpp
+++ b/perception/tensorrt_yolox/include/tensorrt_yolox/tensorrt_yolox_node.hpp
@@ -24,7 +24,11 @@
 #include <std_msgs/msg/header.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <chrono>
 #include <fstream>

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/cnn_classifier.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/cnn_classifier.hpp
@@ -25,7 +25,11 @@
 
 #include <autoware_auto_perception_msgs/msg/traffic_light.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <map>
 #include <memory>

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/color_classifier.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/color_classifier.hpp
@@ -24,7 +24,11 @@
 
 #include <autoware_auto_perception_msgs/msg/traffic_light.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <vector>
 

--- a/perception/traffic_light_classifier/include/traffic_light_classifier/nodelet.hpp
+++ b/perception/traffic_light_classifier/include/traffic_light_classifier/nodelet.hpp
@@ -29,7 +29,11 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <std_msgs/msg/header.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>

--- a/perception/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
+++ b/perception/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
@@ -44,7 +44,11 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#if __has_include(<image_geometry/pinhole_camera_model.hpp>)
+#include <image_geometry/pinhole_camera_model.hpp>
+#else
 #include <image_geometry/pinhole_camera_model.h>
+#endif
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>

--- a/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
+++ b/perception/traffic_light_ssd_fine_detector/include/traffic_light_ssd_fine_detector/nodelet.hpp
@@ -27,7 +27,11 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>

--- a/perception/traffic_light_visualization/include/traffic_light_roi_visualizer/nodelet.hpp
+++ b/perception/traffic_light_visualization/include/traffic_light_roi_visualizer/nodelet.hpp
@@ -23,7 +23,11 @@
 #include <autoware_auto_perception_msgs/msg/traffic_signal_array.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -19,7 +19,11 @@
 #include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 // #include <sensor_msgs/image_encodings.h>
 // #include <opencv2/highgui/highgui.hpp>
 #include <magic_enum.hpp>

--- a/sensing/image_diagnostics/include/image_diagnostics/image_diagnostics_node.hpp
+++ b/sensing/image_diagnostics/include/image_diagnostics/image_diagnostics_node.hpp
@@ -26,7 +26,11 @@
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
 #include <tier4_debug_msgs/msg/int32_stamped.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <string>
 #include <unordered_map>

--- a/sensing/image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -53,7 +53,11 @@
 
 #include <sensor_msgs/image_encodings.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <limits>
 #include <memory>

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/blockage_diag/blockage_diag_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/blockage_diag/blockage_diag_nodelet.hpp
@@ -27,7 +27,11 @@
 #include <std_msgs/msg/header.hpp>
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <string>
 #include <vector>

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/dual_return_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/dual_return_outlier_filter_nodelet.hpp
@@ -26,7 +26,11 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
 
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/search/pcl_search.h>
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
.h header in image common is deprecated at iron.
I added workaround to avoid deprecated warning when building on iron.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
