### PR TITLE
feat(avoidance): additional buffer for perception noise

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -29,44 +29,54 @@
       target_object:
         car:
           enable: true
+          max_expand_ratio: 0.0
           envelope_buffer_margin: 0.3
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
         truck:
           enable: true
+          max_expand_ratio: 0.0
           envelope_buffer_margin: 0.3
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
         bus:
           enable: true
+          max_expand_ratio: 0.0
           envelope_buffer_margin: 0.3
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
         trailer:
           enable: true
+          max_expand_ratio: 0.0
           envelope_buffer_margin: 0.3
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
         unknown:
           enable: false
+          max_expand_ratio: 0.0
           envelope_buffer_margin: 0.3
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
         bicycle:
           enable: false
+          max_expand_ratio: 0.0
           envelope_buffer_margin: 0.8
           safety_buffer_lateral: 1.0
           safety_buffer_longitudinal: 1.0
         motorcycle:
           enable: false
+          max_expand_ratio: 0.0
           envelope_buffer_margin: 0.8
           safety_buffer_lateral: 1.0
           safety_buffer_longitudinal: 1.0
         pedestrian:
           enable: false
+          max_expand_ratio: 0.0
           envelope_buffer_margin: 0.8
           safety_buffer_lateral: 1.0
           safety_buffer_longitudinal: 1.0
