### PR TITLE
fix(distortion_corrector_node): fix dereference of uninitialized iterator

### DIFF
--- a/sensing/pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp
+++ b/sensing/pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp
@@ -222,7 +222,6 @@ bool DistortionCorrectorComponent::undistortPointCloud(
 
   // For performance, do not instantiate `rclcpp::Time` inside of the for-loop
   double twist_stamp = rclcpp::Time(twist_it->header.stamp).seconds();
-  double imu_stamp = rclcpp::Time(imu_it->header.stamp).seconds();
 
   // For performance, instantiate outside of the for-loop
   tf2::Quaternion baselink_quat{};
@@ -251,6 +250,9 @@ bool DistortionCorrectorComponent::undistortPointCloud(
     }
 
     if (use_imu_ && !angular_velocity_queue_.empty()) {
+      // For performance, do not instantiate `rclcpp::Time` inside of the for-loop
+      double imu_stamp = rclcpp::Time(imu_it->header.stamp).seconds();
+
       for (;
            (imu_it != std::end(angular_velocity_queue_) - 1 &&
             *it_time_stamp > rclcpp::Time(imu_it->header.stamp).seconds());


### PR DESCRIPTION
## Description
Deal with the bug reported on[ this ticket (TIER IV internal)](https://tier4.atlassian.net/browse/RT1-2334).
Fixed a situation where if `angular_velocity_queue_` is empty, the iterator for that deque is referenced in an uninitialized state.



## Tests performed

The bug reported on [ this ticket (TIER IV internal)](https://tier4.atlassian.net/browse/RT1-2334) is fixed.


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
