### PR TITLE
fix(velocity_smoother): add acc limit on manual driving

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -786,8 +786,10 @@ MotionVelocitySmootherNode::calcInitialMotion(
       // We should plan from the current vehicle speed, but if the initial value is greater than the
       // velocity limit, the current planning algorithm decelerates with a very high deceleration.
       // To avoid this, we set the initial value of the vehicle speed to be below the speed limit.
+      const auto p = smoother_->getBaseParam();
       const auto v0 = std::min(target_vel, vehicle_speed);
-      const Motion initial_motion = {v0, vehicle_acceleration};
+      const auto a0 = std::clamp(vehicle_acceleration, p.min_decel, p.max_accel);
+      const Motion initial_motion = {v0, a0};
       return {initial_motion, InitializeType::EGO_VELOCITY};
     }
   }


### PR DESCRIPTION
## Description

Add an acceleration limit to enable "engage on manual driving when accelerating". 

## Tests performed

Run psim, and real vehicle experiment

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

 enable "engage on manual driving when accelerating". 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
