### PR TITLE
fix(avoidance): fill prev driving lanes at first time

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3186,6 +3186,12 @@ void AvoidanceModule::updateData()
   if (prev_reference_.points.empty()) {
     prev_reference_ = avoidance_data_.reference_path;
   }
+  if (prev_driving_lanes_.empty()) {
+    prev_driving_lanes_ = utils::calcLaneAroundPose(
+      planner_data_->route_handler, avoidance_data_.reference_pose,
+      planner_data_->parameters.forward_path_length,
+      planner_data_->parameters.backward_path_length);
+  }
 #endif
 
   fillShiftLine(avoidance_data_, debug_data_);


### PR DESCRIPTION
## Description

Bug in https://github.com/autowarefoundation/autoware.universe/pull/3871. `prev_driving_lanes_` must be filled at first cycle.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [ ] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/c9d21a36-3c38-5e52-b1b1-d9d18ca4eee5?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
