### PR TITLE
fix(avoidance): not init rtc status at onProcessEntry

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3164,7 +3164,6 @@ void AvoidanceModule::updateData()
 void AvoidanceModule::processOnEntry()
 {
   initVariables();
-  initRTCStatus();
   waitApproval();
 }
 


### PR DESCRIPTION
## Description

- fix bugs in another PR https://github.com/autowarefoundation/autoware.universe/pull/3798
- don't init rtc status at `onProcessEntry()`

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIO (OLD MANAGER)](https://evaluation.tier4.jp/evaluation/reports/b2ff5dcd-a4cf-571b-b00d-c20a8de445aa?project_id=prd_jt)
- [x] [PASS TIER IV INTERNAL SCENARIO (NEW MANAGER)
](https://evaluation.tier4.jp/evaluation/reports/d26c3910-6532-570f-adbb-310a762fc69c?project_id=prd_jt)
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
