### PR TITLE
fix(motion_utils): fix logic to calculate decel distantace

### DIFF
--- a/common/motion_utils/src/distance/distance.cpp
+++ b/common/motion_utils/src/distance/distance.cpp
@@ -88,12 +88,12 @@ std::tuple<double, double, double> update(
  * @param (am) minimum deceleration [m/ss]
  * @param (ja) maximum jerk [m/sss]
  * @param (jd) minimum jerk [m/sss]
- * @param (t_max_dec) duration of constant deceleration [s]
+ * @param (t_min_acc) duration of constant deceleration [s]
  * @return moving distance until velocity is reached vt [m]
  */
 boost::optional<double> calcDecelDistPlanType1(
   const double v0, const double vt, const double a0, const double am, const double ja,
-  const double jd, const double t_max_dec)
+  const double jd, const double t_min_acc)
 {
   constexpr double epsilon = 1e-3;
 
@@ -103,7 +103,7 @@ boost::optional<double> calcDecelDistPlanType1(
   const auto [x1, v1, a1] = update(0.0, v0, a0, j1, t1);
 
   // zero jerk time
-  const double t2 = epsilon < t_max_dec ? t_max_dec : 0.0;
+  const double t2 = epsilon < t_min_acc ? t_min_acc : 0.0;
   const auto [x2, v2, a2] = update(x1, v1, a1, 0.0, t2);
 
   // positive jerk time
@@ -239,15 +239,15 @@ boost::optional<double> calcDecelDistWithJerkAndAccConstraints(
   const double jerk_acc, const double jerk_dec)
 {
   constexpr double epsilon = 1e-3;
-  const double jerk_before_max_dec = acc_min < current_acc ? jerk_dec : jerk_acc;
-  const double t_before_max_dec = (acc_min - current_acc) / jerk_before_max_dec;
-  const double jerk_after_max_dec = jerk_acc;
-  const double t_after_max_dec = (0.0 - acc_min) / jerk_after_max_dec;
+  const double jerk_before_min_acc = acc_min < current_acc ? jerk_dec : jerk_acc;
+  const double t_before_min_acc = (acc_min - current_acc) / jerk_before_min_acc;
+  const double jerk_after_min_acc = jerk_acc;
+  const double t_after_min_acc = (0.0 - acc_min) / jerk_after_min_acc;
 
-  const double t_during_max_dec =
-    (target_vel - current_vel - current_acc * t_before_max_dec -
-     0.5 * jerk_before_max_dec * std::pow(t_before_max_dec, 2) - acc_min * t_after_max_dec -
-     0.5 * jerk_after_max_dec * std::pow(t_after_max_dec, 2)) /
+  const double t_during_min_acc =
+    (target_vel - current_vel - current_acc * t_before_min_acc -
+     0.5 * jerk_before_min_acc * std::pow(t_before_min_acc, 2) - acc_min * t_after_min_acc -
+     0.5 * jerk_after_min_acc * std::pow(t_after_min_acc, 2)) /
     acc_min;
 
   // check if it is possible to decelerate to the target velocity
@@ -255,9 +255,9 @@ boost::optional<double> calcDecelDistWithJerkAndAccConstraints(
   const auto is_decel_needed =
     0.5 * (0.0 - current_acc) / jerk_acc * current_acc > target_vel - current_vel;
 
-  if (t_during_max_dec > epsilon) {
+  if (t_during_min_acc > epsilon) {
     return calcDecelDistPlanType1(
-      current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec, t_during_max_dec);
+      current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec, t_during_min_acc);
   } else if (is_decel_needed || current_acc > epsilon) {
     return calcDecelDistPlanType2(current_vel, target_vel, current_acc, jerk_acc, jerk_dec);
   }

--- a/common/motion_utils/src/distance/distance.cpp
+++ b/common/motion_utils/src/distance/distance.cpp
@@ -238,6 +238,10 @@ boost::optional<double> calcDecelDistWithJerkAndAccConstraints(
   const double current_vel, const double target_vel, const double current_acc, const double acc_min,
   const double jerk_acc, const double jerk_dec)
 {
+  if (current_vel < target_vel) {
+    return {};
+  }
+
   constexpr double epsilon = 1e-3;
   const double jerk_before_min_acc = acc_min < current_acc ? jerk_dec : jerk_acc;
   const double t_before_min_acc = (acc_min - current_acc) / jerk_before_min_acc;

--- a/common/motion_utils/src/distance/distance.cpp
+++ b/common/motion_utils/src/distance/distance.cpp
@@ -88,12 +88,12 @@ std::tuple<double, double, double> update(
  * @param (am) minimum deceleration [m/ss]
  * @param (ja) maximum jerk [m/sss]
  * @param (jd) minimum jerk [m/sss]
- * @param (t_min_acc) duration of constant deceleration [s]
+ * @param (t_during_min_acc) duration of constant deceleration [s]
  * @return moving distance until velocity is reached vt [m]
  */
 boost::optional<double> calcDecelDistPlanType1(
   const double v0, const double vt, const double a0, const double am, const double ja,
-  const double jd, const double t_min_acc)
+  const double jd, const double t_during_min_acc)
 {
   constexpr double epsilon = 1e-3;
 
@@ -103,7 +103,7 @@ boost::optional<double> calcDecelDistPlanType1(
   const auto [x1, v1, a1] = update(0.0, v0, a0, j1, t1);
 
   // zero jerk time
-  const double t2 = epsilon < t_min_acc ? t_min_acc : 0.0;
+  const double t2 = epsilon < t_during_min_acc ? t_during_min_acc : 0.0;
   const auto [x2, v2, a2] = update(x1, v1, a1, 0.0, t2);
 
   // positive jerk time

--- a/common/motion_utils/src/distance/distance.cpp
+++ b/common/motion_utils/src/distance/distance.cpp
@@ -88,12 +88,12 @@ std::tuple<double, double, double> update(
  * @param (am) minimum deceleration [m/ss]
  * @param (ja) maximum jerk [m/sss]
  * @param (jd) minimum jerk [m/sss]
- * @param (t_min) duration of constant deceleration [s]
+ * @param (t_max_dec) duration of constant deceleration [s]
  * @return moving distance until velocity is reached vt [m]
  */
 boost::optional<double> calcDecelDistPlanType1(
   const double v0, const double vt, const double a0, const double am, const double ja,
-  const double jd, const double t_min)
+  const double jd, const double t_max_dec)
 {
   constexpr double epsilon = 1e-3;
 
@@ -103,7 +103,7 @@ boost::optional<double> calcDecelDistPlanType1(
   const auto [x1, v1, a1] = update(0.0, v0, a0, j1, t1);
 
   // zero jerk time
-  const double t2 = epsilon < t_min ? t_min : 0.0;
+  const double t2 = epsilon < t_max_dec ? t_max_dec : 0.0;
   const auto [x2, v2, a2] = update(x1, v1, a1, 0.0, t2);
 
   // positive jerk time
@@ -239,21 +239,25 @@ boost::optional<double> calcDecelDistWithJerkAndAccConstraints(
   const double jerk_acc, const double jerk_dec)
 {
   constexpr double epsilon = 1e-3;
-  const double t_dec =
-    acc_min < current_acc ? (acc_min - current_acc) / jerk_dec : (acc_min - current_acc) / jerk_acc;
-  const double t_acc = (0.0 - acc_min) / jerk_acc;
-  const double t_min = (target_vel - current_vel - current_acc * t_dec -
-                        0.5 * jerk_dec * t_dec * t_dec - 0.5 * acc_min * t_acc) /
-                       acc_min;
+  const double jerk_before_max_dec = acc_min < current_acc ? jerk_dec : jerk_acc;
+  const double t_before_max_dec = (acc_min - current_acc) / jerk_before_max_dec;
+  const double jerk_after_max_dec = jerk_acc;
+  const double t_after_max_dec = (0.0 - acc_min) / jerk_after_max_dec;
+
+  const double t_during_max_dec =
+    (target_vel - current_vel - current_acc * t_before_max_dec -
+     0.5 * jerk_before_max_dec * std::pow(t_before_max_dec, 2) - acc_min * t_after_max_dec -
+     0.5 * jerk_after_max_dec * std::pow(t_after_max_dec, 2)) /
+    acc_min;
 
   // check if it is possible to decelerate to the target velocity
   // by simply bringing the current acceleration to zero.
   const auto is_decel_needed =
     0.5 * (0.0 - current_acc) / jerk_acc * current_acc > target_vel - current_vel;
 
-  if (t_min > epsilon) {
+  if (t_during_max_dec > epsilon) {
     return calcDecelDistPlanType1(
-      current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec, t_min);
+      current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec, t_during_max_dec);
   } else if (is_decel_needed || current_acc > epsilon) {
     return calcDecelDistPlanType2(current_vel, target_vel, current_acc, jerk_acc, jerk_dec);
   }

--- a/common/motion_utils/test/src/distance/test_distance.cpp
+++ b/common/motion_utils/test/src/distance/test_distance.cpp
@@ -37,21 +37,6 @@ TEST(distance, calcDecelDistWithJerkAndAccConstraints)
     EXPECT_FALSE(dist);
   }
 
-  // invalid deceleration
-  {
-    constexpr double current_vel = 16.7;
-    constexpr double target_vel = 0.0;
-    constexpr double current_acc = -2.5;
-    constexpr double acc_min = -0.5;
-    constexpr double jerk_acc = 1.0;
-    constexpr double jerk_dec = -0.5;
-
-    const auto dist = calcDecelDistWithJerkAndAccConstraints(
-      current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec);
-
-    EXPECT_FALSE(dist);
-  }
-
   // normal stop
   {
     constexpr double current_vel = 16.7;
@@ -107,6 +92,21 @@ TEST(distance, calcDecelDistWithJerkAndAccConstraints)
     constexpr double jerk_dec = -1.5;
 
     constexpr double expected_dist = 58.028;
+    const auto dist = calcDecelDistWithJerkAndAccConstraints(
+      current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec);
+    EXPECT_NEAR(expected_dist, *dist, epsilon);
+  }
+
+  // current_acc is lower than acc_min
+  {
+    constexpr double current_vel = 16.7;
+    constexpr double target_vel = 0.0;
+    constexpr double current_acc = -2.5;
+    constexpr double acc_min = -0.5;
+    constexpr double jerk_acc = 1.0;
+    constexpr double jerk_dec = -0.5;
+
+    constexpr double expected_dist = 217.429;
     const auto dist = calcDecelDistWithJerkAndAccConstraints(
       current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec);
     EXPECT_NEAR(expected_dist, *dist, epsilon);


### PR DESCRIPTION
## Description

- Fixed the logic to calculate deceleration distance with jerk/acc constraints
- Variable names are hard to understand. Changed to the names which are easy to understand the meaning.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Almost no behavior change

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
