### PR TITLE
fix(map_loader): re-align lanelet borders after overwriting coordinates

### DIFF
--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
@@ -41,6 +41,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/LineString.h>
 #include <lanelet2_io/Io.h>
 #include <lanelet2_projection/UTM.h>
 
@@ -107,6 +108,16 @@ lanelet::LaneletMapPtr Lanelet2MapLoaderNode::load_map(
         point.y() = point.attribute("local_y").asDouble().value();
       }
     }
+
+    // realign lanelet borders using updated points
+    for (lanelet::Lanelet lanelet : map->laneletLayer) {
+      auto left = lanelet.leftBound();
+      auto right = lanelet.rightBound();
+      std::tie(left, right) = lanelet::geometry::align(left, right);
+      lanelet.setLeftBound(left);
+      lanelet.setRightBound(right);
+    }
+
     return map;
   } else {
     RCLCPP_ERROR(rclcpp::get_logger("map_loader"), "lanelet2_map_projector_type is not supported");


### PR DESCRIPTION
## Description
resolves: https://github.com/autowarefoundation/autoware.universe/issues/3774

This PR will add the [code required](https://github.com/autowarefoundation/autoware_common/blob/05d31f4655fd0901b7b1b694a1178b65b8fb611f/tmp/lanelet2_extension/lib/autoware_osm_parser.cpp#L36-L43) for "local" projection that was missed out when "local" projection feature was moved from lanelet2_extension to map_loader in https://github.com/autowarefoundation/autoware_common/pull/174.

**Detailed explanation**
When lanelet2 map is loaded from a file, it will look for the orientation of a lanelet borders to register it as either normal linestring or inverted linestring by looking at the geometrical relationship of the borders. Since "local" projection will overwrite the coordinates of loaded points with local_x and local_y tags in the maps, we need to recalculate this orientation of linestrings afterwards.

<!-- Write a brief description of this PR. -->

## Tests performed
[pointcloud_map](https://drive.google.com/file/d/1xY3yM7uRYtNanQNhipON-2FIuKmtSZDB/view?usp=share_link)
[lanelet2_map](https://drive.google.com/file/d/118K4ZHrk9huNWMdkeRyJmvga0gJuQCVX/view?usp=sharing)

Try running planning simulator with the above map from the linked issue.
Autoware isn't capable of calculating correct route with the current main branch.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
