### PR TITLE
fix(lane_change): disable virtual wall by default

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -338,6 +338,11 @@ MarkerArray LaneChangeInterface::getModuleVirtualWall()
 {
   using marker_utils::lane_change_markers::createLaneChangingVirtualWallMarker;
   MarkerArray marker;
+
+  if(!parameters_->publish_debug_marker){
+    return marker;
+  }
+
   if (isWaitingApproval() || current_state_ != ModuleStatus::RUNNING) {
     return marker;
   }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -339,7 +339,7 @@ MarkerArray LaneChangeInterface::getModuleVirtualWall()
   using marker_utils::lane_change_markers::createLaneChangingVirtualWallMarker;
   MarkerArray marker;
 
-  if(!parameters_->publish_debug_marker){
+  if (!parameters_->publish_debug_marker) {
     return marker;
   }
 


### PR DESCRIPTION
## Description

Disable default lane change virtual wall publisher

## Tests performed

Run lane change scenario

On another terminal, execute

```
ros2 param set /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner lane_change.publish_debug_marker true
```

the marker should appear

Run 
```
ros2 param set /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner lane_change.publish_debug_marker false
```
to disable

[Screencast from 2023年06月02日 18時46分52秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/93502286/aca56db7-038f-4841-a94b-06e41d6ba39e)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
