### PR TITLE
feat(tier4_vehicle_rviz_plugin): add velocity_panel

### DIFF
--- a/common/tier4_vehicle_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_vehicle_rviz_plugin/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADERS
   src/tools/steering_angle.hpp
   src/tools/jsk_overlay_utils.hpp
   src/tools/velocity_history.hpp
+  src/tools/velocity_panel.hpp
 )
 
 ## Declare a C++ library
@@ -26,6 +27,7 @@ ament_auto_add_library(tier4_vehicle_rviz_plugin SHARED
   src/tools/steering_angle.cpp
   src/tools/jsk_overlay_utils.cpp
   src/tools/velocity_history.cpp
+  src/tools/velocity_panel.cpp
   ${HEADERS}
 )
 

--- a/common/tier4_vehicle_rviz_plugin/package.xml
+++ b/common/tier4_vehicle_rviz_plugin/package.xml
@@ -10,8 +10,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/tier4_vehicle_rviz_plugin/package.xml
+++ b/common/tier4_vehicle_rviz_plugin/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_auto_control_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>
@@ -25,5 +26,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <rviz plugin="${prefix}/plugins/plugin_description.xml"/>
   </export>
 </package>

--- a/common/tier4_vehicle_rviz_plugin/plugins/plugin_description.xml
+++ b/common/tier4_vehicle_rviz_plugin/plugins/plugin_description.xml
@@ -15,4 +15,11 @@
          type="rviz_plugins::VelocityHistoryDisplay"
          base_class_type="rviz_common::Display">
   </class>
+  <class name="rviz_plugins/VelocityPanel"
+         type="rviz_plugins::VelocityPanel"
+         base_class_type="rviz_common::Panel">
+    <description>
+      This panel visualizes velocity data.
+    </description>
+  </class>
 </library>

--- a/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.cpp
@@ -14,8 +14,8 @@
 
 #include "velocity_panel.hpp"
 
-#include <rviz_common/display_context.hpp>
 #include <Qt>
