### PR TITLE
fix(avoidance): fix previous data inconsistency

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -456,12 +456,6 @@ private:
   // generate output data
 
   /**
-   * @brief generate avoidance path from path shifter.
-   * @return avoidance path.
-   */
-  ShiftedPath generateAvoidancePath(PathShifter & shifter) const;
-
-  /**
    * @brief calculate turn signal infomation.
    * @param avoidance path.
    * @return turn signal command.


### PR DESCRIPTION
## Description

Close https://github.com/autowarefoundation/autoware.universe/issues/4178?notification_referrer_id=NT_kwDOAqz13LM2OTcyODU5NTcyOjQ0ODg5NTY0

If it fails to generate avoidance path, module doesn't update any previous data.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/57fbd44b-3f7a-5c19-9b50-2240cddc0319?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
