### PR TITLE
fix(ground_segmentation): missing classified points bug

### DIFF
--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -326,8 +326,9 @@ void ScanGroundFilterComponent::classifyPointCloudGridScan(
       }
 
       if (
-        !initialized_first_gnd_grid && abs(global_slope_p) < global_slope_max_angle_rad_ &&
-        abs(p->orig_point->z) < non_ground_height_threshold_local) {
+        !initialized_first_gnd_grid &&
+        (abs(global_slope_p) < global_slope_max_angle_rad_ ||
+         abs(p->orig_point->z) < non_ground_height_threshold_local)) {
         ground_cluster.addPoint(p->radius, p->orig_point->z, p->orig_index);
         p->point_state = PointLabel::GROUND;
         initialized_first_gnd_grid = static_cast<bool>(p->grid_id - prev_p->grid_id);


### PR DESCRIPTION
## Description

This fixed the bug that some points cloud closed to vehicle were not classified as GROUND or NON_GROUND points. 

## Related links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/AT-136)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
