### PR TITLE
feat(behavior_path_planner): add turn signal debug marker

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -230,7 +230,7 @@ private:
   /**
    * @brief publish turn signal debug info
    */
-  void publish_turn_signal_debug_data(const TurnSignalDebugData& debug_data);
+  void publish_turn_signal_debug_data(const TurnSignalDebugData & debug_data);
 
   /**
    * @brief publish left and right bound

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -219,12 +219,18 @@ private:
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_maximum_drivable_area_publisher_;
   rclcpp::Publisher<AvoidanceDebugMsgArray>::SharedPtr debug_avoidance_msg_array_publisher_;
   rclcpp::Publisher<LaneChangeDebugMsgArray>::SharedPtr debug_lane_change_msg_array_publisher_;
+  rclcpp::Publisher<MarkerArray>::SharedPtr debug_turn_signal_info_publisher_;
 
   /**
    * @brief publish steering factor from intersection
    */
   void publish_steering_factor(
     const std::shared_ptr<PlannerData> & planner_data, const TurnIndicatorsCommand & turn_signal);
+
+  /**
+   * @brief publish turn signal debug info
+   */
+  void publish_turn_signal_debug_data(const TurnSignalDebugData& debug_data);
 
   /**
    * @brief publish left and right bound

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -150,12 +150,12 @@ struct PlannerData
   mutable TurnSignalDecider turn_signal_decider;
 
   TurnIndicatorsCommand getTurnSignal(
-    const PathWithLaneId & path, const TurnSignalInfo & turn_signal_info)
+    const PathWithLaneId & path, const TurnSignalInfo & turn_signal_info, TurnSignalDebugData & debug_data)
   {
     const auto & current_pose = self_odometry->pose.pose;
     const auto & current_vel = self_odometry->twist.twist.linear.x;
     return turn_signal_decider.getTurnSignal(
-      route_handler, path, turn_signal_info, current_pose, current_vel, parameters);
+      route_handler, path, turn_signal_info, current_pose, current_vel, parameters, debug_data);
   }
 
   template <class T>

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -150,7 +150,8 @@ struct PlannerData
   mutable TurnSignalDecider turn_signal_decider;
 
   TurnIndicatorsCommand getTurnSignal(
-    const PathWithLaneId & path, const TurnSignalInfo & turn_signal_info, TurnSignalDebugData & debug_data)
+    const PathWithLaneId & path, const TurnSignalInfo & turn_signal_info,
+    TurnSignalDebugData & debug_data)
   {
     const auto & current_pose = self_odometry->pose.pose;
     const auto & current_vel = self_odometry->twist.twist.linear.x;

--- a/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
@@ -63,13 +63,19 @@ struct TurnSignalInfo
   geometry_msgs::msg::Pose required_end_point;
 };
 
+struct TurnSignalDebugData
+{
+  TurnSignalInfo intersection_turn_signal_info;
+  TurnSignalInfo behavior_turn_signal_info;
+};
+
 class TurnSignalDecider
 {
 public:
   TurnIndicatorsCommand getTurnSignal(
     const std::shared_ptr<RouteHandler> & route_handler, const PathWithLaneId & path,
     const TurnSignalInfo & turn_signal_info, const Pose & current_pose, const double current_vel,
-    const BehaviorPathPlannerParameters & parameters);
+    const BehaviorPathPlannerParameters & parameters, TurnSignalDebugData & debug_data);
 
   TurnIndicatorsCommand resolve_turn_signal(
     const PathWithLaneId & path, const Pose & current_pose, const size_t current_seg_idx,

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1387,7 +1387,7 @@ void BehaviorPathPlannerNode::publish_steering_factor(
   steering_factor_interface_ptr_->publishSteeringFactor(get_clock()->now());
 }
 
-void BehaviorPathPlannerNode::publish_turn_signal_debug_data(const TurnSignalDebugData& debug_data)
+void BehaviorPathPlannerNode::publish_turn_signal_debug_data(const TurnSignalDebugData & debug_data)
 {
   MarkerArray marker_array;
 
@@ -1404,20 +1404,20 @@ void BehaviorPathPlannerNode::publish_turn_signal_debug_data(const TurnSignalDeb
     const auto & turn_signal_info = debug_data.intersection_turn_signal_info;
 
     auto desired_start_marker = tier4_autoware_utils::createDefaultMarker(
-    "map", current_time, "intersection_turn_signal_desired_start", 0L, Marker::SPHERE,
-    scale, desired_section_color);
+      "map", current_time, "intersection_turn_signal_desired_start", 0L, Marker::SPHERE, scale,
+      desired_section_color);
     auto desired_end_marker = tier4_autoware_utils::createDefaultMarker(
-    "map", current_time, "intersection_turn_signal_desired_end", 0L, Marker::SPHERE,
-    scale, desired_section_color);
+      "map", current_time, "intersection_turn_signal_desired_end", 0L, Marker::SPHERE, scale,
+      desired_section_color);
     desired_start_marker.pose = turn_signal_info.desired_start_point;
     desired_end_marker.pose = turn_signal_info.desired_end_point;
 
     auto required_start_marker = tier4_autoware_utils::createDefaultMarker(
-    "map", current_time, "intersection_turn_signal_required_start", 0L, Marker::SPHERE,
-    scale, required_section_color);
+      "map", current_time, "intersection_turn_signal_required_start", 0L, Marker::SPHERE, scale,
+      required_section_color);
     auto required_end_marker = tier4_autoware_utils::createDefaultMarker(
-    "map", current_time, "intersection_turn_signal_required_end", 0L, Marker::SPHERE,
-    scale, required_section_color);
+      "map", current_time, "intersection_turn_signal_required_end", 0L, Marker::SPHERE, scale,
+      required_section_color);
     required_start_marker.pose = turn_signal_info.required_start_point;
     required_end_marker.pose = turn_signal_info.required_end_point;
 
@@ -1432,20 +1432,20 @@ void BehaviorPathPlannerNode::publish_turn_signal_debug_data(const TurnSignalDeb
     const auto & turn_signal_info = debug_data.behavior_turn_signal_info;
 
     auto desired_start_marker = tier4_autoware_utils::createDefaultMarker(
-    "map", current_time, "behavior_turn_signal_desired_start", 0L, Marker::CUBE,
-    scale, desired_section_color);
+      "map", current_time, "behavior_turn_signal_desired_start", 0L, Marker::CUBE, scale,
+      desired_section_color);
     auto desired_end_marker = tier4_autoware_utils::createDefaultMarker(
-    "map", current_time, "behavior_turn_signal_desired_end", 0L, Marker::CUBE,
-    scale, desired_section_color);
+      "map", current_time, "behavior_turn_signal_desired_end", 0L, Marker::CUBE, scale,
+      desired_section_color);
     desired_start_marker.pose = turn_signal_info.desired_start_point;
     desired_end_marker.pose = turn_signal_info.desired_end_point;
 
     auto required_start_marker = tier4_autoware_utils::createDefaultMarker(
-    "map", current_time, "behavior_turn_signal_required_start", 0L, Marker::CUBE,
-    scale, required_section_color);
+      "map", current_time, "behavior_turn_signal_required_start", 0L, Marker::CUBE, scale,
+      required_section_color);
     auto required_end_marker = tier4_autoware_utils::createDefaultMarker(
-    "map", current_time, "behavior_turn_signal_required_end", 0L, Marker::CUBE,
-    scale, required_section_color);
+      "map", current_time, "behavior_turn_signal_required_end", 0L, Marker::CUBE, scale,
+      required_section_color);
     required_start_marker.pose = turn_signal_info.required_start_point;
     required_end_marker.pose = turn_signal_info.required_end_point;
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -78,6 +78,8 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
       create_publisher<MarkerArray>("~/maximum_drivable_area", 1);
   }
 
+  debug_turn_signal_info_publisher_ = create_publisher<MarkerArray>("~/debug/turn_signal_info", 1);
+
   bound_publisher_ = create_publisher<MarkerArray>("~/debug/bound", 1);
 
   // subscriber
@@ -1336,12 +1338,13 @@ void BehaviorPathPlannerNode::computeTurnSignal(
   const BehaviorModuleOutput & output)
 {
   TurnIndicatorsCommand turn_signal;
+  TurnSignalDebugData debug_data;
   HazardLightsCommand hazard_signal;
   if (output.turn_signal_info.hazard_signal.command == HazardLightsCommand::ENABLE) {
     turn_signal.command = TurnIndicatorsCommand::DISABLE;
     hazard_signal.command = output.turn_signal_info.hazard_signal.command;
   } else {
-    turn_signal = planner_data->getTurnSignal(path, output.turn_signal_info);
+    turn_signal = planner_data->getTurnSignal(path, output.turn_signal_info, debug_data);
     hazard_signal.command = HazardLightsCommand::DISABLE;
   }
   turn_signal.stamp = get_clock()->now();
@@ -1349,6 +1352,7 @@ void BehaviorPathPlannerNode::computeTurnSignal(
   turn_signal_publisher_->publish(turn_signal);
   hazard_signal_publisher_->publish(hazard_signal);
 
+  publish_turn_signal_debug_data(debug_data);
   publish_steering_factor(planner_data, turn_signal);
 }
 
@@ -1381,6 +1385,77 @@ void BehaviorPathPlannerNode::publish_steering_factor(
     steering_factor_interface_ptr_->clearSteeringFactors();
   }
   steering_factor_interface_ptr_->publishSteeringFactor(get_clock()->now());
+}
+
+void BehaviorPathPlannerNode::publish_turn_signal_debug_data(const TurnSignalDebugData& debug_data)
+{
+  MarkerArray marker_array;
+
+  const auto current_time = rclcpp::Time();
+  constexpr double scale_x = 1.0;
+  constexpr double scale_y = 1.0;
+  constexpr double scale_z = 1.0;
+  const auto scale = tier4_autoware_utils::createMarkerScale(scale_x, scale_y, scale_z);
+  const auto desired_section_color = tier4_autoware_utils::createMarkerColor(0.0, 1.0, 0.0, 0.999);
+  const auto required_section_color = tier4_autoware_utils::createMarkerColor(1.0, 0.0, 1.0, 0.999);
+
+  // intersection turn signal info
+  {
+    const auto & turn_signal_info = debug_data.intersection_turn_signal_info;
+
+    auto desired_start_marker = tier4_autoware_utils::createDefaultMarker(
+    "map", current_time, "intersection_turn_signal_desired_start", 0L, Marker::SPHERE,
+    scale, desired_section_color);
+    auto desired_end_marker = tier4_autoware_utils::createDefaultMarker(
+    "map", current_time, "intersection_turn_signal_desired_end", 0L, Marker::SPHERE,
+    scale, desired_section_color);
+    desired_start_marker.pose = turn_signal_info.desired_start_point;
+    desired_end_marker.pose = turn_signal_info.desired_end_point;
+
+    auto required_start_marker = tier4_autoware_utils::createDefaultMarker(
+    "map", current_time, "intersection_turn_signal_required_start", 0L, Marker::SPHERE,
+    scale, required_section_color);
+    auto required_end_marker = tier4_autoware_utils::createDefaultMarker(
+    "map", current_time, "intersection_turn_signal_required_end", 0L, Marker::SPHERE,
+    scale, required_section_color);
+    required_start_marker.pose = turn_signal_info.required_start_point;
+    required_end_marker.pose = turn_signal_info.required_end_point;
+
+    marker_array.markers.push_back(desired_start_marker);
+    marker_array.markers.push_back(desired_end_marker);
+    marker_array.markers.push_back(required_start_marker);
+    marker_array.markers.push_back(required_end_marker);
+  }
+
+  // behavior turn signal info
+  {
+    const auto & turn_signal_info = debug_data.behavior_turn_signal_info;
+
+    auto desired_start_marker = tier4_autoware_utils::createDefaultMarker(
+    "map", current_time, "behavior_turn_signal_desired_start", 0L, Marker::CUBE,
+    scale, desired_section_color);
+    auto desired_end_marker = tier4_autoware_utils::createDefaultMarker(
+    "map", current_time, "behavior_turn_signal_desired_end", 0L, Marker::CUBE,
+    scale, desired_section_color);
+    desired_start_marker.pose = turn_signal_info.desired_start_point;
+    desired_end_marker.pose = turn_signal_info.desired_end_point;
+
+    auto required_start_marker = tier4_autoware_utils::createDefaultMarker(
+    "map", current_time, "behavior_turn_signal_required_start", 0L, Marker::CUBE,
+    scale, required_section_color);
+    auto required_end_marker = tier4_autoware_utils::createDefaultMarker(
+    "map", current_time, "behavior_turn_signal_required_end", 0L, Marker::CUBE,
+    scale, required_section_color);
+    required_start_marker.pose = turn_signal_info.required_start_point;
+    required_end_marker.pose = turn_signal_info.required_end_point;
+
+    marker_array.markers.push_back(desired_start_marker);
+    marker_array.markers.push_back(desired_end_marker);
+    marker_array.markers.push_back(required_start_marker);
+    marker_array.markers.push_back(required_end_marker);
+  }
+
+  debug_turn_signal_info_publisher_->publish(marker_array);
 }
 
 void BehaviorPathPlannerNode::publish_bounds(const PathWithLaneId & path)

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -78,7 +78,7 @@ TurnIndicatorsCommand TurnSignalDecider::getTurnSignal(
     extended_path, current_pose, current_vel, ego_seg_idx, *route_handler, nearest_dist_threshold,
     nearest_yaw_threshold);
 
-  if(intersection_turn_signal_info) {
+  if (intersection_turn_signal_info) {
     debug_data.intersection_turn_signal_info = *intersection_turn_signal_info;
   }
 

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -41,8 +41,10 @@ double calc_distance(
 TurnIndicatorsCommand TurnSignalDecider::getTurnSignal(
   const std::shared_ptr<RouteHandler> & route_handler, const PathWithLaneId & path,
   const TurnSignalInfo & turn_signal_info, const Pose & current_pose, const double current_vel,
-  const BehaviorPathPlannerParameters & parameters)
+  const BehaviorPathPlannerParameters & parameters, TurnSignalDebugData & debug_data)
 {
+  debug_data.behavior_turn_signal_info = turn_signal_info;
+
   // Guard
   if (path.points.empty()) {
     return turn_signal_info.turn_signal;
@@ -75,6 +77,10 @@ TurnIndicatorsCommand TurnSignalDecider::getTurnSignal(
   const auto intersection_turn_signal_info = getIntersectionTurnSignalInfo(
     extended_path, current_pose, current_vel, ego_seg_idx, *route_handler, nearest_dist_threshold,
     nearest_yaw_threshold);
+
+  if(intersection_turn_signal_info) {
+    debug_data.intersection_turn_signal_info = *intersection_turn_signal_info;
+  }
 
   if (!intersection_turn_signal_info) {
     initialize_intersection_info();


### PR DESCRIPTION
## Description
Add turn signal info debug data publisher.

![image](https://github.com/autowarefoundation/autoware.universe/assets/43805014/656a4394-8bf3-483e-977e-3fb5e6762137)

![image](https://github.com/autowarefoundation/autoware.universe/assets/43805014/70def101-72ac-4904-8bf8-172a6bcbaa3c)


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
