### PR TITLE
feat(map_based_prediction): revert old logic

### DIFF
--- a/perception/map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/map_based_prediction/config/map_based_prediction.param.yaml
@@ -11,7 +11,17 @@
     sigma_yaw_angle_deg: 5.0 #[angle degree]
     object_buffer_time_length: 2.0 #[s]
     history_time_length: 1.0 #[s]
-    dist_threshold_for_lane_change_detection: 1.0 #[m]
-    time_threshold_for_lane_change_detection: 5.0 #[s]
-    cutoff_freq_of_velocity_for_lane_change_detection: 0.1 #[Hz]
+
+    lane_change_detection:
+      method: "lat_diff_distance" # choose from "lat_diff_distance" or "time_to_change_lane"
+      time_to_change_lane:
+        dist_threshold_for_lane_change_detection: 1.0 #[m]
+        time_threshold_for_lane_change_detection: 5.0 #[s]
+        cutoff_freq_of_velocity_for_lane_change_detection: 0.1 #[Hz]
+      lat_diff_distance:
+        dist_ratio_threshold_to_left_bound: -0.5 #[ratio]
+        dist_ratio_threshold_to_right_bound: 0.5 #[ratio
+        diff_dist_threshold_to_left_bound: 0.29 #[m]
+        diff_dist_threshold_to_right_bound: -0.29 #[m]
+
     reference_path_resolution: 0.5 #[m]

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -145,9 +145,14 @@ private:
   double sigma_yaw_angle_deg_;
   double object_buffer_time_length_;
   double history_time_length_;
+  std::string lane_change_detection_method_;
   double dist_threshold_to_bound_;
   double time_threshold_to_bound_;
   double cutoff_freq_of_velocity_lpf_;
+  double dist_ratio_threshold_to_left_bound_;
+  double dist_ratio_threshold_to_right_bound_;
+  double diff_dist_threshold_to_left_bound_;
+  double diff_dist_threshold_to_right_bound_;
   double reference_path_resolution_;
 
   // Stop watch
@@ -182,7 +187,7 @@ private:
     const TrackedObject & object, const LaneletsData & current_lanelets_data,
     const double object_detected_time);
   Maneuver predictObjectManeuver(
-    const TrackedObject & object, const LaneletData & current_lanelet,
+    const TrackedObject & object, const LaneletData & current_lanelet_data,
     const double object_detected_time);
   geometry_msgs::msg::Pose compensateTimeDelay(
     const geometry_msgs::msg::Pose & delayed_pose, const geometry_msgs::msg::Twist & twist,
@@ -213,6 +218,13 @@ private:
 
   visualization_msgs::msg::Marker getDebugMarker(
     const TrackedObject & object, const Maneuver & maneuver, const size_t obj_num);
+
+  Maneuver predictObjectManeuverByTimeToLaneChange(
+    const TrackedObject & object, const LaneletData & current_lanelet_data,
+    const double object_detected_time);
+  Maneuver predictObjectManeuverByLatDiffDistance(
+    const TrackedObject & object, const LaneletData & current_lanelet_data,
+    const double object_detected_time);
 };
 }  // namespace map_based_prediction
 


### PR DESCRIPTION
## Description

Revert the old logic of the lane change detection deleted by the following PR
https://github.com/autowarefoundation/autoware.universe/pull/2822
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Lane change detection's behavior in prediction may change a bit.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
