### PR TITLE
feat(gnss_poser): add orthometric height as a option

### DIFF
--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -105,7 +105,7 @@ GNSSStat NavSatFix2UTM(
 }
 GNSSStat NavSatFix2LocalCartesianUTM(
   const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
-  sensor_msgs::msg::NavSatFix nav_sat_fix_origin, const rclcpp::Logger & logger,int height_system)
+  sensor_msgs::msg::NavSatFix nav_sat_fix_origin, const rclcpp::Logger & logger, int height_system)
 {
   GNSSStat utm_local;
   utm_local.coordinate_system = CoordinateSystem::UTM;
@@ -116,13 +116,12 @@ GNSSStat NavSatFix2LocalCartesianUTM(
     GeographicLib::UTMUPS::Forward(
       nav_sat_fix_origin.latitude, nav_sat_fix_origin.longitude, utm_origin.zone,
       utm_origin.east_north_up, utm_origin.x, utm_origin.y);
-    if(height_system==0){
+    if (height_system == 0) {
       utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_origin, logger);
-    }
-    else{
+    } else {
       utm_origin.z = nav_sat_fix_origin.altitude;
     }
-    
+
     // individual coordinates of global coordinate system
     double global_x = 0.0;
     double global_y = 0.0;
@@ -135,10 +134,9 @@ GNSSStat NavSatFix2LocalCartesianUTM(
     // individual coordinates of local coordinate system
     utm_local.x = global_x - utm_origin.x;
     utm_local.y = global_y - utm_origin.y;
-    if(height_system==0){
+    if (height_system == 0) {
       utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
-    }
-    else{
+    } else {
       utm_local.z = nav_sat_fix_msg.altitude - utm_origin.z;
     }
   } catch (const GeographicLib::GeographicErr & err) {

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -105,7 +105,7 @@ GNSSStat NavSatFix2UTM(
 }
 GNSSStat NavSatFix2LocalCartesianUTM(
   const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg,
-  sensor_msgs::msg::NavSatFix nav_sat_fix_origin, const rclcpp::Logger & logger)
+  sensor_msgs::msg::NavSatFix nav_sat_fix_origin, const rclcpp::Logger & logger,int height_system)
 {
   GNSSStat utm_local;
   utm_local.coordinate_system = CoordinateSystem::UTM;
@@ -116,7 +116,13 @@ GNSSStat NavSatFix2LocalCartesianUTM(
     GeographicLib::UTMUPS::Forward(
       nav_sat_fix_origin.latitude, nav_sat_fix_origin.longitude, utm_origin.zone,
       utm_origin.east_north_up, utm_origin.x, utm_origin.y);
-    utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_origin, logger);
+    if(height_system==0){
+      utm_origin.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_origin, logger);
+    }
+    else{
+      utm_origin.z = nav_sat_fix_origin.altitude;
+    }
+    
     // individual coordinates of global coordinate system
     double global_x = 0.0;
     double global_y = 0.0;
@@ -129,7 +135,12 @@ GNSSStat NavSatFix2LocalCartesianUTM(
     // individual coordinates of local coordinate system
     utm_local.x = global_x - utm_origin.x;
     utm_local.y = global_y - utm_origin.y;
-    utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
+    if(height_system==0){
+      utm_local.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger) - utm_origin.z;
+    }
+    else{
+      utm_local.z = nav_sat_fix_msg.altitude - utm_origin.z;
+    }
   } catch (const GeographicLib::GeographicErr & err) {
     RCLCPP_ERROR_STREAM(
       logger, "Failed to convert from LLH to UTM in local coordinates" << err.what());

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -80,7 +80,7 @@ GNSSStat NavSatFix2LocalCartesianWGS84(
   return local_cartesian;
 }
 GNSSStat NavSatFix2UTM(
-  const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg, const rclcpp::Logger & logger)
+  const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg, const rclcpp::Logger & logger, int height_system)
 {
   GNSSStat utm;
   utm.coordinate_system = CoordinateSystem::UTM;
@@ -89,9 +89,12 @@ GNSSStat NavSatFix2UTM(
     GeographicLib::UTMUPS::Forward(
       nav_sat_fix_msg.latitude, nav_sat_fix_msg.longitude, utm.zone, utm.east_north_up, utm.x,
       utm.y);
-
-    utm.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger);
-
+    if(height_system==0){
+      utm.z = EllipsoidHeight2OrthometricHeight(nav_sat_fix_msg, logger);
+    }
+    else{
+      utm.z = nav_sat_fix_msg.altitude;
+    }
     utm.latitude = nav_sat_fix_msg.latitude;
     utm.longitude = nav_sat_fix_msg.longitude;
     utm.altitude = nav_sat_fix_msg.altitude;
@@ -164,9 +167,9 @@ GNSSStat UTM2MGRS(
 
 GNSSStat NavSatFix2MGRS(
   const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg, const MGRSPrecision & precision,
-  const rclcpp::Logger & logger)
+  const rclcpp::Logger & logger,int height_system)
 {
-  const auto utm = NavSatFix2UTM(nav_sat_fix_msg, logger);
+  const auto utm = NavSatFix2UTM(nav_sat_fix_msg, logger,height_system);
   const auto mgrs = UTM2MGRS(utm, precision, logger);
   return mgrs;
 }

--- a/sensing/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
@@ -55,7 +55,7 @@ private:
   bool isFixed(const sensor_msgs::msg::NavSatStatus & nav_sat_status_msg);
   bool canGetCovariance(const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg);
   GNSSStat convert(
-    const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg, CoordinateSystem coordinate_system);
+    const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg, CoordinateSystem coordinate_system,int height_system);
   geometry_msgs::msg::Point getPosition(const GNSSStat & gnss_stat);
   geometry_msgs::msg::Point getMedianPosition(
     const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer);
@@ -101,6 +101,7 @@ private:
 
   autoware_sensing_msgs::msg::GnssInsOrientationStamped::SharedPtr
     msg_gnss_ins_orientation_stamped_;
+  int height_system_;
 };
 }  // namespace gnss_poser
 

