### PR TITLE
feat(obstacle_cruise_planner): add margin time for slow down

### DIFF
--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -166,5 +166,7 @@
       min_ego_velocity: 2.0
       max_ego_velocity: 8.0
 
+      time_margin_on_target_velocity: 1.5 # [s]
+
       # max deceleration during slow down
       max_deceleration: -1.0

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -182,6 +182,8 @@ private:
       max_ego_velocity = node.declare_parameter<double>("slow_down.max_ego_velocity");
       min_ego_velocity = node.declare_parameter<double>("slow_down.min_ego_velocity");
       max_deceleration = node.declare_parameter<double>("slow_down.max_deceleration");
+      time_margin_on_target_velocity =
+        node.declare_parameter<double>("slow_down.time_margin_on_target_velocity");
     }
 
     void onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -196,6 +198,8 @@ private:
         parameters, "slow_down.min_ego_velocity", min_ego_velocity);
       tier4_autoware_utils::updateParam<double>(
         parameters, "slow_down.max_deceleration", max_deceleration);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.time_margin_on_target_velocity", time_margin_on_target_velocity);
     }
 
     double max_lat_margin;
@@ -203,6 +207,7 @@ private:
     double max_ego_velocity;
     double min_ego_velocity;
     double max_deceleration;
+    double time_margin_on_target_velocity;
   };
   SlowDownParam slow_down_param_;
 };


### PR DESCRIPTION
## Description

add time margin before slow down.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/f164c87b-480a-4fbd-865a-2ff99c2ff1b8)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

slow down is applied a bit faster against close obstacles.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
