### PR TITLE
fix(behavior_velocity_traffic_light_module): use VirtualWallMarkerCreator for create/delete virtual wall marker

### DIFF
--- a/planning/behavior_velocity_traffic_light_module/src/debug.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/debug.cpp
@@ -37,7 +37,6 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
 {
   visualization_msgs::msg::MarkerArray wall_marker;
 
-  auto id = module_id_;
   const auto now = this->clock_->now();
 
   for (const auto & p : debug_data_.dead_line_poses) {
@@ -45,7 +44,7 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
       virtual_wall_marker_creator_->createDeadLineVirtualWallMarker(
-        p_front, "traffic_light", now, id),
+        p_front, "traffic_light", now, 0.0, std::to_string(module_id_) + "_"),
       &wall_marker, now);
   }
 
@@ -53,7 +52,8 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      virtual_wall_marker_creator_->createStopVirtualWallMarker(p_front, "traffic_light", now, id),
+      virtual_wall_marker_creator_->createStopVirtualWallMarker(
+        p_front, "traffic_light", now, 0.0, std::to_string(module_id_) + "_"),
       &wall_marker, now);
   }
 

--- a/planning/behavior_velocity_traffic_light_module/src/debug.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/debug.cpp
@@ -44,7 +44,8 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      virtual_wall_marker_creator_->createDeadLineVirtualWallMarker(p_front, "traffic_light", now),
+      virtual_wall_marker_creator_->createDeadLineVirtualWallMarker(
+        p_front, "traffic_light", now, id),
       &wall_marker, now);
   }
 
@@ -52,7 +53,7 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      virtual_wall_marker_creator_->createStopVirtualWallMarker(p_front, "traffic_light", now),
+      virtual_wall_marker_creator_->createStopVirtualWallMarker(p_front, "traffic_light", now, id),
       &wall_marker, now);
   }
 

--- a/planning/behavior_velocity_traffic_light_module/src/debug.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/debug.cpp
@@ -44,7 +44,7 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      motion_utils::createDeadLineVirtualWallMarker(p_front, "traffic_light", now, id++),
+      virtual_wall_marker_creator_->createDeadLineVirtualWallMarker(p_front, "traffic_light", now),
       &wall_marker, now);
   }
 
@@ -52,8 +52,8 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      motion_utils::createStopVirtualWallMarker(p_front, "traffic_light", now, id++), &wall_marker,
-      now);
+      virtual_wall_marker_creator_->createStopVirtualWallMarker(p_front, "traffic_light", now),
+      &wall_marker, now);
   }
 
   return wall_marker;

--- a/planning/behavior_velocity_traffic_light_module/src/debug.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/debug.cpp
@@ -44,7 +44,7 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
       virtual_wall_marker_creator_.createDeadLineVirtualWallMarker(
-        p_front, "traffic_light", now, 0.0, std::to_string(module_id_) + "_"),
+        {p_front}, "traffic_light", now, 0.0, std::to_string(module_id_) + "_"),
       &wall_marker, now);
   }
 
@@ -53,7 +53,7 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
       virtual_wall_marker_creator_.createStopVirtualWallMarker(
-        p_front, "traffic_light", now, 0.0, std::to_string(module_id_) + "_"),
+        {p_front}, "traffic_light", now, 0.0, std::to_string(module_id_) + "_"),
       &wall_marker, now);
   }
 

--- a/planning/behavior_velocity_traffic_light_module/src/debug.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/debug.cpp
@@ -43,7 +43,7 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      virtual_wall_marker_creator_->createDeadLineVirtualWallMarker(
+      virtual_wall_marker_creator_.createDeadLineVirtualWallMarker(
         p_front, "traffic_light", now, 0.0, std::to_string(module_id_) + "_"),
       &wall_marker, now);
   }
@@ -52,7 +52,7 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createVirtualWallMarker
     const auto p_front =
       tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      virtual_wall_marker_creator_->createStopVirtualWallMarker(
+      virtual_wall_marker_creator_.createStopVirtualWallMarker(
         p_front, "traffic_light", now, 0.0, std::to_string(module_id_) + "_"),
       &wall_marker, now);
   }

--- a/planning/behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.hpp
@@ -145,6 +145,9 @@ private:
 
   // Traffic Light State
   autoware_auto_perception_msgs::msg::LookingTrafficSignal looking_tl_state_;
+
+  std::shared_ptr<motion_utils::VirtualWallMarkerCreator> virtual_wall_marker_creator_ =
+    std::make_shared<motion_utils::VirtualWallMarkerCreator>();
 };
 }  // namespace behavior_velocity_planner
 

--- a/planning/behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.hpp
@@ -146,8 +146,7 @@ private:
   // Traffic Light State
   autoware_auto_perception_msgs::msg::LookingTrafficSignal looking_tl_state_;
 
-  std::shared_ptr<motion_utils::VirtualWallMarkerCreator> virtual_wall_marker_creator_ =
-    std::make_shared<motion_utils::VirtualWallMarkerCreator>();
+  motion_utils::VirtualWallMarkerCreator virtual_wall_marker_creator_;
 };
 }  // namespace behavior_velocity_planner
 


### PR DESCRIPTION
## Description

Related with https://github.com/autowarefoundation/autoware.universe/issues/3769

Use `VirtualWallMarkerCreator` for create/delete virtual wall marker as other scene modules.
And namespace prefix necessary because multiple module can be launched.
But `module_id_` derived from lane_id_ is unique(because it is obtained from reguratory element id of lanelet).
So adding this module_id_ as arg of `createVitualWallMarker`.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
