### PR TITLE
feat(intersection): timeout stuck vehicle stop in private area

### DIFF
--- a/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -19,6 +19,7 @@
         stuck_vehicle_vel_thr: 0.833 # 0.833m/s = 3.0km/h
         # enable_front_car_decel_prediction: false # By default this feature is disabled
         # assumed_front_car_decel: 1.0 # [m/ss] the expected deceleration of front car when front car as well as ego are turning
+        timeout_private_area: 3.0 # [s] cancel stuck vehicle stop in private area
 
       collision_detection:
         state_transit_margin_time: 1.0

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -69,6 +69,8 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   ip.stuck_vehicle.enable_front_car_decel_prediction =
     node.declare_parameter<bool>(ns + ".stuck_vehicle.enable_front_car_decel_prediction");
   */
+  ip.stuck_vehicle.timeout_private_area =
+    node.declare_parameter<double>(ns + ".stuck_vehicle.timeout_private_area");
 
   ip.collision_detection.state_transit_margin_time =
     node.declare_parameter<double>(ns + ".collision_detection.state_transit_margin_time");
@@ -132,8 +134,10 @@ void IntersectionModuleManager::launchNewModules(
 
     const auto associative_ids =
       planning_utils::getAssociativeIntersectionLanelets(ll, lanelet_map, routing_graph);
+    const std::string location = ll.attributeOr("location", "else");
+    const bool is_private_area = (location.compare("private") == 0);
     const auto new_module = std::make_shared<IntersectionModule>(
-      module_id, lane_id, planner_data_, intersection_param_, associative_ids,
+      module_id, lane_id, planner_data_, intersection_param_, associative_ids, is_private_area,
       enable_occlusion_detection, node_, logger_.get_child("intersection_module"), clock_);
     generateUUID(module_id);
     /* set RTC status as non_occluded status initially */

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -73,6 +73,7 @@ public:
         assumed_front_car_decel;  //! the expected deceleration of front car when front car as well
       bool enable_front_car_decel_prediction;  //! flag for using above feature
       */
+      double timeout_private_area;
     } stuck_vehicle;
     struct CollisionDetection
     {
@@ -168,8 +169,8 @@ public:
   IntersectionModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
     const PlannerParam & planner_param, const std::set<int> & associative_ids,
-    const bool enable_occlusion_detection, rclcpp::Node & node, const rclcpp::Logger logger,
-    const rclcpp::Clock::SharedPtr clock);
+    const bool is_private_area, const bool enable_occlusion_detection, rclcpp::Node & node,
+    const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
@@ -208,7 +209,10 @@ private:
   StateMachine collision_state_machine_;     //! for stable collision checking
   StateMachine before_creep_state_machine_;  //! for two phase stop
   // NOTE: uuid_ is base member
-  // for occlusion clearance decision
+
+  // for stuck vehicle detection
+  const bool is_private_area_;
+  StateMachine stuck_private_area_timeout_;
 
   // for RTC
   const UUID occlusion_uuid_;


### PR DESCRIPTION
## Description

If a stuck vehicle is detected in private intersection lane, cancel the stop decision after a specified period.

## Related links

parameter PR: https://github.com/autowarefoundation/autoware_launch/pull/406

https://tier4.atlassian.net/browse/RT1-2647

## Tests performed

In Psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
