### PR TITLE
feat(lane_change): removing parameterize minimum prepare distance

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -104,7 +104,6 @@ struct BehaviorPathPlannerParameters
   double minimum_lane_changing_velocity{5.6};
   double lane_change_prepare_duration{4.0};
   double lane_change_finish_judge_buffer{3.0};
-  double minimum_prepare_length;
   LateralAccelerationMap lane_change_lat_acc_map;
 
   double minimum_pull_over_length;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -344,8 +344,6 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
     declare_parameter<double>("lane_change.minimum_lane_changing_velocity");
   p.minimum_lane_changing_velocity =
     std::min(p.minimum_lane_changing_velocity, p.max_acc * p.lane_change_prepare_duration);
-  p.minimum_prepare_length =
-    0.5 * p.max_acc * p.lane_change_prepare_duration * p.lane_change_prepare_duration;
   p.lane_change_finish_judge_buffer =
     declare_parameter<double>("lane_change.lane_change_finish_judge_buffer");
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -578,24 +578,11 @@ bool NormalLaneChange::hasEnoughLength(
   const auto current_pose = getEgoPose();
   const auto & route_handler = *getRouteHandler();
   const auto & common_parameters = planner_data_->parameters;
-  const auto minimum_lane_changing_velocity = common_parameters.minimum_lane_changing_velocity;
-  const auto lateral_jerk = common_parameters.lane_changing_lateral_jerk;
   const double lane_change_length = path.info.length.sum();
-  const double max_lat_acc =
-    common_parameters.lane_change_lat_acc_map.find(minimum_lane_changing_velocity).second;
   const auto shift_intervals =
     route_handler.getLateralIntervalsToPreferredLane(target_lanes.back(), direction);
-  const auto minimum_prepare_length = 0.5 * common_parameters.max_acc *
-                                      common_parameters.lane_change_prepare_duration *
-                                      common_parameters.lane_change_prepare_duration;
-
-  double minimum_lane_change_length_to_preferred_lane = 0.0;
-  for (const auto & shift_length : shift_intervals) {
-    const auto lane_changing_time =
-      PathShifter::calcShiftTimeFromJerk(shift_length, lateral_jerk, max_lat_acc);
-    minimum_lane_change_length_to_preferred_lane +=
-      minimum_lane_changing_velocity * lane_changing_time + minimum_prepare_length;
-  }
+  double minimum_lane_change_length_to_preferred_lane =
+    utils::calcMinimumLaneChangeLength(common_parameters, shift_intervals);
 
   if (lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
     return false;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -575,14 +575,14 @@ bool NormalLaneChange::getLaneChangePaths(
       current_velocity + sampled_longitudinal_acc * prepare_duration,
       minimum_lane_changing_velocity);
 
-
     // get path on original lanes
     const bool disable_prepare_segment = is_near_end_of_current_lane && (getEgoVelocity() < 1.0);
     const double prepare_duration =
       disable_prepare_segment ? 0.0 : common_parameter.lane_change_prepare_duration;
 
     // compute actual longitudinal acceleration
-    const double longitudinal_acc_on_prepare = (prepare_duration < 1e-3) ? 0.0 : ((prepare_velocity - current_velocity) / prepare_duration);
+    const double longitudinal_acc_on_prepare =
+      (prepare_duration < 1e-3) ? 0.0 : ((prepare_velocity - current_velocity) / prepare_duration);
 
     const double prepare_length = current_velocity * prepare_duration +
                                   0.5 * longitudinal_acc_on_prepare * std::pow(prepare_duration, 2);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -597,8 +597,6 @@ bool NormalLaneChange::getLaneChangePaths(
       break;
     }
 
-    std::cerr << "prepare length " << prepare_length << '\n';
-
     auto prepare_segment = getPrepareSegment(
       original_lanelets, arc_length_in_current, backward_path_length, prepare_length);
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -567,7 +567,8 @@ bool NormalLaneChange::getLaneChangePaths(
         ? dist_to_end_of_current_lanes
         : utils::getSignedDistance(getEgoPose(), route_handler.getGoalPose(), original_lanelets);
 
-    return std::abs(distance - lane_change_buffer) < 4.0;
+    return std::abs(distance - lane_change_buffer) <
+           lane_change_parameters_->min_length_for_turn_signal_activation;
   });
 
   for (const auto & sampled_longitudinal_acc : longitudinal_acc_sampling_values) {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -496,8 +496,7 @@ bool NormalLaneChange::getLaneChangePaths(
 
   const auto backward_path_length = common_parameter.backward_path_length;
   const auto forward_path_length = common_parameter.forward_path_length;
-  const auto prepare_duration = common_parameter.lane_change_prepare_duration;
-  const auto minimum_prepare_length = common_parameter.minimum_prepare_length;
+  const auto max_prepare_duration = common_parameter.lane_change_prepare_duration;
   const auto minimum_lane_changing_velocity = common_parameter.minimum_lane_changing_velocity;
   const auto longitudinal_acc_sampling_num = lane_change_parameters_->longitudinal_acc_sampling_num;
   const auto lateral_acc_sampling_num = lane_change_parameters_->lateral_acc_sampling_num;
@@ -511,7 +510,7 @@ bool NormalLaneChange::getLaneChangePaths(
 
   // compute maximum longitudinal deceleration and acceleration
   const auto maximum_deceleration = std::invoke([&minimum_lane_changing_velocity, &current_velocity,
-                                                 &min_longitudinal_acc, &common_parameter, this]() {
+                                                 &min_longitudinal_acc, &common_parameter]() {
     const double min_a = (minimum_lane_changing_velocity - current_velocity) /
                          common_parameter.lane_change_prepare_duration;
     return std::clamp(
@@ -536,6 +535,9 @@ bool NormalLaneChange::getLaneChangePaths(
 
   const auto dist_to_end_of_current_lanes =
     utils::getDistanceToEndOfLane(getEgoPose(), original_lanelets);
+
+  const auto arc_length_in_current =
+    lanelet::utils::getArcCoordinates(original_lanelets, getEgoPose()).length;
 
   const auto arc_position_from_target =
     lanelet::utils::getArcCoordinates(target_lanelets, getEgoPose());
@@ -562,6 +564,18 @@ bool NormalLaneChange::getLaneChangePaths(
     *lane_change_parameters_);
 
   candidate_paths->reserve(longitudinal_acc_sampling_values.size() * lateral_acc_sampling_num);
+  const auto minimum_prepare_length = std::invoke([&]() {
+    const auto distance =
+      !is_goal_in_route
+        ? dist_to_end_of_current_lanes
+        : utils::getSignedDistance(getEgoPose(), route_handler.getGoalPose(), original_lanelets);
+
+    return distance - lane_change_buffer;
+  });
+
+  const auto prepare_duration =
+    std::clamp(minimum_prepare_length / minimum_lane_changing_velocity, 0.1, max_prepare_duration);
+
   for (const auto & sampled_longitudinal_acc : longitudinal_acc_sampling_values) {
     const auto prepare_velocity = std::max(
       current_velocity + sampled_longitudinal_acc * prepare_duration,
@@ -572,18 +586,21 @@ bool NormalLaneChange::getLaneChangePaths(
       (prepare_velocity - current_velocity) / prepare_duration;
 
     // get path on original lanes
-    const double prepare_length = std::max(
+    const double expected_prepare_length =
       current_velocity * prepare_duration +
-        0.5 * longitudinal_acc_on_prepare * std::pow(prepare_duration, 2),
-      minimum_prepare_length);
+      0.5 * longitudinal_acc_on_prepare * std::pow(prepare_duration, 2);
+    const auto prepare_length =
+      std::abs(expected_prepare_length) > 1.0 ? expected_prepare_length : 0.0;
 
     if (prepare_length < target_length) {
       RCLCPP_DEBUG(logger_, "prepare length is shorter than distance to target lane!!");
       break;
     }
 
-    auto prepare_segment =
-      getPrepareSegment(original_lanelets, backward_path_length, prepare_length);
+    std::cerr << "prepare length " << prepare_length << '\n';
+
+    auto prepare_segment = getPrepareSegment(
+      original_lanelets, arc_length_in_current, backward_path_length, prepare_length);
 
     if (prepare_segment.points.empty()) {
       RCLCPP_DEBUG(logger_, "prepare segment is empty!!");

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -575,14 +575,14 @@ bool NormalLaneChange::getLaneChangePaths(
       current_velocity + sampled_longitudinal_acc * prepare_duration,
       minimum_lane_changing_velocity);
 
-    // compute actual longitudinal acceleration
-    const double longitudinal_acc_on_prepare =
-      (prepare_velocity - current_velocity) / prepare_duration;
 
     // get path on original lanes
     const bool disable_prepare_segment = is_near_end_of_current_lane && (getEgoVelocity() < 1.0);
     const double prepare_duration =
       disable_prepare_segment ? 0.0 : common_parameter.lane_change_prepare_duration;
+
+    // compute actual longitudinal acceleration
+    const double longitudinal_acc_on_prepare = (prepare_duration < 1e-3) ? 0.0 : ((prepare_velocity - current_velocity) / prepare_duration);
 
     const double prepare_length = current_velocity * prepare_duration +
                                   0.5 * longitudinal_acc_on_prepare * std::pow(prepare_duration, 2);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -496,7 +496,6 @@ bool NormalLaneChange::getLaneChangePaths(
 
   const auto backward_path_length = common_parameter.backward_path_length;
   const auto forward_path_length = common_parameter.forward_path_length;
-  const auto prepare_duration = common_parameter.lane_change_prepare_duration;
   const auto minimum_lane_changing_velocity = common_parameter.minimum_lane_changing_velocity;
   const auto longitudinal_acc_sampling_num = lane_change_parameters_->longitudinal_acc_sampling_num;
   const auto lateral_acc_sampling_num = lane_change_parameters_->lateral_acc_sampling_num;

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -334,7 +334,7 @@ bool hasEnoughLength(
     const auto lane_changing_time =
       PathShifter::calcShiftTimeFromJerk(shift_length, lateral_jerk, max_lat_acc);
     minimum_lane_change_length_to_preferred_lane +=
-      minimum_lane_changing_velocity * lane_changing_time + common_parameter.minimum_prepare_length;
+      minimum_lane_changing_velocity * lane_changing_time;
   }
 
   if (lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -330,11 +330,14 @@ bool hasEnoughLength(
     route_handler.getLateralIntervalsToPreferredLane(target_lanes.back(), direction);
 
   double minimum_lane_change_length_to_preferred_lane = 0.0;
+  const auto minimum_prepare_length = 0.5 * common_parameter.max_acc *
+                                      common_parameter.lane_change_prepare_duration *
+                                      common_parameter.lane_change_prepare_duration;
   for (const auto & shift_length : shift_intervals) {
     const auto lane_changing_time =
       PathShifter::calcShiftTimeFromJerk(shift_length, lateral_jerk, max_lat_acc);
     minimum_lane_change_length_to_preferred_lane +=
-      minimum_lane_changing_velocity * lane_changing_time;
+      minimum_lane_changing_velocity * lane_changing_time + minimum_prepare_length;
   }
 
   if (lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2833,7 +2833,7 @@ double calcMinimumLaneChangeLength(
   const double & max_lateral_acc = lat_acc.second;
   const double & lateral_jerk = common_param.lane_changing_lateral_jerk;
   const double & finish_judge_buffer = common_param.lane_change_finish_judge_buffer;
-  const auto prepare_buffer = 0.5 * common_param.max_acc *
+  const auto prepare_length = 0.5 * common_param.max_acc *
                               common_param.lane_change_prepare_duration *
                               common_param.lane_change_prepare_duration;
 
@@ -2841,7 +2841,7 @@ double calcMinimumLaneChangeLength(
   for (const auto & shift_interval : shift_intervals) {
     const double t =
       PathShifter::calcShiftTimeFromJerk(shift_interval, lateral_jerk, max_lateral_acc);
-    accumulated_length += vel * t + prepare_buffer + finish_judge_buffer;
+    accumulated_length += vel * t + prepare_length + finish_judge_buffer;
   }
   accumulated_length +=
     common_param.backward_length_buffer_for_end_of_lane * (shift_intervals.size() - 1.0);

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2833,12 +2833,15 @@ double calcMinimumLaneChangeLength(
   const double & max_lateral_acc = lat_acc.second;
   const double & lateral_jerk = common_param.lane_changing_lateral_jerk;
   const double & finish_judge_buffer = common_param.lane_change_finish_judge_buffer;
+  const auto prepare_buffer = 0.5 * common_param.max_acc *
+                              common_param.lane_change_prepare_duration *
+                              common_param.lane_change_prepare_duration;
 
   double accumulated_length = length_to_intersection;
   for (const auto & shift_interval : shift_intervals) {
     const double t =
       PathShifter::calcShiftTimeFromJerk(shift_interval, lateral_jerk, max_lateral_acc);
-    accumulated_length += vel * t + common_param.minimum_prepare_length + finish_judge_buffer;
+    accumulated_length += vel * t + prepare_buffer + finish_judge_buffer;
   }
   accumulated_length +=
     common_param.backward_length_buffer_for_end_of_lane * (shift_intervals.size() - 1.0);


### PR DESCRIPTION
## Description

This PR aims to remove the minimum_prepare_length during lane changing process.

### Motivation
When ego stops at current lane's terminal point (where ego have to stop in order to secure minimum_lane_changing_length), current method allocate `minimum_prepare_length`. However, real world driving doesn't have such distance, and it confuses the surrounding vehicles, because they don't know what ego intention was.

### Before PR
![Before PR](https://github.com/autowarefoundation/autoware.universe/assets/93502286/510a87b7-3c70-415b-a6c4-4a99b78a80a9)

### After PR
![After PR](https://github.com/autowarefoundation/autoware.universe/assets/93502286/34dedfce-9123-4821-869b-c1c9ad953361)


## Related links

None

## Tests performed

Using PSIM

1576/1588
[TEIR IV Internal Link](https://evaluation.tier4.jp/evaluation/reports/54641e30-0940-51ed-957b-010c8b3b7b0b?project_id=prd_jt)

## Notes for reviewers

1. We still compute prepare buffer on the minimum_lane_change_length, to avoid various complicated issues.

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
