### PR TITLE
feat(obstacle_cruise_planner): stabler slow down

### DIFF
--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -86,15 +86,15 @@
           collision_time_margin : 4.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 
       cruise:
-        max_lat_margin: 0.8 # lateral margin between obstacle and trajectory band with ego's width
+        max_lat_margin: 1.0 # lateral margin between obstacle and trajectory band with ego's width
         outside_obstacle:
           obstacle_velocity_threshold : 3.0 # minimum velocity threshold of obstacles outside the trajectory to cruise or stop [m/s]
           ego_obstacle_overlap_time_threshold : 1.0 #  time threshold to decide cut-in obstacle for cruise or stop [s]
           max_prediction_time_for_collision_check : 20.0 # prediction time to check collision between obstacle and ego
 
       slow_down:
-        max_lat_margin: 0.7  # lateral margin between obstacle and trajectory band with ego's width
-        lat_hysteresis_margin: 0.1
+        max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
+        lat_hysteresis_margin: 0.2
 
     cruise:
       pid_based_planner:
@@ -168,3 +168,7 @@
       max_ego_velocity: 8.0
 
       time_margin_on_target_velocity: 1.5 # [s]
+
+      lpf_gain_slow_down_vel: 0.99 # low-pass filter gain for slow down velocity
+      lpf_gain_lat_dist: 0.999 # low-pass filter gain for lateral distance from obstacle to ego's path
+      lpf_gain_dist_to_slow_down: 0.7 # low-pass filter gain for distance to slow down start

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -206,6 +206,10 @@ private:
       min_ego_velocity = node.declare_parameter<double>("slow_down.min_ego_velocity");
       time_margin_on_target_velocity =
         node.declare_parameter<double>("slow_down.time_margin_on_target_velocity");
+      lpf_gain_slow_down_vel = node.declare_parameter<double>("slow_down.lpf_gain_slow_down_vel");
+      lpf_gain_lat_dist = node.declare_parameter<double>("slow_down.lpf_gain_lat_dist");
+      lpf_gain_dist_to_slow_down_start =
+        node.declare_parameter<double>("slow_down.lpf_gain_dist_to_slow_down_start");
     }
 
     void onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -220,6 +224,12 @@ private:
         parameters, "slow_down.min_ego_velocity", min_ego_velocity);
       tier4_autoware_utils::updateParam<double>(
         parameters, "slow_down.time_margin_on_target_velocity", time_margin_on_target_velocity);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.lpf_gain_slow_down_vel", lpf_gain_slow_down_vel);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.lpf_gain_lat_dist", lpf_gain_lat_dist);
+      tier4_autoware_utils::updateParam<double>(
+        parameters, "slow_down.lpf_gain_dist_to_slow_down_start", lpf_gain_dist_to_slow_down_start);
     }
 
     double max_lat_margin;
@@ -228,7 +238,7 @@ private:
     double min_ego_velocity;
     double time_margin_on_target_velocity;
     double lpf_gain_slow_down_vel{0.99};           // TODO(murooka) use rosparam
-    double lpf_gain_precise_lat_dist{0.999};       // TODO(murooka) use rosparam
+    double lpf_gain_lat_dist{0.999};               // TODO(murooka) use rosparam
     double lpf_gain_dist_to_slow_down_start{0.9};  // TODO(murooka) use rosparam
   };
   SlowDownParam slow_down_param_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -188,10 +189,10 @@ private:
   };
   double calculateSlowDownVelocity(
     const SlowDownObstacle & obstacle, const std::optional<SlowDownOutput> & prev_output) const;
