### PR TITLE
feat(lane_change): add dynamic lateral acc lc

### DIFF
--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -12,7 +12,8 @@
 
       minimum_lane_changing_velocity: 2.78        # [m/s]
       prediction_time_resolution: 0.5           # [s]
-      lane_change_sampling_num: 3
+      longitudinal_acceleration_sampling_num: 3
+      lateral_acceleration_sampling_num: 3
 
       # lateral acceleration map
       lateral_acceleration:

--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -8,13 +8,17 @@
       lane_change_finish_judge_buffer: 2.0      # [m]
 
       lane_changing_lateral_jerk: 0.5              # [m/s3]
-      lane_changing_lateral_acc: 0.315             # [m/s2]
-      lane_changing_lateral_acc_at_low_velocity: 0.15 # [m/s2]
       lateral_acc_switching_velocity: 4.0          #[m/s]
 
       minimum_lane_changing_velocity: 2.78        # [m/s]
       prediction_time_resolution: 0.5           # [s]
       lane_change_sampling_num: 3
+
+      # lateral acceleration map
+      lateral_acceleration:
+        velocity: [0.0, 4.0, 10.0]
+        min_values: [0.15, 0.15, 0.15]
+        max_values: [0.5, 0.5, 0.5]
 
       # target object
       target_object:

--- a/planning/behavior_path_planner/docs/behavior_path_planner_lane_change_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_lane_change_design.md
@@ -241,7 +241,6 @@ The following parameters are configurable in `lane_change.param.yaml`.
 | `backward_length_buffer_for_end_of_lane` | [m]    | double | The end of lane buffer to ensure ego vehicle has enough distance to start lane change   | 2.0           |
 | `lane_change_finish_judge_buffer`        | [m]    | double | The additional buffer used to confirm lane change process completion                    | 3.0           |
 | `lane_changing_lateral_jerk`             | [m/s3] | double | Lateral jerk value for lane change path generation                                      | 0.5           |
-| `lane_changing_lateral_acc`              | [m/s2] | double | Lateral acceleration value for lane change path generation                              | 0.5           |
 | `minimum_lane_changing_velocity`         | [m/s]  | double | Minimum speed during lane changing process.                                             | 2.78          |
 | `prediction_time_resolution`             | [s]    | double | Time resolution for object's path interpolation and collision check.                    | 0.5           |
 | `lane_change_sampling_num`               | [-]    | int    | Number of possible lane-changing trajectories that are being influenced by deceleration | 10            |

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -99,8 +99,6 @@ struct BehaviorPathPlannerParameters
 
   // lane change parameters
   double lane_changing_lateral_jerk{0.5};
-  double lane_changing_lateral_acc{0.315};
-  double lane_changing_lateral_acc_at_low_velocity{0.15};
   double lateral_acc_switching_velocity{0.4};
   double minimum_lane_changing_velocity{5.6};
   double lane_change_prepare_duration{4.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -15,9 +15,11 @@
 #ifndef BEHAVIOR_PATH_PLANNER__PARAMETERS_HPP_
 #define BEHAVIOR_PATH_PLANNER__PARAMETERS_HPP_
 
+#include <interpolation/linear_interpolation.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 struct ModuleConfigParameters
@@ -27,6 +29,47 @@ struct ModuleConfigParameters
   bool enable_simultaneous_execution_as_candidate_module{false};
   uint8_t priority{0};
   uint8_t max_module_size{0};
+};
+
+struct LateralAccelerationMap
+{
+  std::vector<double> base_vel;
+  std::vector<double> base_min_acc;
+  std::vector<double> base_max_acc;
+
+  void add(const double velocity, const double min_acc, const double max_acc)
+  {
+    if (base_vel.size() != base_min_acc.size() || base_vel.size() != base_max_acc.size()) {
+      return;
+    }
+
+    size_t idx = 0;
+    for (size_t i = 0; i < base_vel.size(); ++i) {
+      if (velocity < base_vel.at(i)) {
+        break;
+      }
+      idx = i + 1;
+    }
+
+    base_vel.insert(base_vel.begin() + idx, velocity);
+    base_min_acc.insert(base_min_acc.begin() + idx, min_acc);
+    base_max_acc.insert(base_max_acc.begin() + idx, max_acc);
+  }
+
+  std::pair<double, double> find(const double velocity) const
+  {
+    if (!base_vel.empty() && velocity < base_vel.front()) {
+      return std::make_pair(base_min_acc.front(), base_max_acc.front());
+    }
+    if (!base_vel.empty() && velocity > base_vel.back()) {
+      return std::make_pair(base_min_acc.back(), base_max_acc.back());
+    }
+
+    const double min_acc = interpolation::lerp(base_vel, base_min_acc, velocity);
+    const double max_acc = interpolation::lerp(base_vel, base_max_acc, velocity);
+
+    return std::make_pair(min_acc, max_acc);
+  }
 };
 
 struct BehaviorPathPlannerParameters
