### PR TITLE
docs(lidar_centerpoint): fix path of image

### DIFF
--- a/perception/lidar_centerpoint/launch/centerpoint_vs_centerpoint-tiny/README.md
+++ b/perception/lidar_centerpoint/launch/centerpoint_vs_centerpoint-tiny/README.md
@@ -124,7 +124,7 @@ ros2 launch lidar_centerpoint centerpoint_vs_centerpoint-tiny.launch.xml
 
 Then you will see two rviz window show immediately. On the left is the result for lidar centerpoint tiny, and on the right is the result for lidar centerpoint.
 
-![two rviz2 display centerpoint and centerpoint_tiny](https://i.imgur.com/YAYehrf.jpg)
+![two rviz2 display centerpoint and centerpoint_tiny](https://github.com/autowarefoundation/autoware.universe/assets/58775300/2a89063a-8e0e-4f59-8d48-f339d4f7c0ff)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- Link in `lidar_centerpoint` is determined to be broken. So I want to change link path.
![image](https://github.com/autowarefoundation/autoware.universe/assets/58775300/f1693a8d-fce6-4fed-9efe-c718dfffa1fb)
- I uploaded this image file to github, and I got the link below; https://github.com/autowarefoundation/autoware.universe/assets/58775300/2a89063a-8e0e-4f59-8d48-f339d4f7c0ff

![image](https://github.com/autowarefoundation/autoware.universe/assets/58775300/2a89063a-8e0e-4f59-8d48-f339d4f7c0ff)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
