### PR TITLE
fix(behavior_path_planner): fix bad dynamic drivable area expansion at path extremities

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -24,6 +24,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
@@ -64,9 +65,10 @@ def launch_setup(context, *args, **kwargs):
     with open(LaunchConfiguration("behavior_path_planner_param_path").perform(context), "r") as f:
         behavior_path_planner_param = yaml.safe_load(f)["/**"]["ros__parameters"]
 
-    behavior_path_planner_component = ComposableNode(
+    behavior_path_planner_component = Node(
         package="behavior_path_planner",
-        plugin="behavior_path_planner::BehaviorPathPlannerNode",
+        # plugin="behavior_path_planner::BehaviorPathPlannerNode",
+        executable="behavior_path_planner",
         name="behavior_path_planner",
         namespace="",
         remappings=[
@@ -113,7 +115,8 @@ def launch_setup(context, *args, **kwargs):
                 ),
             },
         ],
-        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        prefix="konsole -e gdb -ex run --args",
+        # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
     # smoother param
@@ -209,7 +212,6 @@ def launch_setup(context, *args, **kwargs):
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
-            behavior_path_planner_component,
             behavior_velocity_planner_component,
         ],
         output="screen",
@@ -258,6 +260,7 @@ def launch_setup(context, *args, **kwargs):
     group = GroupAction(
         [
             container,
+            behavior_path_planner_component,
             load_compare_map,
             load_vector_map_inside_area_filter,
         ]

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -24,7 +24,6 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
-from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
@@ -65,10 +64,9 @@ def launch_setup(context, *args, **kwargs):
     with open(LaunchConfiguration("behavior_path_planner_param_path").perform(context), "r") as f:
         behavior_path_planner_param = yaml.safe_load(f)["/**"]["ros__parameters"]
 
-    behavior_path_planner_component = Node(
+    behavior_path_planner_component = ComposableNode(
         package="behavior_path_planner",
-        # plugin="behavior_path_planner::BehaviorPathPlannerNode",
-        executable="behavior_path_planner",
+        plugin="behavior_path_planner::BehaviorPathPlannerNode",
         name="behavior_path_planner",
         namespace="",
         remappings=[
@@ -115,8 +113,7 @@ def launch_setup(context, *args, **kwargs):
                 ),
             },
         ],
-        prefix="konsole -e gdb -ex run --args",
-        # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
     # smoother param
@@ -212,6 +209,7 @@ def launch_setup(context, *args, **kwargs):
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
+            behavior_path_planner_component,
             behavior_velocity_planner_component,
         ],
         output="screen",
@@ -260,7 +258,6 @@ def launch_setup(context, *args, **kwargs):
     group = GroupAction(
         [
             container,
-            behavior_path_planner_component,
             load_compare_map,
             load_vector_map_inside_area_filter,
         ]

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/drivable_area_expansion.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/drivable_area_expansion.hpp
@@ -40,7 +40,7 @@ void expandDrivableArea(
 /// @param[in] expansion_polygons polygons to add to the drivable area
 /// @return expanded drivable area polygon
 polygon_t createExpandedDrivableAreaPolygon(
-  const PathWithLaneId & path, const multipolygon_t & expansion_polygons);
+  const PathWithLaneId & path, const multi_polygon_t & expansion_polygons);
 
 /// @brief Update the drivable area of the given path with the given polygon
 /// @details this function splits the polygon into a left and right bound and sets it in the path

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/expansion.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/expansion.hpp
@@ -36,7 +36,7 @@ namespace drivable_area_expansion
 /// @return distance limit
 double calculateDistanceLimit(
   const linestring_t & base_ls, const polygon_t & expansion_polygon,
-  const multilinestring_t & limit_lines);
+  const multi_linestring_t & limit_lines);
 
 /// @brief Calculate the distance limit required for the polygon to not cross the limit polygons.
 /// @details Calculate the minimum distance from base_ls to an intersection of limit_polygons and
@@ -47,7 +47,7 @@ double calculateDistanceLimit(
 /// @return distance limit
 double calculateDistanceLimit(
   const linestring_t & base_ls, const polygon_t & expansion_polygon,
-  const multipolygon_t & limit_polygons);
+  const multi_polygon_t & limit_polygons);
 
 /// @brief Create a polygon from a base line with a given expansion distance
 /// @param[in] base_ls base linestring from which the polygon is created
