### PR TITLE
fix(yabloc_pose_initializer): disable downloading artifacts by default

### DIFF
--- a/localization/yabloc/yabloc_pose_initializer/download.cmake
+++ b/localization/yabloc/yabloc_pose_initializer/download.cmake
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set(DOWNLOAD_ARTIFACTS OFF CACHE BOOL "enable artifacts download")
+
 set(DATA_URL "https://s3.ap-northeast-2.wasabisys.com/pinto-model-zoo/136_road-segmentation-adas-0001/resources.tar.gz")
 set(DATA_PATH "${CMAKE_CURRENT_SOURCE_DIR}/data")
 set(FILE_HASH 146ed8af689a30b898dc5369870c40fb)
 set(FILE_NAME "resources.tar.gz")
 
-function(download)
+function(download_and_extract)
   message(STATUS "Checking and downloading ${FILE_NAME}")
   set(FILE_PATH ${DATA_PATH}/${FILE_NAME})
   set(STATUS_CODE 0)
@@ -38,11 +40,17 @@ function(download)
       list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
     endif()
   else()
-    message(STATUS "not found ${FILE_NAME}")
-    message(STATUS "File doesn't exists. Downloading now ...")
-    file(DOWNLOAD ${DATA_URL} ${FILE_PATH} STATUS DOWNLOAD_STATUS TIMEOUT 3600)
-    list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
-    list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
+    if(DOWNLOAD_ARTIFACTS)
+      message(STATUS "not found ${FILE_NAME}")
+      message(STATUS "File doesn't exists. Downloading now ...")
+      file(DOWNLOAD ${DATA_URL} ${FILE_PATH} STATUS DOWNLOAD_STATUS TIMEOUT 3600)
+      list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+      list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
+    else()
+      message(WARNING "Skipped download for ${FILE_NAME} (enable by setting DOWNLOAD_ARTIFACTS)")
+      file(MAKE_DIRECTORY "${DATA_PATH}")
+      return()
+    endif()
   endif()
 
   if(${STATUS_CODE} EQUAL 0)
@@ -50,13 +58,10 @@ function(download)
   else()
     message(FATAL_ERROR "Error occurred during download: ${ERROR_MESSAGE}")
   endif()
-endfunction()
 
-function(extract)
   execute_process(COMMAND
     ${CMAKE_COMMAND} -E
     tar xzf "${DATA_PATH}/${FILE_NAME}" WORKING_DIRECTORY "${DATA_PATH}")
 endfunction()
 
-download()
-extract()
+download_and_extract()


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Other packages that use artifacts, have a `DOWNLOAD_ARTIFACTS` option, so that they can be built without access to the internet (e.g. when built with Debian's `sbuild`). This PR adds such option and defaults it to `off`.

See https://github.com/autowarefoundation/autoware-deb-packages/issues/18

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
