### PR TITLE
refactor(control_performance_analysis): refactor structure

### DIFF
--- a/control/control_performance_analysis/config/control_performance_analysis.param.yaml
+++ b/control/control_performance_analysis/config/control_performance_analysis.param.yaml
@@ -4,6 +4,6 @@
     curvature_interval_length: 5.0
     prevent_zero_division_value: 0.001
     odom_interval: 0
-    acceptable_max_distance_to_waypoint: 20.0
-    low_pass_filter_gain: 0.0
+    acceptable_max_distance_to_waypoint: 2.0
+    low_pass_filter_gain: 0.95
     acceptable_max_yaw_difference_rad: 1.0472

--- a/control/control_performance_analysis/config/control_performance_analysis.param.yaml
+++ b/control/control_performance_analysis/config/control_performance_analysis.param.yaml
@@ -4,6 +4,6 @@
     curvature_interval_length: 5.0
     prevent_zero_division_value: 0.001
     odom_interval: 0
-    acceptable_max_distance_to_waypoint: 2.0
-    low_pass_filter_gain: 0.95
+    acceptable_max_distance_to_waypoint: 20.0
+    low_pass_filter_gain: 0.0
     acceptable_max_yaw_difference_rad: 1.0472

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
@@ -42,6 +42,7 @@ using autoware_auto_control_msgs::msg::AckermannControlCommand;
 using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_auto_vehicle_msgs::msg::SteeringReport;
 using control_performance_analysis::msg::DrivingMonitorStamped;
+using control_performance_analysis::msg::Error;
 using control_performance_analysis::msg::ErrorStamped;
 using control_performance_analysis::msg::FloatStamped;
 using geometry_msgs::msg::Pose;
@@ -78,7 +79,7 @@ public:
   void setOdomHistory(const Odometry & odom);
   void setSteeringStatus(const SteeringReport & steering);
 
-  void findCurveRefIdx();
+  boost::optional<int32_t> findCurveRefIdx();
   std::pair<bool, int32_t> findClosestPrevWayPointIdx_path_direction();
   double estimateCurvature();
   double estimatePurePursuitCurvature();
@@ -111,9 +112,8 @@ private:
 
   // Variables computed
 
-  std::unique_ptr<int32_t> idx_prev_wp_;       // the waypoint index, vehicle
-  std::unique_ptr<int32_t> idx_curve_ref_wp_;  // index of waypoint corresponds to front axle center
-  std::unique_ptr<int32_t> idx_next_wp_;       //  the next waypoint index, vehicle heading to
+  std::unique_ptr<int32_t> idx_prev_wp_;  // the waypoint index, vehicle
+  std::unique_ptr<int32_t> idx_next_wp_;  //  the next waypoint index, vehicle heading to
   std::unique_ptr<ErrorStamped> prev_target_vars_{};
   std::unique_ptr<DrivingMonitorStamped> prev_driving_vars_{};
   std::shared_ptr<Pose> interpolated_pose_ptr_;

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_core.hpp
@@ -99,8 +99,6 @@ private:
 
   // Variables Received Outside
   std::shared_ptr<autoware_auto_planning_msgs::msg::Trajectory> current_trajectory_ptr_;
-  std::shared_ptr<PoseArray> current_waypoints_ptr_;
-  std::shared_ptr<std::vector<double>> current_waypoints_vel_ptr_;
   std::shared_ptr<Pose> current_vec_pose_ptr_;
   std::shared_ptr<std::vector<Odometry>> odom_history_ptr_;  // velocities at k-2, k-1, k, k+1
   std::shared_ptr<AckermannControlCommand> current_control_ptr_;

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_node.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_node.hpp
@@ -57,9 +57,6 @@ private:
   rclcpp::Subscription<Odometry>::SharedPtr sub_velocity_;  // subscribe to velocity
   rclcpp::Subscription<SteeringReport>::SharedPtr sub_vehicle_steering_;
 
-  // Self Pose listener.
-  tier4_autoware_utils::SelfPoseListener self_pose_listener_{this};  // subscribe to pose listener.
-
   // Publishers
   rclcpp::Publisher<ErrorStamped>::SharedPtr pub_error_msg_;  // publish error message
   rclcpp::Publisher<DrivingMonitorStamped>::SharedPtr
@@ -78,7 +75,7 @@ private:
   // Parameters
   Params param_{};  // wheelbase, control period and feedback coefficients.
   // State holder
-  std_msgs::msg::Header last_control_cmd_;
+  AckermannControlCommand::ConstSharedPtr last_control_cmd_;
   double d_control_cmd_{0};
 
   // Subscriber Parameters

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
@@ -25,6 +25,7 @@
 #include <tf2/utils.h>
 
 #include <cmath>
+#include <utility>
 #include <vector>
 
 namespace control_performance_analysis

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
@@ -20,6 +20,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/quaternion.hpp>
+#include <geometry_msgs/msg/point.hpp>
 
 #include <tf2/utils.h>
 
@@ -41,21 +42,21 @@ inline std::vector<double> getNormalVector(double yaw_angle)
   return std::vector<double>{-sin(yaw_angle), cos(yaw_angle)};
 }
 
-inline std::vector<double> computeLateralLongitudinalError(
-  const std::vector<double> & closest_point_position, const std::vector<double> & vehicle_position,
+inline std::pair<double, double> computeLateralLongitudinalError(
+  const geometry_msgs::msg::Point & closest_point_position, const geometry_msgs::msg::Point & vehicle_position,
   const double & desired_yaw_angle)
 {
   // Vector to path point originating from the vehicle r - rd
   std::vector<double> vector_to_path_point{
-    vehicle_position[0] - closest_point_position[0],
-    vehicle_position[1] - closest_point_position[1]};
+    vehicle_position.x - closest_point_position.x,
+    vehicle_position.y - closest_point_position.y};
 
   double lateral_error = -sin(desired_yaw_angle) * vector_to_path_point[0] +
                          cos(desired_yaw_angle) * vector_to_path_point[1];
   double longitudinal_error = cos(desired_yaw_angle) * vector_to_path_point[0] +
                               sin(desired_yaw_angle) * vector_to_path_point[1];
 
-  return std::vector<double>{lateral_error, longitudinal_error};
+  return {lateral_error, longitudinal_error};
 }
 
 inline double computeLateralError(

--- a/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
+++ b/control/control_performance_analysis/include/control_performance_analysis/control_performance_analysis_utils.hpp
@@ -19,8 +19,8 @@
 #include <Eigen/Geometry>
 #include <rclcpp/rclcpp.hpp>
 
-#include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
 
 #include <tf2/utils.h>
 
@@ -43,13 +43,12 @@ inline std::vector<double> getNormalVector(double yaw_angle)
 }
 
 inline std::pair<double, double> computeLateralLongitudinalError(
-  const geometry_msgs::msg::Point & closest_point_position, const geometry_msgs::msg::Point & vehicle_position,
-  const double & desired_yaw_angle)
+  const geometry_msgs::msg::Point & closest_point_position,
+  const geometry_msgs::msg::Point & vehicle_position, const double & desired_yaw_angle)
 {
   // Vector to path point originating from the vehicle r - rd
   std::vector<double> vector_to_path_point{
-    vehicle_position.x - closest_point_position.x,
-    vehicle_position.y - closest_point_position.y};
+    vehicle_position.x - closest_point_position.x, vehicle_position.y - closest_point_position.y};
 
   double lateral_error = -sin(desired_yaw_angle) * vector_to_path_point[0] +
                          cos(desired_yaw_angle) * vector_to_path_point[1];
