### PR TITLE
fix(intersection): do not react to rtc for occlusion anymore if occlusion.enable is false

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -330,7 +330,9 @@ void reactRTCApprovalByDecisionResult(
         path->points.at(stop_line_idx).point.pose, VelocityFactor::INTERSECTION);
     }
   }
-  if (!rtc_occlusion_approved && !decision_result.is_detection_area_empty) {
+  if (
+    !rtc_occlusion_approved && !decision_result.is_detection_area_empty &&
+    planner_param.occlusion.enable) {
     const auto occlusion_stop_line_idx = decision_result.stop_lines.occlusion_peeking_stop_line;
     planning_utils::setVelocityFromIndex(occlusion_stop_line_idx, 0.0, path);
     debug_data->occlusion_stop_wall_pose =
@@ -373,7 +375,7 @@ void reactRTCApprovalByDecisionResult(
         path->points.at(stop_line_idx).point.pose, VelocityFactor::INTERSECTION);
     }
   }
-  if (!rtc_occlusion_approved) {
+  if (!rtc_occlusion_approved && planner_param.occlusion.enable) {
     const auto stop_line_idx = decision_result.stop_lines.occlusion_peeking_stop_line;
     planning_utils::setVelocityFromIndex(stop_line_idx, 0.0, path);
     debug_data->occlusion_stop_wall_pose =
@@ -416,7 +418,7 @@ void reactRTCApprovalByDecisionResult(
         path->points.at(stop_line_idx).point.pose, VelocityFactor::INTERSECTION);
     }
   }
-  if (!rtc_occlusion_approved) {
+  if (!rtc_occlusion_approved && planner_param.occlusion.enable) {
     if (planner_param.occlusion.enable_creeping) {
       const size_t occlusion_peeking_stop_line = decision_result.occlusion_stop_line_idx;
       const size_t closest_idx = decision_result.stop_lines.closest_idx;
@@ -455,7 +457,7 @@ void reactRTCApprovalByDecisionResult(
     rtc_occlusion_approved);
   // NOTE: creep_velocity should be inserted first at closest_idx if !rtc_default_approved
 
-  if (!rtc_occlusion_approved) {
+  if (!rtc_occlusion_approved && planner_param.occlusion.enable) {
     const size_t occlusion_peeking_stop_line =
       decision_result.stop_lines.occlusion_peeking_stop_line;
     if (planner_param.occlusion.enable_creeping) {
@@ -477,7 +479,7 @@ void reactRTCApprovalByDecisionResult(
         path->points.at(occlusion_peeking_stop_line).point.pose, VelocityFactor::INTERSECTION);
     }
   }
-  if (!rtc_default_approved) {
+  if (!rtc_default_approved && planner_param.occlusion.enable) {
     const auto stop_line_idx = decision_result.stop_lines.default_stop_line;
     planning_utils::setVelocityFromIndex(stop_line_idx, 0.0, path);
     debug_data->collision_stop_wall_pose =
@@ -520,7 +522,7 @@ void reactRTCApprovalByDecisionResult(
         path->points.at(stop_line_idx).point.pose, VelocityFactor::INTERSECTION);
     }
   }
-  if (!rtc_occlusion_approved) {
+  if (!rtc_occlusion_approved && planner_param.occlusion.enable) {
     const auto stop_line_idx = decision_result.occlusion_stop_line_idx;
     planning_utils::setVelocityFromIndex(stop_line_idx, 0.0, path);
     debug_data->occlusion_stop_wall_pose =
@@ -562,7 +564,7 @@ void reactRTCApprovalByDecisionResult(
         path->points.at(stop_line_idx).point.pose, VelocityFactor::INTERSECTION);
     }
   }
-  if (!rtc_occlusion_approved) {
+  if (!rtc_occlusion_approved && planner_param.occlusion.enable) {
     const auto stop_line_idx = decision_result.stop_lines.occlusion_peeking_stop_line;
     planning_utils::setVelocityFromIndex(stop_line_idx, 0.0, path);
     debug_data->occlusion_stop_wall_pose =


### PR DESCRIPTION
## Description

If the parameter `occlusion.enable` is set to `false`, this module makes no reaction to `INTERSECION_OCCLUSION` RTC.

## Related links

[COMPANY INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-2752)

## Tests performed

### Before PR

with `occlusion.enable = false`, intersection_occlusion wall appears when disapproved.

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/c642104a-6d3f-4474-a444-830b64a7c9ef)

### After PR

with `occlusion.enable = false`, intersection_occlusion wall does not appear.

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/02bae4f1-0ebc-467d-b089-407cd8874dbd)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

if the flag is false, this module does not respond to intersection_occlusion RTC anymore.

## Effects on system behavior

if the flag is false, this module does not respond to intersection_occlusion RTC anymore.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