@@ -64,9 +64,9 @@ polygon_t createExpansionPolygon(
 /// @param[in] uncrossable_lines lines that should not be crossed by the expanded drivable area
 /// @param[in] params expansion parameters
 /// @return expansion polygons
-multipolygon_t createExpansionPolygons(
-  const PathWithLaneId & path, const multipolygon_t & path_footprints,
-  const multipolygon_t & predicted_paths, const multilinestring_t & uncrossable_lines,
+multi_polygon_t createExpansionPolygons(
+  const PathWithLaneId & path, const multi_polygon_t & path_footprints,
+  const multi_polygon_t & predicted_paths, const multi_linestring_t & uncrossable_lines,
   const DrivableAreaExpansionParameters & params);
 
 /// @brief Create polygons for the area where the drivable area should be expanded
@@ -76,9 +76,9 @@ multipolygon_t createExpansionPolygons(
 /// @param[in] predicted_paths polygons of the dynamic objects' predicted paths
 /// @param[in] params expansion parameters
 /// @return expansion polygons
-multipolygon_t createExpansionLaneletPolygons(
+multi_polygon_t createExpansionLaneletPolygons(
   const lanelet::ConstLanelets & path_lanes, const route_handler::RouteHandler & route_handler,
-  const multipolygon_t & path_footprints, const multipolygon_t & predicted_paths,
+  const multi_polygon_t & path_footprints, const multi_polygon_t & predicted_paths,
   const DrivableAreaExpansionParameters & params);
 }  // namespace drivable_area_expansion
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/footprints.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/footprints.hpp
@@ -55,7 +55,7 @@ polygon_t createFootprint(const geometry_msgs::msg::Pose & pose, const polygon_t
 /// @param [in] objects objects from which to create polygons
 /// @param[in] params expansion parameters containing extra offsets to add to the dynamic objects
 /// @return footprint polygons of the object's predicted paths
-multipolygon_t createObjectFootprints(
+multi_polygon_t createObjectFootprints(
   const autoware_auto_perception_msgs::msg::PredictedObjects & objects,
   const DrivableAreaExpansionParameters & params);
 
@@ -63,7 +63,7 @@ multipolygon_t createObjectFootprints(
 /// @param[in] path the path for which to create a footprint
 /// @param[in] params expansion parameters defining how to create the footprint
 /// @return footprint polygons of the path
-multipolygon_t createPathFootprints(
+multi_polygon_t createPathFootprints(
   const PathWithLaneId & path, const DrivableAreaExpansionParameters & params);
 }  // namespace drivable_area_expansion
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__DRIVABLE_AREA_EXPANSION__FOOTPRINTS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/map_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/map_utils.hpp
@@ -28,7 +28,7 @@ namespace drivable_area_expansion
 /// @param[in] lanelet_map lanelet map
 /// @param[in] uncrossable_types types that cannot be crossed
 /// @return the uncrossable linestrings
-multilinestring_t extractUncrossableLines(
+multi_linestring_t extractUncrossableLines(
   const lanelet::LaneletMap & lanelet_map, const std::vector<std::string> & uncrossable_types);
 
 /// @brief Determine if the given linestring has one of the given types

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/types.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/types.hpp
@@ -30,13 +30,13 @@ using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using geometry_msgs::msg::Point;
 
 using point_t = tier4_autoware_utils::Point2d;
-using multipoint_t = tier4_autoware_utils::MultiPoint2d;
+using multi_point_t = tier4_autoware_utils::MultiPoint2d;
 using polygon_t = tier4_autoware_utils::Polygon2d;
 using ring_t = tier4_autoware_utils::LinearRing2d;
-using multipolygon_t = tier4_autoware_utils::MultiPolygon2d;
+using multi_polygon_t = tier4_autoware_utils::MultiPolygon2d;
 using segment_t = tier4_autoware_utils::Segment2d;
 using linestring_t = tier4_autoware_utils::LineString2d;
-using multilinestring_t = tier4_autoware_utils::MultiLineString2d;
+using multi_linestring_t = tier4_autoware_utils::MultiLineString2d;
 
 struct PointDistance
 {

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -200,7 +200,7 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
         end_right.update(*inter_end, it, dist);
     }
   }
-  if (  // illformed expanded drivable area -> keep the original bounds
+  if (  // ill-formed expanded drivable area -> keep the original bounds
     start_left.segment_it == da.end() || start_right.segment_it == da.end() ||
     end_left.segment_it == da.end() || end_right.segment_it == da.end()) {
     return;

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -35,7 +35,7 @@ void expandDrivableArea(
 {
   const auto uncrossable_lines =
     extractUncrossableLines(*route_handler.getLaneletMapPtr(), params.avoid_linestring_types);
-  multilinestring_t uncrossable_lines_in_range;
+  multi_linestring_t uncrossable_lines_in_range;
   const auto & p = path.points.front().point.pose.position;
   for (const auto & line : uncrossable_lines)
     if (boost::geometry::distance(line, point_t{p.x, p.y}) < params.max_path_arc_length)
@@ -63,7 +63,7 @@ Point convert_point(const point_t & p)
 }
 
 polygon_t createExpandedDrivableAreaPolygon(
-  const PathWithLaneId & path, const multipolygon_t & expansion_polygons)
+  const PathWithLaneId & path, const multi_polygon_t & expansion_polygons)
 {
   polygon_t original_da_poly;
   original_da_poly.outer().reserve(path.left_bound.size() + path.right_bound.size() + 1);
@@ -72,7 +72,7 @@ polygon_t createExpandedDrivableAreaPolygon(
     original_da_poly.outer().push_back(convert_point(*it));
   original_da_poly.outer().push_back(original_da_poly.outer().front());
 
-  multipolygon_t unions;
+  multi_polygon_t unions;
   auto expanded_da_poly = original_da_poly;
   for (const auto & p : expansion_polygons) {
     unions.clear();

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -21,7 +21,18 @@
 #include "behavior_path_planner/utils/drivable_area_expansion/types.hpp"
 #include "interpolation/linear_interpolation.hpp"
 
+#include <Eigen/Geometry>
+
 #include <boost/geometry.hpp>
+
+// for writing the svg file
+#include <fstream>
+#include <iostream>
+// for the geometry types
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+// for the svg mapper
+#include <boost/geometry/io/svg/svg_mapper.hpp>
+#include <boost/geometry/io/svg/write.hpp>
 
 namespace drivable_area_expansion
 {
@@ -81,59 +92,6 @@ polygon_t createExpandedDrivableAreaPolygon(
   return expanded_da_poly;
 }
 
-std::array<ring_t::const_iterator, 4> findLeftRightRanges(
-  const PathWithLaneId & path, const ring_t & expanded_drivable_area)
-{
-  const auto is_left_of_segment = [](const point_t & a, const point_t & b, const point_t & p) {
-    return (b.x() - a.x()) * (p.y() - a.y()) - (b.y() - a.y()) * (p.x() - a.x()) > 0;
-  };
-  const auto is_left_of_path_start = [&](const point_t & p) {
-    return is_left_of_segment(
-      convert_point(path.points[0].point.pose.position),
-      convert_point(path.points[1].point.pose.position), p);
-  };
-  const auto is_left_of_path_end = [&, size = path.points.size()](const point_t & p) {
-    return is_left_of_segment(
-      convert_point(path.points[size - 2].point.pose.position),
-      convert_point(path.points[size - 1].point.pose.position), p);
-  };
-  const auto dist_to_path_start = [start = convert_point(path.points.front().point.pose.position)](
-                                    const auto & p) { return boost::geometry::distance(start, p); };
-  const auto dist_to_path_end = [end = convert_point(path.points.back().point.pose.position)](
-                                  const auto & p) { return boost::geometry::distance(end, p); };
-
-  double min_start_dist = std::numeric_limits<double>::max();
-  auto start_transition = expanded_drivable_area.end();
-  double min_end_dist = std::numeric_limits<double>::max();
-  auto end_transition = expanded_drivable_area.end();
-  for (auto it = expanded_drivable_area.begin(); std::next(it) != expanded_drivable_area.end();
-       ++it) {
-    if (is_left_of_path_start(*it) != is_left_of_path_start(*std::next(it))) {
-      const auto dist = dist_to_path_start(*it);
-      if (dist < min_start_dist) {
-        start_transition = it;
-        min_start_dist = dist;
-      }
-    }
-    if (is_left_of_path_end(*it) != is_left_of_path_end(*std::next(it))) {
-      const auto dist = dist_to_path_end(*it);
-      if (dist < min_end_dist) {
-        end_transition = it;
-        min_end_dist = dist;
-      }
-    }
-  }
-  const auto left_start =
-    is_left_of_path_start(*start_transition) ? start_transition : std::next(start_transition);
-  const auto right_start =
-    is_left_of_path_start(*start_transition) ? std::next(start_transition) : start_transition;
-  const auto left_end =
-    is_left_of_path_end(*end_transition) ? end_transition : std::next(end_transition);
-  const auto right_end =
-    is_left_of_path_end(*end_transition) ? std::next(end_transition) : end_transition;
-  return {left_start, left_end, right_start, right_end};
-}
-
 void copy_z_over_arc_length(
   const std::vector<geometry_msgs::msg::Point> & from, std::vector<geometry_msgs::msg::Point> & to)
 {
@@ -164,32 +122,193 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
 {
   const auto original_left_bound = path.left_bound;
   const auto original_right_bound = path.right_bound;
+  const auto is_left_of_segment = [](const point_t & a, const point_t & b, const point_t & p) {
+    return (b.x() - a.x()) * (p.y() - a.y()) - (b.y() - a.y()) * (p.x() - a.x()) > 0;
+  };
+
+  const auto start_segment =
+    segment_t{convert_point(path.left_bound.front()), convert_point(path.right_bound.front())};
+  const auto end_segment =
+    segment_t{convert_point(path.left_bound.back()), convert_point(path.right_bound.back())};
+  point_t start_segment_center;
+  boost::geometry::centroid(start_segment, start_segment_center);
+  const auto path_start_segment =
+    segment_t{start_segment_center, convert_point(path.points[1].point.pose.position)};
+  point_t end_segment_center;
+  boost::geometry::centroid(end_segment, end_segment_center);
+  const auto path_end_segment =
+    segment_t{convert_point(path.points.back().point.pose.position), end_segment_center};
+  const auto is_left_of_path_start = [&](const point_t & p) {
+    return is_left_of_segment(
+      convert_point(path.points[0].point.pose.position),
+      convert_point(path.points[1].point.pose.position), p);
+  };
+  const auto is_left_of_path_end = [&](const point_t & p) {
+    return is_left_of_segment(
+      convert_point(path.points.back().point.pose.position), end_segment_center, p);
+  };
+  const auto segment_to_line_intersection =
+    [](const auto p1, const auto p2, const auto q1, const auto q2) -> std::optional<point_t> {
+    const auto line = Eigen::Hyperplane<double, 2>::Through(q1, q2);
+    const auto segment = Eigen::Hyperplane<double, 2>::Through(p1, p2);
+    const auto intersection = line.intersection(segment);
+    std::optional<point_t> result;
+    const auto is_on_segment =
+      (p1.x() <= p2.x() ? intersection.x() >= p1.x() && intersection.x() <= p2.x()
+                        : intersection.x() <= p1.x() && intersection.x() >= p2.x()) &&
+      (p1.y() <= p2.y() ? intersection.y() >= p1.y() && intersection.y() <= p2.y()
+                        : intersection.y() <= p1.y() && intersection.y() >= p2.y());
+    if (is_on_segment) result = point_t{intersection.x(), intersection.y()};
+    return result;
+  };
+  struct Intersection
+  {
+    ring_t::const_iterator segment_it;
+    point_t intersection_point;
+    double distance = std::numeric_limits<double>::max();
+  };
+  const auto & da = expanded_drivable_area.outer();
+  Intersection start_left;
+  start_left.segment_it = da.end();
+  Intersection end_left;
+  end_left.segment_it = da.end();
+  Intersection start_right;
+  start_right.segment_it = da.end();
+  Intersection end_right;
+  end_right.segment_it = da.end();
+
+  // Declare a stream and an SVG mapper
+  std::ofstream svg("/home/mclement/Pictures/debug.svg");
+  boost::geometry::svg_mapper<tier4_autoware_utils::Point2d> mapper(svg, 400, 400);
+  for (auto it = da.begin(); it != da.end(); ++it) {
+    if (boost::geometry::distance(*it, start_segment.first) < 1e-3) {
+      start_left.intersection_point = *it;
+      start_left.segment_it = it;
+      start_left.distance = 0.0;
+    } else if (boost::geometry::distance(*it, start_segment.second) < 1e-3) {
+      start_right.intersection_point = *it;
+      start_right.segment_it = it;
+      start_right.distance = 0.0;
+    } else if (boost::geometry::distance(*it, end_segment.first) < 1e-3) {
+      end_left.intersection_point = *it;
+      end_left.segment_it = it;
+      end_left.distance = 0.0;
+    } else if (boost::geometry::distance(*it, end_segment.second) < 1e-3) {
+      end_right.intersection_point = *it;
+      end_right.segment_it = it;
+      end_right.distance = 0.0;
+    }
+    const auto inter_start =
+      std::next(it) == da.end()
+        ? segment_to_line_intersection(*it, da.front(), start_segment.first, start_segment.second)
+        : segment_to_line_intersection(
+            *it, *std::next(it), start_segment.first, start_segment.second);
+    if (inter_start) {
+      const auto dist = boost::geometry::distance(*inter_start, path_start_segment);
+      if (is_left_of_path_start(*inter_start)) {
+        if (dist < start_left.distance) {
+          start_left.intersection_point = *inter_start;
+          start_left.segment_it = it;
+          start_left.distance = dist;
+        }
+      } else {
+        if (dist < start_right.distance) {
+          start_right.intersection_point = *inter_start;
+          start_right.segment_it = it;
+          start_right.distance = dist;
+        }
+      }
+    }
+    const auto inter_end =
+      std::next(it) == da.end()
+        ? segment_to_line_intersection(*it, da.front(), end_segment.first, end_segment.second)
+        : segment_to_line_intersection(*it, *std::next(it), end_segment.first, end_segment.second);
+    if (inter_end) {
+      const auto dist = boost::geometry::distance(*inter_end, path_end_segment);
+      if (is_left_of_path_end(*inter_end)) {
+        if (dist < end_left.distance) {
+          end_left.intersection_point = *inter_end;
+          end_left.segment_it = it;
+          end_left.distance = dist;
+        }
+      } else {
+        if (dist < end_right.distance) {
+          end_right.intersection_point = *inter_end;
+          end_right.segment_it = it;
+          end_right.distance = dist;
+        }
+      }
+    }
+  }
+  mapper.add(expanded_drivable_area);
+  mapper.add(path_start_segment);
+  mapper.add(path_end_segment);
+  mapper.add(start_segment);
+  mapper.add(end_segment);
+  mapper.map(expanded_drivable_area, "fill-opacity:0.0;fill:black;stroke:black;stroke-width:1", 1);
+  mapper.map(start_segment, "fill-opacity:0.5;fill:blue;stroke:blue;stroke-width:2", 2);
+  mapper.map(end_segment, "fill-opacity:0.5;fill:blue;stroke:blue;stroke-width:2", 2);
+  mapper.map(path_start_segment, "fill-opacity:0.5;fill:green;stroke:green;stroke-width:2", 2);
+  mapper.map(path_end_segment, "fill-opacity:0.5;fill:green;stroke:green;stroke-width:2", 2);
+  mapper.map(
+    start_left.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
+  mapper.map(
+    start_right.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
+  mapper.map(end_left.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
+  mapper.map(
+    end_right.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
+
+  if (
+    start_left.segment_it == da.end() || start_right.segment_it == da.end() ||
+    end_left.segment_it == da.end() || end_right.segment_it == da.end()) {
+    std::cerr << (start_left.segment_it == da.end()) << " " << (start_right.segment_it == da.end())
+              << " " << (end_left.segment_it == da.end()) << " "
+              << (end_right.segment_it == da.end()) << std::endl;
+    return;
+  }
+
   path.left_bound.clear();
   path.right_bound.clear();
-  const auto begin = expanded_drivable_area.outer().begin();
-  const auto end = std::prev(expanded_drivable_area.outer().end());
-  const auto & [left_start, left_end, right_start, right_end] =
-    findLeftRightRanges(path, expanded_drivable_area.outer());
-  // NOTE: clockwise ordering -> positive increment for left bound, negative for right bound
-  if (left_start < left_end) {
-    path.left_bound.reserve(std::distance(left_start, left_end));
-    for (auto it = left_start; it <= left_end; ++it) path.left_bound.push_back(convert_point(*it));
-  } else {  // loop back
-    path.left_bound.reserve(std::distance(left_start, end) + std::distance(begin, left_end));
-    for (auto it = left_start; it != end; ++it) path.left_bound.push_back(convert_point(*it));
-    for (auto it = begin; it <= left_end; ++it) path.left_bound.push_back(convert_point(*it));
+  path.left_bound.push_back(convert_point(start_left.intersection_point));
+  path.right_bound.push_back(convert_point(start_right.intersection_point));
+  if (!boost::geometry::equals(start_right.intersection_point, *start_right.segment_it))
+    path.right_bound.push_back(convert_point(*start_right.segment_it));
+  if (start_left.segment_it < end_left.segment_it) {
+    for (auto it = std::next(start_left.segment_it); it <= end_left.segment_it; ++it)
+      path.left_bound.push_back(convert_point(*it));
+  } else {
+    for (auto it = std::next(start_left.segment_it); it < da.end(); ++it)
+      path.left_bound.push_back(convert_point(*it));
+    for (auto it = da.begin(); it <= end_left.segment_it; ++it)
+      path.left_bound.push_back(convert_point(*it));
   }
-  if (right_start > right_end) {
-    path.right_bound.reserve(std::distance(right_end, right_start));
-    for (auto it = right_start; it >= right_end; --it)
+  if (!boost::geometry::equals(end_left.intersection_point, *end_left.segment_it))
+    path.left_bound.push_back(convert_point(end_left.intersection_point));
+  if (start_right.segment_it < end_right.segment_it) {
+    for (auto it = std::prev(start_right.segment_it); it >= da.begin(); --it)
       path.right_bound.push_back(convert_point(*it));
-  } else {  // loop back
-    path.right_bound.reserve(std::distance(begin, right_start) + std::distance(right_end, end));
-    for (auto it = right_start; it >= begin; --it) path.right_bound.push_back(convert_point(*it));
-    for (auto it = end - 1; it >= right_end; --it) path.right_bound.push_back(convert_point(*it));
+    for (auto it = std::prev(da.end()); it > end_right.segment_it; --it)
+      path.right_bound.push_back(convert_point(*it));
+  } else {
+    for (auto it = std::prev(start_right.segment_it); it > end_right.segment_it; --it)
+      path.right_bound.push_back(convert_point(*it));
   }
+  if (!boost::geometry::equals(end_right.intersection_point, *std::next(end_right.segment_it)))
+    path.right_bound.push_back(convert_point(end_right.intersection_point));
+
+  // remove possible duplicated points
+  const auto point_cmp = [](const auto & p1, const auto & p2) {
+    return p1.x == p2.x && p1.y == p2.y;
+  };
+  std::unique(path.left_bound.begin(), path.left_bound.end(), point_cmp);
+  std::unique(path.right_bound.begin(), path.right_bound.end(), point_cmp);
   copy_z_over_arc_length(original_left_bound, path.left_bound);
   copy_z_over_arc_length(original_right_bound, path.right_bound);
+
+  for (const auto & p : path.right_bound) {
+    mapper.add(convert_point(p));
+    mapper.map(convert_point(p), "fill-opacity:0.5;fill:grey;stroke:grey;stroke-width:2", 1);
+  }
 }
 
 }  // namespace drivable_area_expansion

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -25,15 +25,6 @@
 
 #include <boost/geometry.hpp>
 
-// for writing the svg file
-#include <fstream>
-#include <iostream>
-// for the geometry types
-#include <tier4_autoware_utils/geometry/geometry.hpp>
-// for the svg mapper
-#include <boost/geometry/io/svg/svg_mapper.hpp>
-#include <boost/geometry/io/svg/write.hpp>
-
 namespace drivable_area_expansion
 {
 
@@ -177,9 +168,6 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
   Intersection end_right;
   end_right.segment_it = da.end();
 
-  // Declare a stream and an SVG mapper
-  std::ofstream svg("/home/mclement/Pictures/debug.svg");
-  boost::geometry::svg_mapper<tier4_autoware_utils::Point2d> mapper(svg, 400, 400);
   for (auto it = da.begin(); it != da.end(); ++it) {
     if (boost::geometry::distance(*it, start_segment.first) < 1e-3) {
       start_left.intersection_point = *it;
@@ -240,24 +228,6 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
       }
     }
   }
-  mapper.add(expanded_drivable_area);
-  mapper.add(path_start_segment);
-  mapper.add(path_end_segment);
-  mapper.add(start_segment);
-  mapper.add(end_segment);
-  mapper.map(expanded_drivable_area, "fill-opacity:0.0;fill:black;stroke:black;stroke-width:1", 1);
-  mapper.map(start_segment, "fill-opacity:0.5;fill:blue;stroke:blue;stroke-width:2", 2);
-  mapper.map(end_segment, "fill-opacity:0.5;fill:blue;stroke:blue;stroke-width:2", 2);
-  mapper.map(path_start_segment, "fill-opacity:0.5;fill:green;stroke:green;stroke-width:2", 2);
-  mapper.map(path_end_segment, "fill-opacity:0.5;fill:green;stroke:green;stroke-width:2", 2);
-  mapper.map(
-    start_left.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
-  mapper.map(
-    start_right.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
-  mapper.map(end_left.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
-  mapper.map(
-    end_right.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
-
   if (
     start_left.segment_it == da.end() || start_right.segment_it == da.end() ||
     end_left.segment_it == da.end() || end_right.segment_it == da.end()) {
@@ -304,11 +274,6 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
   std::unique(path.right_bound.begin(), path.right_bound.end(), point_cmp);
   copy_z_over_arc_length(original_left_bound, path.left_bound);
   copy_z_over_arc_length(original_right_bound, path.right_bound);
-
-  for (const auto & p : path.right_bound) {
-    mapper.add(convert_point(p));
-    mapper.map(convert_point(p), "fill-opacity:0.5;fill:grey;stroke:grey;stroke-width:2", 1);
-  }
 }
 
 }  // namespace drivable_area_expansion

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
@@ -22,10 +22,10 @@ namespace drivable_area_expansion
 
 double calculateDistanceLimit(
   const linestring_t & base_ls, const polygon_t & expansion_polygon,
-  const multilinestring_t & limit_lines)
+  const multi_linestring_t & limit_lines)
 {
   auto dist_limit = std::numeric_limits<double>::max();
-  multipoint_t intersections;
+  multi_point_t intersections;
   boost::geometry::intersection(expansion_polygon, limit_lines, intersections);
   for (const auto & p : intersections)
     dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
@@ -34,11 +34,11 @@ double calculateDistanceLimit(
 
 double calculateDistanceLimit(
   const linestring_t & base_ls, const polygon_t & expansion_polygon,
-  const multipolygon_t & limit_polygons)
+  const multi_polygon_t & limit_polygons)
 {
   auto dist_limit = std::numeric_limits<double>::max();
   for (const auto & polygon : limit_polygons) {
-    multipoint_t intersections;
+    multi_point_t intersections;
     boost::geometry::intersection(expansion_polygon, polygon, intersections);
     for (const auto & p : intersections)
       dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
@@ -50,7 +50,7 @@ polygon_t createExpansionPolygon(
   const linestring_t & base_ls, const double dist, const bool is_left_side)
 {
   namespace strategy = boost::geometry::strategy::buffer;
-  multipolygon_t polygons;
+  multi_polygon_t polygons;
   // set a non 0 value for the buffer as it sometimes causes no polygon to be returned by bg:buffer
   constexpr auto zero = 0.1;
   const auto left_dist = is_left_side ? dist : zero;
@@ -66,7 +66,7 @@ std::array<double, 3> calculate_arc_length_range_and_distance(
   const linestring_t & path_ls, const polygon_t & footprint, const linestring_t & bound,
   const bool is_left, const double path_length)
 {
-  multipoint_t intersections;
+  multi_point_t intersections;
   double expansion_dist = 0.0;
   double from_arc_length = std::numeric_limits<double>::max();
   double to_arc_length = std::numeric_limits<double>::min();
@@ -93,7 +93,7 @@ std::array<double, 3> calculate_arc_length_range_and_distance(
 
 polygon_t create_compensation_polygon(
   const linestring_t & base_ls, const double compensation_dist, const bool is_left,
-  const multilinestring_t uncrossable_lines, const multipolygon_t & predicted_paths)
+  const multi_linestring_t uncrossable_lines, const multi_polygon_t & predicted_paths)
 {
   polygon_t compensation_polygon = createExpansionPolygon(base_ls, compensation_dist, !is_left);
   double dist_limit = std::min(
@@ -106,9 +106,9 @@ polygon_t create_compensation_polygon(
   return compensation_polygon;
 }
 
-multipolygon_t createExpansionPolygons(
-  const PathWithLaneId & path, const multipolygon_t & path_footprints,
-  const multipolygon_t & predicted_paths, const multilinestring_t & uncrossable_lines,
+multi_polygon_t createExpansionPolygons(
+  const PathWithLaneId & path, const multi_polygon_t & path_footprints,
+  const multi_polygon_t & predicted_paths, const multi_linestring_t & uncrossable_lines,
   const DrivableAreaExpansionParameters & params)
 {
   linestring_t path_ls;
@@ -143,7 +143,7 @@ multipolygon_t createExpansionPolygons(
   }
   const auto path_length = static_cast<double>(boost::geometry::length(path_ls));
 
-  multipolygon_t expansion_polygons;
+  multi_polygon_t expansion_polygons;
   for (const auto & footprint : path_footprints) {
     bool is_left = true;
     for (const auto & bound : {left_ls, right_ls}) {
@@ -184,12 +184,12 @@ multipolygon_t createExpansionPolygons(
   return expansion_polygons;
 }
 
-multipolygon_t createExpansionLaneletPolygons(
+multi_polygon_t createExpansionLaneletPolygons(
   const lanelet::ConstLanelets & path_lanes, const route_handler::RouteHandler & route_handler,
-  const multipolygon_t & path_footprints, const multipolygon_t & predicted_paths,
+  const multi_polygon_t & path_footprints, const multi_polygon_t & predicted_paths,
   const DrivableAreaExpansionParameters & params)
 {
-  multipolygon_t expansion_polygons;
+  multi_polygon_t expansion_polygons;
   lanelet::ConstLanelets candidates;
   const auto already_added = [&](const auto & ll) {
     return std::find_if(candidates.begin(), candidates.end(), [&](const auto & l) {

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/footprints.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/footprints.cpp
@@ -39,11 +39,11 @@ polygon_t createFootprint(const geometry_msgs::msg::Pose & pose, const polygon_t
   return translatePolygon(rotatePolygon(base_footprint, angle), pose.position.x, pose.position.y);
 }
 
-multipolygon_t createObjectFootprints(
+multi_polygon_t createObjectFootprints(
   const autoware_auto_perception_msgs::msg::PredictedObjects & objects,
   const DrivableAreaExpansionParameters & params)
 {
-  multipolygon_t footprints;
+  multi_polygon_t footprints;
   if (params.avoid_dynamic_objects) {
     for (const auto & object : objects.objects) {
       const auto front = object.shape.dimensions.x / 2 + params.dynamic_objects_extra_front_offset;
@@ -62,7 +62,7 @@ multipolygon_t createObjectFootprints(
   return footprints;
 }
 
-multipolygon_t createPathFootprints(
+multi_polygon_t createPathFootprints(
   const PathWithLaneId & path, const DrivableAreaExpansionParameters & params)
 {
   const auto left = params.ego_left_offset + params.ego_extra_left_offset;
@@ -73,7 +73,7 @@ multipolygon_t createPathFootprints(
   base_footprint.outer() = {
     point_t{front, left}, point_t{front, right}, point_t{rear, right}, point_t{rear, left},
     point_t{front, left}};
-  multipolygon_t footprints;
+  multi_polygon_t footprints;
   // skip the last footprint as its orientation is usually wrong
   footprints.reserve(path.points.size() - 1);
   double arc_length = 0.0;

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/map_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/map_utils.cpp
@@ -26,10 +26,10 @@
 
 namespace drivable_area_expansion
 {
-multilinestring_t extractUncrossableLines(
+multi_linestring_t extractUncrossableLines(
   const lanelet::LaneletMap & lanelet_map, const std::vector<std::string> & uncrossable_types)
 {
-  multilinestring_t lines;
+  multi_linestring_t lines;
   linestring_t line;
   for (const auto & ls : lanelet_map.lineStringLayer) {
     if (hasTypes(ls, uncrossable_types)) {

--- a/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
@@ -165,13 +165,13 @@ TEST(DrivableAreaExpansionProjection, SubLinestring)
     for (auto i = 0lu; i < ls.size(); ++i) EXPECT_TRUE(boost::geometry::equals(ls[i], sub[i]));
   }
   {
-    // arc lengths equal to existing point: sublinestring with same points
+    // arc lengths equal to existing point: sub-linestring with same points
     const auto sub = sub_linestring(ls, 1.0, 5.0);
     ASSERT_EQ(ls.size() - 2lu, sub.size());
     for (auto i = 0lu; i < sub.size(); ++i) EXPECT_TRUE(boost::geometry::equals(ls[i + 1], sub[i]));
   }
   {
-    // arc lengths inside the original: sublinestring with some interpolated points
+    // arc lengths inside the original: sub-linestring with some interpolated points
     const auto sub = sub_linestring(ls, 1.5, 2.5);
     ASSERT_EQ(sub.size(), 3lu);
     EXPECT_NEAR(sub[0].x(), 1.5, eps);

--- a/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
@@ -298,12 +298,12 @@ TEST(DrivableAreaExpansion, calculateDistanceLimit)
 {
   using drivable_area_expansion::calculateDistanceLimit;
   using drivable_area_expansion::linestring_t;
-  using drivable_area_expansion::multilinestring_t;
+  using drivable_area_expansion::multi_linestring_t;
   using drivable_area_expansion::polygon_t;
 
   {
     const linestring_t base_ls = {{0.0, 0.0}, {10.0, 0.0}};
-    const multilinestring_t uncrossable_lines = {};
+    const multi_linestring_t uncrossable_lines = {};
     const polygon_t expansion_polygon = {
       {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {10.0, -4.0}}, {}};
     const auto limit_distance =
@@ -321,7 +321,7 @@ TEST(DrivableAreaExpansion, calculateDistanceLimit)
   }
   {
     const linestring_t base_ls = {{0.0, 0.0}, {10.0, 0.0}};
-    const multilinestring_t uncrossable_lines = {
+    const multi_linestring_t uncrossable_lines = {
       {{0.0, 2.0}, {10.0, 2.0}}, {{0.0, 1.5}, {10.0, 1.0}}};
     const polygon_t expansion_polygon = {
       {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {10.0, -4.0}}, {}};

--- a/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
@@ -259,13 +259,14 @@ TEST(DrivableAreaExpansionProjection, expandDrivableArea)
     params.max_path_arc_length = 0.0;     // means no limit
     params.extra_arc_length = 1.0;
     params.expansion_method = "polygon";
-    // 4m x 4m ego footprint
+    // 2m x 4m ego footprint
     params.ego_front_offset = 1.0;
     params.ego_rear_offset = -1.0;
     params.ego_left_offset = 2.0;
     params.ego_right_offset = -2.0;
   }
-  // we expect the expand the drivable area by 1m on each side
+  // we expect the drivable area to be expanded by 1m on each side
+  // BUT short paths, due to pruning at the edge of the driving area, there is no expansion
   drivable_area_expansion::expandDrivableArea(
     path, params, dynamic_objects, route_handler, path_lanes);
   // unchanged path points
@@ -274,18 +275,21 @@ TEST(DrivableAreaExpansionProjection, expandDrivableArea)
     EXPECT_NEAR(path.points[i].point.pose.position.x, i, eps);
     EXPECT_NEAR(path.points[i].point.pose.position.y, 0.0, eps);
   }
+
   // expanded left bound
-  ASSERT_EQ(path.left_bound.size(), 2ul);
+  ASSERT_EQ(path.left_bound.size(), 3ul);
   EXPECT_NEAR(path.left_bound[0].x, 0.0, eps);
-  EXPECT_NEAR(path.left_bound[0].y, 2.0, eps);
-  EXPECT_NEAR(path.left_bound[1].x, 2.0, eps);
-  EXPECT_NEAR(path.left_bound[1].y, 2.0, eps);
+  EXPECT_NEAR(path.left_bound[0].y, 1.0, eps);
+  EXPECT_NEAR(path.left_bound[1].x, 1.0, eps);
+  EXPECT_NEAR(path.left_bound[1].y, 1.0, eps);
+  EXPECT_NEAR(path.left_bound[2].x, 2.0, eps);
+  EXPECT_NEAR(path.left_bound[2].y, 1.0, eps);
   // expanded right bound
   ASSERT_EQ(path.right_bound.size(), 3ul);
   EXPECT_NEAR(path.right_bound[0].x, 0.0, eps);
-  EXPECT_NEAR(path.right_bound[0].y, -2.0, eps);
-  EXPECT_NEAR(path.right_bound[1].x, 2.0, eps);
-  EXPECT_NEAR(path.right_bound[1].y, -2.0, eps);
+  EXPECT_NEAR(path.right_bound[0].y, -1.0, eps);
+  EXPECT_NEAR(path.right_bound[1].x, 1.0, eps);
+  EXPECT_NEAR(path.right_bound[1].y, -1.0, eps);
   EXPECT_NEAR(path.right_bound[2].x, 2.0, eps);
   EXPECT_NEAR(path.right_bound[2].y, -1.0, eps);
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR improves the dynamic drivable area expansion, making the bounds look cleaner, especially at the at the start and end of the path.

| Before | After |
|- | - |
| ![dynDA_before](https://github.com/autowarefoundation/autoware.universe/assets/78338830/10bf3058-51b7-49e8-9f4d-6e14d495cc01) | ![dynDA_after](https://github.com/autowarefoundation/autoware.universe/assets/78338830/0781682d-11c3-4ad9-8b2e-884890b950f6) |

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim
Evaluator: https://evaluation.tier4.jp/evaluation/reports/tables/new?project_id=x2_dev&job_id=727d6936-d9ae-5829-98ec-a0f489b09ba9&catalog_id=6888286a-35b1-4121-b322-0c6f0e3d8868&filter=&table_config=date

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
This should not impact the system behavior

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
