### PR TITLE
fix(behavior_velocity_speed_bump_module): use unique virtual wall namespace

### DIFF
--- a/planning/behavior_velocity_speed_bump_module/src/debug.cpp
+++ b/planning/behavior_velocity_speed_bump_module/src/debug.cpp
@@ -102,7 +102,9 @@ visualization_msgs::msg::MarkerArray SpeedBumpModule::createVirtualWallMarkerArr
   for (const auto & p : debug_data_.slow_start_poses) {
     const auto & p_front = calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     appendMarkerArray(
-      createSlowDownVirtualWallMarker(p_front, "speed_bump", now, id++), &wall_marker);
+      createSlowDownVirtualWallMarker(
+        p_front, "speed_bump", now, id++, 0.0, std::to_string(module_id_)),
+      &wall_marker);
   }
 
   return wall_marker;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Use the (unique) `module_id_` as namespace prefix for the virtual wall markers generated by the speed bump scenes.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Tested in the planning simulation.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
