### PR TITLE
feat(start_planner): add curvature limit for path generation

### DIFF
--- a/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
+++ b/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
@@ -15,6 +15,7 @@
       lateral_acceleration_sampling_num: 3
       minimum_lateral_acc: 0.15
       maximum_lateral_acc: 0.5
+      maximum_curvature: 0.1
       # geometric pull out
       enable_geometric_pull_out: true
       divide_pull_out_path: false

--- a/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
+++ b/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
@@ -15,7 +15,7 @@
       lateral_acceleration_sampling_num: 3
       minimum_lateral_acc: 0.15
       maximum_lateral_acc: 0.5
-      maximum_curvature: 0.1
+      maximum_curvature: 0.03
       # geometric pull out
       enable_geometric_pull_out: true
       divide_pull_out_path: false

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/shift_pull_out.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/shift_pull_out.hpp
@@ -55,7 +55,7 @@ public:
   std::shared_ptr<LaneDepartureChecker> lane_departure_checker_;
 
 private:
-  double calcBeforePullOutLongitudinalDistance(
+  double calcPullOutLongitudinalDistance(
     const double lon_acc, const double shift_time, const double shift_length,
     const double max_curvature) const;
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/shift_pull_out.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/shift_pull_out.hpp
@@ -53,6 +53,11 @@ public:
     const PathWithLaneId & path, const double target_after_arc_length, const double dr);
 
   std::shared_ptr<LaneDepartureChecker> lane_departure_checker_;
+
+private:
+  double calcBeforePullOutLongitudinalDistance(
+    const double lon_acc, const double shift_time, const double shift_length,
+    const double max_curvature) const;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
@@ -41,6 +41,7 @@ struct StartPlannerParameters
   double lateral_jerk;
   double maximum_lateral_acc;
   double minimum_lateral_acc;
+  double maximum_curvature;  // maximum curvature considered in the path generation
   double deceleration_interval;
   // geometric pull out
   bool enable_geometric_pull_out;

--- a/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
@@ -53,6 +53,7 @@ StartPlannerModuleManager::StartPlannerModuleManager(
   p.lateral_jerk = node->declare_parameter<double>(ns + "lateral_jerk");
   p.maximum_lateral_acc = node->declare_parameter<double>(ns + "maximum_lateral_acc");
   p.minimum_lateral_acc = node->declare_parameter<double>(ns + "minimum_lateral_acc");
+  p.maximum_curvature = node->declare_parameter<double>(ns + "maximum_curvature");
   p.deceleration_interval = node->declare_parameter<double>(ns + "deceleration_interval");
   // geometric pull out
   p.enable_geometric_pull_out = node->declare_parameter<bool>(ns + "enable_geometric_pull_out");

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -194,7 +194,7 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     const double shift_time =
       PathShifter::calcShiftTimeFromJerk(shift_length, lateral_jerk, lateral_acc);
     const double longitudinal_acc = std::clamp(road_velocity / shift_time, 0.0, /* max acc */ 1.0);
-    const auto pull_out_distance = calcBeforePullOutLongitudinalDistance(
+    const auto pull_out_distance = calcPullOutLongitudinalDistance(
       longitudinal_acc, shift_time, shift_length, parameter.maximum_curvature);
     const double terminal_velocity = longitudinal_acc * shift_time;
 
@@ -290,7 +290,7 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
   return candidate_paths;
 }
 
-double ShiftPullOut::calcBeforePullOutLongitudinalDistance(
+double ShiftPullOut::calcPullOutLongitudinalDistance(
   const double lon_acc, const double shift_time, const double shift_length,
   const double max_curvature) const
 {
@@ -299,6 +299,7 @@ double ShiftPullOut::calcBeforePullOutLongitudinalDistance(
 
   // Required distance for curvature limit
   const auto min_pull_out_distance_by_curvature = [&]() {
+    // Simple model for the shifted path by a double circular-arc approximation on a straight road.
     const double distance =
       std::sqrt(std::max(4.0 * shift_length / max_curvature - shift_length * shift_length, 0.0));
     return distance;


### PR DESCRIPTION
## Description

To prevent a shift path from being too sharp in the start_planner as in the picture below, introduce a curvature limit.

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/8d85a3a4-e796-4057-9642-b998215fb6c0)


The curvature limit is applied in the longitudinal distance calculation, resulting as below.

**max curvature = 0.1**  (longitudinal distance = 5.0 m)
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/8517ebdd-6d7e-48e4-a901-7677e69b0272)

**max curvature = 0.03**  (longitudinal distance = 26.8 m)
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/e52ff1b8-22da-4e7c-8263-953375453bfa)


**max curvature = 0.01**  (longitudinal distance = 45.5 m)
![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/4a5f8c24-e1eb-494b-af10-a899716c3d17)


## Related links

[TIERIV INTERNAL TICKET](https://tier4.atlassian.net/browse/RT1-3083)

TIERIV INTERNAL SCENARIO TEST

## Tests performed

- Psim
- scenario test

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

The shift path in starting gets more smooth.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
