### PR TITLE
feat(avoidance): use intersection area

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -20,6 +20,7 @@
       enable_yield_maneuver_during_shifting: false
       disable_path_update: false
       use_hatched_road_markings: false
+      use_intersection_areas: false
 
       # for debug
       publish_debug_marker: false

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -92,6 +92,7 @@ struct DrivableAreaInfo
   std::vector<DrivableLanes> drivable_lanes{};
   std::vector<Obstacle> obstacles{};  // obstacles to extract from the drivable area
   bool enable_expanding_hatched_road_markings{false};
+  bool enable_expanding_intersection_areas{false};
 
   // temporary only for pull over's freespace planning
   double drivable_margin{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -108,6 +108,9 @@ struct AvoidanceParameters
   // use hatched road markings for avoidance
   bool use_hatched_road_markings{false};
 
+  // use intersection area for avoidance
+  bool use_intersection_areas{false};
+
   // constrains
   bool use_constraints_for_decel{false};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -124,8 +124,9 @@ void filterTargetObjects(
 double extendToRoadShoulderDistanceWithPolygon(
   const std::shared_ptr<route_handler::RouteHandler> & rh,
   const lanelet::ConstLineString3d & target_line, const double to_road_shoulder_distance,
-  const geometry_msgs::msg::Point & overhang_pos,
-  const lanelet::BasicPoint3d & overhang_basic_pose);
+  const lanelet::ConstLanelet & overhang_lanelet, const geometry_msgs::msg::Point & overhang_pos,
+  const lanelet::BasicPoint3d & overhang_basic_pose, const bool use_hatched_road_markings,
+  const bool use_intersection_areas);
 
 void fillAdditionalInfoFromPoint(const AvoidancePlanningData & data, AvoidLineArray & lines);
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -226,7 +226,8 @@ std::vector<DrivableLanes> generateDrivableLanesWithShoulderLanes(
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & shoulder_lanes);
 std::vector<geometry_msgs::msg::Point> calcBound(
   const std::shared_ptr<RouteHandler> route_handler,
-  const std::vector<DrivableLanes> & drivable_lanes, const bool enable_expanding_polygon,
+  const std::vector<DrivableLanes> & drivable_lanes,
+  const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
   const bool is_left);
 
 boost::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes);
@@ -235,8 +236,9 @@ std::vector<DrivableLanes> cutOverlappedLanes(
 
 void generateDrivableArea(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes,
-  const bool enable_expanding_polygon, const double vehicle_length,
-  const std::shared_ptr<const PlannerData> planner_data, const bool is_driving_forward = true);
+  const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
+  const double vehicle_length, const std::shared_ptr<const PlannerData> planner_data,
+  const bool is_driving_forward = true);
 
 void generateDrivableArea(
   PathWithLaneId & path, const double vehicle_length, const double offset,

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -154,7 +154,7 @@ void PlannerManager::generateCombinedDrivableArea(
   } else if (di.is_already_expanded) {
     // for single side shift
     utils::generateDrivableArea(
-      *output.path, di.drivable_lanes, false, data->parameters.vehicle_length, data);
+      *output.path, di.drivable_lanes, false, false, data->parameters.vehicle_length, data);
   } else {
     const auto shorten_lanes = utils::cutOverlappedLanes(*output.path, di.drivable_lanes);
 
@@ -166,7 +166,7 @@ void PlannerManager::generateCombinedDrivableArea(
     // for other modules where multiple modules may be launched
     utils::generateDrivableArea(
       *output.path, expanded_lanes, di.enable_expanding_hatched_road_markings,
-      data->parameters.vehicle_length, data);
+      di.enable_expanding_intersection_areas, data->parameters.vehicle_length, data);
   }
 
   // extract obstacles from drivable area

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2365,6 +2365,9 @@ void AvoidanceModule::generateExtendedDrivableArea(BehaviorModuleOutput & output
     // expand hatched road markings
     current_drivable_area_info.enable_expanding_hatched_road_markings =
       parameters_->use_hatched_road_markings;
+    // expand intersection areas
+    current_drivable_area_info.enable_expanding_intersection_areas =
+      parameters_->use_intersection_areas;
 
     output.drivable_area_info = utils::combineDrivableAreaInfo(
       current_drivable_area_info, getPreviousModuleOutput().drivable_area_info);

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -69,6 +69,7 @@ AvoidanceModuleManager::AvoidanceModuleManager(
       get_parameter<bool>(node, ns + "enable_yield_maneuver_during_shifting");
     p.disable_path_update = get_parameter<bool>(node, ns + "disable_path_update");
     p.use_hatched_road_markings = get_parameter<bool>(node, ns + "use_hatched_road_markings");
+    p.use_intersection_areas = get_parameter<bool>(node, ns + "use_intersection_areas");
     p.publish_debug_marker = get_parameter<bool>(node, ns + "publish_debug_marker");
     p.print_debug_info = get_parameter<bool>(node, ns + "print_debug_info");
   }

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -908,11 +908,11 @@ void filterTargetObjects(
       }
       debug.bounds.push_back(target_line);
 
-      // update to_road_shoulder_distance with expandable polygons
-      if (parameters->use_hatched_road_markings) {
+      {
         o.to_road_shoulder_distance = extendToRoadShoulderDistanceWithPolygon(
-          rh, target_line, o.to_road_shoulder_distance, o.overhang_pose.position,
-          overhang_basic_pose);
+          rh, target_line, o.to_road_shoulder_distance, overhang_lanelet, o.overhang_pose.position,
+          overhang_basic_pose, parameters->use_hatched_road_markings,
+          parameters->use_intersection_areas);
       }
     }
 
