### PR TITLE
feat(avoidance): output avoidance path with unsafe flag when the yield is necessary

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -580,7 +580,6 @@ private:
       return;
     }
 
-    initRTCStatus();
     unlockNewModuleLaunch();
 
     current_raw_shift_lines_.clear();


### PR DESCRIPTION
## Description

Improve avoidance module. It outputs avoidance path even when the path is judged as unsafe so that operator can execute it forcibly.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/371aff93-1ac3-486f-81dc-913c17f8518a)

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/e5a17ba4-3f9f-480e-94c0-d08881eecc7f)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/10a2dea1-6479-5def-beee-9f17108ea001?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
