### PR TITLE
feat(elevation_map_loader): add error handling for std::runtime_error

### DIFF
--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -141,7 +141,7 @@ void ElevationMapLoaderNode::publish()
     try {
       is_bag_loaded = grid_map::GridMapRosConverter::loadFromBag(
         *data_manager_.elevation_map_path_, "elevation_map", elevation_map_);
-    } catch (rosbag2_storage_plugins::SqliteException & e) {
+    } catch (const std::runtime_error & e) {
       is_bag_loaded = false;
     }
     if (!is_bag_loaded) {

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -142,6 +142,7 @@ void ElevationMapLoaderNode::publish()
       is_bag_loaded = grid_map::GridMapRosConverter::loadFromBag(
         *data_manager_.elevation_map_path_, "elevation_map", elevation_map_);
     } catch (const std::runtime_error & e) {
+      RCLCPP_ERROR(this->get_logger(), e.what());
       is_bag_loaded = false;
     }
     if (!is_bag_loaded) {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- The error occurs if there are appropriate .db3 files in directory for elevation map.
- I want to add error-handling code for this. After this PR, if the appropriate .db3 files are not found in the directory, `elevation_map_loader` removes directory and creates elevation map.

## Related links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/AEAP-655)
[TIER IV INTERNAL LINK2](https://star4.slack.com/archives/C4P0NSMB5/p1688621424237299?thread_ts=1688531806.996739&cid=C4P0NSMB5)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- Normal situations

```bash
❯ ros2 launch elevation_map_loader elevation_map_loader.launch.xml
[INFO] [launch]: All log files can be found below /autoware/.ros/log/2023-07-06-10-18-10-560789-dpc2006001-398871
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [elevation_map_loader-1]: process started with pid [398872]
[elevation_map_loader-1] [INFO 1688606290.997290375] [elevation_map_loader]: subscribe map_hash
[elevation_map_loader-1] [INFO 1688606291.000977180] [elevation_map_loader]: subscribe vector_map
[elevation_map_loader-1] [INFO 1688606291.008255707] [elevation_map_loader]: subscribe pointcloud_map
[elevation_map_loader-1] [INFO 1688606291.012054258] [elevation_map_loader]: Create elevation map from pointcloud map 
[elevation_map_loader-1] [INFO 1688606291.441975551] [elevation_map_loader]: Finish creating elevation map. Total time: 0.425 sec
[elevation_map_loader-1] [INFO 1688606296.565674220] [rosbag2_storage]: Opened database '/autoware/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a_0.db3' for READ_WRITE.
[elevation_map_loader-1] [INFO 1688606296.574933011] [elevation_map_loader]: Saving elevation map successful: true
```


- Error handling
  - Case1: Directory exists, but .db3 does not exist.
  - ```bash
    ❯ ros2 launch elevation_map_loader elevation_map_loader.launch.xml
    [INFO] [launch]: All log files can be found below /autoware/.ros/log/2023-07-06-10-19-34-406132-dpc2006001-399009
    [INFO] [launch]: Default logging verbosity is set to INFO
    [INFO] [elevation_map_loader-1]: process started with pid [399010]
    [elevation_map_loader-1] [INFO 1688606374.818641867] [elevation_map_loader]: subscribe map_hash
    [elevation_map_loader-1] [INFO 1688606374.832530801] [elevation_map_loader]: subscribe vector_map
    [elevation_map_loader-1] [INFO 1688606374.840596968] [elevation_map_loader]: subscribe pointcloud_map
    [elevation_map_loader-1] [INFO 1688606374.844793917] [elevation_map_loader]: Load elevation map from: /autoware/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a
    [elevation_map_loader-1] [ERROR 1688606374.844948582] [elevation_map_loader]: Try to load bag, but bag is broken. Remove /autoware/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a
    [elevation_map_loader-1] [INFO 1688606374.845057987] [elevation_map_loader]: Create elevation map from pointcloud map 
    [elevation_map_loader-1] [INFO 1688606375.280030493] [elevation_map_loader]: Finish creating elevation map. Total time: 0.431 sec
    [elevation_map_loader-1] [INFO 1688606380.401162748] [rosbag2_storage]: Opened database '/autoware/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a_0.db3' for READ_WRITE.
    [elevation_map_loader-1] [INFO 1688606380.410786282] [elevation_map_loader]: Saving elevation map successful: true
    ```
  - Case2: .db3 file exists, but .db3 file is broken.
  - ```bash
    ❯ ros2 launch elevation_map_loader elevation_map_loader.launch.xml
    [INFO] [launch]: All log files can be found below /autoware/.ros/log/2023-07-06-10-19-55-486981-dpc2006001-399122
    [INFO] [launch]: Default logging verbosity is set to INFO
    [INFO] [elevation_map_loader-1]: process started with pid [399123]
    [elevation_map_loader-1] [INFO 1688606395.925484773] [elevation_map_loader]: subscribe map_hash
    [elevation_map_loader-1] [INFO 1688606395.928416679] [elevation_map_loader]: subscribe vector_map
    [elevation_map_loader-1] [INFO 1688606395.935859834] [elevation_map_loader]: subscribe pointcloud_map
    [elevation_map_loader-1] [INFO 1688606395.940428703] [elevation_map_loader]: Load elevation map from: /autoware/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a
    [elevation_map_loader-1] [ERROR 1688606395.940626094] [elevation_map_loader]: Try to load bag, but bag is broken. Remove /autoware/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a
    [elevation_map_loader-1] [INFO 1688606395.940764167] [elevation_map_loader]: Create elevation map from pointcloud map 
    [elevation_map_loader-1] [INFO 1688606396.392422123] [elevation_map_loader]: Finish creating elevation map. Total time: 0.448 sec
    [elevation_map_loader-1] [INFO 1688606401.662828475] [rosbag2_storage]: Opened database '/autoware/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a/63cfc18d32c9a46db0b7546b75be522e307abef6af08e207f792f6c2a09d126a_0.db3' for READ_WRITE.
    [elevation_map_loader-1] [INFO 1688606401.672855534] [elevation_map_loader]: Saving elevation map successful: true
    ```
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

`elevation_map_loader` will be able to handle error for the case when the appropriate .db3 files are not found in the directory.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