@@ -1137,27 +1137,46 @@ void filterTargetObjects(
 double extendToRoadShoulderDistanceWithPolygon(
   const std::shared_ptr<route_handler::RouteHandler> & rh,
   const lanelet::ConstLineString3d & target_line, const double to_road_shoulder_distance,
-  const geometry_msgs::msg::Point & overhang_pos, const lanelet::BasicPoint3d & overhang_basic_pose)
+  const lanelet::ConstLanelet & overhang_lanelet, const geometry_msgs::msg::Point & overhang_pos,
+  const lanelet::BasicPoint3d & overhang_basic_pose, const bool use_hatched_road_markings,
+  const bool use_intersection_areas)
 {
   // get expandable polygons for avoidance (e.g. hatched road markings)
   std::vector<lanelet::Polygon3d> expandable_polygons;
-  for (const auto & point : target_line) {
-    const auto new_polygon_candidate = utils::getPolygonByPoint(rh, point, "hatched_road_markings");
-    if (!new_polygon_candidate) {
-      continue;
-    }
 
-    bool is_new_polygon{true};
-    for (const auto & polygon : expandable_polygons) {
-      if (polygon.id() == new_polygon_candidate->id()) {
-        is_new_polygon = false;
-        break;
+  if (use_hatched_road_markings) {
+    for (const auto & point : target_line) {
+      const auto new_polygon_candidate =
+        utils::getPolygonByPoint(rh, point, "hatched_road_markings");
+      if (!new_polygon_candidate) {
+        continue;
+      }
+
+      bool is_new_polygon{true};
+      for (const auto & polygon : expandable_polygons) {
+        if (polygon.id() == new_polygon_candidate->id()) {
+          is_new_polygon = false;
+          break;
+        }
+      }
+
+      if (is_new_polygon) {
+        expandable_polygons.push_back(*new_polygon_candidate);
       }
     }
+  }
 
-    if (is_new_polygon) {
-      expandable_polygons.push_back(*new_polygon_candidate);
+  if (use_intersection_areas) {
+    const std::string area_id_str = overhang_lanelet.attributeOr("intersection_area", "else");
+
+    if (area_id_str != "else") {
+      expandable_polygons.push_back(
+        rh->getLaneletMapPtr()->polygonLayer.get(std::atoi(area_id_str.c_str())));
     }
+  }
+
+  if (expandable_polygons.empty()) {
+    return to_road_shoulder_distance;
   }
 
   // calculate point laterally offset from overhang position to calculate intersection with
@@ -1170,7 +1189,7 @@ double extendToRoadShoulderDistanceWithPolygon(
     const auto closest_target_line_point =
       lanelet::geometry::fromArcCoordinates(target_line, arc_coordinates);
 
-    const double ratio = 10.0 / to_road_shoulder_distance;
+    const double ratio = 100.0 / to_road_shoulder_distance;
     lat_offset_overhang_pos.x =
       closest_target_line_point.x() + (closest_target_line_point.x() - overhang_pos.x) * ratio;
     lat_offset_overhang_pos.y =
@@ -1197,12 +1216,8 @@ double extendToRoadShoulderDistanceWithPolygon(
     }
 
     std::sort(intersect_dist_vec.begin(), intersect_dist_vec.end());
-    if (1 < intersect_dist_vec.size()) {
-      if (std::abs(updated_to_road_shoulder_distance - intersect_dist_vec.at(0)) < 1e-3) {
-        updated_to_road_shoulder_distance =
-          std::max(updated_to_road_shoulder_distance, intersect_dist_vec.at(1));
-      }
-    }
+    updated_to_road_shoulder_distance =
+      std::max(updated_to_road_shoulder_distance, intersect_dist_vec.back());
   }
   return updated_to_road_shoulder_distance;
 }

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -1144,23 +1144,18 @@ double extendToRoadShoulderDistanceWithPolygon(
   // get expandable polygons for avoidance (e.g. hatched road markings)
   std::vector<lanelet::Polygon3d> expandable_polygons;
 
+  const auto exist_polygon = [&](const auto & candidate_polygon) {
+    return std::any_of(
+      expandable_polygons.begin(), expandable_polygons.end(),
+      [&](const auto & polygon) { return polygon.id() == candidate_polygon.id(); });
+  };
+
   if (use_hatched_road_markings) {
     for (const auto & point : target_line) {
       const auto new_polygon_candidate =
         utils::getPolygonByPoint(rh, point, "hatched_road_markings");
-      if (!new_polygon_candidate) {
-        continue;
-      }
 
-      bool is_new_polygon{true};
-      for (const auto & polygon : expandable_polygons) {
-        if (polygon.id() == new_polygon_candidate->id()) {
-          is_new_polygon = false;
-          break;
-        }
-      }
-
-      if (is_new_polygon) {
+      if (!!new_polygon_candidate && !exist_polygon(*new_polygon_candidate)) {
         expandable_polygons.push_back(*new_polygon_candidate);
       }
     }

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1343,8 +1343,9 @@ geometry_msgs::msg::Point calcLongitudinalOffsetGoalPoint(
 
 void generateDrivableArea(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes,
-  const bool enable_expanding_polygon, const double vehicle_length,
-  const std::shared_ptr<const PlannerData> planner_data, const bool is_driving_forward)
+  const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
+  const double vehicle_length, const std::shared_ptr<const PlannerData> planner_data,
+  const bool is_driving_forward)
 {
   // extract data
   const auto transformed_lanes = utils::transformToLanelets(lanes);
@@ -1379,8 +1380,12 @@ void generateDrivableArea(
     };
 
   // Insert Position
-  auto left_bound = calcBound(route_handler, lanes, enable_expanding_polygon, true);
-  auto right_bound = calcBound(route_handler, lanes, enable_expanding_polygon, false);
+  auto left_bound = calcBound(
+    route_handler, lanes, enable_expanding_hatched_road_markings,
+    enable_expanding_intersection_areas, true);
+  auto right_bound = calcBound(
+    route_handler, lanes, enable_expanding_hatched_road_markings,
+    enable_expanding_intersection_areas, false);
 
   if (left_bound.empty() || right_bound.empty()) {
     auto clock{rclcpp::Clock{RCL_ROS_TIME}};
@@ -1515,7 +1520,7 @@ void generateDrivableArea(
 
   // make bound longitudinally monotonic
   // TODO(Murooka) Fix makeBoundLongitudinallyMonotonic
-  if (enable_expanding_polygon) {
+  if (enable_expanding_hatched_road_markings || enable_expanding_intersection_areas) {
     makeBoundLongitudinallyMonotonic(path, true);   // for left bound
     makeBoundLongitudinallyMonotonic(path, false);  // for right bound
   }
@@ -1524,7 +1529,8 @@ void generateDrivableArea(
 // calculate bounds from drivable lanes and hatched road markings
 std::vector<geometry_msgs::msg::Point> calcBound(
   const std::shared_ptr<RouteHandler> route_handler,
-  const std::vector<DrivableLanes> & drivable_lanes, const bool enable_expanding_polygon,
+  const std::vector<DrivableLanes> & drivable_lanes,
+  const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
   const bool is_left)
 {
   // a function to convert drivable lanes to points without duplicated points
@@ -1560,11 +1566,29 @@ std::vector<geometry_msgs::msg::Point> calcBound(
   const auto mod = [&](const int a, const int b) {
     return (a + b) % b;  // NOTE: consider negative value
   };
+  const auto extract_bound_from_polygon =
+    [](const auto & polygon, const auto start_idx, const auto end_idx, const auto clockwise) {
+      std::vector<geometry_msgs::msg::Point> ret;
+      for (size_t i = start_idx; i != end_idx; i = clockwise ? i + 1 : i - 1) {
+        ret.push_back(lanelet::utils::conversion::toGeomMsgPt(polygon[i]));
+
+        if (i + 1 == polygon.size() && clockwise) {
+          i = 0;
+          continue;
+        }
+
+        if (i == 0 && !clockwise) {
+          i = polygon.size() - 1;
+        }
+      }
+
+      return ret;
+    };
 
   // If no need to expand with polygons, return here.
   std::vector<geometry_msgs::msg::Point> output_points;
   const auto bound_points = convert_to_points(drivable_lanes);
-  if (!enable_expanding_polygon) {
+  if (!enable_expanding_hatched_road_markings && !enable_expanding_intersection_areas) {
     for (const auto & point : bound_points) {
       output_points.push_back(lanelet::utils::conversion::toGeomMsgPt(point));
     }
@@ -1573,60 +1597,99 @@ std::vector<geometry_msgs::msg::Point> calcBound(
 
   std::optional<lanelet::Polygon3d> current_polygon{std::nullopt};
   std::vector<size_t> current_polygon_border_indices;
-  for (size_t bound_point_idx = 0; bound_point_idx < bound_points.size(); ++bound_point_idx) {
-    const auto & bound_point = bound_points.at(bound_point_idx);
-    const auto polygon = getPolygonByPoint(route_handler, bound_point, "hatched_road_markings");
+  for (const auto & drivable_lane : drivable_lanes) {
+    // extract target lane and bound.
+    const auto bound_lane = is_left ? drivable_lane.left_lane : drivable_lane.right_lane;
+    const auto bound = is_left ? bound_lane.leftBound3d() : bound_lane.rightBound3d();
 
-    bool will_close_polygon{false};
-    if (!current_polygon) {
-      if (!polygon) {
-        output_points.push_back(lanelet::utils::conversion::toGeomMsgPt(bound_point));
-      } else {
-        // There is a new additional polygon to expand
-        current_polygon = polygon;
-        current_polygon_border_indices.push_back(
-          get_corresponding_polygon_index(*current_polygon, bound_point.id()));
-      }
-    } else {
-      if (!polygon) {
-        will_close_polygon = true;
-      } else {
-        current_polygon_border_indices.push_back(
-          get_corresponding_polygon_index(*current_polygon, bound_point.id()));
-      }
+    if (bound.size() < 2) {
+      continue;
     }
 
-    if (bound_point_idx == bound_points.size() - 1 && current_polygon) {
-      // If drivable lanes ends earlier than polygon, close the polygon
-      will_close_polygon = true;
+    // expand drivable area by intersection areas.
+    const std::string id = bound_lane.attributeOr("intersection_area", "else");
+    if (enable_expanding_intersection_areas && id != "else") {
+      const auto polygon =
+        route_handler->getLaneletMapPtr()->polygonLayer.get(std::atoi(id.c_str()));
+
+      const auto start_itr = std::find_if(polygon.begin(), polygon.end(), [&bound](const auto & p) {
+        return p.id() == bound.front().id();
+      });
+
+      const auto end_itr = std::find_if(polygon.begin(), polygon.end(), [&bound](const auto & p) {
+        return p.id() == bound.back().id();
+      });
+
+      if (start_itr == polygon.end() || end_itr == polygon.end()) {
+        continue;
+      }
+
+      // extract line strings between start_idx and end_idx.
+      const size_t start_idx = std::distance(polygon.begin(), start_itr);
+      const size_t end_idx = std::distance(polygon.begin(), end_itr);
+      for (const auto & point : extract_bound_from_polygon(polygon, start_idx, end_idx, is_left)) {
+        output_points.push_back(point);
+      }
+
+      continue;
     }
 
-    if (will_close_polygon) {
-      // The current additional polygon ends to expand
-      if (current_polygon_border_indices.size() == 1) {
-        output_points.push_back(lanelet::utils::conversion::toGeomMsgPt(
-          (*current_polygon)[current_polygon_border_indices.front()]));
-      } else {
-        const size_t current_polygon_points_num = current_polygon->size();
-        const bool is_polygon_opposite_direction = [&]() {
-          const size_t modulo_diff = mod(
-            static_cast<int>(current_polygon_border_indices[1]) -
-              static_cast<int>(current_polygon_border_indices[0]),
-            current_polygon_points_num);
-          return modulo_diff == 1;
-        }();
+    // expand drivable area by hatched road markings.
+    for (size_t bound_point_idx = 0; bound_point_idx < bound.size(); ++bound_point_idx) {
+      const auto & bound_point = bound[bound_point_idx];
+      const auto polygon = getPolygonByPoint(route_handler, bound_point, "hatched_road_markings");
 
-        const int target_points_num =
-          current_polygon_points_num - current_polygon_border_indices.size() + 1;
-        for (int poly_idx = 0; poly_idx <= target_points_num; ++poly_idx) {
-          const int target_poly_idx = current_polygon_border_indices.front() +
-                                      poly_idx * (is_polygon_opposite_direction ? -1 : 1);
-          output_points.push_back(lanelet::utils::conversion::toGeomMsgPt(
-            (*current_polygon)[mod(target_poly_idx, current_polygon_points_num)]));
+      bool will_close_polygon{false};
+      if (!current_polygon) {
+        if (!polygon) {
+          output_points.push_back(lanelet::utils::conversion::toGeomMsgPt(bound_point));
+        } else {
+          // There is a new additional polygon to expand
+          current_polygon = polygon;
+          current_polygon_border_indices.push_back(
+            get_corresponding_polygon_index(*current_polygon, bound_point.id()));
+        }
+      } else {
+        if (!polygon) {
+          will_close_polygon = true;
+        } else {
+          current_polygon_border_indices.push_back(
+            get_corresponding_polygon_index(*current_polygon, bound_point.id()));
         }
       }
-      current_polygon = std::nullopt;
-      current_polygon_border_indices.clear();
+
+      if (bound_point_idx == bound_points.size() - 1 && current_polygon) {
+        // If drivable lanes ends earlier than polygon, close the polygon
+        will_close_polygon = true;
+      }
+
+      if (will_close_polygon) {
+        // The current additional polygon ends to expand
+        if (current_polygon_border_indices.size() == 1) {
+          output_points.push_back(lanelet::utils::conversion::toGeomMsgPt(
+            (*current_polygon)[current_polygon_border_indices.front()]));
+        } else {
+          const size_t current_polygon_points_num = current_polygon->size();
+          const bool is_polygon_opposite_direction = [&]() {
+            const size_t modulo_diff = mod(
+              static_cast<int>(current_polygon_border_indices[1]) -
+                static_cast<int>(current_polygon_border_indices[0]),
+              current_polygon_points_num);
+            return modulo_diff == 1;
+          }();
+
+          const int target_points_num =
+            current_polygon_points_num - current_polygon_border_indices.size() + 1;
+          for (int poly_idx = 0; poly_idx <= target_points_num; ++poly_idx) {
+            const int target_poly_idx = current_polygon_border_indices.front() +
+                                        poly_idx * (is_polygon_opposite_direction ? -1 : 1);
+            output_points.push_back(lanelet::utils::conversion::toGeomMsgPt(
+              (*current_polygon)[mod(target_poly_idx, current_polygon_points_num)]));
+          }
+        }
+        current_polygon = std::nullopt;
+        current_polygon_border_indices.clear();
+      }
     }
   }
 
@@ -2523,7 +2586,8 @@ BehaviorModuleOutput getReferencePath(
     dp.drivable_area_types_to_skip);
 
   // for old architecture
-  generateDrivableArea(reference_path, expanded_lanes, false, p.vehicle_length, planner_data);
+  generateDrivableArea(
+    reference_path, expanded_lanes, false, false, p.vehicle_length, planner_data);
 
   BehaviorModuleOutput output;
   output.path = std::make_shared<PathWithLaneId>(reference_path);
@@ -2941,6 +3005,11 @@ DrivableAreaInfo combineDrivableAreaInfo(
   combined_drivable_area_info.enable_expanding_hatched_road_markings =
     drivable_area_info1.enable_expanding_hatched_road_markings ||
     drivable_area_info2.enable_expanding_hatched_road_markings;
+
+  // enable expanding intersection areas
+  combined_drivable_area_info.enable_expanding_intersection_areas =
+    drivable_area_info1.enable_expanding_intersection_areas ||
+    drivable_area_info2.enable_expanding_intersection_areas;
 
   return combined_drivable_area_info;
 }

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1608,7 +1608,8 @@ std::vector<geometry_msgs::msg::Point> calcBound(
 
     // expand drivable area by intersection areas.
     const std::string id = bound_lane.attributeOr("intersection_area", "else");
-    if (enable_expanding_intersection_areas && id != "else") {
+    const auto use_intersection_area = enable_expanding_intersection_areas && id != "else";
+    if (use_intersection_area) {
       const auto polygon =
         route_handler->getLaneletMapPtr()->polygonLayer.get(std::atoi(id.c_str()));
 

--- a/planning/static_centerline_optimizer/src/utils.cpp
+++ b/planning/static_centerline_optimizer/src/utils.cpp
@@ -91,7 +91,7 @@ PathWithLaneId get_path_with_lane_id(
   constexpr double vehicle_length = 0.0;
   const auto drivable_lanes = behavior_path_planner::utils::generateDrivableLanes(lanelets);
   behavior_path_planner::utils::generateDrivableArea(
-    path_with_lane_id, drivable_lanes, false, vehicle_length, planner_data);
+    path_with_lane_id, drivable_lanes, false, false, vehicle_length, planner_data);
 
   return path_with_lane_id;
 }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 48eabc2</samp>

This pull request refactors and improves the code for generating and using the drivable area in the behavior path planner. It removes redundant code, adds new parameters and flags, and simplifies the logic for expanding the drivable area by polygons such as hatched road markings and intersection areas. It also makes the functions for drivable area calculation more consistent and flexible. The changes affect several files in the `planning/behavior_path_planner` directory, such as `utils.hpp`, `utils.cpp`, `planner_manager.cpp`, and `avoidance.param.yaml`.

Please approve :arrow_down: before this PR.
https://github.com/autowarefoundation/autoware_launch/pull/439

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/df7cbaf8-54b2-4864-b130-8048913030a8)

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/424cb6e8-bef6-498d-97fb-e74411b093a1)

<!-- Write a brief description of this PR. -->

## Tests performed

Psim

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/df1e2d22-37e0-4f55-85df-d92f60b77c40)

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/73c3a444-e592-4ea0-9012-5b4188a701f5)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/a0b93c42-a4d2-5086-add3-44b919392a24?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
