### PR TITLE
fix(lane_change): not remove unsafe candidate in new architecture

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
+set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
+set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
@@ -168,6 +168,8 @@ public:
     const std::string & name, rclcpp::Node & node,
     const std::shared_ptr<LaneChangeParameters> & parameters);
 
+  ModuleStatus updateState() override;
+
 protected:
   void updateRTCStatus(const double start_distance, const double finish_distance) override;
 };

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -73,10 +73,6 @@ bool LaneChangeInterface::isExecutionRequested() const
 
 bool LaneChangeInterface::isExecutionReady() const
 {
-  if (current_state_ == ModuleStatus::RUNNING) {
-    return true;
-  }
-
   LaneChangePath selected_path;
   module_type_->setPreviousModulePaths(
     getPreviousModuleOutput().reference_path, getPreviousModuleOutput().path);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -14,6 +14,7 @@
 
 #include "behavior_path_planner/scene_module/lane_change/interface.hpp"
 
+#include "behavior_path_planner/module_status.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utils/lane_change/utils.hpp"
 #include "behavior_path_planner/utils/path_utils.hpp"
@@ -97,8 +98,11 @@ ModuleStatus LaneChangeInterface::updateState()
   }
 
   if (module_type_->isCancelConditionSatisfied()) {
-    current_state_ =
-      module_type_->isCancelEnabled() ? ModuleStatus::FAILURE : ModuleStatus::RUNNING;
+    if (module_type_->isCancelEnabled()) {
+      current_state_ = isWaitingApproval() ? ModuleStatus::RUNNING : ModuleStatus::FAILURE;
+    } else {
+      current_state_ = ModuleStatus::RUNNING;
+    }
     return current_state_;
   }
 
@@ -472,6 +476,33 @@ LaneChangeBTModule::LaneChangeBTModule(
     name, node, parameters, createRTCInterfaceMap(node, name, {"left", "right"}),
     std::make_unique<NormalLaneChangeBT>(parameters, LaneChangeModuleType::NORMAL, Direction::NONE)}
 {
+}
+
+ModuleStatus LaneChangeBTModule::updateState()
+{
+  if (!module_type_->isValidPath()) {
+    current_state_ = ModuleStatus::FAILURE;
+    return current_state_;
+  }
+
+  if (module_type_->isAbortState()) {
+    current_state_ = ModuleStatus::RUNNING;
+    return current_state_;
+  }
+
+  if (module_type_->isCancelConditionSatisfied()) {
+    current_state_ =
+      module_type_->isCancelEnabled() ? ModuleStatus::FAILURE : ModuleStatus::RUNNING;
+    return current_state_;
+  }
+
+  if (module_type_->hasFinishedLaneChange()) {
+    current_state_ = ModuleStatus::SUCCESS;
+    return current_state_;
+  }
+
+  current_state_ = ModuleStatus::RUNNING;
+  return current_state_;
 }
 
 void LaneChangeBTModule::updateRTCStatus(const double start_distance, const double finish_distance)


### PR DESCRIPTION
## Description

In new architecture, when `current_state_` returns `ModuleStatus::FAILURE`, planner manager delete the module, and it caused lane change candidate path to be removed each time path is unsafe.

This PR aims to improve the state in when using planner_manager. 

## Related links

[TIER IV internal link](https://star4.slack.com/archives/CEV8XMJBV/p1683871399526129?thread_ts=1683848999.981809&cid=CEV8XMJBV)

## Tests performed

Compile with `USE_OLD_ARCHITECTURE FALSE`.
Then test lane change cancel scenario.

https://github.com/autowarefoundation/autoware.universe/assets/93502286/5c06c5eb-6e2e-4a1a-a2bc-9d454bcb2811

## Notes for reviewers

Behavior Tree's updateState is separated for now.

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