-  std::pair<double, double> calculateDistanceToSlowDownWithConstraints(
+  std::tuple<double, double, double> calculateDistanceToSlowDownWithConstraints(
     const PlannerData & planner_data, const std::vector<TrajectoryPoint> & traj_points,
     const SlowDownObstacle & obstacle, const std::optional<SlowDownOutput> & prev_output,
-    const double dist_to_ego, const double slow_down_vel) const;
+    const double dist_to_ego) const;
 
   struct SlowDownInfo
   {

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -168,12 +168,15 @@ private:
     SlowDownOutput() = default;
     SlowDownOutput(
       const std::string & arg_uuid, const std::vector<TrajectoryPoint> & traj_points,
-      const std::optional<size_t> & idx, const double arg_target_vel,
-      const double arg_precise_lat_dist)
+      const std::optional<size_t> & start_idx, const std::optional<size_t> & end_idx,
+      const double arg_target_vel, const double arg_precise_lat_dist)
     : uuid(arg_uuid), target_vel(arg_target_vel), precise_lat_dist(arg_precise_lat_dist)
     {
-      if (idx) {
-        start_point = traj_points.at(*idx).pose;
+      if (start_idx) {
+        start_point = traj_points.at(*start_idx).pose;
+      }
+      if (end_idx) {
+        end_point = traj_points.at(*end_idx).pose;
       }
     }
 
@@ -181,6 +184,7 @@ private:
     double target_vel;
     double precise_lat_dist;
     std::optional<geometry_msgs::msg::Pose> start_point{std::nullopt};
+    std::optional<geometry_msgs::msg::Pose> end_point{std::nullopt};
   };
   double calculateSlowDownVelocity(
     const SlowDownObstacle & obstacle, const std::optional<SlowDownOutput> & prev_output) const;
@@ -208,8 +212,8 @@ private:
         node.declare_parameter<double>("slow_down.time_margin_on_target_velocity");
       lpf_gain_slow_down_vel = node.declare_parameter<double>("slow_down.lpf_gain_slow_down_vel");
       lpf_gain_lat_dist = node.declare_parameter<double>("slow_down.lpf_gain_lat_dist");
-      lpf_gain_dist_to_slow_down_start =
-        node.declare_parameter<double>("slow_down.lpf_gain_dist_to_slow_down_start");
+      lpf_gain_dist_to_slow_down =
+        node.declare_parameter<double>("slow_down.lpf_gain_dist_to_slow_down");
     }
 
     void onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -229,7 +233,7 @@ private:
       tier4_autoware_utils::updateParam<double>(
         parameters, "slow_down.lpf_gain_lat_dist", lpf_gain_lat_dist);
       tier4_autoware_utils::updateParam<double>(
-        parameters, "slow_down.lpf_gain_dist_to_slow_down_start", lpf_gain_dist_to_slow_down_start);
+        parameters, "slow_down.lpf_gain_dist_to_slow_down", lpf_gain_dist_to_slow_down);
     }
 
     double max_lat_margin;
@@ -237,9 +241,9 @@ private:
     double max_ego_velocity;
     double min_ego_velocity;
     double time_margin_on_target_velocity;
-    double lpf_gain_slow_down_vel{0.99};           // TODO(murooka) use rosparam
-    double lpf_gain_lat_dist{0.999};               // TODO(murooka) use rosparam
-    double lpf_gain_dist_to_slow_down_start{0.9};  // TODO(murooka) use rosparam
+    double lpf_gain_slow_down_vel;
+    double lpf_gain_lat_dist;
+    double lpf_gain_dist_to_slow_down;
   };
   SlowDownParam slow_down_param_;
 

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -962,9 +962,13 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
   // check lateral distance considering hysteresis
   const bool is_lat_dist_low = isLowerConsideringHysteresis(
     precise_lat_dist, is_prev_obstacle_slow_down,
-    p.max_lat_margin_for_slow_down + p.lat_hysteresis_margin_for_slow_down,
-    p.max_lat_margin_for_slow_down - p.lat_hysteresis_margin_for_slow_down);
+    p.max_lat_margin_for_slow_down + p.lat_hysteresis_margin_for_slow_down / 2.0,
+    p.max_lat_margin_for_slow_down - p.lat_hysteresis_margin_for_slow_down / 2.0);
   if (!is_lat_dist_low) {
+    RCLCPP_INFO_EXPRESSION(
+      get_logger(), enable_debug_info_,
+      "[SlowDown] Ignore obstacle (%s) since it's far from trajectory. (%f [m])", object_id.c_str(),
+      precise_lat_dist);
     return std::nullopt;
   }
 

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -1175,7 +1175,6 @@ PlannerData ObstacleCruisePlannerNode::createPlannerData(
   planner_data.ego_vel = ego_odom_ptr_->twist.twist.linear.x;
   planner_data.ego_acc = ego_accel_ptr_->accel.accel.linear.x;
   planner_data.is_driving_forward = is_driving_forward_;
-
   return planner_data;
 }
 

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -415,11 +415,10 @@ double PlannerInterface::calculateSlowDownVelocity(
     if (prev_output) {
       return signal_processing::lowpassFilter(
         obstacle.precise_lat_dist, prev_output->precise_lat_dist,
-        slow_down_param_.lpf_gain_precise_lat_dist);
+        slow_down_param_.lpf_gain_lat_dist);
     }
     return obstacle.precise_lat_dist;
   }();
