### PR TITLE
fix(points_preprocessor): single input topic should be first element

### DIFF
--- a/sensing/pointcloud_preprocessor/launch/preprocessor.launch.py
+++ b/sensing/pointcloud_preprocessor/launch/preprocessor.launch.py
@@ -66,7 +66,9 @@ def generate_launch_description():
                     [
                         "'points_raw/concatenated' if len(",
                         LaunchConfiguration("input_points_raw_list"),
-                        ") > 1 else 'input_points_raw0'",
+                        ") > 1 else ",
+                        LaunchConfiguration("input_points_raw_list"),
+                        "[0]",
                     ]
                 ),
             ),


### PR DESCRIPTION
## Description

Fix bug where a single topic input was unused

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Ran the following snippet:

```xml
    <include file="$(find-pkg-share pointcloud_preprocessor)/launch/preprocessor.launch.xml" >
        <arg name="input_points_raw_list" value="['/top_lidar/pointcloud']" />
    </include>
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

It subscribed to `/top_lidar/pointcloud` instead of `/input_points_raw0`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
