### PR TITLE
feat(avoidance): add hysteresis to avoidance necessity check

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -94,6 +94,10 @@ void fillObjectMovingTime(
   ObjectData & object_data, ObjectDataArray & stopped_objects,
   const std::shared_ptr<AvoidanceParameters> & parameters);
 
+void fillAvoidanceNecessity(
+  ObjectData & object_data, const ObjectDataArray & registered_objects, const double vehicle_width,
+  const std::shared_ptr<AvoidanceParameters> & parameters);
+
 void updateRegisteredObject(
   ObjectDataArray & registered_objects, const ObjectDataArray & now_objects,
   const std::shared_ptr<AvoidanceParameters> & parameters);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -404,12 +404,8 @@ ObjectData AvoidanceModule::createObjectData(
 
   // Check whether the the ego should avoid the object.
   const auto & vehicle_width = planner_data_->parameters.vehicle_width;
-  const auto safety_margin =
-    0.5 * vehicle_width + object_parameter.safety_buffer_lateral * object_data.distance_factor;
-  object_data.avoid_required =
-    (utils::avoidance::isOnRight(object_data) &&
-     std::abs(object_data.overhang_dist) < safety_margin) ||
-    (!utils::avoidance::isOnRight(object_data) && object_data.overhang_dist < safety_margin);
+  utils::avoidance::fillAvoidanceNecessity(
+    object_data, registered_objects_, vehicle_width, parameters_);
 
   return object_data;
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
@@ -220,13 +220,9 @@ ObjectData AvoidanceByLaneChange::createObjectData(
     object_data, object_closest_pose, object_data.overhang_pose.position);
 
   // Check whether the the ego should avoid the object.
-  const auto vehicle_width = planner_data_->parameters.vehicle_width;
-  const auto safety_margin =
-    0.5 * vehicle_width + object_parameter.safety_buffer_lateral * object_data.distance_factor;
-  object_data.avoid_required =
-    (utils::avoidance::isOnRight(object_data) &&
-     std::abs(object_data.overhang_dist) < safety_margin) ||
-    (!utils::avoidance::isOnRight(object_data) && object_data.overhang_dist < safety_margin);
+  const auto & vehicle_width = planner_data_->parameters.vehicle_width;
+  utils::avoidance::fillAvoidanceNecessity(
+    object_data, registered_objects_, vehicle_width, avoidance_parameters_);
 
   return object_data;
 }

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -572,39 +572,32 @@ void fillAvoidanceNecessity(
   const auto safety_margin =
     0.5 * vehicle_width + object_parameter.safety_buffer_lateral * object_data.distance_factor;
 
-  const auto one_shot_necessity =
-    (isOnRight(object_data) && std::abs(object_data.overhang_dist) < safety_margin) ||
-    (!isOnRight(object_data) && object_data.overhang_dist < safety_margin);
+  const auto check_necessity = [&](const auto hysteresis_factor) {
+    return (isOnRight(object_data) &&
+            std::abs(object_data.overhang_dist) < safety_margin * hysteresis_factor) ||
+           (!isOnRight(object_data) &&
+            object_data.overhang_dist < safety_margin * hysteresis_factor);
+  };
 
   const auto id = object_data.object.object_id;
   const auto same_id_obj = std::find_if(
     registered_objects.begin(), registered_objects.end(),
     [&id](const auto & o) { return o.object.object_id == id; });
 
+  // First time
   if (same_id_obj == registered_objects.end()) {
-    object_data.avoid_required = one_shot_necessity;
+    object_data.avoid_required = check_necessity(1.0);
     return;
   }
 
   // FALSE -> FALSE or FALSE -> TRUE
   if (!same_id_obj->avoid_required) {
-    object_data.avoid_required = one_shot_necessity;
+    object_data.avoid_required = check_necessity(1.0);
     return;
   }
 
-  // TRUE -> TRUE
-  if (one_shot_necessity) {
-    object_data.avoid_required = true;
-    return;
-  }
-
-  const auto hysteresis_factor = parameters->safety_check_hysteresis_factor;
-
-  // TRUE -> FALSE (check again with hysteresis factor)
-  object_data.avoid_required =
-    (isOnRight(object_data) &&
-     std::abs(object_data.overhang_dist) < safety_margin * hysteresis_factor) ||
-    (!isOnRight(object_data) && object_data.overhang_dist < safety_margin * hysteresis_factor);
+  // TRUE -> ? (check with hysteresis factor)
+  object_data.avoid_required = check_necessity(parameters->safety_check_hysteresis_factor);
 }
 
 void updateRegisteredObject(

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -563,6 +563,50 @@ void fillObjectMovingTime(
   }
 }
 
+void fillAvoidanceNecessity(
+  ObjectData & object_data, const ObjectDataArray & registered_objects, const double vehicle_width,
+  const std::shared_ptr<AvoidanceParameters> & parameters)
+{
+  const auto t = utils::getHighestProbLabel(object_data.object.classification);
+  const auto object_parameter = parameters->object_parameters.at(t);
+  const auto safety_margin =
+    0.5 * vehicle_width + object_parameter.safety_buffer_lateral * object_data.distance_factor;
+
+  const auto one_shot_necessity =
+    (isOnRight(object_data) && std::abs(object_data.overhang_dist) < safety_margin) ||
+    (!isOnRight(object_data) && object_data.overhang_dist < safety_margin);
+
+  const auto id = object_data.object.object_id;
+  const auto same_id_obj = std::find_if(
+    registered_objects.begin(), registered_objects.end(),
+    [&id](const auto & o) { return o.object.object_id == id; });
+
+  if (same_id_obj == registered_objects.end()) {
+    object_data.avoid_required = one_shot_necessity;
+    return;
+  }
+
+  // FALSE -> FALSE or FALSE -> TRUE
+  if (!same_id_obj->avoid_required) {
+    object_data.avoid_required = one_shot_necessity;
+    return;
+  }
+
+  // TRUE -> TRUE
+  if (one_shot_necessity) {
+    object_data.avoid_required = true;
+    return;
+  }
+
+  const auto hysteresis_factor = parameters->safety_check_hysteresis_factor;
+
+  // TRUE -> FALSE (check again with hysteresis factor)
+  object_data.avoid_required =
+    (isOnRight(object_data) &&
+     std::abs(object_data.overhang_dist) < safety_margin * hysteresis_factor) ||
+    (!isOnRight(object_data) && object_data.overhang_dist < safety_margin * hysteresis_factor);
+}
+
 void updateRegisteredObject(
   ObjectDataArray & registered_objects, const ObjectDataArray & now_objects,
   const std::shared_ptr<AvoidanceParameters> & parameters)


### PR DESCRIPTION
## Description

Add hysteresis factor to judge whether the ego should avoid the object or not to prevent chattering of results.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/6ed2b4d4-701a-4edc-957c-9622fe3a69bd)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/04a73daf-15af-5dc9-85c4-7276fa68ecf4?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
