### PR TITLE
feat(behavior_path_planner): disable behavior turn signal before the intersection

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -191,7 +191,7 @@ boost::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo
 
     const std::string lane_attribute = lane.attributeOr("turn_direction", std::string("none"));
     if (
-      (lane_attribute == "right" || lane_attribute == "left") &&
+      (lane_attribute == "right" || lane_attribute == "left" || lane_attribute == "straight") &&
       dist_to_front_point < search_distance) {
       // update map if necessary
       if (desired_start_point_map_.find(lane_id) == desired_start_point_map_.end()) {


### PR DESCRIPTION
## Description
Disable the turn signal from the each behavior module when the ego vehicle is right in front of the intersection.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

PSim

[Screencast from 2023年06月22日 12時34分44秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/43805014/dad5b299-8a94-48a8-bd9e-ce8af506f745)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No effects on the system.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
