### PR TITLE
feat(utils): add function to visualize drivable lanes

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/marker_util/debug_utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/marker_util/debug_utilities.hpp
@@ -14,6 +14,7 @@
 #ifndef BEHAVIOR_PATH_PLANNER__MARKER_UTIL__DEBUG_UTILITIES_HPP_
 #define BEHAVIOR_PATH_PLANNER__MARKER_UTIL__DEBUG_UTILITIES_HPP_
 
+#include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/utils/path_shifter/path_shifter.hpp"
 #include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 
@@ -36,6 +37,7 @@ namespace marker_utils
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_perception_msgs::msg::PredictedPath;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
+using behavior_path_planner::DrivableLanes;
 using behavior_path_planner::ShiftLineArray;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Polygon;
@@ -125,6 +127,9 @@ MarkerArray createPolygonMarkerArray(
 MarkerArray createObjectsMarkerArray(
   const PredictedObjects & objects, std::string && ns, const int64_t & lane_id, const float & r,
   const float & g, const float & b);
+
+MarkerArray createDrivableLanesMarkerArray(
+  const std::vector<DrivableLanes> & drivable_lanes, std::string && ns);
 
 }  // namespace marker_utils
 

--- a/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
+++ b/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
@@ -390,7 +390,7 @@ MarkerArray createDrivableLanesMarkerArray(
       return marker;
     };
 
-  for (const auto & drivable_lane : drivable_lanes) {
+  const auto get_drivable_lanes = [&msg, &get_lanelet_marker](const DrivableLanes & drivable_lane) {
     {
       msg.markers.push_back(get_lanelet_marker(drivable_lane.right_lane, 1.0, 0.0, 0.0));
     }
@@ -402,7 +402,9 @@ MarkerArray createDrivableLanesMarkerArray(
     std::for_each(
       drivable_lane.middle_lanes.begin(), drivable_lane.middle_lanes.end(),
       [&](const auto & lane) { msg.markers.push_back(get_lanelet_marker(lane, 0.0, 0.0, 1.0)); });
-  }
+  };
+
+  std::for_each(drivable_lanes.begin(), drivable_lanes.end(), get_drivable_lanes);
 
   return msg;
 }

--- a/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
+++ b/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
@@ -361,4 +361,49 @@ MarkerArray createObjectsMarkerArray(
 
   return msg;
 }
+
+MarkerArray createDrivableLanesMarkerArray(
+  const std::vector<DrivableLanes> & drivable_lanes, std::string && ns)
+{
+  MarkerArray msg;
+
+  int32_t i{0};
+
+  const auto get_lanelet_marker =
+    [&ns, &i](const auto & lanelet, const auto r, const auto g, const auto b) {
+      auto marker = createDefaultMarker(
+        "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, bitShift(lanelet.id()) + i++,
+        Marker::LINE_STRIP, createMarkerScale(0.1, 0.0, 0.0), createMarkerColor(r, g, b, 0.999));
+
+      if (!lanelet.polygon3d().empty()) {
+        marker.points.reserve(lanelet.polygon3d().size() + 1);
+      }
+
+      for (const auto & p : lanelet.polygon3d()) {
+        marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
+      }
+
+      if (!marker.points.empty()) {
+        marker.points.push_back(marker.points.front());
+      }
+
+      return marker;
+    };
+
+  for (const auto & drivable_lane : drivable_lanes) {
+    {
+      msg.markers.push_back(get_lanelet_marker(drivable_lane.right_lane, 1.0, 0.0, 0.0));
+    }
+
+    {
+      msg.markers.push_back(get_lanelet_marker(drivable_lane.left_lane, 0.0, 1.0, 0.0));
+    }
+
+    std::for_each(
+      drivable_lane.middle_lanes.begin(), drivable_lane.middle_lanes.end(),
+      [&](const auto & lane) { msg.markers.push_back(get_lanelet_marker(lane, 0.0, 0.0, 1.0)); });
+  }
+
+  return msg;
+}
 }  // namespace marker_utils

--- a/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
+++ b/planning/behavior_path_planner/src/marker_util/debug_utilities.cpp
@@ -375,17 +375,17 @@ MarkerArray createDrivableLanesMarkerArray(
         "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, bitShift(lanelet.id()) + i++,
         Marker::LINE_STRIP, createMarkerScale(0.1, 0.0, 0.0), createMarkerColor(r, g, b, 0.999));
 
-      if (!lanelet.polygon3d().empty()) {
-        marker.points.reserve(lanelet.polygon3d().size() + 1);
+      if (lanelet.polygon3d().empty()) {
+        return marker;
       }
+
+      marker.points.reserve(lanelet.polygon3d().size() + 1);
 
       for (const auto & p : lanelet.polygon3d()) {
         marker.points.push_back(createPoint(p.x(), p.y(), p.z()));
       }
 
-      if (!marker.points.empty()) {
-        marker.points.push_back(marker.points.front());
-      }
+      marker.points.push_back(marker.points.front());
 
       return marker;
     };


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 051fd0c</samp>

Added a new function `createDrivableLanesMarkerArray` to the `debug_utilities` namespace, which creates and returns a marker array message for visualizing the drivable lanes in the behavior path planner. Modified the files `debug_utilities.hpp` and `debug_utilities.cpp` to implement this function.

- RED : RIGHT LANE
- GREEN : LEFT LANE
- BLUE : MIDDLE LANE(s)

![Screenshot from 2023-07-14 13-00-30](https://github.com/autowarefoundation/autoware.universe/assets/44889564/f43113d3-3810-43be-9536-0231c41d6400)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Nothing.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
