### PR TITLE
fix(behavior_path_planner): do not execute goal_planner when the fixed goal is not in current lanes

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -320,16 +320,15 @@ bool GoalPlannerModule::isExecutionRequested() const
     return false;
   }
 
-  // if goal modification is not allowed and goal_pose in current_lanes,
-  // plan path to the original fixed goal
+  // if goal modification is not allowed
+  // 1) goal_pose is in current_lanes, plan path to the original fixed goal
+  // 2) goal_pose is NOT in current_lanes, do not execute goal_planner
   if (!allow_goal_modification_) {
-    if (std::any_of(
-          current_lanes.begin(), current_lanes.end(),
-          [&](const lanelet::ConstLanelet & current_lane) {
-            return lanelet::utils::isInLanelet(goal_pose, current_lane);
-          })) {
-      return true;
-    }
+    // check if goal_pose is in current_lanes.
+    return std::any_of(
+      current_lanes.begin(), current_lanes.end(), [&](const lanelet::ConstLanelet & current_lane) {
+        return lanelet::utils::isInLanelet(goal_pose, current_lane);
+      });
   }
 
   // if (A) or (B) is met execute pull over


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

when setting `left_side_parking_` and the fixed goal is put in the right lane of the current lanes, goal_planner is executed. This blocks other modules to run in the old behavior_path_planner architecture.



e.g.) right LC can not be executed when putting the fixed goal right of current lanes, and the goal is close to the ego-vehicle.


https://github.com/autowarefoundation/autoware.universe/assets/39142679/333c1b85-dfa6-4815-85ba-0f906fe1eef2


and this PR also fix the problem lane change can not be done when approved at the path terminal.
[tier4 internal ticket](https://tier4.atlassian.net/browse/RT1-2382)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

[tier4 internal ticket](https://tier4.atlassian.net/browse/RT1-2382)

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/4935a592-be74-409a-a230-f3af4eecb877)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
not applicable

## Effects on system behavior

not applicable

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
