### PR TITLE
fix(start_planner): use non shifted path is shift line idx invalid

### DIFF
--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -249,6 +249,13 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     path_shifter.setLongitudinalAcceleration(longitudinal_acc);
     path_shifter.setLateralAccelerationLimit(lateral_acc);
 
+    const auto shift_line_idx = path_shifter.getShiftLines().front();
+    if (!has_non_shifted_path && (shift_line_idx.end_idx - shift_line_idx.start_idx <= 1)) {
+      candidate_paths.push_back(non_shifted_path);
+      has_non_shifted_path = true;
+      continue;
+    }
+
     // offset front side
     ShiftedPath shifted_path;
     const bool offset_back = false;


### PR DESCRIPTION
## Description

While `Shift Pull Out` module in the start planner is planning for path, the path shifter's generation fails because the lateral shift distance is small during the start-up from the central line, resulting in the start_idx and end_idx being the same.

This PR aims to fix this by inserting non_shifted_path during the `start_idx - end_idx <= 1` situation.


## Related links

None

## Tests performed

In the start planner's param file, set `enable_back: false`

place ego pose as follows
```
position x: 61444.953125 
position y: 56224.13671875
orientation z: -0.0680803539122891
orientation w: 0.997679841137014
```
             
and goal pose as follows
``` 
position x: 61396.
position y: 56226.2
orientation z: 0.27939585430954345
orientation w: 0.9601760029258388
```

And confirm that `Shift Pull Out` module is running. 
Also the behavior path planner container should be alive.

## Notes for reviewers

None


## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
