### PR TITLE
feat: enable some options for object visualization

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -81,14 +81,14 @@ public:
     m_default_topic{default_topic}
   {
     m_display_type_property = new rviz_common::properties::EnumProperty(
-      "Polygon Type", "3d", "Type of the polygon to display object.");
+      "Polygon Type", "3d", "Type of the polygon to display object.", this);
     // Option values here must correspond to indices in palette_textures_ array in onInitialize()
     // below.
     m_display_type_property->addOption("3d", 0);
     m_display_type_property->addOption("2d", 1);
     m_display_type_property->addOption("Disable", 2);
     m_simple_visualize_mode_property = new rviz_common::properties::EnumProperty(
-      "Visualization Type", "Normal", "Simplicity of the polygon to display object.");
+      "Visualization Type", "Normal", "Simplicity of the polygon to display object.", this);
     m_simple_visualize_mode_property->addOption("Normal", 0);
     m_simple_visualize_mode_property->addOption("Simple", 1);
     // iterate over default values to create and initialize the properties.


### PR DESCRIPTION
## Description
In the object visualization plugin in the autoware_auto_perception_rviz_plugin, the options for computational cost reduction (```Polygon Type```, ```Visualization Type```) is unavailable now. I fixed it.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Before:
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/dbef5461-8ad5-4b55-97e5-90ff8f6e7a97)

After:
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/2b9dbeed-eb67-449e-adc7-ac193e5c26b6)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable. (It affects only RViz. )

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