+#include <rviz_common/display_context.hpp>
 
 namespace rviz_plugins
 {
@@ -23,8 +23,8 @@ namespace rviz_plugins
 VelocityPanel::VelocityPanel(QWidget * parent) : rviz_common::Panel(parent)
 {
   // Set up the layout
-  QVBoxLayout* vlayout = new QVBoxLayout();
-  QGridLayout* glayout = new QGridLayout();
+  QVBoxLayout * vlayout = new QVBoxLayout();
+  QGridLayout * glayout = new QGridLayout();
 
   // Create legends
   glayout->addWidget(new QLabel("[km/h]"), 0, 0, Qt::AlignCenter);
@@ -49,7 +49,7 @@ VelocityPanel::VelocityPanel(QWidget * parent) : rviz_common::Panel(parent)
   glayout->addWidget(max_vehicle_speed_display_, 2, 2, Qt::AlignCenter);
 
   // Create the button display
-  QPushButton* reset_button = new QPushButton("Reset");
+  QPushButton * reset_button = new QPushButton("Reset");
   connect(reset_button, &QPushButton::clicked, this, [this]() {
     vehicle_speed_max_ = 0.0;
     command_speed_max_ = 0.0;
@@ -67,13 +67,16 @@ void VelocityPanel::onInitialize()
   using std::placeholders::_1;
 
   node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
-  sub_velocity_report_ = node_->create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
-    "/vehicle/status/velocity_status", 1, std::bind(&VelocityPanel::onVelocityReport, this, _1));
-  sub_velocity_command_ = node_->create_subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>(
-    "/control/command/control_cmd", 1, std::bind(&VelocityPanel::onVelocityCommand, this, _1));
+  sub_velocity_report_ =
+    node_->create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
+      "/vehicle/status/velocity_status", 1, std::bind(&VelocityPanel::onVelocityReport, this, _1));
+  sub_velocity_command_ =
+    node_->create_subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>(
+      "/control/command/control_cmd", 1, std::bind(&VelocityPanel::onVelocityCommand, this, _1));
 }
 
-void VelocityPanel::onVelocityReport(const autoware_auto_vehicle_msgs::msg::VelocityReport::SharedPtr msg)
+void VelocityPanel::onVelocityReport(
+  const autoware_auto_vehicle_msgs::msg::VelocityReport::SharedPtr msg)
 {
   // Process the velocity message and update the vehicle speed
   // 車両CANからの実車速
@@ -86,7 +89,8 @@ void VelocityPanel::onVelocityReport(const autoware_auto_vehicle_msgs::msg::Velo
   }
 }
 
-void VelocityPanel::onVelocityCommand(const autoware_auto_control_msgs::msg::AckermannControlCommand::SharedPtr msg)
+void VelocityPanel::onVelocityCommand(
+  const autoware_auto_control_msgs::msg::AckermannControlCommand::SharedPtr msg)
 {
   // Process the command message and update the actual speed
   // Autowareからの制御速度

--- a/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.cpp
@@ -1,3 +1,17 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "velocity_panel.hpp"
 
 #include <rviz_common/display_context.hpp>

--- a/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.cpp
@@ -1,0 +1,91 @@
+#include "velocity_panel.hpp"
+
+#include <rviz_common/display_context.hpp>
+#include <Qt>
+
+namespace rviz_plugins
+{
+
+VelocityPanel::VelocityPanel(QWidget * parent) : rviz_common::Panel(parent)
+{
+  // Set up the layout
+  QVBoxLayout* vlayout = new QVBoxLayout();
+  QGridLayout* glayout = new QGridLayout();
+
+  // Create legends
+  glayout->addWidget(new QLabel("[km/h]"), 0, 0, Qt::AlignCenter);
+  glayout->addWidget(new QLabel("Indicated\nSpeed"), 0, 1, Qt::AlignCenter);
+  glayout->addWidget(new QLabel("Actual\nSpeed"), 0, 2, Qt::AlignCenter);
+
+  // Create the value displays
+  current_command_speed_display_ = new QLabel("-");
+  setLabelFormat(current_command_speed_display_);
+  current_vehicle_speed_display_ = new QLabel("-");
+  setLabelFormat(current_vehicle_speed_display_);
+  glayout->addWidget(new QLabel("Current: "), 1, 0, Qt::AlignRight);
+  glayout->addWidget(current_command_speed_display_, 1, 1, Qt::AlignCenter);
+  glayout->addWidget(current_vehicle_speed_display_, 1, 2, Qt::AlignCenter);
+
+  max_command_speed_display_ = new QLabel("-");
+  setLabelFormat(max_command_speed_display_);
+  max_vehicle_speed_display_ = new QLabel("-");
+  setLabelFormat(max_vehicle_speed_display_);
+  glayout->addWidget(new QLabel("Max: "), 2, 0, Qt::AlignRight);
+  glayout->addWidget(max_command_speed_display_, 2, 1, Qt::AlignCenter);
+  glayout->addWidget(max_vehicle_speed_display_, 2, 2, Qt::AlignCenter);
+
+  // Create the button display
+  QPushButton* reset_button = new QPushButton("Reset");
+  connect(reset_button, &QPushButton::clicked, this, [this]() {
+    vehicle_speed_max_ = 0.0;
+    command_speed_max_ = 0.0;
+    updateLabel(max_command_speed_display_, QString::number(command_speed_max_, 'f', 2));
+    updateLabel(max_vehicle_speed_display_, QString::number(vehicle_speed_max_, 'f', 2));
+  });
+  glayout->addWidget(reset_button, 3, 2);
+
+  vlayout->addLayout(glayout);
+  this->setLayout(vlayout);
+}
+
+void VelocityPanel::onInitialize()
+{
+  using std::placeholders::_1;
+
+  node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
+  sub_velocity_report_ = node_->create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
+    "/vehicle/status/velocity_status", 1, std::bind(&VelocityPanel::onVelocityReport, this, _1));
+  sub_velocity_command_ = node_->create_subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>(
+    "/control/command/control_cmd", 1, std::bind(&VelocityPanel::onVelocityCommand, this, _1));
+}
+
+void VelocityPanel::onVelocityReport(const autoware_auto_vehicle_msgs::msg::VelocityReport::SharedPtr msg)
+{
+  // Process the velocity message and update the vehicle speed
+  // 車両CANからの実車速
+  const auto vehicle_speed_kmph = msg->longitudinal_velocity * 3.6;
+  updateLabel(current_vehicle_speed_display_, QString::number(vehicle_speed_kmph, 'f', 2));
+
+  if (vehicle_speed_max_ < vehicle_speed_kmph) {
+    vehicle_speed_max_ = vehicle_speed_kmph;
+    updateLabel(max_vehicle_speed_display_, QString::number(vehicle_speed_max_, 'f', 2));
+  }
+}
+
+void VelocityPanel::onVelocityCommand(const autoware_auto_control_msgs::msg::AckermannControlCommand::SharedPtr msg)
+{
+  // Process the command message and update the actual speed
+  // Autowareからの制御速度
+  const auto command_speed_kmph = std::fabs(msg->longitudinal.speed) * 3.6;
+  updateLabel(current_command_speed_display_, QString::number(command_speed_kmph, 'f', 2));
+
+  if (command_speed_max_ < command_speed_kmph) {
+    command_speed_max_ = command_speed_kmph;
+    updateLabel(max_command_speed_display_, QString::number(command_speed_max_, 'f', 2));
+  }
+}
+
+}  // namespace rviz_plugins
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(rviz_plugins::VelocityPanel, rviz_common::Panel)

--- a/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.hpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.hpp
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RVIZ2_CUSTOM_PLUGIN_VELOCITY_PANEL_HPP_
-#define RVIZ2_CUSTOM_PLUGIN_VELOCITY_PANEL_HPP_
+#ifndef TOOLS__VELOCITY_PANEL_HPP_
+#define TOOLS__VELOCITY_PANEL_HPP_
 
-#include "rviz_common/panel.hpp"
-#include "autoware_auto_vehicle_msgs/msg/velocity_report.hpp"
-#include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
-
-#include <QLabel>
-#include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QLabel>
 #include <QPushButton>
-
+#include <QVBoxLayout>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
+
+#include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
+#include "autoware_auto_vehicle_msgs/msg/velocity_report.hpp"
 
 #include <memory>
 
@@ -42,11 +40,14 @@ public:
 
 private:
   void onVelocityReport(const autoware_auto_vehicle_msgs::msg::VelocityReport::SharedPtr msg);
-  void onVelocityCommand(const autoware_auto_control_msgs::msg::AckermannControlCommand::SharedPtr msg);
+  void onVelocityCommand(
+    const autoware_auto_control_msgs::msg::AckermannControlCommand::SharedPtr msg);
 
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>::SharedPtr sub_velocity_report_;
-  rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr sub_velocity_command_;
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>::SharedPtr
+    sub_velocity_report_;
+  rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
+    sub_velocity_command_;
 
   QLabel * current_vehicle_speed_display_{nullptr};
   QLabel * max_vehicle_speed_display_{nullptr};
@@ -59,12 +60,13 @@ private:
   static void updateLabel(QLabel * label, QString text, QString style_sheet = nullptr)
   {
     label->setText(text);
-    if (style_sheet != nullptr){
+    if (style_sheet != nullptr) {
       label->setStyleSheet(style_sheet);
     }
   }
 
-  static void setLabelFormat(QLabel * label){
+  static void setLabelFormat(QLabel * label)
+  {
     label->setTextInteractionFlags(Qt::TextInteractionFlag::TextSelectableByMouse);
     label->setFont(QFont("Arial", 14, QFont::Bold));
   }
@@ -72,4 +74,4 @@ private:
 
 }  // namespace rviz_plugins
 
-#endif  // RVIZ2_CUSTOM_PLUGIN_VELOCITY_PANEL_HPP_
+#endif  // TOOLS__VELOCITY_PANEL_HPP_

--- a/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.hpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.hpp
@@ -1,3 +1,17 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RVIZ2_CUSTOM_PLUGIN_VELOCITY_PANEL_HPP_
 #define RVIZ2_CUSTOM_PLUGIN_VELOCITY_PANEL_HPP_
 

--- a/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.hpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/velocity_panel.hpp
@@ -1,0 +1,61 @@
+#ifndef RVIZ2_CUSTOM_PLUGIN_VELOCITY_PANEL_HPP_
+#define RVIZ2_CUSTOM_PLUGIN_VELOCITY_PANEL_HPP_
+
+#include "rviz_common/panel.hpp"
+#include "autoware_auto_vehicle_msgs/msg/velocity_report.hpp"
+#include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
+
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rviz_common/panel.hpp>
+
+#include <memory>
+
+namespace rviz_plugins
+{
+
+class VelocityPanel : public rviz_common::Panel
+{
+  Q_OBJECT
+
+public:
+  explicit VelocityPanel(QWidget * parent = nullptr);
+  void onInitialize() override;
+
+private:
+  void onVelocityReport(const autoware_auto_vehicle_msgs::msg::VelocityReport::SharedPtr msg);
+  void onVelocityCommand(const autoware_auto_control_msgs::msg::AckermannControlCommand::SharedPtr msg);
+
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>::SharedPtr sub_velocity_report_;
+  rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr sub_velocity_command_;
+
+  QLabel * current_vehicle_speed_display_{nullptr};
+  QLabel * max_vehicle_speed_display_{nullptr};
+  QLabel * current_command_speed_display_{nullptr};
+  QLabel * max_command_speed_display_{nullptr};
+
+  double vehicle_speed_max_{0.0};
+  double command_speed_max_{0.0};
+
+  static void updateLabel(QLabel * label, QString text, QString style_sheet = nullptr)
+  {
+    label->setText(text);
+    if (style_sheet != nullptr){
+      label->setStyleSheet(style_sheet);
+    }
+  }
+
+  static void setLabelFormat(QLabel * label){
+    label->setTextInteractionFlags(Qt::TextInteractionFlag::TextSelectableByMouse);
+    label->setFont(QFont("Arial", 14, QFont::Bold));
+  }
+};
+
+}  // namespace rviz_plugins
+
+#endif  // RVIZ2_CUSTOM_PLUGIN_VELOCITY_PANEL_HPP_


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
To check the difference between indicated and actual vehicle speed, I have added a velocity panel.
The ability to hold the maximum speed is useful for measuring the maximum speed during evaluation.

![image](https://github.com/autowarefoundation/autoware.universe/assets/19993104/a38d04a6-8345-4b15-aea9-f9bf6e882c21)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I used rosbag and verified that the display and reset functions are correct.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

It does not affect system behavior.
It only works if the velocity panel is added from the RViz panel.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
