### PR TITLE
fix(stop_line): fixed stop line module to pub virtual wall when stop_pose is not null

### DIFF
--- a/planning/behavior_velocity_stop_line_module/src/debug.cpp
+++ b/planning/behavior_velocity_stop_line_module/src/debug.cpp
@@ -99,7 +99,7 @@ motion_utils::VirtualWalls StopLineModule::createVirtualWalls()
 {
   motion_utils::VirtualWalls virtual_walls;
 
-  if (!debug_data_.stop_pose && (state_ == State::APPROACH || state_ == State::STOPPED)) {
+  if (debug_data_.stop_pose && (state_ == State::APPROACH || state_ == State::STOPPED)) {
     motion_utils::VirtualWall wall;
     wall.text = "stopline";
     wall.style = motion_utils::VirtualWallType::stop;


### PR DESCRIPTION
## Description

A minor fix to display virtual wall when stop pose is available

## Tests performed

### Before this PR

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/203a2f2c-44f0-4efb-a744-9ed917e5ac8e)

### After this PR

The wall is visualized.

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/741a056b-1de8-4f65-9be9-d633ae20afc0)

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
