### PR TITLE
fix(start_planner): publish stop path when goal is behind from ego

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -149,6 +149,12 @@ private:
   bool isStopped();
   bool hasFinishedCurrentPath();
 
+  // check if the goal is located behind the ego in the same route segment.
+  bool IsGoalBehindOfEgoInSameRouteSegment() const;
+
+  // generate BehaviorPathOutput with stopping path.
+  BehaviorModuleOutput generateStopOutput() const;
+
   void setDebugData() const;
 };
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -156,7 +156,7 @@ BehaviorModuleOutput StartPlannerModule::plan()
   if (IsGoalBehindOfEgoInSameRouteSegment()) {
     RCLCPP_WARN_THROTTLE(
       getLogger(), *clock_, 5000, "Start plan for a backward goal is not supported now");
-      return generateStopOutput();
+    return generateStopOutput();
   }
 
   if (isWaitingApproval()) {
@@ -303,7 +303,7 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
   if (IsGoalBehindOfEgoInSameRouteSegment()) {
     RCLCPP_WARN_THROTTLE(
       getLogger(), *clock_, 5000, "Start plan for a backward goal is not supported now");
-      return generateStopOutput();
+    return generateStopOutput();
   }
 
   BehaviorModuleOutput output;

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -153,6 +153,12 @@ ModuleStatus StartPlannerModule::updateState()
 
 BehaviorModuleOutput StartPlannerModule::plan()
 {
+  if (IsGoalBehindOfEgoInSameRouteSegment()) {
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 5000, "Start plan for a backward goal is not supported now");
+      return generateStopOutput();
+  }
+
   if (isWaitingApproval()) {
     clearWaitingApproval();
     resetPathCandidate();
@@ -293,6 +299,12 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
 {
   updatePullOutStatus();
   waitApproval();
+
+  if (IsGoalBehindOfEgoInSameRouteSegment()) {
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 5000, "Start plan for a backward goal is not supported now");
+      return generateStopOutput();
+  }
 
   BehaviorModuleOutput output;
   if (!status_.is_safe) {
@@ -830,6 +842,46 @@ TurnSignalInfo StartPlannerModule::calcTurnSignalInfo() const
   }
 
   return turn_signal;
+}
+
+bool StartPlannerModule::IsGoalBehindOfEgoInSameRouteSegment() const
+{
+  const auto & rh = planner_data_->route_handler;
+
+  // Check if the goal and ego are in the same route segment. If not, this is out of scope of this
+  // function. Return false.
+  lanelet::ConstLanelet ego_lanelet;
+  rh->getClosestLaneletWithinRoute(getEgoPose(), &ego_lanelet);
+  const auto is_ego_in_goal_route_section = rh->isInGoalRouteSection(ego_lanelet);
+
+  if (!is_ego_in_goal_route_section) {
+    return false;
+  }
+
+  // If the goal and ego are in the same route segment, check the goal and ego pose relation.
+  // Return true when the goal is located behind of ego.
+  const auto ego_lane_path = rh->getCenterLinePath(
+    lanelet::ConstLanelets{ego_lanelet}, 0.0, std::numeric_limits<double>::max());
+  const auto dist_ego_to_goal = motion_utils::calcSignedArcLength(
+    ego_lane_path.points, getEgoPosition(), rh->getGoalPose().position);
+
+  const bool is_goal_behind_of_ego = (dist_ego_to_goal < 0.0);
+  return is_goal_behind_of_ego;
+}
+
+// NOTE: this must be called after updatePullOutStatus(). This must be fixed.
+BehaviorModuleOutput StartPlannerModule::generateStopOutput() const
+{
+  BehaviorModuleOutput output;
+  output.path = std::make_shared<PathWithLaneId>(generateStopPath());
+
+  DrivableAreaInfo current_drivable_area_info;
+  current_drivable_area_info.drivable_lanes = status_.lanes;
+  output.drivable_area_info = utils::combineDrivableAreaInfo(
+    current_drivable_area_info, getPreviousModuleOutput().drivable_area_info);
+
+  output.reference_path = getPreviousModuleOutput().reference_path;
+  return output;
 }
 
 void StartPlannerModule::setDebugData() const


### PR DESCRIPTION
## Description

The path is not well calculated when the goal is set behind from ego.

before:
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/a875a53e-615b-44a4-9d3a-94adaee85af6)

Now since the plan for a backward direction is not supported, add a function in the start_planner to skip planning when the ego is behind from ego with a warning message.

after:
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/39c8f3c0-6559-45b2-8d1e-95915a812c30)


## Related links

[TIERIV internal link](https://evaluation.tier4.jp/evaluation/reports/a478c75f-2615-544b-9a02-0a80a460aed4?project_id=prd_jt)

## Tests performed

run psim

[Link for scenario test in TIERIV ](https://evaluation.tier4.jp/evaluation/reports/a478c75f-2615-544b-9a02-0a80a460aed4?project_id=prd_jt)

## Notes for reviewers
None

## Interface changes

None
## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
