### PR TITLE
feat(behavior_path_planner): add getter function to confirm which module is waitinng approval

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -100,6 +100,9 @@ class BehaviorPathPlannerNode : public rclcpp::Node
 public:
   explicit BehaviorPathPlannerNode(const rclcpp::NodeOptions & node_options);
 
+  // Getter method for waiting approval modules
+  std::vector<std::string> getWaitingApprovalModules();
+
 private:
   rclcpp::Subscription<LaneletRoute>::SharedPtr route_subscriber_;
   rclcpp::Subscription<HADMapBin>::SharedPtr vector_map_subscriber_;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -330,6 +330,26 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
   }
 }
 
+std::vector<std::string> BehaviorPathPlannerNode::getWaitingApprovalModules()
+{
+#ifdef USE_OLD_ARCHITECTURE
+  auto registered_modules_ptr = bt_manager_->getSceneModules();
+  std::vector<std::string> waiting_approval_modules;
+  for (const auto & module : registered_modules_ptr) {
+    if (module->isWaitingApproval() == true) {
+      waiting_approval_modules.push_back(module->name());
+#else
+  auto all_scene_module_ptr = planner_manager_->getSceneModuleStatus();
+  std::vector<std::string> waiting_approval_modules;
+  for (const auto & module : all_scene_module_ptr) {
+    if (module->is_waiting_approval == true) {
+      waiting_approval_modules.push_back(module->module_name);
+#endif
+    }
+  }
+  return waiting_approval_modules;
+}
+
 BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
 {
   BehaviorPathPlannerParameters p{};


### PR DESCRIPTION
## Description

In the node test, getter function will be necessary to confirm which scene module is waitinng approval.
I implemented getter function for old architecutre and new architecture.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
