### PR TITLE
test(planning_test_utils): add ASSART_NO_THROW_WITH_ERROR_MSG macro

### DIFF
--- a/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/test/test_behavior_path_planner_node_interface.cpp
@@ -98,11 +98,11 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithBehaviorNominalRoute(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithBehaviorNominalRoute(test_target_node));
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   // test with empty route
-  ASSERT_NO_THROW(test_manager->testWithAbnormalRoute(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithAbnormalRoute(test_target_node));
   rclcpp::shutdown();
 }
 
@@ -115,12 +115,12 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithBehaviorNominalRoute(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithBehaviorNominalRoute(test_target_node));
 
   // make sure behavior_path_planner is running
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
-  ASSERT_NO_THROW(test_manager->testRouteWithInvalidEgoPose(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testRouteWithInvalidEgoPose(test_target_node));
 
   rclcpp::shutdown();
 }

--- a/planning/behavior_velocity_planner/test/src/test_behavior_velocity_planner_node_interface.cpp
+++ b/planning/behavior_velocity_planner/test/src/test_behavior_velocity_planner_node_interface.cpp
@@ -128,11 +128,11 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test with nominal path_with_lane_id
-  ASSERT_NO_THROW(test_manager->testWithNominalPathWithLaneId(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   // test with empty path_with_lane_id
-  ASSERT_NO_THROW(test_manager->testWithAbnormalPathWithLaneId(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithAbnormalPathWithLaneId(test_target_node));
   rclcpp::shutdown();
 }
 
@@ -145,12 +145,12 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithNominalPathWithLaneId(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));
 
   // make sure behavior_path_planner is running
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
-  ASSERT_NO_THROW(test_manager->testOffTrackFromPathWithLaneId(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testOffTrackFromPathWithLaneId(test_target_node));
 
   rclcpp::shutdown();
 }

--- a/planning/freespace_planner/test/test_freespace_planner_node_interface.cpp
+++ b/planning/freespace_planner/test/test_freespace_planner_node_interface.cpp
@@ -68,11 +68,11 @@ TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInpu
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test with normal route
-  ASSERT_NO_THROW(test_manager->testWithBehaviorNominalRoute(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithBehaviorNominalRoute(test_target_node));
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   // test with empty route
-  ASSERT_NO_THROW(test_manager->testWithAbnormalRoute(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithAbnormalRoute(test_target_node));
   rclcpp::shutdown();
 }
 
@@ -85,10 +85,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal route
-  ASSERT_NO_THROW(test_manager->testWithBehaviorNominalRoute(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithBehaviorNominalRoute(test_target_node));
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
-  ASSERT_NO_THROW(test_manager->testRouteWithInvalidEgoPose(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testRouteWithInvalidEgoPose(test_target_node));
 
   rclcpp::shutdown();
 }

--- a/planning/obstacle_avoidance_planner/test/test_obstacle_avoidance_planner_node_interface.cpp
+++ b/planning/obstacle_avoidance_planner/test/test_obstacle_avoidance_planner_node_interface.cpp
@@ -54,12 +54,12 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
   test_manager->setPathInputTopicName("obstacle_avoidance_planner/input/path");
 
   // test with normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithNominalPath(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPath(test_target_node));
 
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   // test with trajectory with empty/one point/overlapping point
-  ASSERT_NO_THROW(test_manager->testWithAbnormalPath(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithAbnormalPath(test_target_node));
 
   rclcpp::shutdown();
 }

--- a/planning/obstacle_cruise_planner/test/test_obstacle_cruise_planner_node_interface.cpp
+++ b/planning/obstacle_cruise_planner/test/test_obstacle_cruise_planner_node_interface.cpp
@@ -75,11 +75,11 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalTrajectory(test_target_node));
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   // test for trajectory with empty/one point/overlapping point
-  ASSERT_NO_THROW(test_manager->testWithAbnormalTrajectory(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithAbnormalTrajectory(test_target_node));
 
   rclcpp::shutdown();
 }
@@ -93,11 +93,11 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalTrajectory(test_target_node));
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   // test for trajectory with empty/one point/overlapping point
-  ASSERT_NO_THROW(test_manager->testTrajectoryWithInvalidEgoPose(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testTrajectoryWithInvalidEgoPose(test_target_node));
 
   rclcpp::shutdown();
 }

--- a/planning/obstacle_stop_planner/test/test_obstacle_stop_planner_node_interface.cpp
+++ b/planning/obstacle_stop_planner/test/test_obstacle_stop_planner_node_interface.cpp
@@ -78,7 +78,7 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalTrajectory(test_target_node));
 
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
@@ -97,11 +97,11 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   publishMandatoryTopics(test_manager, test_target_node);
 
   // test for normal trajectory
