### PR TITLE
build: fix missing header (release/2023.06)

### DIFF
--- a/planning/behavior_velocity_blind_spot_module/src/scene.hpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.hpp
@@ -18,6 +18,7 @@
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <behavior_velocity_planner_common/utilization/state_machine.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_object.hpp>
@@ -29,8 +30,6 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 #include <memory>
 #include <string>

--- a/planning/behavior_velocity_blind_spot_module/src/scene.hpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.hpp
@@ -30,6 +30,8 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -20,6 +20,7 @@
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
@@ -38,8 +39,6 @@
 #include <pcl/common/distances.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 #include <memory>
 #include <string>

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -39,6 +39,8 @@
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/planning/behavior_velocity_crosswalk_module/src/scene_walkway.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_walkway.hpp
@@ -29,6 +29,8 @@
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <memory>
 #include <utility>
 #include <vector>

--- a/planning/behavior_velocity_crosswalk_module/src/scene_walkway.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_walkway.hpp
@@ -20,6 +20,7 @@
 
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <lanelet2_extension/utility/query.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
@@ -28,8 +29,6 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 #include <memory>
 #include <utility>

--- a/planning/behavior_velocity_detection_area_module/src/scene.hpp
+++ b/planning/behavior_velocity_detection_area_module/src/scene.hpp
@@ -31,6 +31,8 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <tf2/LinearMath/Transform.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 namespace behavior_velocity_planner
 {
 using PathIndexWithPose = std::pair<size_t, geometry_msgs::msg::Pose>;  // front index, pose

--- a/planning/behavior_velocity_detection_area_module/src/scene.hpp
+++ b/planning/behavior_velocity_detection_area_module/src/scene.hpp
@@ -26,12 +26,11 @@
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <lanelet2_extension/regulatory_elements/detection_area.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <tf2/LinearMath/Transform.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 namespace behavior_velocity_planner
 {

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -21,6 +21,7 @@
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <behavior_velocity_planner_common/utilization/state_machine.hpp>
 #include <grid_map_core/grid_map_core.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <motion_utils/motion_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
@@ -33,8 +34,6 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 #include <algorithm>
 #include <memory>

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -34,6 +34,8 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <algorithm>
 #include <memory>
 #include <set>

--- a/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
@@ -31,6 +31,8 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <memory>
 #include <set>
 #include <string>

--- a/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
@@ -20,6 +20,7 @@
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <behavior_velocity_planner_common/utilization/state_machine.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
@@ -30,8 +31,6 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 #include <memory>
 #include <set>

--- a/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
@@ -22,6 +22,7 @@
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <behavior_velocity_planner_common/utilization/state_machine.hpp>
 #include <lanelet2_extension/regulatory_elements/no_stopping_area.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_perception_msgs/msg/object_classification.hpp>
@@ -33,8 +34,6 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <tf2/LinearMath/Transform.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 #include <memory>
 #include <utility>

--- a/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
@@ -34,6 +34,8 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <tf2/LinearMath/Transform.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <memory>
 #include <utility>
 #include <vector>

--- a/planning/behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.hpp
@@ -19,6 +19,7 @@
 
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
@@ -32,8 +33,6 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 #include <memory>
 #include <string>

--- a/planning/behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.hpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.hpp
@@ -33,6 +33,8 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.hpp
@@ -18,14 +18,13 @@
 #include "types.hpp"
 
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 #include <memory>
 #include <string>

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.hpp
@@ -25,6 +25,8 @@
 
 #include <lanelet2_core/LaneletMap.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>

--- a/planning/behavior_velocity_run_out_module/src/debug.hpp
+++ b/planning/behavior_velocity_run_out_module/src/debug.hpp
@@ -18,6 +18,8 @@
 
 #include <motion_utils/marker/virtual_wall_marker_creator.hpp>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>

--- a/planning/behavior_velocity_run_out_module/src/debug.hpp
+++ b/planning/behavior_velocity_run_out_module/src/debug.hpp
@@ -16,9 +16,8 @@
 
 #include "utils.hpp"
 
-#include <motion_utils/marker/virtual_wall_marker_creator.hpp>
-
 #include <motion_utils/marker/marker_helper.hpp>
+#include <motion_utils/marker/virtual_wall_marker_creator.hpp>
 
 #include <memory>
 #include <string>

--- a/planning/behavior_velocity_stop_line_module/src/scene.hpp
+++ b/planning/behavior_velocity_stop_line_module/src/scene.hpp
@@ -33,6 +33,8 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 namespace behavior_velocity_planner
 {
 class StopLineModule : public SceneModuleInterface

--- a/planning/behavior_velocity_stop_line_module/src/scene.hpp
+++ b/planning/behavior_velocity_stop_line_module/src/scene.hpp
@@ -28,12 +28,11 @@
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <behavior_velocity_planner_common/utilization/util.hpp>
 #include <lanelet2_extension/utility/query.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 namespace behavior_velocity_planner
 {

--- a/planning/behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -27,6 +27,8 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
+#include <motion_utils/marker/marker_helper.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>

--- a/planning/behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -18,6 +18,7 @@
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <lanelet2_extension/regulatory_elements/virtual_traffic_light.hpp>
 #include <lanelet2_extension/utility/query.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
 #include <nlohmann/json.hpp>
 #include <rclcpp/clock.hpp>
 #include <rclcpp/logger.hpp>
@@ -26,8 +27,6 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
-
-#include <motion_utils/marker/marker_helper.hpp>
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

The `behavior_velocity_planner` package fails to build because it does not have all the headers declared.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
