### PR TITLE
fix(behavior_path_planner): fix invalid access for null drivable area bound

### DIFF
--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1376,6 +1376,14 @@ void generateDrivableArea(
   auto left_bound = calcBound(route_handler, lanes, enable_expanding_polygon, true);
   auto right_bound = calcBound(route_handler, lanes, enable_expanding_polygon, false);
 
+  if (left_bound.empty() || right_bound.empty()) {
+    auto clock{rclcpp::Clock{RCL_ROS_TIME}};
+    RCLCPP_ERROR_STREAM_THROTTLE(
+      rclcpp::get_logger("behavior_path_planner").get_child("utils"), clock, 1000,
+      "closest shoulder lanelet not found.");
+    return;
+  }
+
   // Insert points after goal
   lanelet::ConstLanelet goal_lanelet;
   if (

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1380,7 +1380,7 @@ void generateDrivableArea(
     auto clock{rclcpp::Clock{RCL_ROS_TIME}};
     RCLCPP_ERROR_STREAM_THROTTLE(
       rclcpp::get_logger("behavior_path_planner").get_child("utils"), clock, 1000,
-      "closest shoulder lanelet not found.");
+      "The right or left bound of drivable area is empty");
     return;
   }
 


### PR DESCRIPTION
## Description
In ```generateDrivableArea``` function, the invalid access for a left/right bound occurs at ```findNearestSegmentIndexFromLateralDistance``` when left_bound or right_bound is empty.
I fixed it 
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/cbae9fe7-5397-483e-83ea-c9c0db1bbba8)


<!-- Write a brief description of this PR. -->

## Related links
(TIERIV Internal Link: [Scenario](https://evaluation.tier4.jp/evaluation/reports/79acc1ed-151a-5237-9b4b-d31132d41f18/tests/f1f4939f-a33f-5cd9-a6b7-57e03fdc7258/fdcee682-aad0-5bd4-8bf1-616587b96f8c/91396479-ccb3-59f6-9e0a-6d5a31613117?project_id=prd_jt) )

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
I confirmed that the behavior_path_planner becomes not to die when the above rosbag played.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers
no
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
no
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
The behavior_path_planner becomes not to die when the bounds of drivable area are empty.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