-  ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalTrajectory(test_target_node));
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   // test for trajectory with empty/one point/overlapping point
-  ASSERT_NO_THROW(test_manager->testTrajectoryWithInvalidEgoPose(test_target_node));
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testTrajectoryWithInvalidEgoPose(test_target_node));
 
   rclcpp::shutdown();
 }

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
@@ -15,6 +15,21 @@
 #ifndef PLANNING_INTERFACE_TEST_MANAGER__PLANNING_INTERFACE_TEST_MANAGER_HPP_
 #define PLANNING_INTERFACE_TEST_MANAGER__PLANNING_INTERFACE_TEST_MANAGER_HPP_
 
+// since ASSERT_NO_THROW in gtest masks the exception message, redefine it.
+#define ASSERT_NO_THROW_WITH_ERROR_MSG(statement)                                                \
+  try {                                                                                          \
+    statement;                                                                                   \
+    SUCCEED();                                                                                   \
+  } catch (const std::exception & e) {                                                           \
+    FAIL() << "Expected: " << #statement                                                         \
+           << " doesn't throw an exception.\nActual: it throws. Error message: " << e.what()     \
+           << std::endl;                                                                         \
+  } catch (...) {                                                                                \
+    FAIL() << "Expected: " << #statement                                                         \
+           << " doesn't throw an exception.\nActual: it throws. Error message is not available." \
+           << std::endl;                                                                         \
+  }
+
 #include <component_interface_specs/planning.hpp>
 #include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
@@ -41,6 +41,7 @@
 
 #include <boost/optional.hpp>
 
+#include <cxxabi.h>
 #include <lanelet2_io/Io.h>
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>
@@ -358,7 +359,13 @@ void publishToTargetNode(
   typename rclcpp::Publisher<T>::SharedPtr publisher, T data, const int repeat_count = 3)
 {
   if (topic_name.empty()) {
-    throw std::runtime_error(std::string("Topic name for ") + typeid(data).name() + " is empty");
+    int status;
+    char * demangled_name = abi::__cxa_demangle(typeid(data).name(), nullptr, nullptr, &status);
+    if (status == 0) {
+      throw std::runtime_error(std::string("Topic name for ") + demangled_name + " is empty");
+    } else {
+      throw std::runtime_error(std::string("Topic name for ") + typeid(data).name() + " is empty");
+    }
   }
 
   test_utils::setPublisher<T>(test_node, topic_name, publisher);


### PR DESCRIPTION
## Description

since ASSERT_NO_THROW in gtest masks the exception message, I redefine it with error message.

Before

```
3: /home/horibe/workspace/pilot-auto.latest/src/autoware/universe/planning/behavior_velocity_planner/test/src/test_behavior_velocity_planner_node_interface.cpp:169: Failure
3: Expected: test_manager->testOffTrackFromPathWithLaneId(test_target_node) doesn't throw an exception.
3: Actual: it throws. 
```

After

```
3: /home/horibe/workspace/pilot-auto.latest/src/autoware/universe/planning/behavior_velocity_planner/test/src/test_behavior_velocity_planner_node_interface.cpp:153: Failure
3: Failed
3: Expected: test_manager->testOffTrackFromPathWithLaneId(test_target_node) doesn't throw an exception.
3: Actual: it throws. Error message: Topic name for N8nav_msgs3msg9Odometry_ISaIvEEE is empty
```



## Tests performed

run colcon test for planning packages



## Effects on system behavior

None



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
