### PR TITLE
fix: fix data types for lane ids

### DIFF
--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -53,13 +53,13 @@ std::array<geometry_msgs::msg::Point, 3> triangle2points(
   return points;
 }
 
-std::map<int, lanelet::ConstLanelet> getRouteLanelets(
+std::map<lanelet::Id, lanelet::ConstLanelet> getRouteLanelets(
   const lanelet::LaneletMapPtr & lanelet_map,
   const lanelet::routing::RoutingGraphPtr & routing_graph,
   const autoware_planning_msgs::msg::LaneletRoute::ConstSharedPtr & route_ptr,
   const double vehicle_length)
 {
-  std::map<int, lanelet::ConstLanelet> route_lanelets;
+  std::map<lanelet::Id, lanelet::ConstLanelet> route_lanelets;
 
   bool is_route_valid = lanelet::utils::route::isRouteValid(*route_ptr, lanelet_map);
   if (!is_route_valid) {
@@ -315,7 +315,7 @@ void LaneDepartureCheckerNode::onTimer()
 
   // In order to wait for both of map and route will be ready, write this not in callback but here
   if (last_route_ != route_ && !route_->segments.empty()) {
-    std::map<int, lanelet::ConstLanelet>::iterator itr;
+    std::map<lanelet::Id, lanelet::ConstLanelet>::iterator itr;
 
     auto map_route_lanelets_ =
       getRouteLanelets(lanelet_map_, routing_graph_, route_, vehicle_length_m_);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_path.hpp
@@ -42,8 +42,8 @@ struct LaneChangeStatus
   LaneChangePath lane_change_path{};
   lanelet::ConstLanelets current_lanes{};
   lanelet::ConstLanelets target_lanes{};
-  std::vector<uint64_t> lane_follow_lane_ids{};
-  std::vector<uint64_t> lane_change_lane_ids{};
+  std::vector<lanelet::Id> lane_follow_lane_ids{};
+  std::vector<lanelet::Id> lane_change_lane_ids{};
   bool is_safe{false};
   bool is_valid_path{true};
   double start_distance{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -122,7 +122,7 @@ FrenetPoint convertToFrenetPoint(
   return frenet_point;
 }
 
-std::vector<uint64_t> getIds(const lanelet::ConstLanelets & lanelets);
+std::vector<lanelet::Id> getIds(const lanelet::ConstLanelets & lanelets);
 
 // distance (arclength) calculation
 

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -778,9 +778,9 @@ double getSignedDistance(
   return arc_goal.length - arc_current.length;
 }
 
-std::vector<uint64_t> getIds(const lanelet::ConstLanelets & lanelets)
+std::vector<lanelet::Id> getIds(const lanelet::ConstLanelets & lanelets)
 {
-  std::vector<uint64_t> ids;
+  std::vector<lanelet::Id> ids;
   ids.reserve(lanelets.size());
   for (const auto & llt : lanelets) {
     ids.push_back(llt.id());
@@ -1274,7 +1274,7 @@ lanelet::ConstLanelets getCurrentLanesFromPath(
   const auto & current_pose = planner_data->self_odometry->pose.pose;
   const auto & p = planner_data->parameters;
 
-  std::set<uint64_t> lane_ids;
+  std::set<lanelet::Id> lane_ids;
   for (const auto & p : path.points) {
     for (const auto & id : p.lane_ids) {
       lane_ids.insert(id);

--- a/planning/behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.cpp
@@ -629,7 +629,7 @@ bool BlindSpotModule::isTargetObjectType(
 }
 
 boost::optional<geometry_msgs::msg::Pose> BlindSpotModule::getStartPointFromLaneLet(
-  const int lane_id) const
+  const lanelet::Id lane_id) const
 {
   lanelet::ConstLanelet lanelet =
     planner_data_->route_handler_->getLaneletMapPtr()->laneletLayer.get(lane_id);
@@ -653,7 +653,7 @@ boost::optional<geometry_msgs::msg::Pose> BlindSpotModule::getStartPointFromLane
 
 lanelet::ConstLanelets BlindSpotModule::getStraightLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
-  const int lane_id)
+  const lanelet::Id lane_id)
 {
   lanelet::ConstLanelets straight_lanelets;
   const auto intersection_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id);

--- a/planning/behavior_velocity_blind_spot_module/src/scene.hpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.hpp
@@ -201,14 +201,15 @@ private:
    * @param lane_id lane id of objective lanelet
    * @return end point of lanelet
    */
-  boost::optional<geometry_msgs::msg::Pose> getStartPointFromLaneLet(const int lane_id) const;
+  boost::optional<geometry_msgs::msg::Pose> getStartPointFromLaneLet(
+    const lanelet::Id lane_id) const;
 
   /**
    * @brief get straight lanelets in intersection
    */
   lanelet::ConstLanelets getStraightLanelets(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
-    lanelet::routing::RoutingGraphPtr routing_graph_ptr, const int lane_id);
+    lanelet::routing::RoutingGraphPtr routing_graph_ptr, const lanelet::Id lane_id);
 
   /**
    * @brief Modify objects predicted path. remove path point if the time exceeds timer_thr.

--- a/planning/behavior_velocity_crosswalk_module/include/behavior_velocity_crosswalk_module/util.hpp
+++ b/planning/behavior_velocity_crosswalk_module/include/behavior_velocity_crosswalk_module/util.hpp
@@ -105,7 +105,7 @@ std::vector<geometry_msgs::msg::Point> getLinestringIntersects(
   const geometry_msgs::msg::Point & ego_pos, const size_t max_num);
 
 std::optional<lanelet::ConstLineString3d> getStopLineFromMap(
-  const int lane_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
+  const lanelet::Id lane_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   const std::string & attribute_name);
 }  // namespace behavior_velocity_planner
 

--- a/planning/behavior_velocity_crosswalk_module/src/util.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/util.cpp
@@ -209,7 +209,7 @@ std::vector<geometry_msgs::msg::Point> getLinestringIntersects(
 }
 
 std::optional<lanelet::ConstLineString3d> getStopLineFromMap(
-  const int lane_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
+  const lanelet::Id lane_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   const std::string & attribute_name)
 {
   lanelet::ConstLanelet lanelet = lanelet_map_ptr->laneletLayer.get(lane_id);

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -95,7 +95,7 @@ static bool isTargetCollisionVehicleType(
 IntersectionModule::IntersectionModule(
   const int64_t module_id, const int64_t lane_id,
   [[maybe_unused]] std::shared_ptr<const PlannerData> planner_data,
-  const PlannerParam & planner_param, const std::set<int> & associative_ids,
+  const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
   const std::string & turn_direction, const bool has_traffic_light,
   const bool enable_occlusion_detection, const bool is_private_area, rclcpp::Node & node,
   const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock)

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -259,7 +259,7 @@ public:
 
   IntersectionModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const PlannerParam & planner_param, const std::set<int> & associative_ids,
+    const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
     const std::string & turn_direction, const bool has_traffic_light,
     const bool enable_occlusion_detection, const bool is_private_area, rclcpp::Node & node,
     const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock);
@@ -273,7 +273,7 @@ public:
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   motion_utils::VirtualWalls createVirtualWalls() override;
 
-  const std::set<int> & getAssociativeIds() const { return associative_ids_; }
+  const std::set<lanelet::Id> & getAssociativeIds() const { return associative_ids_; }
 
   UUID getOcclusionUUID() const { return occlusion_uuid_; }
   bool getOcclusionSafety() const { return occlusion_safety_; }
@@ -284,7 +284,7 @@ public:
 private:
   rclcpp::Node & node_;
   const int64_t lane_id_;
-  const std::set<int> associative_ids_;
+  const std::set<lanelet::Id> associative_ids_;
   const std::string turn_direction_;
   const bool has_traffic_light_;
 

--- a/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
@@ -39,7 +39,7 @@ namespace bg = boost::geometry;
 MergeFromPrivateRoadModule::MergeFromPrivateRoadModule(
   const int64_t module_id, const int64_t lane_id,
   [[maybe_unused]] std::shared_ptr<const PlannerData> planner_data,
-  const PlannerParam & planner_param, const std::set<int> & associative_ids,
+  const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
   const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock)
 : SceneModuleInterface(module_id, logger, clock),
   lane_id_(lane_id),

--- a/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
@@ -66,7 +66,7 @@ public:
 
   MergeFromPrivateRoadModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const PlannerParam & planner_param, const std::set<int> & associative_ids,
+    const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
     const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock);
 
   /**
@@ -78,11 +78,11 @@ public:
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   motion_utils::VirtualWalls createVirtualWalls() override;
 
-  const std::set<int> & getAssociativeIds() const { return associative_ids_; }
+  const std::set<lanelet::Id> & getAssociativeIds() const { return associative_ids_; }
 
 private:
   const int64_t lane_id_;
-  const std::set<int> associative_ids_;
+  const std::set<lanelet::Id> associative_ids_;
 
   autoware_auto_planning_msgs::msg::PathWithLaneId extractPathNearExitOfPrivateRoad(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path, const double extend_length);

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -117,7 +117,8 @@ static std::optional<size_t> insertPointIndex(
 }
 
 bool hasLaneIds(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p, const std::set<int> & ids)
+  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p,
+  const std::set<lanelet::Id> & ids)
 {
   for (const auto & pid : p.lane_ids) {
     if (ids.find(pid) != ids.end()) {
@@ -128,7 +129,7 @@ bool hasLaneIds(
 }
 
 std::optional<std::pair<size_t, size_t>> findLaneIdsInterval(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const std::set<int> & ids)
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const std::set<lanelet::Id> & ids)
 {
   bool found = false;
   size_t start = 0;
@@ -684,7 +685,7 @@ mergeLaneletsByTopologicalSort(
 IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
   const lanelet::ConstLanelet assigned_lanelet, const lanelet::ConstLanelets & lanelets_on_path,
-  const std::set<int> & associative_ids, const double detection_area_length,
+  const std::set<lanelet::Id> & associative_ids, const double detection_area_length,
   const double occlusion_detection_area_length, const bool consider_wrong_direction_vehicle)
 {
   const auto turn_direction = assigned_lanelet.attributeOr("turn_direction", "else");
@@ -1098,7 +1099,7 @@ std::vector<lanelet::ConstLineString3d> generateDetectionLaneDivisions(
 }
 
 std::optional<InterpolatedPathInfo> generateInterpolatedPath(
-  const int lane_id, const std::set<int> & associative_lane_ids,
+  const lanelet::Id lane_id, const std::set<lanelet::Id> & associative_lane_ids,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path, const double ds,
   const rclcpp::Logger logger)
 {
@@ -1315,7 +1316,7 @@ void cutPredictPathWithDuration(
 TimeDistanceArray calcIntersectionPassingTime(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const std::shared_ptr<const PlannerData> & planner_data, const lanelet::Id lane_id,
-  const std::set<int> & associative_ids, const size_t closest_idx,
+  const std::set<lanelet::Id> & associative_ids, const size_t closest_idx,
   const size_t last_intersection_stop_line_candidate_idx, const double time_delay,
   const double intersection_velocity, const double minimum_ego_velocity,
   const bool use_upstream_velocity, const double minimum_upstream_velocity,
@@ -1496,7 +1497,7 @@ void IntersectionLanelets::update(
 }
 
 static lanelet::ConstLanelets getPrevLanelets(
-  const lanelet::ConstLanelets & lanelets_on_path, const std::set<int> & associative_ids)
+  const lanelet::ConstLanelets & lanelets_on_path, const std::set<lanelet::Id> & associative_ids)
 {
   lanelet::ConstLanelets previous_lanelets;
   for (const auto & ll : lanelets_on_path) {
@@ -1541,7 +1542,8 @@ lanelet::ConstLanelet generatePathLanelet(
 
 std::optional<PathLanelets> generatePathLanelets(
   const lanelet::ConstLanelets & lanelets_on_path,
-  const util::InterpolatedPathInfo & interpolated_path_info, const std::set<int> & associative_ids,
+  const util::InterpolatedPathInfo & interpolated_path_info,
+  const std::set<lanelet::Id> & associative_ids,
   const lanelet::CompoundPolygon3d & first_conflicting_area,
   const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
   const std::optional<lanelet::CompoundPolygon3d> & first_attention_area,

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -40,9 +40,10 @@ std::optional<size_t> insertPoint(
   autoware_auto_planning_msgs::msg::PathWithLaneId * inout_path);
 
 bool hasLaneIds(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p, const std::set<int> & ids);
+  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p,
+  const std::set<lanelet::Id> & ids);
 std::optional<std::pair<size_t, size_t>> findLaneIdsInterval(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const std::set<int> & ids);
+  const autoware_auto_planning_msgs::msg::PathWithLaneId & p, const std::set<lanelet::Id> & ids);
 
 /**
  * @brief get objective polygons for detection area
@@ -50,7 +51,7 @@ std::optional<std::pair<size_t, size_t>> findLaneIdsInterval(
 IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
   const lanelet::ConstLanelet assigned_lanelet, const lanelet::ConstLanelets & lanelets_on_path,
-  const std::set<int> & associative_ids, const double detection_area_length,
+  const std::set<lanelet::Id> & associative_ids, const double detection_area_length,
   const double occlusion_detection_area_length, const bool consider_wrong_direction_vehicle);
 
 /**
@@ -117,7 +118,7 @@ std::vector<lanelet::ConstLineString3d> generateDetectionLaneDivisions(
   const double curvature_threshold, const double curvature_calculation_ds);
 
 std::optional<InterpolatedPathInfo> generateInterpolatedPath(
-  const int lane_id, const std::set<int> & associative_lane_ids,
+  const lanelet::Id lane_id, const std::set<lanelet::Id> & associative_lane_ids,
   const autoware_auto_planning_msgs::msg::PathWithLaneId & input_path, const double ds,
   const rclcpp::Logger logger);
 
@@ -150,7 +151,7 @@ void cutPredictPathWithDuration(
 TimeDistanceArray calcIntersectionPassingTime(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const std::shared_ptr<const PlannerData> & planner_data, const lanelet::Id lane_id,
-  const std::set<int> & associative_ids, const size_t closest_idx,
+  const std::set<lanelet::Id> & associative_ids, const size_t closest_idx,
   const size_t last_intersection_stop_line_candidate_idx, const double time_delay,
   const double intersection_velocity, const double minimum_ego_velocity,
   const bool use_upstream_velocity, const double minimum_upstream_velocity,
@@ -166,7 +167,8 @@ lanelet::ConstLanelet generatePathLanelet(
 
 std::optional<PathLanelets> generatePathLanelets(
   const lanelet::ConstLanelets & lanelets_on_path,
-  const util::InterpolatedPathInfo & interpolated_path_info, const std::set<int> & associative_ids,
+  const util::InterpolatedPathInfo & interpolated_path_info,
+  const std::set<lanelet::Id> & associative_ids,
   const lanelet::CompoundPolygon3d & first_conflicting_area,
   const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
   const std::optional<lanelet::CompoundPolygon3d> & first_attention_area,

--- a/planning/behavior_velocity_intersection_module/src/util_type.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util_type.hpp
@@ -64,8 +64,8 @@ struct InterpolatedPathInfo
 {
   autoware_auto_planning_msgs::msg::PathWithLaneId path;
   double ds{0.0};
-  int lane_id{0};
-  std::set<int> associative_lane_ids{};
+  lanelet::Id lane_id{0};
+  std::set<lanelet::Id> associative_lane_ids{};
   std::optional<std::pair<size_t, size_t>> lane_id_interval{std::nullopt};
 };
 
@@ -175,7 +175,8 @@ struct PathLanelets
   lanelet::ConstLanelets all;
   lanelet::ConstLanelets
     conflicting_interval_and_remaining;  // the left/right-most interval of path conflicting with
-                                         // conflicting lanelets plus the next lane part of the path
+                                         // conflicting lanelets plus the next lane part of the
+                                         // path
 };
 
 struct TargetObject

--- a/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/utilization/util.hpp
@@ -224,13 +224,13 @@ boost::optional<geometry_msgs::msg::Pose> insertStopPoint(
   @brief return 'associative' lanes in the intersection. 'associative' means that a lane shares same
   or lane-changeable parent lanes with `lane` and has same turn_direction value.
  */
-std::set<int> getAssociativeIntersectionLanelets(
+std::set<lanelet::Id> getAssociativeIntersectionLanelets(
   lanelet::ConstLanelet lane, const lanelet::LaneletMapPtr lanelet_map,
   const lanelet::routing::RoutingGraphPtr routing_graph);
 
 template <template <class> class Container>
 lanelet::ConstLanelets getConstLaneletsFromIds(
-  lanelet::LaneletMapConstPtr map, const Container<int> & ids)
+  lanelet::LaneletMapConstPtr map, const Container<lanelet::Id> & ids)
 {
   lanelet::ConstLanelets ret{};
   for (const auto & id : ids) {

--- a/planning/behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner_common/src/utilization/util.cpp
@@ -663,7 +663,7 @@ boost::optional<geometry_msgs::msg::Pose> insertStopPoint(
   return tier4_autoware_utils::getPose(output.points.at(insert_idx.get()));
 }
 
-std::set<int> getAssociativeIntersectionLanelets(
+std::set<lanelet::Id> getAssociativeIntersectionLanelets(
   lanelet::ConstLanelet lane, const lanelet::LaneletMapPtr lanelet_map,
   const lanelet::routing::RoutingGraphPtr routing_graph)
 {
@@ -673,12 +673,12 @@ std::set<int> getAssociativeIntersectionLanelets(
   }
 
   const auto parents = routing_graph->previous(lane);
-  std::set<int> parent_neighbors;
+  std::set<lanelet::Id> parent_neighbors;
   for (const auto & parent : parents) {
     const auto neighbors = routing_graph->besides(parent);
     for (const auto & neighbor : neighbors) parent_neighbors.insert(neighbor.id());
   }
-  std::set<int> associative_intersection_lanelets;
+  std::set<lanelet::Id> associative_intersection_lanelets;
   associative_intersection_lanelets.insert(lane.id());
   for (const auto & parent_neighbor_id : parent_neighbors) {
     const auto parent_neighbor = lanelet_map->laneletLayer.get(parent_neighbor_id);

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager_utils.hpp
@@ -268,7 +268,7 @@ Scenario makeScenarioMsg(const std::string scenario)
   return scenario_msg;
 }
 
-Pose createPoseFromLaneID(const int & lane_id)
+Pose createPoseFromLaneID(const lanelet::Id & lane_id)
 {
   auto map_bin_msg = makeMapBinMsg();
   // create route_handler
@@ -299,7 +299,7 @@ Pose createPoseFromLaneID(const int & lane_id)
   return middle_pose;
 }
 
-Odometry makeInitialPoseFromLaneId(const int & lane_id)
+Odometry makeInitialPoseFromLaneId(const lanelet::Id & lane_id)
 {
   Odometry current_odometry;
   current_odometry.pose.pose = createPoseFromLaneID(lane_id);

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1676,7 +1676,7 @@ PathWithLaneId RouteHandler::getCenterLinePath(
 
   // append a point only when having one point so that yaw calculation would work
   if (reference_path.points.size() == 1) {
-    const int lane_id = static_cast<int>(reference_path.points.front().lane_ids.front());
+    const lanelet::Id lane_id = static_cast<int>(reference_path.points.front().lane_ids.front());
     const auto lanelet = lanelet_map_ptr_->laneletLayer.get(lane_id);
     const auto point = reference_path.points.front().point.pose.position;
     const auto lane_yaw = lanelet::utils::getLaneletAngle(lanelet, point);

--- a/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
+++ b/planning/static_centerline_optimizer/include/static_centerline_optimizer/static_centerline_optimizer_node.hpp
@@ -45,20 +45,21 @@ private:
     const LoadMap::Request::SharedPtr request, const LoadMap::Response::SharedPtr response);
 
   // plan route
-  std::vector<unsigned int> plan_route(const int start_lanelet_id, const int end_lanelet_id);
+  std::vector<lanelet::Id> plan_route(
+    const lanelet::Id start_lanelet_id, const lanelet::Id end_lanelet_id);
   void on_plan_route(
     const PlanRoute::Request::SharedPtr request, const PlanRoute::Response::SharedPtr response);
 
   // plan path
-  std::vector<TrajectoryPoint> plan_path(const std::vector<unsigned int> & route_lane_ids);
+  std::vector<TrajectoryPoint> plan_path(const std::vector<lanelet::Id> & route_lane_ids);
   void on_plan_path(
     const PlanPath::Request::SharedPtr request, const PlanPath::Response::SharedPtr response);
 
   void evaluate(
-    const std::vector<unsigned int> & route_lane_ids,
+    const std::vector<lanelet::Id> & route_lane_ids,
     const std::vector<TrajectoryPoint> & optimized_traj_points);
   void save_map(
-    const std::string & lanelet2_output_file_path, const std::vector<unsigned int> & route_lane_ids,
+    const std::string & lanelet2_output_file_path, const std::vector<lanelet::Id> & route_lane_ids,
     const std::vector<TrajectoryPoint> & optimized_traj_points);
 
   HADMapBin::ConstSharedPtr map_bin_ptr_{nullptr};

--- a/planning/static_centerline_optimizer/msg/PointsWithLaneId.msg
+++ b/planning/static_centerline_optimizer/msg/PointsWithLaneId.msg
@@ -1,2 +1,2 @@
-uint32 lane_id
+int64 lane_id
 geometry_msgs/Point[] points

--- a/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
@@ -75,9 +75,9 @@ Path convert_to_path(const PathWithLaneId & path_with_lane_id)
   return lanelets;
 }
 
-std::vector<unsigned int> get_lane_ids_from_route(const LaneletRoute & route)
+std::vector<lanelet::Id> get_lane_ids_from_route(const LaneletRoute & route)
 {
-  std::vector<unsigned int> lane_ids;
+  std::vector<lanelet::Id> lane_ids;
   for (const auto & segment : route.segments) {
     const auto & target_lanelet_id = segment.preferred_primitive.id;
     lane_ids.push_back(target_lanelet_id);
@@ -87,10 +87,10 @@ std::vector<unsigned int> get_lane_ids_from_route(const LaneletRoute & route)
 }
 
 lanelet::ConstLanelets get_lanelets_from_ids(
-  const RouteHandler & route_handler, const std::vector<unsigned int> & lane_ids)
+  const RouteHandler & route_handler, const std::vector<lanelet::Id> & lane_ids)
 {
   lanelet::ConstLanelets lanelets;
-  for (const int lane_id : lane_ids) {
+  for (const lanelet::Id lane_id : lane_ids) {
     const auto lanelet = route_handler.getLaneletsFromId(lane_id);
     lanelets.push_back(lanelet);
   }
@@ -166,10 +166,10 @@ std::array<double, 3> convertHexStringToDecimal(const std::string & hex_str_colo
   return std::array<double, 3>{r / 255.0, g / 255.0, b / 255.0};
 }
 
-std::vector<unsigned int> check_lanelet_connection(
+std::vector<lanelet::Id> check_lanelet_connection(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & route_lanelets)
 {
-  std::vector<unsigned int> unconnected_lane_ids;
+  std::vector<lanelet::Id> unconnected_lane_ids;
 
   for (size_t i = 0; i < route_lanelets.size() - 1; ++i) {
     const auto next_lanelets = route_handler.getNextLanelets(route_lanelets.at(i));
@@ -234,8 +234,8 @@ void StaticCenterlineOptimizerNode::run()
   const auto lanelet2_input_file_path = declare_parameter<std::string>("lanelet2_input_file_path");
   const auto lanelet2_output_file_path =
     declare_parameter<std::string>("lanelet2_output_file_path");
-  const int start_lanelet_id = declare_parameter<int>("start_lanelet_id");
-  const int end_lanelet_id = declare_parameter<int>("end_lanelet_id");
+  const lanelet::Id start_lanelet_id = declare_parameter<int64_t>("start_lanelet_id");
+  const lanelet::Id end_lanelet_id = declare_parameter<int64_t>("end_lanelet_id");
 
   // process
   load_map(lanelet2_input_file_path);
@@ -301,12 +301,12 @@ void StaticCenterlineOptimizerNode::on_load_map(
   response->message = "InvalidMapFormat";
 }
 
-std::vector<unsigned int> StaticCenterlineOptimizerNode::plan_route(
-  const int start_lanelet_id, const int end_lanelet_id)
+std::vector<lanelet::Id> StaticCenterlineOptimizerNode::plan_route(
+  const lanelet::Id start_lanelet_id, const lanelet::Id end_lanelet_id)
 {
   if (!map_bin_ptr_ || !route_handler_ptr_) {
     RCLCPP_ERROR(get_logger(), "Map or route handler is not ready. Return empty lane ids.");
-    return std::vector<unsigned int>{};
+    return std::vector<lanelet::Id>{};
   }
 
   // calculate check points (= start and goal pose)
@@ -350,15 +350,15 @@ void StaticCenterlineOptimizerNode::on_plan_route(
     return;
   }
 
-  const int start_lanelet_id = request->start_lane_id;
-  const int end_lanelet_id = request->end_lane_id;
+  const lanelet::Id start_lanelet_id = request->start_lane_id;
+  const lanelet::Id end_lanelet_id = request->end_lane_id;
 
   // plan route
   const auto route_lane_ids = plan_route(start_lanelet_id, end_lanelet_id);
   const auto route_lanelets = get_lanelets_from_ids(*route_handler_ptr_, route_lane_ids);
 
   // extract lane ids
-  std::vector<unsigned int> lane_ids;
+  std::vector<lanelet::Id> lane_ids;
   for (const auto & lanelet : route_lanelets) {
     lane_ids.push_back(lanelet.id());
   }
@@ -375,7 +375,7 @@ void StaticCenterlineOptimizerNode::on_plan_route(
 }
 
 std::vector<TrajectoryPoint> StaticCenterlineOptimizerNode::plan_path(
-  const std::vector<unsigned int> & route_lane_ids)
+  const std::vector<lanelet::Id> & route_lane_ids)
 {
   if (!route_handler_ptr_) {
     RCLCPP_ERROR(get_logger(), "Route handler is not ready. Return empty trajectory.");
@@ -494,7 +494,7 @@ void StaticCenterlineOptimizerNode::on_plan_path(
 }
 
 void StaticCenterlineOptimizerNode::evaluate(
-  const std::vector<unsigned int> & route_lane_ids,
+  const std::vector<lanelet::Id> & route_lane_ids,
   const std::vector<TrajectoryPoint> & optimized_traj_points)
 {
   const auto route_lanelets = get_lanelets_from_ids(*route_handler_ptr_, route_lane_ids);
@@ -567,7 +567,7 @@ void StaticCenterlineOptimizerNode::evaluate(
 }
 
 void StaticCenterlineOptimizerNode::save_map(
-  const std::string & lanelet2_output_file_path, const std::vector<unsigned int> & route_lane_ids,
+  const std::string & lanelet2_output_file_path, const std::vector<lanelet::Id> & route_lane_ids,
   const std::vector<TrajectoryPoint> & optimized_traj_points)
 {
   if (!route_handler_ptr_) {

--- a/planning/static_centerline_optimizer/srv/PlanPath.srv
+++ b/planning/static_centerline_optimizer/srv/PlanPath.srv
@@ -1,6 +1,6 @@
 uint32 map_id
-uint32[] route
+int64[] route
 ---
 static_centerline_optimizer/PointsWithLaneId[] points_with_lane_ids
 string message
-uint32[] unconnected_lane_ids
+int64[] unconnected_lane_ids

--- a/planning/static_centerline_optimizer/srv/PlanRoute.srv
+++ b/planning/static_centerline_optimizer/srv/PlanRoute.srv
@@ -1,5 +1,5 @@
-uint32 start_lane_id
-uint32 end_lane_id
+int64 start_lane_id
+int64 end_lane_id
 ---
-uint32[] lane_ids
+int64[] lane_ids
 string message


### PR DESCRIPTION
## Description
Lanelet2 uses int64 as data type to store ids.
However, there are inconsistency in control/planning modules to store the data.

I have searched the code in Autoware with keyword "lane_id" and "lanelet_id" and tried to fix as much as possible to use int64_t or lanelet::Id for data type declaration.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
