### PR TITLE
feat(shift_decider): keep parking gear command after the state transitions from arrived_goal

### DIFF
--- a/control/shift_decider/src/shift_decider.cpp
+++ b/control/shift_decider/src/shift_decider.cpp
@@ -86,7 +86,10 @@ void ShiftDecider::updateCurrentShiftCmd()
       shift_cmd_.command = current_gear_ptr_->report;
     }
   } else {
-    if (autoware_state_->state == AutowareState::ARRIVED_GOAL && park_on_goal_) {
+    if (
+      (autoware_state_->state == AutowareState::ARRIVED_GOAL ||
+       autoware_state_->state == AutowareState::WAITING_FOR_ROUTE) &&
+      park_on_goal_) {
       shift_cmd_.command = GearCommand::PARK;
     } else {
       shift_cmd_.command = current_gear_ptr_->report;


### PR DESCRIPTION
## Description

In the [current implementation](https://github.com/autowarefoundation/autoware.universe/blob/2424d6b770d9623e9ddadbeae32e6e8d32a67348/control/shift_decider/src/shift_decider.cpp#L89_L93) of shift_decider, the Autoware sends parking gear command only when the ```autoware_state``` is ```ARRIVED_GOAL```, then sends gear command according to current gear state.

However, in the case of using a vehicle that takes time to transition the gear state, the vehicle cannot complete a gear transition while the  ```autoware_state``` is ```ARRIVED_GOAL```. In such a case, the Autoware switches the gear command to ```DRIVING``` before the vehicle gear switches to parking.

As this would cause incorrect gear transition, I changed the gear command to keep the Parking after ```autoware_state``` switches from ```ARRIVED_GOAL``` to ```WAITING_FOR_ROUTE```

![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/37b5eb76-dd68-4bc0-b675-7df186e5c040)



<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Vehicles with slow gear transitions become to properly shift into Parking after arriving goal
No affects on vehicles with non-slow gear transitions.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
