### PR TITLE
feat(obstacle_avoidance_planner): use proxqp by default

### DIFF
--- a/common/qp_interface/include/qp_interface/osqp_interface.hpp
+++ b/common/qp_interface/include/qp_interface/osqp_interface.hpp
@@ -69,6 +69,8 @@ public:
   void updateEpsRel(const double eps_rel) override;
   void updateVerbose(const bool verbose) override;
 
+  bool isSolved() const override;
+
   // Updates problem parameters while keeping solution in memory.
   //
   // Args:
@@ -98,7 +100,7 @@ public:
   /// \brief Get the number of iteration taken to solve the problem
   inline int64_t getTakenIter() const { return static_cast<int64_t>(m_latest_work_info.iter); }
   /// \brief Get the status message for the latest problem solved
-  inline std::string getStatusMessage() const
+  inline std::string getStatusMessage() const override
   {
     return static_cast<std::string>(m_latest_work_info.status);
   }
@@ -108,8 +110,6 @@ public:
   inline double getObjVal() const { return m_latest_work_info.obj_val; }
   /// \brief Returns flag asserting interface condition (Healthy condition: 0).
   inline int64_t getExitFlag() const { return m_exitflag; }
-
-  void logUnsolvedStatus(const std::string & prefix_message = "") const;
 
   // Setter functions for warm start
   bool setWarmStart(

--- a/common/qp_interface/include/qp_interface/proxqp_interface.hpp
+++ b/common/qp_interface/include/qp_interface/proxqp_interface.hpp
@@ -22,6 +22,7 @@
 
 #include <limits>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace qp
@@ -39,6 +40,9 @@ public:
   void updateEpsAbs(const double eps_abs) override;
   void updateEpsRel(const double eps_rel) override;
   void updateVerbose(const bool verbose) override;
+
+  bool isSolved() const override;
+  std::string getStatusMessage() const override;
 
 private:
   proxsuite::proxqp::Settings<double> m_settings;

--- a/common/qp_interface/include/qp_interface/qp_interface.hpp
+++ b/common/qp_interface/include/qp_interface/qp_interface.hpp
@@ -18,6 +18,7 @@
 #include <Eigen/Core>
 
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace qp
@@ -37,6 +38,10 @@ public:
   virtual void updateEpsAbs([[maybe_unused]] const double eps_abs) = 0;
   virtual void updateEpsRel([[maybe_unused]] const double eps_rel) = 0;
   virtual void updateVerbose([[maybe_unused]] const bool verbose) {}
+
+  void logUnsolvedStatus(const std::string & prefix_message = "") const;
+  virtual bool isSolved() const = 0;
+  virtual std::string getStatusMessage() const = 0;
 
 protected:
   bool m_enable_warm_start;

--- a/common/qp_interface/src/osqp_interface.cpp
+++ b/common/qp_interface/src/osqp_interface.cpp
@@ -16,7 +16,7 @@
 
 #include "qp_interface/osqp_csc_matrix_conv.hpp"
 
-#include <rclcpp/rclcpp.hpp>
+#include <iostream>
 
 namespace qp
 {
@@ -250,25 +250,9 @@ bool OSQPInterface::setDualVariables(const std::vector<double> & dual_variables)
   return true;
 }
 
-void OSQPInterface::logUnsolvedStatus(const std::string & prefix_message) const
+bool OSQPInterface::isSolved() const
 {
-  const int status = getStatus();
-  if (status == 1) {
-    // No need to log since optimization was solved.
-    return;
-  }
-
-  // create message
-  std::string output_message = "";
-  if (prefix_message != "") {
-    output_message = prefix_message + " ";
-  }
-
-  const auto status_message = getStatusMessage();
-  output_message += "Optimization failed due to " + status_message;
-
-  // log with warning
-  RCLCPP_WARN(rclcpp::get_logger("osqp_interface"), output_message.c_str());
+  return static_cast<int>(m_latest_work_info.status_val) == OSQP_SOLVED;
 }
 
 void OSQPInterface::updateP(const Eigen::MatrixXd & P_new)

--- a/common/qp_interface/src/proxqp_interface.cpp
+++ b/common/qp_interface/src/proxqp_interface.cpp
@@ -92,6 +92,14 @@ void ProxQPInterface::updateVerbose(const bool is_verbose)
   m_settings.verbose = is_verbose;
 }
 
