### PR TITLE
fix(obstacle_velocity_limiter): remove hardcoded parameter

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.py
@@ -108,7 +108,6 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             obstacle_velocity_limiter_param,
             vehicle_info_param,
-            {"obstacles.dynamic_source": "static_only"},
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )


### PR DESCRIPTION
## Description
Remove a hardcoded parameter in the motion planning launch file.
This prevented setting the parameter through its parameter file.

## Tests performed

Tested in Psim.

## Effects on system behavior

Parameters of the obstacle_velocity_limiter are correctly set from its parameter file.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
