### PR TITLE
fix(stopline): fix virtual wall marker id duplication

### DIFF
--- a/planning/behavior_velocity_stop_line_module/src/debug.cpp
+++ b/planning/behavior_velocity_stop_line_module/src/debug.cpp
@@ -107,7 +107,8 @@ visualization_msgs::msg::MarkerArray StopLineModule::createVirtualWallMarkerArra
     *debug_data_.stop_pose, debug_data_.base_link2front, 0.0, 0.0);
   if (state_ == State::APPROACH || state_ == State::STOPPED) {
     appendMarkerArray(
-      virtual_wall_marker_creator_->createStopVirtualWallMarker({p_front}, "stopline", now),
+      virtual_wall_marker_creator_->createStopVirtualWallMarker(
+        {p_front}, "stopline", now, 0.0, std::to_string(module_id_) + "_"),
       &wall_marker, now);
   }
 


### PR DESCRIPTION
## Description

Fixed stopline module to use module_id_ for virtual wall marker creator.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

### Before this PR

The first stopline virtual wall on the path is not visualized due to the error
![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/1b8bf4db-d248-4b3a-aef3-f1351d3f2645)

### After this PR
![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/a34e6238-a3e9-4754-aec8-f8de1cbd9924)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
