### PR TITLE
feat(euclidean cluster): adding fast euclidean cluster

### DIFF
--- a/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
+++ b/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
@@ -83,6 +83,7 @@ private:
   std::map<uint8_t, int> max_search_distance_for_divider_;
 
   bool ignore_unknown_tracker_;
+  bool use_fast_euclidean_cluster_;
 
   void setMaxSearchRange();
 

--- a/perception/detection_by_tracker/src/detection_by_tracker_core.cpp
+++ b/perception/detection_by_tracker/src/detection_by_tracker_core.cpp
@@ -158,13 +158,14 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
     "~/output", rclcpp::QoS{1});
 
   ignore_unknown_tracker_ = declare_parameter<bool>("ignore_unknown_tracker", true);
+  use_fast_euclidean_cluster_ = declare_parameter<bool>("use_fast_euclidean_cluster", false);
 
   // set maximum search setting for merger/divider
   setMaxSearchRange();
 
   shape_estimator_ = std::make_shared<ShapeEstimator>(true, true);
   cluster_ = std::make_shared<euclidean_cluster::VoxelGridBasedEuclideanCluster>(
-    false, 10, 10000, 0.7, 0.3, 0);
+    false, 10, 10000, 0.7, 0.3, 0, use_fast_euclidean_cluster_);
   debugger_ = std::make_shared<Debugger>(this);
 }
 
@@ -319,7 +320,7 @@ float DetectionByTracker::optimizeUnderSegmentedObject(
 
   // initialize clustering parameters
   euclidean_cluster::VoxelGridBasedEuclideanCluster cluster(
-    false, 4, 10000, initial_cluster_range, initial_voxel_size, 0);
+    false, 4, 10000, initial_cluster_range, initial_voxel_size, 0, use_fast_euclidean_cluster_);
 
   // convert to pcl
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_cluster(new pcl::PointCloud<pcl::PointXYZ>);