@@ -57,37 +56,6 @@ inline std::pair<double, double> computeLateralLongitudinalError(
                               sin(desired_yaw_angle) * vector_to_path_point[1];
 
   return {lateral_error, longitudinal_error};
-}
-
-inline double computeLateralError(
-  std::vector<double> & closest_point_position, std::vector<double> & vehicle_position,
-  double & yaw_angle)
-{
-  // Normal vector of vehicle direction
-  std::vector<double> normal_vector = getNormalVector(yaw_angle);
-
-  // Vector to path point originating from the vehicle
-  std::vector<double> vector_to_path_point{
-    closest_point_position[0] - vehicle_position[0],
-    closest_point_position[1] - vehicle_position[1]};
-
-  double lateral_error =
-    normal_vector[0] * vector_to_path_point[0] + normal_vector[1] * vector_to_path_point[1];
-
-  return lateral_error;
-}
-
-/*
- *  Shortest distance between two angles. As the angles are cyclic, interpolation between to
- *  angles must be  carried out using the distance value instead of using the end values of
- *  two points.
- * */
-inline double angleDistance(const double & target_angle, const double & reference_angle)
-{
-  double diff = std::fmod(target_angle - reference_angle + M_PI_2, 2 * M_PI) - M_PI_2;
-  double diff_signed_correction = diff < -M_PI_2 ? diff + 2 * M_PI : diff;  // Fix sign
-
-  return -1.0 * diff_signed_correction;
 }
 
 inline geometry_msgs::msg::Quaternion createOrientationMsgFromYaw(double yaw_angle)

--- a/control/control_performance_analysis/package.xml
+++ b/control/control_performance_analysis/package.xml
@@ -27,7 +27,6 @@
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
-  <depend>tier4_debug_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>motion_utils</depend>
@@ -41,6 +40,7 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
+  <depend>tier4_debug_msgs</depend>
   <depend>vehicle_info_util</depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>global_parameter_loader</exec_depend>

--- a/control/control_performance_analysis/package.xml
+++ b/control/control_performance_analysis/package.xml
@@ -27,6 +27,7 @@
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>tier4_debug_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>motion_utils</depend>

