### PR TITLE
feat(pull_out): support pull out normal lane

### DIFF
--- a/planning/behavior_path_planner/config/pull_out/pull_out.param.yaml
+++ b/planning/behavior_path_planner/config/pull_out/pull_out.param.yaml
@@ -11,9 +11,9 @@
       enable_shift_pull_out: true
       shift_pull_out_velocity: 2.0
       pull_out_sampling_num: 4
-      minimum_shift_pull_out_distance: 20.0
+      minimum_shift_pull_out_distance: 0.0
       maximum_lateral_jerk: 2.0
-      minimum_lateral_jerk: 0.5
+      minimum_lateral_jerk: 0.1
       deceleration_interval: 15.0
       # geometric pull out
       enable_geometric_pull_out: true

--- a/planning/behavior_path_planner/config/pull_out/pull_out.param.yaml
+++ b/planning/behavior_path_planner/config/pull_out/pull_out.param.yaml
@@ -4,6 +4,7 @@
       th_arrived_distance: 1.0
       th_stopped_velocity: 0.01
       th_stopped_time: 1.0
+      th_blinker_on_lateral_offset: 1.0
       collision_check_margin: 1.0
       collision_check_distance_from_end: 1.0
       # shift pull out

--- a/planning/behavior_path_planner/docs/behavior_path_planner_pull_out_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_pull_out_design.md
@@ -90,8 +90,8 @@ Pull out distance is calculated by the speed, lateral deviation, and the lateral
 | shift_pull_out_velocity         | [m/s]  | double | velocity of shift pull out                                                                                           | 2.0           |
 | pull_out_sampling_num           | [-]    | int    | Number of samplings in the minimum to maximum range of lateral_jerk                                                  | 4             |
 | maximum_lateral_jerk            | [m/s3] | double | maximum lateral jerk                                                                                                 | 2.0           |
-| minimum_lateral_jerk            | [m/s3] | double | minimum lateral jerk                                                                                                 | 0.5           |
-| minimum_shift_pull_out_distance | [m]    | double | minimum shift pull out distance. if calculated pull out distance is shorter than this, use this for path generation. | 20.0          |
+| minimum_lateral_jerk            | [m/s3] | double | minimum lateral jerk                                                                                                 | 0.1           |
+| minimum_shift_pull_out_distance | [m]    | double | minimum shift pull out distance. if calculated pull out distance is shorter than this, use this for path generation. | 0.0           |
 
 #### **geometric pull out**
 

--- a/planning/behavior_path_planner/docs/behavior_path_planner_pull_out_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_pull_out_design.md
@@ -54,6 +54,7 @@ PullOutPath --o PullOutPlannerBase
 | th_arrived_distance_m             | [m]   | double | distance threshold for arrival of path termination                   | 1.0           |
 | th_stopped_velocity_mps           | [m/s] | double | velocity threshold for arrival of path termination                   | 0.01          |
 | th_stopped_time_sec               | [s]   | double | time threshold for arrival of path termination                       | 1.0           |
+| th_blinker_on_lateral_offset      | [m]   | double | lateral distance threshold for turning on blinker                    | 1.0           |
 | collision_check_margin            | [m]   | double | Obstacle collision check margin                                      | 1.0           |
 | collision_check_distance_from_end | [m]   | double | collision check distance from end point. currently only for pull out | 15.0          |
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -57,6 +57,7 @@ using nav_msgs::msg::Odometry;
 using route_handler::RouteHandler;
 using tier4_planning_msgs::msg::LateralOffset;
 using PlanResult = PathWithLaneId::SharedPtr;
