### PR TITLE
test(planning_test_utils): create route and odometry from lane_id

### DIFF
--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
@@ -89,7 +89,6 @@ using geometry_msgs::msg::Quaternion;
 using geometry_msgs::msg::TransformStamped;
 using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
-using planning_interface::Route;
 using sensor_msgs::msg::PointCloud2;
 using tf2_msgs::msg::TFMessage;
 using tier4_api_msgs::msg::CrosswalkStatus;
@@ -99,6 +98,11 @@ using tier4_planning_msgs::msg::LateralOffset;
 using tier4_planning_msgs::msg::Scenario;
 using tier4_planning_msgs::msg::VelocityLimit;
 using tier4_v2x_msgs::msg::VirtualTrafficLightStateArray;
+
+enum class ModuleName {
+  UNKNOWN = 0,
+  PULL_OUT,
+};
 
 class PlanningInterfaceTestManager
 {
@@ -110,7 +114,7 @@ public:
 
   void publishInitialPose(
     rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift = 0.0,
-    std::string module_name = "");
+    ModuleName module_name = ModuleName::UNKNOWN);
 
   void publishMaxVelocity(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishPointCloud(rclcpp::Node::SharedPtr target_node, std::string topic_name);
@@ -156,7 +160,7 @@ public:
   void testWithAbnormalRoute(rclcpp::Node::SharedPtr target_node);
 
   void testWithBehaviorNominalRoute(
-    rclcpp::Node::SharedPtr target_node, std::string module_name = "");
+    rclcpp::Node::SharedPtr target_node, ModuleName module_name = ModuleName::UNKNOWN);
 
   void testWithNominalPathWithLaneId(rclcpp::Node::SharedPtr target_node);
   void testWithAbnormalPathWithLaneId(rclcpp::Node::SharedPtr target_node);
