### PR TITLE
fix(planning_debug_tools): bag directory designation of perception reproducer

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_reproducer.py
@@ -146,8 +146,8 @@ class PerceptionReproducer(Node):
         # load rosbag
         print("Stared loading rosbag")
         if os.path.isdir(args.bag):
-            for bag_file in sorted(os.listdir(args.directory)):
-                self.load_rosbag(args.directory + "/" + bag_file)
+            for bag_file in sorted(os.listdir(args.bag)):
+                self.load_rosbag(args.bag + "/" + bag_file)
         else:
             self.load_rosbag(args.bag)
         print("Ended loading rosbag")


### PR DESCRIPTION
## Description

The `bag` argument for the bag directory of perception_reproducer did not work.

<!-- Write a brief description of this PR. -->

## Tests performed

planning simulator
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
