### PR TITLE
feat(map_based_prediction): enable create prediction path to adjacent lanelet

### DIFF
--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1124,15 +1124,21 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     // Step1.1 Get the left lanelet
     lanelet::routing::LaneletPaths left_paths;
     auto opt_left = routing_graph_ptr_->left(current_lanelet_data.lanelet);
+    auto adjacent_left = routing_graph_ptr_->adjacentLeft(current_lanelet_data.lanelet);
     if (!!opt_left) {
       left_paths = routing_graph_ptr_->possiblePaths(*opt_left, possible_params);
+    } else if (!!adjacent_left) {
+      left_paths = routing_graph_ptr_->possiblePaths(*adjacent_left, possible_params);
     }
 
     // Step1.2 Get the right lanelet
     lanelet::routing::LaneletPaths right_paths;
     auto opt_right = routing_graph_ptr_->right(current_lanelet_data.lanelet);
+    auto adjacent_right = routing_graph_ptr_->adjacentRight(current_lanelet_data.lanelet);
     if (!!opt_right) {
       right_paths = routing_graph_ptr_->possiblePaths(*opt_right, possible_params);
+    } else if (!!adjacent_right) {
+      right_paths = routing_graph_ptr_->possiblePaths(*adjacent_right, possible_params);
     }
 
     // Step1.3 Get the centerline


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

The previous notation could not correctly predict LC on some maps because it could not produce a Prediction Path for adjacent unconnected lanes.

To avoid the above problem, we changed the notation so that the Prediction Path is also shown for adjacent connected lanes.

Note that oncoming lanes are not counted as adjacent.

This change is part of the following PR.
https://github.com/autowarefoundation/autoware.universe/pull/3007

- Reference
  - [lanelet2 document](http://docs.ros.org/en/noetic/api/lanelet2_routing/html/doxygen/namespacelanelet_1_1routing.html#a82b3974e584a830129154dca6f0b7be1)
- lanelet2 issue: https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/147

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

Tested in psim and lsim.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

- prediction path will be appeared adjacent left/right lane
- see [TIER IV INTERNAL TICKET](https://tier4.atlassian.net/browse/RT1-954)


Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
