### PR TITLE
fix(tier4_planning_rviz_plugin): fix plugin crash

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
@@ -417,10 +417,8 @@ protected:
     point_manual_object_->estimateVertexCount(msg_ptr->points.size() * 3 * 8);
     point_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);
 
-    // if also this part is commented out, no crash
-    // preVisualizePathFootprintDetail(msg_ptr);
+    preVisualizePathFootprintDetail(msg_ptr);
 
-    /* this part should be commented out
     const float offset_from_baselink = property_offset_.getFloat();
     const auto info = vehicle_footprint_info_;
     const float top = info->length - info->rear_overhang - offset_from_baselink;
@@ -497,7 +495,6 @@ protected:
 
       visualizePathFootprintDetail(msg_ptr, p_idx);
     }
-    */
 
     footprint_manual_object_->end();
     point_manual_object_->end();

--- a/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
@@ -417,8 +417,10 @@ protected:
     point_manual_object_->estimateVertexCount(msg_ptr->points.size() * 3 * 8);
     point_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);
 
-    preVisualizePathFootprintDetail(msg_ptr);
+    // if also this part is commented out, no crash
+    // preVisualizePathFootprintDetail(msg_ptr);
 
+    /* this part should be commented out
     const float offset_from_baselink = property_offset_.getFloat();
     const auto info = vehicle_footprint_info_;
     const float top = info->length - info->rear_overhang - offset_from_baselink;
@@ -495,6 +497,7 @@ protected:
 
       visualizePathFootprintDetail(msg_ptr, p_idx);
     }
+    */
 
     footprint_manual_object_->end();
     point_manual_object_->end();

--- a/common/tier4_planning_rviz_plugin/src/path/display.cpp
+++ b/common/tier4_planning_rviz_plugin/src/path/display.cpp
@@ -53,23 +53,21 @@ void AutowarePathWithLaneIdDisplay::preVisualizePathFootprintDetail(
   const autoware_auto_planning_msgs::msg::PathWithLaneId::ConstSharedPtr msg_ptr)
 {
   const size_t size = msg_ptr->points.size();
-  if (size > lane_id_obj_ptrs_.size()) {
-    for (std::size_t i = lane_id_obj_ptrs_.size(); i < size; i++) {
-      std::unique_ptr<Ogre::SceneNode> node_ptr;
-      node_ptr.reset(scene_node_->createChildSceneNode());
-      auto text_ptr =
-        std::make_unique<rviz_rendering::MovableText>("not initialized", "Liberation Sans", 0.1);
-      text_ptr->setVisible(false);
-      text_ptr->setTextAlignment(
-        rviz_rendering::MovableText::H_CENTER, rviz_rendering::MovableText::V_ABOVE);
-      node_ptr->attachObject(text_ptr.get());
-      lane_id_obj_ptrs_.push_back(std::make_pair(std::move(node_ptr), std::move(text_ptr)));
-    }
-  } else {
-    for (std::size_t i = lane_id_obj_ptrs_.size() - 1; i >= size; i--) {
-      scene_node_->removeChild(lane_id_obj_ptrs_.at(i).first.get());
-    }
-    lane_id_obj_ptrs_.resize(size);
+  // clear previous text
+  for (const auto & [node_ptr, text_ptr] : lane_id_obj_ptrs_) {
+    scene_node_->removeChild(node_ptr.get());
+  }
+  lane_id_obj_ptrs_.clear();
+  for (std::size_t i = 0; i < size; i++) {
+    std::unique_ptr<Ogre::SceneNode> node_ptr;
+    node_ptr.reset(scene_node_->createChildSceneNode());
+    auto text_ptr =
+      std::make_unique<rviz_rendering::MovableText>("not initialized", "Liberation Sans", 0.1);
+    text_ptr->setVisible(false);
+    text_ptr->setTextAlignment(
+      rviz_rendering::MovableText::H_CENTER, rviz_rendering::MovableText::V_ABOVE);
+    node_ptr->attachObject(text_ptr.get());
+    lane_id_obj_ptrs_.push_back(std::make_pair(std::move(node_ptr), std::move(text_ptr)));
   }
 }
 


### PR DESCRIPTION
## Description

Before this PR the plugin crashes frequently.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/3819

## Tests performed

After this PR I do not encounter any crashes anymore when visualizing lane_ids on Rviz.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
