### PR TITLE
feat(obstacle_cruise_planner): suppress flickering to entry slow down

### DIFF
--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -96,6 +96,9 @@
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
         lat_hysteresis_margin: 0.2
 
+        successive_num_to_entry_slow_down_condition: 5
+        successive_num_to_exit_slow_down_condition: 5
+
     cruise:
       pid_based_planner:
         use_velocity_limit_based_planner: true

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -24,6 +24,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -186,11 +187,59 @@ private:
     double max_lat_margin_for_cruise;
     double max_lat_margin_for_slow_down;
     double lat_hysteresis_margin_for_slow_down;
+    int successive_num_to_entry_slow_down_condition;
+    int successive_num_to_exit_slow_down_condition;
   };
   BehaviorDeterminationParam behavior_determination_param_;
 
   std::unordered_map<std::string, bool> need_to_clear_vel_limit_{
     {"cruise", false}, {"slow_down", false}};
+
+  struct SlowDownConditionCounter
+  {
+    void resetCurrentUuids() { current_uuids_.clear(); }
+    void addCurrentUuid(const std::string & uuid) { current_uuids_.push_back(uuid); }
+    void removeCounterUnlessUpdated()
+    {
+      std::vector<std::string> obsolete_uuids;
+      for (const auto & key_and_value : counter_) {
+        if (
+          std::find(current_uuids_.begin(), current_uuids_.end(), key_and_value.first) ==
+          current_uuids_.end()) {
+          obsolete_uuids.push_back(key_and_value.first);
+        }
+      }
+
+      for (const auto & obsolete_uuid : obsolete_uuids) {
+        counter_.erase(obsolete_uuid);
+      }
+    }
+
+    int increaseCounter(const std::string & uuid)
+    {
+      if (counter_.count(uuid) != 0) {
+        counter_.at(uuid) = std::max(1, counter_.at(uuid) + 1);
+      } else {
+        counter_.emplace(uuid, 1);
+      }
+      return counter_.at(uuid);
+    }
+    int decreaseCounter(const std::string & uuid)
+    {
+      if (counter_.count(uuid) != 0) {
+        counter_.at(uuid) = std::min(-1, counter_.at(uuid) - 1);
+      } else {
+        counter_.emplace(uuid, -1);
+      }
+      return counter_.at(uuid);
+    }
+    void reset(const std::string & uuid) { counter_.emplace(uuid, 0); }
+
+    // NOTE: positive is for meeting entrying condition, and negative is for exiting.
+    std::unordered_map<std::string, int> counter_;
+    std::vector<std::string> current_uuids_;
+  };
+  SlowDownConditionCounter slow_down_condition_counter_;
 
   EgoNearestParam ego_nearest_param_;
 

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -1004,7 +1004,6 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
     }
     return false;
   }();
-  std::cerr << "is_slow_down_required " << is_slow_down_required << std::endl;
   if (!is_slow_down_required) {
     RCLCPP_INFO_EXPRESSION(
       get_logger(), enable_debug_info_,

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -263,6 +263,10 @@ ObstacleCruisePlannerNode::BehaviorDeterminationParam::BehaviorDeterminationPara
     node.declare_parameter<double>("behavior_determination.slow_down.max_lat_margin");
   lat_hysteresis_margin_for_slow_down =
     node.declare_parameter<double>("behavior_determination.slow_down.lat_hysteresis_margin");
+  successive_num_to_entry_slow_down_condition = node.declare_parameter<int>(
+    "behavior_determination.slow_down.successive_num_to_entry_slow_down_condition");
+  successive_num_to_exit_slow_down_condition = node.declare_parameter<int>(
+    "behavior_determination.slow_down.successive_num_to_exit_slow_down_condition");
 }
 
 void ObstacleCruisePlannerNode::BehaviorDeterminationParam::onParam(
@@ -315,6 +319,12 @@ void ObstacleCruisePlannerNode::BehaviorDeterminationParam::onParam(
   tier4_autoware_utils::updateParam<double>(
     parameters, "behavior_determination.slow_down.lat_hysteresis_margin",
     lat_hysteresis_margin_for_slow_down);
+  tier4_autoware_utils::updateParam<int>(
+    parameters, "behavior_determination.slow_down.successive_num_to_entry_slow_down_condition",
+    successive_num_to_entry_slow_down_condition);
+  tier4_autoware_utils::updateParam<int>(
+    parameters, "behavior_determination.slow_down.successive_num_to_exit_slow_down_condition",
+    successive_num_to_exit_slow_down_condition);
 }
 
 ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions & node_options)
@@ -621,6 +631,7 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
   std::vector<StopObstacle> stop_obstacles;
   std::vector<CruiseObstacle> cruise_obstacles;
   std::vector<SlowDownObstacle> slow_down_obstacles;
+  slow_down_condition_counter_.resetCurrentUuids();
   for (const auto & obstacle : obstacles) {
     const auto obstacle_poly = obstacle.toPolygon();
 
@@ -651,6 +662,7 @@ ObstacleCruisePlannerNode::determineEgoBehaviorAgainstObstacles(
       continue;
     }
   }
+  slow_down_condition_counter_.removeCounterUnlessUpdated();
 
   // Check target obstacles' consistency
   checkConsistency(objects_ptr_->header.stamp, *objects_ptr_, traj_points, stop_obstacles);
@@ -953,9 +965,9 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
   const std::vector<TrajectoryPoint> & traj_points, const Obstacle & obstacle,
   const double precise_lat_dist)
 {
-  std::cerr << precise_lat_dist << std::endl;
   const auto & object_id = obstacle.uuid.substr(0, 4);
   const auto & p = behavior_determination_param_;
+  slow_down_condition_counter_.addCurrentUuid(obstacle.uuid);
 
   const bool is_prev_obstacle_slow_down =
     getObstacleFromUuid(prev_slow_down_obstacles_, obstacle.uuid).has_value();
@@ -969,7 +981,31 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
     precise_lat_dist, is_prev_obstacle_slow_down,
     p.max_lat_margin_for_slow_down + p.lat_hysteresis_margin_for_slow_down / 2.0,
     p.max_lat_margin_for_slow_down - p.lat_hysteresis_margin_for_slow_down / 2.0);
-  if (!is_lat_dist_low) {
+
+  const bool is_slow_down_required = [&]() {
+    if (is_prev_obstacle_slow_down) {
+      // check if exiting slow down
+      if (!is_lat_dist_low) {
+        const int count = slow_down_condition_counter_.decreaseCounter(obstacle.uuid);
+        if (count <= -p.successive_num_to_exit_slow_down_condition) {
+          slow_down_condition_counter_.reset(obstacle.uuid);
+          return false;
+        }
+      }
+      return true;
+    }
+    // check if entrying slow down
+    if (is_lat_dist_low) {
+      const int count = slow_down_condition_counter_.increaseCounter(obstacle.uuid);
+      if (p.successive_num_to_entry_slow_down_condition <= count) {
+        slow_down_condition_counter_.reset(obstacle.uuid);
+        return true;
+      }
+    }
+    return false;
+  }();
+  std::cerr << "is_slow_down_required " << is_slow_down_required << std::endl;
+  if (!is_slow_down_required) {
     RCLCPP_INFO_EXPRESSION(
       get_logger(), enable_debug_info_,
       "[SlowDown] Ignore obstacle (%s) since it's far from trajectory. (%f [m])", object_id.c_str(),


### PR DESCRIPTION
## Description

suppress flickering of slow down entry/exit
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator & real vehicle

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
