### PR TITLE
fix(obstacle_cruise_planner): insert slow down with precise constraints

### DIFF
--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -168,6 +168,3 @@
       max_ego_velocity: 8.0
 
       time_margin_on_target_velocity: 1.5 # [s]
-
-      # max deceleration during slow down
-      max_deceleration: -1.0

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -162,7 +162,7 @@ protected:
 
 private:
   double calculateSlowDownVelocity(const SlowDownObstacle & obstacle) const;
-  double calculateDistanceToSlowDownWithAccConstraint(
+  std::optional<double> calculateDistanceToSlowDownWithConstraints(
     const PlannerData & planner_data, const std::vector<TrajectoryPoint> & traj_points,
     const SlowDownObstacle & obstacle, const double dist_to_ego, const double slow_down_vel) const;
 

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -181,7 +181,6 @@ private:
       min_lat_margin = node.declare_parameter<double>("slow_down.min_lat_margin");
       max_ego_velocity = node.declare_parameter<double>("slow_down.max_ego_velocity");
       min_ego_velocity = node.declare_parameter<double>("slow_down.min_ego_velocity");
-      max_deceleration = node.declare_parameter<double>("slow_down.max_deceleration");
       time_margin_on_target_velocity =
         node.declare_parameter<double>("slow_down.time_margin_on_target_velocity");
     }
@@ -197,8 +196,6 @@ private:
       tier4_autoware_utils::updateParam<double>(
         parameters, "slow_down.min_ego_velocity", min_ego_velocity);
       tier4_autoware_utils::updateParam<double>(
-        parameters, "slow_down.max_deceleration", max_deceleration);
-      tier4_autoware_utils::updateParam<double>(
         parameters, "slow_down.time_margin_on_target_velocity", time_margin_on_target_velocity);
     }
 
@@ -206,7 +203,6 @@ private:
     double min_lat_margin;
     double max_ego_velocity;
     double min_ego_velocity;
-    double max_deceleration;
     double time_margin_on_target_velocity;
   };
   SlowDownParam slow_down_param_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -162,7 +162,7 @@ protected:
 
 private:
   double calculateSlowDownVelocity(const SlowDownObstacle & obstacle) const;
-  std::optional<double> calculateDistanceToSlowDownWithConstraints(
+  double calculateDistanceToSlowDownWithConstraints(
     const PlannerData & planner_data, const std::vector<TrajectoryPoint> & traj_points,
     const SlowDownObstacle & obstacle, const double dist_to_ego, const double slow_down_vel) const;
 

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -328,7 +328,7 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
     const auto dist_to_slow_down_start = calculateDistanceToSlowDownWithConstraints(
       planner_data, slow_down_traj_points, obstacle, dist_to_ego, slow_down_vel);
     if (!dist_to_slow_down_start) {
-      // NOTE: Target slow down velocity is higher than the ego's velocity.
+      // NOTE: no need to slow down
       continue;
     }
     const auto slow_down_start_idx =
@@ -396,21 +396,20 @@ std::optional<double> PlannerInterface::calculateDistanceToSlowDownWithConstrain
   const PlannerData & planner_data, const std::vector<TrajectoryPoint> & traj_points,
   const SlowDownObstacle & obstacle, const double dist_to_ego, const double slow_down_vel) const
 {
-  const auto & p = slow_down_param_;
   const double abs_ego_offset = planner_data.is_driving_forward
                                   ? std::abs(vehicle_info_.max_longitudinal_offset_m)
                                   : std::abs(vehicle_info_.min_longitudinal_offset_m);
 
-  const auto deceleration_min_dist = motion_utils::calcDecelDistWithJerkAndAccConstraints(
-    planner_data.ego_vel, slow_down_vel, planner_data.ego_acc, p.max_deceleration,
-    longitudinal_info_.max_jerk, longitudinal_info_.min_jerk);
-  if (!deceleration_min_dist) {
-    return std::nullopt;
-  }
-
   const double deceleration_dist =
     motion_utils::calcSignedArcLength(traj_points, 0, obstacle.front_collision_point) -
     abs_ego_offset - dist_to_ego;
+
+  const auto deceleration_min_dist = motion_utils::calcDecelDistWithJerkAndAccConstraints(
+    planner_data.ego_vel, slow_down_vel, planner_data.ego_acc, longitudinal_info_.min_accel,
+    longitudinal_info_.max_jerk, longitudinal_info_.min_jerk);
+  if (!deceleration_min_dist) {
+    return dist_to_ego + deceleration_dist;
+  }
 
   return dist_to_ego + std::max(deceleration_dist, *deceleration_min_dist) + abs_ego_offset + slow_down_vel * p.time_margin_on_target_velocity;
 }

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -325,12 +325,8 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
     const double slow_down_vel = calculateSlowDownVelocity(obstacle);
 
     // calculate slow down start distance, and insert slow down velocity
-    const auto dist_to_slow_down_start = calculateDistanceToSlowDownWithConstraints(
+    const double dist_to_slow_down_start = calculateDistanceToSlowDownWithConstraints(
       planner_data, slow_down_traj_points, obstacle, dist_to_ego, slow_down_vel);
-    if (!dist_to_slow_down_start) {
-      // NOTE: no need to slow down
-      continue;
-    }
     const auto slow_down_start_idx =
       insert_slow_down_to_trajectory(*dist_to_slow_down_start, slow_down_vel);
 
@@ -341,7 +337,7 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
     // NOTE: slow_down_start_idx will not be wrong since inserted back point is after inserted
     // front point.
     const auto slow_down_end_idx =
-      *dist_to_slow_down_start < dist_to_slow_down_end
+      dist_to_slow_down_start < dist_to_slow_down_end
         ? insert_slow_down_to_trajectory(dist_to_slow_down_end, slow_down_vel)
         : std::nullopt;
     if (!slow_down_end_idx) {
@@ -392,7 +388,7 @@ double PlannerInterface::calculateSlowDownVelocity(const SlowDownObstacle & obst
   return slow_down_vel;
 }
 
-std::optional<double> PlannerInterface::calculateDistanceToSlowDownWithConstraints(
+double PlannerInterface::calculateDistanceToSlowDownWithConstraints(
   const PlannerData & planner_data, const std::vector<TrajectoryPoint> & traj_points,
   const SlowDownObstacle & obstacle, const double dist_to_ego, const double slow_down_vel) const
 {
@@ -411,5 +407,6 @@ std::optional<double> PlannerInterface::calculateDistanceToSlowDownWithConstrain
     return dist_to_ego + deceleration_dist;
   }
 
-  return dist_to_ego + std::max(deceleration_dist, *deceleration_min_dist) + abs_ego_offset + slow_down_vel * p.time_margin_on_target_velocity;
+  return dist_to_ego + std::max(deceleration_dist, *deceleration_min_dist) + abs_ego_offset +
+         slow_down_vel * p.time_margin_on_target_velocity;
 }


### PR DESCRIPTION
## Description

Regarding the slow down feature against close obstacles, the slow down point is calculated only considering the initial velocity and acceleration constraint.
In this PR, the initial acceleration and jerk constraints are considered as well to calculate a precise slow down point.

Also min_acceleration in common.param.yaml is used for this calculation instead of having a parameter in the obstacle_cruise_planner package.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No large deceleration by the slow down feature
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
