### PR TITLE
fix(intersection): fix invalid access

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -446,7 +446,6 @@ IntersectionLanelets getObjectiveLanelets(
   // get conflicting lanes on assigned lanelet
   const auto & conflicting_lanelets =
     lanelet::utils::getConflictingLanelets(routing_graph_ptr, assigned_lanelet);
-  const auto & adjacent_followings = routing_graph_ptr->following(conflicting_lanelets.back());
 
   // final objective lanelets
   lanelet::ConstLanelets detection_lanelets;
@@ -463,6 +462,8 @@ IntersectionLanelets getObjectiveLanelets(
   } else {
     if (consider_wrong_direction_vehicle) {
       for (const auto & conflicting_lanelet : conflicting_lanelets) {
+        const auto & adjacent_followings =
+          routing_graph_ptr->following(conflicting_lanelets.back());
         if (lanelet::utils::contains(yield_lanelets, conflicting_lanelet)) {
           continue;
         }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9daee14</samp>

Refactor `getObjectiveLanelets` function in `util.cpp` to improve readability. Declare `adjacent_followings` variable only when needed.

https://github.com/autowarefoundation/autoware.universe/pull/3947

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
