### PR TITLE
fix(obstacle_avoidance_planner): smooth path connection after optimization

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -512,10 +512,11 @@ std::vector<TrajectoryPoint> ObstacleAvoidancePlanner::extendTrajectory(
     trajectory_utils::findEgoSegmentIndex(traj_points, joint_start_pose, ego_nearest_param_);
 
   // crop trajectory for extension
-  constexpr double joint_traj_length_for_smoothing = 5.0;
+  constexpr double joint_traj_max_length_for_smoothing = 15.0;
+  constexpr double joint_traj_min_length_for_smoothing = 5.0;
   const auto joint_end_traj_point_idx = trajectory_utils::getPointIndexAfter(
     traj_points, joint_start_pose.position, joint_start_traj_seg_idx,
-    joint_traj_length_for_smoothing);
+    joint_traj_max_length_for_smoothing, joint_traj_min_length_for_smoothing);
 
   // calculate full trajectory points
   const auto full_traj_points = [&]() {

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -523,16 +523,26 @@ std::vector<TrajectoryPoint> ObstacleAvoidancePlanner::extendTrajectory(
     if (!joint_end_traj_point_idx) {
       return optimized_traj_points;
     }
+
     const auto extended_traj_points = std::vector<TrajectoryPoint>{
       traj_points.begin() + *joint_end_traj_point_idx, traj_points.end()};
-    return concatVectors(optimized_traj_points, extended_traj_points);
+
+    // NOTE: if optimized_traj_points's back is non zero velocity and extended_traj_points' front is
+    // zero velocity, the zero velocity will be inserted in the whole joint trajectory.
+    auto modified_optimized_traj_points = optimized_traj_points;
+    if (!extended_traj_points.empty() && !modified_optimized_traj_points.empty()) {
+      modified_optimized_traj_points.back().longitudinal_velocity_mps =
+        extended_traj_points.front().longitudinal_velocity_mps;
+    }
+
+    return concatVectors(modified_optimized_traj_points, extended_traj_points);
   }();
 
   // resample trajectory points
   auto resampled_traj_points = trajectory_utils::resampleTrajectoryPoints(
     full_traj_points, traj_param_.output_delta_arc_length);
 
-  // update velocity on joint
+  // update stop velocity on joint
   for (size_t i = joint_start_traj_seg_idx + 1; i <= joint_end_traj_point_idx; ++i) {
     if (hasZeroVelocity(traj_points.at(i))) {
       if (i != 0 && !hasZeroVelocity(traj_points.at(i - 1))) {


### PR DESCRIPTION
## Description

The trajectory optimization is applied to the first 100 meters.
The optimized trajectory's end point and the input path are connected smoothly by spline interpolation with the joint length = 5 meters.

In some cases, 5 meters is too short and the jointed trajectory's curvature is high, resulting in slow down by motion_velocity_smoother.
This PR changes the method of the connection.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No change behvavior.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
