### PR TITLE
feat(behavior_velocity_crosswalk_module): different z for each debug text marker

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/debug.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/debug.cpp
@@ -74,7 +74,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
       }
       marker.text = string_stream.str();
       marker.pose.position = point.collision_point;
-      marker.pose.position.z += 2.0;
+      marker.pose.position.z += 2.0 + i * 0.5;  // NOTE: so that the texts will not overlap
       msg.markers.push_back(marker);
     }
   }


### PR DESCRIPTION
## Description

In order to see multiple text markers, I set the different z positions for each text marker.
without this PR
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/e6e49c9f-d387-48db-a2e8-0010817fd088)


with this PR
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/e55ef703-a52a-4758-a94a-16823413c9ac)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
