### PR TITLE
feat(obstacle_cruise_planner): hysteresis for slow down decision

### DIFF
--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -86,14 +86,15 @@
           collision_time_margin : 4.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 
       cruise:
-        max_lat_margin: 0.5 # lateral margin between obstacle and trajectory band with ego's width
+        max_lat_margin: 0.8 # lateral margin between obstacle and trajectory band with ego's width
         outside_obstacle:
           obstacle_velocity_threshold : 3.0 # minimum velocity threshold of obstacles outside the trajectory to cruise or stop [m/s]
           ego_obstacle_overlap_time_threshold : 1.0 #  time threshold to decide cut-in obstacle for cruise or stop [s]
           max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
 
       slow_down:
-        max_lat_margin: 1.0  # lateral margin between obstacle and trajectory band with ego's width
+        max_lat_margin: 0.7  # lateral margin between obstacle and trajectory band with ego's width
+        lat_hysteresis_margin: 0.1
 
     cruise:
       pid_based_planner:

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -185,6 +185,7 @@ private:
     double max_lat_margin_for_stop;
     double max_lat_margin_for_cruise;
     double max_lat_margin_for_slow_down;
+    double lat_hysteresis_margin_for_slow_down;
   };
   BehaviorDeterminationParam behavior_determination_param_;
 


### PR DESCRIPTION
## Description

We set the detection area to select slow down obstacles.
When the obstacle is on the longitudinal edge of the detection area with some noises, the slow down decision flickers.
To avoid this, this PR uses hysteresis condition to check if the object is inside the detection area or not.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No flickering of slow down obstacle decision.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
