### PR TITLE
perf(behavior_path_planner): simplify calculateDistanceLimit for dynamic drivable area expansion

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -24,6 +24,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
@@ -64,9 +65,10 @@ def launch_setup(context, *args, **kwargs):
     with open(LaunchConfiguration("behavior_path_planner_param_path").perform(context), "r") as f:
         behavior_path_planner_param = yaml.safe_load(f)["/**"]["ros__parameters"]
 
-    behavior_path_planner_component = ComposableNode(
+    behavior_path_planner_component = Node(
         package="behavior_path_planner",
-        plugin="behavior_path_planner::BehaviorPathPlannerNode",
+        # plugin="behavior_path_planner::BehaviorPathPlannerNode",
+        executable="behavior_path_planner",
         name="behavior_path_planner",
         namespace="",
         remappings=[
@@ -117,7 +119,8 @@ def launch_setup(context, *args, **kwargs):
                 "bt_tree_config_path": LaunchConfiguration("behavior_path_planner_tree_param_path"),
             },
         ],
-        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        prefix="konsole -e gdb -ex run --args",
+        # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
     # smoother param
@@ -213,7 +216,6 @@ def launch_setup(context, *args, **kwargs):
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
-            behavior_path_planner_component,
             behavior_velocity_planner_component,
         ],
         output="screen",
@@ -262,6 +264,7 @@ def launch_setup(context, *args, **kwargs):
     group = GroupAction(
         [
             container,
+            behavior_path_planner_component,
             load_compare_map,
             load_vector_map_inside_area_filter,
         ]

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -24,7 +24,6 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
-from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
@@ -65,10 +64,9 @@ def launch_setup(context, *args, **kwargs):
     with open(LaunchConfiguration("behavior_path_planner_param_path").perform(context), "r") as f:
         behavior_path_planner_param = yaml.safe_load(f)["/**"]["ros__parameters"]
 
-    behavior_path_planner_component = Node(
+    behavior_path_planner_component = ComposableNode(
         package="behavior_path_planner",
-        # plugin="behavior_path_planner::BehaviorPathPlannerNode",
-        executable="behavior_path_planner",
+        plugin="behavior_path_planner::BehaviorPathPlannerNode",
         name="behavior_path_planner",
         namespace="",
         remappings=[
@@ -119,8 +117,7 @@ def launch_setup(context, *args, **kwargs):
                 "bt_tree_config_path": LaunchConfiguration("behavior_path_planner_tree_param_path"),
             },
         ],
-        prefix="konsole -e gdb -ex run --args",
-        # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
     # smoother param
@@ -216,6 +213,7 @@ def launch_setup(context, *args, **kwargs):
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
+            behavior_path_planner_component,
             behavior_velocity_planner_component,
         ],
         output="screen",
@@ -264,7 +262,6 @@ def launch_setup(context, *args, **kwargs):
     group = GroupAction(
         [
             container,
-            behavior_path_planner_component,
             load_compare_map,
             load_vector_map_inside_area_filter,
         ]

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -33,13 +33,19 @@ void expandDrivableArea(
 {
   const auto uncrossable_lines =
     extractUncrossableLines(*route_handler.getLaneletMapPtr(), params.avoid_linestring_types);
+  multilinestring_t uncrossable_lines_in_range;
+  const auto & p = path.points.front().point.pose.position;
+  for (const auto & line : uncrossable_lines)
+    if (boost::geometry::distance(line, point_t{p.x, p.y}) < params.max_path_arc_length)
+      uncrossable_lines_in_range.push_back(line);
   const auto path_footprints = createPathFootprints(path, params);
   const auto predicted_paths = createObjectFootprints(dynamic_objects, params);
   const auto expansion_polygons =
     params.expansion_method == "lanelet"
       ? createExpansionLaneletPolygons(
           path_lanes, route_handler, path_footprints, predicted_paths, params)
-      : createExpansionPolygons(path, path_footprints, predicted_paths, uncrossable_lines, params);
+      : createExpansionPolygons(
+          path, path_footprints, predicted_paths, uncrossable_lines_in_range, params);
   const auto expanded_drivable_area = createExpandedDrivableAreaPolygon(path, expansion_polygons);
   updateDrivableAreaBounds(path, expanded_drivable_area);
 }

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
@@ -25,10 +25,6 @@ double calculateDistanceLimit(
   const multilinestring_t & limit_lines)
 {
   auto dist_limit = std::numeric_limits<double>::max();
-  boost::geometry::for_each_point(limit_lines, [&](const auto & point) {
-    if (boost::geometry::within(point, expansion_polygon))
-      dist_limit = std::min(dist_limit, boost::geometry::distance(point, base_ls));
-  });
   multipoint_t intersections;
   boost::geometry::intersection(expansion_polygon, limit_lines, intersections);
   for (const auto & p : intersections)
@@ -42,16 +38,10 @@ double calculateDistanceLimit(
 {
   auto dist_limit = std::numeric_limits<double>::max();
   for (const auto & polygon : limit_polygons) {
-    for (const auto & p : polygon.outer()) {
-      if (boost::geometry::within(p, expansion_polygon)) {
-        dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
-      }
-    }
     multipoint_t intersections;
     boost::geometry::intersection(expansion_polygon, polygon, intersections);
-    for (const auto & p : intersections) {
+    for (const auto & p : intersections)
       dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
-    }
   }
   return dist_limit;
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR reduces the cost of running the dynamic drivable area expansion.
Currently, the calculations are very heavy and do not scale well with the number of "uncrossable lines".
This PR improves the performances but do not completely solve the scaling issue.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Tested in Psim.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Running the dynamic drivable area expansion is less expensive, but the precision is reduced and the drivable area may  slightly cross some lines we do not want to cross (e.g., road borders).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
