### PR TITLE
fix(dummy_perception_publisher): fix runtime error

### DIFF
--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -170,7 +170,7 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
   if (publish_ground_truth_objects_) {
     ground_truth_objects_pub_ =
       this->create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects>(
-        "~output/debug/ground_truth_objects", qos);
+        "~/output/debug/ground_truth_objects", qos);
   }
 
   using std::chrono_literals::operator""ms;


### PR DESCRIPTION
## Description

fix runtime error

- https://github.com/autowarefoundation/autoware.universe/pull/3731

died `dummy_percption_publisher`

```
[ERROR] [dummy_perception_publisher_node-40]: process has died [pid 1836737, exit code -6, cmd '/home/satoshi/pilot-auto/install/dummy_perception_publisher/lib/dummy_perception_publisher/dummy_perception_publisher_node --ros-args -r __node:=dummy_perception_publisher -r __ns:=/simulation -p use_sim_time:=False -p wheel_radius:=0.383 -p wheel_width:=0.235 -p wheel_base:=2.79 -p wheel_tread:=1.64 -p front_overhang:
=1.0 -p rear_overhang:=1.1 -p left_overhang:=0.128 -p right_overhang:=0.128 -p vehicle_height:=2.5 -p max_steer_angle:=0.7 --params-file /tmp/launch_params_beil9v60 --params-file /tmp/launch_params_dprqtbiu --params-file /tmp/launch_params_9298ceju --params-file /tmp/launch_params_vpw95otd --params-file /tmp/launch_params_v0p06epd --params-file /tmp/launch_params_1ndka5ul --params-file /tmp/launch_params_13y9o8mf
 -r output/dynamic_object:=/perception/object_recognition/detection/labeled_clusters -r output/objects_pose:=debug/object_pose -r output/points_raw:=/perception/obstacle_segmentation/pointcloud -r input/object:=dummy_perception_publisher/object_info -r input/reset:=input/reset -r output/debug/ground_truth_objects:=debug/ground_truth_objects'].
```