--- a/control/control_performance_analysis/scripts/control_performance_plot.py
+++ b/control/control_performance_analysis/scripts/control_performance_plot.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+
+import rclpy
+from rclpy.node import Node
+from control_performance_analysis.msg import ErrorStamped, DrivingMonitorStamped
+from tier4_debug_msgs.msg import BoolStamped
+from nav_msgs.msg import Odometry
+import matplotlib.pyplot as plt
+import math
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i","--interval",help="interval distance to plot")
+parser.add_argument("-r", "--realtime_plot", default=True, help="Enable real-time plotting")
+
+class PlotterNode(Node):
+    def __init__(self, realtime_plot):
+        super().__init__('plotter_node')
+
+        self.realtime_plot = realtime_plot
+
+        self.subscription_error = self.create_subscription(ErrorStamped, '/control_performance/performance_vars', self.error_callback, 10)
+        self.subscription_driving = self.create_subscription(DrivingMonitorStamped, 'driving_topic', self.driving_callback, 10)
+        self.subscription_odometry = self.create_subscription(Odometry, '/localization/kinematic_state', self.odometry_callback, 10)
+        self.subscription_plot = self.create_subscription(BoolStamped, '/make_plot', self.make_plot_callback, 10)
+        self.curvature = None
+        self.velocity = None
+        self.lateral_error = None
+        self.pose_distance_threshold = 0.2  # Define the pose distance threshold to trigger plot update
+        self.previous_pos = None
+
+        self.abs_curvature_arr = []
+        self.abs_velocity_arr = []
+        self.abs_lateral_error_arr = []
+
+        self.fig, self.ax = plt.subplots(3, 3, figsize=(12, 9))
+        self.velocities = [(0.0, 3.0), (3.0, 6.0), (6.0, 9.0), (9.0, 12.0), (12.0, 15.0), (15.0, 18.0), (18.0, 21.0), (21.0, 24.0), (24.0, float('inf'))]
+        plt.pause(0.1)
+
+    def error_callback(self, msg):
+        print("error_callback!")
+        self.lateral_error = msg.error.lateral_error
+        self.curvature = msg.error.curvature_estimate
+
+    def driving_callback(self, msg):
+        print("driving_callback!")
+
+    def make_plot_callback(self, msg):
+        if msg.data is True:
+            self.update_plot()
+
+    def odometry_callback(self, msg):
+        print("odometry_callback!")
+        current_pos = msg.pose.pose.position
+        self.velocity = msg.twist.twist.linear.x
+
+        if self.previous_pos is None:
+            self.previous_pos = current_pos
+            return
+
+        if self.curvature is None:
+            print("waiting curvature")
+            return
+        if self.velocity is None:
+            print("waiting velocity")
+            return
+        if self.lateral_error is None:
+            print("waiting lateral_error")
+            return
+        
+
+
+        pose_distance = self.calculate_distance(self.previous_pos, current_pos)
+        print("pose_distance = ", pose_distance)
+        if pose_distance >= self.pose_distance_threshold:
+            print("update!")
+            self.abs_curvature_arr.append(abs(self.curvature))
+            self.abs_lateral_error_arr.append(abs(self.lateral_error))
+            self.abs_velocity_arr.append(abs(self.velocity))
+            if self.realtime_plot is True:
+                self.update_plot()
+            self.previous_pos = current_pos
+
+        
+
+    def calculate_distance(self, pos1, pos2):
+        distance = math.sqrt((pos2.x - pos1.x)**2 + (pos2.y - pos1.y)**2)
+        return distance
+
+    # def update_plot(self):
+    #     if self.curvature is not None and self.velocity is not None and self.lateral_error is not None:
+    #         self.curvature_arr.append(self.curvature)
+    #         self.lateral_error_arr.append(self.lateral_error)
+    #         self.velocity_arr.append(self.velocity)
+    #         self.ax.cla()  # Clear the existing plot
+    #         self.ax.scatter(self.curvature_arr, self.velocity_arr, self.lateral_error_arr)
+    #         plt.pause(0.001)
+    #     else:
+    #         print("waiting data in update_data")
+
+    def update_plot(self):
+        for i, (vel_min, vel_max) in enumerate(self.velocities):
+            indices = [j for j, v in enumerate(self.abs_velocity_arr) if vel_min <= v <= vel_max]
+
+            if len(indices) > 0:
+                ax = self.ax[i // 3, i % 3]
+                ax.cla()
+                ax.scatter([self.abs_curvature_arr[j] for j in indices], [self.abs_lateral_error_arr[j] for j in indices])
+                ax.set_xlabel('Curvature')
+                ax.set_ylabel('Lateral Error')
+                ax.set_title(f'Velocity: {vel_min} - {vel_max}')
+        
+        plt.tight_layout()
+        plt.pause(0.1)  # Pause to allow the plot to update
+
+
+def main(args=None):
+    rclpy.init()
+
+    args = parser.parse_args(args)
+    realtime_plot = args.realtime_plot
+
+    plotter_node = PlotterNode(realtime_plot)
+    print("spin start!")
+    rclpy.spin(plotter_node)
+    print("spin end!")
+    plotter_node.destroy_node()
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/control/control_performance_analysis/scripts/control_performance_plot.py
+++ b/control/control_performance_analysis/scripts/control_performance_plot.py
@@ -15,34 +15,45 @@
 # limitations under the License.
 
 import argparse
-
-
-import rclpy
-from rclpy.node import Node
-from control_performance_analysis.msg import ErrorStamped, DrivingMonitorStamped
-from tier4_debug_msgs.msg import BoolStamped
-from nav_msgs.msg import Odometry
-import matplotlib.pyplot as plt
 import math
 
+from control_performance_analysis.msg import DrivingMonitorStamped
+from control_performance_analysis.msg import ErrorStamped
+import matplotlib.pyplot as plt
+from nav_msgs.msg import Odometry
+import rclpy
+from rclpy.node import Node
+from tier4_debug_msgs.msg import BoolStamped
+
 parser = argparse.ArgumentParser()
-parser.add_argument("-i","--interval",help="interval distance to plot")
+parser.add_argument("-i", "--interval", help="interval distance to plot")
 parser.add_argument("-r", "--realtime_plot", default=True, help="Enable real-time plotting")
+
 
 class PlotterNode(Node):
     def __init__(self, realtime_plot):
-        super().__init__('plotter_node')
+        super().__init__("plotter_node")
 
         self.realtime_plot = realtime_plot
 
-        self.subscription_error = self.create_subscription(ErrorStamped, '/control_performance/performance_vars', self.error_callback, 10)
-        self.subscription_driving = self.create_subscription(DrivingMonitorStamped, 'driving_topic', self.driving_callback, 10)
-        self.subscription_odometry = self.create_subscription(Odometry, '/localization/kinematic_state', self.odometry_callback, 10)
-        self.subscription_plot = self.create_subscription(BoolStamped, '/make_plot', self.make_plot_callback, 10)
+        self.subscription_error = self.create_subscription(
+            ErrorStamped, "/control_performance/performance_vars", self.error_callback, 10
+        )
+        self.subscription_driving = self.create_subscription(
+            DrivingMonitorStamped, "driving_topic", self.driving_callback, 10
+        )
+        self.subscription_odometry = self.create_subscription(
+            Odometry, "/localization/kinematic_state", self.odometry_callback, 10
+        )
+        self.subscription_plot = self.create_subscription(
+            BoolStamped, "/make_plot", self.make_plot_callback, 10
+        )
         self.curvature = None
         self.velocity = None
         self.lateral_error = None
-        self.pose_distance_threshold = 0.2  # Define the pose distance threshold to trigger plot update
+        self.pose_distance_threshold = (
+            0.2  # Define the pose distance threshold to trigger plot update
+        )
         self.previous_pos = None
 
         self.abs_curvature_arr = []
@@ -50,7 +61,17 @@ class PlotterNode(Node):
         self.abs_lateral_error_arr = []
 
         self.fig, self.ax = plt.subplots(3, 3, figsize=(12, 9))
-        self.velocities = [(0.0, 3.0), (3.0, 6.0), (6.0, 9.0), (9.0, 12.0), (12.0, 15.0), (15.0, 18.0), (18.0, 21.0), (21.0, 24.0), (24.0, float('inf'))]
+        self.velocities = [
+            (0.0, 3.0),
+            (3.0, 6.0),
+            (6.0, 9.0),
+            (9.0, 12.0),
+            (12.0, 15.0),
+            (15.0, 18.0),
+            (18.0, 21.0),
+            (21.0, 24.0),
+            (24.0, float("inf")),
+        ]
         plt.pause(0.1)
 
     def error_callback(self, msg):
@@ -83,8 +104,6 @@ class PlotterNode(Node):
         if self.lateral_error is None:
             print("waiting lateral_error")
             return
-        
-
 
         pose_distance = self.calculate_distance(self.previous_pos, current_pos)
         print("pose_distance = ", pose_distance)
@@ -97,10 +116,8 @@ class PlotterNode(Node):
                 self.update_plot()
             self.previous_pos = current_pos
 
-        
-
     def calculate_distance(self, pos1, pos2):
-        distance = math.sqrt((pos2.x - pos1.x)**2 + (pos2.y - pos1.y)**2)
+        distance = math.sqrt((pos2.x - pos1.x) ** 2 + (pos2.y - pos1.y) ** 2)
         return distance
 
     # def update_plot(self):
@@ -121,11 +138,14 @@ class PlotterNode(Node):
             if len(indices) > 0:
                 ax = self.ax[i // 3, i % 3]
                 ax.cla()
-                ax.scatter([self.abs_curvature_arr[j] for j in indices], [self.abs_lateral_error_arr[j] for j in indices])
-                ax.set_xlabel('Curvature')
-                ax.set_ylabel('Lateral Error')
-                ax.set_title(f'Velocity: {vel_min} - {vel_max}')
-        
+                ax.scatter(
+                    [self.abs_curvature_arr[j] for j in indices],
+                    [self.abs_lateral_error_arr[j] for j in indices],
+                )
+                ax.set_xlabel("Curvature")
+                ax.set_ylabel("Lateral Error")
+                ax.set_title(f"Velocity: {vel_min} - {vel_max}")
+
         plt.tight_layout()
         plt.pause(0.1)  # Pause to allow the plot to update
 
@@ -143,5 +163,6 @@ def main(args=None):
     plotter_node.destroy_node()
     rclpy.shutdown()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/control/control_performance_analysis/src/control_performance_analysis_core.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_core.cpp
@@ -15,7 +15,7 @@
 #include "control_performance_analysis/control_performance_analysis_core.hpp"
 
 #include "motion_utils/trajectory/interpolation.hpp"
-#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -51,7 +51,6 @@ ControlPerformanceAnalysisCore::ControlPerformanceAnalysisCore(Params & p) : p_{
 
 void ControlPerformanceAnalysisCore::setCurrentWaypoints(const Trajectory & trajectory)
 {
-  std::cerr << "setCurrentWaypoints is called. trajectory size : " << trajectory.points.size() << std::endl;
   current_trajectory_ptr_ = std::make_shared<Trajectory>(trajectory);
 }
 
@@ -86,45 +85,24 @@ std::pair<bool, int32_t> ControlPerformanceAnalysisCore::findClosestPrevWayPoint
     return std::make_pair(false, std::numeric_limits<int32_t>::quiet_NaN());
   }
 
-  auto closest_idx = motion_utils::findNearestIndex(
-    current_trajectory_ptr_->points, *current_vec_pose_ptr_, p_.acceptable_max_distance_to_waypoint_,
-    p_.acceptable_max_yaw_difference_rad_);
+  const auto closest_segment = motion_utils::findNearestSegmentIndex(
+    current_trajectory_ptr_->points, *current_vec_pose_ptr_,
+    p_.acceptable_max_distance_to_waypoint_, p_.acceptable_max_yaw_difference_rad_);
 
-  if (!closest_idx) {  // fail to find closest idx
+  if (!closest_segment) {  // fail to find closest idx
     return std::make_pair(false, std::numeric_limits<int32_t>::quiet_NaN());
   }
 
-  // find the prev and next waypoint
-
-  if (*closest_idx != 0 && (*closest_idx + 1) != current_trajectory_ptr_->points.size()) {
-    const auto dist_to_prev = tier4_autoware_utils::calcDistance2d(
-      *current_vec_pose_ptr_, current_trajectory_ptr_->points.at(*closest_idx - 1));
-    const auto dist_to_next = tier4_autoware_utils::calcDistance2d(
-      *current_vec_pose_ptr_, current_trajectory_ptr_->points.at(*closest_idx + 1));
-    if (dist_to_next > dist_to_prev) {
-      idx_prev_wp_ = std::make_unique<int32_t>(*closest_idx - 1);
-      idx_next_wp_ = std::make_unique<int32_t>(*closest_idx);
-    } else {
-      idx_prev_wp_ = std::make_unique<int32_t>(*closest_idx);
-      idx_next_wp_ = std::make_unique<int32_t>(*closest_idx + 1);
-    }
-  } else if (*closest_idx == 0) {
-    idx_prev_wp_ = std::make_unique<int32_t>(*closest_idx);
-    idx_next_wp_ = std::make_unique<int32_t>(*closest_idx + 1);
-  } else {
-    idx_prev_wp_ = std::make_unique<int32_t>(*closest_idx - 1);
-    idx_next_wp_ = std::make_unique<int32_t>(*closest_idx);
-  }
-  return (idx_prev_wp_ && idx_next_wp_)
-           ? std::make_pair(true, *idx_prev_wp_)
-           : std::make_pair(false, std::numeric_limits<int32_t>::quiet_NaN());
+  idx_prev_wp_ = std::make_unique<int32_t>(closest_segment.get());
+  idx_next_wp_ = std::make_unique<int32_t>(closest_segment.get() + 1);
+  return std::make_pair(true, *idx_prev_wp_);
 }
 
 bool ControlPerformanceAnalysisCore::isDataReady() const
 {
   const auto waiting = [this](const std::string & name) {
     rclcpp::Clock clock{RCL_ROS_TIME};
-    RCLCPP_WARN_THROTTLE(logger_, clock, 1000, "waiting for %s data ...", name.c_str());
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(logger_, clock, 1000, "waiting for %s data ...", name.c_str());
     return false;
   };
 
@@ -154,46 +132,32 @@ bool ControlPerformanceAnalysisCore::isDataReady() const
 bool ControlPerformanceAnalysisCore::calculateErrorVars()
 {
   // Check if data is ready.
-  if (!isDataReady() || !idx_prev_wp_) {
+  if (!isDataReady()) {
     return false;
   }
 
-  // Find and set the waypoint L-wheelbase meters ahead of the current waypoint.
-  findCurveRefIdx();
-  
+  // update closest index
+  findClosestPrevWayPointIdx_path_direction();
+
   // Get the interpolated pose
   const auto [success, pose_interp_wp] = calculateClosestPose();
 
   if (!success) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, clock_, 1000,
-      "Cannot get interpolated pose, velocity, acceleration, and steering into control_performance "
-      "algorithm");
+    RCLCPP_WARN_THROTTLE(logger_, clock_, 1000, "Cannot get interpolated variables.");
     return false;
   }
 
-  // Get Yaw angles of the reference waypoint and the vehicle
-  const double & target_yaw = tf2::getYaw(pose_interp_wp.orientation);
-  const double & vehicle_yaw_angle = tf2::getYaw(current_vec_pose_ptr_->orientation);
-
-  // Compute Curvature at the point where the front axle might follow
-  // get the waypoint corresponds to the front_axle center
-
-  if (!idx_curve_ref_wp_) {
-    RCLCPP_WARN(logger_, "Cannot find index of curvature reference waypoint ");
-    return false;
-  }
-
-  const double & curvature_est = estimateCurvature();                // three point curvature
-  const double & curvature_est_pp = estimatePurePursuitCurvature();  // pure pursuit curvature
+  const double curvature_est = estimateCurvature();                // three point curvature
+  const double curvature_est_pp = estimatePurePursuitCurvature();  // pure pursuit curvature
 
   // Compute lateral, longitudinal, heading error w.r.t. frenet frame
-
+  const double target_yaw = tf2::getYaw(pose_interp_wp.orientation);
   const auto [lateral_error, longitudinal_error] = utils::computeLateralLongitudinalError(
     pose_interp_wp.position, current_vec_pose_ptr_->position, target_yaw);
 
   // Compute the yaw angle error.
-  const double & heading_yaw_error = utils::angleDistance(vehicle_yaw_angle, target_yaw);
+  const double heading_yaw_error =
+    tier4_autoware_utils::calcYawDeviation(pose_interp_wp, *current_vec_pose_ptr_);
 
   // Set the values of ErrorMsgVars.
 
@@ -202,41 +166,42 @@ bool ControlPerformanceAnalysisCore::calculateErrorVars()
   error_vars.error.heading_error = heading_yaw_error;
 
   // odom history contains k + 1, k, k - 1 ... steps. We are in kth step
-  const uint & odom_size = odom_history_ptr_->size();
+  const uint odom_size = odom_history_ptr_->size();
 
   error_vars.header.stamp = odom_history_ptr_->at(odom_size - 2).header.stamp;  // we are in step k
 
-  const double & Vx = odom_history_ptr_->at(odom_size - 2).twist.twist.linear.x;
+  const double Vx = odom_history_ptr_->at(odom_size - 2).twist.twist.linear.x;
+
   // Current acceleration calculation
   const auto ds = tier4_autoware_utils::calcDistance2d(
     odom_history_ptr_->at(odom_size - 1).pose.pose, odom_history_ptr_->at(odom_size - 2).pose.pose);
 
-  const double & vel_mean = (odom_history_ptr_->at(odom_size - 1).twist.twist.linear.x +
-                             odom_history_ptr_->at(odom_size - 2).twist.twist.linear.x) /
-                            2.0;
-  const double & dv = odom_history_ptr_->at(odom_size - 1).twist.twist.linear.x -
-                      odom_history_ptr_->at(odom_size - 2).twist.twist.linear.x;
-  const double & dt = ds / std::max(vel_mean, p_.prevent_zero_division_value_);
-  const double & Ax = dv / std::max(dt, p_.prevent_zero_division_value_);  // current acceleration
+  const double vel_mean = (odom_history_ptr_->at(odom_size - 1).twist.twist.linear.x +
+                           odom_history_ptr_->at(odom_size - 2).twist.twist.linear.x) /
+                          2.0;
+  const double dv = odom_history_ptr_->at(odom_size - 1).twist.twist.linear.x -
+                    odom_history_ptr_->at(odom_size - 2).twist.twist.linear.x;
+  const double dt = ds / std::max(vel_mean, p_.prevent_zero_division_value_);
+  const double Ax = dv / std::max(dt, p_.prevent_zero_division_value_);  // current acceleration
 
-  const double & longitudinal_error_velocity =
+  const double longitudinal_error_velocity =
     Vx * cos(heading_yaw_error) - *interpolated_velocity_ptr_ * (1 - curvature_est * lateral_error);
-  const double & lateral_error_velocity =
+  const double lateral_error_velocity =
     Vx * sin(heading_yaw_error) - *interpolated_velocity_ptr_ * curvature_est * longitudinal_error;
 
-  const double & steering_cmd = current_control_ptr_->lateral.steering_tire_angle;
-  const double & current_steering_val = current_vec_steering_msg_ptr_->steering_tire_angle;
+  const double steering_cmd = current_control_ptr_->lateral.steering_tire_angle;
+  const double current_steering_val = current_vec_steering_msg_ptr_->steering_tire_angle;
   error_vars.error.control_effort_energy = contR * steering_cmd * steering_cmd;  // u*R*u';
 
-  const double & heading_velocity_error = (Vx * tan(current_steering_val)) / p_.wheelbase_ -
-                                          *this->interpolated_velocity_ptr_ * curvature_est;
+  const double heading_velocity_error = (Vx * tan(current_steering_val)) / p_.wheelbase_ -
+                                        *this->interpolated_velocity_ptr_ * curvature_est;
 
-  const double & lateral_acceleration_error =
+  const double lateral_acceleration_error =
     -curvature_est * *interpolated_acceleration_ptr_ * longitudinal_error -
     curvature_est * *interpolated_velocity_ptr_ * longitudinal_error_velocity +
     Vx * heading_velocity_error * cos(heading_yaw_error) + Ax * sin(heading_yaw_error);
 
-  const double & longitudinal_acceleration_error =
+  const double longitudinal_acceleration_error =
     curvature_est * *interpolated_acceleration_ptr_ * lateral_error +
     curvature_est * *interpolated_velocity_ptr_ * lateral_error_velocity -
     Vx * heading_velocity_error * sin(heading_yaw_error) + Ax * cos(heading_yaw_error) -
@@ -265,23 +230,23 @@ bool ControlPerformanceAnalysisCore::calculateErrorVars()
   if (prev_target_vars_) {
     // LPF for error vars
 
-    const auto apply_lpf = [&](auto & var, const auto & prev_var) {
+    const auto lpf = [&](auto & var, const auto & prev_var) {
       var = p_.lpf_gain_ * prev_var + (1 - p_.lpf_gain_) * var;
     };
     auto & error = error_vars.error;
     const auto & prev_error = prev_target_vars_->error;
-    apply_lpf(error.curvature_estimate, prev_error.curvature_estimate);
-    apply_lpf(error.curvature_estimate_pp, prev_error.curvature_estimate_pp);
-    apply_lpf(error.lateral_error, prev_error.lateral_error);
-    apply_lpf(error.lateral_error_velocity, prev_error.lateral_error_velocity);
-    apply_lpf(error.lateral_error_acceleration, prev_error.lateral_error_acceleration);
-    apply_lpf(error.longitudinal_error, prev_error.longitudinal_error);
-    apply_lpf(error.longitudinal_error_velocity, prev_error.longitudinal_error_velocity);
-    apply_lpf(error.longitudinal_error_acceleration, prev_error.longitudinal_error_acceleration);
-    apply_lpf(error.heading_error, prev_error.heading_error);
-    apply_lpf(error.heading_error_velocity, prev_error.heading_error_velocity);
-    apply_lpf(error.control_effort_energy, prev_error.control_effort_energy);
-    apply_lpf(error.error_energy, prev_error.error_energy);
+    lpf(error.curvature_estimate, prev_error.curvature_estimate);
+    lpf(error.curvature_estimate_pp, prev_error.curvature_estimate_pp);
+    lpf(error.lateral_error, prev_error.lateral_error);
+    lpf(error.lateral_error_velocity, prev_error.lateral_error_velocity);
+    lpf(error.lateral_error_acceleration, prev_error.lateral_error_acceleration);
+    lpf(error.longitudinal_error, prev_error.longitudinal_error);
+    lpf(error.longitudinal_error_velocity, prev_error.longitudinal_error_velocity);
+    lpf(error.longitudinal_error_acceleration, prev_error.longitudinal_error_acceleration);
+    lpf(error.heading_error, prev_error.heading_error);
+    lpf(error.heading_error_velocity, prev_error.heading_error_velocity);
+    lpf(error.control_effort_energy, prev_error.control_effort_energy);
+    lpf(error.error_energy, prev_error.error_energy);
   }
 
   prev_target_vars_ = std::make_unique<msg::ErrorStamped>(error_vars);
@@ -356,30 +321,17 @@ bool ControlPerformanceAnalysisCore::calculateDrivingVars()
       }
       if (prev_driving_vars_) {
         // LPF for driving status vars
-
-        driving_status_vars.longitudinal_acceleration.data =
-          p_.lpf_gain_ * prev_driving_vars_->longitudinal_acceleration.data +
-          (1 - p_.lpf_gain_) * driving_status_vars.longitudinal_acceleration.data;
-
-        driving_status_vars.lateral_acceleration.data =
-          p_.lpf_gain_ * prev_driving_vars_->lateral_acceleration.data +
-          (1 - p_.lpf_gain_) * driving_status_vars.lateral_acceleration.data;
-
-        driving_status_vars.lateral_jerk.data =
-          p_.lpf_gain_ * prev_driving_vars_->lateral_jerk.data +
-          (1 - p_.lpf_gain_) * driving_status_vars.lateral_jerk.data;
-
-        driving_status_vars.longitudinal_jerk.data =
-          p_.lpf_gain_ * prev_driving_vars_->longitudinal_jerk.data +
-          (1 - p_.lpf_gain_) * driving_status_vars.longitudinal_jerk.data;
-
-        driving_status_vars.controller_processing_time.data =
-          p_.lpf_gain_ * prev_driving_vars_->controller_processing_time.data +
-          (1 - p_.lpf_gain_) * driving_status_vars.controller_processing_time.data;
-
-        driving_status_vars.desired_steering_angle.data =
-          p_.lpf_gain_ * prev_driving_vars_->desired_steering_angle.data +
-          (1 - p_.lpf_gain_) * driving_status_vars.desired_steering_angle.data;
+        const auto lpf = [&](auto & var, const auto & prev_var) {
+          var = p_.lpf_gain_ * prev_var + (1 - p_.lpf_gain_) * var;
+        };
+        auto & curr = driving_status_vars;
+        const auto & prev = prev_driving_vars_;
+        lpf(curr.longitudinal_acceleration.data, prev->longitudinal_acceleration.data);
+        lpf(curr.lateral_acceleration.data, prev->lateral_acceleration.data);
+        lpf(curr.lateral_jerk.data, prev->lateral_jerk.data);
+        lpf(curr.longitudinal_jerk.data, prev->longitudinal_jerk.data);
+        lpf(curr.controller_processing_time.data, prev->controller_processing_time.data);
+        lpf(curr.desired_steering_angle.data, prev->desired_steering_angle.data);
       }
 
       prev_driving_vars_ =
@@ -389,8 +341,7 @@ bool ControlPerformanceAnalysisCore::calculateDrivingVars()
       last_steering_report.stamp = current_vec_steering_msg_ptr_->stamp;
 
     } else if (last_steering_report.stamp != current_vec_steering_msg_ptr_->stamp) {
-      driving_status_vars.lateral_acceleration.header.set__stamp(
-        current_vec_steering_msg_ptr_->stamp);
+      driving_status_vars.lateral_acceleration.header.stamp = current_vec_steering_msg_ptr_->stamp;
       driving_status_vars.lateral_acceleration.data =
         odom_history_ptr_->at(odom_size - 1).twist.twist.linear.x *
         tan(current_vec_steering_msg_ptr_->steering_tire_angle) / p_.wheelbase_;
@@ -409,37 +360,30 @@ void ControlPerformanceAnalysisCore::setSteeringStatus(const SteeringReport & st
   current_vec_steering_msg_ptr_ = std::make_shared<SteeringReport>(steering);
 }
 
-void ControlPerformanceAnalysisCore::findCurveRefIdx()
+boost::optional<int32_t> ControlPerformanceAnalysisCore::findCurveRefIdx()
 {
   // Get the previous waypoint as the reference
   if (!interpolated_pose_ptr_) {
     RCLCPP_WARN_THROTTLE(
       logger_, clock_, 1000, "Cannot set the curvature_idx, no valid interpolated pose ...");
-
-    return;
+    return boost::none;
   }
 
   auto fun_distance_cond = [this](auto point_t) {
-    const double dist = std::hypot(
-      point_t.pose.position.x - this->interpolated_pose_ptr_->position.x,
-      point_t.pose.position.y - this->interpolated_pose_ptr_->position.y);
-
+    const double dist = tier4_autoware_utils::calcDistance2d(point_t.pose, *interpolated_pose_ptr_);
     return dist > p_.wheelbase_;
   };
 
   auto it = std::find_if(
-    current_trajectory_ptr_->points.cbegin() + *idx_prev_wp_, current_trajectory_ptr_->points.cend(),
-    fun_distance_cond);
+    current_trajectory_ptr_->points.cbegin() + *idx_prev_wp_,
+    current_trajectory_ptr_->points.cend(), fun_distance_cond);
 
   if (it == current_trajectory_ptr_->points.cend()) {
-    std::cerr << "it -> prev!" << std::endl;
     it = std::prev(it);
   }
 
-  const int32_t & temp_idx_curve_ref_wp = std::distance(current_trajectory_ptr_->points.cbegin(), it);
-  idx_curve_ref_wp_ = std::make_unique<int32_t>(temp_idx_curve_ref_wp);
-  std::cerr << "current_waypoints_ptr_ size = " << current_trajectory_ptr_->points.size() << ", temp_idx_curve_ref_wp = " << temp_idx_curve_ref_wp << ", idx_curve_ref_wp_ = " << *idx_curve_ref_wp_ << std::endl;
-  
+  const auto idx_curve_ref_wp = std::distance(current_trajectory_ptr_->points.cbegin(), it);
+  return idx_curve_ref_wp;
 }
 
 std::pair<bool, Pose> ControlPerformanceAnalysisCore::calculateClosestPose()
@@ -447,7 +391,6 @@ std::pair<bool, Pose> ControlPerformanceAnalysisCore::calculateClosestPose()
   const auto interp_point =
     motion_utils::calcInterpolatedPoint(*current_trajectory_ptr_, *current_vec_pose_ptr_);
 
-  std::cerr << __func__ << ":" << __LINE__ << "  current_waypoints_ptr_ size = " << current_trajectory_ptr_->points.size() << std::endl;
   const double interp_steering_angle = std::atan(p_.wheelbase_ * estimateCurvature());
 
   setInterpolatedVars(
@@ -476,48 +419,53 @@ void ControlPerformanceAnalysisCore::setInterpolatedVars(
 
 double ControlPerformanceAnalysisCore::estimateCurvature()
 {
+  // Find and set the waypoint L-wheelbase meters ahead of the current waypoint.
+  const auto idx_curve_ref_wp_optional = findCurveRefIdx();
+
   // Get idx of front-axle center reference point on the trajectory.
   // get the waypoint corresponds to the front_axle center.
-  if (!idx_curve_ref_wp_) {
+  if (!idx_curve_ref_wp_optional) {
     RCLCPP_WARN(logger_, "Cannot find index of curvature reference waypoint ");
     return 0;
   }
+  const auto idx_curve_ref_wp = idx_curve_ref_wp_optional.get();
+
   const auto & points = current_trajectory_ptr_->points;
 
-  const Pose front_axleWP_pose = points.at(*idx_curve_ref_wp_).pose;
+  const Pose front_axleWP_pose = points.at(idx_curve_ref_wp).pose;
 
   // for guarding -1 in finding previous waypoint for the front axle
-  const int32_t idx_prev_waypoint =
-    *idx_curve_ref_wp_ >= 1 ? *idx_curve_ref_wp_ - 1 : *idx_curve_ref_wp_;
+  const int32_t idx_prev_waypoint = std::max(idx_curve_ref_wp - 1, 0);
 
   const Pose front_axleWP_pose_prev = points.at(idx_prev_waypoint).pose;
 
   // Compute arc-length ds between 2 points.
-  const double ds_arc_length = std::hypot(
-    front_axleWP_pose_prev.position.x - front_axleWP_pose.position.x,
-    front_axleWP_pose_prev.position.y - front_axleWP_pose.position.y);
+  const double ds_arc_length =
+    tier4_autoware_utils::calcDistance2d(front_axleWP_pose_prev, front_axleWP_pose);
 
   // Define waypoints 10 meters behind the rear axle if exist.
   // If not exist, we will take the first point of the
   // curvature triangle as the start point of the trajectory.
-  const auto & num_of_back_indices = std::round(p_.curvature_interval_length_ / ds_arc_length);
-  const int32_t loc_of_back_idx =
-    (*idx_curve_ref_wp_ - num_of_back_indices < 0) ? 0 : *idx_curve_ref_wp_ - num_of_back_indices;
+  const auto num_of_indices =
+    std::max(static_cast<int32_t>(std::round(p_.curvature_interval_length_ / ds_arc_length)), 1);
+
+  const int32_t loc_of_back_idx = std::max(idx_curve_ref_wp - num_of_indices, 0);
 
   // Define location of forward point 10 meters ahead of the front axle on curve.
-  const uint32_t max_idx =
-    std::distance(points.cbegin(), points.cend());
+  const int32_t max_idx = points.size() - 1;
 
-  const auto num_of_forward_indices = num_of_back_indices;
-  const int32_t loc_of_forward_idx = (*idx_curve_ref_wp_ + num_of_forward_indices > max_idx)
-                                       ? max_idx - 1
-                                       : *idx_curve_ref_wp_ + num_of_forward_indices - 1;
+  const int32_t loc_of_forward_idx = std::min(idx_curve_ref_wp + num_of_indices, max_idx);
 
   // We have three indices of the three trajectory poses.
   // We compute a curvature estimate from these points.
-  const double estimated_curvature = tier4_autoware_utils::calcCurvature(
-    points.at(loc_of_back_idx).pose.position, points.at(*idx_curve_ref_wp_).pose.position,
-    points.at(loc_of_forward_idx).pose.position);
+  double estimated_curvature = 0.0;
+  try {
+    estimated_curvature = tier4_autoware_utils::calcCurvature(
+      points.at(loc_of_back_idx).pose.position, points.at(idx_curve_ref_wp).pose.position,
+      points.at(loc_of_forward_idx).pose.position);
+  } catch (...) {
+    estimated_curvature = 0.0;
+  }
 
   return estimated_curvature;
 }
@@ -532,21 +480,18 @@ double ControlPerformanceAnalysisCore::estimatePurePursuitCurvature()
     return 0;
   }
 
-  const uint32_t & odom_size = odom_history_ptr_->size();
-  const double & Vx = odom_history_ptr_->at(odom_size - 1).twist.twist.linear.x;
+  const uint32_t odom_size = odom_history_ptr_->size();
+  const double Vx = odom_history_ptr_->at(odom_size - 1).twist.twist.linear.x;
   const double look_ahead_distance_pp = std::max(p_.wheelbase_, 2 * Vx);
 
   auto fun_distance_cond = [this, &look_ahead_distance_pp](auto point_t) {
-    const double dist = std::hypot(
-      point_t.pose.position.x - this->interpolated_pose_ptr_->position.x,
-      point_t.pose.position.y - this->interpolated_pose_ptr_->position.y);
-
+    const double dist = tier4_autoware_utils::calcDistance2d(point_t, *interpolated_pose_ptr_);
     return dist > look_ahead_distance_pp;
   };
 
   auto it = std::find_if(
-    current_trajectory_ptr_->points.cbegin() + *idx_prev_wp_, current_trajectory_ptr_->points.cend(),
-    fun_distance_cond);
+    current_trajectory_ptr_->points.cbegin() + *idx_prev_wp_,
+    current_trajectory_ptr_->points.cend(), fun_distance_cond);
 
   Pose target_pose_pp;
 
@@ -572,13 +517,10 @@ double ControlPerformanceAnalysisCore::estimatePurePursuitCurvature()
     target_pose_pp.orientation = last_pose_on_traj.orientation;
   } else {
     // idx of the last waypoint on the trajectory is
-    const int32_t & temp_idx_pp = std::distance(current_trajectory_ptr_->points.cbegin(), it);
-    const Pose & last_pose_on_traj = current_trajectory_ptr_->points.at(temp_idx_pp).pose;
+    const int32_t temp_idx_pp = std::distance(current_trajectory_ptr_->points.cbegin(), it);
+    const Pose last_pose_on_traj = current_trajectory_ptr_->points.at(temp_idx_pp).pose;
 
-    target_pose_pp.position.z = last_pose_on_traj.position.z;
-    target_pose_pp.position.x = last_pose_on_traj.position.x;
-    target_pose_pp.position.y = last_pose_on_traj.position.y;
-    target_pose_pp.orientation = last_pose_on_traj.orientation;
+    target_pose_pp = last_pose_on_traj;
   }
 
   // We have target pose for the pure pursuit.

--- a/control/control_performance_analysis/src/control_performance_analysis_core.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_core.cpp
@@ -34,10 +34,10 @@ ControlPerformanceAnalysisCore::ControlPerformanceAnalysisCore()
   odom_history_ptr_ = std::make_shared<std::vector<Odometry>>();
   p_.odom_interval_ = 0;
   p_.curvature_interval_length_ = 10.0;
-  p_.acceptable_max_distance_to_waypoint_ = 10.0;
+  p_.acceptable_max_distance_to_waypoint_ = 1.5;
   p_.acceptable_max_yaw_difference_rad_ = 1.0472;
   p_.prevent_zero_division_value_ = 0.001;
-  p_.lpf_gain_ = 0.0;
+  p_.lpf_gain_ = 0.8;
   p_.wheelbase_ = 2.74;
 }
 

