### PR TITLE
fix(lane_change): dont cut centerline but insert stop

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
+set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
+set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
 
 set(common_src
   src/steering_factor_interface.cpp

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -125,7 +125,7 @@ public:
 
   virtual void updateSpecialData() {}
 
-  virtual void insertStopPoint([[maybe_unused]]PathWithLaneId & path){};
+  virtual void insertStopPoint([[maybe_unused]] PathWithLaneId & path){};
 
   const LaneChangeStatus & getLaneChangeStatus() const { return status_; }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -125,7 +125,7 @@ public:
 
   virtual void updateSpecialData() {}
 
-  virtual void insertStopPoint([[maybe_unused]] PathWithLaneId & path){}
+  virtual void insertStopPoint([[maybe_unused]] PathWithLaneId & path) {}
 
   const LaneChangeStatus & getLaneChangeStatus() const { return status_; }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -125,7 +125,7 @@ public:
 
   virtual void updateSpecialData() {}
 
-  virtual void insertStopPoint([[maybe_unused]] PathWithLaneId & path){};
+  virtual void insertStopPoint([[maybe_unused]] PathWithLaneId & path){}
 
   const LaneChangeStatus & getLaneChangeStatus() const { return status_; }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -125,6 +125,8 @@ public:
 
   virtual void updateSpecialData() {}
 
+  virtual void insertStopPoint([[maybe_unused]]PathWithLaneId & path){};
+
   const LaneChangeStatus & getLaneChangeStatus() const { return status_; }
 
   const LaneChangePaths & getDebugValidPath() const { return debug_valid_path_; }

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -55,6 +55,8 @@ public:
 
   void extendOutputDrivableArea(BehaviorModuleOutput & output) override;
 
+  void insertStopPoint(PathWithLaneId & path) override;
+
   PathWithLaneId getReferencePath() const override;
 
   std::optional<PathWithLaneId> extendPath() override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -336,7 +336,7 @@ PathWithLaneId getCenterLinePathFromRootLanelet(
 PathWithLaneId getCenterLinePath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & lanelet_sequence,
   const Pose & pose, const double backward_path_length, const double forward_path_length,
-  const BehaviorPathPlannerParameters & parameter, const double optional_length = 0.0);
+  const BehaviorPathPlannerParameters & parameter);
 
 PathWithLaneId setDecelerationVelocity(
   const RouteHandler & route_handler, const PathWithLaneId & input,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -244,9 +244,6 @@ BehaviorModuleOutput LaneChangeInterface::planWaitingApproval()
   *prev_approved_path_ = *getPreviousModuleOutput().path;
   module_type_->insertStopPoint(*prev_approved_path_);
 
-  const auto candidate = planCandidate();
-  path_candidate_ = std::make_shared<PathWithLaneId>(candidate.path_candidate);
-
   BehaviorModuleOutput out;
   out.path = std::make_shared<PathWithLaneId>(*prev_approved_path_);
   out.reference_path = getPreviousModuleOutput().reference_path;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -242,9 +242,13 @@ BehaviorModuleOutput LaneChangeInterface::plan()
 BehaviorModuleOutput LaneChangeInterface::planWaitingApproval()
 {
   *prev_approved_path_ = *getPreviousModuleOutput().path;
+  module_type_->insertStopPoint(*prev_approved_path_);
+
+  const auto candidate = planCandidate();
+  path_candidate_ = std::make_shared<PathWithLaneId>(candidate.path_candidate);
 
   BehaviorModuleOutput out;
-  out.path = std::make_shared<PathWithLaneId>(*getPreviousModuleOutput().path);
+  out.path = std::make_shared<PathWithLaneId>(*prev_approved_path_);
   out.reference_path = getPreviousModuleOutput().reference_path;
   out.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
   out.drivable_area_info = getPreviousModuleOutput().drivable_area_info;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -158,7 +158,9 @@ void NormalLaneChange::insertStopPoint(PathWithLaneId & path)
     status_.lane_change_path.reference_lanelets.back());
   const double lane_change_buffer =
     utils::calcMinimumLaneChangeLength(getCommonParam(), shift_intervals, 0.0);
-  const auto stopping_distance = motion_utils::calcArcLength(path.points) - lane_change_buffer;
+  constexpr double stop_point_buffer{1.0};
+  const auto stopping_distance = std::max(
+    motion_utils::calcArcLength(path.points) - lane_change_buffer - stop_point_buffer, 0.0);
 
   const auto stop_point = utils::insertStopPoint(stopping_distance, path);
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -154,8 +154,8 @@ void NormalLaneChange::extendOutputDrivableArea(BehaviorModuleOutput & output)
 
 void NormalLaneChange::insertStopPoint(PathWithLaneId & path)
 {
-  const auto shift_intervals =
-    getRouteHandler()->getLateralIntervalsToPreferredLane(status_.lane_change_path.reference_lanelets.back());
+  const auto shift_intervals = getRouteHandler()->getLateralIntervalsToPreferredLane(
+    status_.lane_change_path.reference_lanelets.back());
   const double lane_change_buffer =
     utils::calcMinimumLaneChangeLength(getCommonParam(), shift_intervals, 0.0);
   const auto stopping_distance = motion_utils::calcArcLength(path.points) - lane_change_buffer;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -152,6 +152,17 @@ void NormalLaneChange::extendOutputDrivableArea(BehaviorModuleOutput & output)
     *output.path, expanded_lanes, false, common_parameters.vehicle_length, planner_data_);
 }
 
