### PR TITLE
fix(behavior_path_planner): fix invalid access in avoidance module

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3049,7 +3049,7 @@ TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) con
   }
 
   // compute blinker start idx and end idx
-  const size_t blinker_start_idx = [&]() {
+  size_t blinker_start_idx = [&]() {
     for (size_t idx = start_idx; idx <= end_idx; ++idx) {
       const double current_shift_length = path.shift_length.at(idx);
       if (current_shift_length > 0.1) {
@@ -3058,7 +3058,13 @@ TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) con
     }
     return start_idx;
   }();
-  const size_t blinker_end_idx = end_idx;
+  size_t blinker_end_idx = end_idx;
+
+  // prevent invalid access for out-of-range
+  blinker_start_idx =
+    std::min(std::max(std::size_t(0), blinker_start_idx), path.path.points.size() - 1);
+  blinker_end_idx =
+    std::min(std::max(blinker_start_idx, blinker_end_idx), path.path.points.size() - 1);
 
   const auto blinker_start_pose = path.path.points.at(blinker_start_idx).point.pose;
   const auto blinker_end_pose = path.path.points.at(blinker_end_idx).point.pose;


### PR DESCRIPTION
## Description
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/5c1b2c27-0ae6-4d8e-b89a-d69fb6b72e01)

When avoiding near the goal, the avoidance module occasionally dies with the following error when the path length changes
```
[component_container_mt-28] terminate called after throwing an instance of 'std::out_of_range'
[component_container_mt-28]   what():  vector::_M_range_check: __n (which is 209) >= this->size() (which is 86)
[ERROR] [component_container_mt-28]: process has died [pid 1028191, exit code -6, cmd '/opt/ros/humble/lib/rclcpp_components/component_container_mt --ros-args -r __node:=behavior_planning_container -r __ns:=/planning/scenario_planning/lane_driving/behavior_planning -p use_sim_time:=False -p wheel_radius:=0.31 -p wheel_width:=0.18 -p wheel_base:=2.75 -p wheel_tread:=1.485 -p front_overhang:=0.8 -p rear_overhang:=0.85 -p left_overhang:=0.105 -p right_overhang:=0.105 -p vehicle_height:=2.5 -p max_steer_angle:=0.65'].
```
This is because ```blinker_end_idx``` can be larger than the size of the path.
(In the case of the image above, the size of path was 158 and blinker_end_idx266 was 266.)

I fixed this  by forcing the blinker index to be less than the size of the path
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
