### PR TITLE
ci: remove global codeowners

### DIFF
--- a/.github/workflows/update-codeowners-from-packages.yaml
+++ b/.github/workflows/update-codeowners-from-packages.yaml
@@ -27,7 +27,6 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/update-codeowners-from-packages@v1
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          global-codeowners: "@autowarefoundation/autoware-global-codeowners"
           pr-labels: |
             bot
             update-codeowners-from-packages


### PR DESCRIPTION
## Description

Remove global codeowners. The repository rules now allows admins to bypass.
https://github.com/orgs/community/discussions/46626#discussioncomment-5731948

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
