### PR TITLE
fix(motion_utils): check if the buffer is empty

### DIFF
--- a/common/motion_utils/src/vehicle/vehicle_state_checker.cpp
+++ b/common/motion_utils/src/vehicle/vehicle_state_checker.cpp
@@ -31,7 +31,7 @@ void VehicleStopCheckerBase::addTwist(const TwistStamped & twist)
   twist_buffer_.push_front(twist);
 
   const auto now = clock_->now();
-  while (true) {
+  while (!twist_buffer_.empty()) {
     // Check oldest data time
     const auto time_diff = now - twist_buffer_.back().header.stamp;
 


### PR DESCRIPTION
## Description

In the current implementation, node will die if the data that has old timestamp is passed to the VehicleStopChecker.
This can happen when traffic load increases and message subscribe is delayed.

This is the same issue as [this PR](https://github.com/autowarefoundation/autoware.universe/pull/1980).

## Tests performed

I added the test and confirmed the program will not die.

### Before the change
```
$ ./build/motion_utils/test_motion_utils --gtest_filter="vehicle_stop_checker*"
Note: Google Test filter = vehicle_stop_checker*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from vehicle_stop_checker
[ RUN      ] vehicle_stop_checker.isVehicleStopped
fish: Job 1, './build/motion_utils/test_motio…' terminated by signal SIGSEGV (Address boundary error)
```

### After the change
```
$ ./build/motion_utils/test_motion_utils --gtest_filter="vehicle_stop_checker*"
Note: Google Test filter = vehicle_stop_checker*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from vehicle_stop_checker
[ RUN      ] vehicle_stop_checker.isVehicleStopped
[       OK ] vehicle_stop_checker.isVehicleStopped (3044 ms)
[----------] 1 test from vehicle_stop_checker (3044 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (3044 ms total)
[  PASSED  ] 1 test.
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