--- a/perception/euclidean_cluster/CMakeLists.txt
+++ b/perception/euclidean_cluster/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(
 
 ament_auto_add_library(cluster_lib SHARED
   lib/utils.cpp
+  lib/euclidean_cluster_interface.cpp
   lib/euclidean_cluster.cpp
   lib/voxel_grid_based_euclidean_cluster.cpp
 )

--- a/perception/euclidean_cluster/README.md
+++ b/perception/euclidean_cluster/README.md
@@ -4,18 +4,18 @@
 
 euclidean_cluster is a package for clustering points into smaller parts to classify objects.
 
-This package has two clustering methods: `euclidean_cluster` and `voxel_grid_based_euclidean_cluster`.
+This package has three clustering methods: `euclidean_cluster`, `fast_euclidean_cluster` and `voxel_grid_based_euclidean_cluster`.
 
 ## Inner-workings / Algorithms
 
 ### euclidean_cluster
 
-`pcl::EuclideanClusterExtraction` is applied to points. See [official document](https://pcl.readthedocs.io/en/latest/cluster_extraction.html) for details.
+`pcl::EuclideanClusterExtraction` or `Fast Euclidean Cluster` is applied to points. See [official document](https://pcl.readthedocs.io/en/latest/cluster_extraction.html) or [1] for details.
 
 ### voxel_grid_based_euclidean_cluster
 
 1. A centroid in each voxel is calculated by `pcl::VoxelGrid`.
-2. The centroids are clustered by `pcl::EuclideanClusterExtraction`.
+2. The centroids are clustered by `pcl::EuclideanClusterExtraction` or `Fast Euclidean Cluster`[1].
 3. The input points are clustered based on the clustered centroids.
 
 ## Inputs / Outputs
@@ -39,12 +39,13 @@ This package has two clustering methods: `euclidean_cluster` and `voxel_grid_bas
 
 #### euclidean_cluster
 
-| Name               | Type  | Description                                                                                  |
-| ------------------ | ----- | -------------------------------------------------------------------------------------------- |
-| `use_height`       | bool  | use point.z for clustering                                                                   |
-| `min_cluster_size` | int   | the minimum number of points that a cluster needs to contain in order to be considered valid |
-| `max_cluster_size` | int   | the maximum number of points that a cluster needs to contain in order to be considered valid |
-| `tolerance`        | float | the spatial cluster tolerance as a measure in the L2 Euclidean space                         |
+| Name                         | Type  | Description                                                                                  |
+| ---------------------------- | ----- | -------------------------------------------------------------------------------------------- |
+| `use_height`                 | bool  | use point.z for clustering                                                                   |
+| `min_cluster_size`           | int   | the minimum number of points that a cluster needs to contain in order to be considered valid |
+| `max_cluster_size`           | int   | the maximum number of points that a cluster needs to contain in order to be considered valid |
+| `tolerance`                  | float | the spatial cluster tolerance as a measure in the L2 Euclidean space                         |
+| `use_fast_euclidean_cluster` | bool  | select fast euclidean cluster method                                                         |
 
 #### voxel_grid_based_euclidean_cluster
 
@@ -56,6 +57,7 @@ This package has two clustering methods: `euclidean_cluster` and `voxel_grid_bas
 | `tolerance`                   | float | the spatial cluster tolerance as a measure in the L2 Euclidean space                         |
 | `voxel_leaf_size`             | float | the voxel leaf size of x and y                                                               |
 | `min_points_number_per_voxel` | int   | the minimum number of points for a voxel                                                     |
+| `use_fast_euclidean_cluster`  | bool  | select fast euclidean cluster method                                                         |
 
 ## Assumptions / Known limits
 
@@ -90,12 +92,7 @@ Example:
 
 ## (Optional) References/External links
 
-<!-- Write links you referred to when you implemented.
-
-Example:
-  [1] {link_to_a_thesis}
-  [2] {link_to_an_issue}
--->
+[1] [Yu Cao, Yancheng Wang, Yifei Xue, Huiqing Zhang and Yizhen Lao, FEC: Fast Euclidean Clustering for Point Cloud Segmentation](https://doi.org/10.3390/drones6110325).
 
 ## (Optional) Future extensions / Unimplemented parts
 

--- a/perception/euclidean_cluster/README.md
+++ b/perception/euclidean_cluster/README.md
@@ -92,6 +92,7 @@ Example:
 
 ## (Optional) References/External links
 
+<!-- cspell:ignore Yancheng, Yifei, Huiqing, Yizhen -->
 [1] [Yu Cao, Yancheng Wang, Yifei Xue, Huiqing Zhang and Yizhen Lao, FEC: Fast Euclidean Clustering for Point Cloud Segmentation](https://doi.org/10.3390/drones6110325).
 
 ## (Optional) Future extensions / Unimplemented parts

--- a/perception/euclidean_cluster/README.md
+++ b/perception/euclidean_cluster/README.md
@@ -93,6 +93,7 @@ Example:
 ## (Optional) References/External links
 
 <!-- cspell:ignore Yancheng, Yifei, Huiqing, Yizhen -->
+
 [1] [Yu Cao, Yancheng Wang, Yifei Xue, Huiqing Zhang and Yizhen Lao, FEC: Fast Euclidean Clustering for Point Cloud Segmentation](https://doi.org/10.3390/drones6110325).
 
 ## (Optional) Future extensions / Unimplemented parts

--- a/perception/euclidean_cluster/config/euclidean_cluster.param.yaml
+++ b/perception/euclidean_cluster/config/euclidean_cluster.param.yaml
@@ -4,3 +4,4 @@
     min_cluster_size: 10
     tolerance: 0.7
     use_height: false
+    use_fast_euclidean_cluster: true

--- a/perception/euclidean_cluster/config/voxel_grid_based_euclidean_cluster.param.yaml
+++ b/perception/euclidean_cluster/config/voxel_grid_based_euclidean_cluster.param.yaml
@@ -6,6 +6,7 @@
     min_cluster_size: 10
     max_cluster_size: 3000
     use_height: false
+    use_fast_euclidean_cluster: true
     input_frame: "base_link"
     max_x: 70.0
     min_x: -70.0

--- a/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster.hpp
@@ -28,7 +28,9 @@ class EuclideanCluster : public EuclideanClusterInterface
 public:
   EuclideanCluster();
   EuclideanCluster(bool use_height, int min_cluster_size, int max_cluster_size);
-  EuclideanCluster(bool use_height, int min_cluster_size, int max_cluster_size, float tolerance);
+  EuclideanCluster(
+    bool use_height, int min_cluster_size, int max_cluster_size, float tolerance,
+    bool use_fast_euclidean_cluster);
   bool cluster(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) override;
@@ -36,6 +38,7 @@ public:
 
 private:
   float tolerance_;
+  bool use_fast_euclidean_cluster_{false};
 };
 
 }  // namespace euclidean_cluster

--- a/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster_interface.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster_interface.hpp
@@ -33,9 +33,9 @@ namespace euclidean_cluster
 class EuclideanClusterInterface
 {
 public:
-  struct ClassifedPoint
+  struct ClassifiedPoint
   {
-    size_t point_indice;
+    size_t point_indices;
     int class_index;
   };
   EuclideanClusterInterface() = default;

--- a/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster_interface.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/euclidean_cluster_interface.hpp
@@ -16,16 +16,28 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <omp.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/kdtree/kdtree.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+#include <pcl/segmentation/extract_clusters.h>
 
+#include <ctime>
+#include <iostream>
 #include <vector>
 
 namespace euclidean_cluster
 {
+
 class EuclideanClusterInterface
 {
 public:
+  struct ClassifedPoint
+  {
+    size_t point_indice;
+    int class_index;
+  };
   EuclideanClusterInterface() = default;
   EuclideanClusterInterface(bool use_height, int min_cluster_size, int max_cluster_size)
   : use_height_(use_height),
@@ -37,6 +49,10 @@ public:
   void setUseHeight(bool use_height) { use_height_ = use_height; }
   void setMinClusterSize(int size) { min_cluster_size_ = size; }
   void setMaxClusterSize(int size) { max_cluster_size_ = size; }
+  void fastClusterExtract(
+    const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & cloud, const int min_cluster_size,
+    const double tolerance, const int max_cluster_size,
+    std::vector<pcl::PointIndices> & cluster_indices);
   virtual bool cluster(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) = 0;

--- a/perception/euclidean_cluster/include/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
+++ b/perception/euclidean_cluster/include/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
@@ -31,7 +31,7 @@ public:
   VoxelGridBasedEuclideanCluster(bool use_height, int min_cluster_size, int max_cluster_size);
   VoxelGridBasedEuclideanCluster(
     bool use_height, int min_cluster_size, int max_cluster_size, float tolerance,
-    float voxel_leaf_size, int min_points_number_per_voxel);
+    float voxel_leaf_size, int min_points_number_per_voxel, bool use_fast_euclidean_cluster);
   bool cluster(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) override;
@@ -47,6 +47,7 @@ private:
   float tolerance_;
   float voxel_leaf_size_;
   int min_points_number_per_voxel_;
+  bool use_fast_euclidean_cluster_{false};
 };
 
 }  // namespace euclidean_cluster

--- a/perception/euclidean_cluster/lib/euclidean_cluster_interface.cpp
+++ b/perception/euclidean_cluster/lib/euclidean_cluster_interface.cpp
@@ -1,0 +1,127 @@
+
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "euclidean_cluster/euclidean_cluster_interface.hpp"
+
+namespace euclidean_cluster
+{
+
+void EuclideanClusterInterface::fastClusterExtract(
+  const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & cloud, const int min_cluster_size,
+  const double tolerance, const int max_cluster_size,
+  std::vector<pcl::PointIndices> & cluster_indices)
+{
+  // std::vector<pcl::PointIndices> cluster_indices;
+  std::vector<pcl::PointCloud<pcl::PointXYZ>> clusters;
+  if (cloud->points.size() < static_cast<size_t>(min_cluster_size)) {
+    cluster_indices.clear();
+    clusters.clear();
+    return;
+  }
+
+  cluster_indices.resize(cloud->points.size());
+
+  pcl::KdTreeFLANN<pcl::PointXYZ> cloud_kdtreeflann;
+  cloud_kdtreeflann.setInputCloud(cloud);
+
+  std::vector<ClassifedPoint> classified_points;
+  for (size_t i = 0; i < cloud->points.size(); ++i) {
+    ClassifedPoint current_point;
+    current_point.point_indice = i;
+    current_point.class_index = 0;
+    classified_points.push_back(current_point);
+  }
+  int class_idx = 1, temp_class_idx = -1;
+  std::vector<float> nn_distances;
+  std::vector<int> nn_indices;
+
+  // assign cluster index for each point
+  for (size_t i = 0; i < classified_points.size(); ++i) {
+    auto * point = &classified_points[i];
+    if (point->class_index == 0) {
+      nn_distances.clear();
+      nn_indices.clear();
+      cloud_kdtreeflann.radiusSearch(
+        cloud->points[i], tolerance, nn_indices, nn_distances, max_cluster_size);
+
+      int min_class_idx = class_idx;
+      for (size_t j = 0; j < nn_indices.size(); ++j) {
+        auto * point_with_tag = &classified_points[nn_indices[j]];
+
+        if ((point_with_tag->class_index > 0) && (point_with_tag->class_index < min_class_idx)) {
+          min_class_idx = point_with_tag->class_index;
+        }
+      }
+      for (size_t j = 0; j < nn_indices.size(); ++j) {
+        auto * point_with_tag = &classified_points[nn_indices[j]];
+        temp_class_idx = point_with_tag->class_index;
+        if (temp_class_idx > min_class_idx) {
+          for (size_t k = 0; k < classified_points.size(); ++k) {
+            if (classified_points[k].class_index == temp_class_idx) {
+              classified_points[k].class_index = min_class_idx;
+            }
+          }
+        }
+        classified_points[nn_indices[j]].class_index = min_class_idx;
+      }
+      class_idx++;
+    }
+  }
+  std::sort(
+    classified_points.begin(), classified_points.end(),
+    [](const ClassifedPoint & p0, const ClassifedPoint & p1) {
+      return p0.class_index < p1.class_index;
+    });
+  int new_class_idx = 0;
+  int prev_class_idx = 0;
+  pcl::PointIndices::Ptr object_indices(new pcl::PointIndices);
+  clusters.clear();
+  std::vector<pcl::PointCloud<pcl::PointXYZ>> temp_clusters;
+  // rearrange cluster index and build clusters
+  for (auto point = classified_points.begin(); point < classified_points.end(); point++) {
+    if (point->class_index == prev_class_idx) {
+      point->class_index = new_class_idx;
+      object_indices->indices.push_back(point->point_indice);
+      continue;
+    }
+
+    if (point->class_index == prev_class_idx + 1) {
+      new_class_idx = point->class_index;
+      prev_class_idx = point->class_index;
+      //
+      if (object_indices->indices.size() > 0) {
+        cluster_indices.push_back(*object_indices);
+        object_indices->indices.clear();
+      }
+      object_indices->indices.push_back(point->point_indice);
+      continue;
+    }
+
+    if (point->class_index > prev_class_idx + 1) {
+      new_class_idx = prev_class_idx + 1;
+      prev_class_idx = point->class_index;
+      point->class_index = new_class_idx;
+
+      if (object_indices->indices.size() > 0) {
+        cluster_indices.push_back(*object_indices);
+        object_indices->indices.clear();
+      }
+      object_indices->indices.push_back(point->point_indice);
+      continue;
+    }
+  }
+}
+
+}  // namespace euclidean_cluster

--- a/perception/euclidean_cluster/lib/euclidean_cluster_interface.cpp
+++ b/perception/euclidean_cluster/lib/euclidean_cluster_interface.cpp
@@ -36,10 +36,10 @@ void EuclideanClusterInterface::fastClusterExtract(
   pcl::KdTreeFLANN<pcl::PointXYZ> cloud_kdtreeflann;
   cloud_kdtreeflann.setInputCloud(cloud);
 
-  std::vector<ClassifedPoint> classified_points;
+  std::vector<ClassifiedPoint> classified_points;
   for (size_t i = 0; i < cloud->points.size(); ++i) {
-    ClassifedPoint current_point;
-    current_point.point_indice = i;
+    ClassifiedPoint current_point;
+    current_point.point_indices = i;
     current_point.class_index = 0;
     classified_points.push_back(current_point);
   }
@@ -81,7 +81,7 @@ void EuclideanClusterInterface::fastClusterExtract(
   }
   std::sort(
     classified_points.begin(), classified_points.end(),
-    [](const ClassifedPoint & p0, const ClassifedPoint & p1) {
+    [](const ClassifiedPoint & p0, const ClassifiedPoint & p1) {
       return p0.class_index < p1.class_index;
     });
   int new_class_idx = 0;
@@ -93,7 +93,7 @@ void EuclideanClusterInterface::fastClusterExtract(
   for (auto point = classified_points.begin(); point < classified_points.end(); point++) {
     if (point->class_index == prev_class_idx) {
       point->class_index = new_class_idx;
-      object_indices->indices.push_back(point->point_indice);
+      object_indices->indices.push_back(point->point_indices);
       continue;
     }
 
@@ -105,7 +105,7 @@ void EuclideanClusterInterface::fastClusterExtract(
         cluster_indices.push_back(*object_indices);
         object_indices->indices.clear();
       }
-      object_indices->indices.push_back(point->point_indice);
+      object_indices->indices.push_back(point->point_indices);
       continue;
     }
 
@@ -118,7 +118,7 @@ void EuclideanClusterInterface::fastClusterExtract(
         cluster_indices.push_back(*object_indices);
         object_indices->indices.clear();
       }
-      object_indices->indices.push_back(point->point_indice);
+      object_indices->indices.push_back(point->point_indices);
       continue;
     }
   }

--- a/perception/euclidean_cluster/lib/euclidean_cluster_interface.cpp
+++ b/perception/euclidean_cluster/lib/euclidean_cluster_interface.cpp
@@ -74,7 +74,9 @@ void EuclideanClusterInterface::fastClusterExtract(
             }
           }
         }
-        classified_points[nn_indices[j]].class_index = min_class_idx;
+        if (temp_class_idx == 0) {
+          classified_points[nn_indices[j]].class_index = min_class_idx;
+        }
       }
       class_idx++;
     }

--- a/perception/euclidean_cluster/package.xml
+++ b/perception/euclidean_cluster/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>tier4_debug_msgs</depend>
   <depend>tier4_perception_msgs</depend>
 
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
@@ -23,6 +23,16 @@ namespace euclidean_cluster
 EuclideanClusterNode::EuclideanClusterNode(const rclcpp::NodeOptions & options)
 : Node("euclidean_cluster_node", options)
 {
+  // initialize debug tool
+  {
+    using tier4_autoware_utils::DebugPublisher;
+    using tier4_autoware_utils::StopWatch;
+    stop_watch_ptr_ = std::make_unique<StopWatch<std::chrono::milliseconds>>();
+    debug_publisher_ptr_ = std::make_unique<DebugPublisher>(this, "euclidean_cluster_node");
+    stop_watch_ptr_->tic("cyclic_time");
+    stop_watch_ptr_->tic("processing_time");
+  }
+
   const bool use_height = this->declare_parameter("use_height", false);
   const int min_cluster_size = this->declare_parameter("min_cluster_size", 3);
   const int max_cluster_size = this->declare_parameter("max_cluster_size", 200);
@@ -45,6 +55,7 @@ EuclideanClusterNode::EuclideanClusterNode(const rclcpp::NodeOptions & options)
 void EuclideanClusterNode::onPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr input_msg)
 {
+  stop_watch_ptr_->toc("processing_time", true);
   // convert ros to pcl
   pcl::PointCloud<pcl::PointXYZ>::Ptr raw_pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::fromROSMsg(*input_msg, *raw_pointcloud_ptr);
@@ -57,6 +68,15 @@ void EuclideanClusterNode::onPointCloud(
   tier4_perception_msgs::msg::DetectedObjectsWithFeature output;
   convertPointCloudClusters2Msg(input_msg->header, clusters, output);
   cluster_pub_->publish(output);
+
+  if (debug_publisher_ptr_) {
+    const double cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
+    const double processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
+    debug_publisher_ptr_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+      "debug/cyclic_time_ms", cyclic_time_ms);
+    debug_publisher_ptr_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+      "debug/processing_time_ms", processing_time_ms);
+  }
 
   // build debug msg
   if (debug_pub_->get_subscription_count() < 1) {

--- a/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/euclidean_cluster_node.cpp
@@ -27,8 +27,10 @@ EuclideanClusterNode::EuclideanClusterNode(const rclcpp::NodeOptions & options)
   const int min_cluster_size = this->declare_parameter("min_cluster_size", 3);
   const int max_cluster_size = this->declare_parameter("max_cluster_size", 200);
   const float tolerance = this->declare_parameter("tolerance", 1.0);
-  cluster_ =
-    std::make_shared<EuclideanCluster>(use_height, min_cluster_size, max_cluster_size, tolerance);
+  const bool use_fast_euclidean_cluster =
+    this->declare_parameter("use_fast_euclidean_cluster", false);
+  cluster_ = std::make_shared<EuclideanCluster>(
+    use_height, min_cluster_size, max_cluster_size, tolerance, use_fast_euclidean_cluster);
 
   using std::placeholders::_1;
   pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(

--- a/perception/euclidean_cluster/src/euclidean_cluster_node.hpp
+++ b/perception/euclidean_cluster/src/euclidean_cluster_node.hpp
@@ -17,6 +17,8 @@
 #include "euclidean_cluster/euclidean_cluster.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/ros/debug_publisher.hpp>
+#include <tier4_autoware_utils/system/stop_watch.hpp>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -39,6 +41,10 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr debug_pub_;
 
   std::shared_ptr<EuclideanCluster> cluster_;
+  // debugger
+  std::unique_ptr<tier4_autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{
+    nullptr};
+  std::unique_ptr<tier4_autoware_utils::DebugPublisher> debug_publisher_ptr_{nullptr};
 };
 
 }  // namespace euclidean_cluster

--- a/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
+++ b/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
@@ -30,9 +30,11 @@ VoxelGridBasedEuclideanClusterNode::VoxelGridBasedEuclideanClusterNode(
   const float tolerance = this->declare_parameter("tolerance", 1.0);
   const float voxel_leaf_size = this->declare_parameter("voxel_leaf_size", 0.5);
   const int min_points_number_per_voxel = this->declare_parameter("min_points_number_per_voxel", 3);
+  const bool use_fast_euclidean_cluster =
+    this->declare_parameter("use_fast_euclidean_cluster", false);
   cluster_ = std::make_shared<VoxelGridBasedEuclideanCluster>(
     use_height, min_cluster_size, max_cluster_size, tolerance, voxel_leaf_size,
-    min_points_number_per_voxel);
+    min_points_number_per_voxel, use_fast_euclidean_cluster);
 
   using std::placeholders::_1;
   pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(

--- a/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.hpp
+++ b/perception/euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.hpp
@@ -17,6 +17,8 @@
 #include "euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_autoware_utils/ros/debug_publisher.hpp>
+#include <tier4_autoware_utils/system/stop_watch.hpp>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -39,6 +41,10 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr debug_pub_;
 
   std::shared_ptr<VoxelGridBasedEuclideanCluster> cluster_;
+  // debugger
+  std::unique_ptr<tier4_autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{
+    nullptr};
+  std::unique_ptr<tier4_autoware_utils::DebugPublisher> debug_publisher_ptr_{nullptr};
 };
 
 }  // namespace euclidean_cluster


