### PR TITLE
fix(behavior_path_planner): copy z in dynamic drivable area expansion

### DIFF
--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -19,6 +19,7 @@
 #include "behavior_path_planner/utils/drivable_area_expansion/map_utils.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/parameters.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/types.hpp"
+#include "interpolation/linear_interpolation.hpp"
 
 #include <boost/geometry.hpp>
 
@@ -144,8 +145,12 @@ void copy_z_over_arc_length(
       s_from_prev = s_from;
       s_from += tier4_autoware_utils::calcDistance2d(from[i_from], from[i_from + 1]);
     }
-    const auto ratio = (s_to - s_from_prev) / (s_from - s_from_prev);
-    to[i_to].z = from[i_from - 1].z + ratio * (from[i_from].z - from[i_from - 1].z);
+    if (s_from - s_from_prev != 0.0) {
+      const auto ratio = (s_to - s_from_prev) / (s_from - s_from_prev);
+      to[i_to].z = interpolation::lerp(from[i_from - 1].z, from[i_from].z, ratio);
+    } else {
+      to[i_to].z = to[i_to - 1].z;
+    }
   }
 }
 

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -68,9 +68,7 @@ polygon_t createExpandedDrivableAreaPolygon(
   for (const auto & p : expansion_polygons) {
     unions.clear();
     boost::geometry::union_(expanded_da_poly, p, unions);
-    if (unions.size() != 1)  // union of overlapping polygons should produce a single polygon
-      continue;
-    else
+    if (unions.size() == 1)  // union of overlapping polygons should produce a single polygon
       expanded_da_poly = unions[0];
   }
   return expanded_da_poly;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
When the drivable area is dynamically expanded, the z values were set to 0.
This PR fixes this issue by copying the z values from the original drivable area.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Tested in Psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
