### PR TITLE
feat(detected_object_validation): add BOUNDING_BOX interface to lanelet filter

### DIFF
--- a/perception/detected_object_validation/include/detected_object_filter/object_lanelet_filter.hpp
+++ b/perception/detected_object_validation/include/detected_object_filter/object_lanelet_filter.hpp
@@ -63,6 +63,8 @@ private:
   lanelet::ConstLanelets getIntersectedLanelets(
     const LinearRing2d &, const lanelet::ConstLanelets &);
   bool isPolygonOverlapLanelets(const Polygon2d &, const lanelet::ConstLanelets &);
+  geometry_msgs::msg::Polygon setFootprint(
+    const autoware_auto_perception_msgs::msg::DetectedObject &);
 };
 
 }  // namespace object_lanelet_filter

--- a/perception/detected_object_validation/object-lanelet-filter.md
+++ b/perception/detected_object_validation/object-lanelet-filter.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The `object_lanelet_filter` is a node that filters detected object by using vector map.  
+The `object_lanelet_filter` is a node that filters detected object by using vector map.
 The objects only inside of the vector map will be published.
 
 ## Inner-workings / Algorithms
@@ -39,7 +39,7 @@ The objects only inside of the vector map will be published.
 
 ## Assumptions / Known limits
 
-Filtering is performed based on the shape polygon of the object.
+The lanelet filter is performed based on the shape polygon and bounding box of the objects.
 
 ## (Optional) Error detection and handling
 

--- a/perception/detected_object_validation/src/object_lanelet_filter.cpp
+++ b/perception/detected_object_validation/src/object_lanelet_filter.cpp
@@ -82,13 +82,6 @@ void ObjectLaneletFilterNode::objectCallback(
     return;
   }
 
-  // if shape is BOUNDING_BOX, make foot print
-  for (auto & object : transformed_objects.objects) {
-    if (object.shape.type == object.shape.BOUNDING_BOX) {
-      object.shape.footprint = setFootprint(object);
-    }
-  }
-
   // calculate convex hull
   const auto convex_hull = getConvexHull(transformed_objects);
   // get intersected lanelets
@@ -96,7 +89,7 @@ void ObjectLaneletFilterNode::objectCallback(
 
   int index = 0;
   for (const auto & object : transformed_objects.objects) {
-    const auto & footprint = object.shape.footprint;
+    const auto footprint = setFootprint(object);
     const auto & label = object.classification.front().label;
     if (filter_target_.isTarget(label)) {
       Polygon2d polygon;
@@ -120,21 +113,25 @@ void ObjectLaneletFilterNode::objectCallback(
 geometry_msgs::msg::Polygon ObjectLaneletFilterNode::setFootprint(
   const autoware_auto_perception_msgs::msg::DetectedObject & detected_object)
 {
-  const auto object_size = detected_object.shape.dimensions;
-  const double x_front = object_size.x / 2.0;
-  const double x_rear = -object_size.x / 2.0;
-  const double y_left = object_size.y / 2.0;
-  const double y_right = -object_size.y / 2.0;
-
   geometry_msgs::msg::Polygon footprint;
-  footprint.points.push_back(
-    geometry_msgs::build<geometry_msgs::msg::Point32>().x(x_front).y(y_left).z(0.0));
-  footprint.points.push_back(
-    geometry_msgs::build<geometry_msgs::msg::Point32>().x(x_front).y(y_right).z(0.0));
-  footprint.points.push_back(
-    geometry_msgs::build<geometry_msgs::msg::Point32>().x(x_rear).y(y_right).z(0.0));
-  footprint.points.push_back(
-    geometry_msgs::build<geometry_msgs::msg::Point32>().x(x_rear).y(y_left).z(0.0));
+  if (detected_object.shape.type == autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    const auto object_size = detected_object.shape.dimensions;
+    const double x_front = object_size.x / 2.0;
+    const double x_rear = -object_size.x / 2.0;
+    const double y_left = object_size.y / 2.0;
+    const double y_right = -object_size.y / 2.0;
+
+    footprint.points.push_back(
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(x_front).y(y_left).z(0.0));
+    footprint.points.push_back(
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(x_front).y(y_right).z(0.0));
+    footprint.points.push_back(
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(x_rear).y(y_right).z(0.0));
+    footprint.points.push_back(
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(x_rear).y(y_left).z(0.0));
+  } else {
+    footprint = detected_object.shape.footprint;
+  }
   return footprint;
 }
 
@@ -144,7 +141,8 @@ LinearRing2d ObjectLaneletFilterNode::getConvexHull(
   MultiPoint2d candidate_points;
   for (const auto & object : detected_objects.objects) {
     const auto & pos = object.kinematics.pose_with_covariance.pose.position;
-    for (const auto & p : object.shape.footprint.points) {
+    const auto footprint = setFootprint(object);
+    for (const auto & p : footprint.points) {
       candidate_points.emplace_back(p.x + pos.x, p.y + pos.y);
     }
   }


### PR DESCRIPTION
## Description

For now, the lanelet filter handle only POLYGON shape type.
So this PR adapt to BOUNDING_BOX shape type.
This change can be used for radar detection.

## Tests performed

Tested by rosbag.

![Screenshot from 2023-06-13 01-01-43](https://github.com/autowarefoundation/autoware.universe/assets/16330533/adbacbbe-57c3-4a03-a294-3a16fed8927d)

Purple objects is input objects and red objects is filtered objects.

## Effects on system behavior

This PR doesn't effect to POLYGON type, so doesn't effect to system behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
