### PR TITLE
fix(behavior_velocity_occlusion_spot_module): delete unnecessary arg from member function of VirtualWallMarkerCreator

### DIFF
--- a/planning/behavior_velocity_occlusion_spot_module/src/debug.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/debug.cpp
@@ -221,14 +221,13 @@ MarkerArray OcclusionSpotModule::createVirtualWallMarkerArray()
   MarkerArray wall_marker;
   std::string module_name = "occlusion_spot";
   std::vector<Pose> slow_down_poses;
-  size_t module_id = 0;
   for (size_t id = 0; id < debug_data_.debug_poses.size(); id++) {
     const auto p_front =
       calcOffsetPose(debug_data_.debug_poses.at(id), debug_data_.baselink_to_front, 0.0, 0.0);
     slow_down_poses.push_back(p_front);
     appendMarkerArray(
       virtual_wall_marker_creator_->createSlowDownVirtualWallMarker(
-        slow_down_poses, module_name, current_time, module_id),
+        slow_down_poses, module_name, current_time),
       &wall_marker, current_time);
   }
   return wall_marker;


### PR DESCRIPTION
## Description

Related with https://github.com/autowarefoundation/autoware.universe/issues/3769

There are two types of scene module exist in `behavior_velocity_planner`.
- multiple module can be launched
- only one module can be launched

And `occlusion_spot_module` is the type of only one module can be launched.

So prefix of namespace is unnecesary. Thi PR delete arg used for prefix.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
