### PR TITLE
fix(intersection): fix uninitialized tl_arrow_info variable issue

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -650,29 +650,26 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
   }
 
   const auto & current_pose = planner_data_->current_odometry->pose;
-  // dynamically change detection area based on tl_arrow_solid_on
-  const bool tl_arrow_solid_on =
-    util::isTrafficLightArrowActivated(assigned_lanelet, planner_data_->traffic_light_id_map);
-  if (
-    !intersection_lanelets_ ||
-    intersection_lanelets_.value().tl_arrow_solid_on != tl_arrow_solid_on) {
+  if (!intersection_lanelets_) {
     const auto lanelets_on_path =
       planning_utils::getLaneletsOnPath(*path, lanelet_map_ptr, current_pose);
     intersection_lanelets_ = util::getObjectiveLanelets(
       lanelet_map_ptr, routing_graph_ptr, assigned_lanelet, lanelets_on_path, associative_ids_,
-      interpolated_path_info, planner_param_.common.attention_area_length,
-      planner_param_.occlusion.occlusion_attention_area_length,
-      planner_param_.common.consider_wrong_direction_vehicle, tl_arrow_solid_on);
+      planner_param_.common.attention_area_length,
+      planner_param_.occlusion.occlusion_attention_area_length);
   }
+  const bool tl_arrow_solid_on =
+    util::isTrafficLightArrowActivated(assigned_lanelet, planner_data_->traffic_light_id_map);
+  intersection_lanelets_.value().update(tl_arrow_solid_on, interpolated_path_info);
 
-  const auto & conflicting_lanelets = intersection_lanelets_.value().conflicting;
-  const auto & first_conflicting_area = intersection_lanelets_.value().first_conflicting_area;
+  const auto & conflicting_lanelets = intersection_lanelets_.value().conflicting();
+  const auto & first_conflicting_area = intersection_lanelets_.value().first_conflicting_area();
   if (conflicting_lanelets.empty() || !first_conflicting_area) {
     RCLCPP_DEBUG(logger_, "conflicting area is empty");
     return IntersectionModule::Indecisive{};
   }
 
-  const auto & first_attention_area = intersection_lanelets_.value().first_attention_area;
+  const auto & first_attention_area = intersection_lanelets_.value().first_attention_area();
   const auto & dummy_first_attention_area =
     first_attention_area ? first_attention_area.value() : first_conflicting_area.value();
   const auto intersection_stop_lines_opt = util::generateIntersectionStopLines(
@@ -745,13 +742,12 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
     return IntersectionModule::Indecisive{};
   }
 
-  const auto & attention_lanelets = intersection_lanelets_.value().attention;
-  const auto & adjacent_lanelets = intersection_lanelets_.value().adjacent;
-  const auto & occlusion_attention_lanelets = intersection_lanelets_.value().occlusion_attention;
-  const auto & attention_area = intersection_lanelets_.value().attention_area;
-  const auto & occlusion_attention_area = intersection_lanelets_.value().occlusion_attention_area;
-  debug_data_.attention_area = attention_area;
-  debug_data_.adjacent_area = intersection_lanelets_.value().adjacent_area;
+  const auto & attention_lanelets = intersection_lanelets_.value().attention();
+  const auto & adjacent_lanelets = intersection_lanelets_.value().adjacent();
+  const auto & occlusion_attention_lanelets = intersection_lanelets_.value().occlusion_attention();
+  const auto & occlusion_attention_area = intersection_lanelets_.value().occlusion_attention_area();
+  debug_data_.attention_area = intersection_lanelets_.value().attention_area();
+  debug_data_.adjacent_area = intersection_lanelets_.value().adjacent_area();
 
   // get intersection area
   const auto intersection_area = planner_param_.common.use_intersection_area

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -665,7 +665,6 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
   const auto & conflicting_lanelets = intersection_lanelets_.value().conflicting();
   const auto & first_conflicting_area = intersection_lanelets_.value().first_conflicting_area();
   if (conflicting_lanelets.empty() || !first_conflicting_area) {
-    RCLCPP_DEBUG(logger_, "conflicting area is empty");
     return IntersectionModule::Indecisive{};
   }
 

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -656,7 +656,8 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
     intersection_lanelets_ = util::getObjectiveLanelets(
       lanelet_map_ptr, routing_graph_ptr, assigned_lanelet, lanelets_on_path, associative_ids_,
       planner_param_.common.attention_area_length,
-      planner_param_.occlusion.occlusion_attention_area_length);
+      planner_param_.occlusion.occlusion_attention_area_length,
+      planner_param_.common.consider_wrong_direction_vehicle);
   }
   const bool tl_arrow_solid_on =
     util::isTrafficLightArrowActivated(assigned_lanelet, planner_data_->traffic_light_id_map);

