### PR TITLE
fix(image_projection_based_fusion): correct helper function parameter type

### DIFF
--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/geometry.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/geometry.hpp
@@ -62,7 +62,7 @@ void transformPoints(
 
 bool is_inside(
   const sensor_msgs::msg::RegionOfInterest & outer,
-  const sensor_msgs::msg::RegionOfInterest & inner, const float outer_offset_scale = 1.1);
+  const sensor_msgs::msg::RegionOfInterest & inner, const double outer_offset_scale = 1.1);
 
 }  // namespace image_projection_based_fusion
 


### PR DESCRIPTION
## Description

[is_inside](https://github.com/autowarefoundation/autoware.universe/blob/55cb3d58e4e9f509258b384c17c7bba86d39d4c0/perception/image_projection_based_fusion/src/utils/geometry.cpp#L165-L174) function wrong declared in [geometry.hpp](https://github.com/autowarefoundation/autoware.universe/blob/main/perception/image_projection_based_fusion/include/image_projection_based_fusion/utils/geometry.hpp) file, it causes symbol lookup error.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