--- a/sensing/gnss_poser/launch/gnss_poser.launch.xml
+++ b/sensing/gnss_poser/launch/gnss_poser.launch.xml
@@ -17,6 +17,8 @@
   <arg name="buff_epoch" default="1"/>
   <arg name="use_gnss_ins_orientation" default="true"/>
   <arg name="plane_zone" default="9"/>
+  <arg name="height_system" default="1" description="0:Orthometric Height 1:Ellipsoid Height"/>
+
 
   <node pkg="gnss_poser" exec="gnss_poser" name="gnss_poser" output="screen">
     <remap from="fix" to="$(var input_topic_fix)"/>
@@ -35,5 +37,6 @@
     <param name="plane_zone" value="$(var plane_zone)"/>
     <param name="use_gnss_ins_orientation" value="$(var use_gnss_ins_orientation)"/>
     <param from="$(var param_file)"/>
+    <param name="height_system" value="$(var height_system)"/>
   </node>
 </launch>

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -34,7 +34,8 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
   use_gnss_ins_orientation_(declare_parameter("use_gnss_ins_orientation", true)),
   plane_zone_(declare_parameter<int>("plane_zone", 9)),
   msg_gnss_ins_orientation_stamped_(
-    std::make_shared<autoware_sensing_msgs::msg::GnssInsOrientationStamped>())
+    std::make_shared<autoware_sensing_msgs::msg::GnssInsOrientationStamped>()),
+  height_system_(declare_parameter<int>("height_system", 1))
 {
   int coordinate_system =
     declare_parameter("coordinate_system", static_cast<int>(CoordinateSystem::MGRS));
@@ -80,7 +81,7 @@ void GNSSPoser::callbackNavSatFix(
   }
 
   // get position in coordinate_system
-  const auto gnss_stat = convert(*nav_sat_fix_msg_ptr, coordinate_system_);
+  const auto gnss_stat = convert(*nav_sat_fix_msg_ptr, coordinate_system_,height_system_);
   const auto position = getPosition(gnss_stat);
 
   // calc median position
@@ -179,16 +180,16 @@ bool GNSSPoser::canGetCovariance(const sensor_msgs::msg::NavSatFix & nav_sat_fix
 }
 
 GNSSStat GNSSPoser::convert(
-  const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg, CoordinateSystem coordinate_system)
+  const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg, CoordinateSystem coordinate_system,int height_system)
 {
   GNSSStat gnss_stat;
   if (coordinate_system == CoordinateSystem::UTM) {
-    gnss_stat = NavSatFix2UTM(nav_sat_fix_msg, this->get_logger());
+    gnss_stat = NavSatFix2UTM(nav_sat_fix_msg, this->get_logger(),height_system);
   } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_UTM) {
     gnss_stat =
       NavSatFix2LocalCartesianUTM(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::MGRS) {
-    gnss_stat = NavSatFix2MGRS(nav_sat_fix_msg, MGRSPrecision::_100MICRO_METER, this->get_logger());
+    gnss_stat = NavSatFix2MGRS(nav_sat_fix_msg, MGRSPrecision::_100MICRO_METER, this->get_logger(),height_system);
   } else if (coordinate_system == CoordinateSystem::PLANE) {
     gnss_stat = NavSatFix2PLANE(nav_sat_fix_msg, plane_zone_, this->get_logger());
   } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_WGS84) {

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -187,8 +187,8 @@ GNSSStat GNSSPoser::convert(
   if (coordinate_system == CoordinateSystem::UTM) {
     gnss_stat = NavSatFix2UTM(nav_sat_fix_msg, this->get_logger(), height_system);
   } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_UTM) {
-    gnss_stat =
-      NavSatFix2LocalCartesianUTM(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger(),height_system);
+    gnss_stat = NavSatFix2LocalCartesianUTM(
+      nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger(), height_system);
   } else if (coordinate_system == CoordinateSystem::MGRS) {
     gnss_stat = NavSatFix2MGRS(
       nav_sat_fix_msg, MGRSPrecision::_100MICRO_METER, this->get_logger(), height_system);

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -187,7 +187,7 @@ GNSSStat GNSSPoser::convert(
     gnss_stat = NavSatFix2UTM(nav_sat_fix_msg, this->get_logger(),height_system);
   } else if (coordinate_system == CoordinateSystem::LOCAL_CARTESIAN_UTM) {
     gnss_stat =
-      NavSatFix2LocalCartesianUTM(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger());
+      NavSatFix2LocalCartesianUTM(nav_sat_fix_msg, nav_sat_fix_origin_, this->get_logger(),height_system);
   } else if (coordinate_system == CoordinateSystem::MGRS) {
     gnss_stat = NavSatFix2MGRS(nav_sat_fix_msg, MGRSPrecision::_100MICRO_METER, this->get_logger(),height_system);
   } else if (coordinate_system == CoordinateSystem::PLANE) {


### PR DESCRIPTION
## Description

* Added to gnss_poser package as an option to convert ellipsoid height to orthometric height. 
* Added a height_system parameter to gnss_poser.launch and user can select whether use ellipsoid to orthometric height conversion.
* Output always will be orthometric height.  

Closes: https://github.com/autowarefoundation/autoware.universe/issues/3693

## Tests performed

Tested using bag collected from YTU Davutpasa campus with Robione robot.
Will be tested on vehicle too. 

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
