### PR TITLE
fix(autonomous_emergency_braking): fix imu tranform to base_link

### DIFF
--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -23,11 +23,11 @@
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 #include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <visualization_msgs/msg/marker.hpp>
-#include <geometry_msgs/msg/vector3.hpp>
 
 #include <boost/optional.hpp>
 

--- a/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
+++ b/control/autonomous_emergency_braking/include/autonomous_emergency_braking/node.hpp
@@ -27,6 +27,7 @@
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <visualization_msgs/msg/marker.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
 
 #include <boost/optional.hpp>
 
@@ -60,6 +61,7 @@ using vehicle_info_util::VehicleInfo;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 using Path = std::vector<geometry_msgs::msg::Pose>;
+using Vector3 = geometry_msgs::msg::Vector3;
 
 struct ObjectData
 {
@@ -155,7 +157,7 @@ public:
 
   PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
   VelocityReport::ConstSharedPtr current_velocity_ptr_{nullptr};
-  Imu::ConstSharedPtr imu_ptr_{nullptr};
+  Vector3::SharedPtr angular_velocity_ptr_{nullptr};
   Trajectory::ConstSharedPtr predicted_traj_ptr_{nullptr};
   AutowareState::ConstSharedPtr autoware_state_{nullptr};
 

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -152,9 +152,22 @@ void AEB::onVelocity(const VelocityReport::ConstSharedPtr input_msg)
   current_velocity_ptr_ = input_msg;
 }
 
-void AEB::onImu(const Imu::ConstSharedPtr input_msg)
-{
-  imu_ptr_ = input_msg;
+void AEB::onImu(const Imu::ConstSharedPtr input_msg) {
+  // transform imu
+  geometry_msgs::msg::TransformStamped transform_stamped{};
+  try {
+    transform_stamped = tf_buffer_.lookupTransform(
+      "base_link", input_msg->header.frame_id, input_msg->header.stamp,
+      rclcpp::Duration::from_seconds(0.5));
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_ERROR_STREAM(
+      get_logger(),
+      "[AEB] Failed to look up transform from base_link to" << input_msg->header.frame_id);
+    return;
+  }
+
+  angular_velocity_ptr_ = std::make_shared<Vector3>();
+  tf2::doTransform(input_msg->angular_velocity, *angular_velocity_ptr_, transform_stamped);
 }
 
 void AEB::onPredictedTrajectory(
@@ -225,7 +238,7 @@ bool AEB::isDataReady()
     return missing("object pointcloud");
   }
 
-  if (use_imu_path_ && !imu_ptr_) {
+  if (use_imu_path_ && !angular_velocity_ptr_) {
     return missing("imu");
   }
 
@@ -286,7 +299,7 @@ bool AEB::checkCollision(MarkerArray & debug_markers)
   if (use_imu_path_) {
     Path ego_path;
     std::vector<Polygon2d> ego_polys;
-    const double current_w = imu_ptr_->angular_velocity.z;
+    const double current_w = angular_velocity_ptr_->z;
     constexpr double color_r = 0.0 / 256.0;
     constexpr double color_g = 148.0 / 256.0;
     constexpr double color_b = 205.0 / 256.0;

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -152,7 +152,8 @@ void AEB::onVelocity(const VelocityReport::ConstSharedPtr input_msg)
   current_velocity_ptr_ = input_msg;
 }
 
-void AEB::onImu(const Imu::ConstSharedPtr input_msg) {
+void AEB::onImu(const Imu::ConstSharedPtr input_msg)
+{
   // transform imu
   geometry_msgs::msg::TransformStamped transform_stamped{};
   try {


### PR DESCRIPTION
## Description

This node uses original IMU value, so trajectory made by odometry is opposite direction when IMU is located upside down.
I'll fix it to use tranform.
In addition, I do transform only angular velocity because other informartion is not used.

## Related links

https://tier4.atlassian.net/browse/AEAP-557

## Tests performed

I confirmed frajectory is right direction by below rosbag.
https://drive.google.com/file/d/1LdELkVLbqb8twDXPr-cU538EZVscSX5j/view?usp=sharing
This rosbag has necesarry information only.


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