+bool ProxQPInterface::isSolved() const
+{
+  if (m_qp_ptr) {
+    return m_qp_ptr->results.info.status == proxsuite::proxqp::QPSolverOutput::PROXQP_SOLVED;
+  }
+  return false;
+}
+
 int ProxQPInterface::getIteration() const
 {
   if (m_qp_ptr) {
@@ -106,6 +114,32 @@ int ProxQPInterface::getStatus() const
     return static_cast<int>(m_qp_ptr->results.info.status);
   }
   return 0;
+}
+
+std::string ProxQPInterface::getStatusMessage() const
+{
+  if (m_qp_ptr) {
+    if (m_qp_ptr->results.info.status == proxsuite::proxqp::QPSolverOutput::PROXQP_SOLVED) {
+      return "PROXQP_SOLVED";
+    }
+    if (
+      m_qp_ptr->results.info.status == proxsuite::proxqp::QPSolverOutput::PROXQP_MAX_ITER_REACHED) {
+      return "PROXQP_MAX_ITER_REACHED";
+    }
+    if (
+      m_qp_ptr->results.info.status ==
+      proxsuite::proxqp::QPSolverOutput::PROXQP_PRIMAL_INFEASIBLE) {
+      return "PROXQP_PRIMAL_INFEASIBLE";
+    }
+    if (
+      m_qp_ptr->results.info.status == proxsuite::proxqp::QPSolverOutput::PROXQP_DUAL_INFEASIBLE) {
+      return "PROXQP_DUAL_INFEASIBLE";
+    }
+    if (m_qp_ptr->results.info.status == proxsuite::proxqp::QPSolverOutput::PROXQP_NOT_RUN) {
+      return "PROXQP_NOT_RUN";
+    }
+  }
+  return "";
 }
 
 std::vector<double> ProxQPInterface::optimizeImpl()

--- a/common/qp_interface/src/qp_interface.cpp
+++ b/common/qp_interface/src/qp_interface.cpp
@@ -14,6 +14,8 @@
 
 #include "qp_interface/qp_interface.hpp"
 
+#include <rclcpp/rclcpp.hpp>
+
 #include <iostream>
 #include <string>
 #include <vector>
@@ -66,5 +68,25 @@ std::vector<double> QPInterface::optimize(
   const auto result = optimizeImpl();
 
   return result;
+}
+
+void QPInterface::logUnsolvedStatus(const std::string & prefix_message) const
+{
+  if (isSolved()) {
+    // No need logging since optimization was solved.
+    return;
+  }
+
+  // create message
+  std::string output_message = "";
+  if (prefix_message != "") {
+    output_message = prefix_message + " ";
+  }
+
+  const auto status_message = getStatusMessage();
+  output_message += "Optimization failed due to " + status_message;
+
+  // log with warning
+  RCLCPP_WARN(rclcpp::get_logger("qp_interface"), output_message.c_str());
 }
 }  // namespace qp

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/eb_path_smoother.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/eb_path_smoother.hpp
@@ -17,12 +17,13 @@
 
 #include "obstacle_avoidance_planner/common_structs.hpp"
 #include "obstacle_avoidance_planner/type_alias.hpp"
