### PR TITLE
fix(obstacle_cruise_planner): stick to feasible slow down velocity

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -170,8 +170,12 @@ private:
     SlowDownOutput(
       const std::string & arg_uuid, const std::vector<TrajectoryPoint> & traj_points,
       const std::optional<size_t> & start_idx, const std::optional<size_t> & end_idx,
-      const double arg_target_vel, const double arg_precise_lat_dist)
-    : uuid(arg_uuid), target_vel(arg_target_vel), precise_lat_dist(arg_precise_lat_dist)
+      const double arg_target_vel, const double arg_feasible_target_vel,
+      const double arg_precise_lat_dist)
+    : uuid(arg_uuid),
+      target_vel(arg_target_vel),
+      feasible_target_vel(arg_feasible_target_vel),
+      precise_lat_dist(arg_precise_lat_dist)
     {
       if (start_idx) {
         start_point = traj_points.at(*start_idx).pose;
@@ -183,6 +187,7 @@ private:
 
     std::string uuid;
     double target_vel;
+    double feasible_target_vel;
     double precise_lat_dist;
     std::optional<geometry_msgs::msg::Pose> start_point{std::nullopt};
     std::optional<geometry_msgs::msg::Pose> end_point{std::nullopt};


### PR DESCRIPTION
## Description

Currently, a slow-down velocity which is feasible based on initial velocity/acceleration with acceleration/jerk constraints is calculated every time.
However, depending on the controllability, the feasible slow-down velocity increased little by little.
To suppress this increase, the first slow-down velocity is memorized and use it to ignore the effect of controllability.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No behavior change
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
