### PR TITLE
fix(shift_decider): prevent chattering of gear command when target speed is near 0

### DIFF
--- a/control/shift_decider/include/shift_decider/shift_decider.hpp
+++ b/control/shift_decider/include/shift_decider/shift_decider.hpp
@@ -50,6 +50,7 @@ private:
   autoware_auto_system_msgs::msg::AutowareState::SharedPtr autoware_state_;
   autoware_auto_vehicle_msgs::msg::GearCommand shift_cmd_;
   autoware_auto_vehicle_msgs::msg::GearReport::SharedPtr current_gear_ptr_;
+  uint8_t prev_shift_command = autoware_auto_vehicle_msgs::msg::GearCommand::PARK;
 
   bool park_on_goal_;
 };

--- a/control/shift_decider/src/shift_decider.cpp
+++ b/control/shift_decider/src/shift_decider.cpp
@@ -83,7 +83,7 @@ void ShiftDecider::updateCurrentShiftCmd()
     } else if (control_cmd_->longitudinal.speed < -vel_threshold) {
       shift_cmd_.command = GearCommand::REVERSE;
     } else {
-      shift_cmd_.command = current_gear_ptr_->report;
+      shift_cmd_.command = prev_shift_command;
     }
   } else {
     if (
@@ -95,6 +95,7 @@ void ShiftDecider::updateCurrentShiftCmd()
       shift_cmd_.command = current_gear_ptr_->report;
     }
   }
+  prev_shift_command = shift_cmd_.command;
 }
 
 void ShiftDecider::initTimer(double period_s)


### PR DESCRIPTION
## Description

If the target speed is around 0.01(```vel_threshold```) when Autoware engages, gear command may chatter on DRIVE and PARKING ( = ```current_gear_ptr_->report```).

Such gear command chattering can adversely affect hardware, so this PR prevents chattering by sending the same gear command as last time when the target speed is low.

![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/514b14cf-fe58-47f8-8d6a-3af1d44ba13d)

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
no tests

<!-- Describe how you have tested this PR. -->

## Notes for reviewers
none
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
none
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
This PR prevents chattering of gear command.

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