--- a/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
@@ -83,19 +83,17 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopR
   }
 
   /* get detection area */
-  if (!intersection_lanelets_.has_value()) {
+  if (!intersection_lanelets_) {
     const auto & assigned_lanelet =
       planner_data_->route_handler_->getLaneletMapPtr()->laneletLayer.get(lane_id_);
     const auto lanelets_on_path = planning_utils::getLaneletsOnPath(
       *path, lanelet_map_ptr, planner_data_->current_odometry->pose);
     intersection_lanelets_ = util::getObjectiveLanelets(
       lanelet_map_ptr, routing_graph_ptr, assigned_lanelet, lanelets_on_path, associative_ids_,
-      interpolated_path_info, planner_param_.attention_area_length,
-      planner_param_.occlusion_attention_area_length,
-      planner_param_.consider_wrong_direction_vehicle,
-      false /* tl_arrow_solid on does not matter here*/);
+      planner_param_.attention_area_length, 0.0);
   }
-  const auto & first_conflicting_area = intersection_lanelets_.value().first_conflicting_area;
+  intersection_lanelets_.value().update(false, interpolated_path_info);
+  const auto & first_conflicting_area = intersection_lanelets_.value().first_conflicting_area();
   if (!first_conflicting_area) {
     return false;
   }

--- a/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
@@ -90,7 +90,8 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopR
       *path, lanelet_map_ptr, planner_data_->current_odometry->pose);
     intersection_lanelets_ = util::getObjectiveLanelets(
       lanelet_map_ptr, routing_graph_ptr, assigned_lanelet, lanelets_on_path, associative_ids_,
-      planner_param_.attention_area_length, 0.0);
+      planner_param_.attention_area_length, planner_param_.occlusion_attention_area_length,
+      planner_param_.consider_wrong_direction_vehicle);
   }
   intersection_lanelets_.value().update(false, interpolated_path_info);
   const auto & first_conflicting_area = intersection_lanelets_.value().first_conflicting_area();

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -403,7 +403,7 @@ IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
   const lanelet::ConstLanelet assigned_lanelet, const lanelet::ConstLanelets & lanelets_on_path,
   const std::set<int> & associative_ids, const double detection_area_length,
