### PR TITLE
docs(traffic_light_arbiter): fix the datatype of input topics

### DIFF
--- a/perception/traffic_light_arbiter/README.md
+++ b/perception/traffic_light_arbiter/README.md
@@ -12,11 +12,11 @@ A node that merges traffic light/signal state from image recognition and externa
 
 #### Input
 
-| Name                             | Type                                         | Description                                              |
-| -------------------------------- | -------------------------------------------- | -------------------------------------------------------- |
-| ~/sub/vector_map                 | autoware_auto_mapping_msgs::msg::HADMapBin   | The vector map to get valid traffic signal ids.          |
-| ~/sub/perception_traffic_signals | autoware_perception_msgs::msg::TrafficSignal | The traffic signals from the image recognition pipeline. |
-| ~/sub/external_traffic_signals   | autoware_perception_msgs::msg::TrafficSignal | The traffic signals from an external system.             |
+| Name                             | Type                                              | Description                                              |
+| -------------------------------- | ------------------------------------------------- | -------------------------------------------------------- |
+| ~/sub/vector_map                 | autoware_auto_mapping_msgs::msg::HADMapBin        | The vector map to get valid traffic signal ids.          |
+| ~/sub/perception_traffic_signals | autoware_perception_msgs::msg::TrafficSignalArray | The traffic signals from the image recognition pipeline. |
+| ~/sub/external_traffic_signals   | autoware_perception_msgs::msg::TrafficSignalArray | The traffic signals from an external system.             |
 
 #### Output
 


### PR DESCRIPTION
## Description

Fixed the incorrect datatype in README.md.
The correct datatype shoud be `TrafficSignalArray`.
https://github.com/autowarefoundation/autoware.universe/blob/main/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp#L58-L64


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