-  std::cerr << "=============" << stable_precise_lat_dist << "=================" << std::endl;
 
   const double ratio = std::clamp(
     (std::abs(stable_precise_lat_dist) - p.min_lat_margin) / (p.max_lat_margin - p.min_lat_margin),

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -116,6 +116,94 @@ std::optional<T> getObjectFromUuid(const std::vector<T> & objects, const std::st
   }
   return *itr;
 }
+
+// TODO(murooka) following two functions are copied from behavior_velocity_planner.
+// These should be refactored.
+double findReachTime(
+  const double jerk, const double accel, const double velocity, const double distance,
+  const double t_min, const double t_max)
+{
+  const double j = jerk;
+  const double a = accel;
+  const double v = velocity;
+  const double d = distance;
+  const double min = t_min;
+  const double max = t_max;
+  auto f = [](const double t, const double j, const double a, const double v, const double d) {
+    return j * t * t * t / 6.0 + a * t * t / 2.0 + v * t - d;
+  };
+  if (f(min, j, a, v, d) > 0 || f(max, j, a, v, d) < 0) {
+    std::logic_error("[obstacle_cruise_planner](findReachTime): search range is invalid");
+  }
+  const double eps = 1e-5;
+  const int warn_iter = 100;
+  double lower = min;
+  double upper = max;
+  double t;
+  int iter = 0;
+  for (int i = 0;; i++) {
+    t = 0.5 * (lower + upper);
+    const double fx = f(t, j, a, v, d);
+    // std::cout<<"fx: "<<fx<<" up: "<<upper<<" lo: "<<lower<<" t: "<<t<<std::endl;
+    if (std::abs(fx) < eps) {
+      break;
+    } else if (fx > 0.0) {
+      upper = t;
+    } else {
+      lower = t;
+    }
+    iter++;
+    if (iter > warn_iter)
+      std::cerr << "[obstacle_cruise_planner](findReachTime): current iter is over warning"
+                << std::endl;
+  }
+  return t;
+}
+
+double calcDecelerationVelocityFromDistanceToTarget(
+  const double max_slowdown_jerk, const double max_slowdown_accel, const double current_accel,
+  const double current_velocity, const double distance_to_target)
+{
+  if (max_slowdown_jerk > 0 || max_slowdown_accel > 0) {
+    std::logic_error("max_slowdown_jerk and max_slowdown_accel should be negative");
+  }
+  // case0: distance to target is behind ego
+  if (distance_to_target <= 0) return current_velocity;
+  auto ft = [](const double t, const double j, const double a, const double v, const double d) {
+    return j * t * t * t / 6.0 + a * t * t / 2.0 + v * t - d;
+  };
+  auto vt = [](const double t, const double j, const double a, const double v) {
+    return j * t * t / 2.0 + a * t + v;
+  };
+  const double j_max = max_slowdown_jerk;
+  const double a0 = current_accel;
+  const double a_max = max_slowdown_accel;
+  const double v0 = current_velocity;
+  const double l = distance_to_target;
+  const double t_const_jerk = (a_max - a0) / j_max;
+  const double d_const_jerk_stop = ft(t_const_jerk, j_max, a0, v0, 0.0);
+  const double d_const_acc_stop = l - d_const_jerk_stop;
+
+  if (d_const_acc_stop < 0) {
+    // case0: distance to target is within constant jerk deceleration
+    // use binary search instead of solving cubic equation
+    const double t_jerk = findReachTime(j_max, a0, v0, l, 0, t_const_jerk);
+    const double velocity = vt(t_jerk, j_max, a0, v0);
+    return velocity;
+  } else {
+    const double v1 = vt(t_const_jerk, j_max, a0, v0);
+    const double discriminant_of_stop = 2.0 * a_max * d_const_acc_stop + v1 * v1;
+    // case3: distance to target is farther than distance to stop
+    if (discriminant_of_stop <= 0) {
+      return 0.0;
+    }
+    // case2: distance to target is within constant accel deceleration
+    // solve d = 0.5*a^2+v*t by t
+    const double t_acc = (-v1 + std::sqrt(discriminant_of_stop)) / a_max;
+    return vt(t_acc, 0.0, a_max, v1);
+  }
+  return current_velocity;
+}
 }  // namespace
 
 std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
