### PR TITLE
fix(traffic_light map_based detector): vibration offset computation

### DIFF
--- a/perception/traffic_light_map_based_detector/src/node.cpp
+++ b/perception/traffic_light_map_based_detector/src/node.cpp
@@ -286,15 +286,25 @@ bool MapBasedDetector::getTrafficLightRoi(
     tf2::Vector3 map2tl = getTrafficLightTopLeft(traffic_light);
     tf2::Vector3 camera2tl = tf_map2camera.inverse() * map2tl;
     // max vibration
-    const double max_vibration_x =
-      std::sin(config.max_vibration_yaw * 0.5) * camera2tl.z() + config.max_vibration_width * 0.5;
-    const double max_vibration_y = std::sin(config.max_vibration_pitch * 0.5) * camera2tl.z() +
-                                   config.max_vibration_height * 0.5;
-    const double max_vibration_z = config.max_vibration_depth * 0.5;
+    double camera2tl_xz_distance = tf2::Vector3(camera2tl.getX(), 0.0, camera2tl.getZ()).length();
+    double camera2tl_yz_distance = tf2::Vector3(0.0, camera2tl.getY(), camera2tl.getZ()).length();
+
+    tf2::Vector3 tlr_z_basis =
+      tf2::Vector3(camera2tl.getX(), camera2tl.getY(), camera2tl.getZ()).normalized();
+    tf2::Vector3 tlr_y_basis = tf2::Vector3(0.0, 1.0, 0.0);
+    tf2::Vector3 tlr_x_basis = tlr_y_basis.cross(tlr_z_basis);
+
+    tf2::Vector3 tlr_offset = (std::sin(config.max_vibration_yaw * 0.5) * camera2tl_xz_distance +
+                               config.max_vibration_width * 0.5) *
+                                tlr_x_basis +
+                              (std::sin(config.max_vibration_pitch * 0.5) * camera2tl_yz_distance +
+                               config.max_vibration_height * 0.5) *
+                                tlr_y_basis +
+                              (config.max_vibration_depth * 0.5) * tlr_z_basis;
+
     // enlarged target position in camera coordinate
     {
-      tf2::Vector3 point3d =
-        camera2tl - tf2::Vector3(max_vibration_x, max_vibration_y, max_vibration_z);
+      tf2::Vector3 point3d = camera2tl - tlr_offset;
       if (point3d.z() <= 0.0) {
         return false;
       }
@@ -310,15 +320,25 @@ bool MapBasedDetector::getTrafficLightRoi(
     tf2::Vector3 map2tl = getTrafficLightBottomRight(traffic_light);
     tf2::Vector3 camera2tl = tf_map2camera.inverse() * map2tl;
     // max vibration
-    const double max_vibration_x =
-      std::sin(config.max_vibration_yaw * 0.5) * camera2tl.z() + config.max_vibration_width * 0.5;
-    const double max_vibration_y = std::sin(config.max_vibration_pitch * 0.5) * camera2tl.z() +
-                                   config.max_vibration_height * 0.5;
-    const double max_vibration_z = config.max_vibration_depth * 0.5;
+    double camera2tl_xz_distance = tf2::Vector3(camera2tl.getX(), 0.0, camera2tl.getZ()).length();
+    double camera2tl_yz_distance = tf2::Vector3(0.0, camera2tl.getY(), camera2tl.getZ()).length();
+
+    tf2::Vector3 tlr_z_basis =
+      tf2::Vector3(camera2tl.getX(), camera2tl.getY(), camera2tl.getZ()).normalized();
+    tf2::Vector3 tlr_y_basis = tf2::Vector3(0.0, 1.0, 0.0);
+    tf2::Vector3 tlr_x_basis = tlr_y_basis.cross(tlr_z_basis);
+
+    tf2::Vector3 tlr_offset = (std::sin(config.max_vibration_yaw * 0.5) * camera2tl_xz_distance +
+                               config.max_vibration_width * 0.5) *
+                                tlr_x_basis +
+                              (std::sin(config.max_vibration_pitch * 0.5) * camera2tl_yz_distance +
+                               config.max_vibration_height * 0.5) *
+                                tlr_y_basis +
+                              (config.max_vibration_depth * 0.5) * tlr_z_basis;
+
     // enlarged target position in camera coordinate
     {
-      tf2::Vector3 point3d =
-        camera2tl + tf2::Vector3(max_vibration_x, max_vibration_y, -max_vibration_z);
+      tf2::Vector3 point3d = camera2tl + tlr_offset;
       if (point3d.z() <= 0.0) {
         return false;
       }


### PR DESCRIPTION
## Description
As mentioned before internally, I think that the computations regarding the offsets produced by the `vibrations` are incorrect. The effect is small when the ROIs are near the optical center but increases as the ROIs get away from it.

<!-- Write a brief description of this PR. -->

## Tests performed
Validated using the # 4 data from 2023/04/17

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
