### PR TITLE
Remove duplicated diagnostic analyzer

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/planning.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/planning.param.yaml
@@ -46,12 +46,6 @@
                   contains: [": trajectory_validation_relative_angle"]
                   timeout: 1.0
 
-                trajectory_relative_angle:
-                  type: diagnostic_aggregator/GenericAnalyzer
-                  path: trajectory_validation_relative_angle
-                  contains: [": trajectory_validation_relative_angle"]
-                  timeout: 1.0
-
                 trajectory_lateral_acceleration:
                   type: diagnostic_aggregator/GenericAnalyzer
                   path: trajectory_validation_lateral_acceleration


### PR DESCRIPTION
## Description

`trajectory_validation_relative_angle` diagnostic is duplicated and is appearing twice in the diagnostic aggregator output.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
