### PR TITLE
chore(lane_change): add z-pos in debug marker

### DIFF
--- a/planning/behavior_path_planner/src/marker_util/lane_change/debug.cpp
+++ b/planning/behavior_path_planner/src/marker_util/lane_change/debug.cpp
@@ -185,11 +185,12 @@ MarkerArray showPolygon(
     }
     const auto & color = colors.at(idx);
     const auto & ego_polygon = info.ego_polygon.outer();
+    const auto poly_z = info.current_pose.position.z;  // temporally
     ego_marker.id = ++id;
     ego_marker.color = createMarkerColor(color[0], color[1], color[2], 0.8);
     ego_marker.points.reserve(ego_polygon.size());
     for (const auto & p : ego_polygon) {
-      ego_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), 0.0));
+      ego_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), poly_z));
     }
     marker_array.markers.push_back(ego_marker);
 
@@ -198,7 +199,7 @@ MarkerArray showPolygon(
     obj_marker.color = createMarkerColor(color[0], color[1], color[2], 0.8);
     obj_marker.points.reserve(obj_polygon.size());
     for (const auto & p : obj_polygon) {
-      obj_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), 0.0));
+      obj_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), poly_z));
     }
     marker_array.markers.push_back(obj_marker);
     ++idx;


### PR DESCRIPTION
## Description

Add z-pos in debug marker.

## Tests performed

Check in the Psim
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/09326deb-bfb2-4c67-977f-32c52ebbebf8)

Not applicable.

## Effects on system behavior

None
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
