### PR TITLE
fix(avoidance): reset avoidance module when the driving lane update is updated

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -185,6 +185,7 @@ private:
   ShiftedPath prev_output_;
   ShiftedPath prev_linear_shift_path_;  // used for shift point check
   PathWithLaneId prev_reference_;
+  lanelet::ConstLanelets prev_driving_lanes_;
 
   // for raw_shift_line registration
   AvoidLineArray registered_raw_shift_lines_;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -80,14 +80,20 @@ void pushUniqueVector(T & base_vector, const T & additional_vector)
 bool isDrivingSameLane(
   const lanelet::ConstLanelets & previous_lanes, const lanelet::ConstLanelets & current_lanes)
 {
-  const auto compare = [](const auto & a, const auto & b) { return a.id() < b.id(); };
+  std::multiset<lanelet::Id> prev_ids{};
+  std::multiset<lanelet::Id> curr_ids{};
+  std::multiset<lanelet::Id> same_ids{};
 
-  lanelet::ConstLanelets same_id_lanes{};
+  std::for_each(
+    previous_lanes.begin(), previous_lanes.end(), [&](const auto & l) { prev_ids.insert(l.id()); });
+  std::for_each(
+    current_lanes.begin(), current_lanes.end(), [&](const auto & l) { curr_ids.insert(l.id()); });
+
   std::set_intersection(
-    previous_lanes.begin(), previous_lanes.end(), current_lanes.begin(), current_lanes.end(),
-    std::inserter(same_id_lanes, same_id_lanes.end()), compare);
+    prev_ids.begin(), prev_ids.end(), curr_ids.begin(), curr_ids.end(),
+    std::inserter(same_ids, same_ids.end()));
 
-  return !same_id_lanes.empty();
+  return !same_ids.empty();
 }
 }  // namespace
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -103,6 +103,7 @@ BehaviorModuleOutput NormalLaneChange::generateOutput()
   output.turn_signal_info = updateOutputTurnSignal();
 
   if (isAbortState()) {
+    output.reference_path = std::make_shared<PathWithLaneId>(prev_module_reference_path_);
     return output;
   }
 


### PR DESCRIPTION
## Description

Since the avoidance module always update only reference path but not update shift line, it applies shift lines to wrong reference path when the previous module output reference path is changed. Therefore, sometimes invalid path will be generated like this :arrow_down: 

https://github.com/autowarefoundation/autoware.universe/assets/44889564/7b90e461-2598-4dba-87d9-8ec045945fd6

In this PR, the avoidance module always check the ego's drivng lane and exit as SUCCESS when the driving lane is updated.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/edae0190-7bb8-4bd2-be70-22666df1f4a9

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/a36a91b9-643a-5778-ac7e-275e71cb0c02?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
