### PR TITLE
feat(planner_manager): output module status

### DIFF
--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -18,6 +18,7 @@
 #include "behavior_path_planner/utils/utils.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
+#include <magic_enum.hpp>
 
 #include <boost/format.hpp>
 
@@ -640,20 +641,7 @@ void PlannerManager::print() const
   }
 
   const auto get_status = [](const auto & m) {
-    const auto status = m->getCurrentStatus();
-    if (status == ModuleStatus::RUNNING) {
-      return "RUNNING";
-    }
-
-    if (status == ModuleStatus::FAILURE) {
-      return "FAILURE";
-    }
-
-    if (status == ModuleStatus::SUCCESS) {
-      return "SUCCESS";
-    }
-
-    return "NONE";
+    return magic_enum::enum_name(m->getCurrentStatus());
   };
 
   size_t max_string_num = 0;

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -639,6 +639,23 @@ void PlannerManager::print() const
     return;
   }
 
+  const auto get_status = [](const auto & m) {
+    const auto status = m->getCurrentStatus();
+    if (status == ModuleStatus::RUNNING) {
+      return "RUNNING";
+    }
+
+    if (status == ModuleStatus::FAILURE) {
+      return "FAILURE";
+    }
+
+    if (status == ModuleStatus::SUCCESS) {
+      return "SUCCESS";
+    }
+
+    return "NONE";
+  };
+
   size_t max_string_num = 0;
 
   std::ostringstream string_stream;
@@ -655,13 +672,15 @@ void PlannerManager::print() const
   string_stream << "\n";
   string_stream << "approved modules  : ";
   for (const auto & m : approved_module_ptrs_) {
-    string_stream << "[" << m->name() << "]->";
+    string_stream << "[" << m->name() << "(" << get_status(m) << ")"
+                  << "]->";
   }
 
   string_stream << "\n";
   string_stream << "candidate module  : ";
   for (const auto & m : candidate_module_ptrs_) {
-    string_stream << "[" << m->name() << "]->";
+    string_stream << "[" << m->name() << "(" << get_status(m) << ")"
+                  << "]->";
   }
 
   string_stream << "\n" << std::fixed << std::setprecision(1);


### PR DESCRIPTION
## Description

```
[component_container_mt-27] [INFO] [1684297570.183024344] [planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.planner_manager]: 
[component_container_mt-27] ***********************************************************
[component_container_mt-27]                   planner manager status              
[component_container_mt-27] -----------------------------------------------------------
[component_container_mt-27] registered modules: [pull_out][goal_planner][side_shift][lane_change_left][lane_change_right][avoidance][avoidance_by_lane_change]
[component_container_mt-27] approved modules  : [avoidance(RUNNING)]->[lane_change_right(RUNNING)]->
[component_container_mt-27] candidate module  :                                                         
[component_container_mt-27] processing time   : [avoidance_by_lane_change : 1.2ms]
[component_container_mt-27]                     [avoidance                : 2.6ms]
[component_container_mt-27]                     [lane_change_left         : 0.1ms]
[component_container_mt-27]                     [side_shift               : 0.6ms]                                                                                                                              
[component_container_mt-27]                     [goal_planner             : 0.4ms]     
[component_container_mt-27]                     [lane_change_right        : 3.3ms]
[component_container_mt-27]                     [pull_out                 : 0.0ms]     
[component_container_mt-27]                     [total_time               : 8.7ms]   
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