@@ -62,6 +105,7 @@ struct BehaviorPathPlannerParameters
   double minimum_lane_changing_velocity{5.6};
   double lane_change_prepare_duration{4.0};
   double minimum_prepare_length;
+  LateralAccelerationMap lane_change_lat_acc_map;
 
   double minimum_pull_over_length;
   double minimum_pull_out_length;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -15,7 +15,6 @@
 #define BEHAVIOR_PATH_PLANNER__UTILS__LANE_CHANGE__LANE_CHANGE_MODULE_DATA_HPP_
 
 #include "behavior_path_planner/utils/avoidance/avoidance_module_data.hpp"
-#include "interpolation/linear_interpolation.hpp"
 #include "lanelet2_core/geometry/Lanelet.h"
 
 #include "autoware_auto_planning_msgs/msg/path_point_with_lane_id.hpp"
@@ -102,47 +101,6 @@ struct AvoidanceByLCParameters
 
   // execute only when lane change end point is before the object.
   bool execute_only_when_lane_change_finish_before_object{false};
-};
-
-struct LateralAccelerationMap
-{
-  std::vector<double> base_vel;
-  std::vector<double> base_min_acc;
-  std::vector<double> base_max_acc;
-
-  void add(const double velocity, const double min_acc, const double max_acc)
-  {
-    if (base_vel.size() != base_min_acc.size() || base_vel.size() != base_max_acc.size()) {
-      return;
-    }
-
-    size_t idx = 0;
-    for (size_t i = 0; i < base_vel.size(); ++i) {
-      if (velocity < base_vel.at(i)) {
-        break;
-      }
-      idx = i + 1;
-    }
-
-    base_vel.insert(base_vel.begin() + idx, velocity);
-    base_min_acc.insert(base_min_acc.begin() + idx, min_acc);
-    base_max_acc.insert(base_max_acc.begin() + idx, max_acc);
-  }
-
-  std::pair<double, double> find(const double velocity)
-  {
-    if (!base_vel.empty() && velocity < base_vel.front()) {
-      return std::make_pair(base_min_acc.front(), base_max_acc.front());
-    }
-    if (!base_vel.empty() && velocity > base_vel.back()) {
-      return std::make_pair(base_min_acc.back(), base_max_acc.back());
-    }
-
-    const double min_acc = interpolation::lerp(base_vel, base_min_acc, velocity);
-    const double max_acc = interpolation::lerp(base_vel, base_max_acc, velocity);
-
-    return std::make_pair(min_acc, max_acc);
-  }
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -15,12 +15,14 @@
 #define BEHAVIOR_PATH_PLANNER__UTILS__LANE_CHANGE__LANE_CHANGE_MODULE_DATA_HPP_
 
 #include "behavior_path_planner/utils/avoidance/avoidance_module_data.hpp"
+#include "interpolation/linear_interpolation.hpp"
 #include "lanelet2_core/geometry/Lanelet.h"
 
 #include "autoware_auto_planning_msgs/msg/path_point_with_lane_id.hpp"
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace behavior_path_planner
@@ -100,6 +102,47 @@ struct AvoidanceByLCParameters
 
   // execute only when lane change end point is before the object.
   bool execute_only_when_lane_change_finish_before_object{false};
+};
+
+struct LateralAccelerationMap
+{
+  std::vector<double> base_vel;
+  std::vector<double> base_min_acc;
+  std::vector<double> base_max_acc;
+
+  void add(const double velocity, const double min_acc, const double max_acc)
+  {
+    if (base_vel.size() != base_min_acc.size() || base_vel.size() != base_max_acc.size()) {
+      return;
+    }
+
+    size_t idx = 0;
+    for (size_t i = 0; i < base_vel.size(); ++i) {
+      if (velocity < base_vel.at(i)) {
+        break;
+      }
+      idx = i + 1;
+    }
+
+    base_vel.insert(base_vel.begin() + idx, velocity);
+    base_min_acc.insert(base_min_acc.begin() + idx, min_acc);
+    base_max_acc.insert(base_max_acc.begin() + idx, max_acc);
+  }
+
+  std::pair<double, double> find(const double velocity)
+  {
+    if (!base_vel.empty() && velocity < base_vel.front()) {
+      return std::make_pair(base_min_acc.front(), base_max_acc.front());
+    }
+    if (!base_vel.empty() && velocity > base_vel.back()) {
+      return std::make_pair(base_min_acc.back(), base_max_acc.back());
+    }
+
+    const double min_acc = interpolation::lerp(base_vel, base_min_acc, velocity);
+    const double max_acc = interpolation::lerp(base_vel, base_max_acc, velocity);
+
+    return std::make_pair(min_acc, max_acc);
+  }
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -32,7 +32,8 @@ struct LaneChangeParameters
   double backward_lane_length{200.0};
   double lane_change_finish_judge_buffer{3.0};
   double prediction_time_resolution{0.5};
-  int lane_change_sampling_num{10};
+  int longitudinal_acc_sampling_num{10};
+  int lateral_acc_sampling_num{10};
 
   // collision check
   bool enable_prepare_segment_collision_check{true};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -67,15 +67,16 @@ bool isPathInLanelets(
   const lanelet::ConstLanelets & target_lanelets);
 
 double calcLaneChangingLength(
-  const double lane_changing_velocity, const double shift_length,
-  const BehaviorPathPlannerParameters & common_parameter);
+  const double lane_changing_velocity, const double shift_length, const double lateral_acc,
+  const double lateral_jerk);
 
 std::optional<LaneChangePath> constructCandidatePath(
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_segment,
   const PathWithLaneId & target_lane_reference_path, const ShiftLine & shift_line,
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
-  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double acceleration,
-  const LaneChangePhaseInfo lane_change_length, const LaneChangePhaseInfo lane_change_velocity,
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double longitudinal_acceleration,
+  const double lateral_acceleration, const LaneChangePhaseInfo lane_change_length,
+  const LaneChangePhaseInfo lane_change_velocity,
   const BehaviorPathPlannerParameters & common_parameter,
   const LaneChangeParameters & lane_change_param);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -372,10 +372,6 @@ boost::optional<std::pair<Pose, Polygon2d>> getEgoExpectedPoseAndConvertToPolygo
 
 bool checkPathRelativeAngle(const PathWithLaneId & path, const double angle_threshold);
 
