### PR TITLE
fix(fault_injection_node): fix history_depth in subscriber qos

### DIFF
--- a/simulator/fault_injection/src/fault_injection_node/fault_injection_node.cpp
+++ b/simulator/fault_injection/src/fault_injection_node/fault_injection_node.cpp
@@ -55,7 +55,7 @@ FaultInjectionNode::FaultInjectionNode(rclcpp::NodeOptions node_options)
 
   // Subscriber
   sub_simulation_events_ = this->create_subscription<SimulationEvents>(
-    "~/input/simulation_events", rclcpp::QoS{1},
+    "~/input/simulation_events", rclcpp::QoS{rclcpp::KeepLast(10)},
     std::bind(&FaultInjectionNode::onSimulationEvents, this, _1));
 
   // Load all config


### PR DESCRIPTION
## Description

The changes concern the increase of the `history_depth` value from 1 to 10 in the `QoS` set in the subscriber in `fault_injection_node`.
This fix is necessary for a situation where there are many messages published from another node almost at the same time - the queue depth must be greater so that all messages can be processed by the `fault_injection_node`.

## Tests performed

Local tests with scenarios publishing several (2-3) messages at the same time to node `fault_injection_node`

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
