### PR TITLE
fix(lane_change): fix activation timing of the  passParkedObject funtion

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -183,9 +183,8 @@ bool isParkedObject(
 
 bool passParkedObject(
   const RouteHandler & route_handler, const LaneChangePath & lane_change_path,
-  const PathWithLaneId & current_lane_path, const std::vector<ExtendedPredictedObject> & objects,
-  const double minimum_lane_change_length, const bool is_goal_in_route,
-  const double object_check_min_road_shoulder_width, const double object_shiftable_ratio_threshold);
+  const std::vector<ExtendedPredictedObject> & objects, const double minimum_lane_change_length,
+  const bool is_goal_in_route, const LaneChangeParameters & lane_change_parameters);
 
 boost::optional<size_t> getLeadingStaticObjectIdx(
   const RouteHandler & route_handler, const LaneChangePath & lane_change_path,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -714,20 +714,10 @@ bool NormalLaneChange::getLaneChangePaths(
         continue;
       }
 
-      if (candidate_paths->empty()) {
-        const double object_check_min_road_shoulder_width =
-          lane_change_parameters_->object_check_min_road_shoulder_width;
-        const double object_shiftable_ratio_threshold =
-          lane_change_parameters_->object_shiftable_ratio_threshold;
-        const auto current_lane_path = route_handler.getCenterLinePath(
-          original_lanelets, 0.0, std::numeric_limits<double>::max());
-        const bool pass_parked_object = utils::lane_change::passParkedObject(
-          route_handler, *candidate_path, current_lane_path, target_objects.target_lane,
-          lane_change_buffer, is_goal_in_route, object_check_min_road_shoulder_width,
-          object_shiftable_ratio_threshold);
-        if (pass_parked_object) {
-          return false;
-        }
+      if (utils::lane_change::passParkedObject(
+            route_handler, *candidate_path, target_objects.target_lane, lane_change_buffer,
+            is_goal_in_route, *lane_change_parameters_)) {
+        return false;
       }
       candidate_paths->push_back(*candidate_path);
 

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -1039,11 +1039,17 @@ bool isParkedObject(
 
 bool passParkedObject(
   const RouteHandler & route_handler, const LaneChangePath & lane_change_path,
-  const PathWithLaneId & current_lane_path, const std::vector<ExtendedPredictedObject> & objects,
-  const double minimum_lane_change_length, const bool is_goal_in_route,
-  const double object_check_min_road_shoulder_width, const double object_shiftable_ratio_threshold)
+  const std::vector<ExtendedPredictedObject> & objects, const double minimum_lane_change_length,
+  const bool is_goal_in_route, const LaneChangeParameters & lane_change_parameters)
 {
+  const auto & object_check_min_road_shoulder_width =
+    lane_change_parameters.object_check_min_road_shoulder_width;
+  const auto & object_shiftable_ratio_threshold =
+    lane_change_parameters.object_shiftable_ratio_threshold;
   const auto & path = lane_change_path.path;
+  const auto & current_lanes = lane_change_path.reference_lanelets;
+  const auto current_lane_path =
+    route_handler.getCenterLinePath(current_lanes, 0.0, std::numeric_limits<double>::max());
 
   if (objects.empty() || path.points.empty() || current_lane_path.points.empty()) {
     return false;


### PR DESCRIPTION
## Description
Before this PR, `passParkedObject` function only activates when there is no candidate path. So in this PR, I changed the activation condition for the function.

[TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/2ead60e8-9840-5c60-a54a-3a902aa50099?project_id=prd_jt)
1562/1580
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