-double calcLaneChangingTime(
-  const double lane_changing_velocity, const double shift_length,
-  const BehaviorPathPlannerParameters & common_parameter);
-
 double calcMinimumLaneChangeLength(
   const BehaviorPathPlannerParameters & common_param, const std::vector<double> & shift_intervals,
   const double length_to_intersection = 0.0);

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -728,7 +728,10 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.lane_change_finish_judge_buffer =
     declare_parameter<double>(parameter("lane_change_finish_judge_buffer"));
   p.prediction_time_resolution = declare_parameter<double>(parameter("prediction_time_resolution"));
-  p.lane_change_sampling_num = declare_parameter<int>(parameter("lane_change_sampling_num"));
+  p.longitudinal_acc_sampling_num =
+    declare_parameter<int>(parameter("longitudinal_acceleration_sampling_num"));
+  p.lateral_acc_sampling_num =
+    declare_parameter<int>(parameter("lateral_acceleration_sampling_num"));
 
   // collision check
   p.enable_prepare_segment_collision_check =
@@ -764,11 +767,13 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.publish_debug_marker = declare_parameter<bool>(parameter("publish_debug_marker"));
 
   // validation of parameters
-  if (p.lane_change_sampling_num < 1) {
+  if (p.longitudinal_acc_sampling_num < 1 || p.lateral_acc_sampling_num) {
     RCLCPP_FATAL_STREAM(
-      get_logger(), "lane_change_sampling_num must be positive integer. Given parameter: "
-                      << p.lane_change_sampling_num << std::endl
-                      << "Terminating the program...");
+      get_logger(),
+      "lane_change_sampling_num must be positive integer. Given longitudinal parameter: "
+        << p.longitudinal_acc_sampling_num
+        << "Given lateral parameter: " << p.lateral_acc_sampling_num << std::endl
+        << "Terminating the program...");
     exit(EXIT_FAILURE);
   }
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -417,7 +417,7 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   if (
     lateral_acc_velocity.size() != min_lateral_acc.size() ||
     lateral_acc_velocity.size() != max_lateral_acc.size()) {
-    RCLCPP_ERROR(get_logger(), "Lane Change lateral acceleration map has invalid size.");
+    RCLCPP_ERROR(get_logger(), "Lane change lateral acceleration map has invalid size.");
     exit(EXIT_FAILURE);
   }
   for (size_t i = 0; i < lateral_acc_velocity.size(); ++i) {

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -767,7 +767,7 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.publish_debug_marker = declare_parameter<bool>(parameter("publish_debug_marker"));
 
   // validation of parameters
-  if (p.longitudinal_acc_sampling_num < 1 || p.lateral_acc_sampling_num) {
+  if (p.longitudinal_acc_sampling_num < 1 || p.lateral_acc_sampling_num < 1) {
     RCLCPP_FATAL_STREAM(
       get_logger(),
       "lane_change_sampling_num must be positive integer. Given longitudinal parameter: "

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -410,6 +410,14 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.minimum_prepare_length =
     0.5 * p.max_acc * p.lane_change_prepare_duration * p.lane_change_prepare_duration;
 
+  // lateral acceleration map for lane change
+  p.lane_change_lat_acc_map.add(0.0, 0.2, 0.315);
+  p.lane_change_lat_acc_map.add(3.0, 0.2, 0.315);
+  p.lane_change_lat_acc_map.add(5.0, 0.2, 0.315);
+  p.lane_change_lat_acc_map.add(6.0, 0.315, 0.4);
+  p.lane_change_lat_acc_map.add(7.0, 0.315, 0.45);
+  p.lane_change_lat_acc_map.add(10.0, 0.315, 0.50);
+
   p.backward_length_buffer_for_end_of_pull_over =
     declare_parameter<double>("backward_length_buffer_for_end_of_pull_over");
   p.backward_length_buffer_for_end_of_pull_out =

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -831,7 +831,9 @@ bool NormalLaneChange::getAbortPath()
   const auto lateral_jerk = behavior_path_planner::PathShifter::calcJerkFromLatLonDistance(
     shift_line.end_shift_length, abort_start_dist, current_velocity);
   path_shifter.setVelocity(current_velocity);
-  path_shifter.setLateralAccelerationLimit(common_param.lane_changing_lateral_acc);
+  const auto lateral_acc_range = common_param.lane_change_lat_acc_map.find(current_velocity);
+  const double & max_lateral_acc = lateral_acc_range.second;
+  path_shifter.setLateralAccelerationLimit(max_lateral_acc);
 
   if (lateral_jerk > lane_change_parameters_->abort_max_lateral_jerk) {
     RCLCPP_ERROR_STREAM(

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -325,7 +325,7 @@ bool NormalLaneChange::getLaneChangePaths(
   // get velocity
   const auto current_velocity = getEgoTwist().linear.x;
 
-  // compute maximum_deceleration
+  // compute maximum longitudinal deceleration
   const auto maximum_deceleration =
     std::invoke([&minimum_lane_changing_velocity, &current_velocity, &common_parameter, this]() {
       const double min_a = (minimum_lane_changing_velocity - current_velocity) /
@@ -334,7 +334,8 @@ bool NormalLaneChange::getLaneChangePaths(
         min_a, -std::abs(common_parameter.min_acc), -std::numeric_limits<double>::epsilon());
     });
 
-  const auto acceleration_resolution = std::abs(maximum_deceleration) / lane_change_sampling_num;
+  const auto longitudinal_acc_resolution =
+    std::abs(maximum_deceleration) / lane_change_sampling_num;
 
   const auto target_length =
     utils::getArcLengthToTargetLanelet(original_lanelets, target_lanelets.front(), getEgoPose());
@@ -364,17 +365,18 @@ bool NormalLaneChange::getLaneChangePaths(
   LaneChangeTargetObjectIndices dynamic_object_indices;
 
   candidate_paths->reserve(lane_change_sampling_num);
-  for (double sampled_acc = 0.0; sampled_acc >= maximum_deceleration;
-       sampled_acc -= acceleration_resolution) {
-    const auto prepare_velocity =
-      std::max(current_velocity + sampled_acc * prepare_duration, minimum_lane_changing_velocity);
+  for (double sampled_longitudinal_acc = 0.0; sampled_longitudinal_acc >= maximum_deceleration;
+       sampled_longitudinal_acc -= longitudinal_acc_resolution) {
+    const auto prepare_velocity = std::max(
+      current_velocity + sampled_longitudinal_acc * prepare_duration,
+      minimum_lane_changing_velocity);
 
-    // compute actual acceleration
-    const double acceleration = (prepare_velocity - current_velocity) / prepare_duration;
+    // compute actual longitudinal acceleration
+    const double longitudinal_acc = (prepare_velocity - current_velocity) / prepare_duration;
 
     // get path on original lanes
     const double prepare_length = std::max(
-      current_velocity * prepare_duration + 0.5 * acceleration * std::pow(prepare_duration, 2),
+      current_velocity * prepare_duration + 0.5 * longitudinal_acc * std::pow(prepare_duration, 2),
       minimum_prepare_length);
 
     if (prepare_length < target_length) {
@@ -415,107 +417,116 @@ bool NormalLaneChange::getLaneChangePaths(
 
     // we assume constant velocity during lane change
     const auto lane_changing_velocity = prepare_velocity;
-    const auto lane_changing_length = utils::lane_change::calcLaneChangingLength(
-      lane_changing_velocity, shift_length, common_parameter);
 
-    if (lane_changing_length + prepare_length > dist_to_end_of_current_lanes) {
-      RCLCPP_DEBUG(
-        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-        "lane changing path too long");
-      continue;
-    }
+    // get lateral acceleration range
+    const auto [min_lateral_acc, max_lateral_acc] =
+      common_parameter.lane_change_lat_acc_map.find(lane_changing_velocity);
 
-    if (is_goal_in_route) {
-      const double s_start =
-        lanelet::utils::getArcCoordinates(target_lanelets, lane_changing_start_pose).length;
-      const double s_goal =
-        lanelet::utils::getArcCoordinates(target_lanelets, route_handler.getGoalPose()).length;
-      if (
-        s_start + lane_changing_length + lane_change_parameters_->lane_change_finish_judge_buffer +
-          next_lane_change_buffer >
-        s_goal) {
+    for (double lateral_acc = min_lateral_acc; lateral_acc <= max_lateral_acc;
+         lateral_acc += 0.05) {
+      const auto lane_changing_length = utils::lane_change::calcLaneChangingLength(
+        lane_changing_velocity, shift_length, lateral_acc,
+        common_parameter.lane_changing_lateral_jerk);
+
+      if (lane_changing_length + prepare_length > dist_to_end_of_current_lanes) {
         RCLCPP_DEBUG(
           rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-          "length of lane changing path is longer than length to goal!!");
+          "lane changing path too long");
         continue;
       }
-    }
 
-    const auto target_segment = utils::lane_change::getTargetSegment(
-      route_handler, target_lanelets, forward_path_length, lane_changing_start_pose,
-      target_lane_length, lane_changing_length, lane_changing_velocity, next_lane_change_buffer);
+      if (is_goal_in_route) {
+        const double s_start =
+          lanelet::utils::getArcCoordinates(target_lanelets, lane_changing_start_pose).length;
+        const double s_goal =
+          lanelet::utils::getArcCoordinates(target_lanelets, route_handler.getGoalPose()).length;
+        if (
+          s_start + lane_changing_length +
+            lane_change_parameters_->lane_change_finish_judge_buffer + next_lane_change_buffer >
+          s_goal) {
+          RCLCPP_DEBUG(
+            rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+            "length of lane changing path is longer than length to goal!!");
+          continue;
+        }
+      }
 
-    if (target_segment.points.empty()) {
-      RCLCPP_DEBUG(
-        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-        "target segment is empty!! something wrong...");
-      continue;
-    }
+      const auto target_segment = utils::lane_change::getTargetSegment(
+        route_handler, target_lanelets, forward_path_length, lane_changing_start_pose,
+        target_lane_length, lane_changing_length, lane_changing_velocity, next_lane_change_buffer);
 
-    const auto resample_interval = utils::lane_change::calcLaneChangeResampleInterval(
-      lane_changing_length, lane_changing_velocity);
+      if (target_segment.points.empty()) {
+        RCLCPP_DEBUG(
+          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+          "target segment is empty!! something wrong...");
+        continue;
+      }
 
-    const auto lc_length = LaneChangePhaseInfo{prepare_length, lane_changing_length};
-    const auto target_lane_reference_path = utils::lane_change::getReferencePathFromTargetLane(
-      route_handler, target_lanelets, lane_changing_start_pose, target_lane_length,
-      lc_length.lane_changing, forward_path_length, resample_interval, is_goal_in_route,
-      next_lane_change_buffer);
+      const auto resample_interval = utils::lane_change::calcLaneChangeResampleInterval(
+        lane_changing_length, lane_changing_velocity);
 
-    if (target_lane_reference_path.points.empty()) {
-      RCLCPP_DEBUG(
-        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-        "target_lane_reference_path is empty!!");
-      continue;
-    }
+      const auto lc_length = LaneChangePhaseInfo{prepare_length, lane_changing_length};
+      const auto target_lane_reference_path = utils::lane_change::getReferencePathFromTargetLane(
+        route_handler, target_lanelets, lane_changing_start_pose, target_lane_length,
+        lc_length.lane_changing, forward_path_length, resample_interval, is_goal_in_route,
+        next_lane_change_buffer);
 
-    const auto shift_line = utils::lane_change::getLaneChangingShiftLine(
-      prepare_segment, target_segment, target_lane_reference_path, shift_length);
+      if (target_lane_reference_path.points.empty()) {
+        RCLCPP_DEBUG(
+          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+          "target_lane_reference_path is empty!!");
+        continue;
+      }
 
-    const auto lc_velocity = LaneChangePhaseInfo{prepare_velocity, lane_changing_velocity};
+      const auto shift_line = utils::lane_change::getLaneChangingShiftLine(
+        prepare_segment, target_segment, target_lane_reference_path, shift_length);
 
-    const auto candidate_path = utils::lane_change::constructCandidatePath(
-      prepare_segment, target_segment, target_lane_reference_path, shift_line, original_lanelets,
-      target_lanelets, sorted_lane_ids, acceleration, lc_length, lc_velocity, common_parameter,
-      *lane_change_parameters_);
+      const auto lc_velocity = LaneChangePhaseInfo{prepare_velocity, lane_changing_velocity};
 
-    if (!candidate_path) {
-      RCLCPP_DEBUG(
-        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-        "no candidate path!!");
-      continue;
-    }
+      const auto candidate_path = utils::lane_change::constructCandidatePath(
+        prepare_segment, target_segment, target_lane_reference_path, shift_line, original_lanelets,
+        target_lanelets, sorted_lane_ids, longitudinal_acc, lateral_acc, lc_length, lc_velocity,
+        common_parameter, *lane_change_parameters_);
 
-    const auto is_valid = utils::lane_change::hasEnoughLength(
-      *candidate_path, original_lanelets, target_lanelets, getEgoPose(), route_handler,
-      minimum_lane_changing_velocity, common_parameter, direction);
+      if (!candidate_path) {
+        RCLCPP_DEBUG(
+          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+          "no candidate path!!");
+        continue;
+      }
 
-    if (!is_valid) {
-      RCLCPP_DEBUG(
-        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-        "invalid candidate path!!");
-      continue;
-    }
+      const auto is_valid = utils::lane_change::hasEnoughLength(
+        *candidate_path, original_lanelets, target_lanelets, getEgoPose(), route_handler,
+        minimum_lane_changing_velocity, common_parameter, direction);
 
-    if (candidate_paths->empty()) {
-      // only compute dynamic object indices once
-      const auto backward_target_lanes_for_object_filtering =
-        utils::lane_change::getBackwardLanelets(
-          route_handler, target_lanelets, getEgoPose(), check_length_);
-      dynamic_object_indices = utils::lane_change::filterObjectIndices(
-        {*candidate_path}, *dynamic_objects, backward_target_lanes_for_object_filtering,
-        getEgoPose(), common_parameter.forward_path_length, *lane_change_parameters_,
-        lateral_buffer);
-    }
-    candidate_paths->push_back(*candidate_path);
+      if (!is_valid) {
+        RCLCPP_DEBUG(
+          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
+          "invalid candidate path!!");
+        continue;
+      }
 
-    const auto is_safe = utils::lane_change::isLaneChangePathSafe(
-      *candidate_path, dynamic_objects, dynamic_object_indices, getEgoPose(), getEgoTwist(),
-      common_parameter, *lane_change_parameters_, common_parameter.expected_front_deceleration,
-      common_parameter.expected_rear_deceleration, ego_pose_before_collision, object_debug_,
-      acceleration);
+      if (candidate_paths->empty()) {
+        // only compute dynamic object indices once
+        const auto backward_target_lanes_for_object_filtering =
+          utils::lane_change::getBackwardLanelets(
+            route_handler, target_lanelets, getEgoPose(), check_length_);
+        dynamic_object_indices = utils::lane_change::filterObjectIndices(
+          {*candidate_path}, *dynamic_objects, backward_target_lanes_for_object_filtering,
+          getEgoPose(), common_parameter.forward_path_length, *lane_change_parameters_,
+          lateral_buffer);
+      }
+      candidate_paths->push_back(*candidate_path);
 
-    if (is_safe) {
-      return true;
+      const auto is_safe = utils::lane_change::isLaneChangePathSafe(
+        *candidate_path, dynamic_objects, dynamic_object_indices, getEgoPose(), getEgoTwist(),
+        common_parameter, *lane_change_parameters_, common_parameter.expected_front_deceleration,
+        common_parameter.expected_rear_deceleration, ego_pose_before_collision, object_debug_,
+        longitudinal_acc);
+
+      if (is_safe) {
+        return true;
+      }
     }
   }
 

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -100,8 +100,9 @@ std::optional<LaneChangePath> constructCandidatePath(
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_segment,
   const PathWithLaneId & target_lane_reference_path, const ShiftLine & shift_line,
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
-  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double acceleration,
-  const LaneChangePhaseInfo lane_change_length, const LaneChangePhaseInfo lane_change_velocity,
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double longitudinal_acceleration,
+  const double lateral_acceleration, const LaneChangePhaseInfo lane_change_length,
+  const LaneChangePhaseInfo lane_change_velocity,
   const BehaviorPathPlannerParameters & common_parameter,
   const LaneChangeParameters & lane_change_param)
 {
@@ -114,12 +115,8 @@ std::optional<LaneChangePath> constructCandidatePath(
   bool offset_back = false;
 
   const auto lane_changing_velocity = lane_change_velocity.lane_changing;
-  const auto lateral_acc = lane_changing_velocity < common_parameter.lateral_acc_switching_velocity
-                             ? common_parameter.lane_changing_lateral_acc_at_low_velocity
-                             : common_parameter.lane_changing_lateral_acc;
-
   path_shifter.setVelocity(lane_changing_velocity);
-  path_shifter.setLateralAccelerationLimit(std::abs(lateral_acc));
+  path_shifter.setLateralAccelerationLimit(std::abs(lateral_acceleration));
 
   if (!path_shifter.generate(&shifted_path, offset_back)) {
     RCLCPP_DEBUG(
@@ -131,7 +128,7 @@ std::optional<LaneChangePath> constructCandidatePath(
   const auto & lane_changing_length = lane_change_length.lane_changing;
 
   LaneChangePath candidate_path;
-  candidate_path.acceleration = acceleration;
+  candidate_path.acceleration = longitudinal_acceleration;
   candidate_path.length.prepare = prepare_length;
   candidate_path.length.lane_changing = lane_changing_length;
   candidate_path.duration.prepare = std::invoke([&]() {
@@ -206,13 +203,16 @@ bool hasEnoughLength(
   const BehaviorPathPlannerParameters & common_parameter, const Direction direction)
 {
   const double lane_change_length = path.length.sum();
+  const double & lateral_jerk = common_parameter.lane_changing_lateral_jerk;
+  const double max_lat_acc =
+    common_parameter.lane_change_lat_acc_map.find(minimum_lane_changing_velocity).second;
   const auto shift_intervals =
     route_handler.getLateralIntervalsToPreferredLane(target_lanes.back(), direction);
 
   double minimum_lane_change_length_to_preferred_lane = 0.0;
   for (const auto & shift_length : shift_intervals) {
     const auto lane_changing_time =
-      utils::calcLaneChangingTime(minimum_lane_changing_velocity, shift_length, common_parameter);
+      PathShifter::calcShiftTimeFromJerk(shift_length, lateral_jerk, max_lat_acc);
     minimum_lane_change_length_to_preferred_lane +=
       minimum_lane_changing_velocity * lane_changing_time + common_parameter.minimum_prepare_length;
   }
@@ -418,11 +418,11 @@ PathWithLaneId getPrepareSegment(
 }
 
 double calcLaneChangingLength(
-  const double lane_changing_velocity, const double shift_length,
-  const BehaviorPathPlannerParameters & common_parameter)
+  const double lane_changing_velocity, const double shift_length, const double lateral_acc,
+  const double lateral_jerk)
 {
   const auto required_time =
-    utils::calcLaneChangingTime(lane_changing_velocity, shift_length, common_parameter);
+    PathShifter::calcShiftTimeFromJerk(shift_length, lateral_jerk, lateral_acc);
   const auto lane_changing_length = lane_changing_velocity * required_time;
 
   RCLCPP_DEBUG(

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2640,18 +2640,6 @@ bool checkPathRelativeAngle(const PathWithLaneId & path, const double angle_thre
   return true;
 }
 
-double calcLaneChangingTime(
-  const double lane_changing_velocity, const double shift_length,
-  const BehaviorPathPlannerParameters & common_parameter)
-{
-  const double lateral_acc =
-    lane_changing_velocity < common_parameter.lateral_acc_switching_velocity
-      ? common_parameter.lane_changing_lateral_acc_at_low_velocity
-      : common_parameter.lane_changing_lateral_acc;
-  const double & lateral_jerk = common_parameter.lane_changing_lateral_jerk;
-  return PathShifter::calcShiftTimeFromJerk(shift_length, lateral_jerk, lateral_acc);
-}
-
 double calcMinimumLaneChangeLength(
   const BehaviorPathPlannerParameters & common_param, const std::vector<double> & shift_intervals,
   const double length_to_intersection)
@@ -2661,11 +2649,15 @@ double calcMinimumLaneChangeLength(
   }
 
   const double & vel = common_param.minimum_lane_changing_velocity;
+  const auto lat_acc = common_param.lane_change_lat_acc_map.find(vel);
+  const double & max_lateral_acc = lat_acc.second;
+  const double & lateral_jerk = common_param.lane_changing_lateral_jerk;
 
   double accumulated_length =
     length_to_intersection + common_param.backward_length_buffer_for_end_of_lane;
   for (const auto & shift_interval : shift_intervals) {
-    const double t = calcLaneChangingTime(vel, shift_interval, common_param);
+    const double t =
+      PathShifter::calcShiftTimeFromJerk(shift_interval, lateral_jerk, max_lateral_acc);
     accumulated_length += vel * t + common_param.minimum_prepare_length;
   }
 

--- a/planning/behavior_path_planner/test/test_lane_change_utils.cpp
+++ b/planning/behavior_path_planner/test/test_lane_change_utils.cpp
@@ -37,10 +37,8 @@ TEST(BehaviorPathPlanningLaneChangeUtilsTest, projectCurrentPoseToTarget)
   EXPECT_NEAR(result.position.y, 3, epsilon);
 }
 
-TEST(BehaviorPathPlanningLaneChangeUtilsTest, LateralAccelerationMap)
+TEST(BehaviorPathPlanningLaneChangeUtilsTest, TESTLateralAccelerationMap)
 {
-  using behavior_path_planner::LateralAccelerationMap;
-
   LateralAccelerationMap lat_acc_map;
   lat_acc_map.add(0.0, 0.2, 0.315);
   lat_acc_map.add(3.0, 0.2, 0.315);

--- a/planning/behavior_path_planner/test/test_lane_change_utils.cpp
+++ b/planning/behavior_path_planner/test/test_lane_change_utils.cpp
@@ -36,3 +36,75 @@ TEST(BehaviorPathPlanningLaneChangeUtilsTest, projectCurrentPoseToTarget)
   EXPECT_NEAR(result.position.x, -4, epsilon);
   EXPECT_NEAR(result.position.y, 3, epsilon);
 }
+
+TEST(BehaviorPathPlanningLaneChangeUtilsTest, LateralAccelerationMap)
+{
+  using behavior_path_planner::LateralAccelerationMap;
+
+  LateralAccelerationMap lat_acc_map;
+  lat_acc_map.add(0.0, 0.2, 0.315);
+  lat_acc_map.add(3.0, 0.2, 0.315);
+  lat_acc_map.add(5.0, 0.2, 0.315);
+  lat_acc_map.add(6.0, 0.315, 0.40);
+  lat_acc_map.add(10.0, 0.315, 0.50);
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(-1.0);
+    EXPECT_NEAR(min_acc, 0.2, epsilon);
+    EXPECT_NEAR(max_acc, 0.315, epsilon);
+  }
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(0.0);
+    EXPECT_NEAR(min_acc, 0.2, epsilon);
+    EXPECT_NEAR(max_acc, 0.315, epsilon);
+  }
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(1.0);
+    EXPECT_NEAR(min_acc, 0.2, epsilon);
+    EXPECT_NEAR(max_acc, 0.315, epsilon);
+  }
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(3.0);
+    EXPECT_NEAR(min_acc, 0.2, epsilon);
+    EXPECT_NEAR(max_acc, 0.315, epsilon);
+  }
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(5.0);
+    EXPECT_NEAR(min_acc, 0.2, epsilon);
+    EXPECT_NEAR(max_acc, 0.315, epsilon);
+  }
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(5.5);
+    EXPECT_NEAR(min_acc, 0.2575, epsilon);
+    EXPECT_NEAR(max_acc, 0.3575, epsilon);
+  }
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(6.0);
+    EXPECT_NEAR(min_acc, 0.315, epsilon);
+    EXPECT_NEAR(max_acc, 0.4, epsilon);
+  }
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(8.0);
+    EXPECT_NEAR(min_acc, 0.315, epsilon);
+    EXPECT_NEAR(max_acc, 0.45, epsilon);
+  }
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(10.0);
+    EXPECT_NEAR(min_acc, 0.315, epsilon);
+    EXPECT_NEAR(max_acc, 0.50, epsilon);
+  }
+
+  {
+    const auto [min_acc, max_acc] = lat_acc_map.find(11.0);
+    EXPECT_NEAR(min_acc, 0.315, epsilon);
+    EXPECT_NEAR(max_acc, 0.50, epsilon);
+  }
+}


### PR DESCRIPTION
## Description
Currently, lane change can only use a single lateral acceleration value to calculate the length of lane change length. However, we can handle many more scenarios by extending the lateral acceleration values, we add a lateral acceleration map for the lane change module. This enables the lane change module to dynamically change its lateral acceleration depending on ego vehicle velocity.

[Launch PR](https://github.com/autowarefoundation/autoware_launch/pull/352)
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Unit Tests

Scenario Test 1301/1350
[TIER IV Internal Link](https://evaluation.tier4.jp/evaluation/reports/53a42baf-34ac-5ed1-b30f-d4e930486989?project_id=prd_jt)
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
There is no interface change caused by this PR.
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
Lateral acceleration of the lane change module will be changed based on the situation. For example, if the lane change module perform lane change in a short lane, the lateral acceleration value will be increasing.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
