### PR TITLE
fix(lane_change): fix external lane change target lane lengths

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
+set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
+set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -531,8 +531,12 @@ PathWithLaneId getReferencePathFromTargetLane(
         next_lane_change_buffer;
       return std::min(dist_from_lc_start, s_goal);
     }
-    return std::min(dist_from_lc_start, target_lane_length);
+    return std::min(dist_from_lc_start, target_lane_length - next_lane_change_buffer);
   });
+
+  if (s_end - s_start < lane_changing_length) {
+    return PathWithLaneId();
+  }
 
   RCLCPP_DEBUG(
     rclcpp::get_logger("behavior_path_planner")


### PR DESCRIPTION
## Description

When the lane change target length is shorter than forward paths, the resultant lane change path will be extended until the end of the target lane, as following image.

![Screenshot from 2023-05-23 18-37-26](https://github.com/autowarefoundation/autoware.universe/assets/93502286/2ff20684-76ee-4ac8-a08b-1bd73177dcf8)

This is not expected behavior.

The expected behavior is some buffer is available to allow ego vehicle to return to the original lane properly.

After this PR
![Screenshot from 2023-05-23 18-33-32](https://github.com/autowarefoundation/autoware.universe/assets/93502286/31f2f832-9de9-471f-9611-7e47c244c836)



## Related links

[TIER IV internal link](https://tier4.atlassian.net/jira/software/c/projects/RT0/boards/438?modal=detail&selectedIssue=RT1-2378&quickFilter=772)

## Tests performed

1. Enable external lane change module.
2. Set lane change goal at the start of intersection lanelet.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