-  const double occlusion_detection_area_length)
+  const double occlusion_detection_area_length, const bool consider_wrong_direction_vehicle)
 {
   const auto turn_direction = assigned_lanelet.attributeOr("turn_direction", "else");
 

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -14,6 +14,8 @@
 
 #include "util.hpp"
 
+#include "util_type.hpp"
+
 #include <behavior_velocity_planner_common/utilization/path_utilization.hpp>
 #include <behavior_velocity_planner_common/utilization/trajectory_utils.hpp>
 #include <behavior_velocity_planner_common/utilization/util.hpp>
@@ -400,9 +402,8 @@ static std::vector<lanelet::CompoundPolygon3d> getPolygon3dFromLanelets(
 IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
   const lanelet::ConstLanelet assigned_lanelet, const lanelet::ConstLanelets & lanelets_on_path,
-  const std::set<int> & associative_ids, const InterpolatedPathInfo & interpolated_path_info,
-  const double detection_area_length, const double occlusion_detection_area_length,
-  const bool consider_wrong_direction_vehicle, const bool tl_arrow_solid_on)
+  const std::set<int> & associative_ids, const double detection_area_length,
+  const double occlusion_detection_area_length)
 {
   const auto turn_direction = assigned_lanelet.attributeOr("turn_direction", "else");
 
@@ -494,9 +495,8 @@ IntersectionLanelets getObjectiveLanelets(
   }
 
   // get possible lanelet path that reaches conflicting_lane longer than given length
-  // if traffic light arrow is active, this process is unnecessary
   lanelet::ConstLanelets detection_and_preceding_lanelets;
-  if (!tl_arrow_solid_on) {
+  {
     const double length = detection_area_length;
     std::set<lanelet::Id> detection_ids;
     for (const auto & ll : detection_lanelets) {
@@ -538,36 +538,16 @@ IntersectionLanelets getObjectiveLanelets(
   }
 
   IntersectionLanelets result;
-  if (!tl_arrow_solid_on) {
-    result.attention = std::move(detection_and_preceding_lanelets);
-  } else {
-    result.attention = std::move(detection_lanelets);
-  }
-  result.conflicting = std::move(conflicting_ex_ego_lanelets);
-  result.adjacent = planning_utils::getConstLaneletsFromIds(lanelet_map_ptr, associative_ids);
-  result.occlusion_attention = std::move(occlusion_detection_and_preceding_lanelets);
+  result.attention_ = std::move(detection_and_preceding_lanelets);
+  result.attention_non_preceding_ = std::move(detection_lanelets);
+  result.conflicting_ = std::move(conflicting_ex_ego_lanelets);
+  result.adjacent_ = planning_utils::getConstLaneletsFromIds(lanelet_map_ptr, associative_ids);
+  result.occlusion_attention_ = std::move(occlusion_detection_and_preceding_lanelets);
   // compoundPolygon3d
-  result.attention_area = getPolygon3dFromLanelets(result.attention);
-  result.conflicting_area = getPolygon3dFromLanelets(result.conflicting);
-  result.adjacent_area = getPolygon3dFromLanelets(result.adjacent);
-  result.occlusion_attention_area = getPolygon3dFromLanelets(result.occlusion_attention);
-
-  // find the first conflicting/detection area polygon intersecting the path
-  const auto & path = interpolated_path_info.path;
-  const auto & lane_interval = interpolated_path_info.lane_id_interval.value();
-  {
-    auto first = getFirstPointInsidePolygons(path, lane_interval, result.conflicting_area);
-    if (first) {
-      result.first_conflicting_area = first.value().second;
-    }
-  }
-  {
-    auto first = getFirstPointInsidePolygons(path, lane_interval, result.attention_area);
-    if (first) {
-      result.first_attention_area = first.value().second;
-    }
-  }
-
+  result.attention_area_ = getPolygon3dFromLanelets(result.attention_);
+  result.conflicting_area_ = getPolygon3dFromLanelets(result.conflicting_);
+  result.adjacent_area_ = getPolygon3dFromLanelets(result.adjacent_);
+  result.occlusion_attention_area_ = getPolygon3dFromLanelets(result.occlusion_attention_);
   return result;
 }
 
@@ -1128,6 +1108,27 @@ double calcDistanceUntilIntersectionLanelet(
     path.points.at(dst_idx).point.pose.position.x - lane_first_point.x(),
     path.points.at(dst_idx).point.pose.position.y - lane_first_point.y());
   return distance;
+}
+
+void IntersectionLanelets::update(
+  const bool tl_arrow_solid_on, const InterpolatedPathInfo & interpolated_path_info)
+{
+  tl_arrow_solid_on_ = tl_arrow_solid_on;
+  // find the first conflicting/detection area polygon intersecting the path
+  const auto & path = interpolated_path_info.path;
+  const auto & lane_interval = interpolated_path_info.lane_id_interval.value();
+  {
+    auto first = getFirstPointInsidePolygons(path, lane_interval, conflicting_area_);
+    if (first) {
+      first_conflicting_area_ = first.value().second;
+    }
+  }
+  {
+    auto first = getFirstPointInsidePolygons(path, lane_interval, attention_area_);
+    if (first) {
+      first_attention_area_ = first.value().second;
+    }
+  }
 }
 
 }  // namespace util

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -57,7 +57,7 @@ IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
   const lanelet::ConstLanelet assigned_lanelet, const lanelet::ConstLanelets & lanelets_on_path,
   const std::set<int> & associative_ids, const double detection_area_length,
-  const double occlusion_detection_area_length);
+  const double occlusion_detection_area_length, const bool consider_wrong_direction_vehicle);
 
 /**
  * @brief Generate a stop line for stuck vehicle

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -56,9 +56,8 @@ std::optional<std::pair<size_t, size_t>> findLaneIdsInterval(
 IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
   const lanelet::ConstLanelet assigned_lanelet, const lanelet::ConstLanelets & lanelets_on_path,
-  const std::set<int> & associative_ids, const InterpolatedPathInfo & interpolated_path_info,
-  const double detection_area_length, const double occlusion_detection_area_length,
-  const bool consider_wrong_direction_vehicle, const bool tl_arrow_solid_on = false);
+  const std::set<int> & associative_ids, const double detection_area_length,
+  const double occlusion_detection_area_length);
 
 /**
  * @brief Generate a stop line for stuck vehicle

--- a/planning/behavior_velocity_intersection_module/src/util_type.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util_type.hpp
@@ -51,31 +51,6 @@ struct DebugData
   std::optional<geometry_msgs::msg::Point> nearest_occlusion_projection_point = std::nullopt;
 };
 
-struct IntersectionLanelets
-{
-  bool tl_arrow_solid_on;
-  lanelet::ConstLanelets attention;
-  lanelet::ConstLanelets conflicting;
-  lanelet::ConstLanelets adjacent;
-  lanelet::ConstLanelets occlusion_attention;  // for occlusion detection
-  std::vector<lanelet::CompoundPolygon3d> attention_area;
-  std::vector<lanelet::CompoundPolygon3d> conflicting_area;
-  std::vector<lanelet::CompoundPolygon3d> adjacent_area;
-  std::vector<lanelet::CompoundPolygon3d> occlusion_attention_area;
-  // the first area intersecting with the path
-  // even if lane change/re-routing happened on the intersection, these areas area are supposed to
-  // be invariant under the 'associative' lanes.
-  std::optional<lanelet::CompoundPolygon3d> first_conflicting_area;
-  std::optional<lanelet::CompoundPolygon3d> first_attention_area;
-};
-
-struct DescritizedLane
-{
-  int lane_id;
-  // discrete fine lines from left to right
-  std::vector<lanelet::ConstLineString2d> divisions;
-};
-
 struct InterpolatedPathInfo
 {
   autoware_auto_planning_msgs::msg::PathWithLaneId path;
@@ -83,6 +58,67 @@ struct InterpolatedPathInfo
   int lane_id;
   std::set<int> associative_lane_ids;
   std::optional<std::pair<size_t, size_t>> lane_id_interval;
+};
+
+struct IntersectionLanelets
+{
+public:
+  void update(const bool tl_arrow_solid_on, const InterpolatedPathInfo & interpolated_path_info);
+  const lanelet::ConstLanelets & attention() const
+  {
+    return tl_arrow_solid_on_ ? attention_non_preceding_ : attention_;
+  }
+  const lanelet::ConstLanelets & conflicting() const { return conflicting_; }
+  const lanelet::ConstLanelets & adjacent() const { return adjacent_; }
+  const lanelet::ConstLanelets & occlusion_attention() const
+  {
+    return tl_arrow_solid_on_ ? attention_non_preceding_ : occlusion_attention_;
+  }
+  const std::vector<lanelet::CompoundPolygon3d> & attention_area() const
+  {
+    return tl_arrow_solid_on_ ? attention_non_preceding_area_ : attention_area_;
+  }
+  const std::vector<lanelet::CompoundPolygon3d> & conflicting_area() const
+  {
+    return conflicting_area_;
+  }
+  const std::vector<lanelet::CompoundPolygon3d> & adjacent_area() const { return adjacent_area_; }
+  const std::vector<lanelet::CompoundPolygon3d> & occlusion_attention_area() const
+  {
+    return occlusion_attention_area_;
+  }
+  const std::optional<lanelet::CompoundPolygon3d> & first_conflicting_area() const
+  {
+    return first_conflicting_area_;
+  }
+  const std::optional<lanelet::CompoundPolygon3d> & first_attention_area() const
+  {
+    return first_attention_area_;
+  }
+
+  lanelet::ConstLanelets attention_;
+  lanelet::ConstLanelets attention_non_preceding_;
+  lanelet::ConstLanelets conflicting_;
+  lanelet::ConstLanelets adjacent_;
+  lanelet::ConstLanelets occlusion_attention_;  // for occlusion detection
+  std::vector<lanelet::CompoundPolygon3d> attention_area_;
+  std::vector<lanelet::CompoundPolygon3d> attention_non_preceding_area_;
+  std::vector<lanelet::CompoundPolygon3d> conflicting_area_;
+  std::vector<lanelet::CompoundPolygon3d> adjacent_area_;
+  std::vector<lanelet::CompoundPolygon3d> occlusion_attention_area_;
+  // the first area intersecting with the path
+  // even if lane change/re-routing happened on the intersection, these areas area are supposed to
+  // be invariant under the 'associative' lanes.
+  bool tl_arrow_solid_on_ = false;
+  std::optional<lanelet::CompoundPolygon3d> first_conflicting_area_ = std::nullopt;
+  std::optional<lanelet::CompoundPolygon3d> first_attention_area_ = std::nullopt;
+};
+
+struct DescritizedLane
+{
+  int lane_id;
+  // discrete fine lines from left to right
+  std::vector<lanelet::ConstLineString2d> divisions;
 };
 
 struct IntersectionStopLines


### PR DESCRIPTION
## Description

`IntersectionLanelets::tl_arrow_solid_on` was uninitialized and was not updated carelessly. Due to this bug when `left/right arrow` is not solid on when turning left/right each variable was like this when I debug printed.

```
tl_arrow_solid_on = 0, intersection_lanelets_.value().tl_arrow_solid_on = 144
```

So for most of the time when the path is covering the intersection [this condition](https://github.com/autowarefoundation/autoware.universe/blob/e282c4fe9b6acb6c98874665b2277375f0a6a70b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp#L656-L658) was true in every iteration. So `first_conflicting_area` was null at first, and then initialized to an area after a few iterations.

But if `lanelets_.value().tl_arrow_solid_on` is left _**uninitialized to 0**_, that condition will be applied only at the first time that the corresponding intersection module is activated, so `first_conflicting_area` was permanently 0.

## Related links

https://tier4.atlassian.net/browse/RT1-2875?focusedCommentId=128666&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-128666

## Tests performed

no degradation on the CI: https://evaluation.tier4.jp/evaluation/reports/50fcf368-aa63-574e-9de2-89eb26f5e8bc?project_id=prd_jt

## Notes for reviewers

## Interface changes

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
