### PR TITLE
feat(obstacle_cruise_planner): stabler slow down

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -206,6 +206,10 @@ private:
       min_ego_velocity = node.declare_parameter<double>("slow_down.min_ego_velocity");
       time_margin_on_target_velocity =
         node.declare_parameter<double>("slow_down.time_margin_on_target_velocity");
+      lpf_gain_slow_down_vel = node.declare_parameter<double>("slow_down.lpf_gain_slow_down_vel");
+      lpf_gain_lat_dist = node.declare_parameter<double>("slow_down.lpf_gain_lat_dist");
+      lpf_gain_dist_to_slow_down_start =
+        node.declare_parameter<double>("slow_down.lpf_gain_dist_to_slow_down_start");
     }
 
     void onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -220,6 +224,12 @@ private:
         parameters, "slow_down.min_ego_velocity", min_ego_velocity);
       tier4_autoware_utils::updateParam<double>(
         parameters, "slow_down.time_margin_on_target_velocity", time_margin_on_target_velocity);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.lpf_gain_slow_down_vel", lpf_gain_slow_down_vel);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.lpf_gain_lat_dist", lpf_gain_lat_dist);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.lpf_gain_dist_to_slow_down_start", lpf_gain_dist_to_slow_down_start);
     }
 
     double max_lat_margin;
@@ -228,7 +238,7 @@ private:
     double min_ego_velocity;
     double time_margin_on_target_velocity;
     double lpf_gain_slow_down_vel{0.99};           // TODO(murooka) use rosparam
-    double lpf_gain_precise_lat_dist{0.999};       // TODO(murooka) use rosparam
+    double lpf_gain_lat_dist{0.999};               // TODO(murooka) use rosparam
     double lpf_gain_dist_to_slow_down_start{0.9};  // TODO(murooka) use rosparam
   };
   SlowDownParam slow_down_param_;

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -962,9 +962,13 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
   // check lateral distance considering hysteresis
   const bool is_lat_dist_low = isLowerConsideringHysteresis(
     precise_lat_dist, is_prev_obstacle_slow_down,
-    p.max_lat_margin_for_slow_down + p.lat_hysteresis_margin_for_slow_down,
-    p.max_lat_margin_for_slow_down - p.lat_hysteresis_margin_for_slow_down);
+    p.max_lat_margin_for_slow_down + p.lat_hysteresis_margin_for_slow_down / 2.0,
+    p.max_lat_margin_for_slow_down - p.lat_hysteresis_margin_for_slow_down / 2.0);
   if (!is_lat_dist_low) {
+    RCLCPP_INFO_EXPRESSION(
+      get_logger(), enable_debug_info_,
+      "[SlowDown] Ignore obstacle (%s) since it's far from trajectory. (%f [m])", object_id.c_str(),
+      precise_lat_dist);
     return std::nullopt;
   }
 

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -415,11 +415,10 @@ double PlannerInterface::calculateSlowDownVelocity(
     if (prev_output) {
       return signal_processing::lowpassFilter(
         obstacle.precise_lat_dist, prev_output->precise_lat_dist,
-        slow_down_param_.lpf_gain_precise_lat_dist);
+        slow_down_param_.lpf_gain_lat_dist);
     }
     return obstacle.precise_lat_dist;
   }();
-  std::cerr << "=============" << stable_precise_lat_dist << "=================" << std::endl;
 
   const double ratio = std::clamp(
     (std::abs(stable_precise_lat_dist) - p.min_lat_margin) / (p.max_lat_margin - p.min_lat_margin),


### PR DESCRIPTION
## Description

must be merged after https://github.com/autowarefoundation/autoware.universe/pull/3775

added a lower-pass filter for
- lateral distance from obstacle to the path
- slow down start distance
- slow down velocity
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator
scenario simulator
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

stabler slow down
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
