### PR TITLE
fix(behavior_path_planner): skip unnecessary process in updateDate() when module_status is not RUNNING

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -198,7 +198,7 @@ void SideShiftModule::updateData()
   }
 #endif
 
-  if (!current_state_ == ModuleStatus::RUNNING) {
+  if (current_state_ != ModuleStatus::RUNNING) {
     return;
   }
 

--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -186,6 +186,11 @@ ModuleStatus SideShiftModule::updateState()
 
 void SideShiftModule::updateData()
 {
+  // when side shift is not requested, don't update data.
+  if (!lateral_offset_change_request_) {
+    return;
+  }
+
   // special for avoidance: take behind distance upt ot shift-start-point if it exist.
   const auto longest_dist_to_shift_line = [&]() {
     double max_dist = 0.0;


### PR DESCRIPTION
## Description

skip unnecessary process in updateDate() when module_status is not RUNNING.
But `requested_lateral_offset_` should be updated to judge whether execution is excecuted.
So the part of retriving `requested_lateral_offset_` is kept.

<!-- Write a brief description of this PR. -->
confirmed with psim
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
