### PR TITLE
fix(behavior_velocity_intersection_module): behavior_velocity_intersection_module dies due empty conflicting_lanelets

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -899,6 +899,7 @@ bool IntersectionModule::checkCollision(
     const auto object_direction = util::getObjectPoseWithVelocityDirection(object.kinematics);
     const auto is_in_adjacent_lanelets = util::checkAngleForTargetLanelets(
       object_direction, adjacent_lanelets, planner_param_.common.attention_area_angle_thr,
+      planner_param_.common.consider_wrong_direction_vehicle,
       planner_param_.common.attention_area_margin);
     if (is_in_adjacent_lanelets) {
       continue;
@@ -913,12 +914,14 @@ bool IntersectionModule::checkCollision(
       } else if (util::checkAngleForTargetLanelets(
                    object_direction, attention_area_lanelets,
                    planner_param_.common.attention_area_angle_thr,
+                   planner_param_.common.consider_wrong_direction_vehicle,
                    planner_param_.common.attention_area_margin)) {
         target_objects.objects.push_back(object);
       }
     } else if (util::checkAngleForTargetLanelets(
                  object_direction, attention_area_lanelets,
                  planner_param_.common.attention_area_angle_thr,
+                 planner_param_.common.consider_wrong_direction_vehicle,
                  planner_param_.common.attention_area_margin)) {
       // intersection_area is not available, use detection_area_with_margin as before
       target_objects.objects.push_back(object);

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -448,7 +448,7 @@ IntersectionLanelets getObjectiveLanelets(
     lanelet::utils::getConflictingLanelets(routing_graph_ptr, assigned_lanelet);
   std::vector<lanelet::ConstLanelet> adjacent_followings;
 
-  if(!conflicting_lanelets.empty()){
+  if (!conflicting_lanelets.empty()) {
     for (const auto & conflicting_lanelet : conflicting_lanelets) {
       for (const auto & following_lanelet : routing_graph_ptr->following(conflicting_lanelet)) {
         adjacent_followings.push_back(following_lanelet);

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -447,7 +447,7 @@ IntersectionLanelets getObjectiveLanelets(
   const auto & conflicting_lanelets =
     lanelet::utils::getConflictingLanelets(routing_graph_ptr, assigned_lanelet);
   std::vector<lanelet::ConstLanelet> adjacent_followings;
-  
+
   for (const auto & conflicting_lanelet : conflicting_lanelets) {
     for (const auto & following_lanelet : routing_graph_ptr->following(conflicting_lanelet)) {
       adjacent_followings.push_back(following_lanelet);
@@ -1001,7 +1001,8 @@ Polygon2d generateStuckVehicleDetectAreaPolygon(
 
 bool checkAngleForTargetLanelets(
   const geometry_msgs::msg::Pose & pose, const lanelet::ConstLanelets & target_lanelets,
-  const double detection_area_angle_thr, const bool consider_wrong_direction_vehicle, const double margin)
+  const double detection_area_angle_thr, const bool consider_wrong_direction_vehicle,
+  const double margin)
 {
   for (const auto & ll : target_lanelets) {
     if (!lanelet::utils::isInLanelet(pose, ll, margin)) {
@@ -1011,8 +1012,7 @@ bool checkAngleForTargetLanelets(
     const double pose_angle = tf2::getYaw(pose.orientation);
     const double angle_diff = tier4_autoware_utils::normalizeRadian(ll_angle - pose_angle);
     if (consider_wrong_direction_vehicle) {
-      if (std::fabs(angle_diff) > 1.57 ||
-          std::fabs(angle_diff) < detection_area_angle_thr) {
+      if (std::fabs(angle_diff) > 1.57 || std::fabs(angle_diff) < detection_area_angle_thr) {
         return true;
       }
     } else {

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -447,17 +447,16 @@ IntersectionLanelets getObjectiveLanelets(
   const auto & conflicting_lanelets =
     lanelet::utils::getConflictingLanelets(routing_graph_ptr, assigned_lanelet);
   std::vector<lanelet::ConstLanelet> adjacent_followings;
-
-  if (!conflicting_lanelets.empty()) {
-    for (const auto & conflicting_lanelet : conflicting_lanelets) {
-      for (const auto & following_lanelet : routing_graph_ptr->following(conflicting_lanelet)) {
-        adjacent_followings.push_back(following_lanelet);
-      }
-      for (const auto & following_lanelet : routing_graph_ptr->previous(conflicting_lanelet)) {
-        adjacent_followings.push_back(following_lanelet);
-      }
+  
+  for (const auto & conflicting_lanelet : conflicting_lanelets) {
+    for (const auto & following_lanelet : routing_graph_ptr->following(conflicting_lanelet)) {
+      adjacent_followings.push_back(following_lanelet);
+    }
+    for (const auto & following_lanelet : routing_graph_ptr->previous(conflicting_lanelet)) {
+      adjacent_followings.push_back(following_lanelet);
     }
   }
+
   // final objective lanelets
   lanelet::ConstLanelets detection_lanelets;
   lanelet::ConstLanelets conflicting_ex_ego_lanelets;
@@ -477,11 +476,9 @@ IntersectionLanelets getObjectiveLanelets(
           continue;
         }
         detection_lanelets.push_back(conflicting_lanelet);
-        if (!adjacent_followings.empty()) {
-          for (const auto & adjacent_following : adjacent_followings) {
-            detection_lanelets.push_back(adjacent_following);
-          }
-        }
+      }
+      for (const auto & adjacent_following : adjacent_followings) {
+        detection_lanelets.push_back(adjacent_following);
       }
     } else {
       // otherwise we need to know the priority from RightOfWay

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -446,8 +446,18 @@ IntersectionLanelets getObjectiveLanelets(
   // get conflicting lanes on assigned lanelet
   const auto & conflicting_lanelets =
     lanelet::utils::getConflictingLanelets(routing_graph_ptr, assigned_lanelet);
-  const auto & adjacent_followings = routing_graph_ptr->following(conflicting_lanelets.back());
+  std::vector<lanelet::ConstLanelet> adjacent_followings;
 
+  if(!conflicting_lanelets.empty()){
+    for (const auto & conflicting_lanelet : conflicting_lanelets) {
+      for (const auto & following_lanelet : routing_graph_ptr->following(conflicting_lanelet)) {
+        adjacent_followings.push_back(following_lanelet);
+      }
+      for (const auto & following_lanelet : routing_graph_ptr->previous(conflicting_lanelet)) {
+        adjacent_followings.push_back(following_lanelet);
+      }
+    }
+  }
   // final objective lanelets
   lanelet::ConstLanelets detection_lanelets;
   lanelet::ConstLanelets conflicting_ex_ego_lanelets;
@@ -468,7 +478,9 @@ IntersectionLanelets getObjectiveLanelets(
         }
         detection_lanelets.push_back(conflicting_lanelet);
         if (!adjacent_followings.empty()) {
-          detection_lanelets.push_back(adjacent_followings.front());
+          for (const auto & adjacent_following : adjacent_followings) {
+            detection_lanelets.push_back(adjacent_following);
+          }
         }
       }
     } else {

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -1001,7 +1001,7 @@ Polygon2d generateStuckVehicleDetectAreaPolygon(
 
 bool checkAngleForTargetLanelets(
   const geometry_msgs::msg::Pose & pose, const lanelet::ConstLanelets & target_lanelets,
-  const double detection_area_angle_thr, const double margin)
+  const double detection_area_angle_thr, const bool consider_wrong_direction_vehicle, const double margin)
 {
   for (const auto & ll : target_lanelets) {
     if (!lanelet::utils::isInLanelet(pose, ll, margin)) {
@@ -1010,10 +1010,15 @@ bool checkAngleForTargetLanelets(
     const double ll_angle = lanelet::utils::getLaneletAngle(ll, pose.position);
     const double pose_angle = tf2::getYaw(pose.orientation);
     const double angle_diff = tier4_autoware_utils::normalizeRadian(ll_angle - pose_angle);
-    if (
-      std::fabs(angle_diff) < detection_area_angle_thr / 2 ||
-      std::fabs(angle_diff) > detection_area_angle_thr) {
-      return true;
+    if (consider_wrong_direction_vehicle) {
+      if (std::fabs(angle_diff) > 1.57 ||
+          std::fabs(angle_diff) < detection_area_angle_thr) {
+        return true;
+      }
+    } else {
+      if (std::fabs(angle_diff) < detection_area_angle_thr) {
+        return true;
+      }
     }
   }
   return false;

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -144,7 +144,8 @@ Polygon2d generateStuckVehicleDetectAreaPolygon(
 
 bool checkAngleForTargetLanelets(
   const geometry_msgs::msg::Pose & pose, const lanelet::ConstLanelets & target_lanelets,
-  const double detection_area_angle_thr, const double margin = 0.0);
+  const double detection_area_angle_thr, const bool consider_wrong_direction_vehicle,
+  const double margin = 0.0);
 
 void cutPredictPathWithDuration(
   autoware_auto_perception_msgs::msg::PredictedObjects * objects_ptr,


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/3947
Sometimes `conflicting_lanelets` can be empty so can not calculate `adjacent_followings`  and `behavior_velocity_intersection_module` dies.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
