### PR TITLE
fix(run_out): clear stop pose to prevent virtual wall from remaining

### DIFF
--- a/planning/behavior_velocity_run_out_module/src/debug.cpp
+++ b/planning/behavior_velocity_run_out_module/src/debug.cpp
@@ -184,6 +184,8 @@ motion_utils::VirtualWalls RunOutDebug::createVirtualWalls()
     wall.pose = p;
     virtual_walls.push_back(wall);
   }
+  stop_pose_.clear();
+
   return virtual_walls;
 }
 


### PR DESCRIPTION
## Description

Virtual wall marker of run out module didn't disappear because the deletion of stop pose was removed here.
https://github.com/autowarefoundation/autoware.universe/pull/3851/files#diff-530cf815b1cfc7b84fa40747b0dff416310bfd62b2c2530483b190a122fb9456L186


https://github.com/autowarefoundation/autoware.universe/assets/11865769/ec4ba12f-6e4d-4133-9493-66500e5e4846



## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I tested on a simple planning simulator.

https://github.com/autowarefoundation/autoware.universe/assets/11865769/06d5bdb4-429a-4f58-8721-f16737b020b7



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
