### PR TITLE
fix(dynamic_avoidance): ignore obstacles with non target label

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -116,6 +116,7 @@ public:
   }
 
 private:
+  bool isLabelTargetObstacle(const uint8_t label) const;
   std::vector<DynamicAvoidanceObject> calcTargetObjects() const;
   std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> getAdjacentLanes(
     const double forward_distance, const double backward_distance) const;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -238,6 +238,37 @@ BehaviorModuleOutput DynamicAvoidanceModule::planWaitingApproval()
   return out;
 }
 
+bool DynamicAvoidanceModule::isLabelTargetObstacle(const uint8_t label) const
+{
+  using autoware_auto_perception_msgs::msg::ObjectClassification;
+
+  if (label == ObjectClassification::CAR && parameters_->avoid_car) {
+    return true;
+  }
+  if (label == ObjectClassification::TRUCK && parameters_->avoid_truck) {
+    return true;
+  }
+  if (label == ObjectClassification::BUS && parameters_->avoid_bus) {
+    return true;
+  }
+  if (label == ObjectClassification::TRAILER && parameters_->avoid_trailer) {
+    return true;
+  }
+  if (label == ObjectClassification::UNKNOWN && parameters_->avoid_unknown) {
+    return true;
+  }
+  if (label == ObjectClassification::BICYCLE && parameters_->avoid_bicycle) {
+    return true;
+  }
+  if (label == ObjectClassification::MOTORCYCLE && parameters_->avoid_motorcycle) {
+    return true;
+  }
+  if (label == ObjectClassification::PEDESTRIAN && parameters_->avoid_pedestrian) {
+    return true;
+  }
+  return false;
+}
+
 std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject>
 DynamicAvoidanceModule::calcTargetObjects() const
 {
@@ -247,6 +278,13 @@ DynamicAvoidanceModule::calcTargetObjects() const
   // 1. convert predicted objects to dynamic avoidance objects
   std::vector<DynamicAvoidanceObject> input_objects;
   for (const auto & predicted_object : predicted_objects) {
+    // check label
+    const bool is_label_target_obstacle =
+      isLabelTargetObstacle(predicted_object.classification.front().label);
+    if (!is_label_target_obstacle) {
+      continue;
+    }
+
     const double path_projected_vel =
       calcObstacleProjectedVelocity(prev_module_path->points, predicted_object);
     // check if velocity is high enough


### PR DESCRIPTION
## Description

The implementation of filtering obstacles for dynamic avoidance by their label is missing.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No behavior change.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
