### PR TITLE
refactor(avoidance): rename ununderstandable params

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -28,7 +28,7 @@
       # avoidance is performed for the object type with true
       target_object:
         car:
-          enable: true                                 # [-]
+          is_target: true                              # [-]
           moving_speed_threshold: 1.0                  # [m/s]
           moving_time_threshold: 1.0                   # [s]
           max_expand_ratio: 0.0                        # [-]
@@ -37,7 +37,7 @@
           safety_buffer_lateral: 0.7                   # [m]
           safety_buffer_longitudinal: 0.0              # [m]
         truck:
-          enable: true
+          is_target: true
           moving_speed_threshold: 1.0
           moving_time_threshold: 1.0
           max_expand_ratio: 0.0
@@ -46,7 +46,7 @@
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
         bus:
-          enable: true
+          is_target: true
           moving_speed_threshold: 1.0
           moving_time_threshold: 1.0
           max_expand_ratio: 0.0
@@ -55,7 +55,7 @@
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
         trailer:
-          enable: true
+          is_target: true
           moving_speed_threshold: 1.0
           moving_time_threshold: 1.0
           max_expand_ratio: 0.0
@@ -64,7 +64,7 @@
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
         unknown:
-          enable: false
+          is_target: false
           moving_speed_threshold: 1.0
           moving_time_threshold: 1.0
           max_expand_ratio: 0.0
@@ -73,7 +73,7 @@
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
         bicycle:
-          enable: false
+          is_target: false
           moving_speed_threshold: 1.0
           moving_time_threshold: 1.0
           max_expand_ratio: 0.0
@@ -82,7 +82,7 @@
           safety_buffer_lateral: 1.0
           safety_buffer_longitudinal: 1.0
         motorcycle:
-          enable: false
+          is_target: false
           moving_speed_threshold: 1.0
           moving_time_threshold: 1.0
           max_expand_ratio: 0.0
@@ -91,7 +91,7 @@
           safety_buffer_lateral: 1.0
           safety_buffer_longitudinal: 1.0
         pedestrian:
-          enable: false
+          is_target: false
           moving_speed_threshold: 1.0
           moving_time_threshold: 1.0
           max_expand_ratio: 0.0
@@ -104,12 +104,12 @@
 
       # For target object filtering
       target_filtering:
-        # filtering moving objects
-        threshold_time_force_avoidance_for_stopped_vehicle: 10.0 # [s]
+        # params for avoidance of not-parked objects
+        threshold_time_force_avoidance_for_stopped_vehicle: 10.0    # [s]
+        object_ignore_section_traffic_light_in_front_distance: 30.0 # [m]
+        object_ignore_section_crosswalk_in_front_distance: 30.0     # [m]
+        object_ignore_section_crosswalk_behind_distance: 30.0       # [m]
         # detection range
-        object_ignore_distance_traffic_light: 30.0      # [m]
-        object_ignore_distance_crosswalk_forward: 30.0  # [m]
-        object_ignore_distance_crosswalk_backward: 30.0 # [m]
         object_check_forward_distance: 150.0            # [m]
         object_check_backward_distance: 2.0             # [m]
         object_check_goal_distance: 20.0                # [m]

--- a/planning/behavior_path_planner/docs/behavior_path_planner_avoidance_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_avoidance_design.md
@@ -608,7 +608,7 @@ This module supports all object classes, and it can set following parameters ind
 
 ```yaml
 car:
-  enable: true # [-]
+  is_target: true # [-]
   moving_speed_threshold: 1.0 # [m/s]
   moving_time_threshold: 1.0 # [s]
   max_expand_ratio: 0.0 # [-]
@@ -618,15 +618,15 @@ car:
   safety_buffer_longitudinal: 0.0 # [m]
 ```
 
-| Name                       | Unit  | Type   | Description                                                                                                | Default value |
-| :------------------------- | ----- | ------ | ---------------------------------------------------------------------------------------------------------- | ------------- |
-| enable                     | [-]   | bool   | Allow avoidance for object type CAR                                                                        | false         |
-| moving_speed_threshold     | [m/s] | double | Objects with speed greater than this will be judged as moving ones.                                        | 1.0           |
-| moving_time_threshold      | [s]   | double | Objects keep moving longer duration than this will be excluded from avoidance target.                      | 1.0           |
-| envelope_buffer_margin     | [m]   | double | Allow avoidance for object type TRAILER                                                                    | 0.3           |
-| avoid_margin_lateral       | [m]   | double | The lateral distance between ego and avoidance targets.                                                    | 1.0           |
-| safety_buffer_lateral      | [m]   | double | Creates an additional lateral gap that will prevent the vehicle from getting to near to the obstacle.      | 0.5           |
-| safety_buffer_longitudinal | [m]   | double | Creates an additional longitudinal gap that will prevent the vehicle from getting to near to the obstacle. | 0.0           |
+| Name                       | Unit  | Type   | Description                                                                                                               | Default value |
+| :------------------------- | ----- | ------ | ------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| is_target                  | [-]   | bool   | By setting this flag `true`, this module avoid those class objects.                                                       | false         |
+| moving_speed_threshold     | [m/s] | double | Objects with speed greater than this will be judged as moving ones.                                                       | 1.0           |
+| moving_time_threshold      | [s]   | double | Objects keep moving longer duration than this will be excluded from avoidance target.                                     | 1.0           |
+| envelope_buffer_margin     | [m]   | double | The buffer between raw boundary box of detected objects and enveloped polygon that is used for avoidance path generation. | 0.3           |
+| avoid_margin_lateral       | [m]   | double | The lateral distance between ego and avoidance targets.                                                                   | 1.0           |
+| safety_buffer_lateral      | [m]   | double | Creates an additional lateral gap that will prevent the vehicle from getting to near to the obstacle.                     | 0.5           |
+| safety_buffer_longitudinal | [m]   | double | Creates an additional longitudinal gap that will prevent the vehicle from getting to near to the obstacle.                | 0.0           |
 
 Parameters for the logic to compensate perception noise of the far objects.
 
