### PR TITLE
fix(replace motorbike with motorcycle): fix yolox's labelmap

### DIFF
--- a/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -199,6 +199,8 @@ void TrtYoloXNode::replaceLabelMap()
     auto & label = label_map_[i];
     if (label == "PERSON") {
       label = "PEDESTRIAN";
+    } else if (label == "MOTORBIKE") {
+      label = "MOTORCYCLE";
     } else if (
       label != "CAR" && label != "PEDESTRIAN" && label != "BUS" && label != "TRUCK" &&
       label != "BICYCLE" && label != "MOTORCYCLE") {


### PR DESCRIPTION
## Description

- replace motorbike with motorcycle in the label map, so that it is consistent with autoware's classes.

## Tests performed

https://tier4.atlassian.net/wiki/spaces/~459732634/pages/2806087707/20230630#tensorrt_yolox%E3%81%AEclass%E4%BF%AE%E6%AD%A3

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
