### PR TITLE
docs(planning_validator): add unit

### DIFF
--- a/planning/planning_validator/README.md
+++ b/planning/planning_validator/README.md
@@ -63,15 +63,15 @@ The following parameters can be set for the `planning_validator`:
 
 The input trajectory is detected as invalid if the index exceeds the following thresholds.
 
-| Name                              | Type   | Description                                                                                                   | Default value |
-| :-------------------------------- | :----- | :------------------------------------------------------------------------------------------------------------ | :------------ |
-| `thresholds.interval`             | double | invalid threshold of the distance of two neighboring trajectory points                                        | 100.0         |
-| `thresholds.relative_angle`       | double | invalid threshold of the relative angle of two neighboring trajectory points                                  | 2.0           |
-| `thresholds.curvature`            | double | invalid threshold of the curvature in each trajectory point                                                   | 1.0           |
-| `thresholds.lateral_acc`          | double | invalid threshold of the lateral acceleration in each trajectory point                                        | 9.8           |
-| `thresholds.longitudinal_max_acc` | double | invalid threshold of the maximum longitudinal acceleration in each trajectory point                           | 9.8           |
-| `thresholds.longitudinal_min_acc` | double | invalid threshold of the minimum longitudinal deceleration in each trajectory point                           | -9.8          |
-| `thresholds.steering`             | double | invalid threshold of the steering angle in each trajectory point                                              | 1.414         |
-| `thresholds.steering_rate`        | double | invalid threshold of the steering angle rate in each trajectory point                                         | 10.0          |
-| `thresholds.velocity_deviation`   | double | invalid threshold of the velocity deviation between the ego velocity and the trajectory point closest to ego. | 100.0         |
-| `thresholds.distance_deviation`   | double | invalid threshold of the distance deviation between the ego position and the trajectory point closest to ego. | 100.0         |
+| Name                              | Type   | Description                                                                                                        | Default value |
+| :-------------------------------- | :----- | :----------------------------------------------------------------------------------------------------------------- | :------------ |
+| `thresholds.interval`             | double | invalid threshold of the distance of two neighboring trajectory points [m]                                         | 100.0         |
+| `thresholds.relative_angle`       | double | invalid threshold of the relative angle of two neighboring trajectory points [rad]                                 | 2.0           |
+| `thresholds.curvature`            | double | invalid threshold of the curvature in each trajectory point [1/m]                                                  | 1.0           |
+| `thresholds.lateral_acc`          | double | invalid threshold of the lateral acceleration in each trajectory point [m/ss]                                      | 9.8           |
+| `thresholds.longitudinal_max_acc` | double | invalid threshold of the maximum longitudinal acceleration in each trajectory point [m/ss]                         | 9.8           |
+| `thresholds.longitudinal_min_acc` | double | invalid threshold of the minimum longitudinal deceleration in each trajectory point [m/ss]                         | -9.8          |
+| `thresholds.steering`             | double | invalid threshold of the steering angle in each trajectory point [rad]                                             | 1.414         |
+| `thresholds.steering_rate`        | double | invalid threshold of the steering angle rate in each trajectory point [rad/s]                                      | 10.0          |
+| `thresholds.velocity_deviation`   | double | invalid threshold of the velocity deviation between the ego velocity and the trajectory point closest to ego [m/s] | 100.0         |
+| `thresholds.distance_deviation`   | double | invalid threshold of the distance deviation between the ego position and the trajectory point closest to ego [m]   | 100.0         |


### PR DESCRIPTION
## Description

Add unit for parameters

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
