### PR TITLE
feat(map_based_prediction): suppress lane change decision flickering

### DIFF
--- a/perception/map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/map_based_prediction/config/map_based_prediction.param.yaml
@@ -23,5 +23,6 @@
         dist_ratio_threshold_to_right_bound: 0.5 #[ratio
         diff_dist_threshold_to_left_bound: 0.29 #[m]
         diff_dist_threshold_to_right_bound: -0.29 #[m]
+      num_continuous_state_transition: 3
 
     reference_path_resolution: 0.5 #[m]

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -59,6 +59,13 @@ struct LateralKinematicsToLanelet
   double filtered_right_lateral_velocity;
 };
 
+enum class Maneuver {
+  UNINITIALIZED = 0,
+  LANE_FOLLOW = 1,
+  LEFT_LANE_CHANGE = 2,
+  RIGHT_LANE_CHANGE = 3,
+};
+
 struct ObjectData
 {
   std_msgs::msg::Header header;
@@ -69,12 +76,9 @@ struct ObjectData
   double time_delay;
   // for lane change prediction
   std::unordered_map<lanelet::ConstLanelet, LateralKinematicsToLanelet> lateral_kinematics_set;
-};
-
-enum class Maneuver {
-  LANE_FOLLOW = 0,
-  LEFT_LANE_CHANGE = 1,
-  RIGHT_LANE_CHANGE = 2,
+  Maneuver one_shot_maneuver{Maneuver::UNINITIALIZED};
+  Maneuver output_maneuver{
+    Maneuver::UNINITIALIZED};  // output maneuver considering previous one shot maneuvers
 };
 
 struct LaneletData
@@ -153,6 +157,7 @@ private:
   double dist_ratio_threshold_to_right_bound_;
   double diff_dist_threshold_to_left_bound_;
   double diff_dist_threshold_to_right_bound_;
+  int num_continuous_state_transition_;
   double reference_path_resolution_;
 
   // Stop watch


### PR DESCRIPTION
## Description

Currently, lane change decision in the prediction is one shot.
To suppress the flickering decision, if the internal state (lane change left/right, lane follow) changed N times in a row, the output state will be changed.

For example, if N is 2
- FOLLOW (initial state) -> LEFT
    - Output is FOLLOW
- FOLLOW (initial state) -> LEFT -> LEFT (2 LEFT in a row)
    - Output is LEFT
- FOLLOW (initial state) -> LEFT -> LEFT -> FOLLOW
    - Output is LEFT
- FOLLOW (initial state) -> LEFT -> LEFT -> FOLLOW -> FOLLOW (2 FOLLOW in a row)
    - Output is FOLLOW


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
