### PR TITLE
fix(mpc_lateral_controller): butterworth coeffs calculation

### DIFF
--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/lowpass_filter.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/lowpass_filter.hpp
@@ -33,7 +33,6 @@ private:
   double m_y2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
   double m_u1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
   double m_u2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
-  double m_a0;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
   double m_a1;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
   double m_a2;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time
   double m_b0;  //!< @brief filter coefficient calculated with cutoff frequency and sampling time

--- a/control/mpc_lateral_controller/src/lowpass_filter.cpp
+++ b/control/mpc_lateral_controller/src/lowpass_filter.cpp
@@ -34,7 +34,7 @@ void Butterworth2dFilter::initialize(const double & dt, const double & f_cutoff_
   m_u2 = 0.0;
   m_u1 = 0.0;
 
-  // 2d Butterworth low pass filter
+  // 2d Butterworth low pass filter with bi-linear transformation
   const double f_sampling_hz = 1.0 / dt;
   const double xi = 1.0 / std::tan(M_PI * f_cutoff_hz / f_sampling_hz);
   const double xi_2 = xi * xi;

--- a/control/mpc_lateral_controller/src/lowpass_filter.cpp
+++ b/control/mpc_lateral_controller/src/lowpass_filter.cpp
@@ -34,20 +34,21 @@ void Butterworth2dFilter::initialize(const double & dt, const double & f_cutoff_
   m_u2 = 0.0;
   m_u1 = 0.0;
 
-  /* 2d butterworth lowpass filter with bi-linear transformation */
-  double wc = 2.0 * M_PI * f_cutoff_hz;
-  double n = 2 / dt;
-  m_a0 = n * n + sqrt(2) * wc * n + wc * wc;
-  m_a1 = 2 * wc * wc - 2 * n * n;
-  m_a2 = n * n - sqrt(2) * wc * n + wc * wc;
-  m_b0 = wc * wc;
-  m_b1 = 2 * m_b0;
+  // 2d Butterworth low pass filter
+  const double f_sampling_hz = 1.0 / dt;
+  const double xi = 1.0 / std::tan(M_PI * f_cutoff_hz / f_sampling_hz);
+  const double xi_2 = xi * xi;
+  const double q = std::sqrt(2);
+  m_b0 = 1.0 / (1.0 + q * xi + xi_2);
+  m_b1 = 2.0 * m_b0;
   m_b2 = m_b0;
+  m_a1 = 2.0 * (xi_2 - 1.0) * m_b0;
+  m_a2 = -(1.0 - q * xi + xi_2) * m_b0;
 }
 
 double Butterworth2dFilter::filter(const double & u0)
 {
-  double y0 = (m_b2 * m_u2 + m_b1 * m_u1 + m_b0 * u0 - m_a2 * m_y2 - m_a1 * m_y1) / m_a0;
+  double y0 = m_b2 * m_u2 + m_b1 * m_u1 + m_b0 * u0 + m_a2 * m_y2 + m_a1 * m_y1;
   m_y2 = m_y1;
   m_y1 = y0;
   m_u2 = m_u1;
@@ -66,7 +67,7 @@ void Butterworth2dFilter::filt_vector(const std::vector<double> & t, std::vector
   double u0 = 0.0;
   for (size_t i = 0; i < t.size(); ++i) {
     u0 = t.at(i);
-    y0 = (m_b2 * u2 + m_b1 * u1 + m_b0 * u0 - m_a2 * y2 - m_a1 * y1) / m_a0;
+    y0 = m_b2 * u2 + m_b1 * u1 + m_b0 * u0 + m_a2 * y2 + m_a1 * y1;
     y2 = y1;
     y1 = y0;
     u2 = u1;
@@ -100,7 +101,6 @@ void Butterworth2dFilter::filtfilt_vector(
 void Butterworth2dFilter::getCoefficients(std::vector<double> & coeffs) const
 {
   coeffs.clear();
-  coeffs.push_back(m_a0);
   coeffs.push_back(m_a1);
   coeffs.push_back(m_a2);
   coeffs.push_back(m_b0);

--- a/control/mpc_lateral_controller/test/test_lowpass_filter.cpp
+++ b/control/mpc_lateral_controller/test/test_lowpass_filter.cpp
@@ -95,7 +95,7 @@ TEST(TestLowpassFilter, Butterworth2dFilterCoeffs)
 {
   using autoware::motion::control::mpc_lateral_controller::Butterworth2dFilter;
 
-  // Case 1: 
+  // Case 1:
   // cutoff_frequency = 1.0 [Hz], sampling_time = 0.033
   //
   //   0.0093487 +0.0186974z +0.0093487z²
@@ -115,7 +115,7 @@ TEST(TestLowpassFilter, Butterworth2dFilterCoeffs)
     EXPECT_NEAR(coeff.at(4), 0.0093487, ep);   // b2
   }
 
-  // Case 1: 
+  // Case 1:
   // cutoff_frequency = 2.0 [Hz], sampling_time = 0.05
   //
   //    0.0674553 +0.1349105z +0.0674553z²

--- a/control/mpc_lateral_controller/test/test_lowpass_filter.cpp
+++ b/control/mpc_lateral_controller/test/test_lowpass_filter.cpp
@@ -76,7 +76,7 @@ TEST(TestLowpassFilter, Butterworth2dFilter)
   std::vector<double> filtered_vec;
   filter.filt_vector(original_vec, filtered_vec);
   ASSERT_EQ(filtered_vec.size(), original_vec.size());
-  EXPECT_EQ(filtered_vec[0], original_vec[0]);
+  EXPECT_NEAR(filtered_vec[0], original_vec[0], 1.0e-10);
   for (size_t i = 1; i < filtered_vec.size(); ++i) {
     EXPECT_LT(filtered_vec[i], original_vec[i]);
   }
@@ -87,5 +87,51 @@ TEST(TestLowpassFilter, Butterworth2dFilter)
 
   std::vector<double> coefficients;
   filter.getCoefficients(coefficients);
-  EXPECT_EQ(coefficients.size(), size_t(6));
+  EXPECT_EQ(coefficients.size(), size_t(5));
+}
+
+// Comparison of the coefficients
+TEST(TestLowpassFilter, Butterworth2dFilterCoeffs)
+{
+  using autoware::motion::control::mpc_lateral_controller::Butterworth2dFilter;
+
+  // Case 1: 
+  // cutoff_frequency = 1.0 [Hz], sampling_time = 0.033
+  //
+  //   0.0093487 +0.0186974z +0.0093487z²
+  //   ----------------------------------
+  //       0.7458606 -1.7084658z +z²
+  {
+    const double sampling_time = 0.033;
+    const double f_cutoff_hz = 1.0;
+    Butterworth2dFilter butt_filter(sampling_time, f_cutoff_hz);
+    std::vector<double> coeff;
+    butt_filter.getCoefficients(coeff);
+    constexpr double ep = 1.0e-6;
+    EXPECT_NEAR(coeff.at(0), 1.7084658, ep);   // a1
+    EXPECT_NEAR(coeff.at(1), -0.7458606, ep);  // a2
+    EXPECT_NEAR(coeff.at(2), 0.0093487, ep);   // b0
+    EXPECT_NEAR(coeff.at(3), 0.0186974, ep);   // b1
+    EXPECT_NEAR(coeff.at(4), 0.0093487, ep);   // b2
+  }
+
+  // Case 1: 
+  // cutoff_frequency = 2.0 [Hz], sampling_time = 0.05
+  //
+  //    0.0674553 +0.1349105z +0.0674553z²
+  //    ----------------------------------
+  //        0.4128016 -1.1429805z +z²
+  {
+    const double sampling_time = 0.05;
+    const double f_cutoff_hz = 2.0;
+    Butterworth2dFilter butt_filter(sampling_time, f_cutoff_hz);
+    std::vector<double> coeff;
+    butt_filter.getCoefficients(coeff);
+    constexpr double ep = 1.0e-6;
+    EXPECT_NEAR(coeff.at(0), 1.1429805, ep);   // a1
+    EXPECT_NEAR(coeff.at(1), -0.4128016, ep);  // a2
+    EXPECT_NEAR(coeff.at(2), 0.0674553, ep);   // b0
+    EXPECT_NEAR(coeff.at(3), 0.1349105, ep);   // b1
+    EXPECT_NEAR(coeff.at(4), 0.0674553, ep);   // b2
+  }
 }


### PR DESCRIPTION
## Description

The coefficient calculation in the Butterworth filter was wrong (just `tan` was not considered for the `fc/fs`). This PR corrects them and a unit test was added. The filtering behavior does not change that much as in the attached plots (the overshoot is slightly improved).

- Fix Butterworth coefficient calculation
- Add unit test to check the Butterworth coefficients

## Related links

None

## Tests performed

**Before**
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/6c631af6-e4a7-4824-a769-0b5626ea89f5)
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/a7e1f52a-abc3-449a-9924-55a4378a338e)



**After**

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/864c8e50-5e5c-4399-ba41-b4f6da10c4dc)
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/25334ead-8745-4120-b92a-74fa1a4adfd5)



## Notes for reviewers

None
## Interface changes

None

## Effects on system behavior

Almost none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
