### PR TITLE
docs: fix msg type in traffic_light_multi_camera_fusion/README.md

### DIFF
--- a/perception/traffic_light_multi_camera_fusion/README.md
+++ b/perception/traffic_light_multi_camera_fusion/README.md
@@ -20,9 +20,9 @@ You don't need to configure these topics manually. Just provide the `camera_name
 
 ## Output topics
 
-| Name                       | Type                                           | Description                        |
-| -------------------------- | ---------------------------------------------- | ---------------------------------- |
-| `~/output/traffic_signals` | tier4_perception_msgs::TrafficLightSignalArray | traffic light signal fusion result |
+| Name                       | Type                                              | Description                        |
+| -------------------------- | ------------------------------------------------- | ---------------------------------- |
+| `~/output/traffic_signals` | autoware_perception_msgs::TrafficLightSignalArray | traffic light signal fusion result |
 
 ## Node parameters
 


### PR DESCRIPTION
## Description

replace old msg type with new traffic signal type `autoware_perception_msgs::msg::TrafficSignalArray` in traffic_light_multi_camera_fusion/README.md

ref
- https://github.com/autowarefoundation/autoware.universe/blob/main/perception/traffic_light_multi_camera_fusion/src/node.cpp#L179
- https://github.com/autowarefoundation/autoware.universe/blob/main/perception/traffic_light_multi_camera_fusion/include/traffic_light_multi_camera_fusion/node.hpp#L77
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
