### PR TITLE
feat(dummy_perception_publisher): publish ground truth object in option

### DIFF
--- a/simulator/dummy_perception_publisher/README.md
+++ b/simulator/dummy_perception_publisher/README.md
@@ -17,11 +17,11 @@ This node publishes the result of the dummy detection with the type of perceptio
 
 ### Output
 
-| Name                          | Type                                                     | Description                     |
-| ----------------------------- | -------------------------------------------------------- | ------------------------------- |
-| `output/dynamic_object`       | `tier4_perception_msgs::msg::DetectedObjectsWithFeature` | dummy detection objects         |
-| `output/points_raw`           | `sensor_msgs::msg::PointCloud2`                          | point cloud of objects          |
-| `output/ground_truth_objects` | `autoware_auto_perception_msgs::msg::TrackedObjects`     | ground truth objects (optional) |
+| Name                                | Type                                                     | Description             |
+| ----------------------------------- | -------------------------------------------------------- | ----------------------- |
+| `output/dynamic_object`             | `tier4_perception_msgs::msg::DetectedObjectsWithFeature` | dummy detection objects |
+| `output/points_raw`                 | `sensor_msgs::msg::PointCloud2`                          | point cloud of objects  |
+| `output/debug/ground_truth_objects` | `autoware_auto_perception_msgs::msg::TrackedObjects`     | ground truth objects    |
 
 ## Parameters
 

--- a/simulator/dummy_perception_publisher/README.md
+++ b/simulator/dummy_perception_publisher/README.md
@@ -17,10 +17,11 @@ This node publishes the result of the dummy detection with the type of perceptio
 
 ### Output
 
-| Name                    | Type                                                     | Description            |
-| ----------------------- | -------------------------------------------------------- | ---------------------- |
-| `output/dynamic_object` | `tier4_perception_msgs::msg::DetectedObjectsWithFeature` | Publishes objects      |
-| `output/points_raw`     | `sensor_msgs::msg::PointCloud2`                          | point cloud of objects |
+| Name                          | Type                                                     | Description                     |
+| ----------------------------- | -------------------------------------------------------- | ------------------------------- |
+| `output/dynamic_object`       | `tier4_perception_msgs::msg::DetectedObjectsWithFeature` | dummy detection objects         |
+| `output/points_raw`           | `sensor_msgs::msg::PointCloud2`                          | point cloud of objects          |
+| `output/ground_truth_objects` | `autoware_auto_perception_msgs::msg::TrackedObjects`     | ground truth objects (optional) |
 
 ## Parameters
 
@@ -31,6 +32,9 @@ This node publishes the result of the dummy detection with the type of perceptio
 | `enable_ray_tracing`        | bool   | true          | if True, use ray tracking                        |
 | `use_object_recognition`    | bool   | true          | if True, publish objects topic                   |
 | `use_base_link_z`           | bool   | true          | if True, node uses z coordinate of ego base_link |
+| `publish_ground_truth`      | bool   | false         | if True, publish ground truth objects            |
+| `use_fixed_random_seed`     | bool   | false         | if True, use fixed random seed                   |
+| `random_seed`               | int    | 0             | random seed                                      |
 
 ### Node Parameters
 

--- a/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
+++ b/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
@@ -20,6 +20,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
@@ -53,6 +54,13 @@ struct ObjectInfo
   double std_dev_z;
   double std_dev_yaw;
   tf2::Transform tf_map2moved_object;
+  // pose and twist
+  geometry_msgs::msg::TwistWithCovariance twist_covariance_;
+  geometry_msgs::msg::PoseWithCovariance pose_covariance_;
+  // convert to TrackedObject
+  // (todo) currently need object input to get id and header information, but it should be removed
+  autoware_auto_perception_msgs::msg::TrackedObject toTrackedObject(
+    const dummy_perception_publisher::msg::Object & object) const;
 };
 
 class PointCloudCreator
@@ -106,6 +114,8 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_pub_;
   rclcpp::Publisher<tier4_perception_msgs::msg::DetectedObjectsWithFeature>::SharedPtr
     detected_object_with_feature_pub_;