-#include "osqp_interface/osqp_interface.hpp"
+#include "qp_interface/qp_interface.hpp"
 
 #include <Eigen/Core>
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -49,6 +50,8 @@ private:
     // qp
     struct QPParam
     {
+      std::string solver;
+      bool enable_warm_start;
       int max_iteration;
       double eps_abs;
       double eps_rel;
@@ -59,7 +62,6 @@ private:
     void onParam(const std::vector<rclcpp::Parameter> & parameters);
 
     // option
-    bool enable_warm_start;
     bool enable_optimization_validation;
 
     // common
@@ -108,7 +110,7 @@ private:
   rclcpp::Publisher<Trajectory>::SharedPtr debug_eb_traj_pub_;
   rclcpp::Publisher<Trajectory>::SharedPtr debug_eb_fixed_traj_pub_;
 
-  std::unique_ptr<autoware::common::osqp::OSQPInterface> osqp_solver_ptr_;
+  std::shared_ptr<qp::QPInterface> qp_interface_ptr_;
   std::shared_ptr<std::vector<TrajectoryPoint>> prev_eb_traj_points_ptr_{nullptr};
 
   std::vector<TrajectoryPoint> insertFixedPoint(
@@ -117,11 +119,9 @@ private:
   std::tuple<std::vector<TrajectoryPoint>, size_t> getPaddedTrajectoryPoints(
     const std::vector<TrajectoryPoint> & traj_points) const;
 
-  void updateConstraint(
+  std::optional<std::vector<double>> optimizeTrajectory(
     const std_msgs::msg::Header & header, const std::vector<TrajectoryPoint> & traj_points,
     const bool is_goal_contained, const int pad_start_idx);
-
-  std::optional<std::vector<double>> optimizeTrajectory();
 
   std::optional<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>
   convertOptimizedPointsToTrajectory(

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -146,8 +146,6 @@ private:
     void onParam(const std::vector<rclcpp::Parameter> & parameters);
 
     // option
-    bool enable_warm_start;
-    bool enable_manual_warm_start;
     bool enable_optimization_validation;
     bool steer_limit_constraint;
     int mpt_visualize_sampling_num;  // for debug
@@ -157,7 +155,10 @@ private:
     int num_points;
 
     // qp
-    std::string qp_solver{"proxqp"};
+    std::string solver;
+    bool enable_warm_start;
+    bool enable_manual_warm_start;
+    double eps_abs;
 
     // kinematics
     double optimization_center_offset;

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -231,8 +231,6 @@ private:
   StateEquationGenerator state_equation_generator_;
   std::shared_ptr<qp::QPInterface> qp_interface_ptr_;
 
-  const double osqp_epsilon_ = 1.0e-3;
-
   // vehicle circles
   std::vector<double> vehicle_circle_longitudinal_offsets_;  // from base_link
   std::vector<double> vehicle_circle_radiuses_;

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -21,7 +21,7 @@
 #include "obstacle_avoidance_planner/common_structs.hpp"
 #include "obstacle_avoidance_planner/state_equation_generator.hpp"
 #include "obstacle_avoidance_planner/type_alias.hpp"
-#include "osqp_interface/osqp_interface.hpp"
+#include "qp_interface/qp_interface.hpp"
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
 
@@ -156,6 +156,9 @@ private:
     double delta_arc_length;
     int num_points;
 
+    // qp
+    std::string qp_solver{"proxqp"};
+
     // kinematics
     double optimization_center_offset;
     double max_steer_rad;
@@ -225,7 +228,7 @@ private:
   MPTParam mpt_param_;
 
   StateEquationGenerator state_equation_generator_;
-  std::unique_ptr<autoware::common::osqp::OSQPInterface> osqp_solver_ptr_;
+  std::shared_ptr<qp::QPInterface> qp_interface_ptr_;
 
   const double osqp_epsilon_ = 1.0e-3;
 

--- a/planning/obstacle_avoidance_planner/package.xml
+++ b/planning/obstacle_avoidance_planner/package.xml
@@ -21,6 +21,7 @@
   <depend>nav_msgs</depend>
   <depend>osqp_interface</depend>
   <depend>planning_test_utils</depend>
+  <depend>qp_interface</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/planning/obstacle_avoidance_planner/package.xml
+++ b/planning/obstacle_avoidance_planner/package.xml
@@ -19,7 +19,6 @@
   <depend>interpolation</depend>
   <depend>motion_utils</depend>
   <depend>nav_msgs</depend>
-  <depend>osqp_interface</depend>
   <depend>planning_test_utils</depend>
   <depend>qp_interface</depend>
   <depend>rclcpp</depend>

--- a/planning/obstacle_avoidance_planner/src/eb_path_smoother.cpp
+++ b/planning/obstacle_avoidance_planner/src/eb_path_smoother.cpp
@@ -14,14 +14,16 @@
 
 #include "obstacle_avoidance_planner/eb_path_smoother.hpp"
 
-// NOTE: Do not include OSQP before ProxQP. It will cause a build error. This is because OSQP
-// defines WARM_START with a macro which ProxQP uses in a enum.
 #include "motion_utils/motion_utils.hpp"
 #include "obstacle_avoidance_planner/type_alias.hpp"
 #include "obstacle_avoidance_planner/utils/geometry_utils.hpp"
 #include "obstacle_avoidance_planner/utils/trajectory_utils.hpp"
-#include "qp_interface/osqp_interface.hpp"
+// clang-format off
+// NOTE: Do not include OSQP before ProxQP. It will cause a build error. This is because OSQP
+// defines WARM_START with a macro which ProxQP uses in a enum.
 #include "qp_interface/proxqp_interface.hpp"
+#include "qp_interface/osqp_interface.hpp"
+// clang-format on
 
 #include <algorithm>
 #include <chrono>


### PR DESCRIPTION
## Description

depends on https://github.com/autowarefoundation/autoware.universe/pull/3699

use ProxQP for obstacle_avoidance_planner's EB and MPT with the qp_interface package.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
No behavior change

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
