### PR TITLE
fix(mission_planner): keep uuid when rerouting with modified goal

### DIFF
--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -373,8 +373,10 @@ void MissionPlanner::on_modified_goal(const ModifiedGoal::Message::ConstSharedPt
     change_state(RouteState::Message::CHANGING);
 
     const std::vector<geometry_msgs::msg::Pose> empty_waypoints;
-    const auto new_route =
+    auto new_route =
       create_route(msg->header, empty_waypoints, msg->pose, normal_route_->allow_modification);
+    // create_route generate new uuid, so set the original uuid again to keep that.
+    new_route.uuid = msg->uuid;
     if (new_route.segments.empty()) {
       change_route(*normal_route_);
       change_state(RouteState::Message::SET);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

keep uuid when rerouting with modified goal

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

not applicable

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

not applicable

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
