### PR TITLE
fix(avoidance): don't clear waiting approval if raw shift line exists

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2685,7 +2685,7 @@ BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
     [](const auto & o) { return !o.is_avoidable; });
 
   const auto candidate = planCandidate();
-  if (!avoidance_data_.safe_new_sl.empty()) {
+  if (!avoidance_data_.unapproved_raw_sl.empty()) {
     updateCandidateRTCStatus(candidate);
     waitApproval();
   } else if (all_unavoidable) {


### PR DESCRIPTION
## Description

Sometimes, `safe_new_sl` size will be zero even when the avoidance target object is exists since the module ignores shift line whose lateral offset is less than threshold.

In that situation, the avoidance module clears waiting approval, and avoidance module is registered as `approved_module_stack` in planner manager. But it is an unexpected behavior because the modue doesn't recieve any approval and inserts any shift lines.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/d92be9f1-063f-44db-90ad-61a560b4c586

In this PR, the avoidance module clears waiting approval only when there is no raw shift lines. (Basically, raw shift lines will be generated for all of the avoidance target.)


https://github.com/autowarefoundation/autoware.universe/assets/44889564/372b7ce1-a94b-4264-856a-533b93cf6e01


[[TIER IV INTERNAL LINK]](https://tier4.atlassian.net/browse/RT1-2780)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [ ] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/374f9b9d-fa38-5c39-9b5f-39062ac810be?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