+using unique_identifier_msgs::msg::UUID;
 
 struct BoolStamped
 {
@@ -140,6 +141,7 @@ struct PlannerData
   PathWithLaneId::SharedPtr reference_path{std::make_shared<PathWithLaneId>()};
   PathWithLaneId::SharedPtr prev_output_path{std::make_shared<PathWithLaneId>()};
   std::optional<PoseWithUuidStamped> prev_modified_goal{};
+  std::optional<UUID> prev_route_id{};
   lanelet::ConstLanelets current_lanes{};
   std::shared_ptr<RouteHandler> route_handler{std::make_shared<RouteHandler>()};
   BehaviorPathPlannerParameters parameters{};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_module.hpp
@@ -47,18 +47,20 @@ using lane_departure_checker::LaneDepartureChecker;
 
 struct PullOutStatus
 {
-  PullOutPath pull_out_path;
-  size_t current_path_idx = 0;
-  PlannerType planner_type = PlannerType::NONE;
-  PathWithLaneId backward_path;
-  lanelet::ConstLanelets current_lanes;
-  lanelet::ConstLanelets pull_out_lanes;
-  std::vector<DrivableLanes> lanes;
-  std::vector<uint64_t> lane_follow_lane_ids;
-  std::vector<uint64_t> pull_out_lane_ids;
-  bool is_safe = false;
-  bool back_finished = false;
-  Pose pull_out_start_pose;
+  PullOutPath pull_out_path{};
+  size_t current_path_idx{0};
+  PlannerType planner_type{PlannerType::NONE};
+  PathWithLaneId backward_path{};
+  lanelet::ConstLanelets current_lanes{};
+  lanelet::ConstLanelets pull_out_lanes{};
+  std::vector<DrivableLanes> lanes{};
+  std::vector<uint64_t> lane_follow_lane_ids{};
+  std::vector<uint64_t> pull_out_lane_ids{};
+  bool is_safe{false};
+  bool back_finished{false};
+  Pose pull_out_start_pose{};
+
+  PullOutStatus() {}
 };
 
 class PullOutModule : public SceneModuleInterface
@@ -114,6 +116,7 @@ private:
   std::unique_ptr<rclcpp::Time> last_route_received_time_;
   std::unique_ptr<rclcpp::Time> last_pull_out_start_update_time_;
   std::unique_ptr<Pose> last_approved_pose_;
+  mutable bool has_received_new_route_{false};
 
   std::shared_ptr<PullOutPlannerBase> getCurrentPlanner() const;
   PathWithLaneId getFullPath() const;
@@ -141,6 +144,11 @@ private:
   bool hasFinishedCurrentPath();
 
   void setDebugData() const;
+
+// temporary for old architecture
+#ifdef USE_OLD_ARCHITECTURE
+  mutable bool is_executed_{false};
+#endif
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_planner_parameters.hpp
@@ -44,6 +44,7 @@ struct GoalPlannerParameters
   double th_arrived_distance;
   double th_stopped_velocity;
   double th_stopped_time;
+  double th_blinker_on_lateral_offset;
 
   // goal search
   std::string search_priority;   // "efficient_path" or "close_goal"

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/pull_out/pull_out_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/pull_out/pull_out_parameters.hpp
@@ -28,6 +28,7 @@ struct PullOutParameters
   double th_arrived_distance;
   double th_stopped_velocity;
   double th_stopped_time;
+  double th_blinker_on_lateral_offset;
   double collision_check_margin;
   double collision_check_distance_from_end;
   // shift pull out

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/pull_out/pull_out_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/pull_out/pull_out_path.hpp
@@ -26,9 +26,9 @@ namespace behavior_path_planner
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 struct PullOutPath
 {
-  std::vector<PathWithLaneId> partial_paths;
-  Pose start_pose;
-  Pose end_pose;
+  std::vector<PathWithLaneId> partial_paths{};
+  Pose start_pose{};
+  Pose end_pose{};
 };
 }  // namespace behavior_path_planner
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__PULL_OUT__PULL_OUT_PATH_HPP_

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1034,6 +1034,7 @@ PullOutParameters BehaviorPathPlannerNode::getPullOutParam()
   p.th_arrived_distance = declare_parameter<double>(ns + "th_arrived_distance");
   p.th_stopped_velocity = declare_parameter<double>(ns + "th_stopped_velocity");
   p.th_stopped_time = declare_parameter<double>(ns + "th_stopped_time");
+  p.th_blinker_on_lateral_offset = declare_parameter<double>(ns + "th_blinker_on_lateral_offset");
   p.collision_check_margin = declare_parameter<double>(ns + "collision_check_margin");
   p.collision_check_distance_from_end =
     declare_parameter<double>(ns + "collision_check_distance_from_end");
@@ -1266,6 +1267,8 @@ void BehaviorPathPlannerNode::run()
     planner_data_->prev_modified_goal = modified_goal;
     modified_goal_publisher_->publish(modified_goal);
   }
