### PR TITLE
feat(avoidance): don't avoid objects around crosswalks

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -74,7 +74,9 @@
         threshold_time_object_is_moving: 1.0            # [s]
         threshold_time_force_avoidance_for_stopped_vehicle: 10.0 # [s]
         # detection range
-        object_check_force_avoidance_clearance: 30.0    # [m]
+        object_ignore_distance_traffic_light: 30.0      # [m]
+        object_ignore_distance_crosswalk_forward: 30.0  # [m]
+        object_ignore_distance_crosswalk_backward: 30.0 # [m]
         object_check_forward_distance: 150.0            # [m]
         object_check_backward_distance: 2.0             # [m]
         object_check_goal_distance: 20.0                # [m]

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -119,8 +119,14 @@ struct AvoidanceParameters
   // vehicles with speed greater than this will not be avoided
   double threshold_speed_object_is_stopped;
 
-  // execute only when there is no intersection or crosswalk behind of the stopped vehicle.
-  double object_check_force_avoidance_clearance;
+  // execute only when there is no intersection behind of the stopped vehicle.
+  double object_ignore_distance_traffic_light;
+
+  // execute only when there is no crosswalk near the stopped vehicle.
+  double object_ignore_distance_crosswalk_forward;
+
+  // execute only when there is no crosswalk near the stopped vehicle.
+  double object_ignore_distance_crosswalk_backward;
 
   // distance to avoid object detection
   double object_check_forward_distance;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -579,8 +579,12 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
       declare_parameter<double>(ns + "threshold_time_object_is_moving");
     p.threshold_time_force_avoidance_for_stopped_vehicle =
       declare_parameter<double>(ns + "threshold_time_force_avoidance_for_stopped_vehicle");
-    p.object_check_force_avoidance_clearance =
-      declare_parameter<double>(ns + "object_check_force_avoidance_clearance");
+    p.object_ignore_distance_traffic_light =
+      declare_parameter<double>(ns + "object_ignore_distance_traffic_light");
+    p.object_ignore_distance_crosswalk_forward =
+      declare_parameter<double>(ns + "object_ignore_distance_crosswalk_forward");
+    p.object_ignore_distance_crosswalk_backward =
+      declare_parameter<double>(ns + "object_ignore_distance_crosswalk_backward");
     p.object_check_forward_distance =
       declare_parameter<double>(ns + "object_check_forward_distance");
     p.object_check_backward_distance =

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -775,7 +775,6 @@ void filterTargetObjects(
         utils::getDistanceToCrosswalk(ego_pose, data.current_lanelets, *rh->getOverallGraphPtr()) -
         o.longitudinal;
       {
-        const auto object_to_crosswalk = to_crosswalk - o.longitudinal;
         const auto stop_for_crosswalk =
           to_crosswalk < parameters->object_ignore_distance_crosswalk_forward &&
           to_crosswalk > -1.0 * parameters->object_ignore_distance_crosswalk_backward;

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -755,18 +755,36 @@ void filterTargetObjects(
       }
     }
 
-    // force avoidance for stopped vehicle
-    {
+    const auto stop_time_longer_than_threshold =
+      o.stop_time > parameters->threshold_time_force_avoidance_for_stopped_vehicle;
+
+    if (stop_time_longer_than_threshold && parameters->enable_force_avoidance_for_stopped_vehicle) {
+      // force avoidance for stopped vehicle
+      bool not_parked_object = true;
+
+      // check traffic light
       const auto to_traffic_light =
         utils::getDistanceToNextTrafficLight(object_pose, data.current_lanelets);
+      {
+        not_parked_object = to_traffic_light < parameters->object_ignore_distance_traffic_light;
+      }
 
-      o.to_stop_factor_distance = std::min(to_traffic_light, o.to_stop_factor_distance);
-    }
+      // check crosswalk
+      const auto & ego_pose = planner_data->self_odometry->pose.pose;
+      const auto to_crosswalk =
+        utils::getDistanceToCrosswalk(ego_pose, data.current_lanelets, *rh->getOverallGraphPtr()) -
+        o.longitudinal;
+      {
+        const auto object_to_crosswalk = to_crosswalk - o.longitudinal;
+        const auto stop_for_crosswalk =
+          to_crosswalk < parameters->object_ignore_distance_crosswalk_forward &&
+          to_crosswalk > -1.0 * parameters->object_ignore_distance_crosswalk_backward;
+        not_parked_object = not_parked_object || stop_for_crosswalk;
+      }
 
-    if (
-      o.stop_time > parameters->threshold_time_force_avoidance_for_stopped_vehicle &&
-      parameters->enable_force_avoidance_for_stopped_vehicle) {
-      if (o.to_stop_factor_distance > parameters->object_check_force_avoidance_clearance) {
+      o.to_stop_factor_distance = std::min(to_traffic_light, to_crosswalk);
+
+      if (!not_parked_object) {
         o.last_seen = now;
         o.avoid_margin = avoid_margin;
         data.target_objects.push_back(o);


### PR DESCRIPTION
## Description

- ignore objects around crosswalk in avoidance module. (now, ignore only objects that are stopping for traffic light.)
- https://github.com/autowarefoundation/autoware_launch/pull/362

<!-- Write a brief description of this PR. -->

## Tests performed

![rviz_screenshot_2023_05_19-11_46_44](https://github.com/autowarefoundation/autoware.universe/assets/44889564/a7a88348-29d6-4357-816e-a1388432118f)
![rviz_screenshot_2023_05_19-11_47_20](https://github.com/autowarefoundation/autoware.universe/assets/44889564/959b487d-13e2-4692-875b-6fed6e878172)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
