### PR TITLE
fix(behavior_velocity_intersection_module): visualize virtuall wall of merge_from_private_road

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_intersection_module/src/debug.cpp
@@ -257,6 +257,7 @@ motion_utils::VirtualWalls MergeFromPrivateRoadModule::createVirtualWalls()
     wall.style = motion_utils::VirtualWallType::stop;
     wall.pose = debug_data_.virtual_wall_pose;
     wall.text = "merge_from_private_road";
+    virtual_walls.push_back(wall);
   }
   return virtual_walls;
 }


### PR DESCRIPTION
## Description

Fix the issue that the virtul wall of the merge_from_private_road module does not visualize in RViz.

<!-- Write a brief description of this PR. -->

## Tests performed
Before:
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/bcdc4667-56b7-44c3-a8a6-23bf4ec2096c)

After:
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/d7ee9bcd-10e5-4e7f-b6d8-a15a84af9660)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable. (It affects for only visualization)
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
