### PR TITLE
fix(geometric_parallel_parking): add check for empty path

### DIFF
--- a/planning/behavior_path_planner/src/utils/geometric_parallel_parking/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/src/utils/geometric_parallel_parking/geometric_parallel_parking.cpp
@@ -352,7 +352,9 @@ PathWithLaneId GeometricParallelParking::generateStraightPath(const Pose & start
   auto path = planner_data_->route_handler->getCenterLinePath(
     current_lanes, current_arc_position.length, start_arc_position.length, true);
   path.header = planner_data_->route_handler->getRouteHeader();
-  path.points.back().point.longitudinal_velocity_mps = 0;
+  if (!path.points.empty()) {
+    path.points.back().point.longitudinal_velocity_mps = 0;
+  }
 
   return path;
 }


### PR DESCRIPTION
## Description

Fix for the process die due to the empty path.

## Tests performed

run psim


## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
