### PR TITLE
feat(obstacle_avoidance_planner): make virtual wall green when no stop planning

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -419,10 +419,6 @@ void ObstacleAvoidancePlanner::insertZeroVelocityOutsideDrivableArea(
 {
   time_keeper_ptr_->tic(__func__);
 
-  if (!enable_outside_drivable_area_stop_) {
-    return;
-  }
-
   if (optimized_traj_points.empty()) {
     return;
   }
@@ -443,7 +439,7 @@ void ObstacleAvoidancePlanner::insertZeroVelocityOutsideDrivableArea(
   // 3. assign zero velocity to the first point being outside the drivable area
   const auto first_outside_idx = [&]() -> std::optional<size_t> {
     for (size_t i = ego_idx; i < static_cast<size_t>(end_idx); ++i) {
-      auto & traj_point = optimized_traj_points.at(i);
+      const auto & traj_point = optimized_traj_points.at(i);
 
       // check if the footprint is outside the drivable area
       const bool is_outside = geometry_utils::isOutsideDrivableAreaFromRectangleFootprint(
@@ -458,9 +454,11 @@ void ObstacleAvoidancePlanner::insertZeroVelocityOutsideDrivableArea(
     return std::nullopt;
   }();
 
-  if (first_outside_idx) {
-    for (size_t i = *first_outside_idx; i < optimized_traj_points.size(); ++i) {
-      optimized_traj_points.at(i).longitudinal_velocity_mps = 0.0;
+  if (enable_outside_drivable_area_stop_) {
+    if (first_outside_idx) {
+      for (size_t i = *first_outside_idx; i < optimized_traj_points.size(); ++i) {
+        optimized_traj_points.at(i).longitudinal_velocity_mps = 0.0;
+      }
     }
   }
 
@@ -471,8 +469,12 @@ void ObstacleAvoidancePlanner::publishVirtualWall(const geometry_msgs::msg::Pose
 {
   time_keeper_ptr_->tic(__func__);
 
-  const auto virtual_wall_marker = motion_utils::createStopVirtualWallMarker(
+  auto virtual_wall_marker = motion_utils::createStopVirtualWallMarker(
     stop_pose, "outside drivable area", now(), 0, vehicle_info_.max_longitudinal_offset_m);
+  if (!enable_outside_drivable_area_stop_) {
+    virtual_wall_marker.markers.front().color =
+      tier4_autoware_utils::createMarkerColor(0.0, 1.0, 0.0, 0.5);
+  }
 
   virtual_wall_pub_->publish(virtual_wall_marker);
   time_keeper_ptr_->toc(__func__, "      ");


### PR DESCRIPTION
## Description

When `enable_outside_drivable_area_stop` is false, which means no stop planning when the trajectory is outside the drivable area, currently we have no way to detect the trajectory outside the drivable area.
To detect it, with this PR, the virtual wall whose color is green will be published.

![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/b6522ea0-3fd2-422b-8948-7364612551de)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
