### PR TITLE
fix(behavior_path_planner): print avoidance and lane change debug mes…

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -234,10 +234,8 @@ private:
   /**
    * @brief publish debug messages
    */
-#ifdef USE_OLD_ARCHITECTURE
   void publishSceneModuleDebugMsg(
     const std::shared_ptr<SceneModuleVisitor> & debug_messages_data_ptr);
-#endif
 
   /**
    * @brief publish path candidate

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -17,6 +17,7 @@
 
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/scene_module/scene_module_manager_interface.hpp"
+#include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utils/lane_following/module_data.hpp"
 
 #include <lanelet2_extension/utility/utilities.hpp>
@@ -224,6 +225,11 @@ public:
    * @brief show planner manager internal condition.
    */
   void print() const;
+
+  /**
+   * @brief visit each module and get debug information.
+   */
+  std::shared_ptr<SceneModuleVisitor> getDebugMsg();
 
 private:
   /**
@@ -460,6 +466,8 @@ private:
   mutable std::unordered_map<std::string, double> processing_time_;
 
   mutable std::vector<ModuleUpdateInfo> debug_info_;
+
+  mutable std::shared_ptr<SceneModuleVisitor> debug_msg_ptr_;
 
   bool verbose_{false};
 };

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1295,6 +1295,7 @@ void BehaviorPathPlannerNode::run()
   publishPathCandidate(bt_manager_->getSceneModules(), planner_data_);
   publishSceneModuleDebugMsg(bt_manager_->getAllSceneModuleDebugMsgData());
 #else
+  publishSceneModuleDebugMsg(planner_manager_->getDebugMsg());
   publishPathCandidate(planner_manager_->getSceneModuleManagers(), planner_data_);
   publishPathReference(planner_manager_->getSceneModuleManagers(), planner_data_);
   stop_reason_publisher_->publish(planner_manager_->getStopReasons());
@@ -1416,7 +1417,6 @@ void BehaviorPathPlannerNode::publish_bounds(const PathWithLaneId & path)
   bound_publisher_->publish(msg);
 }
 
-#ifdef USE_OLD_ARCHITECTURE
 void BehaviorPathPlannerNode::publishSceneModuleDebugMsg(
   const std::shared_ptr<SceneModuleVisitor> & debug_messages_data_ptr)
 {
@@ -1430,7 +1430,6 @@ void BehaviorPathPlannerNode::publishSceneModuleDebugMsg(
     debug_lane_change_msg_array_publisher_->publish(*lane_change_debug_message);
   }
 }
-#endif
 
 #ifdef USE_OLD_ARCHITECTURE
 void BehaviorPathPlannerNode::publishPathCandidate(

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -718,4 +718,17 @@ void PlannerManager::print() const
   RCLCPP_INFO_STREAM(logger_, string_stream.str());
 }
 
+std::shared_ptr<SceneModuleVisitor> PlannerManager::getDebugMsg()
+{
+  debug_msg_ptr_ = std::make_shared<SceneModuleVisitor>();
+  for (const auto & approved_module : approved_module_ptrs_) {
+    approved_module->acceptVisitor(debug_msg_ptr_);
+  }
+
+  for (const auto & candidate_module : candidate_module_ptrs_) {
+    candidate_module->acceptVisitor(debug_msg_ptr_);
+  }
+  return debug_msg_ptr_;
+}
+
 }  // namespace behavior_path_planner


### PR DESCRIPTION
## Description

Fix avoidance and lane change debug message not printing 

## Tests performed
![Screenshot from 2023-06-23 14-26-21](https://github.com/autowarefoundation/autoware.universe/assets/93502286/a2d58630-0cd9-49b1-9e01-ca91feba2250)

Check via PSIM.

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
