### PR TITLE
fix(avoidance_by_lc): fix execution requesting logic

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
@@ -55,8 +55,7 @@ std::pair<bool, bool> AvoidanceByLaneChange::getSafePath(LaneChangePath & safe_p
     return {false, false};
   }
 
-  const auto direction = utils::avoidance::isOnRight(o_front) ? Direction::LEFT : Direction::RIGHT;
-  const auto target_lanes = getLaneChangeLanes(current_lanes, direction);
+  const auto target_lanes = getLaneChangeLanes(current_lanes, direction_);
 
   if (target_lanes.empty()) {
     return {false, false};
@@ -65,7 +64,7 @@ std::pair<bool, bool> AvoidanceByLaneChange::getSafePath(LaneChangePath & safe_p
   // find candidate paths
   LaneChangePaths valid_paths{};
   const auto found_safe_path =
-    getLaneChangePaths(current_lanes, target_lanes, direction, &valid_paths);
+    getLaneChangePaths(current_lanes, target_lanes, direction_, &valid_paths);
 
   if (valid_paths.empty()) {
     return {false, false};
@@ -95,6 +94,14 @@ void AvoidanceByLaneChange::updateSpecialData()
 
   avoidance_debug_data_ = DebugData();
   avoidance_data_ = calcAvoidancePlanningData(avoidance_debug_data_);
+
+  if (avoidance_data_.target_objects.empty()) {
+    direction_ = Direction::NONE;
+  } else {
+    direction_ = utils::avoidance::isOnRight(avoidance_data_.target_objects.front())
+                   ? Direction::LEFT
+                   : Direction::RIGHT;
+  }
 
   utils::avoidance::updateRegisteredObject(registered_objects_, avoidance_data_.target_objects, p);
   utils::avoidance::compensateDetectionLost(


### PR DESCRIPTION
## Description

For now, avoidance by lane change module doesn't work correctly so I fixed it.

It needs to set `direction_` properly to activate this module.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/134d01f8-35fc-4949-9f08-6c8efbe6be77)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

enable avoidance by lc module. ([here](https://github.com/autowarefoundation/autoware_launch/blob/518116062c2a49904bfa6d94c8aa0b32e905bc26/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml#L72))

```yaml
    avoidance_by_lc:
      enable_module: true
...
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