@@ -638,18 +638,18 @@ Parameters for the logic to compensate perception noise of the far objects.
 
 namespace: `avoidance.target_filtering.`
 
-| Name                                      | Unit | Type   | Description                                                                                                                                                                                                                            | Default value |
-| :---------------------------------------- | :--- | :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| threshold_distance_object_is_on_center    | [m]  | double | Vehicles around the center line within this distance will be excluded from avoidance target.                                                                                                                                           | 1.0           |
-| object_ignore_distance_traffic_light      | [m]  | double | If the distance between traffic light and vehicle is less than this parameter, this module will ignore it.                                                                                                                             | 30.0          |
-| object_ignore_distance_crosswalk_forward  | [m]  | double | If the front distance between crosswalk and vehicle is less than this parameter, this module will ignore it.                                                                                                                           | 30.0          |
-| object_ignore_distance_crosswalk_backward | [m]  | double | If the back distance between crosswalk and vehicle is less than this parameter, this module will ignore it.                                                                                                                            | 30.0          |
-| object_check_forward_distance             | [m]  | double | Forward distance to search the avoidance target.                                                                                                                                                                                       | 150.0         |
-| object_check_backward_distance            | [m]  | double | Backward distance to search the avoidance target.                                                                                                                                                                                      | 2.0           |
-| object_check_goal_distance                | [m]  | double | Backward distance to search the avoidance target.                                                                                                                                                                                      | 20.0          |
-| object_check_shiftable_ratio              | [m]  | double | Vehicles around the center line within this distance will be excluded from avoidance target.                                                                                                                                           | 0.6           |
-| object_check_min_road_shoulder_width      | [m]  | double | Vehicles around the center line within this distance will be excluded from avoidance target.                                                                                                                                           | 0.5           |
-| object_last_seen_threshold                | [s]  | double | For the compensation of the detection lost. The object is registered once it is observed as an avoidance target. When the detection loses, the timer will start and the object will be un-registered when the time exceeds this limit. | 2.0           |
+| Name                                                  | Unit | Type   | Description                                                                                                                                                                                                                            | Default value |
+| :---------------------------------------------------- | :--- | :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| threshold_distance_object_is_on_center                | [m]  | double | Vehicles around the center line within this distance will be excluded from avoidance target.                                                                                                                                           | 1.0           |
+| object_ignore_section_traffic_light_in_front_distance | [m]  | double | If the distance between traffic light and vehicle is less than this parameter, this module will ignore it.                                                                                                                             | 30.0          |
+| object_ignore_section_crosswalk_in_front_distance     | [m]  | double | If the front distance between crosswalk and vehicle is less than this parameter, this module will ignore it.                                                                                                                           | 30.0          |
+| object_ignore_section_crosswalk_behind_distance       | [m]  | double | If the back distance between crosswalk and vehicle is less than this parameter, this module will ignore it.                                                                                                                            | 30.0          |
+| object_check_forward_distance                         | [m]  | double | Forward distance to search the avoidance target.                                                                                                                                                                                       | 150.0         |
+| object_check_backward_distance                        | [m]  | double | Backward distance to search the avoidance target.                                                                                                                                                                                      | 2.0           |
+| object_check_goal_distance                            | [m]  | double | Backward distance to search the avoidance target.                                                                                                                                                                                      | 20.0          |
+| object_check_shiftable_ratio                          | [m]  | double | Vehicles around the center line within this distance will be excluded from avoidance target.                                                                                                                                           | 0.6           |
+| object_check_min_road_shoulder_width                  | [m]  | double | Vehicles around the center line within this distance will be excluded from avoidance target.                                                                                                                                           | 0.5           |
+| object_last_seen_threshold                            | [s]  | double | For the compensation of the detection lost. The object is registered once it is observed as an avoidance target. When the detection loses, the timer will start and the object will be un-registered when the time exceeds this limit. | 2.0           |
 
 ### Safety check parameters
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -48,7 +48,7 @@ using geometry_msgs::msg::TransformStamped;
 
 struct ObjectParameter
 {
-  bool enable{false};
+  bool is_target{false};
 
   double moving_speed_threshold{0.0};
 
@@ -134,13 +134,13 @@ struct AvoidanceParameters
   double threshold_distance_object_is_on_center;
 
   // execute only when there is no intersection behind of the stopped vehicle.
-  double object_ignore_distance_traffic_light;
+  double object_ignore_section_traffic_light_in_front_distance;
 
   // execute only when there is no crosswalk near the stopped vehicle.
-  double object_ignore_distance_crosswalk_forward;
+  double object_ignore_section_crosswalk_in_front_distance;
 
   // execute only when there is no crosswalk near the stopped vehicle.
-  double object_ignore_distance_crosswalk_backward;
+  double object_ignore_section_crosswalk_behind_distance;
 
   // distance to avoid object detection
   double object_check_forward_distance;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -581,7 +581,7 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
   {
     const auto get_object_param = [&](std::string && ns) {
       ObjectParameter param{};
-      param.enable = declare_parameter<bool>(ns + "enable");
+      param.is_target = declare_parameter<bool>(ns + "is_target");
       param.moving_speed_threshold = declare_parameter<double>(ns + "moving_speed_threshold");
       param.moving_time_threshold = declare_parameter<double>(ns + "moving_time_threshold");
       param.max_expand_ratio = declare_parameter<double>(ns + "max_expand_ratio");
@@ -616,12 +616,12 @@ AvoidanceParameters BehaviorPathPlannerNode::getAvoidanceParam()
     std::string ns = "avoidance.target_filtering.";
     p.threshold_time_force_avoidance_for_stopped_vehicle =
       declare_parameter<double>(ns + "threshold_time_force_avoidance_for_stopped_vehicle");
-    p.object_ignore_distance_traffic_light =
-      declare_parameter<double>(ns + "object_ignore_distance_traffic_light");
-    p.object_ignore_distance_crosswalk_forward =
-      declare_parameter<double>(ns + "object_ignore_distance_crosswalk_forward");
-    p.object_ignore_distance_crosswalk_backward =
-      declare_parameter<double>(ns + "object_ignore_distance_crosswalk_backward");
+    p.object_ignore_section_traffic_light_in_front_distance =
+      declare_parameter<double>(ns + "object_ignore_section_traffic_light_in_front_distance");
+    p.object_ignore_section_crosswalk_in_front_distance =
+      declare_parameter<double>(ns + "object_ignore_section_crosswalk_in_front_distance");
+    p.object_ignore_section_crosswalk_behind_distance =
+      declare_parameter<double>(ns + "object_ignore_section_crosswalk_behind_distance");
     p.object_check_forward_distance =
       declare_parameter<double>(ns + "object_check_forward_distance");
     p.object_check_backward_distance =

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -47,7 +47,7 @@ void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parame
   const auto update_object_param = [&p, &parameters](
                                      const auto & semantic, const std::string & ns) {
     auto & config = p->object_parameters.at(semantic);
-    updateParam<bool>(parameters, ns + "enable", config.enable);
+    updateParam<bool>(parameters, ns + "is_target", config.is_target);
     updateParam<double>(parameters, ns + "moving_speed_threshold", config.moving_speed_threshold);
     updateParam<double>(parameters, ns + "moving_time_threshold", config.moving_time_threshold);
     updateParam<double>(parameters, ns + "max_expand_ratio", config.max_expand_ratio);

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -107,7 +107,7 @@ bool isTargetObjectType(
     return false;
   }
 
-  return parameters->object_parameters.at(t).enable;
+  return parameters->object_parameters.at(t).is_target;
 }
 
 bool isVehicleTypeObject(const ObjectData & object)
@@ -951,7 +951,8 @@ void filterTargetObjects(
       const auto to_traffic_light =
         utils::getDistanceToNextTrafficLight(object_pose, data.current_lanelets);
       {
-        not_parked_object = to_traffic_light < parameters->object_ignore_distance_traffic_light;
+        not_parked_object =
+          to_traffic_light < parameters->object_ignore_section_traffic_light_in_front_distance;
       }
 
       // check crosswalk
@@ -961,8 +962,8 @@ void filterTargetObjects(
         o.longitudinal;
       {
         const auto stop_for_crosswalk =
-          to_crosswalk < parameters->object_ignore_distance_crosswalk_forward &&
-          to_crosswalk > -1.0 * parameters->object_ignore_distance_crosswalk_backward;
+          to_crosswalk < parameters->object_ignore_section_crosswalk_in_front_distance &&
+          to_crosswalk > -1.0 * parameters->object_ignore_section_crosswalk_behind_distance;
         not_parked_object = not_parked_object || stop_for_crosswalk;
       }
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b65669e</samp>

This pull request renames and updates some parameters and variables related to the avoidance module in the behavior path planner. The changes improve the clarity and consistency of the code and documentation in the `planning/behavior_path_planner` package. The changes affect the YAML configuration file, the markdown design file, and several source and header files.

Please approve :arrow_down: before this PR.
https://github.com/autowarefoundation/autoware_launch/pull/422

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