### PR DESCRIPTION
## Description

This PR adds fast euclidean cluster algorithm option for perforamce improvement. 

## Related links
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-3051)
## Tests performed
Here is comparision of computation time for 3 input poincloud and it shows the improvement of Fast EC for few ms:
| | Current euclidean cluster | Fast euclidean cluster |
| --- |---|---|
| Current input (downsampled) |![sample_rosbag_EC_downsample_input](https://github.com/autowarefoundation/autoware.universe/assets/94814556/989c9ab4-6d83-44de-acbe-42f83332d7a2) | ![sample_rosbag_FEC_downsample_input](https://github.com/autowarefoundation/autoware.universe/assets/94814556/6da3ec62-a79b-4874-ae42-6b037eca4db5) |
| pointcloud_map_filterred input |![sample_rosbag_EC_map_filter_input_zoomin](https://github.com/autowarefoundation/autoware.universe/assets/94814556/f63069c8-b3c2-4287-991f-a9c0702b4c12) | ![sample_rosbag_FEC_map_filter_input_zoomin](https://github.com/autowarefoundation/autoware.universe/assets/94814556/9a2b5afc-637f-4c47-9ecb-30bd38adad9b) |
|  obstacle_segmentation input | ![sample_rosbag_EC_ground_segmentation_input](https://github.com/autowarefoundation/autoware.universe/assets/94814556/846e6873-7330-4512-a62a-76c662c33af6)|![sample_rosbag_FEC_ground_segmentation_input](https://github.com/autowarefoundation/autoware.universe/assets/94814556/4cf116a1-e1c5-4cc8-8ddc-a8c3571e35f8)|

Each input pointcloud number as figure:
![pointcloud_numbers](https://github.com/autowarefoundation/autoware.universe/assets/94814556/6d8f8e51-286c-4b66-a714-cba7438a197b)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Release Notes:

- New Feature: Added a fast Euclidean cluster algorithm option for improved performance in the `euclidean_cluster` package. The package now supports three clustering methods: `euclidean_cluster`, `fast_euclidean_cluster`, and `voxel_grid_based_euclidean_cluster`. The `DetectionByTracker` and `EuclideanCluster` classes have been modified to include a new boolean parameter `use_fast_euclidean_cluster` for selecting the fast Euclidean cluster method. Documentation updates and dependencies on `tier4_debug_msgs` were added.

> "Clusters dance with speed,
> Fast Euclidean, they heed.
> Performance enhanced,
> Bugs have no chance.
> Tier4 Debug, we succeed!"
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->