### PR TITLE
feat(behavior_path_planner): add a length ratio parameter for lane change turn signal deactivation

### DIFF
--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -6,7 +6,6 @@
 
       backward_length_buffer_for_end_of_lane: 3.0 # [m]
       lane_change_finish_judge_buffer: 2.0      # [m]
-      min_length_for_turn_signal_activation: 10.0 #[m]
 
       lane_changing_lateral_jerk: 0.5              # [m/s3]
       lateral_acc_switching_velocity: 4.0          #[m/s]
@@ -15,6 +14,10 @@
       prediction_time_resolution: 0.5           # [s]
       longitudinal_acceleration_sampling_num: 5
       lateral_acceleration_sampling_num: 3
+
+      # turn signal
+      min_length_for_turn_signal_activation: 10.0 # [m]
+      length_ratio_for_turn_signal_deactivation: 0.8 # ratio (desired end position)
 
       # longitudinal acceleration
       min_longitudinal_acc: -1.0

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -37,6 +37,7 @@ struct LaneChangeParameters
 
   // turn signal
   double min_length_for_turn_signal_activation{10.0};
+  double length_ratio_for_turn_signal_deactivation{0.8};
 
   // acceleration data
   double min_longitudinal_acc{-1.0};

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -778,9 +778,11 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.lateral_acc_sampling_num =
     declare_parameter<int>(parameter("lateral_acceleration_sampling_num"));
 
-  // min length
+  // turn signal
   p.min_length_for_turn_signal_activation =
     declare_parameter<double>(parameter("min_length_for_turn_signal_activation"));
+  p.length_ratio_for_turn_signal_deactivation =
+    declare_parameter<double>(parameter("length_ratio_for_turn_signal_deactivation"));
 
   // acceleration
   p.min_longitudinal_acc = declare_parameter<double>(parameter("min_longitudinal_acc"));

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -736,7 +736,7 @@ void NormalLaneChange::calcTurnSignalInfo()
   });
 
   // desired end pose
-  const auto & length_ratio =
+  const auto length_ratio =
     std::clamp(lane_change_parameters_->length_ratio_for_turn_signal_deactivation, 0.0, 1.0);
   const auto desired_end_length = path.length.lane_changing * length_ratio;
   turn_signal_info.desired_end_point = get_blinker_pose(shifted_path, desired_end_length);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -736,7 +736,8 @@ void NormalLaneChange::calcTurnSignalInfo()
   });
 
   // desired end pose
-  const auto & length_ratio = lane_change_parameters_->length_ratio_for_turn_signal_deactivation;
+  const auto & length_ratio =
+    std::clamp(lane_change_parameters_->length_ratio_for_turn_signal_deactivation, 0.0, 1.0);
   const auto desired_end_length = path.length.lane_changing * length_ratio;
   turn_signal_info.desired_end_point = get_blinker_pose(shifted_path, desired_end_length);
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -116,9 +116,6 @@ BehaviorModuleOutput NormalLaneChange::generateOutput()
     const auto stop_point = utils::insertStopPoint(stop_dist + current_dist, *output.path);
   }
 
-  output.reference_path = std::make_shared<PathWithLaneId>(getReferencePath());
-  output.turn_signal_info = updateOutputTurnSignal();
-
   const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path->points);
   output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
     *output.path, getEgoPose(), current_seg_idx, prev_turn_signal_info_, output.turn_signal_info,
@@ -720,8 +717,11 @@ void NormalLaneChange::calcTurnSignalInfo()
   };
 
   const auto & path = status_.lane_change_path;
+  const auto & shifted_path = path.shifted_path.path;
+
   TurnSignalInfo turn_signal_info{};
 
+  // desired start pose = prepare start pose
   turn_signal_info.desired_start_point = std::invoke([&]() {
     const auto blinker_start_duration = planner_data_->parameters.turn_signal_search_time;
     const auto prepare_duration = planner_data_->parameters.lane_change_prepare_duration;
@@ -734,11 +734,17 @@ void NormalLaneChange::calcTurnSignalInfo()
     const auto diff_length = std::abs(current_twist.linear.x) * diff_time;
     return get_blinker_pose(path.path, diff_length);
   });
-  turn_signal_info.desired_end_point = path.shift_line.end;
 
+  // desired end pose
+  const auto & length_ratio = lane_change_parameters_->length_ratio_for_turn_signal_deactivation;
+  const auto desired_end_length = path.length.lane_changing * length_ratio;
+  turn_signal_info.desired_end_point = get_blinker_pose(shifted_path, desired_end_length);
+
+  // required start pose = lane changing start pose
   turn_signal_info.required_start_point = path.shift_line.start;
+
+  // required end pose = in the middle of the lane change
   const auto mid_lane_change_length = path.length.lane_changing / 2;
-  const auto & shifted_path = path.shifted_path.path;
   turn_signal_info.required_end_point = get_blinker_pose(shifted_path, mid_lane_change_length);
 
   status_.lane_change_path.turn_signal_info = turn_signal_info;


### PR DESCRIPTION
## Description
Add a new parameter for tuning the position of the end of the turn signal of the lane change.

[autoware launch PR](https://github.com/autowarefoundation/autoware_launch/pull/398)
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

PSim 
[Screencast from 2023年06月15日 15時57分03秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/43805014/654fb722-023e-4265-9818-ef56b04ff6da)



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