+  rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
+    ground_truth_objects_pub_;
   rclcpp::Subscription<dummy_perception_publisher::msg::Object>::SharedPtr object_sub_;
   rclcpp::TimerBase::SharedPtr timer_;
   tf2_ros::Buffer tf_buffer_;
@@ -117,6 +127,7 @@ private:
   bool use_object_recognition_;
   bool use_real_param_;
   bool use_base_link_z_;
+  bool publish_ground_truth_objects_;
   std::unique_ptr<PointCloudCreator> pointcloud_creator_;
 
   double angle_increment_;

--- a/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -21,6 +21,8 @@
         <param name="use_object_recognition" value="$(var use_object_recognition)"/>
         <param name="object_centric_pointcloud" value="false"/>
         <param name="use_base_link_z" value="$(var use_base_link_z)"/>
+        <param name="publish_ground_truth" value="true"/>
+        <remap from="output/ground_truth_objects" to="/perception/object_recognition/ground_truth_objects"/>
       </node>
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
         <arg name="input/objects" value="/perception/object_recognition/detection/labeled_clusters"/>

--- a/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -22,7 +22,7 @@
         <param name="object_centric_pointcloud" value="false"/>
         <param name="use_base_link_z" value="$(var use_base_link_z)"/>
         <param name="publish_ground_truth" value="true"/>
-        <remap from="output/ground_truth_objects" to="/perception/object_recognition/ground_truth_objects"/>
+        <remap from="output/debug/ground_truth_objects" to="/perception/object_recognition/debug/ground_truth_objects"/>
       </node>
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
         <arg name="input/objects" value="/perception/object_recognition/detection/labeled_clusters"/>

--- a/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -22,7 +22,7 @@
         <param name="object_centric_pointcloud" value="false"/>
         <param name="use_base_link_z" value="$(var use_base_link_z)"/>
         <param name="publish_ground_truth" value="true"/>
-        <remap from="output/debug/ground_truth_objects" to="/perception/object_recognition/debug/ground_truth_objects"/>
+        <remap from="output/debug/ground_truth_objects" to="debug/ground_truth_objects"/>
       </node>
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
         <arg name="input/objects" value="/perception/object_recognition/detection/labeled_clusters"/>

--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -33,6 +33,9 @@
 #include <utility>
 #include <vector>
 
+using autoware_auto_perception_msgs::msg::TrackedObject;
+using autoware_auto_perception_msgs::msg::TrackedObjects;
+
 ObjectInfo::ObjectInfo(
   const dummy_perception_publisher::msg::Object & object, const rclcpp::Time & current_time)
 : length(object.shape.dimensions.x),
