### PR TITLE
fix(ndt_scan_matcher): set lifetime for MonteCarlo particles marker

### DIFF
--- a/localization/ndt_scan_matcher/src/debug.cpp
+++ b/localization/ndt_scan_matcher/src/debug.cpp
@@ -31,6 +31,7 @@ visualization_msgs::msg::MarkerArray make_debug_markers(
   marker.action = visualization_msgs::msg::Marker::ADD;
   marker.scale = scale;
   marker.id = i;
+  marker.lifetime = rclcpp::Duration::from_seconds(10.0); // 10.0 is the lifetime in seconds.
 
   marker.ns = "initial_pose_transform_probability_color_marker";
   marker.pose = particle.initial_pose;
@@ -60,9 +61,6 @@ visualization_msgs::msg::MarkerArray make_debug_markers(
   marker.ns = "result_pose_index_color_marker";
   marker.pose = particle.result_pose;
   marker.color = exchange_color_crc((1.0 * i) / 100);
-
-  marker.lifetime = rclcpp::Duration::from_seconds(10.0);  // 10.0 is the lifetime in seconds.
-
   marker_array.markers.push_back(marker);
 
   return marker_array;

--- a/localization/ndt_scan_matcher/src/debug.cpp
+++ b/localization/ndt_scan_matcher/src/debug.cpp
@@ -60,6 +60,9 @@ visualization_msgs::msg::MarkerArray make_debug_markers(
   marker.ns = "result_pose_index_color_marker";
   marker.pose = particle.result_pose;
   marker.color = exchange_color_crc((1.0 * i) / 100);
+
+  marker.lifetime = rclcpp::Duration::from_seconds(10.0); // 10.0 is the lifetime in seconds.
+
   marker_array.markers.push_back(marker);
 
   return marker_array;

--- a/localization/ndt_scan_matcher/src/debug.cpp
+++ b/localization/ndt_scan_matcher/src/debug.cpp
@@ -61,7 +61,7 @@ visualization_msgs::msg::MarkerArray make_debug_markers(
   marker.pose = particle.result_pose;
   marker.color = exchange_color_crc((1.0 * i) / 100);
 
-  marker.lifetime = rclcpp::Duration::from_seconds(10.0); // 10.0 is the lifetime in seconds.
+  marker.lifetime = rclcpp::Duration::from_seconds(10.0);  // 10.0 is the lifetime in seconds.
 
   marker_array.markers.push_back(marker);
 

--- a/localization/ndt_scan_matcher/src/debug.cpp
+++ b/localization/ndt_scan_matcher/src/debug.cpp
@@ -31,7 +31,7 @@ visualization_msgs::msg::MarkerArray make_debug_markers(
   marker.action = visualization_msgs::msg::Marker::ADD;
   marker.scale = scale;
   marker.id = i;
-  marker.lifetime = rclcpp::Duration::from_seconds(10.0); // 10.0 is the lifetime in seconds.
+  marker.lifetime = rclcpp::Duration::from_seconds(10.0);  // 10.0 is the lifetime in seconds.
 
   marker.ns = "initial_pose_transform_probability_color_marker";
   marker.pose = particle.initial_pose;


### PR DESCRIPTION
## Description
Set lifetime for MonteCarlo particles marker in ndt_scan_matcher so that it won't last so long.
<!-- Write a brief description of this PR. -->

## Related links
N/A
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
N/A
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
N/A
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
None
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
None
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
