### PR TITLE
fix(behavior_path_planner): fix sampling warning

### DIFF
--- a/planning/behavior_path_planner/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/path_utils.cpp
@@ -59,6 +59,9 @@ PathWithLaneId resamplePathWithSpline(
   const PathWithLaneId & path, const double interval, const bool keep_input_points,
   const std::pair<double, double> target_section)
 {
+  std::cerr << "path.points.size() = " << path.points.size() << std::endl;
+  std::cerr << "path length = " << motion_utils::calcArcLength(path.points) << std::endl;
+
   if (path.points.size() < 2) {
     return path;
   }
@@ -108,12 +111,16 @@ PathWithLaneId resamplePathWithSpline(
 
   std::vector<double> s_out = s_in;
 
+  // sampling from interval distance
   const auto start_s = std::max(target_section.first, 0.0);
   const auto end_s = std::min(target_section.second, s_vec.back());
   for (double s = start_s; s < end_s; s += interval) {
     if (!find_almost_same_values(s_out, s)) {
       s_out.push_back(s);
     }
+  }
+  if (!find_almost_same_values(s_out, end_s)) {
+    s_out.push_back(end_s);
   }
 
   // Insert Stop Point
@@ -133,7 +140,8 @@ PathWithLaneId resamplePathWithSpline(
     }
   }
 
-  if (s_out.empty()) {
+  // spline resample required more than 2 points for yaw angle calculation
+  if (s_out.size() < 2) {
     return path;
   }
 

--- a/planning/behavior_path_planner/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/path_utils.cpp
@@ -59,9 +59,6 @@ PathWithLaneId resamplePathWithSpline(
   const PathWithLaneId & path, const double interval, const bool keep_input_points,
   const std::pair<double, double> target_section)
 {
-  std::cerr << "path.points.size() = " << path.points.size() << std::endl;
-  std::cerr << "path length = " << motion_utils::calcArcLength(path.points) << std::endl;
-
   if (path.points.size() < 2) {
     return path;
   }


### PR DESCRIPTION
## Description

This PR improves the path resampling applied at the end of the `behavior_path_planner`. It considers the path end point for resampling to remove annoying resampling warn message:

```
[component_container_mt-27] The number of resampling intervals is less than 2
[component_container_mt-27] The number of resampling intervals is less than 2
[component_container_mt-27] The number of resampling intervals is less than 2
[component_container_mt-27] The number of resampling intervals is less than 2
[component_container_mt-27] The number of resampling intervals is less than 2
[component_container_mt-27] The number of resampling intervals is less than 2
```



## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
