### PR TITLE
fix(goal_planner): fix goal planner execution

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -294,13 +294,6 @@ bool GoalPlannerModule::isExecutionRequested() const
       return lanelet::utils::isInLanelet(goal_pose, current_lane);
     });
 
-  // if goal modification is not allowed
-  // 1) goal_pose is in current_lanes, plan path to the original fixed goal
-  // 2) goal_pose is NOT in current_lanes, do not execute goal_planner
-  if (!allow_goal_modification_) {
-    return goal_is_in_current_lanes;
-  }
-
   // check that goal is in current neghibor shoulder lane
   const bool goal_is_in_current_shoulder_lanes = std::invoke([&]() {
     lanelet::ConstLanelet neighbor_shoulder_lane{};
@@ -329,6 +322,13 @@ bool GoalPlannerModule::isExecutionRequested() const
   if (self_to_goal_arc_length < 0.0 || self_to_goal_arc_length > request_length) {
     // if current position is far from goal or behind goal, do not execute goal_planner
     return false;
+  }
+
+  // if goal modification is not allowed
+  // 1) goal_pose is in current_lanes, plan path to the original fixed goal
+  // 2) goal_pose is NOT in current_lanes, do not execute goal_planner
+  if (!allow_goal_modification_) {
+    return goal_is_in_current_lanes;
   }
 
   // if (A) or (B) is met execute pull over

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -276,37 +276,59 @@ bool GoalPlannerModule::isExecutionRequested() const
   if (current_state_ == ModuleStatus::RUNNING) {
     return true;
   }
-  const auto & route_handler = planner_data_->route_handler;
 
-  // if current position is far from goal, do not execute pull over
+  const auto & route_handler = planner_data_->route_handler;
   const Pose & current_pose = planner_data_->self_odometry->pose.pose;
   const Pose & goal_pose = route_handler->getGoalPose();
+
+  // if goal is shoulder lane, allow goal modification
+  allow_goal_modification_ =
+    route_handler->isAllowedGoalModification() || checkOriginalGoalIsInShoulder();
+
+  // check if goal_pose is in current_lanes.
   lanelet::ConstLanelet current_lane{};
   const lanelet::ConstLanelets current_lanes = utils::getCurrentLanes(planner_data_);
   lanelet::utils::query::getClosestLanelet(current_lanes, current_pose, &current_lane);
-  const double self_to_goal_arc_length =
-    utils::getSignedDistance(current_pose, goal_pose, current_lanes);
-  allow_goal_modification_ =
-    route_handler->isAllowedGoalModification() || checkOriginalGoalIsInShoulder();
-  const double request_length =
-    allow_goal_modification_ ? calcModuleRequestLength() : parameters_->minimum_request_length;
-  const double backward_goal_search_length =
-    allow_goal_modification_ ? parameters_->backward_goal_search_length : 0.0;
-  if (
-    self_to_goal_arc_length < -backward_goal_search_length ||
-    self_to_goal_arc_length > request_length) {
-    return false;
-  }
+  const bool goal_is_in_current_lanes = std::any_of(
+    current_lanes.begin(), current_lanes.end(), [&](const lanelet::ConstLanelet & current_lane) {
+      return lanelet::utils::isInLanelet(goal_pose, current_lane);
+    });
 
   // if goal modification is not allowed
   // 1) goal_pose is in current_lanes, plan path to the original fixed goal
   // 2) goal_pose is NOT in current_lanes, do not execute goal_planner
   if (!allow_goal_modification_) {
-    // check if goal_pose is in current_lanes.
-    return std::any_of(
-      current_lanes.begin(), current_lanes.end(), [&](const lanelet::ConstLanelet & current_lane) {
-        return lanelet::utils::isInLanelet(goal_pose, current_lane);
-      });
+    return goal_is_in_current_lanes;
+  }
+
+  // check that goal is in current neghibor shoulder lane
+  const bool goal_is_in_current_shoulder_lanes = std::invoke([&]() {
+    lanelet::ConstLanelet neighbor_shoulder_lane{};
+    for (const auto & lane : current_lanes) {
+      const bool has_shoulder_lane =
+        left_side_parking_ ? route_handler->getLeftShoulderLanelet(lane, &neighbor_shoulder_lane)
+                           : route_handler->getRightShoulderLanelet(lane, &neighbor_shoulder_lane);
+      if (has_shoulder_lane && lanelet::utils::isInLanelet(goal_pose, neighbor_shoulder_lane)) {
+        return true;
+      }
+    }
+    return false;
+  });
+
+  // if goal is not in current_lanes and current_shoulder_lanes, do not execute goal_planner,
+  // because goal arc coordinates cannot be calculated.
+  if (!goal_is_in_current_lanes && !goal_is_in_current_shoulder_lanes) {
+    return false;
+  }
+
+  // if goal arc coordinates can be calculated, check if goal is in request_length
+  const double self_to_goal_arc_length =
+    utils::getSignedDistance(current_pose, goal_pose, current_lanes);
+  const double request_length =
+    allow_goal_modification_ ? calcModuleRequestLength() : parameters_->minimum_request_length;
+  if (self_to_goal_arc_length < 0.0 || self_to_goal_arc_length > request_length) {
+    // if current position is far from goal or behind goal, do not execute goal_planner
+    return false;
   }
 
   // if (A) or (B) is met execute pull over


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Fix goal planner execution.
goal arc coordinates can not be calculated correctly if the goal pose is not in current_lanes.
This causes executing `goal_planner` at inappropriate timing

```
component_container_mt-28] isExecutionRequested: 303, backward_goal_search_length : 20
[component_container_mt-28] isExecutionRequested: 304, request_length : 100
[component_container_mt-28] isExecutionRequested: 305, self_to_goal_arc_length : -0.518109 
```
![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/733c8848-9794-40f7-856c-e9229640604f)


```
[component_container_mt-28] isExecutionRequested: 303, backward_goal_search_length : 20
[component_container_mt-28] isExecutionRequested: 304, request_length : 100
[component_container_mt-28] isExecutionRequested: 305, self_to_goal_arc_length : 99.2417
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/14f2bc03-7d1c-4202-bb67-5b76196fed9d)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
[
tier4 internal ticket](https://tier4.atlassian.net/browse/RT1-2650)

## Tests performed

<!-- Describe how you have tested this PR. -->
psim


![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/02a5bacc-a50e-40a3-9249-40fb3466c344)


![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/938cf5d3-a518-4ece-bade-5564a943358d)

[ tier4 internal scenario test
](https://evaluation.tier4.jp/evaluation/reports/402042a1-c57c-58c0-b8be-3595a6680b03?project_id=prd_jt)

1333/1372 -> 1333/1372


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
