### PR TITLE
fix(behavior_path_planner): extract obstacles from drivable area without intersection

### DIFF
--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -224,6 +224,7 @@ std::vector<PolygonPoint> generatePolygonInsideBounds(
     full_polygon.push_back(polygon_point);
   }
 
+  // 1. check the case where the polygon intersects the bound
   std::vector<PolygonPoint> inside_poly;
   bool has_intersection = false;  // NOTE: between obstacle polygon and bound
   for (int i = 0; i < static_cast<int>(full_polygon.size()); ++i) {
@@ -262,10 +263,25 @@ std::vector<PolygonPoint> generatePolygonInsideBounds(
     inside_poly.push_back(intersect_point);
     continue;
   }
-
   if (has_intersection) {
     return inside_poly;
   }
+
+  // 2. check the case where the polygon does not intersect the bound
+  const bool is_polygon_fully_inside_bounds = [&]() {
+    for (int i = 0; i < static_cast<int>(full_polygon.size()); ++i) {
+      const auto & curr_poly = full_polygon.at(i);
+      const bool is_curr_outside = curr_poly.is_outside_bounds(is_object_right);
+      if (is_curr_outside) {
+        return false;
+      }
+    }
+    return true;
+  }();
+  if (is_polygon_fully_inside_bounds) {
+    return full_polygon;
+  }
+
   return std::vector<PolygonPoint>{};
 }
 

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -269,8 +269,7 @@ std::vector<PolygonPoint> generatePolygonInsideBounds(
 
   // 2. check the case where the polygon does not intersect the bound
   const bool is_polygon_fully_inside_bounds = [&]() {
-    for (int i = 0; i < static_cast<int>(full_polygon.size()); ++i) {
-      const auto & curr_poly = full_polygon.at(i);
+    for (const auto & curr_poly : full_polygon) {
       const bool is_curr_outside = curr_poly.is_outside_bounds(is_object_right);
       if (is_curr_outside) {
         return false;


### PR DESCRIPTION
## Description

In the scenario where dynamic avoidance and avoidance are launching, without this PR, the following obstacle's extraction from the drivable area is ignored since there is no intersection between the obstacle and the bound.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/067991c9-46fa-4091-9ad3-0a228b2dc8da)


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Dynamic avoidance can be used with avoidance/lane change module.
There seems to be some corner cases though.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
