### PR TITLE
docs(mission_planner): remove duplicated param from readme

### DIFF
--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -22,7 +22,6 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 | `arrival_check_duration`   | double | Duration threshold for goal check                                                                                |
 | `goal_angle_threshold`     | double | Max goal pose angle for goal approve                                                                             |
 | `enable_correct_goal_pose` | bool   | Enabling correction of goal pose according to the closest lanelet orientation                                    |
-| `enable_correct_goal_pose` | bool   | Enabling correction of goal pose according to the closest lanelet orientation                                    |
 | `reroute_time_threshold`   | double | If the time to the rerouting point at the current velocity is greater than this threshold, rerouting is possible |
 | `minimum_reroute_length`   | double | Minimum Length for publishing a new route                                                                        |
 


### PR DESCRIPTION
## Description

Removes [duplicated param from mission_planner readme](https://github.com/autowarefoundation/autoware.universe/blob/main/planning/mission_planner/README.md#:~:text=for%20goal%20approve-,enable_correct_goal_pose,Enabling%20correction%20of%20goal%20pose%20according%20to%20the%20closest%20lanelet%20orientation,-reroute_time_threshold)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

No need

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