--- a/control/control_performance_analysis/src/control_performance_analysis_node.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_node.cpp
@@ -136,20 +136,17 @@ void ControlPerformanceAnalysisNode::onVelocity(const Odometry::ConstSharedPtr m
   if (!current_odom_ptr_) {
     if (isDataReady()) {
       current_odom_ptr_ = msg;
-      current_pose_ = self_pose_listener_.getCurrentPose();
       control_performance_core_ptr_->setOdomHistory(*current_odom_ptr_);
-      prev_traj = *current_trajectory_ptr_;
-      prev_cmd = *current_control_msg_ptr_;
-      prev_steering = *current_vec_steering_msg_ptr_;
     }
     return;
   }
 
-  control_performance_core_ptr_->setCurrentWaypoints(prev_traj);
+  current_pose_ = self_pose_listener_.getCurrentPose();
+  control_performance_core_ptr_->setCurrentWaypoints(*current_trajectory_ptr_);
   control_performance_core_ptr_->setCurrentPose(current_pose_->pose);
-  control_performance_core_ptr_->setCurrentControlValue(prev_cmd);
+  control_performance_core_ptr_->setCurrentControlValue(*current_control_msg_ptr_);
   control_performance_core_ptr_->setOdomHistory(*msg);  // k+1, k, k-1
-  control_performance_core_ptr_->setSteeringStatus(prev_steering);
+  control_performance_core_ptr_->setSteeringStatus(*current_vec_steering_msg_ptr_);
 
   if (!control_performance_core_ptr_->isDataReady()) {
     return;
@@ -178,9 +175,6 @@ void ControlPerformanceAnalysisNode::onVelocity(const Odometry::ConstSharedPtr m
   } else {
     RCLCPP_ERROR(get_logger(), "Cannot compute driving vars ...");
   }
-  prev_traj = *current_trajectory_ptr_;
-  prev_cmd = *current_control_msg_ptr_;
-  prev_steering = *current_vec_steering_msg_ptr_;
   current_odom_ptr_ = msg;
   current_pose_ = self_pose_listener_.getCurrentPose();
 }

--- a/control/control_performance_analysis/src/control_performance_analysis_node.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_node.cpp
@@ -76,9 +76,6 @@ ControlPerformanceAnalysisNode::ControlPerformanceAnalysisNode(
   pub_error_msg_ = create_publisher<ErrorStamped>("~/output/error_stamped", 1);
 
   pub_driving_msg_ = create_publisher<DrivingMonitorStamped>("~/output/driving_status_stamped", 1);
-
-  // Wait for first self pose
-  self_pose_listener_.waitForFirstPose();
 }
 
 void ControlPerformanceAnalysisNode::onTrajectory(const Trajectory::ConstSharedPtr msg)
@@ -99,33 +96,19 @@ void ControlPerformanceAnalysisNode::onTrajectory(const Trajectory::ConstSharedP
 void ControlPerformanceAnalysisNode::onControlRaw(
   const AckermannControlCommand::ConstSharedPtr control_msg)
 {
-  static bool initialized = false;
-  if (!control_msg) {
-    RCLCPP_ERROR(get_logger(), "control command has not been received yet ...");
-
-    return;
-  } else if (!initialized) {
-    initialized = true;
-    current_control_msg_ptr_ = control_msg;
-    last_control_cmd_.stamp = current_control_msg_ptr_->stamp;
-
-  } else {
-    current_control_msg_ptr_ = control_msg;
+  if (last_control_cmd_) {
     const rclcpp::Duration & duration =
-      (rclcpp::Time(current_control_msg_ptr_->stamp) - rclcpp::Time(last_control_cmd_.stamp));
+      (rclcpp::Time(control_msg->stamp) - rclcpp::Time(last_control_cmd_->stamp));
     d_control_cmd_ = duration.seconds() * 1000;  // ms
-    last_control_cmd_.stamp = current_control_msg_ptr_->stamp;
   }
+
+  last_control_cmd_ = current_control_msg_ptr_;
+  current_control_msg_ptr_ = control_msg;
 }
 
 void ControlPerformanceAnalysisNode::onVecSteeringMeasured(
   const SteeringReport::ConstSharedPtr meas_steer_msg)
 {
-  if (!meas_steer_msg) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 5000, "waiting for vehicle measured steering message ...");
-    return;
-  }
   current_vec_steering_msg_ptr_ = meas_steer_msg;
 }
 
@@ -140,21 +123,12 @@ void ControlPerformanceAnalysisNode::onVelocity(const Odometry::ConstSharedPtr m
     return;
   }
 
-  current_pose_ = self_pose_listener_.getCurrentPose();
   control_performance_core_ptr_->setCurrentWaypoints(*current_trajectory_ptr_);
-  control_performance_core_ptr_->setCurrentPose(current_pose_->pose);
+  control_performance_core_ptr_->setCurrentPose(current_odom_ptr_->pose.pose);
   control_performance_core_ptr_->setCurrentControlValue(*current_control_msg_ptr_);
   control_performance_core_ptr_->setSteeringStatus(*current_vec_steering_msg_ptr_);
 
   if (!control_performance_core_ptr_->isDataReady()) {
-    return;
-  }
-  // Find the index of the next waypoint.
-  const std::pair<bool, int32_t> & prev_closest_wp_pose_idx =
-    control_performance_core_ptr_->findClosestPrevWayPointIdx_path_direction();
-
-  if (!prev_closest_wp_pose_idx.first) {
-    RCLCPP_ERROR(get_logger(), "Cannot find closest waypoint");
     return;
   }
 
@@ -172,7 +146,6 @@ void ControlPerformanceAnalysisNode::onVelocity(const Odometry::ConstSharedPtr m
   } else {
     RCLCPP_ERROR(get_logger(), "Cannot compute driving vars ...");
   }
-  current_pose_ = self_pose_listener_.getCurrentPose();
 }
 
 bool ControlPerformanceAnalysisNode::isDataReady() const

