### PR TITLE
fix(image_projection_based_fusion): fix type of roi_probability_threshold

### DIFF
--- a/perception/image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
@@ -28,7 +28,7 @@ RoiDetectedObjectFusionNode::RoiDetectedObjectFusionNode(const rclcpp::NodeOptio
   fusion_params_.passthrough_lower_bound_probability_threshold =
     declare_parameter<double>("passthrough_lower_bound_probability_threshold");
   fusion_params_.use_roi_probability = declare_parameter<bool>("use_roi_probability");
-  fusion_params_.roi_probability_threshold = declare_parameter<bool>("roi_probability_threshold");
+  fusion_params_.roi_probability_threshold = declare_parameter<double>("roi_probability_threshold");
   fusion_params_.min_iou_threshold = declare_parameter<double>("min_iou_threshold");
 }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- `roi_probability_threshold` should be double according to [README](https://github.com/autowarefoundation/autoware.universe/blob/e9f2f4fb4bd1b1dc105d5fd3964565028d426c1b/perception/image_projection_based_fusion/docs/roi-detected-object-fusion.md?plain=1#L51).
- However, in code, the type of `roi_probability_threshold` is wrong. So I fix this.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I checked this PR with logging_simulator.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

I have confirmed that the Autoware performs the same as the current Autoware.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
