### PR TITLE
fix(behavior_velocity_no_stopping_area_module): add arg for namespace prefix

### DIFF
--- a/planning/behavior_velocity_no_stopping_area_module/src/debug.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/debug.cpp
@@ -174,8 +174,9 @@ visualization_msgs::msg::MarkerArray NoStoppingAreaModule::createVirtualWallMark
     stop_poses.push_back(p_front);
   }
   appendMarkerArray(
-    virtual_wall_marker_creator_->createStopVirtualWallMarker(stop_poses, "no_stopping_area", now),
-    &wall_marker, now, module_id_);
+    virtual_wall_marker_creator_->createStopVirtualWallMarker(
+      stop_poses, "no_stopping_area", now, 0.0, std::to_string(module_id_) + "_"),
+    &wall_marker, now);
 
   return wall_marker;
 }

--- a/planning/behavior_velocity_no_stopping_area_module/src/debug.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/debug.cpp
@@ -175,7 +175,7 @@ visualization_msgs::msg::MarkerArray NoStoppingAreaModule::createVirtualWallMark
   }
   appendMarkerArray(
     virtual_wall_marker_creator_->createStopVirtualWallMarker(stop_poses, "no_stopping_area", now),
-    &wall_marker, now);
+    &wall_marker, now, module_id_);
 
   return wall_marker;
 }


### PR DESCRIPTION
## Description

Related with https://github.com/autowarefoundation/autoware.universe/issues/3769

Namespace prefix necessary because multiple module can be launched.
Module_id_ derived from lane_id_ is unique(because it is obtained from reguratory element id of lanelet).

Add this module_id_ as arg of `createVitualWallMarker`.

<!-- Write a brief description of this PR. -->

## Tests performed

### Before this PR
![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/0011dc4c-cabe-4049-8567-9fa037e64234)

### After this PR

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/f85aa49c-5c61-452e-8c2d-92c72fea445b)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