```
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140667628806144) at ./nptl/pthread_kill.c:44                                                                                                                                                                                                                                                                                                                     
44      ./nptl/pthread_kill.c: No such file or directory.                                                                                                                                                                                                                                                                                                                                                                       
[Current thread is 1 (Thread 0x7fefbc0be000 (LWP 1836737))]                                                                                                                                                                                                                                                                                                                                                                     
(gdb) bt                                                                                                                                                                                                                                                                                                                                                                                                                        
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140667628806144) at ./nptl/pthread_kill.c:44                                                                                                                                                                                                                                                                                                                     
#1  __pthread_kill_internal (signo=6, threadid=140667628806144) at ./nptl/pthread_kill.c:78                                                                                                                                                                                                                                                                                                                                     
#2  __GI___pthread_kill (threadid=140667628806144, signo=signo@entry=6) at ./nptl/pthread_kill.c:89                                                                                                                                                                                                                                                                                                                             
#3  0x00007fefbd422476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26                                                                                                                                                                                                                                                                                                                                           
#4  0x00007fefbd4087f3 in __GI_abort () at ./stdlib/abort.c:79                                                                                                                                                                                                                                                                                                                                                                  
#5  0x00007fefbd7b1bbe in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6                                                                                                                                                                                                                                                                                                                                                       
#6  0x00007fefbd7bd24c in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6                                                                                                                                                                                                                                                                                                                                                       
#7  0x00007fefbd7bd2b7 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6                                                                                                                                                                                                                                                                                                                                         
#8  0x00007fefbd7bd518 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6                                                                                                                                                                                                                                                                                                                                              
#9  0x00007fefbe13b490 in ?? () from /opt/ros/humble/lib/librclcpp.so                                                                                                                                                                                                                                                                                                                                                           
#10 0x00007fefbe1d9977 in rclcpp::PublisherBase::PublisherBase(rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rosidl_message_type_support_t const&, rcl_publisher_options_s const&) () from /opt/ros/humble/lib/librclcpp.so                                                                                                              
#11 0x000056176883d4ac in rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> >::Publisher (this=0x561769bf4990, node_base=0x561769b74af0,                                                                                                                                                                                                                       
    topic=..., qos=..., options=...) at /opt/ros/humble/include/rclcpp/rclcpp/publisher.hpp:137                                                                                                                                                                                                                                                                                                                                 
#12 0x000056176883d76a in __gnu_cxx::new_allocator<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >::construct<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> >, rclcpp::node_interfaces::NodeBaseInterface*&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator
<char> > const&, rclcpp::QoS const&, rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&> (__p=0x561769bf4990, this=<optimized out>) at /usr/include/c++/11/ext/new_allocator.h:160                                                                                                                                                                                                                             
#13 std::allocator_traits<std::allocator<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > > >::construct<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> >, rclcpp::node_interfaces::NodeBaseInterface*&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >
 const&, rclcpp::QoS const&, rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&> (__p=0x561769bf4990, __a=...) at /usr/include/c++/11/bits/alloc_traits.h:516                                                                                                                                                                                                                                                  
#14 std::_Sp_counted_ptr_inplace<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> >, std::allocator<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<rclcpp::node_interfaces::NodeBaseInterface*&, std::__cxx11::basic_string<char
, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&, rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&> (__a=..., this=0x561769bf4980)                                                                                                                                                                                                                                                
    at /usr/include/c++/11/bits/shared_ptr_base.h:519                                                                                                                                                                                                                                                                                                                                                                           
#15 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> >, std::allocator<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >, rclcpp::node_interfaces::NodeBaseInterface*&, std::__cxx11::basic_string<char, std::char_traits
<char>, std::allocator<char> > const&, rclcpp::QoS const&, rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&> (__a=..., __p=<optimized out>, this=<optimized out>)                                                                                                                                                                                                                                            
    at /usr/include/c++/11/bits/shared_ptr_base.h:650                                                                                                                                                                                                                                                                                                                                                                           
#16 std::__shared_ptr<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> >, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >, rclcpp::node_interfaces::NodeBaseInterface*&, std::__cxx11::basic_string<char, std::char_traits<cha
r>, std::allocator<char> > const&, rclcpp::QoS const&, rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&> (__tag=..., this=<optimized out>)                                                                                                                                                                                                                                                                   
    at /usr/include/c++/11/bits/shared_ptr_base.h:1342                                                                                                                                                                                                                                                                                                                                                                          
#17 std::shared_ptr<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >::shared_ptr<std::allocator<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >, rclcpp::node_interfaces::NodeBaseInterface*&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > cons
t&, rclcpp::QoS const&, rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&> (__tag=..., this=<optimized out>) at /usr/include/c++/11/bits/shared_ptr.h:409                                                                                                                                                                                                                                                     
#18 std::allocate_shared<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> >, std::allocator<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >, rclcpp::node_interfaces::NodeBaseInterface*&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclc
pp::QoS const&, rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&> (__a=...) at /usr/include/c++/11/bits/shared_ptr.h:863                                                                     
#19 std::make_shared<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> >, rclcpp::node_interfaces::NodeBaseInterface*&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&, rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&> () at /usr/include/c++/11/bits/shared_ptr.h:879
#20 rclcpp::create_publisher_factory<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >(rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&)::{lambda(rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::c
har_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&)#1}::operator()(rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&) const (qos=..., topic_name="~output/debug/ground_truth_objects", node_base=<optimized out>, __closure=<optimized out>)
    at /opt/ros/humble/include/rclcpp/rclcpp/publisher_factory.hpp:76                                                                                                                                           
#21 std::__invoke_impl<std::shared_ptr<rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >, rclcpp::create_publisher_factory<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >(rclcpp:
:PublisherOptionsWithAllocator<std::allocator<void> > const&)::{lambda(rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&)#1}&, rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&>(std::__invoke_other, rclcpp::creat
e_publisher_factory<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >(rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&)::{lambda(rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>,
 std::allocator<char> > const&, rclcpp::QoS const&)#1}&, rclcpp::node_interfaces::NodeBaseInterface*&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&) (__f=...) at /usr/include/c++/11/bits/invoke.h:61
#22 std::__invoke_r<std::shared_ptr<rclcpp::PublisherBase>, rclcpp::create_publisher_factory<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >(rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&)::{lambda(rclcpp::node_interfaces::Nod
eBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&)#1}&, rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&>(rclcpp::create_publisher_factory<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void>, rc
lcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > >(rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&)::{lambda(rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&)#1}&, rclcpp::node_interfaces::NodeBaseInterface*&&, std::__cxx11::ba
sic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&) (__fn=...) at /usr/include/c++/11/bits/invoke.h:116                                                                 
#23 std::_Function_handler<std::shared_ptr<rclcpp::PublisherBase> (rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&), rclcpp::create_publisher_factory<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObj
ects_<std::allocator<void> >, std::allocator<void> > >(rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&)::{lambda(rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&)#1}>::_M_invoke(std::_Any_data const&, rclcpp::node_interfaces::NodeBaseInterface*&&, std::__cxx11::basic_string<char, std::char_tr
aits<char>, std::allocator<char> > const&, rclcpp::QoS const&) (__functor=..., __args#0=<optimized out>, __args#1="~output/debug/ground_truth_objects", __args#2=...)                                           
    at /usr/include/c++/11/bits/std_function.h:291                                                                                                                                                              
#24 0x00007fefbe196f4c in rclcpp::node_interfaces::NodeTopics::create_publisher(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::PublisherFactory const&, rclcpp::QoS const&) () from /opt/ros/humble/lib/librclcpp.so
#25 0x000056176882c590 in rclcpp::detail::create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> >, rclcpp::Node, rclcpp::Node> (node_parameters=..., node_topics=..., topic_name="~output/debug/ground_truth_objects", qos=..., options=...)
    at /opt/ros/humble/include/rclcpp/rclcpp/create_publisher.hpp:65                                                                                                                                            
#26 0x00005617688145a1 in rclcpp::create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<autoware_auto_perception_msgs::msg::Track--Type <RET> for more, q to quit, c to continue without paging--
edObjects_<std::allocator<void> >, std::allocator<void> >, rclcpp::Node&> (options=..., qos=..., topic_name="~output/debug/ground_truth_objects", node=...)                                                     
    at /opt/ros/humble/include/rclcpp/rclcpp/create_publisher.hpp:94                                                                                                                                            
#27 rclcpp::Node::create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects_<std::allocator<void> >, std::allocator<void> > > (options=..., qos=..., topic_name="~output/debug/ground_truth_objects", this=0x561769b62fa0) at /opt/ros/humble/include/rclcpp/rclcpp/node_impl.hpp:82
#28 DummyPerceptionPublisherNode::DummyPerceptionPublisherNode (this=this@entry=0x561769b62fa0) at /home/satoshi/pilot-auto/src/autoware/universe/simulator/dummy_perception_publisher/src/node.cpp:172         
#29 0x00005617688091a8 in __gnu_cxx::new_allocator<DummyPerceptionPublisherNode>::construct<DummyPerceptionPublisherNode> (__p=0x561769b62fa0, this=<optimized out>)                                            
    at /usr/include/c++/11/ext/new_allocator.h:160                                                                                                                                                              
#30 std::allocator_traits<std::allocator<DummyPerceptionPublisherNode> >::construct<DummyPerceptionPublisherNode> (__p=0x561769b62fa0, __a=...) at /usr/include/c++/11/bits/alloc_traits.h:516                  
#31 std::_Sp_counted_ptr_inplace<DummyPerceptionPublisherNode, std::allocator<DummyPerceptionPublisherNode>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<>(std::allocator<DummyPerceptionPublisherNode>) (__a=..., this=0x561769b62f90) at /usr/include/c++/11/bits/shared_ptr_base.h:519
#32 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<DummyPerceptionPublisherNode, std::allocator<DummyPerceptionPublisherNode>>(DummyPerceptionPublisherNode*&, std::_Sp_alloc_shared_tag<std::allocator<DummyPerceptionPublisherNode> >) (__a=..., __p=<optimized out>, this=<optimized out>) at /usr/include/c++/11/bits/shared_ptr_base.h:650
#33 std::__shared_ptr<DummyPerceptionPublisherNode, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<DummyPerceptionPublisherNode>>(std::_Sp_alloc_shared_tag<std::allocator<DummyPerceptionPublisherNode> >) (__tag=..., this=<optimized out>) at /usr/include/c++/11/bits/shared_ptr_base.h:1342
#34 std::shared_ptr<DummyPerceptionPublisherNode>::shared_ptr<std::allocator<DummyPerceptionPublisherNode>>(std::_Sp_alloc_shared_tag<std::allocator<DummyPerceptionPublisherNode> >) (__tag=...,               
    this=<optimized out>) at /usr/include/c++/11/bits/shared_ptr.h:409                                                                                                                                          
#35 std::allocate_shared<DummyPerceptionPublisherNode, std::allocator<DummyPerceptionPublisherNode>>(std::allocator<DummyPerceptionPublisherNode> const&) (__a=...)                                             
    at /usr/include/c++/11/bits/shared_ptr.h:863                                                                                                                                                                
#36 std::make_shared<DummyPerceptionPublisherNode> () at /usr/include/c++/11/bits/shared_ptr.h:879                                                                                                              
#37 main (argc=<optimized out>, argv=<optimized out>) at /home/satoshi/pilot-auto/src/autoware/universe/simulator/dummy_perception_publisher/src/main.cpp:24
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
