### PR TITLE
feat(behavior_velocity_crosswalk_module): looser stop decision

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
@@ -21,12 +21,13 @@
       stuck_vehicle_attention_range: 10.0 # [m] the detection area is defined as X meters behind the crosswalk
 
       # param for pass judge logic
+      disable_stop_for_yield_cancel: false
       ego_pass_first_margin: 6.0 # [s] time margin for ego pass first situation (the module judges that ego don't have to stop at TTC + MARGIN < TTV condition)
       ego_pass_later_margin: 10.0 # [s] time margin for object pass first situation (the module judges that ego don't have to stop at TTV + MARGIN < TTC condition)
       stop_object_velocity_threshold: 0.28 # [m/s] velocity threshold for the module to judge whether the objects is stopped (0.28 m/s = 1.0 kmph)
       min_object_velocity: 1.39 # [m/s] minimum object velocity (compare the estimated velocity by perception module with this parameter and adopt the larger one to calculate TTV. 1.39 m/s = 5.0 kmph)
       max_yield_timeout: 3.0 # [s] if the pedestrian does not move for X seconds after stopping before the crosswalk, the module judge that ego is able to pass first.
-      ego_yield_query_stop_duration: 0.1 # [s] the amount of time which ego should be stopping to query whether it yields or not
+      ego_yield_query_stop_duration: 3.0 # [s] the amount of time which ego should be stopping to query whether it yields or not
 
       # param for input data
       tl_state_timeout: 3.0 # [s] timeout threshold for traffic light signal