@@ -41,7 +44,9 @@ ObjectInfo::ObjectInfo(
   std_dev_x(std::sqrt(object.initial_state.pose_covariance.covariance[0])),
   std_dev_y(std::sqrt(object.initial_state.pose_covariance.covariance[7])),
   std_dev_z(std::sqrt(object.initial_state.pose_covariance.covariance[14])),
-  std_dev_yaw(std::sqrt(object.initial_state.pose_covariance.covariance[35]))
+  std_dev_yaw(std::sqrt(object.initial_state.pose_covariance.covariance[35])),
+  twist_covariance_(object.initial_state.twist_covariance),
+  pose_covariance_(object.initial_state.pose_covariance)
 {
   // calculate current pose
   const auto & initial_pose = object.initial_state.pose_covariance.pose;
@@ -53,10 +58,10 @@ ObjectInfo::ObjectInfo(
   const double elapsed_time = current_time.seconds() - rclcpp::Time(object.header.stamp).seconds();
 
   double move_distance;
+  double current_vel = initial_vel + initial_acc * elapsed_time;
   if (initial_acc == 0.0) {
     move_distance = initial_vel * elapsed_time;
   } else {
-    double current_vel = initial_vel + initial_acc * elapsed_time;
     if (initial_acc < 0 && 0 < initial_vel) {
       current_vel = std::max(current_vel, 0.0);
     }
@@ -97,6 +102,24 @@ ObjectInfo::ObjectInfo(
   ros_map2moved_object.translation.z = current_pose.position.z;
   ros_map2moved_object.rotation = current_pose.orientation;
   tf2::fromMsg(ros_map2moved_object, tf_map2moved_object);
+  // set twist and pose information
+  twist_covariance_.twist.linear.x = current_vel;
+  pose_covariance_.pose = current_pose;
+}
+
+TrackedObject ObjectInfo::toTrackedObject(
+  const dummy_perception_publisher::msg::Object & object) const
+{
+  TrackedObject tracked_object;
+  tracked_object.kinematics.pose_with_covariance = pose_covariance_;
+  tracked_object.kinematics.twist_with_covariance = twist_covariance_;
+  tracked_object.classification.push_back(object.classification);
+  tracked_object.shape.type = object.shape.type;
+  tracked_object.shape.dimensions.x = length;
+  tracked_object.shape.dimensions.y = width;
+  tracked_object.shape.dimensions.z = height;
+  tracked_object.object_id = object.id;
+  return tracked_object;
 }
 
 DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
@@ -109,6 +132,7 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
   use_base_link_z_ = this->declare_parameter("use_base_link_z", true);
   const bool object_centric_pointcloud =
     this->declare_parameter("object_centric_pointcloud", false);
+  publish_ground_truth_objects_ = this->declare_parameter("publish_ground_truth", false);
 
   if (object_centric_pointcloud) {
     pointcloud_creator_ =
@@ -124,6 +148,7 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
   std::random_device seed_gen;
   random_generator_.seed(seed_gen());
 
+  // create subscriber and publisher
   rclcpp::QoS qos{1};
   qos.transient_local();
   detected_object_with_feature_pub_ =
@@ -134,6 +159,13 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
     "input/object", 100,
     std::bind(&DummyPerceptionPublisherNode::objectCallback, this, std::placeholders::_1));
 
+  // optional ground truth publisher
+  if (publish_ground_truth_objects_) {
+    ground_truth_objects_pub_ =
+      this->create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects>(
+        "output/ground_truth_objects", qos);
+  }
+
   using std::chrono_literals::operator""ms;
   timer_ = rclcpp::create_timer(
     this, get_clock(), 100ms, std::bind(&DummyPerceptionPublisherNode::timerCallback, this));
@@ -143,6 +175,7 @@ void DummyPerceptionPublisherNode::timerCallback()
 {
   // output msgs
   tier4_perception_msgs::msg::DetectedObjectsWithFeature output_dynamic_object_msg;
+  autoware_auto_perception_msgs::msg::TrackedObjects output_ground_truth_objects_msg;
   geometry_msgs::msg::PoseStamped output_moved_object_pose;
   sensor_msgs::msg::PointCloud2 output_pointcloud_msg;
   std_msgs::msg::Header header;
@@ -223,6 +256,7 @@ void DummyPerceptionPublisherNode::timerCallback()
       tf_base_link2noised_moved_object =
         tf_base_link2map * object_info.tf_map2moved_object * tf_moved_object2noised_moved_object;
 
+      // add DetectedObjectWithFeature
       tier4_perception_msgs::msg::DetectedObjectWithFeature feature_object;
       feature_object.object.classification.push_back(object.classification);
       feature_object.object.kinematics.pose_with_covariance = object.initial_state.pose_covariance;
@@ -237,6 +271,10 @@ void DummyPerceptionPublisherNode::timerCallback()
       feature_object.object.shape = object.shape;
       pcl::toROSMsg(*pointcloud, feature_object.feature.cluster);
       output_dynamic_object_msg.feature_objects.push_back(feature_object);
+
+      // add Tracked Object
+      TrackedObject gt_tracked_object = object_info.toTrackedObject(object);
+      output_ground_truth_objects_msg.objects.push_back(gt_tracked_object);
 
       // check delete idx
       tf2::Transform tf_base_link2moved_object;
@@ -262,11 +300,16 @@ void DummyPerceptionPublisherNode::timerCallback()
   output_dynamic_object_msg.header.stamp = current_time;
   output_pointcloud_msg.header.frame_id = "base_link";
   output_pointcloud_msg.header.stamp = current_time;
+  output_ground_truth_objects_msg.header.frame_id = "base_link";
+  output_ground_truth_objects_msg.header.stamp = current_time;
 
   // publish
   pointcloud_pub_->publish(output_pointcloud_msg);
   if (use_object_recognition_) {
     detected_object_with_feature_pub_->publish(output_dynamic_object_msg);
+  }
+  if (publish_ground_truth_objects_) {
+    ground_truth_objects_pub_->publish(output_ground_truth_objects_msg);
   }
 }
 

--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -133,6 +133,9 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
   const bool object_centric_pointcloud =
     this->declare_parameter("object_centric_pointcloud", false);
   publish_ground_truth_objects_ = this->declare_parameter("publish_ground_truth", false);
+  const unsigned int random_seed =
+    static_cast<unsigned int>(this->declare_parameter("random_seed", 0));
+  const bool use_fixed_random_seed = this->declare_parameter("use_fixed_random_seed", false);
 
   if (object_centric_pointcloud) {
     pointcloud_creator_ =
@@ -145,8 +148,12 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
   // parameters for vehicle centric point cloud generation
   angle_increment_ = this->declare_parameter("angle_increment", 0.25 * M_PI / 180.0);
 
-  std::random_device seed_gen;
-  random_generator_.seed(seed_gen());
+  if (use_fixed_random_seed) {
+    random_generator_.seed(random_seed);
+  } else {
+    std::random_device seed_gen;
+    random_generator_.seed(seed_gen());
+  }
 
   // create subscriber and publisher
   rclcpp::QoS qos{1};

--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -216,6 +216,18 @@ void DummyPerceptionPublisherNode::timerCallback()
     obj_infos.push_back(obj_info);
   }
 
+  // publish ground truth
+  // add Tracked Object
+  if (publish_ground_truth_objects_) {
+    for (auto object : objects_) {
+      const auto object_info = ObjectInfo(object, current_time);
+      TrackedObject gt_tracked_object = object_info.toTrackedObject(object);
+      gt_tracked_object.existence_probability = 1.0;
+      output_ground_truth_objects_msg.objects.push_back(gt_tracked_object);
+    }
+  }
+
+  // publish noised detected objects
   pcl::PointCloud<pcl::PointXYZ>::Ptr merged_pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr detected_merged_pointcloud_ptr(
     new pcl::PointCloud<pcl::PointXYZ>);
@@ -272,10 +284,6 @@ void DummyPerceptionPublisherNode::timerCallback()
       pcl::toROSMsg(*pointcloud, feature_object.feature.cluster);
       output_dynamic_object_msg.feature_objects.push_back(feature_object);
 
-      // add Tracked Object
-      TrackedObject gt_tracked_object = object_info.toTrackedObject(object);
-      output_ground_truth_objects_msg.objects.push_back(gt_tracked_object);
-
       // check delete idx
       tf2::Transform tf_base_link2moved_object;
       tf_base_link2moved_object = tf_base_link2map * object_info.tf_map2moved_object;
@@ -300,7 +308,7 @@ void DummyPerceptionPublisherNode::timerCallback()
   output_dynamic_object_msg.header.stamp = current_time;
   output_pointcloud_msg.header.frame_id = "base_link";
   output_pointcloud_msg.header.stamp = current_time;
-  output_ground_truth_objects_msg.header.frame_id = "base_link";
+  output_ground_truth_objects_msg.header.frame_id = "map";
   output_ground_truth_objects_msg.header.stamp = current_time;
 
   // publish

--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -170,7 +170,7 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
   if (publish_ground_truth_objects_) {
     ground_truth_objects_pub_ =
       this->create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects>(
-        "output/ground_truth_objects", qos);
+        "~output/debug/ground_truth_objects", qos);
   }
 
   using std::chrono_literals::operator""ms;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Dummy detections are generated by removing undetected parts from the ground truth with a certain probability, and then adding appropriate noise.

- This PR added option to
  - Publish ground truth as a TrackedObjects
  - Enable to fix the random seed used in noise generation.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested in Psim.

- pink bounding box: ground truth
- blue bounding box: dummy detection
![image](https://github.com/autowarefoundation/autoware.universe/assets/20086766/a475caa4-56e7-45e1-8167-dd29b9250202)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
