### PR TITLE
fix(start_planner): fix winker near intersection

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -834,7 +834,8 @@ TurnSignalInfo StartPlannerModule::calcTurnSignalInfo() const
   const bool is_near_intersection = std::invoke([&]() {
     const double check_length = parameters_->intersection_search_length;
     double accumulated_length = 0.0;
-    for (size_t i = 0; i < path.points.size() - 1; ++i) {
+    const size_t current_idx = motion_utils::findNearestIndex(path.points, current_pose.position);
+    for (size_t i = current_idx; i < path.points.size() - 1; ++i) {
       const auto & p = path.points.at(i);
       for (const auto & lane : planner_data_->route_handler->getLaneletsFromIds(p.lane_ids)) {
         const std::string turn_direction = lane.attributeOr("turn_direction", "else");


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

fix https://github.com/autowarefoundation/autoware.universe/pull/4026

should calculate length from current pose to judge near intersection.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