+        lower_distance_for_polygon_expansion: 30.0      # [m]
+        upper_distance_for_polygon_expansion: 100.0     # [m]
 
       # For target object filtering
       target_filtering:

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -50,6 +50,8 @@ struct ObjectParameter
 {
   bool enable{false};
 
+  double max_expand_ratio{0.0};
+
   double envelope_buffer_margin{0.0};
 
   double safety_buffer_lateral{1.0};
@@ -114,6 +116,12 @@ struct AvoidanceParameters
 
   // comfortable jerk
   double nominal_jerk;
+
+  // upper distance for envelope polygon expansion.
+  double upper_distance_for_polygon_expansion;
+
+  // lower distance for envelope polygon expansion.
+  double lower_distance_for_polygon_expansion;
 
   // Vehicles whose distance to the center of the path is
   // less than this will not be considered for avoidance.

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -316,6 +316,9 @@ struct ObjectData  // avoidance target
   // lateral shiftable ratio
   double shiftable_ratio{0.0};
 
+  // distance factor for perception noise (0.0~1.0)
+  double distance_factor{0.0};
+
   // count up when object disappeared. Removed when it exceeds threshold.
   rclcpp::Time last_seen;
   double lost_time{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -88,7 +88,7 @@ void insertDecelPoint(
 
 void fillObjectEnvelopePolygon(
   ObjectData & object_data, const ObjectDataArray & registered_objects, const Pose & closest_pose,
-  const std::shared_ptr<AvoidanceParameters> & parameters);
+  const Pose & ego_pose, const std::shared_ptr<AvoidanceParameters> & parameters);
 
 void fillObjectMovingTime(
   ObjectData & object_data, ObjectDataArray & stopped_objects,

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -88,7 +88,7 @@ void insertDecelPoint(
 
 void fillObjectEnvelopePolygon(
   ObjectData & object_data, const ObjectDataArray & registered_objects, const Pose & closest_pose,
-  const Pose & ego_pose, const std::shared_ptr<AvoidanceParameters> & parameters);
+  const std::shared_ptr<AvoidanceParameters> & parameters);
 
 void fillObjectMovingTime(
   ObjectData & object_data, ObjectDataArray & stopped_objects,

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -577,24 +577,31 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   {
     const auto get_object_param = [&](std::string && ns) {
       ObjectParameter param{};
-      param.enable = declare_parameter<bool>("avoidance.target_object." + ns + "enable");
-      param.envelope_buffer_margin =
-        declare_parameter<double>("avoidance.target_object." + ns + "envelope_buffer_margin");
-      param.safety_buffer_lateral =
-        declare_parameter<double>("avoidance.target_object." + ns + "safety_buffer_lateral");
+      param.enable = declare_parameter<bool>(ns + "enable");
+      param.max_expand_ratio = declare_parameter<double>(ns + "max_expand_ratio");
+      param.envelope_buffer_margin = declare_parameter<double>(ns + "envelope_buffer_margin");
+      param.safety_buffer_lateral = declare_parameter<double>(ns + "safety_buffer_lateral");
       param.safety_buffer_longitudinal =
-        declare_parameter<double>("avoidance.target_object." + ns + "safety_buffer_longitudinal");
+        declare_parameter<double>(ns + "safety_buffer_longitudinal");
       return param;
     };
 
-    p.object_parameters.emplace(ObjectClassification::MOTORCYCLE, get_object_param("motorcycle."));
-    p.object_parameters.emplace(ObjectClassification::CAR, get_object_param("car."));
-    p.object_parameters.emplace(ObjectClassification::TRUCK, get_object_param("truck."));
-    p.object_parameters.emplace(ObjectClassification::TRAILER, get_object_param("trailer."));
-    p.object_parameters.emplace(ObjectClassification::BUS, get_object_param("bus."));
-    p.object_parameters.emplace(ObjectClassification::PEDESTRIAN, get_object_param("pedestrian."));
-    p.object_parameters.emplace(ObjectClassification::BICYCLE, get_object_param("bicycle."));
-    p.object_parameters.emplace(ObjectClassification::UNKNOWN, get_object_param("unknown."));
+    const std::string ns = "avoidance.target_object.";
+    p.object_parameters.emplace(
+      ObjectClassification::MOTORCYCLE, get_object_param(ns + "motorcycle."));
+    p.object_parameters.emplace(ObjectClassification::CAR, get_object_param(ns + "car."));
+    p.object_parameters.emplace(ObjectClassification::TRUCK, get_object_param(ns + "truck."));
+    p.object_parameters.emplace(ObjectClassification::TRAILER, get_object_param(ns + "trailer."));
+    p.object_parameters.emplace(ObjectClassification::BUS, get_object_param(ns + "bus."));
+    p.object_parameters.emplace(
+      ObjectClassification::PEDESTRIAN, get_object_param(ns + "pedestrian."));
+    p.object_parameters.emplace(ObjectClassification::BICYCLE, get_object_param(ns + "bicycle."));
+    p.object_parameters.emplace(ObjectClassification::UNKNOWN, get_object_param(ns + "unknown."));
+
+    p.lower_distance_for_polygon_expansion =
+      declare_parameter<double>(ns + "lower_distance_for_polygon_expansion");
+    p.upper_distance_for_polygon_expansion =
+      declare_parameter<double>(ns + "upper_distance_for_polygon_expansion");
   }
 
   // target filtering

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -379,7 +379,7 @@ ObjectData AvoidanceModule::createObjectData(
 
   // Calc envelop polygon.
   utils::avoidance::fillObjectEnvelopePolygon(
-    object_data, registered_objects_, object_closest_pose, parameters_);
+    object_data, registered_objects_, object_closest_pose, getEgoPose(), parameters_);
 
   // calc object centroid.
   object_data.centroid = return_centroid<Point2d>(object_data.envelope_poly);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -372,14 +372,22 @@ ObjectData AvoidanceModule::createObjectData(
   const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
   const auto object_closest_index = findNearestIndex(path_points, object_pose.position);
   const auto object_closest_pose = path_points.at(object_closest_index).point.pose;
+  const auto t = utils::getHighestProbLabel(object.classification);
+  const auto object_parameter = parameters_->object_parameters.at(t);
 
   ObjectData object_data{};
 
   object_data.object = object;
 
+  const auto lower = parameters_->lower_distance_for_polygon_expansion;
+  const auto upper = parameters_->upper_distance_for_polygon_expansion;
+  const auto clamp =
+    std::clamp(calcDistance2d(getEgoPose(), object_pose) - lower, 0.0, upper) / upper;
+  object_data.distance_factor = object_parameter.max_expand_ratio * clamp + 1.0;
+
   // Calc envelop polygon.
   utils::avoidance::fillObjectEnvelopePolygon(
-    object_data, registered_objects_, object_closest_pose, getEgoPose(), parameters_);
+    object_data, registered_objects_, object_closest_pose, parameters_);
 
   // calc object centroid.
   object_data.centroid = return_centroid<Point2d>(object_data.envelope_poly);
@@ -395,10 +403,9 @@ ObjectData AvoidanceModule::createObjectData(
     object_data, object_closest_pose, object_data.overhang_pose.position);
 
   // Check whether the the ego should avoid the object.
-  const auto t = utils::getHighestProbLabel(object.classification);
-  const auto object_parameter = parameters_->object_parameters.at(t);
   const auto & vehicle_width = planner_data_->parameters.vehicle_width;
-  const auto safety_margin = 0.5 * vehicle_width + object_parameter.safety_buffer_lateral;
+  const auto safety_margin =
+    0.5 * vehicle_width + object_parameter.safety_buffer_lateral * object_data.distance_factor;
   object_data.avoid_required =
     (utils::avoidance::isOnRight(object_data) &&
      std::abs(object_data.overhang_dist) < safety_margin) ||
@@ -602,7 +609,7 @@ void AvoidanceModule::fillDebugData(const AvoidancePlanningData & data, DebugDat
   const auto & base_link2front = planner_data_->parameters.base_link2front;
   const auto & vehicle_width = planner_data_->parameters.vehicle_width;
 
-  const auto max_avoid_margin = object_parameter.safety_buffer_lateral +
+  const auto max_avoid_margin = object_parameter.safety_buffer_lateral * o_front.distance_factor +
                                 parameters_->lateral_collision_margin + 0.5 * vehicle_width;
 
   const auto variable = helper_.getSharpAvoidanceDistance(
@@ -3265,8 +3272,8 @@ double AvoidanceModule::calcDistanceToStopLine(const ObjectData & object) const
   const auto t = utils::getHighestProbLabel(object.object.classification);
   const auto object_parameter = parameters_->object_parameters.at(t);
 
-  const auto avoid_margin =
-    object_parameter.safety_buffer_lateral + p->lateral_collision_margin + 0.5 * vehicle_width;
+  const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
+                            p->lateral_collision_margin + 0.5 * vehicle_width;
   const auto variable = helper_.getMinimumAvoidanceDistance(
     helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin));
   const auto constant =

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -48,6 +48,7 @@ void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parame
                                      const auto & semantic, const std::string & ns) {
     auto & config = p->object_parameters.at(semantic);
     updateParam<bool>(parameters, ns + "enable", config.enable);
+    updateParam<double>(parameters, ns + "max_expand_ratio", config.max_expand_ratio);
     updateParam<double>(parameters, ns + "envelope_buffer_margin", config.envelope_buffer_margin);
     updateParam<double>(parameters, ns + "safety_buffer_lateral", config.safety_buffer_lateral);
     updateParam<double>(
@@ -64,6 +65,13 @@ void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parame
     update_object_param(ObjectClassification::PEDESTRIAN, ns + "pedestrian.");
     update_object_param(ObjectClassification::BICYCLE, ns + "bicycle.");
     update_object_param(ObjectClassification::UNKNOWN, ns + "unknown.");
+
+    updateParam<double>(
+      parameters, ns + "lower_distance_for_polygon_expansion",
+      p->lower_distance_for_polygon_expansion);
+    updateParam<double>(
+      parameters, ns + "upper_distance_for_polygon_expansion",
+      p->upper_distance_for_polygon_expansion);
   }
 
   {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
@@ -181,20 +181,29 @@ ObjectData AvoidanceByLaneChange::createObjectData(
   const AvoidancePlanningData & data, const PredictedObject & object) const
 {
   using boost::geometry::return_centroid;
+  using motion_utils::findNearestIndex;
+  using tier4_autoware_utils::calcDistance2d;
 
   const auto & path_points = data.reference_path.points;
   const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
-  const auto object_closest_index =
-    motion_utils::findNearestIndex(path_points, object_pose.position);
+  const auto object_closest_index = findNearestIndex(path_points, object_pose.position);
   const auto object_closest_pose = path_points.at(object_closest_index).point.pose;
+  const auto t = utils::getHighestProbLabel(object.classification);
+  const auto object_parameter = avoidance_parameters_->object_parameters.at(t);
 
   ObjectData object_data{};
 
   object_data.object = object;
 
+  const auto lower = avoidance_parameters_->lower_distance_for_polygon_expansion;
+  const auto upper = avoidance_parameters_->upper_distance_for_polygon_expansion;
+  const auto clamp =
+    std::clamp(calcDistance2d(getEgoPose(), object_pose) - lower, 0.0, upper) / upper;
+  object_data.distance_factor = object_parameter.max_expand_ratio * clamp + 1.0;
+
   // Calc envelop polygon.
   utils::avoidance::fillObjectEnvelopePolygon(
-    object_data, registered_objects_, object_closest_pose, getEgoPose(), avoidance_parameters_);
+    object_data, registered_objects_, object_closest_pose, avoidance_parameters_);
 
   // calc object centroid.
   object_data.centroid = return_centroid<Point2d>(object_data.envelope_poly);
@@ -211,10 +220,9 @@ ObjectData AvoidanceByLaneChange::createObjectData(
     object_data, object_closest_pose, object_data.overhang_pose.position);
 
   // Check whether the the ego should avoid the object.
-  const auto t = utils::getHighestProbLabel(object.classification);
-  const auto object_parameter = avoidance_parameters_->object_parameters.at(t);
   const auto vehicle_width = planner_data_->parameters.vehicle_width;
-  const auto safety_margin = 0.5 * vehicle_width + object_parameter.safety_buffer_lateral;
+  const auto safety_margin =
+    0.5 * vehicle_width + object_parameter.safety_buffer_lateral * object_data.distance_factor;
   object_data.avoid_required =
     (utils::avoidance::isOnRight(object_data) &&
      std::abs(object_data.overhang_dist) < safety_margin) ||

--- a/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
@@ -194,7 +194,7 @@ ObjectData AvoidanceByLaneChange::createObjectData(
 
   // Calc envelop polygon.
   utils::avoidance::fillObjectEnvelopePolygon(
-    object_data, registered_objects_, object_closest_pose, avoidance_parameters_);
+    object_data, registered_objects_, object_closest_pose, getEgoPose(), avoidance_parameters_);
 
   // calc object centroid.
   object_data.centroid = return_centroid<Point2d>(object_data.envelope_poly);

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -483,22 +483,15 @@ void insertDecelPoint(
 
 void fillObjectEnvelopePolygon(
   ObjectData & object_data, const ObjectDataArray & registered_objects, const Pose & closest_pose,
-  const Pose & ego_pose, const std::shared_ptr<AvoidanceParameters> & parameters)
+  const std::shared_ptr<AvoidanceParameters> & parameters)
 {
   using boost::geometry::within;
 
   const auto t = utils::getHighestProbLabel(object_data.object.classification);
   const auto object_parameter = parameters->object_parameters.at(t);
 
-  const auto & obj_pose = object_data.object.kinematics.initial_pose_with_covariance.pose;
-  const auto lower = parameters->lower_distance_for_polygon_expansion;
-  const auto upper = parameters->upper_distance_for_polygon_expansion;
-  const auto distance_factor = object_parameter.max_expand_ratio *
-                               std::clamp(calcDistance2d(ego_pose, obj_pose) - lower, 0.0, upper) /
-                               upper;
-
   const auto & envelope_buffer_margin =
-    object_parameter.envelope_buffer_margin * (1.0 + distance_factor);
+    object_parameter.envelope_buffer_margin * object_data.distance_factor;
 
   const auto id = object_data.object.object_id;
   const auto same_id_obj = std::find_if(
@@ -781,7 +774,7 @@ void filterTargetObjects(
 
     // calculate avoid_margin dynamically
     // NOTE: This calculation must be after calculating to_road_shoulder_distance.
-    const double max_avoid_margin = object_parameter.safety_buffer_lateral +
+    const double max_avoid_margin = object_parameter.safety_buffer_lateral * o.distance_factor +
                                     parameters->lateral_collision_margin + 0.5 * vehicle_width;
     const double min_safety_lateral_distance =
       object_parameter.safety_buffer_lateral + 0.5 * vehicle_width;


### PR DESCRIPTION
## Description

**Assumption**: Perception results for far objects have larger detection error than the result for near one.

Sometimes, the avoidance module changes the judgement whether the ego should avoid or not after the ego gets quite a bit closer to the object because of the detection error. The judgement chattering causes unexpected sudden deceleration so that the module keeps avoidable distance to object.

In this PR, it is able to set `max_expand_ratio > 0`, and the avoidance module expands objects `envelope_polygon_buffer` and `safety_buffer_lateral` based on the distance between the ego and object so that far objects are judged to be avoided more frequently than nearby objects. As a result, it prevents a sudden change from "not need to avoid" to "should avoid" after approaching it.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/3b56f000-ab8d-4e53-8b47-ce36e454492f)

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/efd3d832-7ae6-4edf-8fc6-db71c708d5b7)

:arrow_down: This must be merged before this PR.
https://github.com/autowarefoundation/autoware_launch/pull/373

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/e8815da4-8b0c-5528-bfd3-7bb1b35a039a?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
