### PR TITLE
fix(behavior_velocity_planner): expend the ego_lane_with_next_lane area

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -934,8 +934,6 @@ bool IntersectionModule::checkCollision(
   using lanelet::utils::getPolygonFromArcLength;
 
   const auto & objects_ptr = planner_data_->predicted_objects;
-  const auto lanelets_on_path = planning_utils::getLaneletsOnPath(
-    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
   // extract target objects
   autoware_auto_perception_msgs::msg::PredictedObjects target_objects;
   target_objects.header = objects_ptr->header;
@@ -1062,6 +1060,8 @@ bool IntersectionModule::checkCollision(
         long double lanes_length = 0.0;
         std::vector<lanelet::ConstLanelet> ego_lane_with_next_lanes;
 
+        const auto lanelets_on_path = planning_utils::getLaneletsOnPath(
+          path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
         for (const auto & lane : lanelets_on_path) {
           lanes_length += bg::length(lane.centerline());
           ego_lane_with_next_lanes.push_back(lane);

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -1061,7 +1061,8 @@ bool IntersectionModule::checkCollision(
         std::vector<lanelet::ConstLanelet> ego_lane_with_next_lanes;
 
         const auto lanelets_on_path = planning_utils::getLaneletsOnPath(
-          path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
+          path, planner_data_->route_handler_->getLaneletMapPtr(),
+          planner_data_->current_odometry->pose);
         for (const auto & lane : lanelets_on_path) {
           lanes_length += bg::length(lane.centerline());
           ego_lane_with_next_lanes.push_back(lane);

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -934,7 +934,9 @@ bool IntersectionModule::checkCollision(
   using lanelet::utils::getPolygonFromArcLength;
 
   const auto & objects_ptr = planner_data_->predicted_objects;
-
+  const auto lanelets_on_path =
+    planning_utils::getLaneletsOnPath(path, planner_data_->route_handler_->getLaneletMapPtr(),
+                                      planner_data_->current_odometry->pose);
   // extract target objects
   autoware_auto_perception_msgs::msg::PredictedObjects target_objects;
   target_objects.header = objects_ptr->header;
@@ -1057,8 +1059,19 @@ bool IntersectionModule::checkCollision(
         const double end_arc_length = std::max(
           0.0, closest_arc_coords.length + (*end_time_distance_itr).second + base_link2front -
                  distance_until_intersection);
+
+        long double lanes_length = 0.0;
+        std::vector<lanelet::ConstLanelet> ego_lane_with_next_lanes;
+
+        for (const auto & lane : lanelets_on_path) {
+          lanes_length += bg::length(lane.centerline());
+          ego_lane_with_next_lanes.push_back(lane);
+          if (lanes_length > start_arc_length && lanes_length < end_arc_length) {
+            break;
+          }
+        }
         const auto trimmed_ego_polygon =
-          getPolygonFromArcLength(ego_lane_with_next_lane, start_arc_length, end_arc_length);
+          getPolygonFromArcLength(ego_lane_with_next_lanes, start_arc_length, end_arc_length);
 
         Polygon2d polygon{};
         for (const auto & p : trimmed_ego_polygon) {

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -934,9 +934,8 @@ bool IntersectionModule::checkCollision(
   using lanelet::utils::getPolygonFromArcLength;
 
   const auto & objects_ptr = planner_data_->predicted_objects;
-  const auto lanelets_on_path =
-    planning_utils::getLaneletsOnPath(path, planner_data_->route_handler_->getLaneletMapPtr(),
-                                      planner_data_->current_odometry->pose);
+  const auto lanelets_on_path = planning_utils::getLaneletsOnPath(
+    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
   // extract target objects
   autoware_auto_perception_msgs::msg::PredictedObjects target_objects;
   target_objects.header = objects_ptr->header;


### PR DESCRIPTION
## Description

fixes: https://github.com/autowarefoundation/autoware.universe/issues/4153

`ego_lane_with_next_lane` only keeps 2 lanes and in some cases, the total length of these combined lanes may not be in the range of `start_arc_length` and `end_arc_length` calculated beforehand. now I add lanelets to `ego_lane_with_next_lanes` until the total length of added lanelets is between arc values.

## Tests performed

https://github.com/autowarefoundation/autoware.universe/assets/32412808/fe7df7cf-45ac-40ba-b107-3602ec9ded02


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
