### PR TITLE
fix(system_error_monitor): time type mismatch error

### DIFF
--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -213,7 +213,11 @@ int isInNoFaultCondition(
 AutowareErrorMonitor::AutowareErrorMonitor()
 : Node(
     "system_error_monitor",
-    rclcpp::NodeOptions().automatically_declare_parameters_from_overrides(true))
+    rclcpp::NodeOptions().automatically_declare_parameters_from_overrides(true)),
+  diag_array_stamp_(0, 0, this->get_clock()->get_clock_type()),
+  autoware_state_stamp_(0, 0, this->get_clock()->get_clock_type()),
+  current_gate_mode_stamp_(0, 0, this->get_clock()->get_clock_type()),
+  control_mode_stamp_(0, 0, this->get_clock()->get_clock_type())
 {
   // Parameter
   get_parameter_or<int>("update_rate", params_.update_rate, 10);
@@ -385,7 +389,7 @@ void AutowareErrorMonitor::onControlMode(
 bool AutowareErrorMonitor::isDataReady()
 {
   if (!diag_array_) {
-    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "waiting for diag_array msg...");
+    RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 5000, "waiting for diag_array msg...");
     return false;
   }
 


### PR DESCRIPTION
## Description

- Fix time type in the contractor to fix the following error message:

```
[system_error_monitor-16] [ERROR 1684318632.789706285] [system.system_error_monitor] operator()(): clock type is different...:(L421)
```

- Change log level from warn to info for the first time when the diag is not received. 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
