### PR TITLE
fix(obstacle_stop_planner): add missing params to the default config file

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -232,6 +232,7 @@ BehaviorModuleOutput LaneChangeInterface::planWaitingApproval()
   module_type_->setPreviousModulePaths(
     getPreviousModuleOutput().reference_path, getPreviousModuleOutput().path);
   module_type_->updateLaneChangeStatus();
+  setObjectDebugVisualization();
 
   // change turn signal when the vehicle reaches at the end of the path for waiting lane change
   out.turn_signal_info = getCurrentTurnSignalInfo(*out.path, out.turn_signal_info);
@@ -248,8 +249,6 @@ BehaviorModuleOutput LaneChangeInterface::planWaitingApproval()
   updateRTCStatus(
     candidate.start_distance_to_path_change, candidate.finish_distance_to_path_change);
   is_abort_path_approved_ = false;
-
-  setObjectDebugVisualization();
 
   return out;
 }

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -2,6 +2,8 @@
   ros__parameters:
     chattering_threshold: 0.5                 # even if the obstacle disappears, the stop judgment continues for chattering_threshold [s]
     max_velocity: 20.0                        # max velocity [m/s]
+    ego_nearest_dist_threshold: 3.0           # [m]
+    ego_nearest_yaw_threshold: 1.046          # [rad] = 60 [deg]
     enable_slow_down: False                   # whether to use slow down planner [-]
     enable_z_axis_obstacle_filtering: True    # filter obstacles in z axis (height) [-]
     z_axis_filtering_buffer: 0.0              # additional buffer for z axis filtering [m]


### PR DESCRIPTION
## Description

Two parameters seemed to be missing from the default config file:

    ego_nearest_dist_threshold: 3.0           # [m]
    ego_nearest_yaw_threshold: 1.046          # [rad] = 60 [deg]

I have retrieved these values from: planning_test_utils/config/test_nearest_search_param.yaml

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
