### PR TITLE
fix(traffic_light_arbiter): use the traffic light id instead of the regulatory element id

### DIFF
--- a/perception/traffic_light_arbiter/include/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/traffic_light_arbiter/include/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -46,7 +46,7 @@ private:
   void onExternalMsg(const TrafficSignalArray::ConstSharedPtr msg);
   void arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp);
 
-  std::unordered_set<lanelet::Id> map_regulatory_elements_set_;
+  std::unordered_set<lanelet::Id> map_traffic_signal_id_set_;
 
   double external_time_tolerance_;
   double perception_time_tolerance_;

--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -74,9 +74,9 @@ void TrafficLightArbiter::onMap(const LaneletMapBin::ConstSharedPtr msg)
   lanelet::utils::conversion::fromBinMsg(*msg, map);
 
   const auto traffic_signal_ids = lanelet::filter_traffic_signal_ids(map);
-  map_regulatory_elements_set_.clear();
+  map_traffic_signal_id_set_.clear();
   for (const auto & traffic_light_id : traffic_signal_ids) {
-    map_regulatory_elements_set_.emplace(traffic_light_id);
+    map_traffic_signal_id_set_.emplace(traffic_light_id);
   }
 }
 
@@ -111,14 +111,14 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
   using ElementAndPriority = std::pair<Element, bool>;
   std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> regulatory_element_signals_map;
 
-  if (map_regulatory_elements_set_.empty()) {
+  if (map_traffic_signal_id_set_.empty()) {
     RCLCPP_WARN(get_logger(), "Received traffic signal messages before a map");
     return;
   }
 
   auto add_signal_function = [&](const auto & signal, bool priority) {
     const auto id = signal.traffic_signal_id;
-    if (!map_regulatory_elements_set_.count(id)) {
+    if (!map_traffic_signal_id_set_.count(id)) {
       RCLCPP_WARN(
         get_logger(), "Received a traffic signal not present in the current map (%lu)", id);
       return;


### PR DESCRIPTION
## Description

The original code used the regulatory element id of the traffic lights. However, it should use the traffic light id instead. I've updated the code to extract traffic light ids from the regulatory elements of traffic lights.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested on planning simulator.

https://github.com/autowarefoundation/autoware.universe/assets/11865769/d7a5759f-a914-4da7-9cde-e0783c7ea7b7

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
