### PR TITLE
fix(roi_cluster_fusion): fuse unknown roi

### DIFF
--- a/perception/image_projection_based_fusion/docs/roi-cluster-fusion.md
+++ b/perception/image_projection_based_fusion/docs/roi-cluster-fusion.md
@@ -41,6 +41,7 @@ The clusters are projected onto image planes, and then if the ROIs of clusters a
 | `only_allow_inside_cluster` | bool  | if `true`, the only clusters contained inside RoIs by a detector                 |
 | `roi_scale_factor`          | float | the scale factor for offset of detector RoIs if `only_allow_inside_cluster=true` |
 | `iou_threshold`             | float | the IoU threshold to overwrite a label of clusters with a label of roi           |
+| `unknown_iou_threshold`     | float | the IoU threshold to fuse cluster with unknown label of roi                      |
 | `rois_number`               | int   | the number of input rois                                                         |
 | `debug_mode`                | bool  | If `true`, subscribe and publish images for visualization.                       |
 

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_cluster_fusion/node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_cluster_fusion/node.hpp
@@ -45,6 +45,8 @@ protected:
   bool only_allow_inside_cluster_{false};
   float roi_scale_factor_{1.1f};
   float iou_threshold_{0.0f};
+  float unknown_iou_threshold_{0.0f};
+  float min_roi_existence_prob_{0.1f};
   bool remove_unknown_;
   float trust_distance_;
 

--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_cluster_fusion/node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_cluster_fusion/node.hpp
@@ -46,7 +46,8 @@ protected:
   float roi_scale_factor_{1.1f};
   float iou_threshold_{0.0f};
   float unknown_iou_threshold_{0.0f};
-  float min_roi_existence_prob_{0.1f};
+  const float min_roi_existence_prob_ =
+    0.1;  // keep small value to lessen affect on merger object stage
   bool remove_unknown_;
   float trust_distance_;
 

--- a/perception/image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
+++ b/perception/image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
@@ -51,6 +51,7 @@
       <param name="only_allow_inside_cluster" value="true"/>
       <param name="roi_scale_factor" value="1.1"/>
       <param name="iou_threshold" value="0.35"/>
+      <param name="unknown_iou_threshold" value="0.1"/>
       <param name="rois_number" value="$(var input/rois_number)"/>
       <param name="remove_unknown" value="$(var remove_unknown)"/>
       <param name="trust_distance" value="$(var trust_distance)"/>

--- a/perception/image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
@@ -72,7 +72,7 @@ void RoiClusterFusionNode::postprocess(DetectedObjectsWithFeature & output_clust
     if (
       feature_object.object.classification.front().label !=
         autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN ||
-      feature_object.object.existence_probability > min_roi_existence_prob_) {
+      feature_object.object.existence_probability >= min_roi_existence_prob_) {
       known_objects.feature_objects.push_back(feature_object);
     }
   }
@@ -199,6 +199,14 @@ void RoiClusterFusionNode::fuseOnSingleImage(
         autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN) {
       output_cluster_msg.feature_objects.at(index).object.classification =
         feature_obj.object.classification;
+
+      // Update existence_probability for fused objects
+      if (
+        output_cluster_msg.feature_objects.at(index).object.existence_probability <
+        min_roi_existence_prob_) {
+        output_cluster_msg.feature_objects.at(index).object.existence_probability =
+          min_roi_existence_prob_;
+      }
     }
 
     // fuse with unknown roi
@@ -210,7 +218,7 @@ void RoiClusterFusionNode::fuseOnSingleImage(
         autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN) {
       output_cluster_msg.feature_objects.at(index).object.classification =
         feature_obj.object.classification;
-      // separate unknown object fused with roi by existence_probability
+      // Update existence_probability for fused objects
       if (
         output_cluster_msg.feature_objects.at(index).object.existence_probability <
         min_roi_existence_prob_) {


### PR DESCRIPTION
## Description

This is to modify existence probability of unknown objects based on unknown roi from camera-based object detection model to differentiate with some kind of ghost pointcloud or exhausted gas poincloud unknown objects. 

## Related links
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-976)

## Tests performed

Perforamce is confirmed by Lsim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
