### PR TITLE
fix(obstacle_stop_planner): extendTrajectory function causes NaN poses

### DIFF
--- a/planning/obstacle_stop_planner/src/planner_utils.cpp
+++ b/planning/obstacle_stop_planner/src/planner_utils.cpp
@@ -455,9 +455,9 @@ TrajectoryPoints extendTrajectory(const TrajectoryPoints & input, const double e
   }
 
   const auto goal_point = input.back();
-  double interpolation_distance = 0.1;
+  constexpr double interpolation_distance = 0.1;
 
-  double extend_sum = 0.0;
+  double extend_sum = interpolation_distance;
   while (extend_sum <= (extend_distance - interpolation_distance)) {
     const auto extend_trajectory_point = getExtendTrajectoryPoint(extend_sum, goal_point);
     output.push_back(extend_trajectory_point);


### PR DESCRIPTION
## Description
In obstacle_stop_planner, extendTrajectory function causes Nan positions so it causes issue: https://github.com/autowarefoundation/autoware.universe/issues/3666
Closes: https://github.com/autowarefoundation/autoware.universe/issues/3666
<!-- Write a brief description of this PR. -->

## Tests performed
Tested in planning_simulator and it solves the issue.
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