@@ -255,7 +259,8 @@ private:
     rclcpp::Node::SharedPtr target_node, const LaneletRoute & abnormal_route);
 
   void publishBehaviorNominalRoute(
-    rclcpp::Node::SharedPtr target_node, std::string topic_name, std::string module_name = "");
+    rclcpp::Node::SharedPtr target_node, std::string topic_name,
+    ModuleName module_name = ModuleName::UNKNOWN);
   void publishNominalPathWithLaneId(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishAbNominalPathWithLaneId(rclcpp::Node::SharedPtr target_node, std::string topic_name);
 

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
@@ -109,7 +109,8 @@ public:
     rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift = 0.0);
 
   void publishInitialPose(
-    rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift = 0.0);
+    rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift = 0.0,
+    std::string module_name = "");
 
   void publishMaxVelocity(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishPointCloud(rclcpp::Node::SharedPtr target_node, std::string topic_name);
@@ -154,7 +155,8 @@ public:
   void testWithNominalRoute(rclcpp::Node::SharedPtr target_node);
   void testWithAbnormalRoute(rclcpp::Node::SharedPtr target_node);
 
-  void testWithBehaviorNominalRoute(rclcpp::Node::SharedPtr target_node);
+  void testWithBehaviorNominalRoute(
+    rclcpp::Node::SharedPtr target_node, std::string module_name = "");
 
   void testWithNominalPathWithLaneId(rclcpp::Node::SharedPtr target_node);
   void testWithAbnormalPathWithLaneId(rclcpp::Node::SharedPtr target_node);
@@ -252,7 +254,8 @@ private:
   void publishAbnormalRoute(
     rclcpp::Node::SharedPtr target_node, const LaneletRoute & abnormal_route);
 
-  void publishBehaviorNominalRoute(rclcpp::Node::SharedPtr target_node, std::string topic_name);
+  void publishBehaviorNominalRoute(
+    rclcpp::Node::SharedPtr target_node, std::string topic_name, std::string module_name = "");
   void publishNominalPathWithLaneId(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishAbNominalPathWithLaneId(rclcpp::Node::SharedPtr target_node, std::string topic_name);
 

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 The Autoware Foundation
+// Copyright 2023 Tier IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include <lanelet2_extension/projection/mgrs_projector.hpp>
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
+#include <route_handler/route_handler.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
@@ -64,6 +65,7 @@ using autoware_auto_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::LaneletPrimitive;
 using autoware_planning_msgs::msg::LaneletRoute;
 using autoware_planning_msgs::msg::LaneletSegment;
+using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
@@ -71,6 +73,7 @@ using geometry_msgs::msg::TransformStamped;
 using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
 using planning_interface::Route;
+using route_handler::RouteHandler;
 using sensor_msgs::msg::PointCloud2;
 using tf2_msgs::msg::TFMessage;
 using tier4_autoware_utils::createPoint;
@@ -174,30 +177,6 @@ Route::Message makeNormalRoute()
   return route;
 }
 
-// this is for the test lanelet2_map.osm
-// file hash: a9f84cff03b55a64917bc066451276d2293b0a54f5c088febca0c7fdf2f245d5
-Route::Message makeBehaviorNormalRoute()
-{
-  Route::Message route;
-  route.header.frame_id = "map";
-  route.start_pose =
-    createPose({3722.16015625, 73723.515625, 0.233112560494183, 0.9724497591854532});
-  route.goal_pose =
-    createPose({3778.362060546875, 73721.2734375, -0.5107480274693206, 0.8597304533609347});
-
-  std::vector<int> primitive_ids = {9102, 9178, 54, 112};
-  for (int id : primitive_ids) {
-    route.segments.push_back(createLaneletSegment(id));
-  }
-
-  std::array<uint8_t, 16> uuid_bytes{210, 87,  16,  126, 98,  151, 58, 28,
-                                     252, 221, 230, 92,  122, 170, 46, 6};
-  route.uuid.uuid = uuid_bytes;
-
-  route.allow_modification = false;
-  return route;
-}
-
 OccupancyGrid makeCostMapMsg(size_t width = 150, size_t height = 150, double resolution = 0.2)
 {
   nav_msgs::msg::OccupancyGrid costmap_msg;
@@ -288,6 +267,127 @@ Scenario makeScenarioMsg(const std::string scenario)
   scenario_msg.current_scenario = scenario;
   scenario_msg.activating_scenarios = {scenario};
   return scenario_msg;
+}
+
+Pose createPoseFromLaneID(const int & lane_id)
+{
+  auto map_bin_msg = makeMapBinMsg();
+  // create route_handler
+  auto route_handler = std::make_shared<RouteHandler>();
+  route_handler->setMap(map_bin_msg);
+
+  // get middle idx of the lanelet
+  const auto lanelet = route_handler->getLaneletsFromId(lane_id);
+  const auto center_line = lanelet.centerline();
+  const size_t middle_point_idx = std::floor(center_line.size() / 2.0);
+
+  // get middle position of the lanelet
+  geometry_msgs::msg::Point middle_pos;
+  middle_pos.x = center_line[middle_point_idx].x();
+  middle_pos.y = center_line[middle_point_idx].y();
+
+  // get next middle position of the lanelet
+  geometry_msgs::msg::Point next_middle_pos;
+  next_middle_pos.x = center_line[middle_point_idx + 1].x();
+  next_middle_pos.y = center_line[middle_point_idx + 1].y();
+
+  // calculate middle pose
+  geometry_msgs::msg::Pose middle_pose;
+  middle_pose.position = middle_pos;
+  const double yaw = tier4_autoware_utils::calcAzimuthAngle(middle_pos, next_middle_pos);
+  middle_pose.orientation = tier4_autoware_utils::createQuaternionFromYaw(yaw);
+
+  return middle_pose;
+}
+
+Odometry makeInitialPoseFromLaneId(const int & lane_id)
+{
+  Odometry current_odometry;
+  current_odometry.pose.pose = createPoseFromLaneID(lane_id);
+  current_odometry.header.frame_id = "map";
+
+  return current_odometry;
+}
+
+RouteSections combine_consecutive_route_sections(
+  const RouteSections & route_sections1, const RouteSections & route_sections2)
+{
+  RouteSections route_sections;
+  route_sections.reserve(route_sections1.size() + route_sections2.size());
+  if (!route_sections1.empty()) {
+    // remove end route section because it is overlapping with first one in next route_section
+    route_sections.insert(route_sections.end(), route_sections1.begin(), route_sections1.end() - 1);
+  }
+  if (!route_sections2.empty()) {
+    route_sections.insert(route_sections.end(), route_sections2.begin(), route_sections2.end());
+  }
+  return route_sections;
+}
+
+Route::Message makeBehaviorRouteFromLaneId(const int & start_lane_id, const int & goal_lane_id)
+{
+  Route::Message route;
+  route.header.frame_id = "map";
+  auto start_pose = createPoseFromLaneID(start_lane_id);
+  auto goal_pose = createPoseFromLaneID(goal_lane_id);
+  route.start_pose = start_pose;
+  route.goal_pose = goal_pose;
+
+  auto map_bin_msg = makeMapBinMsg();
+  // create route_handler
+  auto route_handler = std::make_shared<RouteHandler>();
+  route_handler->setMap(map_bin_msg);
+
+  LaneletRoute route_msg;
+  RouteSections route_sections;
+  lanelet::ConstLanelets all_route_lanelets;
+
+  lanelet::ConstLanelets path_lanelets;
+  if (!route_handler->planPathLaneletsBetweenCheckpoints(start_pose, goal_pose, &path_lanelets)) {
+    return route_msg;
+  }
+  for (const auto & lane : path_lanelets) {
+    all_route_lanelets.push_back(lane);
+  }
+  // create local route sections
+  route_handler->setRouteLanelets(path_lanelets);
+  const auto local_route_sections = route_handler->createMapSegments(path_lanelets);
+  route_sections = combine_consecutive_route_sections(route_sections, local_route_sections);
+  for (const auto & route_section : route_sections) {
+    for (const auto & primitive : route_section.primitives) {
+      std::cerr << "primitive: " << primitive.id << std::endl;
+    }
+    std::cerr << "preferred_primitive id : " << route_section.preferred_primitive.id << std::endl;
+  }
+  route_handler->setRouteLanelets(all_route_lanelets);
+  route.segments = route_sections;
+
+  route.allow_modification = false;
+  return route;
+}
+
+// this is for the test lanelet2_map.osm
+// file hash: a9f84cff03b55a64917bc066451276d2293b0a54f5c088febca0c7fdf2f245d5
+Route::Message makeBehaviorNormalRoute()
+{
+  Route::Message route;
+  route.header.frame_id = "map";
+  route.start_pose =
+    createPose({3722.16015625, 73723.515625, 0.233112560494183, 0.9724497591854532});
+  route.goal_pose =
+    createPose({3778.362060546875, 73721.2734375, -0.5107480274693206, 0.8597304533609347});
+
+  std::vector<int> primitive_ids = {9102, 9178, 54, 112};
+  for (int id : primitive_ids) {
+    route.segments.push_back(createLaneletSegment(id));
+  }
+
+  std::array<uint8_t, 16> uuid_bytes{210, 87,  16,  126, 98,  151, 58, 28,
+                                     252, 221, 230, 92,  122, 170, 46, 6};
+  route.uuid.uuid = uuid_bytes;
+
+  route.allow_modification = false;
+  return route;
 }
 
 template <typename T>

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
@@ -324,6 +324,8 @@ RouteSections combineConsecutiveRouteSections(
   return route_sections;
 }
 
+// Function to create a route from given start and goal lanelet ids
+// start pose and goal pose are set to the middle of the lanelet
 Route::Message makeBehaviorRouteFromLaneId(const int & start_lane_id, const int & goal_lane_id)
 {
   Route::Message route;
@@ -342,10 +344,13 @@ Route::Message makeBehaviorRouteFromLaneId(const int & start_lane_id, const int 
   RouteSections route_sections;
   lanelet::ConstLanelets all_route_lanelets;
 
+  // Plan the path between checkpoints (start and goal poses)
   lanelet::ConstLanelets path_lanelets;
   if (!route_handler->planPathLaneletsBetweenCheckpoints(start_pose, goal_pose, &path_lanelets)) {
     return route_msg;
   }
+
+  // Add all path_lanelets to all_route_lanelets
   for (const auto & lane : path_lanelets) {
     all_route_lanelets.push_back(lane);
   }

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
@@ -309,7 +309,7 @@ Odometry makeInitialPoseFromLaneId(const int & lane_id)
   return current_odometry;
 }
 
-RouteSections combine_consecutive_route_sections(
+RouteSections combineConsecutiveRouteSections(
   const RouteSections & route_sections1, const RouteSections & route_sections2)
 {
   RouteSections route_sections;
@@ -352,7 +352,7 @@ Route::Message makeBehaviorRouteFromLaneId(const int & start_lane_id, const int 
   // create local route sections
   route_handler->setRouteLanelets(path_lanelets);
   const auto local_route_sections = route_handler->createMapSegments(path_lanelets);
-  route_sections = combine_consecutive_route_sections(route_sections, local_route_sections);
+  route_sections = combineConsecutiveRouteSections(route_sections, local_route_sections);
   for (const auto & route_section : route_sections) {
     for (const auto & primitive : route_section.primitives) {
       std::cerr << "primitive: " << primitive.id << std::endl;

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
@@ -72,7 +72,6 @@ using geometry_msgs::msg::PoseStamped;
 using geometry_msgs::msg::TransformStamped;
 using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
-using planning_interface::Route;
 using route_handler::RouteHandler;
 using sensor_msgs::msg::PointCloud2;
 using tf2_msgs::msg::TFMessage;
@@ -166,11 +165,11 @@ HADMapBin convertToMapBinMsg(
   return map_bin_msg;
 }
 
-Route::Message makeNormalRoute()
+LaneletRoute makeNormalRoute()
 {
   const std::array<double, 4> start_pose{5.5, 4., 0., M_PI_2};
   const std::array<double, 4> goal_pose{8.0, 26.3, 0, 0};
-  Route::Message route;
+  LaneletRoute route;
   route.header.frame_id = "map";
   route.start_pose = createPose(start_pose);
   route.goal_pose = createPose(goal_pose);
@@ -326,9 +325,9 @@ RouteSections combineConsecutiveRouteSections(
 
 // Function to create a route from given start and goal lanelet ids
 // start pose and goal pose are set to the middle of the lanelet
-Route::Message makeBehaviorRouteFromLaneId(const int & start_lane_id, const int & goal_lane_id)
+LaneletRoute makeBehaviorRouteFromLaneId(const int & start_lane_id, const int & goal_lane_id)
 {
-  Route::Message route;
+  LaneletRoute route;
   route.header.frame_id = "map";
   auto start_pose = createPoseFromLaneID(start_lane_id);
   auto goal_pose = createPoseFromLaneID(goal_lane_id);
@@ -373,9 +372,9 @@ Route::Message makeBehaviorRouteFromLaneId(const int & start_lane_id, const int 
 
 // this is for the test lanelet2_map.osm
 // file hash: a9f84cff03b55a64917bc066451276d2293b0a54f5c088febca0c7fdf2f245d5
-Route::Message makeBehaviorNormalRoute()
+LaneletRoute makeBehaviorNormalRoute()
 {
-  Route::Message route;
+  LaneletRoute route;
   route.header.frame_id = "map";
   route.start_pose =
     createPose({3722.16015625, 73723.515625, 0.233112560494183, 0.9724497591854532});

--- a/planning/planning_test_utils/package.xml
+++ b/planning/planning_test_utils/package.xml
@@ -25,6 +25,7 @@
   <depend>lanelet2_io</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>route_handler</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_api_msgs</depend>

--- a/planning/planning_test_utils/src/planning_interface_test_manager.cpp
+++ b/planning/planning_test_utils/src/planning_interface_test_manager.cpp
@@ -108,9 +108,9 @@ void PlanningInterfaceTestManager::publishParkingScenario(
 
 void PlanningInterfaceTestManager::publishInitialPose(
   rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift,
-  std::string module_name)
+  ModuleName module_name)
 {
-  if (module_name == "PullOut") {
+  if (module_name == ModuleName::PULL_OUT) {
     test_utils::publishToTargetNode(
       test_node_, target_node, topic_name, initial_pose_pub_,
       test_utils::makeInitialPoseFromLaneId(10291));
@@ -249,9 +249,9 @@ void PlanningInterfaceTestManager::publishNominalRoute(
 }
 
 void PlanningInterfaceTestManager::publishBehaviorNominalRoute(
-  rclcpp::Node::SharedPtr target_node, std::string topic_name, std::string module_name)
+  rclcpp::Node::SharedPtr target_node, std::string topic_name, ModuleName module_name)
 {
-  if (module_name == "PullOut") {
+  if (module_name == ModuleName::PULL_OUT) {
     test_utils::publishToTargetNode(
       test_node_, target_node, topic_name, behavior_normal_route_pub_,
       test_utils::makeBehaviorRouteFromLaneId(10291, 10333), 5);
@@ -346,7 +346,7 @@ void PlanningInterfaceTestManager::testWithNominalRoute(rclcpp::Node::SharedPtr 
 
 // test for normal working
 void PlanningInterfaceTestManager::testWithBehaviorNominalRoute(
-  rclcpp::Node::SharedPtr target_node, std::string module_name)
+  rclcpp::Node::SharedPtr target_node, ModuleName module_name)
 {
   publishBehaviorNominalRoute(target_node, input_route_name_, module_name);
 }

--- a/planning/planning_test_utils/src/planning_interface_test_manager.cpp
+++ b/planning/planning_test_utils/src/planning_interface_test_manager.cpp
@@ -107,10 +107,17 @@ void PlanningInterfaceTestManager::publishParkingScenario(
 }
 
 void PlanningInterfaceTestManager::publishInitialPose(
-  rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift)
+  rclcpp::Node::SharedPtr target_node, std::string topic_name, const double shift,
+  std::string module_name)
 {
-  test_utils::publishToTargetNode(
-    test_node_, target_node, topic_name, initial_pose_pub_, test_utils::makeInitialPose(shift));
+  if (module_name == "PullOut") {
+    test_utils::publishToTargetNode(
+      test_node_, target_node, topic_name, initial_pose_pub_,
+      test_utils::makeInitialPoseFromLaneId(10291));
+  } else {
+    test_utils::publishToTargetNode(
+      test_node_, target_node, topic_name, initial_pose_pub_, test_utils::makeInitialPose(shift));
+  }
 }
 
 void PlanningInterfaceTestManager::publishParkingState(
@@ -242,11 +249,17 @@ void PlanningInterfaceTestManager::publishNominalRoute(
 }
 
 void PlanningInterfaceTestManager::publishBehaviorNominalRoute(
-  rclcpp::Node::SharedPtr target_node, std::string topic_name)
+  rclcpp::Node::SharedPtr target_node, std::string topic_name, std::string module_name)
 {
-  test_utils::publishToTargetNode(
-    test_node_, target_node, topic_name, behavior_normal_route_pub_,
-    test_utils::makeBehaviorNormalRoute(), 5);
+  if (module_name == "PullOut") {
+    test_utils::publishToTargetNode(
+      test_node_, target_node, topic_name, behavior_normal_route_pub_,
+      test_utils::makeBehaviorRouteFromLaneId(10291, 10333), 5);
+  } else {
+    test_utils::publishToTargetNode(
+      test_node_, target_node, topic_name, behavior_normal_route_pub_,
+      test_utils::makeBehaviorNormalRoute(), 5);
+  }
 }
 
 void PlanningInterfaceTestManager::publishAbnormalRoute(
@@ -332,9 +345,10 @@ void PlanningInterfaceTestManager::testWithNominalRoute(rclcpp::Node::SharedPtr 
 }
 
 // test for normal working
-void PlanningInterfaceTestManager::testWithBehaviorNominalRoute(rclcpp::Node::SharedPtr target_node)
+void PlanningInterfaceTestManager::testWithBehaviorNominalRoute(
+  rclcpp::Node::SharedPtr target_node, std::string module_name)
 {
-  publishBehaviorNominalRoute(target_node, input_route_name_);
+  publishBehaviorNominalRoute(target_node, input_route_name_, module_name);
 }
 
 // check to see if target node is dead.

--- a/planning/planning_test_utils/test_map/lanelet2_map.osm
+++ b/planning/planning_test_utils/test_map/lanelet2_map.osm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm generator="VMB">
-  <MetaInfo format_version="1" map_version="45"/>
+  <MetaInfo format_version="1" map_version="49"/>
   <node id="285" lat="35.90327302735748" lon="139.93366161080428">
     <tag k="mgrs_code" v="54SVE037737"/>
     <tag k="local_x" v="3774.4814"/>
@@ -298,10 +298,10 @@
     <tag k="local_y" v="73725.9509"/>
     <tag k="ele" v="19.326"/>
   </node>
-  <node id="1717" lat="35.903035750319326" lon="139.93296722229033">
+  <node id="1717" lat="35.90303577003312" lon="139.93296720872823">
     <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3711.5306"/>
-    <tag k="local_y" v="73719.604"/>
+    <tag k="local_x" v="3711.5294"/>
+    <tag k="local_y" v="73719.6062"/>
     <tag k="ele" v="19.298"/>
   </node>
   <node id="1718" lat="35.90304351918274" lon="139.93298478811423">
@@ -310,10 +310,10 @@
     <tag k="local_y" v="73720.4484"/>
     <tag k="ele" v="19.283"/>
   </node>
-  <node id="1719" lat="35.903090527622695" lon="139.93309266666856">
+  <node id="1719" lat="35.903090448737906" lon="139.93309271759293">
     <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3722.9174"/>
-    <tag k="local_y" v="73725.5562"/>
+    <tag k="local_x" v="3722.9219"/>
+    <tag k="local_y" v="73725.5474"/>
     <tag k="ele" v="19.297"/>
   </node>
   <node id="1720" lat="35.903117916472254" lon="139.93315541662315">
@@ -346,53 +346,53 @@
     <tag k="local_y" v="73733.8477"/>
     <tag k="ele" v="19.313"/>
   </node>
-  <node id="1726" lat="35.903420666268175" lon="139.93398880603775">
+  <node id="1726" lat="35.90340566209689" lon="139.93395484148746">
     <tag k="mgrs_code" v="54SVE038737"/>
-    <tag k="local_x" v="3804.187"/>
-    <tag k="local_y" v="73761.292"/>
-    <tag k="ele" v="19.364"/>
+    <tag k="local_x" v="3801.1038"/>
+    <tag k="local_y" v="73759.6612"/>
+    <tag k="ele" v="19.435"/>
   </node>
-  <node id="1727" lat="35.90339025006459" lon="139.93391911163323">
+  <node id="1727" lat="35.90338424520524" lon="139.93390575613373">
     <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3797.8608"/>
-    <tag k="local_y" v="73757.9869"/>
-    <tag k="ele" v="19.383"/>
+    <tag k="local_x" v="3796.6483"/>
+    <tag k="local_y" v="73757.334"/>
+    <tag k="ele" v="19.441"/>
   </node>
-  <node id="1728" lat="35.903359805210954" lon="139.93384944426168">
+  <node id="1728" lat="35.90336302355955" lon="139.9338570349776">
     <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3791.537"/>
-    <tag k="local_y" v="73754.6786"/>
-    <tag k="ele" v="19.354"/>
+    <tag k="local_x" v="3792.2259"/>
+    <tag k="local_y" v="73755.0281"/>
+    <tag k="ele" v="19.421"/>
   </node>
-  <node id="1729" lat="35.903356833160885" lon="139.93384258382252">
+  <node id="1729" lat="35.90334158003398" lon="139.9338078990602">
     <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3790.9143"/>
-    <tag k="local_y" v="73754.3557"/>
-    <tag k="ele" v="19.35"/>
+    <tag k="local_x" v="3787.7658"/>
+    <tag k="local_y" v="73752.698"/>
+    <tag k="ele" v="19.398"/>
   </node>
-  <node id="1730" lat="35.90350588900912" lon="139.93418391708528">
+  <node id="1730" lat="35.903488690798085" lon="139.93414531444566">
     <tag k="mgrs_code" v="54SVE038737"/>
-    <tag k="local_x" v="3821.8974"/>
-    <tag k="local_y" v="73770.5527"/>
-    <tag k="ele" v="19.326"/>
-  </node>
-  <node id="1731" lat="35.90347847184114" lon="139.93412116684632">
-    <tag k="mgrs_code" v="54SVE038737"/>
-    <tag k="local_x" v="3816.2015"/>
-    <tag k="local_y" v="73767.5734"/>
-    <tag k="ele" v="19.349"/>
-  </node>
-  <node id="1732" lat="35.9034510555424" lon="139.9340584166392">
-    <tag k="mgrs_code" v="54SVE038737"/>
-    <tag k="local_x" v="3810.5056"/>
-    <tag k="local_y" v="73764.5942"/>
+    <tag k="local_x" v="3818.393"/>
+    <tag k="local_y" v="73768.6831"/>
     <tag k="ele" v="19.351"/>
   </node>
-  <node id="1733" lat="35.903423666910605" lon="139.93399563840126">
+  <node id="1731" lat="35.90346933015638" lon="139.93410086884995">
     <tag k="mgrs_code" v="54SVE038737"/>
-    <tag k="local_x" v="3804.8072"/>
-    <tag k="local_y" v="73761.6181"/>
-    <tag k="ele" v="19.359"/>
+    <tag k="local_x" v="3814.3587"/>
+    <tag k="local_y" v="73766.5794"/>
+    <tag k="ele" v="19.375"/>
+  </node>
+  <node id="1732" lat="35.90344824663266" lon="139.93405256571728">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3809.9742"/>
+    <tag k="local_y" v="73764.2884"/>
+    <tag k="ele" v="19.408"/>
+  </node>
+  <node id="1733" lat="35.9034268540604" lon="139.9340034733358">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3805.5181"/>
+    <tag k="local_y" v="73761.9639"/>
+    <tag k="ele" v="19.414"/>
   </node>
   <node id="1735" lat="35.90347094455968" lon="139.93396475019426">
     <tag k="mgrs_code" v="54SVE038737"/>
@@ -442,11 +442,11 @@
     <tag k="local_y" v="73766.5695"/>
     <tag k="ele" v="19.36"/>
   </node>
-  <node id="1780" lat="35.903508444417575" lon="139.93418975036099">
+  <node id="1780" lat="35.90350808554113" lon="139.93418974409207">
     <tag k="mgrs_code" v="54SVE038737"/>
-    <tag k="local_x" v="3822.4269"/>
-    <tag k="local_y" v="73770.8304"/>
-    <tag k="ele" v="19.323"/>
+    <tag k="local_x" v="3822.4259"/>
+    <tag k="local_y" v="73770.7906"/>
+    <tag k="ele" v="19.383"/>
   </node>
   <node id="1786" lat="35.90298505515497" lon="139.93298969406558">
     <tag k="mgrs_code" v="54SVE037737"/>
@@ -514,23 +514,23 @@
     <tag k="local_y" v="73742.0426"/>
     <tag k="ele" v="19.278"/>
   </node>
-  <node id="1888" lat="35.90333163887532" lon="139.933784889193">
+  <node id="1888" lat="35.903320549101885" lon="139.93375964302746">
     <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3785.6773"/>
-    <tag k="local_y" v="73751.618"/>
-    <tag k="ele" v="19.334"/>
+    <tag k="local_x" v="3783.3856"/>
+    <tag k="local_y" v="73750.4128"/>
+    <tag k="ele" v="19.378"/>
   </node>
-  <node id="1889" lat="35.903306416617546" lon="139.93372719497546">
+  <node id="1889" lat="35.90330127234957" lon="139.93371542144462">
     <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3780.4403"/>
-    <tag k="local_y" v="73748.8772"/>
-    <tag k="ele" v="19.31"/>
+    <tag k="local_x" v="3779.3716"/>
+    <tag k="local_y" v="73748.3182"/>
+    <tag k="ele" v="19.36"/>
   </node>
-  <node id="1890" lat="35.90328208315763" lon="139.93367141700938">
+  <node id="1890" lat="35.90328199467983" lon="139.93367119989563">
     <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3775.3773"/>
-    <tag k="local_y" v="73746.2331"/>
-    <tag k="ele" v="19.296"/>
+    <tag k="local_x" v="3775.3576"/>
+    <tag k="local_y" v="73746.2235"/>
+    <tag k="ele" v="19.338"/>
   </node>
   <node id="1891" lat="35.90316830586952" lon="139.93358030536598">
     <tag k="mgrs_code" v="54SVE037737"/>
@@ -921,12 +921,6 @@
     <tag k="local_x" v="3753.07"/>
     <tag k="local_y" v="73766.9282"/>
     <tag k="ele" v="19.222"/>
-  </node>
-  <node id="2458" lat="35.90355455549028" lon="139.9341588612564">
-    <tag k="mgrs_code" v="54SVE038737"/>
-    <tag k="local_x" v="3819.6952"/>
-    <tag k="local_y" v="73775.9754"/>
-    <tag k="ele" v="19.308"/>
   </node>
   <node id="2464" lat="35.90298750026038" lon="139.93299183315978">
     <tag k="mgrs_code" v="54SVE037737"/>
@@ -4235,30 +4229,6 @@
     <tag k="local_y" v="73710.9551"/>
     <tag k="ele" v="24.685"/>
   </node>
-  <node id="9469" lat="35.903038950697436" lon="139.93311046950768">
-    <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3724.4615"/>
-    <tag k="local_y" v="73719.8178"/>
-    <tag k="ele" v="19.2866"/>
-  </node>
-  <node id="9483" lat="35.90306229902791" lon="139.93309633560054">
-    <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3723.2143"/>
-    <tag k="local_y" v="73722.4215"/>
-    <tag k="ele" v="19.3463"/>
-  </node>
-  <node id="9499" lat="35.90320563954146" lon="139.93335284612755">
-    <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3746.5361"/>
-    <tag k="local_y" v="73738.0679"/>
-    <tag k="ele" v="19.3086"/>
-  </node>
-  <node id="9511" lat="35.903189074641915" lon="139.93331472621512">
-    <tag k="mgrs_code" v="54SVE037737"/>
-    <tag k="local_x" v="3743.076"/>
-    <tag k="local_y" v="73736.2681"/>
-    <tag k="ele" v="19.2831"/>
-  </node>
   <node id="9535" lat="35.903098242397945" lon="139.93311064103221">
     <tag k="mgrs_code" v="54SVE037737"/>
     <tag k="local_x" v="3724.5488"/>
@@ -4468,6 +4438,138 @@
     <tag k="local_x" v="3763.2341"/>
     <tag k="local_y" v="73740.7876"/>
     <tag k="ele" v="20.4593"/>
+  </node>
+  <node id="10277" lat="35.90306090793571" lon="139.93294282721627">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3709.3596"/>
+    <tag k="local_y" v="73722.4185"/>
+    <tag k="ele" v="19.298"/>
+  </node>
+  <node id="10284" lat="35.90306351183022" lon="139.93294873290418">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3709.8957"/>
+    <tag k="local_y" v="73722.7015"/>
+    <tag k="ele" v="19.298"/>
+  </node>
+  <node id="10286" lat="35.90307134657019" lon="139.93296650839122">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3711.5093"/>
+    <tag k="local_y" v="73723.553"/>
+    <tag k="ele" v="19.283"/>
+  </node>
+  <node id="10288" lat="35.90311827614205" lon="139.9330744378961">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3721.306"/>
+    <tag k="local_y" v="73728.652"/>
+    <tag k="ele" v="19.297"/>
+  </node>
+  <node id="10290" lat="35.9031260044727" lon="139.93309221261998">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3722.9194"/>
+    <tag k="local_y" v="73729.4917"/>
+    <tag k="ele" v="19.2833"/>
+  </node>
+  <node id="10292" lat="35.90314568683441" lon="139.93313700694864">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3726.9856"/>
+    <tag k="local_y" v="73731.6307"/>
+    <tag k="ele" v="19.308"/>
+  </node>
+  <node id="10294" lat="35.903148695474435" lon="139.93314392225795">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3727.6133"/>
+    <tag k="local_y" v="73731.9576"/>
+    <tag k="ele" v="19.306"/>
+  </node>
+  <node id="10295" lat="35.9031701566804" lon="139.93319308977314">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3732.0763"/>
+    <tag k="local_y" v="73734.2896"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="10296" lat="35.90318183974552" lon="139.93321975067957">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3734.4964"/>
+    <tag k="local_y" v="73735.5592"/>
+    <tag k="ele" v="19.3088"/>
+  </node>
+  <node id="10297" lat="35.90319165168298" lon="139.93324230894328">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3736.544"/>
+    <tag k="local_y" v="73736.6253"/>
+    <tag k="ele" v="19.317"/>
+  </node>
+  <node id="10299" lat="35.90319463607214" lon="139.93324913371987">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3737.1635"/>
+    <tag k="local_y" v="73736.9496"/>
+    <tag k="ele" v="19.313"/>
+  </node>
+  <node id="10300" lat="35.90322017132386" lon="139.93330763132505">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3742.4734"/>
+    <tag k="local_y" v="73739.7243"/>
+    <tag k="ele" v="19.3"/>
+  </node>
+  <node id="10301" lat="35.90325278001473" lon="139.93338305928077">
+    <tag k="mgrs_code" v="54SVE037737"/>
+    <tag k="local_x" v="3749.3197"/>
+    <tag k="local_y" v="73743.2669"/>
+    <tag k="ele" v="19.2908"/>
+  </node>
+  <node id="10311" lat="35.903553138238784" lon="139.93422224200194">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3825.4131"/>
+    <tag k="local_y" v="73775.7558"/>
+    <tag k="ele" v="19.3582"/>
+  </node>
+  <node id="10313" lat="35.90357687188703" lon="139.9342063046628">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3824.0036"/>
+    <tag k="local_y" v="73778.404"/>
+    <tag k="ele" v="19.3582"/>
+  </node>
+  <node id="10321" lat="35.903529351231974" lon="139.93423805926076">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3826.8117"/>
+    <tag k="local_y" v="73773.1018"/>
+    <tag k="ele" v="19.3582"/>
+  </node>
+  <node id="10324" lat="35.90356481029795" lon="139.93424850108602">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3827.7969"/>
+    <tag k="local_y" v="73777.0246"/>
+    <tag k="ele" v="19.3691"/>
+  </node>
+  <node id="10326" lat="35.90357453395563" lon="139.93427037816235">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3829.7829"/>
+    <tag k="local_y" v="73778.0816"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="10327" lat="35.9035820543687" lon="139.93428729709274">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3831.3188"/>
+    <tag k="local_y" v="73778.8991"/>
+    <tag k="ele" v="19.2578"/>
+  </node>
+  <node id="10329" lat="35.90358854305812" lon="139.9342325648723">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3826.3875"/>
+    <tag k="local_y" v="73779.6727"/>
+    <tag k="ele" v="19.3691"/>
+  </node>
+  <node id="10331" lat="35.903598258645" lon="139.93425444649384">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3828.3739"/>
+    <tag k="local_y" v="73780.7288"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="10332" lat="35.90360578174504" lon="139.9342713631754">
+    <tag k="mgrs_code" v="54SVE038737"/>
+    <tag k="local_x" v="3829.9096"/>
+    <tag k="local_y" v="73781.5466"/>
+    <tag k="ele" v="19.2578"/>
   </node>
   <way id="35">
     <nd ref="2007"/>
@@ -5087,11 +5189,6 @@
     <nd ref="425"/>
     <nd ref="285"/>
     <tag k="type" v="pedestrian_marking"/>
-  </way>
-  <way id="354">
-    <nd ref="2458"/>
-    <nd ref="2201"/>
-    <tag k="type" v="stop_line"/>
   </way>
   <way id="367">
     <nd ref="1890"/>
@@ -5901,18 +5998,6 @@
     <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
   </way>
-  <way id="9522">
-    <nd ref="9483"/>
-    <nd ref="9469"/>
-    <tag k="type" v="stop_line"/>
-    <tag k="subtype" v="solid"/>
-  </way>
-  <way id="9524">
-    <nd ref="9511"/>
-    <nd ref="9499"/>
-    <tag k="type" v="stop_line"/>
-    <tag k="subtype" v="solid"/>
-  </way>
   <way id="9536">
     <nd ref="1718"/>
     <nd ref="1719"/>
@@ -6028,6 +6113,78 @@
     <nd ref="10267"/>
     <nd ref="10268"/>
     <tag k="type" v="stop_line"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10285">
+    <nd ref="10277"/>
+    <nd ref="10284"/>
+    <nd ref="10286"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10289">
+    <nd ref="10286"/>
+    <nd ref="10288"/>
+    <nd ref="10290"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10293">
+    <nd ref="10290"/>
+    <nd ref="10292"/>
+    <nd ref="10294"/>
+    <nd ref="10295"/>
+    <nd ref="10296"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10298">
+    <nd ref="10296"/>
+    <nd ref="10297"/>
+    <nd ref="10299"/>
+    <nd ref="10300"/>
+    <nd ref="10301"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10309">
+    <nd ref="10301"/>
+    <nd ref="1886"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10312">
+    <nd ref="2201"/>
+    <nd ref="10311"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10314">
+    <nd ref="1739"/>
+    <nd ref="10313"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10322">
+    <nd ref="1780"/>
+    <nd ref="10321"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10325">
+    <nd ref="10311"/>
+    <nd ref="10324"/>
+    <nd ref="10326"/>
+    <nd ref="10327"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="10330">
+    <nd ref="10313"/>
+    <nd ref="10329"/>
+    <nd ref="10331"/>
+    <nd ref="10332"/>
+    <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
   </way>
   <way id="10265">
@@ -6448,6 +6605,78 @@
   <relation id="10257">
     <member type="way" role="left" ref="10254"/>
     <member type="way" role="right" ref="10256"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10287">
+    <member type="way" role="left" ref="10285"/>
+    <member type="way" role="right" ref="9098"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10291">
+    <member type="way" role="left" ref="10289"/>
+    <member type="way" role="right" ref="9536"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10303">
+    <member type="way" role="left" ref="10293"/>
+    <member type="way" role="right" ref="9542"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10304">
+    <member type="way" role="left" ref="10298"/>
+    <member type="way" role="right" ref="9543"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road_shoulder"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10310">
+    <member type="way" role="left" ref="10309"/>
+    <member type="way" role="right" ref="9175"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10316">
+    <member type="way" role="left" ref="10314"/>
+    <member type="way" role="right" ref="10312"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10323">
+    <member type="way" role="left" ref="10322"/>
+    <member type="way" role="right" ref="10312"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="10333">
+    <member type="way" role="left" ref="10330"/>
+    <member type="way" role="right" ref="10325"/>
     <tag k="type" v="lanelet"/>
     <tag k="subtype" v="road"/>
     <tag k="speed_limit" v="10"/>


### PR DESCRIPTION
## Description

Related with https://github.com/autowarefoundation/autoware.universe/issues/3723

create odometry from lane_id and make route from start pose and goal pose which derived from lane_id.
In this PR, route for pull put is implemented.
And shoulder lane is added for the map.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
