### PR TITLE
fix(behavior_velocity_virtual_traffic_light_module): properly use the VirtualWallMarkerCreator and set unique namespace

### DIFF
--- a/planning/behavior_velocity_virtual_traffic_light_module/src/debug.cpp
+++ b/planning/behavior_velocity_virtual_traffic_light_module/src/debug.cpp
@@ -52,28 +52,15 @@ namespace
 
 visualization_msgs::msg::MarkerArray VirtualTrafficLightModule::createVirtualWallMarkerArray()
 {
-  visualization_msgs::msg::MarkerArray wall_marker;
-
   const auto & d = module_data_;
-  const auto now = clock_->now();
-
   // virtual_wall_stop_line
-  if (d.stop_head_pose_at_stop_line) {
-    appendMarkerArray(
-      virtual_wall_marker_creator_->createStopVirtualWallMarker(
-        {*d.stop_head_pose_at_stop_line}, "virtual_traffic_light", now),
-      &wall_marker, now);
-  }
-
+  std::vector<geometry_msgs::msg::Pose> wall_poses;
+  if (d.stop_head_pose_at_stop_line) wall_poses.push_back(*d.stop_head_pose_at_stop_line);
   // virtual_wall_end_line
-  if (d.stop_head_pose_at_end_line) {
-    appendMarkerArray(
-      virtual_wall_marker_creator_->createStopVirtualWallMarker(
-        {*d.stop_head_pose_at_end_line}, "virtual_traffic_light", now),
-      &wall_marker, now);
-  }
+  if (d.stop_head_pose_at_end_line) wall_poses.push_back(*d.stop_head_pose_at_end_line);
 
-  return wall_marker;
+  return virtual_wall_marker_creator_->createStopVirtualWallMarker(
+    wall_poses, "virtual_traffic_light", clock_->now(), 0.0, std::to_string(module_id_));
 }
 
 visualization_msgs::msg::MarkerArray VirtualTrafficLightModule::createDebugMarkerArray()


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Ensure a single call to the `VirtualWallMarkerCreator` and set a unique namespace, even if multiple modules run in parallel.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
