### PR TITLE
fix(lane_change): do not prematurely combine lane change lanes 

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -204,8 +204,6 @@ protected:
     const lanelet::ConstLanelets & target_lanelets, Direction direction,
     LaneChangePaths * candidate_paths, const bool check_safety) const = 0;
 
-  virtual std::vector<DrivableLanes> getDrivableLanes() const = 0;
-
   virtual TurnSignalInfo calcTurnSignalInfo() = 0;
 
   virtual bool isValidPath(const PathWithLaneId & path) const = 0;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -104,8 +104,6 @@ protected:
     const lanelet::ConstLanelets & target_lanelets, Direction direction,
     LaneChangePaths * candidate_paths, const bool check_safety = true) const override;
 
-  std::vector<DrivableLanes> getDrivableLanes() const override;
-
   TurnSignalInfo calcTurnSignalInfo() override;
 
   bool isValidPath(const PathWithLaneId & path) const override;
@@ -136,8 +134,6 @@ protected:
   PathWithLaneId getPrepareSegment(
     const lanelet::ConstLanelets & current_lanes, const double arc_length_from_current,
     const double backward_path_length, const double prepare_length) const override;
-
-  std::vector<DrivableLanes> getDrivableLanes() const override;
 };
 }  // namespace behavior_path_planner
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__NORMAL_HPP_

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -158,7 +158,8 @@ void NormalLaneChange::extendOutputDrivableArea(BehaviorModuleOutput & output)
   const auto & common_parameters = planner_data_->parameters;
   const auto & dp = planner_data_->drivable_area_expansion_parameters;
 
-  const auto drivable_lanes = getDrivableLanes();
+  const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
+    *getRouteHandler(), status_.current_lanes, status_.lane_change_lanes);
   const auto shorten_lanes = utils::cutOverlappedLanes(*output.path, drivable_lanes);
   const auto expanded_lanes = utils::expandLanelets(
     shorten_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
@@ -762,13 +763,6 @@ bool NormalLaneChange::getLaneChangePaths(
   return false;
 }
 
-std::vector<DrivableLanes> NormalLaneChange::getDrivableLanes() const
-{
-  return utils::lane_change::generateDrivableLanes(
-    *getRouteHandler(), status_.current_lanes, status_.lane_change_lanes);
-  // return utils::combineDrivableLanes(prev_drivable_area_info_.drivable_lanes, drivable_lanes);
-}
-
 PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
 {
   const auto current_pose = getEgoPose();
@@ -1116,11 +1110,5 @@ PathWithLaneId NormalLaneChangeBT::getPrepareSegment(
     getRouteHandler()->getCenterLinePath(current_lanes, s_start, s_end);
 
   return prepare_segment;
-}
-
-std::vector<DrivableLanes> NormalLaneChangeBT::getDrivableLanes() const
-{
-  return utils::lane_change::generateDrivableLanes(
-    *getRouteHandler(), status_.current_lanes, status_.lane_change_lanes);
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -764,9 +764,9 @@ bool NormalLaneChange::getLaneChangePaths(
 
 std::vector<DrivableLanes> NormalLaneChange::getDrivableLanes() const
 {
-  const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
+  return utils::lane_change::generateDrivableLanes(
     *getRouteHandler(), status_.current_lanes, status_.lane_change_lanes);
-  return utils::combineDrivableLanes(prev_drivable_area_info_.drivable_lanes, drivable_lanes);
+  // return utils::combineDrivableLanes(prev_drivable_area_info_.drivable_lanes, drivable_lanes);
 }
 
 PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const


### PR DESCRIPTION
## Description

When lc path is extended, the drivable area isn’t extending and it caused ego vehicle to decelerate unexpectedly (0m:23s)

https://github.com/autowarefoundation/autoware.universe/assets/93502286/58feb8f7-eb55-47dc-95c2-f922d284d2b0

![image](https://github.com/autowarefoundation/autoware.universe/assets/93502286/70e08dd7-2260-4cf1-9b3d-2342894d50ee)

This is because as the `combineDrivableLanes` combines drivable lane without using any `route_handler`'s api is prematurely called, for example 

<img src="https://github.com/autowarefoundation/autoware.universe/assets/93502286/726c63bd-31eb-4982-9b2b-6b7002c84b04" width="200" />

therefore, the function couldn't deduce that the lanes in adjacent to each other, which results in drivable lanes is concatenated to each other (C3, C4, T3, T4) in the image.

the `DrivableLanes` overlap checker will remove the overlap and it cause issues to lane change behavior. 

In this PR, the `combineDrivableLanes` is removed, and some refactoring is performed.

## Related links

None

## Tests performed

1. Set [forward_path_length](https://github.com/autowarefoundation/autoware_launch/blob/dfc7eae1b8be6ac97e4343ef2953459e461b5482/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml#L10C6-L10C6) to `200` 

2. Test the following scenario.

```bash
webauto ci scenario run --project-id prd_jt --scenario-id aa653c7b-fe2c-4713-8187-810c548e4e4b --runtime-path /$HOME/develop/awf --scenario-parameters __tier4_modifier_Ve=8.3333,__tier4_modifier_d=70
```

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
