### PR TITLE
fix(behavior_path_planner): fix offset calculation for turn signal in start_planner

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -796,7 +796,14 @@ TurnSignalInfo StartPlannerModule::calcTurnSignalInfo() const
   // pull out path does not overlap
   const double distance_from_end =
     motion_utils::calcSignedArcLength(path.points, end_pose.position, current_pose.position);
-  const double lateral_offset = inverseTransformPoint(end_pose.position, start_pose).y;
+
+  if (path.points.empty()) {
+    return {};
+  }
+  const auto closest_idx = motion_utils::findNearestIndex(path.points, start_pose.position);
+  const auto lane_id = path.points.at(closest_idx).lane_ids.front();
+  const auto lane = planner_data_->route_handler->getLaneletMapPtr()->laneletLayer.get(lane_id);
+  const double lateral_offset = lanelet::utils::getLateralDistanceToCenterline(lane, start_pose);
 
   if (distance_from_end < 0.0 && lateral_offset > parameters_->th_blinker_on_lateral_offset) {
     turn_signal.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;


### PR DESCRIPTION
## Description


Currently, there is a issue with the offset calculation in start_planner, and so the turn signal turn on unnecessarily.
This is because the current offset calculation method does not support curved lanes.
For example, in the case of the image below, the offset is calculated to be -1.53.
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/250080f5-02da-4642-abd9-a60619bba38d)

I solved this problem by calculating the distance from the centerline of the lanelet as an offset.


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
I confirmed that the turn signal turned on properly when starting from near the curve
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
none
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
none
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
The turn signal lighting at the time of departure becomes appropriate

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
