### PR TITLE
feat(velocity_smoother): plan from ego velocity on manual mode

### DIFF
--- a/planning/motion_velocity_smoother/config/default_motion_velocity_smoother.param.yaml
+++ b/planning/motion_velocity_smoother/config/default_motion_velocity_smoother.param.yaml
@@ -56,3 +56,5 @@
 
     # system
     over_stop_velocity_warn_thr: 1.389  # used to check if the optimization exceeds the input velocity on the stop point
+
+    plan_from_ego_speed_on_manual_mode: true  # planning is done from ego velocity/acceleration on MANUAL mode. This should be true for smooth transition from MANUAL to AUTONOMOUS, but could be false for debugging.

--- a/planning/motion_velocity_smoother/launch/motion_velocity_smoother.launch.xml
+++ b/planning/motion_velocity_smoother/launch/motion_velocity_smoother.launch.xml
@@ -25,6 +25,8 @@
     <remap from="~/input/trajectory" to="$(var input_trajectory)"/>
     <remap from="~/output/trajectory" to="$(var output_trajectory)"/>
     <remap from="~/input/external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity"/>
+    <remap from="~/input/acceleration" to="/localization/acceleration"/>
+    <remap from="~/input/operation_mode_state" to="/system/operation_mode/state"/>
     <!-- Topic for setting maximum speed from the outside (input topic) -->
     <remap from="~/output/current_velocity_limit_mps" to="/planning/scenario_planning/current_max_velocity"/>
     <!-- Topic for displaying the set maximum speed (output topic) -->

--- a/planning/motion_velocity_smoother/test/test_motion_velocity_smoother_node_interface.cpp
+++ b/planning/motion_velocity_smoother/test/test_motion_velocity_smoother_node_interface.cpp
@@ -62,6 +62,10 @@ void publishMandatoryTopics(
   test_manager->publishOdometry(test_target_node, "/localization/kinematic_state");
   test_manager->publishMaxVelocity(
     test_target_node, "motion_velocity_smoother/input/external_velocity_limit_mps");
+  test_manager->publishOperationModeState(
+    test_target_node, "motion_velocity_smoother/input/operation_mode_state");
+  test_manager->publishAcceleration(
+    test_target_node, "motion_velocity_smoother/input/acceleration");
 }
 
 TEST(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInput)


### PR DESCRIPTION
## Description

**Summary:**
The `motion_velocity_smoother` calculates the velocity based on the ego-velocity and ego-acceleration when driving on manual mode.

Needs to merge with https://github.com/autowarefoundation/autoware_launch/pull/396

**Background:**
The current velocity planning intentionally relies on the previously planned trajectory's vehicle speed rather than the actual vehicle speed. This separation between the uncertain motion of the vehicle and the ideal planning is crucial for effective design. However, when the planned velocity and the actual vehicle velocity significantly differ, such as during manual driving, enabling Autoware control during manual driving can sometimes lead to adverse effects (e.g., strong brake) due to the disconnect between the planned value and the actual value. To address this, this PR has made improvements by incorporating the actual vehicle speed into the planning process specifically during manual driving, aiming to mitigate these adverse effects.

**Notation:**
It is helpful for debugging to drive the vehicle manually, assuming it is running in autonomous mode. However, this PR prevents the debug since the planning behavior changes depending on the mode. In that case, you can disable the features introduced in the PR by the following command:

```
$ ros2 param set /planning/scenario_planning/motion_velocity_smoother plan_from_ego_speed_on_manual_mode false
```


https://github.com/autowarefoundation/autoware.universe/assets/21360593/7da6914a-f318-4831-8d57-258a1afa1925


## Related links

[TIERIV internal link](https://tier4.atlassian.net/browse/RT1-2726)

## Tests performed

Run psim and real vehicle experiment. This PR is tested well in both.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

Improves the Autoware engage in manual driving

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
