### PR TITLE
fix(behavior_velocity_speed_bump_module): fix virtual wall base_link2front offset

### DIFF
--- a/planning/behavior_velocity_speed_bump_module/src/debug.cpp
+++ b/planning/behavior_velocity_speed_bump_module/src/debug.cpp
@@ -101,7 +101,7 @@ motion_utils::VirtualWalls SpeedBumpModule::createVirtualWalls()
   wall.ns = std::to_string(module_id_) + "_";
   wall.style = motion_utils::VirtualWallType::slowdown;
   for (const auto & p : debug_data_.slow_start_poses) {
-    wall.pose = p;
+    wall.pose = tier4_autoware_utils::calcOffsetPose(p, debug_data_.base_link2front, 0.0, 0.0);
     virtual_walls.push_back(wall);
   }
   return virtual_walls;


### PR DESCRIPTION
## Description

closes #3927 

## Tests performed

Results for [slow_start_margin](https://github.com/autowarefoundation/autoware_launch/blob/65884add50a684ddf8674e6e065ea5eb97888f81/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/speed_bump.param.yaml#LL4C7-L4C24) : `0.0`

**Before:** 

![Screenshot from 2023-06-09 16-29-35](https://github.com/autowarefoundation/autoware.universe/assets/48479081/505acd2b-4411-4d10-b9a0-fd713dc822b0)

---

**After:**

![Screenshot from 2023-06-09 16-28-38](https://github.com/autowarefoundation/autoware.universe/assets/48479081/11a39ac7-6335-4db8-894d-7169fbad94ac)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