--- a/planning/behavior_velocity_crosswalk_module/src/debug.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/debug.cpp
@@ -43,26 +43,29 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   int32_t uid = planning_utils::bitShift(module_id);
 
   {
-    size_t i = 0;
-    for (const auto & p : debug_data.collision_points) {
+    for (size_t i = 0; i < debug_data.collision_points.size(); ++i) {
+      const auto & collision_point = debug_data.collision_points.at(i);
+      const auto & point = collision_point.first;
+      const auto & state = collision_point.second;
+
       auto marker = createDefaultMarker(
         "map", now, "collision point state", uid + i++, Marker::TEXT_VIEW_FACING,
         createMarkerScale(0.0, 0.0, 1.0), createMarkerColor(1.0, 1.0, 1.0, 0.999));
       std::ostringstream string_stream;
       string_stream << std::fixed << std::setprecision(2);
-      string_stream << "(module, ttc, ttv, state)=(" << module_id << " , " << p.time_to_collision
-                    << " , " << p.time_to_vehicle;
-      switch (p.state) {
-        case CollisionPointState::YIELD:
+      string_stream << "(module, ttc, ttv, state)=(" << module_id << " , "
+                    << point.time_to_collision << " , " << point.time_to_vehicle;
+      switch (state) {
+        case CollisionState::YIELD:
           string_stream << " , YIELD)";
           break;
-        case CollisionPointState::EGO_PASS_FIRST:
+        case CollisionState::EGO_PASS_FIRST:
           string_stream << " , EGO_PASS_FIRST)";
           break;
-        case CollisionPointState::EGO_PASS_LATER:
+        case CollisionState::EGO_PASS_LATER:
           string_stream << " , EGO_PASS_LATER)";
           break;
-        case CollisionPointState::IGNORE:
+        case CollisionState::IGNORE:
           string_stream << " , IGNORE)";
           break;
         default:
@@ -70,7 +73,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
           break;
       }
       marker.text = string_stream.str();
-      marker.pose.position = p.collision_point;
+      marker.pose.position = point.collision_point;
       marker.pose.position.z += 2.0;
       msg.markers.push_back(marker);
     }
@@ -131,8 +134,8 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     auto marker = createDefaultMarker(
       "map", now, "collision point", uid, Marker::POINTS, createMarkerScale(0.25, 0.25, 0.0),
       createMarkerColor(1.0, 0.0, 1.0, 0.999));
-    for (const auto & p : debug_data.collision_points) {
-      marker.points.push_back(p.collision_point);
+    for (const auto & collision_point : debug_data.collision_points) {
+      marker.points.push_back(collision_point.first.collision_point);
     }
     msg.markers.push_back(marker);
   }

--- a/planning/behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/manager.cpp
@@ -119,6 +119,8 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
   cp.ego_pass_later_margin = node.declare_parameter<double>(ns + ".ego_pass_later_margin");
   cp.stop_object_velocity = node.declare_parameter<double>(ns + ".stop_object_velocity_threshold");
   cp.min_object_velocity = node.declare_parameter<double>(ns + ".min_object_velocity");
+  cp.disable_stop_for_yield_cancel =
+    node.declare_parameter<bool>(ns + ".disable_stop_for_yield_cancel");
   cp.max_yield_timeout = node.declare_parameter<double>(ns + ".max_yield_timeout");
   cp.ego_yield_query_stop_duration =
     node.declare_parameter<double>(ns + ".ego_yield_query_stop_duration");

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -124,6 +124,26 @@ void sortCrosswalksByDistance(
 
   std::sort(crosswalks.begin(), crosswalks.end(), compare);
 }
+
+std::vector<Point2d> calcOverlappingPoints(const Polygon2d & polygon1, const Polygon2d & polygon2)
+{
+  // NOTE: If one polygon is fully inside the other polygon, the result is empty.
+  std::vector<Point2d> intersection{};
+  bg::intersection(polygon1, polygon2, intersection);
+
+  if (bg::within(polygon1, polygon2)) {
+    for (const auto & p : polygon1.outer()) {
+      intersection.push_back(Point2d{p.x(), p.y()});
+    }
+  }
+  if (bg::within(polygon2, polygon1)) {
+    for (const auto & p : polygon2.outer()) {
+      intersection.push_back(Point2d{p.x(), p.y()});
+    }
+  }
+
+  return intersection;
+}
 }  // namespace
 
 CrosswalkModule::CrosswalkModule(
@@ -290,28 +310,36 @@ boost::optional<StopFactor> CrosswalkModule::findNearestStopFactor(
     return {};
   }
 
-  const auto now = clock_->now();
-
-  const auto ignore_crosswalk = debug_data_.ignore_crosswalk = isRedSignalForPedestrians();
-
-  // Get attention area
+  // Get attention area, which is ego's footprints on the crosswalk
   const auto attention_area = getAttentionArea(sparse_resample_path, crosswalk_attention_range);
 
   // Check stuck vehicle
   const bool found_stuck_vehicle =
     isStuckVehicle(sparse_resample_path, objects_ptr->objects, path_intersects);
 
+  // Update object state
+  object_info_manager_.init();
+  for (const auto & object : objects_ptr->objects) {
+    const auto & obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
+    const auto obj_uuid = toHexString(object.object_id);
+
+    const auto is_object_stopped =
+      std::hypot(obj_vel.x, obj_vel.y) < planner_param_.stop_object_velocity;
+    object_info_manager_.update(obj_uuid, is_object_stopped, clock_->now());
+  }
+  object_info_manager_.finalize();
+
   // Check pedestrian for stop
   bool found_pedestrians = false;
   geometry_msgs::msg::Point first_stop_point{};
   double minimum_stop_dist = std::numeric_limits<double>::max();
   StopFactor stop_factor;
+  const auto ignore_crosswalk = debug_data_.ignore_crosswalk = isRedSignalForPedestrians();
   for (const auto & object : objects_ptr->objects) {
     const auto & obj_pos = object.kinematics.initial_pose_with_covariance.pose.position;
-    const auto & obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
     const auto obj_uuid = toHexString(object.object_id);
 
-    if (!isTargetType(object)) {
+    if (!isCrosswalkUserType(object)) {
       continue;
     }
 
@@ -319,23 +347,16 @@ boost::optional<StopFactor> CrosswalkModule::findNearestStopFactor(
       continue;
     }
 
-    for (auto & cp : getCollisionPoints(
-           sparse_resample_path, object, attention_area, crosswalk_attention_range)) {
-      const auto is_ignore_object = ignore_objects_.count(obj_uuid) != 0;
-      if (is_ignore_object) {
-        cp.state = CollisionPointState::IGNORE;
-      }
+    // NOTE: Collision points are calculated on each predicted path
+    const auto collision_point =
+      getCollisionPoints(sparse_resample_path, object, attention_area, crosswalk_attention_range);
 
-      const auto is_stop_object =
-        std::hypot(obj_vel.x, obj_vel.y) < planner_param_.stop_object_velocity;
-      if (!is_stop_object) {
-        ignore_objects_.erase(obj_uuid);
-        stopped_objects_.erase(obj_uuid);
-      }
+    for (const auto & cp : collision_point) {
+      const auto collision_state =
+        getCollisionState(obj_uuid, cp.time_to_collision, cp.time_to_vehicle);
+      debug_data_.collision_points.push_back(std::make_pair(cp, collision_state));
 
-      debug_data_.collision_points.push_back(cp);
-
-      if (cp.state != CollisionPointState::YIELD) {
+      if (collision_state != CollisionState::YIELD) {
         continue;
       }
 
@@ -350,35 +371,6 @@ boost::optional<StopFactor> CrosswalkModule::findNearestStopFactor(
         first_stop_point = cp.collision_point;
         minimum_stop_dist = dist_ego2cp;
       }
-
-      if (!is_stop_object) {
-        continue;
-      }
-
-      const auto reached_stop_point =
-        dist_ego2cp - base_link2front < planner_param_.stop_position_threshold ||
-        p_stop_line.get().first - base_link2front < planner_param_.stop_position_threshold;
-
-      const auto is_yielding_now =
-        planner_data_->isVehicleStopped(planner_param_.ego_yield_query_stop_duration) &&
-        reached_stop_point;
-      if (!is_yielding_now) {
-        continue;
-      }
-
-      const auto has_object_stopped = stopped_objects_.count(obj_uuid) != 0;
-      if (!has_object_stopped) {
-        stopped_objects_.insert(std::make_pair(obj_uuid, now));
-        continue;
-      }
-
-      const auto stopped_time = (now - stopped_objects_.at(obj_uuid)).seconds();
-      const auto no_intent_to_cross = stopped_time > planner_param_.max_yield_timeout;
-      if (!no_intent_to_cross) {
-        continue;
-      }
-
-      ignore_objects_.insert(std::make_pair(obj_uuid, now));
     }
   }
 
@@ -620,23 +612,16 @@ std::vector<CollisionPoint> CrosswalkModule::getCollisionPoints(
       const auto & p_obj_back = obj_path.path.at(i + 1);
       const auto obj_one_step_polygon = createOneStepPolygon(p_obj_front, p_obj_back, obj_polygon);
 
-      std::vector<Point2d> tmp_intersects{};
-      bg::intersection(obj_one_step_polygon, attention_area, tmp_intersects);
-
-      if (bg::within(obj_one_step_polygon, attention_area)) {
-        for (const auto & p : obj_one_step_polygon.outer()) {
-          const Point2d point{p.x(), p.y()};
-          tmp_intersects.push_back(point);
-        }
-      }
-
-      if (tmp_intersects.empty()) {
+      // Calculate intersection points between object and attention area
+      const auto tmp_intersection = calcOverlappingPoints(obj_one_step_polygon, attention_area);
+      if (tmp_intersection.empty()) {
         continue;
       }
 
+      // Calculate nearest collision point
       double minimum_stop_dist = std::numeric_limits<double>::max();
       geometry_msgs::msg::Point nearest_collision_point{};
-      for (const auto & p : tmp_intersects) {
+      for (const auto & p : tmp_intersection) {
         const auto cp = createPoint(p.x(), p.y(), ego_pos.z);
         const auto dist_ego2cp = calcSignedArcLength(ego_path.points, ego_pos, cp);
 
@@ -694,24 +679,30 @@ CollisionPoint CrosswalkModule::createCollisionPoint(
     std::max(0.0, dist_ego2cp - planner_param_.stop_margin - base_link2front) /
     std::max(ego_vel.x, min_ego_velocity);
   collision_point.time_to_vehicle = std::max(0.0, dist_obj2cp) / velocity;
-  collision_point.state =
-    getCollisionPointState(collision_point.time_to_collision, collision_point.time_to_vehicle);
 
   return collision_point;
 }
 
-CollisionPointState CrosswalkModule::getCollisionPointState(
-  const double ttc, const double ttv) const
+CollisionState CrosswalkModule::getCollisionState(
+  const std::string & obj_uuid, const double ttc, const double ttv) const
 {
+  // check if the state is ignore first
+  const auto time_to_stop = object_info_manager_.getTimeToStop(obj_uuid, clock_->now());
+  const auto intent_to_cross =
+    time_to_stop ? *time_to_stop < planner_param_.max_yield_timeout : true;
+  if (!intent_to_cross) {
+    return CollisionState::IGNORE;
+  }
+
+  // compare time to collision and vehicle
   if (ttc + planner_param_.ego_pass_first_margin < ttv) {
-    return CollisionPointState::EGO_PASS_FIRST;
+    return CollisionState::EGO_PASS_FIRST;
   }
 
   if (ttv + planner_param_.ego_pass_later_margin < ttc) {
-    return CollisionPointState::EGO_PASS_LATER;
+    return CollisionState::EGO_PASS_LATER;
   }
-
-  return CollisionPointState::YIELD;
+  return CollisionState::YIELD;
 }
 
 void CrosswalkModule::applySafetySlowDownSpeed(
@@ -906,7 +897,7 @@ bool CrosswalkModule::isVehicle(const PredictedObject & object)
   return false;
 }
 
-bool CrosswalkModule::isTargetType(const PredictedObject & object) const
+bool CrosswalkModule::isCrosswalkUserType(const PredictedObject & object) const
 {
   if (object.classification.empty()) {
     return false;

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -692,7 +692,7 @@ CollisionState CrosswalkModule::getCollisionState(
 {
   // First, check if the object can be ignored
   const auto obj_state = object_info_manager_.getState(obj_uuid);
-  if (obj_state == ObjectInfo::State::IGNORED) {
+  if (obj_state == ObjectInfo::State::FULLY_STOPPED) {
     return CollisionState::IGNORE;
   }
 

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -92,6 +92,70 @@ public:
     bool look_pedestrian;
   };
 
+  struct ObjectInfoManager
+  {
+    struct ObjectInfo
+    {
+      enum class State { STOP = 0, OTHER };  // APPROACH, LEAVE, OTHER };
+      State state;
+      boost::optional<rclcpp::Time> time_to_start_stopped{boost::none};
+    };
+    void init() { current_uuids_.clear(); }
+    void update(const std::string & uuid, const bool is_object_stopped, const rclcpp::Time & now)
+    {
+      // update current uuids
+      current_uuids_.push_back(uuid);
+
+      // update object info
+      const auto state = is_object_stopped ? ObjectInfo::State::STOP : ObjectInfo::State::OTHER;
+      const auto time_to_start_stopped = [&]() -> boost::optional<rclcpp::Time> {
+        if (is_object_stopped) return now;
+        return boost::none;
+      }();
+      if (objects.count(uuid) == 0) {
+        objects.emplace(uuid, ObjectInfo{state, time_to_start_stopped});
+        return;
+      }
+
+      if (objects.at(uuid).state != ObjectInfo::State::STOP) {
+        objects.at(uuid).time_to_start_stopped = time_to_start_stopped;
+      }
+      objects.at(uuid).state = state;
+    }
+    void finalize()
+    {
+      std::vector<std::string> obsolete_uuids;
+      for (const auto & object : objects) {
+        if (
+          std::find(current_uuids_.begin(), current_uuids_.end(), object.first) ==
+          current_uuids_.end()) {
+          obsolete_uuids.push_back(object.first);
+        }
+      }
+      for (const auto & obsolete_uuid : obsolete_uuids) {
+        objects.erase(obsolete_uuid);
+      }
+    }
+
+    bool isStopped(const std::string & uuid) const
+    {
+      if (objects.count(uuid) != 0) {
+        return objects.at(uuid).state == ObjectInfo::State::STOP;
+      }
+      return false;
+    }
+    boost::optional<double> getTimeToStop(const std::string & uuid, const rclcpp::Time & now) const
+    {
+      if (objects.count(uuid) == 0 || !objects.at(uuid).time_to_start_stopped) {
+        return boost::none;
+      }
+      return (now - *objects.at(uuid).time_to_start_stopped).seconds();
+    }
+
+    std::unordered_map<std::string, ObjectInfo> objects;
+    std::vector<std::string> current_uuids_;
+  };
+
   CrosswalkModule(
     const int64_t module_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
     const PlannerParam & planner_param, const bool use_regulatory_element,
@@ -138,7 +202,8 @@ private:
     const double dist_obj2cp, const geometry_msgs::msg::Vector3 & ego_vel,
     const geometry_msgs::msg::Vector3 & obj_vel) const;
 
-  CollisionPointState getCollisionPointState(const double ttc, const double ttv) const;
+  CollisionState getCollisionState(
+    const std::string & obj_uuid, const double ttc, const double ttv) const;
 
   void applySafetySlowDownSpeed(
     PathWithLaneId & output, const std::vector<geometry_msgs::msg::Point> & path_intersects);
@@ -158,7 +223,7 @@ private:
 
   static bool isVehicle(const PredictedObject & object);
 
-  bool isTargetType(const PredictedObject & object) const;
+  bool isCrosswalkUserType(const PredictedObject & object) const;
 
   static geometry_msgs::msg::Polygon createObjectPolygon(
     const double width_m, const double length_m);
@@ -189,9 +254,7 @@ private:
   // Parameter
   const PlannerParam planner_param_;
 
-  // Ignore objects
-  std::unordered_map<std::string, rclcpp::Time> stopped_objects_;
-  std::unordered_map<std::string, rclcpp::Time> ignore_objects_;
+  ObjectInfoManager object_info_manager_;
 
   // Debug
   mutable DebugData debug_data_;

--- a/planning/behavior_velocity_crosswalk_module/src/util.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/util.hpp
@@ -24,6 +24,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #define EIGEN_MPL2_ONLY
@@ -43,14 +44,13 @@ using tier4_autoware_utils::createPoint;
 using tier4_autoware_utils::Point2d;
 using tier4_planning_msgs::msg::StopFactor;
 
-enum class CollisionPointState { YIELD, EGO_PASS_FIRST, EGO_PASS_LATER, IGNORE };
+enum class CollisionState { YIELD, EGO_PASS_FIRST, EGO_PASS_LATER, IGNORE };
 
 struct CollisionPoint
 {
   geometry_msgs::msg::Point collision_point{};
   double time_to_collision{};
   double time_to_vehicle{};
-  CollisionPointState state{CollisionPointState::EGO_PASS_FIRST};
 };
 
 struct StopFactorInfo
@@ -78,7 +78,7 @@ struct DebugData
   boost::optional<geometry_msgs::msg::Point> range_near_point{boost::none};
   boost::optional<geometry_msgs::msg::Point> range_far_point{boost::none};
 
-  std::vector<CollisionPoint> collision_points;
+  std::vector<std::pair<CollisionPoint, CollisionState>> collision_points;
 
   std::vector<geometry_msgs::msg::Pose> stop_poses;
   std::vector<geometry_msgs::msg::Pose> slow_poses;


### PR DESCRIPTION
## Description

NOTE: The behavior of the crosswalk module will not change with this PR

- minor refactoring
    - create `ObjectInfoManager` to manage the object state (stopped, fully_stopped = can be yield, other)
- add option of `disable_stop_for_yield_cancel` not to wait while stopping for canceling yield
   - set to false by default
   - The flag can be set to true for more aggressive behavior

- launcher PR for https://github.com/autowarefoundation/autoware_launch/pull/449
<!-- Write a brief description of this PR. -->

## Tests performed

- planning simulator
- scenario simulator
    - no degradation: https://evaluation.tier4.jp/evaluation/reports/0d3efa4d-ac33-53e5-9c01-827a6716d70a?project_id=prd_jt (1575/1588)
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
