### PR TITLE
ci(pre-commit): add check-jsonschema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,12 @@ repos:
         args: [--quiet]
         exclude: .cu
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.23.2
+    hooks:
+      - id: check-metaschema
+        files: ^.+/schema/.*schema\.json$
+
   - repo: local
     hooks:
       - id: prettier-svg


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Use check-jsonschema from https://github.com/python-jsonschema/check-jsonschema to validate the JSON Schema files against their meta-schema. It is a CLI wrapper around the python library from https://github.com/python-jsonschema/jsonschema/

Relates to https://github.com/autowarefoundation/autoware-github-actions/issues/232

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Ran pre-commit locally on both a compliant and non-compliant .json schema file (currently only a single file under perception/lidar_apollo_segmentation_tvm_nodes/schema/lidar_apollo_segmentation_tvm_nodes.schema.json).

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Fails pre-commit if a schema file does not respect its meta-schema format.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
