### PR TITLE
fix(goal_planner): add buffer to stop_pose for restarting

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
@@ -161,7 +161,9 @@ private:
 
   // approximate distance from the start point to the end point of pull_over.
   // this is used as an assumed value to decelerate, etc., before generating the actual path.
-  double approximate_pull_over_distance_{20.0};
+  const double approximate_pull_over_distance_{20.0};
+  // ego may exceed the stop distance, so add a buffer
+  const double stop_distance_buffer_{2.0};
 
   // for parking policy
   bool left_side_parking_{true};
@@ -186,7 +188,8 @@ private:
 
   // stop or decelerate
   void decelerateForTurnSignal(const Pose & stop_pose, PathWithLaneId & path) const;
-  void decelerateBeforeSearchStart(const Pose & search_start_pose, PathWithLaneId & path) const;
+  void decelerateBeforeSearchStart(
+    const Pose & search_start_offset_pose, PathWithLaneId & path) const;
   PathWithLaneId generateStopPath();
   PathWithLaneId generateFeasibleStopPath();
   boost::optional<double> calcFeasibleDecelDistance(const double target_velocity) const;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

when the parking space is occupied and the ego-vehicle waits for the other vehicle, then the other vehicle goes away the ego-vehicle is required to restart parking again in that space.
But if the ego vehicle exceeds the stop_line or is close to the pull over start pose, it keeps stopping.

To fix this problem, in this PR,  
- add buffer to stop_pose 
- add buffer to search start pose
- check `distance_to_restart` only when the path is separated (e.g. geometric parallel parking)

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

[tier4 internal ticket](https://tier4.atlassian.net/jira/software/c/projects/RT1/boards/501?modal=detail&selectedIssue=RT1-2291&assignee=5e7857f83c888c0c29805978)

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

https://github.com/autowarefoundation/autoware.universe/assets/39142679/1c5edc73-15fb-4eba-b60e-277319afcaa5


[tier4 internal scneario test](https://evaluation.tier4.jp/evaluation/reports/5a0bc00c-fae4-5107-ab16-7c45b045c266?project_id=prd_jt) 994/1372

baseline 990/1372([2023/05/24](https://evaluation.tier4.jp/evaluation/reports/0f691e18-1e93-5a81-afdb-53b3025250ae/?project_id=prd_jt))
pull over 74/74

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

not applicable

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->


not applicable


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
