### PR TITLE
feat(behavior_path_planner): use new framework

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
+set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
 
 set(common_src
   src/steering_factor_interface.cpp


### PR DESCRIPTION
## Description

We TIER IV would like to develop new sub-module manager without BehaviorTree.
https://github.com/orgs/autowarefoundation/discussions/3097

Now, we confirmed that basically the new manager can be avhieve all of the scenarios in awf and TIER IV internal.
Therefore, I would like to transit the default manager from old one to new one.

And, the new manager design is [here](https://autowarefoundation.github.io/autoware.universe/main/planning/behavior_path_planner/docs/behavior_path_planner_manager_design/).

<!-- Write a brief description of this PR. -->

## Related links

- https://github.com/orgs/autowarefoundation/discussions/3097
- https://github.com/orgs/autowarefoundation/discussions/3600
- https://autowarefoundation.github.io/autoware.universe/main/planning/behavior_path_planner/docs/behavior_path_planner_manager_design/

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

- [x] [TIER IV INTERNAL SCENARIOS WITH NEW MANAGER](https://evaluation.tier4.jp/evaluation/reports/6933b130-644a-547f-bb18-7b8d037aeb1b?project_id=prd_jt) (1360/1372)
- [x] [TIER IV INTERNAL SCENARIOS BASE LINE](https://evaluation.tier4.jp/evaluation/reports/212eece0-cbdf-5bdf-948b-974615b4fb7b?project_id=prd_jt)  (1327/1372)
- [x] [AWF SCENARIOS WITH NEW MANAGER](https://evaluation.tier4.jp/evaluation/reports/34104086-f211-53ee-b405-15c70d9b4352?project_id=awf) (132/138)
- [x] [AWF SCENARIOS BASE LINE](https://evaluation.tier4.jp/evaluation/reports/0650ccc2-c15b-590f-a3e5-d7baa6c68195?project_id=awf) (128/138)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
