### PR TITLE
docs(mkdocs): enable instant loading of mathjax equations

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -97,3 +97,4 @@
         sd "/edit/main/docs/" "/edit/main/" {source}
         sd "docs_dir: .*" "docs_dir: ." {source}
         sd "assets/(\w+)" "docs/assets/\$1" {source}
+    - source: docs/assets/js/mathjax.js

--- a/docs/assets/js/mathjax.js
+++ b/docs/assets/js/mathjax.js
@@ -1,0 +1,16 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise()
+})

--- a/docs/assets/js/mathjax.js
+++ b/docs/assets/js/mathjax.js
@@ -3,14 +3,14 @@ window.MathJax = {
     inlineMath: [["\\(", "\\)"]],
     displayMath: [["\\[", "\\]"]],
     processEscapes: true,
-    processEnvironments: true
+    processEnvironments: true,
   },
   options: {
     ignoreHtmlClass: ".*|",
-    processHtmlClass: "arithmatex"
-  }
+    processHtmlClass: "arithmatex",
+  },
 };
 
 document$.subscribe(() => {
-  MathJax.typesetPromise()
-})
+  MathJax.typesetPromise();
+});

--- a/docs/js/mathjax.js
+++ b/docs/js/mathjax.js
@@ -1,0 +1,3 @@
+document$.subscribe(() => {
+  MathJax.typesetPromise()
+})

--- a/docs/js/mathjax.js
+++ b/docs/js/mathjax.js
@@ -1,3 +1,0 @@
-document$.subscribe(() => {
-  MathJax.typesetPromise()
-})

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -45,6 +45,7 @@ extra_css:
   - https://use.fontawesome.com/releases/v5.15.4/css/all.css
 
 extra_javascript:
+  - js/mathjax.js
   - https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 
 plugins:
@@ -67,8 +68,7 @@ markdown_extensions:
   - fontawesome_markdown
   - footnotes
   - md_in_html
-  - mdx_math:
-      enable_dollar_delimiter: True
+  - mdx_math
   - mdx_truly_sane_lists:
       nested_indent: 2
   - plantuml_markdown:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -45,8 +45,9 @@ extra_css:
   - https://use.fontawesome.com/releases/v5.15.4/css/all.css
 
 extra_javascript:
-  - js/mathjax.js
-  - https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+  - docs/assets/js/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:
   - awesome-pages
@@ -74,7 +75,8 @@ markdown_extensions:
   - plantuml_markdown:
       server: http://www.plantuml.com/plantuml
       format: svg
-  - pymdownx.arithmatex
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -67,7 +67,8 @@ markdown_extensions:
   - fontawesome_markdown
   - footnotes
   - md_in_html
-  - mdx_math
+  - mdx_math:
+      enable_dollar_delimiter: True
   - mdx_truly_sane_lists:
       nested_indent: 2
   - plantuml_markdown:


### PR DESCRIPTION
## Description

~I fixed the rendering error mathjax equations of the autoware.universe documentation. (like this page: https://autowarefoundation.github.io/autoware.universe/main/planning/obstacle_avoidance_planner/docs/eb/)~

~It looks like the page should be reloaded on some environments (like mobile Firefox, google chrome desktop).~

Currently, autoware-documentation and autoware.universe documentation do not seem to support `instant loading` of math equations.
related: https://github.com/squidfunk/mkdocs-material/issues/2530

### How to reproduce 
When you open the [home page of obstacle_avoidance_planner](https://autowarefoundation.github.io/autoware.universe/main/planning/obstacle_avoidance_planner/) and then go to the details of `getEBTrajectory` part by clicking the link on `here`, you are likely to see the math equations not rendered first. Then you need to reload the page to get the equations rendered.

### After this PR

You do not need to reload the detail page to get the equations rendered.

## Tests performed

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