@@ -340,13 +428,10 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
     const auto & obstacle = obstacles.at(i);
     const auto prev_output = getObjectFromUuid(prev_slow_down_output_, obstacle.uuid);
 
-    // calculate slow down velocity
-    const double raw_slow_down_vel = calculateSlowDownVelocity(obstacle, prev_output);
-
     // calculate slow down start distance, and insert slow down velocity
-    const auto [dist_to_slow_down_start, dist_to_slow_down_end] =
+    const auto [dist_to_slow_down_start, dist_to_slow_down_end, feasible_slow_down_vel] =
       calculateDistanceToSlowDownWithConstraints(
-        planner_data, slow_down_traj_points, obstacle, prev_output, dist_to_ego, raw_slow_down_vel);
+        planner_data, slow_down_traj_points, obstacle, prev_output, dist_to_ego);
 
     // calculate slow down end distance, and insert slow down velocity
     // NOTE: slow_down_start_idx will not be wrong since inserted back point is after inserted
@@ -363,9 +448,9 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
     const double stable_slow_down_vel = [&]() {
       if (prev_output) {
         return signal_processing::lowpassFilter(
-          raw_slow_down_vel, prev_output->target_vel, slow_down_param_.lpf_gain_slow_down_vel);
+          feasible_slow_down_vel, prev_output->target_vel, slow_down_param_.lpf_gain_slow_down_vel);
       }
-      return raw_slow_down_vel;
+      return feasible_slow_down_vel;
     }();
 
     // insert slow down velocity between slow start and end
@@ -431,28 +516,37 @@ double PlannerInterface::calculateSlowDownVelocity(
   return slow_down_vel;
 }
 
