### PR TITLE
fix(behavior_path_planner): extract backward obstacles correctly

### DIFF
--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -190,6 +190,7 @@ std::vector<PolygonPoint> generatePolygonInsideBounds(
   }
 
   std::vector<PolygonPoint> inside_poly;
+  bool has_intersection = false;  // NOTE: between obstacle polygon and bound
   for (int i = 0; i < static_cast<int>(full_polygon.size()); ++i) {
     const auto & curr_poly = full_polygon.at(i);
     const auto & prev_poly = full_polygon.at(i == 0 ? full_polygon.size() - 1 : i - 1);
@@ -214,6 +215,7 @@ std::vector<PolygonPoint> generatePolygonInsideBounds(
       bound, intersection->first, intersection->second);
     const auto intersect_point =
       PolygonPoint{intersection->second, intersection->first, lon_dist, 0.0};
+    has_intersection = true;
 
     if (is_prev_outside && !is_curr_outside) {
       inside_poly.push_back(intersect_point);
@@ -226,7 +228,10 @@ std::vector<PolygonPoint> generatePolygonInsideBounds(
     continue;
   }
 
-  return inside_poly;
+  if (has_intersection) {
+    return inside_poly;
+  }
+  return std::vector<PolygonPoint>{};
 }
 
 std::vector<geometry_msgs::msg::Point> convertToGeometryPoints(


### PR DESCRIPTION
## Description

Backward obstacle extraction from the drivable area is wrong in a case with a specific map.

without this PR
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/dec1b357-74c5-4518-936f-ef6ddb8ab19e)

with this PR
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/77cf714a-fda3-489f-9c07-daf01dc976aa)

![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/1c6a80a1-1125-4d75-b809-6189f3aa25b2)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No behavior change

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