+void NormalLaneChange::insertStopPoint(PathWithLaneId & path)
+{
+  const auto shift_intervals =
+    getRouteHandler()->getLateralIntervalsToPreferredLane(status_.lane_change_path.reference_lanelets.back());
+  const double lane_change_buffer =
+    utils::calcMinimumLaneChangeLength(getCommonParam(), shift_intervals, 0.0);
+  const auto stopping_distance = motion_utils::calcArcLength(path.points) - lane_change_buffer;
+
+  const auto stop_point = utils::insertStopPoint(stopping_distance, path);
+}
+
 PathWithLaneId NormalLaneChange::getReferencePath() const
 {
   return utils::getCenterLinePathFromRootLanelet(status_.lane_change_lanes.front(), planner_data_);

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2388,7 +2388,7 @@ PathWithLaneId getCenterLinePathFromRootLanelet(
 PathWithLaneId getCenterLinePath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & lanelet_sequence,
   const Pose & pose, const double backward_path_length, const double forward_path_length,
-  const BehaviorPathPlannerParameters & parameter, const double optional_length)
+  const BehaviorPathPlannerParameters & parameter)
 {
   PathWithLaneId reference_path;
 
@@ -2401,27 +2401,20 @@ PathWithLaneId getCenterLinePath(
   const double s_backward = std::max(0., s - backward_path_length);
   double s_forward = s + forward_path_length;
 
-  const double lane_length = lanelet::utils::getLaneletLength2d(lanelet_sequence);
-  const auto shift_intervals =
-    route_handler.getLateralIntervalsToPreferredLane(lanelet_sequence.back());
-  const double lane_change_buffer =
-    utils::calcMinimumLaneChangeLength(parameter, shift_intervals, optional_length);
-
   if (route_handler.isDeadEndLanelet(lanelet_sequence.back())) {
-    const double forward_length = std::max(lane_length - lane_change_buffer, 0.0);
-    s_forward = std::min(s_forward, forward_length);
+    const double lane_length = lanelet::utils::getLaneletLength2d(lanelet_sequence);
+    s_forward = std::clamp(s_forward, 0.0, lane_length);
   }
 
   if (route_handler.isInGoalRouteSection(lanelet_sequence.back())) {
     const auto goal_arc_coordinates =
       lanelet::utils::getArcCoordinates(lanelet_sequence, route_handler.getGoalPose());
-    const double forward_length = std::max(goal_arc_coordinates.length - lane_change_buffer, 0.0);
-    s_forward = std::min(s_forward, forward_length);
+    s_forward = std::clamp(s_forward, 0.0, goal_arc_coordinates.length);
   }
 
   const auto raw_path_with_lane_id =
     route_handler.getCenterLinePath(lanelet_sequence, s_backward, s_forward, true);
-  const auto resampled_path_with_lane_id = motion_utils::resamplePath(
+  auto resampled_path_with_lane_id = motion_utils::resamplePath(
     raw_path_with_lane_id, parameter.input_path_interval, parameter.enable_akima_spline_first);
 
   // convert centerline, which we consider as CoG center,  to rear wheel center

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2529,12 +2529,14 @@ BehaviorModuleOutput getReferencePath(
   output.reference_path = std::make_shared<PathWithLaneId>(reference_path);
   output.drivable_area_info.drivable_lanes = drivable_lanes;
 
+#ifdef USE_OLD_ARCHITECTURE
   const auto shift_intervals =
     route_handler->getLateralIntervalsToPreferredLane(current_lanes_with_backward_margin.back());
   const double lane_change_buffer = utils::calcMinimumLaneChangeLength(p, shift_intervals, 0.0);
   const auto stopping_distance =
     motion_utils::calcArcLength(output.path->points) - lane_change_buffer;
   const auto stop_point = utils::insertStopPoint(stopping_distance, *output.path);
+#endif
 
   return output;
 }

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2529,6 +2529,13 @@ BehaviorModuleOutput getReferencePath(
   output.reference_path = std::make_shared<PathWithLaneId>(reference_path);
   output.drivable_area_info.drivable_lanes = drivable_lanes;
 
+  const auto shift_intervals =
+    route_handler->getLateralIntervalsToPreferredLane(current_lanes_with_backward_margin.back());
+  const double lane_change_buffer = utils::calcMinimumLaneChangeLength(p, shift_intervals, 0.0);
+  const auto stopping_distance =
+    motion_utils::calcArcLength(output.path->points) - lane_change_buffer;
+  const auto stop_point = utils::insertStopPoint(stopping_distance, *output.path);
+
   return output;
 }
 


### PR DESCRIPTION
## Description

During lane change, when path is not approved until the very end, the centerline is cut, so that ego vehicle stop. 

But now, instead of cut the centerline, we would like to add stop point.

### Before PR
![cap- 2023-06-21-12-37-03](https://github.com/autowarefoundation/autoware.universe/assets/93502286/1e2d6f2d-186c-432a-ac4e-12ae019e7a6e)

### After PR
![cap- 2023-06-21-13-01-36](https://github.com/autowarefoundation/autoware.universe/assets/93502286/ea35efd8-2b29-4740-bf07-c12f6ceb467d)

## Related links

## Tests performed

PSIM

## Notes for reviewers

Note
1. Due to some not yet known issue regarding vehicle stopping in cut path case and insert stop point case, which affects lane change candidate path generation, in this PR, as a temporary solution, the stop point is hard coded with additional `1 meter` buffer.

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
