### PR TITLE
fix(compare_map_segmentation): fix bug when set dynamic map loader for no split map

### DIFF
--- a/perception/compare_map_segmentation/README.md
+++ b/perception/compare_map_segmentation/README.md
@@ -78,7 +78,7 @@ This filter is a combination of the distance_based_compare_map_filter and voxel_
 
 | Name                            | Type  | Description                                                                                                                             | Default value |
 | :------------------------------ | :---- | :-------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| `use_dynamic_map_loading`       | bool  | map loading mode selection, `true` for dynamic map loading, `false` for static map loading                                              | true          |
+| `use_dynamic_map_loading`       | bool  | map loading mode selection, `true` for dynamic map loading, `false` for static map loading, recommended for no-split map pointcloud     | true          |
 | `distance_threshold`            | float | Threshold distance to compare input points with map points [m]                                                                          | 0.5           |
 | `map_update_distance_threshold` | float | Threshold of vehicle movement distance when map update is necessary (in dynamic map loading) [m]                                        | 10.0          |
 | `map_loader_radius`             | float | Radius of map need to be loaded (in dynamic map loading) [m]                                                                            | 150.0         |

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -170,8 +170,10 @@ protected:
   rclcpp::CallbackGroup::SharedPtr timer_callback_group_;
 
   /** Map grid size. It might be defined by using metadata */
-  double map_grid_size_x_ = -1.0;
-  double map_grid_size_y_ = -1.0;
+  float map_grid_size_x_ = -1.0;
+  float map_grid_size_y_ = -1.0;
+
+  bool is_split_map = false;
 
   /** \brief Array to hold loaded map grid positions for fast map grid searching.
    */
@@ -235,6 +237,14 @@ public:
   /** Update loaded map grid array for fast searching*/
   virtual inline void updateVoxelGridArray()
   {
+    if (!is_split_map) {
+      (*mutex_ptr_).lock();
+      current_voxel_grid_array_.assign(1, std::make_shared<MapGridVoxelInfo>());
+      current_voxel_grid_array_.at(0) =
+        std::make_shared<MapGridVoxelInfo>(current_voxel_grid_dict_.begin()->second);
+      (*mutex_ptr_).unlock();
+      return;
+    }
     origin_x_ = std::floor((current_position_.value().x - map_loader_radius_) / map_grid_size_x_) *
                 map_grid_size_x_;
     origin_y_ = std::floor((current_position_.value().y - map_loader_radius_) / map_grid_size_y_) *
@@ -276,6 +286,10 @@ public:
   {
     map_grid_size_x_ = map_cell_to_add.metadata.max_x - map_cell_to_add.metadata.min_x;
     map_grid_size_y_ = map_cell_to_add.metadata.max_y - map_cell_to_add.metadata.min_y;
+
+    is_split_map = (std::remainder(map_cell_to_add.metadata.min_x, map_grid_size_x_) == 0.0) &&
+                   (std::remainder(map_cell_to_add.metadata.min_y, map_grid_size_y_) == 0.0);
+
     pcl::PointCloud<pcl::PointXYZ> map_cell_pc_tmp;
     pcl::fromROSMsg(map_cell_to_add.pointcloud, map_cell_pc_tmp);
 

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -176,8 +176,6 @@ protected:
   double origin_x_remainder_ = 0.0;
   double origin_y_remainder_ = 0.0;
 
-  bool is_split_map = false;
-
   /** \brief Array to hold loaded map grid positions for fast map grid searching.
    */
   std::vector<std::shared_ptr<MapGridVoxelInfo>> current_voxel_grid_array_;

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -354,6 +354,14 @@ bool VoxelGridDynamicMapLoader::is_close_to_map(
   if (current_voxel_grid_dict_.size() == 0) {
     return false;
   }
+  // For no split map
+  if (!is_split_map) {
+    if (is_close_to_neighbor_voxels(
+          point, distance_threshold, current_voxel_grid_array_.at(0)->map_cell_pc_ptr,
+          current_voxel_grid_array_.at(0)->map_cell_voxel_grid)) {
+      return true;
+    }
+  }
 
   // Compare point with map grid that point belong to
 

--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -354,14 +354,6 @@ bool VoxelGridDynamicMapLoader::is_close_to_map(
   if (current_voxel_grid_dict_.size() == 0) {
     return false;
   }
-  // For no split map
-  if (!is_split_map) {
-    if (is_close_to_neighbor_voxels(
-          point, distance_threshold, current_voxel_grid_array_.at(0)->map_cell_pc_ptr,
-          current_voxel_grid_array_.at(0)->map_cell_voxel_grid)) {
-      return true;
-    }
-  }
 
   // Compare point with map grid that point belong to
 


### PR DESCRIPTION
## Description

This PR to fix pointcloud_container died bug when [use_dynamic_map_loading = True](https://github.com/autowarefoundation/autoware_launch/blob/a26a82134e041c22ea32a4077e85a6219c3a8257/autoware_launch/config/perception/object_recognition/detection/pointcloud_map_filter.param.yaml#L16) but no-split map is used.

## Related links
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-2391)
[TIER IV INTERNAL LINK 2](https://star4.slack.com/archives/C03S84LDJGG/p1684237947381389)

## Tests performed

Confirmed by logging_simulator.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
