### PR TITLE
feat(behavior_path_planner): enable lane change to activate turn signal when stopping

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
+set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
+set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -6,6 +6,7 @@
 
       backward_length_buffer_for_end_of_lane: 3.0 # [m]
       lane_change_finish_judge_buffer: 2.0      # [m]
+      min_length_for_turn_signal_activation: 10.0 #[m]
 
       lane_changing_lateral_jerk: 0.5              # [m/s3]
       lateral_acc_switching_velocity: 4.0          #[m/s]

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -137,6 +137,8 @@ public:
 
   const BehaviorPathPlannerParameters & getCommonParam() const { return planner_data_->parameters; }
 
+  LaneChangeParameters getLaneChangeParam() const { return *lane_change_parameters_; }
+
   bool isCancelEnabled() const { return lane_change_parameters_->enable_cancel_lane_change; }
 
   bool isAbortEnabled() const { return lane_change_parameters_->enable_abort_lane_change; }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -165,6 +165,10 @@ public:
 
   std::string getModuleTypeStr() const { return std::string{magic_enum::enum_name(type_)}; }
 
+  LaneChangeModuleType getModuleType() const { return type_; }
+
+  TurnSignalDecider getTurnSignalDecider() { return planner_data_->turn_signal_decider; }
+
   Direction getDirection() const
   {
     if (direction_ == Direction::NONE && !status_.lane_change_path.path.points.empty()) {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
@@ -93,6 +93,9 @@ public:
 
   MarkerArray getModuleVirtualWall() override;
 
+  TurnSignalInfo getCurrentTurnSignalInfo(
+    const PathWithLaneId & path, const TurnSignalInfo & original_turn_signal_info);
+
 protected:
   std::shared_ptr<LaneChangeParameters> parameters_;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -35,6 +35,9 @@ struct LaneChangeParameters
   int longitudinal_acc_sampling_num{10};
   int lateral_acc_sampling_num{10};
 
+  // turn signal
+  double min_length_for_turn_signal_activation{10.0};
+
   // acceleration data
   double min_longitudinal_acc{-1.0};
   double max_longitudinal_acc{1.0};

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -778,6 +778,10 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.lateral_acc_sampling_num =
     declare_parameter<int>(parameter("lateral_acceleration_sampling_num"));
 
+  // min length
+  p.min_length_for_turn_signal_activation =
+    declare_parameter<double>(parameter("min_length_for_turn_signal_activation"));
+
   // acceleration
   p.min_longitudinal_acc = declare_parameter<double>(parameter("min_longitudinal_acc"));
   p.max_longitudinal_acc = declare_parameter<double>(parameter("max_longitudinal_acc"));

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -249,6 +249,55 @@ BehaviorModuleOutput LaneChangeInterface::planWaitingApproval()
     getPreviousModuleOutput().reference_path, getPreviousModuleOutput().path);
   module_type_->updateLaneChangeStatus();
 
+  // change turn signal when the vehicle reaches at the end of the path for waiting lane change
+  const auto & target_lanes = module_type_->getLaneChangeStatus().lane_change_lanes;
+  if (
+    !out.path->points.empty() && !target_lanes.empty() &&
+    module_type_->getModuleType() == LaneChangeModuleType::NORMAL) {
+    const double minimum_lc_turn_signal_length = 10.0;
+    const auto & route_handler = module_type_->getRouteHandler();
+    const auto & common_parameter = module_type_->getCommonParam();
+    const auto shift_intervals =
+      route_handler->getLateralIntervalsToPreferredLane(target_lanes.back());
+    const double next_lane_change_buffer =
+      utils::calcMinimumLaneChangeLength(common_parameter, shift_intervals);
+    const double & nearest_dist_threshold = common_parameter.ego_nearest_dist_threshold;
+    const double & nearest_yaw_threshold = common_parameter.ego_nearest_yaw_threshold;
+
+    const double buffer = next_lane_change_buffer + minimum_lc_turn_signal_length;
+    const double path_length = motion_utils::calcArcLength(out.path->points);
+    const auto & current_pose = module_type_->getEgoPose();
+    const auto & front_point = out.path->points.front().point.pose.position;
+    const size_t & current_nearest_seg_idx =
+      motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+        out.path->points, current_pose, nearest_dist_threshold, nearest_yaw_threshold);
+    const double length_front_to_ego = motion_utils::calcSignedArcLength(
+      out.path->points, front_point, static_cast<size_t>(0), current_pose.position,
+      current_nearest_seg_idx);
+    const auto start_pose = motion_utils::calcLongitudinalOffsetPose(
+      out.path->points, 0, std::max(path_length - buffer, 0.0));
+    if (path_length - length_front_to_ego < buffer && start_pose) {
+      // modify turn signal
+      const auto new_turn_signal_info = [&](const Direction & direction) {
+        TurnSignalInfo new_turn_signal_info;
+        new_turn_signal_info.desired_start_point = *start_pose;
+        new_turn_signal_info.desired_end_point = out.path->points.back().point.pose;
+        new_turn_signal_info.required_start_point = new_turn_signal_info.desired_start_point;
+        new_turn_signal_info.required_end_point = new_turn_signal_info.desired_end_point;
+        if (direction == Direction::LEFT) {
+          new_turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+        } else if (direction == Direction::RIGHT) {
+          new_turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
+        }
+        return new_turn_signal_info;
+      };
+      const auto lc_turn_signal_info = new_turn_signal_info(module_type_->getDirection());
+      out.turn_signal_info = module_type_->getTurnSignalDecider().use_prior_turn_signal(
+        *out.path, current_pose, current_nearest_seg_idx, out.turn_signal_info, lc_turn_signal_info,
+        nearest_dist_threshold, nearest_yaw_threshold);
+    }
+  }
+
   if (!module_type_->isValidPath()) {
     path_candidate_ = std::make_shared<PathWithLaneId>();
     return out;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -413,19 +413,18 @@ void LaneChangeInterface::acceptVisitor(const std::shared_ptr<SceneModuleVisitor
 TurnSignalInfo LaneChangeInterface::getCurrentTurnSignalInfo(
   const PathWithLaneId & path, const TurnSignalInfo & original_turn_signal_info)
 {
-  TurnSignalInfo current_turn_signal_info;
-
   const auto & target_lanes = module_type_->getLaneChangeStatus().lane_change_lanes;
   const auto & is_valid = module_type_->getLaneChangeStatus().is_valid_path;
   const auto & lane_change_path = module_type_->getLaneChangeStatus().lane_change_path;
 
   if (
-    module_type_->getModuleType() != LaneChangeModuleType::NORMAL || !target_lanes.empty() ||
+    module_type_->getModuleType() != LaneChangeModuleType::NORMAL || target_lanes.empty() ||
     !is_valid) {
-    return current_turn_signal_info;
+    return original_turn_signal_info;
   }
 
   // check direction
+  TurnSignalInfo current_turn_signal_info;
   const auto & current_pose = module_type_->getEgoPose();
   const auto direction = module_type_->getDirection();
   if (direction == Direction::LEFT) {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -420,7 +420,7 @@ TurnSignalInfo LaneChangeInterface::getCurrentTurnSignalInfo(
   const auto & lane_change_path = module_type_->getLaneChangeStatus().lane_change_path;
 
   if (
-    module_type_->getModuleType() == LaneChangeModuleType::NORMAL || !target_lanes.empty() ||
+    module_type_->getModuleType() != LaneChangeModuleType::NORMAL || !target_lanes.empty() ||
     !is_valid) {
     return current_turn_signal_info;
   }


### PR DESCRIPTION
## Description
Currently, the lane change module cannot activate turn signal when the ego vehicle approaches at the end of current path. In this PR, it can fire the signal even when the approved lane change path is not available.

launch: https://github.com/autowarefoundation/autoware_launch/pull/397
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
[Screencast from 2023年06月11日 01時34分35秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/43805014/f37b7ac5-3cc8-47f8-a5b3-3e19e0b866e0)

PSim


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
