### PR TITLE
chore(surround_obstacle_checker): skip pcd transform when pcd is empty

### DIFF
--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -333,6 +333,9 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacle() cons
 
 boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCloud() const
 {
+  if (pointcloud_ptr_->data.empty()) {
+    return boost::none;
+  }
   const auto transform_stamped =
     getTransform("base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
 

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -196,7 +196,7 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
 void SurroundObstacleCheckerNode::onTimer()
 {
   if (!odometry_ptr_) {
-    RCLCPP_WARN_THROTTLE(
+    RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for current velocity...");
     return;
   }
@@ -206,13 +206,13 @@ void SurroundObstacleCheckerNode::onTimer()
   }
 
   if (node_param_.use_pointcloud && !pointcloud_ptr_) {
-    RCLCPP_WARN_THROTTLE(
+    RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for pointcloud info...");
     return;
   }
 
   if (node_param_.use_dynamic_object && !object_ptr_) {
-    RCLCPP_WARN_THROTTLE(
+    RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for dynamic object info...");
     return;
   }


### PR DESCRIPTION
## Description

skip pcd transform when pcd is empty in surround_obstacle_checker.

This PR solves the annoying warning in psim.

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/96ac41bb-0509-4ab2-94d0-7721cebbe41a)


## Tests performed

run psim.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