--- a/control/control_performance_analysis/src/control_performance_analysis_node.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_node.cpp
@@ -165,11 +165,10 @@ void ControlPerformanceAnalysisNode::onVelocity(const Odometry::ConstSharedPtr m
     RCLCPP_ERROR(get_logger(), "Cannot compute error vars ...");
   }
   if (control_performance_core_ptr_->calculateDrivingVars()) {
-    control_performance_core_ptr_->driving_status_vars.controller_processing_time.header.stamp =
-      current_control_msg_ptr_->stamp;
-    control_performance_core_ptr_->driving_status_vars.controller_processing_time.data =
-      d_control_cmd_;
-    pub_driving_msg_->publish(control_performance_core_ptr_->driving_status_vars);
+    auto & status_vars = control_performance_core_ptr_->driving_status_vars;
+    status_vars.controller_processing_time.header.stamp = current_control_msg_ptr_->stamp;
+    status_vars.controller_processing_time.data = d_control_cmd_;
+    pub_driving_msg_->publish(status_vars);
   } else {
     RCLCPP_ERROR(get_logger(), "Cannot compute driving vars ...");
   }

--- a/control/control_performance_analysis/src/control_performance_analysis_utils.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_utils.cpp
@@ -35,18 +35,5 @@ double triangleArea(
   return 0.5 * (m1 + m2 + m3);
 }
 
-double curvatureFromThreePoints(
-  std::array<double, 2> const & a, std::array<double, 2> const & b, std::array<double, 2> const & c)
-{
-  double area = triangleArea(a, b, c);
-
-  double a_mag = std::hypot(a[0] - b[0], a[1] - b[1]);  // magnitude of triangle edges
-  double b_mag = std::hypot(b[0] - c[0], b[1] - c[1]);
-  double c_mag = std::hypot(c[0] - a[0], c[1] - a[1]);
-
-  double curvature = 4 * area / std::max(a_mag * b_mag * c_mag, 1e-4);
-
-  return curvature;
-}
 }  // namespace utils
 }  // namespace control_performance_analysis


### PR DESCRIPTION
## Description

The `control_performance_analysis` stops calculation when the ego vehicle is located far from the trajectory. It is ok, but the calculation will never restart after the vehicle comes back to the trajectory. It is due to the closest_idx calculation handling.

This PR refactors the code structure to fix the above issue.

Also, this PR includes some refactors, mainly replacing the duplicated implementation with util packages (motion_utils, autoware_utils, etc.) and adds python script to plot the tracking error.



## Tests performed

Run psim and check the performance check

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