+
+  planner_data_->prev_route_id = planner_data_->route_handler->getRouteUuid();
 
   if (planner_data_->parameters.visualize_maximum_drivable_area) {
     const auto maximum_drivable_area = marker_utils::createFurthestLineStringMarkerArray(

--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -31,6 +31,7 @@
 
 using motion_utils::calcLongitudinalOffsetPose;
 using tier4_autoware_utils::calcOffsetPose;
+using tier4_autoware_utils::inverseTransformPoint;
 
 namespace behavior_path_planner
 {
@@ -104,13 +105,33 @@ void PullOutModule::processOnExit()
 
 bool PullOutModule::isExecutionRequested() const
 {
+  has_received_new_route_ =
+    !planner_data_->prev_route_id ||
+    *planner_data_->prev_route_id != planner_data_->route_handler->getRouteUuid();
+
+#ifdef USE_OLD_ARCHITECTURE
+  if (is_executed_) {
+    return true;
+  }
+#endif
+
   if (current_state_ == ModuleStatus::RUNNING) {
     return true;
+  }
+
+  if (!has_received_new_route_) {
+#ifdef USE_OLD_ARCHITECTURE
+    is_executed_ = false;
+#endif
+    return false;
   }
 
   const bool is_stopped = utils::l2Norm(planner_data_->self_odometry->twist.twist.linear) <
                           parameters_->th_arrived_distance;
   if (!is_stopped) {
+#ifdef USE_OLD_ARCHITECTURE
+    is_executed_ = false;
+#endif
     return false;
   }
 
@@ -126,19 +147,15 @@ bool PullOutModule::isExecutionRequested() const
   auto lanes = current_lanes;
   lanes.insert(lanes.end(), pull_out_lanes.begin(), pull_out_lanes.end());
   if (LaneDepartureChecker::isOutOfLane(lanes, vehicle_footprint)) {
+#ifdef USE_OLD_ARCHITECTURE
+    is_executed_ = false;
+#endif
     return false;
   }
 
-  // Check if any of the footprint points are in the shoulder lane
-  lanelet::Lanelet closest_shoulder_lanelet;
-  if (!lanelet::utils::query::getClosestLanelet(
-        pull_out_lanes, planner_data_->self_odometry->pose.pose, &closest_shoulder_lanelet)) {
-    return false;
-  }
-  if (!isOverlappedWithLane(closest_shoulder_lanelet, vehicle_footprint)) {
-    return false;
-  }
-
+#ifdef USE_OLD_ARCHITECTURE
+  is_executed_ = true;
+#endif
   return true;
 }
 
@@ -390,6 +407,9 @@ void PullOutModule::incrementPathIndex()
 
 PathWithLaneId PullOutModule::getCurrentPath() const
 {
+  if (status_.pull_out_path.partial_paths.size() <= status_.current_path_idx) {
+    return PathWithLaneId{};
+  }
   return status_.pull_out_path.partial_paths.at(status_.current_path_idx);
 }
 
@@ -532,28 +552,21 @@ PathWithLaneId PullOutModule::generateStopPath() const
 
 void PullOutModule::updatePullOutStatus()
 {
-  // if new route is received, reset status
-  const bool has_received_new_route =
-    last_route_received_time_ == nullptr ||
-    *last_route_received_time_ != planner_data_->route_handler->getRouteHeader().stamp;
-  if (has_received_new_route) {
-    RCLCPP_INFO(getLogger(), "Receive new route, so reset status");
-    resetStatus();
+  if (has_received_new_route_) {
+    status_ = PullOutStatus();
   }
-  last_route_received_time_ =
-    std::make_unique<rclcpp::Time>(planner_data_->route_handler->getRouteHeader().stamp);
 
   // skip updating if enough time has not passed for preventing chattering between back and pull_out
-  if (!has_received_new_route && !status_.back_finished) {
-    if (last_pull_out_start_update_time_ == nullptr) {
+  if (!has_received_new_route_ && !last_pull_out_start_update_time_ && !status_.back_finished) {
+    if (!last_pull_out_start_update_time_) {
       last_pull_out_start_update_time_ = std::make_unique<rclcpp::Time>(clock_->now());
     }
     const auto elapsed_time = (clock_->now() - *last_pull_out_start_update_time_).seconds();
     if (elapsed_time < parameters_->backward_path_update_duration) {
       return;
     }
-    last_pull_out_start_update_time_ = std::make_unique<rclcpp::Time>(clock_->now());
   }
+  last_pull_out_start_update_time_ = std::make_unique<rclcpp::Time>(clock_->now());
 
   const auto & route_handler = planner_data_->route_handler;
   const auto & current_pose = planner_data_->self_odometry->pose.pose;
@@ -711,7 +724,14 @@ bool PullOutModule::hasFinishedPullOut() const
     lanelet::utils::getArcCoordinates(status_.current_lanes, current_pose);
   const auto arclength_pull_out_end =
     lanelet::utils::getArcCoordinates(status_.current_lanes, status_.pull_out_path.end_pose);
-  return arclength_current.length - arclength_pull_out_end.length > 0.0;
+
+  const bool has_finished = arclength_current.length - arclength_pull_out_end.length > 0.0;
+
+#ifdef USE_OLD_ARCHITECTURE
+  is_executed_ = !has_finished;
+#endif
+
+  return has_finished;
 }
 
 void PullOutModule::checkBackFinished()
@@ -776,7 +796,10 @@ bool PullOutModule::hasFinishedCurrentPath()
 TurnSignalInfo PullOutModule::calcTurnSignalInfo() const
 {
   TurnSignalInfo turn_signal{};  // output
-  const auto & current_pose = planner_data_->self_odometry->pose.pose;
+
+  const Pose & current_pose = planner_data_->self_odometry->pose.pose;
+  const Pose & start_pose = status_.pull_out_path.start_pose;
+  const Pose & end_pose = status_.pull_out_path.end_pose;
 
   // turn on hazard light when backward driving
   if (!status_.back_finished) {
@@ -785,26 +808,31 @@ TurnSignalInfo PullOutModule::calcTurnSignalInfo() const
     turn_signal.desired_start_point = back_start_pose;
     turn_signal.required_start_point = back_start_pose;
     // pull_out start_pose is same to backward driving end_pose
-    turn_signal.required_end_point = status_.pull_out_path.start_pose;
-    turn_signal.desired_end_point = status_.pull_out_path.start_pose;
+    turn_signal.required_end_point = start_pose;
+    turn_signal.desired_end_point = start_pose;
     return turn_signal;
   }
 
   // turn on right signal until passing pull_out end point
   const auto path = getFullPath();
   // pull out path does not overlap
-  const double distance_from_end = motion_utils::calcSignedArcLength(
-    path.points, status_.pull_out_path.end_pose.position, current_pose.position);
-  if (distance_from_end < 0.0) {
+  const double distance_from_end =
+    motion_utils::calcSignedArcLength(path.points, end_pose.position, current_pose.position);
+  const double lateral_offset = inverseTransformPoint(end_pose.position, start_pose).y;
+
+  if (distance_from_end < 0.0 && lateral_offset > parameters_->th_blinker_on_lateral_offset) {
+    turn_signal.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+  } else if (
+    distance_from_end < 0.0 && lateral_offset < -parameters_->th_blinker_on_lateral_offset) {
     turn_signal.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
   } else {
     turn_signal.turn_signal.command = TurnIndicatorsCommand::DISABLE;
   }
 
-  turn_signal.desired_start_point = status_.pull_out_path.start_pose;
-  turn_signal.required_start_point = status_.pull_out_path.start_pose;
-  turn_signal.required_end_point = status_.pull_out_path.end_pose;
-  turn_signal.desired_end_point = status_.pull_out_path.end_pose;
+  turn_signal.desired_start_point = start_pose;
+  turn_signal.required_start_point = start_pose;
+  turn_signal.required_end_point = end_pose;
+  turn_signal.desired_end_point = end_pose;
 
   return turn_signal;
 }

--- a/planning/behavior_path_planner/src/utils/pull_out/util.cpp
+++ b/planning/behavior_path_planner/src/utils/pull_out/util.cpp
@@ -96,23 +96,22 @@ Pose getBackedPose(
   return backed_pose;
 }
 
-// getShoulderLanesOnCurrentPose
 lanelet::ConstLanelets getPullOutLanes(const std::shared_ptr<const PlannerData> & planner_data)
 {
-  const double pull_out_lane_length = 200.0;
   const double & vehicle_width = planner_data->parameters.vehicle_width;
   const auto & route_handler = planner_data->route_handler;
-  const auto current_pose = planner_data->self_odometry->pose.pose;
+  const auto & current_pose = planner_data->self_odometry->pose.pose;
 
   lanelet::ConstLanelet current_shoulder_lane;
   lanelet::ConstLanelets shoulder_lanes;
   if (route_handler->getPullOutStartLane(
         route_handler->getShoulderLanelets(), current_pose, vehicle_width,
         &current_shoulder_lane)) {
-    shoulder_lanes = route_handler->getShoulderLaneletSequence(
-      current_shoulder_lane, current_pose, pull_out_lane_length, pull_out_lane_length);
+    // pull out from shoulder lane
+    return route_handler->getShoulderLaneletSequence(current_shoulder_lane, current_pose);
   }
 
-  return shoulder_lanes;
+  // pull out from road lane
+  return utils::getExtendedCurrentLanes(planner_data);
 }
 }  // namespace behavior_path_planner::pull_out_utils


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- pull out from the road lane not just `road_shoulder`
- always execute pull out when a new route is received and ego-vehicle is stopped.
- disable the blinker if the lateral shift offset is smaller than `th_blinker_on_lateral_offset: 1.0`

red arrow: pull out start point
yellow arrow: pull out end point

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/35f56db6-f0e9-4325-a42b-456663bd820d)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/65de709c-e678-47bc-b015-aafcbe658fec)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/13ae30db-a4f9-4698-847c-15b7a9b45151)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/1b34d365-ddbd-4be7-81c7-cb3e4fa925fa)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim
[tier4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/0c03e577-97a3-5601-a357-b2e10296126b?project_id=prd_jt) 1339/1372


(baseline
https://evaluation.tier4.jp/evaluation/reports/90dcdc1b-b5b3-58d8-85ad-0c28654b65a0?project_id=prd_jt
1330/1372)

new archi
https://evaluation.tier4.jp/evaluation/reports/a62d2285-9947-57fa-b673-7dd30854accc?project_id=prd_jt
1302/1372
not degrated

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

not applicable  

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

not applicable


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
