### PR TITLE
fix(trajectory_follower_node): add MPC parameter

### DIFF
--- a/control/trajectory_follower_node/param/lateral/mpc.param.yaml
+++ b/control/trajectory_follower_node/param/lateral/mpc.param.yaml
@@ -65,6 +65,7 @@
     keep_steer_control_until_converged: true
     new_traj_duration_time: 1.0
     new_traj_end_dist: 0.3
+    mpc_converged_threshold_rps:  0.01 # threshold of mpc convergence check [rad/s]
 
     # steer offset
     steering_offset:


### PR DESCRIPTION
## Description

In the parameter file for testing `trajectory_follower_node` I added a missing parameter compared to [autoware_launch](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml).
Without this parameter the test would fail for MPC lateral controller.
I came across this problem while working on #3696 and testing my solution.

## Tests performed

I ran `colcon test` on `trajectory_follower_node` and the test passes for MPC. It only fails for pure_pursuit which is expected (#3696).

## Effects on system behavior

`colcon test` passes.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
