### PR TITLE
fix(pointcloud_preprocessor): change velocoty_report to twist_with_covariance

### DIFF
--- a/sensing/pointcloud_preprocessor/docs/concatenate-data.md
+++ b/sensing/pointcloud_preprocessor/docs/concatenate-data.md
@@ -16,9 +16,9 @@ The figure below represents the reception time of each sensor data and how it is
 
 ### Input
 
-| Name            | Type                                              | Description                                                                   |
-| --------------- | ------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `~/input/twist` | `autoware_auto_vehicle_msgs::msg::VelocityReport` | The vehicle odometry is used to interpolate the timestamp of each sensor data |
+| Name            | Type                                             | Description                                                                   |
+| --------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `~/input/twist` | `geometry_msgs::msg::TwistWithCovarianceStamped` | The vehicle odometry is used to interpolate the timestamp of each sensor data |
 
 ### Output
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_data_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_data_nodelet.hpp
@@ -68,9 +68,9 @@
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
-#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <tier4_debug_msgs/msg/int32_stamped.hpp>
@@ -125,7 +125,7 @@ private:
   /** \brief A vector of subscriber. */
   std::vector<rclcpp::Subscription<PointCloud2>::SharedPtr> filters_;
 
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>::SharedPtr sub_twist_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr sub_twist_;
 
   rclcpp::TimerBase::SharedPtr timer_;
   diagnostic_updater::Updater updater_{this};
@@ -163,7 +163,7 @@ private:
   void cloud_callback(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_ptr,
     const std::string & topic_name);
-  void twist_callback(const autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr input);
+  void twist_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr input);
   void timer_callback();
 
   void checkConcatStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);

--- a/sensing/pointcloud_preprocessor/package.xml
+++ b/sensing/pointcloud_preprocessor/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>cgal</depend>
   <depend>cv_bridge</depend>

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
@@ -482,7 +482,7 @@ void PointCloudConcatenateDataSynchronizerComponent::twist_callback(
 
   auto twist_ptr = std::make_shared<geometry_msgs::msg::TwistStamped>();
   twist_ptr->header = input->header;
-  twist_ptr->twist = msg.twist;
+  twist_ptr->twist = input->twist.twist;
   twist_ptr_queue_.push_back(twist_ptr);
 }
 

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
@@ -161,8 +161,8 @@ PointCloudConcatenateDataSynchronizerComponent::PointCloudConcatenateDataSynchro
     }
     auto twist_cb = std::bind(
       &PointCloudConcatenateDataSynchronizerComponent::twist_callback, this, std::placeholders::_1);
-    sub_twist_ = this->create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
-      "/vehicle/status/velocity_status", rclcpp::QoS{100}, twist_cb);
+    sub_twist_ = this->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
+      "~/input/twist", rclcpp::QoS{100}, twist_cb);
   }
 
   // Set timer
@@ -461,7 +461,7 @@ void PointCloudConcatenateDataSynchronizerComponent::timer_callback()
 }
 
 void PointCloudConcatenateDataSynchronizerComponent::twist_callback(
-  const autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr input)
+  const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr input)
 {
   // if rosbag restart, clear buffer
   if (!twist_ptr_queue_.empty()) {
@@ -481,10 +481,8 @@ void PointCloudConcatenateDataSynchronizerComponent::twist_callback(
   }
 
   auto twist_ptr = std::make_shared<geometry_msgs::msg::TwistStamped>();
-  twist_ptr->header.stamp = input->header.stamp;
-  twist_ptr->twist.linear.x = input->longitudinal_velocity;
-  twist_ptr->twist.linear.y = input->lateral_velocity;
-  twist_ptr->twist.angular.z = input->heading_rate;
+  twist_ptr->header = input->header;
+  twist_ptr->twist = msg.twist;
   twist_ptr_queue_.push_back(twist_ptr);
 }
 


### PR DESCRIPTION
## Description
Even the ego vehicle twist topic is changed to `/sensing/vehicle_velocity_converter/twist_with_covariance` in https://github.com/autowarefoundation/autoware.universe/pull/1120, concatenate data node still uses `/vehicle/status/velocity_status`.
Since the velocity in `vehicle_velocity_converter/twist_with_covariance` is different from `velocity_status` after https://github.com/autowarefoundation/autoware.universe/pull/2641, the velocity used in the sensing stack should be only twist_with_covariance

<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/59

[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C057JDFS5M2/p1685504865398939)

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
Sensing module internal topic change.
Change input topic of concatenate_data from velocoty_report to twist_with_covariance
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
point clouds are concatenated with correct odometry compensation.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
