### PR TITLE
fix(accel_brake_map_calibrator): fix view_statistics script

### DIFF
--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/scripts/calc_utils.py
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/scripts/calc_utils.py
@@ -69,7 +69,15 @@ class CalcUtils:
 
     @staticmethod
     def create_2d_map(
-        x, y, data, color_factor, x_index_list, x_thresh, y_index_list, y_thresh, calibration_method
+        x,
+        y,
+        data,
+        color_factor,
+        x_index_list,
+        x_thresh,
+        y_index_list,
+        y_thresh,
+        calibration_method="four_cell",
     ):
         if x.shape != y.shape or y.shape != data.shape:
             print("Error: the shape of x, y, data must be same")

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/scripts/plotter.py
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/scripts/plotter.py
@@ -28,8 +28,7 @@ class Plotter(object):
         plt.subplots_adjust(left=0.04, right=0.98, bottom=0.05, top=0.95, wspace=0.1, hspace=0.4)
 
     def subplot(self, plot_num):
-        subplot_str = str(self.total_height) + str(self.total_width) + str(plot_num)
-        fig = plt.subplot(subplot_str)
+        fig = plt.subplot(self.total_height, self.total_width, plot_num)
         return fig
 
     def subplot_more(self, plot_num):


### PR DESCRIPTION
## Description
I fixed view_statistics.py script in the accel_brake_map_calibrator package.


After:
<!-- Write a brief description of this PR. -->

## Tests performed
Before:
The script causes the following error.
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/d773faac-4dbe-48cf-81d4-fc24b47481f7)

After:
The script can output matplot image
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/e5437a77-b514-4e9d-9873-2619a36355f9)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior
It does not affect autonomous driving behavior.

<!-- Describe how this PR affects the system behavior. -->


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