-std::pair<double, double> PlannerInterface::calculateDistanceToSlowDownWithConstraints(
+std::tuple<double, double, double> PlannerInterface::calculateDistanceToSlowDownWithConstraints(
   const PlannerData & planner_data, const std::vector<TrajectoryPoint> & traj_points,
   const SlowDownObstacle & obstacle, const std::optional<SlowDownOutput> & prev_output,
-  const double dist_to_ego, const double slow_down_vel) const
+  const double dist_to_ego) const
 {
   const auto & p = slow_down_param_;
   const double abs_ego_offset = planner_data.is_driving_forward
                                   ? std::abs(vehicle_info_.max_longitudinal_offset_m)
                                   : std::abs(vehicle_info_.min_longitudinal_offset_m);
 
+  // calculate slow down velocity
+  const double slow_down_vel = calculateSlowDownVelocity(obstacle, prev_output);
+
+  // calculate distance to collision points
   const double dist_to_front_collision =
     motion_utils::calcSignedArcLength(traj_points, 0, obstacle.front_collision_point);
   const double dist_to_back_collision =
     motion_utils::calcSignedArcLength(traj_points, 0, obstacle.back_collision_point);
 
+  // calculate distance during deceleration, slow down preparation, and slow down
   const double slow_down_prepare_dist = slow_down_vel * p.time_margin_on_target_velocity;
   const double deceleration_dist =
     dist_to_front_collision - abs_ego_offset - dist_to_ego - slow_down_prepare_dist;
   const double slow_down_dist =
     dist_to_back_collision - dist_to_front_collision + slow_down_prepare_dist;
 
-  // function to apply low-pass filter to distance to start/end slow down
+  // calculate distance to start/end slow down
+  const double dist_to_slow_down_start = dist_to_ego + deceleration_dist;
+  const double dist_to_slow_down_end = dist_to_ego + deceleration_dist + slow_down_dist;
+
+  // apply low-pass filter to distance to start/end slow down
   const auto apply_lowpass_filter = [&](const double dist_to_slow_down, const auto prev_point) {
     if (prev_output && prev_point) {
       const size_t seg_idx =
@@ -464,35 +558,37 @@ std::pair<double, double> PlannerInterface::calculateDistanceToSlowDownWithConst
     }
     return dist_to_slow_down;
   };
-
-  // calculate distance to end slow down
-  const double dist_to_slow_down_end = dist_to_back_collision - abs_ego_offset;
+  const double filtered_dist_to_slow_down_start =
+    apply_lowpass_filter(dist_to_slow_down_start, prev_output->start_point);
   const double filtered_dist_to_slow_down_end =
     apply_lowpass_filter(dist_to_slow_down_end, prev_output->end_point);
 
-  // calculate distance to start slow down
-  // const double dist_to_slow_down_start = dist_to_ego + deceleration_dist;
-  const double dist_to_slow_down_start = [&]() {
-    // NOTE: If dist_to_ego is larger than filtered_dist_to_slow_down_end, the ego will accelerate
-    // since slow down already ends. However, this makes deceleration_min_dist forward due to higher
-    // ego velocity, resulting in slow down again.
-    if (dist_to_ego < filtered_dist_to_slow_down_end) {
-      // calculate minimum longitudinal distance during deceleration
-      const auto deceleration_min_dist = motion_utils::calcDecelDistWithJerkAndAccConstraints(
-        planner_data.ego_vel, slow_down_vel, planner_data.ego_acc, longitudinal_info_.min_accel,
-        longitudinal_info_.max_jerk, longitudinal_info_.min_jerk);
-      if (deceleration_min_dist) {
-        return dist_to_ego + std::max(deceleration_dist, *deceleration_min_dist);
+  // calculate velocity considering constraints
+  const double feasible_slow_down_vel = [&]() {
+    if (deceleration_dist < 0) {
+      if (prev_output) {
+        return prev_output->target_vel;
       }
+      return slow_down_vel;
     }
-    return dist_to_ego + deceleration_dist;
+    if (planner_data.ego_vel < slow_down_vel) {
+      return slow_down_vel;
+    }
+    if (planner_data.ego_acc < longitudinal_info_.min_accel) {
+      const double squared_vel =
+        std::pow(planner_data.ego_vel, 2) + 2 * deceleration_dist * longitudinal_info_.min_accel;
+      if (squared_vel < 0) {
+        return slow_down_vel;
+      }
+      return std::max(std::sqrt(squared_vel), slow_down_vel);
+    }
+    // TODO(murooka) Calculate more precisely. Final acceleration should be zero.
+    const double min_feasible_slow_down_vel = calcDecelerationVelocityFromDistanceToTarget(
+      longitudinal_info_.min_jerk, longitudinal_info_.min_accel, planner_data.ego_acc,
+      planner_data.ego_vel, deceleration_dist);
+    return std::max(min_feasible_slow_down_vel, slow_down_vel);
   }();
-  const double filtered_dist_to_slow_down_start =
-    apply_lowpass_filter(dist_to_slow_down_start, prev_output->start_point);
 
-  if (filtered_dist_to_slow_down_end < filtered_dist_to_slow_down_start) {
-    return std::make_pair(
-      filtered_dist_to_slow_down_start, filtered_dist_to_slow_down_start + slow_down_dist);
-  }
-  return std::make_pair(filtered_dist_to_slow_down_start, filtered_dist_to_slow_down_end);
+  return std::make_tuple(
+    filtered_dist_to_slow_down_start, filtered_dist_to_slow_down_end, feasible_slow_down_vel);
 }


### PR DESCRIPTION
## Description

- added a lower-pass filter for
    - lateral distance from obstacle to the path
    - slow down start distance
    - slow down velocity

- calculate slow down velocity from the distance constraints using behavior_velocity_planner's util function.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- planning simulator
- scenario simulator
    - without this PR: https://evaluation.tier4.jp/evaluation/reports/fc75b567-170a-5d09-8e6a-26088cf2ff8f?project_id=prd_jt (1692/1722 pass)
    - with this PR: https://evaluation.tier4.jp/evaluation/reports/534ac908-f7c4-52d6-ab98-bb2813475ddc?project_id=prd_jt (1697/1722 pass)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Stabler slow down planning against close obstacles.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
