### PR TITLE
fix(behavior_velocity_intersection_module): fix condition of use_stuck_stopline

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -278,14 +278,14 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
   // (5) stuck vehicle stop line
   int stuck_stop_line_ip_int = 0;
   if (use_stuck_stopline) {
-    stuck_stop_line_ip_int = std::get<0>(lane_interval_ip);
-  } else {
     const auto stuck_stop_line_idx_ip_opt =
       getFirstPointInsidePolygon(path_ip, lane_interval_ip, first_conflicting_area);
     if (!stuck_stop_line_idx_ip_opt) {
       return std::nullopt;
     }
     stuck_stop_line_ip_int = stuck_stop_line_idx_ip_opt.value();
+  } else {
+    stuck_stop_line_ip_int = std::get<0>(lane_interval_ip);
   }
   const auto stuck_stop_line_ip = static_cast<size_t>(
     std::max(0, stuck_stop_line_ip_int - stop_line_margin_idx_dist - base2front_idx_dist));


### PR DESCRIPTION
## Description
The relationship between the parameter ```use_stuck_stopline``` and corresponding behavior of Autoware  was reversed. I fixed it.


<!-- Write a brief description of this PR. -->

## Tests performed

I confirmed that the position of the intersection stop_line changes for stuck vehicles when ```use_stuck_stopline``` is true
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/0fd6ce43-03e6-47bf-ab06-2b2b54fcf922)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
