### PR TITLE
fix(simple_planning_simulator): old style arg for static_tf_publisher

### DIFF
--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -85,18 +85,6 @@ def launch_setup(context, *args, **kwargs):
             "map",
             "--child-frame-id",
             "odom",
-            "--x",
-            "0.0",
-            "--y",
-            "0.0",
-            "--z",
-            "0.0",
-            "--roll",
-            "0.0",
-            "--pitch",
-            "0.0",
-            "--yaw",
-            "0.0",
         ],
     )
 

--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
@@ -80,7 +80,24 @@ def launch_setup(context, *args, **kwargs):
         executable="static_transform_publisher",
         name="static_map_to_odom_tf_publisher",
         output="screen",
-        arguments=["0.0", "0.0", "0.0", "0", "0", "0", "map", "odom"],
+        arguments=[
+            "--frame-id",
+            "map",
+            "--child-frame-id",
+            "odom",
+            "--x",
+            "0.0",
+            "--y",
+            "0.0",
+            "--z",
+            "0.0",
+            "--roll",
+            "0.0",
+            "--pitch",
+            "0.0",
+            "--yaw",
+            "0.0",
+        ],
     )
 
     group = GroupAction([simple_planning_simulator_node, map_to_odom_tf_publisher])


### PR DESCRIPTION
## Description

Fix old-style arg for static_tf_publisher to remove the following error:

```
[static_transform_publisher-48] [WARN 1684291838.681769706] [] parse_args(): Old-style arguments are deprecated; see --help for new-style arguments:(L258)
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
