### PR TITLE
fix(lane_change): get lane change lanes actual length

### DIFF
--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     lane_change:
-      lane_changing_safety_check_duration: 8.0  # [s]
+      backward_lane_length: 200.0 #[m]
       prepare_duration: 4.0         # [s]
 
       backward_length_buffer_for_end_of_lane: 3.0 # [m]

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -238,9 +238,6 @@ protected:
 
   PathWithLaneId prev_approved_path_{};
 
-  double lane_change_lane_length_{200.0};
-  double check_length_{100.0};
-
   bool is_abort_path_approved_{false};
   bool is_abort_approval_requested_{false};
   bool is_activated_{false};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -28,6 +28,7 @@ namespace behavior_path_planner
 struct LaneChangeParameters
 {
   // trajectory generation
+  double backward_lane_length{200.0};
   double lane_change_finish_judge_buffer{3.0};
   double prediction_time_resolution{0.5};
   int lane_change_sampling_num{10};

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -709,6 +709,7 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   const auto parameter = [](std::string && name) { return "lane_change." + name; };
 
   // trajectory generation
+  p.backward_lane_length = declare_parameter<double>(parameter("backward_lane_length"));
   p.lane_change_finish_judge_buffer =
     declare_parameter<double>(parameter("lane_change_finish_judge_buffer"));
   p.prediction_time_resolution = declare_parameter<double>(parameter("prediction_time_resolution"));


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbbf366</samp>

This pull request updates the lane change scene module to use a new parameter `backward_lane_length` for the lane change planning and safety checks. It also removes some unused variables and parameters and improves the logic to get the target lane and the candidate paths. The parameter is added to the configuration file and the node.

## Related links

[New parameter is needed in the autoware_launch](https://github.com/autowarefoundation/autoware_launch/pull/346)

## Tests performed

1. Test via planning simulator
2. CI (old arch)
3. CI (new arch)

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
