### PR TITLE
feat(avoidance): flexible avoidance path generation

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -145,11 +145,9 @@
         longitudinal:
           prepare_time: 2.0                             # [s]
           min_prepare_distance: 1.0                     # [m]
-          min_avoidance_distance: 10.0                  # [m]
-          min_nominal_avoidance_speed: 7.0              # [m/s]
-          min_sharp_avoidance_speed: 1.0                # [m/s]
           min_slow_down_speed: 1.38                     # [m/s]
           buf_slow_down_speed: 0.56                     # [m/s]
+          nominal_avoidance_speed: 8.33                 # [m/s]
 
       # For yield maneuver
       yield:
@@ -157,7 +155,6 @@
 
       # For stop maneuver
       stop:
-        min_distance: 10.0                              # [m]
         max_distance: 20.0                              # [m]
         stop_buffer: 1.0                                # [m]
 
@@ -167,9 +164,10 @@
 
         # lateral constraints
         lateral:
-          nominal_lateral_jerk: 0.2                     # [m/sss]
-          max_lateral_jerk: 1.0                         # [m/sss]
-          max_lateral_acceleration: 0.5                 # [m/ss]
+          velocity: [1.0, 1.38, 11.1]                   # [m/s]
+          max_accel_values: [0.5, 0.5, 0.5]             # [m/ss]
+          min_jerk_values: [0.2, 0.2, 0.2]              # [m/sss]
+          max_jerk_values: [1.0, 1.0, 1.0]             # [m/sss]
 
         # longitudinal constraints
         longitudinal:

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -425,12 +425,6 @@ private:
    * @brief trim invalid shift lines whose gradient it too large to follow.
    * @param target shift lines.
    */
-  void trimTooSharpShift(AvoidLineArray & shift_lines) const;
-
-  /*
-   * @brief trim invalid shift lines whose gradient it too large to follow.
-   * @param target shift lines.
-   */
   void trimSharpReturn(AvoidLineArray & shift_lines, const double threshold) const;
 
   /**

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -199,9 +199,6 @@ struct AvoidanceParameters
   // keep target velocity in yield maneuver
   double yield_velocity;
 
-  // minimum stop distance
-  double stop_min_distance;
-
   // maximum stop distance
   double stop_max_distance;
 
@@ -214,25 +211,14 @@ struct AvoidanceParameters
   // Even if the vehicle speed is zero, avoidance will start after a distance of this much.
   double min_prepare_distance;
 
-  // minimum distance while avoiding TODO(Horibe): will be changed to jerk constraint later
-  double min_avoidance_distance;
-
-  // minimum speed for jerk calculation in a nominal situation, i.e. there is an enough
-  // distance for avoidance, and the object is very far from ego. In that case, the
-  // vehicle speed is unknown passing along the object. Then use this speed as a minimum.
-  // Note: This parameter is needed because we have to plan an avoidance path in advance
-  //       without knowing the speed of the distant path.
-  double min_nominal_avoidance_speed;
-
-  // minimum speed for jerk calculation in a tight situation, i.e. there is NOT an enough
-  // distance for avoidance. Need a sharp avoidance path to avoid the object.
-  double min_sharp_avoidance_speed;
-
   // minimum slow down speed
   double min_slow_down_speed;
 
   // slow down speed buffer
   double buf_slow_down_speed;
+
+  // nominal avoidance sped
+  double nominal_avoidance_speed;
 
   // The margin is configured so that the generated avoidance trajectory does not come near to the
   // road shoulder.
@@ -243,13 +229,6 @@ struct AvoidanceParameters
 
   // Even if the obstacle is very large, it will not avoid more than this length for left direction
   double max_left_shift_length;
-
-  // Avoidance path is generated with this jerk.
-  // If there is no margin, the jerk increases up to max lateral jerk.
-  double nominal_lateral_jerk;
-
-  // if the avoidance path exceeds this lateral jerk, it will be not used anymore.
-  double max_lateral_jerk;
 
   // To prevent large acceleration while avoidance.
   double max_lateral_acceleration;
@@ -283,6 +262,18 @@ struct AvoidanceParameters
 
   // For shift line generation process. Remove sharp(=jerky) shift line.
   double sharp_shift_filter_threshold;
+
+  // target velocity matrix
+  std::vector<double> velocity_map;
+
+  // Minimum lateral jerk limitation map.
+  std::vector<double> lateral_min_jerk_map;
+
+  // Maximum lateral jerk limitation map.
+  std::vector<double> lateral_max_jerk_map;
+
+  // Maximum lateral acceleration limitation map.
+  std::vector<double> lateral_max_accel_map;
 
   // target velocity matrix
   std::vector<double> target_velocity_matrix;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/helper.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/helper.hpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <vector>
 
 namespace behavior_path_planner::helper::avoidance
 {
@@ -37,13 +38,6 @@ class AvoidanceHelper
 public:
   explicit AvoidanceHelper(const std::shared_ptr<AvoidanceParameters> & parameters)
   : parameters_{parameters}
-  {
-  }
-
-  AvoidanceHelper(
-    const std::shared_ptr<const PlannerData> & data,
-    const std::shared_ptr<AvoidanceParameters> & parameters)
-  : data_{data}, parameters_{parameters}
   {
   }
 
@@ -64,50 +58,72 @@ public:
 
   double getEgoSpeed() const { return std::abs(data_->self_odometry->twist.twist.linear.x); }
 
-  double getNominalAvoidanceEgoSpeed() const
+  size_t getConstraintsMapIndex(const double velocity, const std::vector<double> & values) const
   {
-    return std::max(getEgoSpeed(), parameters_->min_nominal_avoidance_speed);
+    const auto itr = std::find_if(
+      values.begin(), values.end(), [&](const auto value) { return velocity < value; });
+    const auto idx = std::distance(values.begin(), itr);
+    return 0 < idx ? idx - 1 : 0;
   }
 
-  double getSharpAvoidanceEgoSpeed() const
+  double getLateralMinJerkLimit() const
   {
-    return std::max(getEgoSpeed(), parameters_->min_sharp_avoidance_speed);
+    const auto idx = getConstraintsMapIndex(getEgoSpeed(), parameters_->velocity_map);
+    return parameters_->lateral_min_jerk_map.at(idx);
+  }
+
+  double getLateralMaxJerkLimit() const
+  {
+    const auto idx = getConstraintsMapIndex(getEgoSpeed(), parameters_->velocity_map);
+    return parameters_->lateral_max_jerk_map.at(idx);
+  }
+
+  double getLateralMaxAccelLimit() const
+  {
+    const auto idx = getConstraintsMapIndex(getEgoSpeed(), parameters_->velocity_map);
+    return parameters_->lateral_max_accel_map.at(idx);
+  }
+
+  double getAvoidanceEgoSpeed() const
+  {
+    const auto & values = parameters_->velocity_map;
+    const auto idx = getConstraintsMapIndex(getEgoSpeed(), values);
+    return std::max(getEgoSpeed(), values.at(idx));
   }
 
   double getNominalPrepareDistance() const
   {
     const auto & p = parameters_;
-    const auto epsilon_m = 0.01;  // for floating error to pass "has_enough_distance" check.
-    const auto nominal_distance =
-      std::max(getEgoSpeed() * p->prepare_time, p->min_prepare_distance);
-    return nominal_distance + epsilon_m;
+    return std::max(getEgoSpeed() * p->prepare_time, p->min_prepare_distance);
   }
 
   double getNominalAvoidanceDistance(const double shift_length) const
   {
     const auto & p = parameters_;
-    const auto distance_by_jerk = PathShifter::calcLongitudinalDistFromJerk(
-      shift_length, p->nominal_lateral_jerk, getNominalAvoidanceEgoSpeed());
-
-    return std::max(p->min_avoidance_distance, distance_by_jerk);
+    const auto nominal_speed = std::max(getEgoSpeed(), p->nominal_avoidance_speed);
+    const auto nominal_jerk =
+      p->lateral_min_jerk_map.at(getConstraintsMapIndex(nominal_speed, p->velocity_map));
+    return PathShifter::calcLongitudinalDistFromJerk(shift_length, nominal_jerk, nominal_speed);
   }
 
-  double getMinimumAvoidanceDistance(const double shift_length) const
+  double getMinAvoidanceDistance(const double shift_length) const
   {
     const auto & p = parameters_;
-    const auto distance_by_jerk = PathShifter::calcLongitudinalDistFromJerk(
-      shift_length, p->max_lateral_jerk, p->min_sharp_avoidance_speed);
+    return PathShifter::calcLongitudinalDistFromJerk(
+      shift_length, p->lateral_max_jerk_map.front(), p->velocity_map.front());
+  }
 
-    return std::max(p->min_avoidance_distance, distance_by_jerk);
+  double getMaxAvoidanceDistance(const double shift_length) const
+  {
+    const auto distance_from_jerk = PathShifter::calcLongitudinalDistFromJerk(
+      shift_length, getLateralMinJerkLimit(), getAvoidanceEgoSpeed());
+    return std::max(getNominalAvoidanceDistance(shift_length), distance_from_jerk);
   }
 
   double getSharpAvoidanceDistance(const double shift_length) const
   {
-    const auto & p = parameters_;
-    const auto distance_by_jerk = PathShifter::calcLongitudinalDistFromJerk(
-      shift_length, p->max_lateral_jerk, getSharpAvoidanceEgoSpeed());
-
-    return std::max(p->min_avoidance_distance, distance_by_jerk);
+    return PathShifter::calcLongitudinalDistFromJerk(
+      shift_length, getLateralMaxJerkLimit(), getAvoidanceEgoSpeed());
   }
 
   double getEgoShift() const

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -301,10 +301,7 @@ void AvoidanceModule::fillAvoidanceTargetObjects(
   filterTargetObjects(objects, data, debug, planner_data_, parameters_);
 
   // Calculate the distance needed to safely decelerate the ego vehicle to a stop line.
-  // TODO(Satoshi OTA) use helper_ after the manager transition
-  helper::avoidance::AvoidanceHelper helper(planner_data_, parameters_);
-
-  const auto feasible_stop_distance = helper.getFeasibleDecelDistance(0.0, false);
+  const auto feasible_stop_distance = helper_.getFeasibleDecelDistance(0.0, false);
   std::for_each(data.target_objects.begin(), data.target_objects.end(), [&, this](auto & o) {
     o.to_stop_line = calcDistanceToStopLine(o);
     fillObjectStoppableJudge(o, registered_objects_, feasible_stop_distance, parameters_);
@@ -856,7 +853,7 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
 
     // use absolute dist for return-to-center, relative dist from current for avoiding.
     const auto avoiding_shift = desire_shift_length - current_ego_shift;
-    const auto nominal_avoid_distance = helper_.getNominalAvoidanceDistance(avoiding_shift);
+    const auto nominal_avoid_distance = helper_.getMaxAvoidanceDistance(avoiding_shift);
 
     // ego already has enough positive shift.
     const auto has_enough_positive_shift = avoiding_shift < -1e-3 && desire_shift_length > 1e-3;
@@ -898,10 +895,10 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
 
     // calculate lateral jerk.
     const auto required_jerk = PathShifter::calcJerkFromLatLonDistance(
-      avoiding_shift, remaining_distance, helper_.getSharpAvoidanceEgoSpeed());
+      avoiding_shift, remaining_distance, helper_.getAvoidanceEgoSpeed());
 
     // relax lateral jerk limit. avoidable.
-    if (required_jerk < parameters_->max_lateral_jerk) {
+    if (required_jerk < helper_.getLateralMaxJerkLimit()) {
       return desire_shift_length;
     }
 
@@ -913,7 +910,7 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
 
     // output avoidance path under lateral jerk constraints.
     const auto feasible_shift_length = PathShifter::calcLateralDistFromJerk(
-      remaining_distance, parameters_->max_lateral_jerk, helper_.getSharpAvoidanceEgoSpeed());
+      remaining_distance, helper_.getLateralMaxJerkLimit(), helper_.getAvoidanceEgoSpeed());
 
     RCLCPP_WARN_THROTTLE(
       getLogger(), *clock_, 1000,
@@ -969,9 +966,9 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
 
     // use absolute dist for return-to-center, relative dist from current for avoiding.
     const auto feasible_avoid_distance =
-      helper_.getNominalAvoidanceDistance(feasible_shift_length.get() - current_ego_shift);
+      helper_.getMaxAvoidanceDistance(feasible_shift_length.get() - current_ego_shift);
     const auto feasible_return_distance =
-      helper_.getNominalAvoidanceDistance(feasible_shift_length.get());
+      helper_.getMaxAvoidanceDistance(feasible_shift_length.get());
 
     AvoidLine al_avoid;
     {
@@ -1613,7 +1610,7 @@ void AvoidanceModule::trimSharpReturn(AvoidLineArray & shift_lines, const double
 
         // Still negative, but it has an enough long distance. Finish merging.
         const auto nominal_distance =
-          helper_.getNominalAvoidanceDistance(sl_combined.getRelativeLength());
+          helper_.getMaxAvoidanceDistance(sl_combined.getRelativeLength());
         const auto long_distance =
           isZero(sl_combined.end_shift_length) ? nominal_distance : nominal_distance * 5.0;
         if (sl_combined.getRelativeLongitudinal() > long_distance) {
@@ -1654,8 +1651,8 @@ void AvoidanceModule::trimTooSharpShift(AvoidLineArray & avoid_lines) const
 
   const auto isInJerkLimit = [this](const auto & al) {
     const auto required_jerk = path_shifter_.calcJerkFromLatLonDistance(
-      al.getRelativeLength(), al.getRelativeLongitudinal(), helper_.getSharpAvoidanceEgoSpeed());
-    return std::fabs(required_jerk) < parameters_->max_lateral_jerk;
+      al.getRelativeLength(), al.getRelativeLongitudinal(), helper_.getAvoidanceEgoSpeed());
+    return std::fabs(required_jerk) < helper_.getLateralMaxJerkLimit();
   };
 
   for (size_t i = 0; i < avoid_lines_orig.size(); ++i) {
@@ -1789,7 +1786,7 @@ void AvoidanceModule::addReturnShiftLineFromEgo(AvoidLineArray & sl_candidates) 
   const auto & arclength_from_ego = avoidance_data_.arclength_from_ego;
 
   const auto nominal_prepare_distance = helper_.getNominalPrepareDistance();
-  const auto nominal_avoid_distance = helper_.getNominalAvoidanceDistance(last_sl.end_shift_length);
+  const auto nominal_avoid_distance = helper_.getMaxAvoidanceDistance(last_sl.end_shift_length);
 
   if (arclength_from_ego.empty()) {
     return;
@@ -2732,15 +2729,15 @@ void AvoidanceModule::addNewShiftLines(
     avoidance_data_.reference_path.points.at(front_new_shift_line.start_idx)
       .point.longitudinal_velocity_mps;
   const double shift_time = PathShifter::calcShiftTimeFromJerk(
-    front_new_shift_line.getRelativeLength(), parameters_->max_lateral_jerk,
-    parameters_->max_lateral_acceleration);
+    front_new_shift_line.getRelativeLength(), helper_.getLateralMaxJerkLimit(),
+    helper_.getLateralMaxAccelLimit());
   const double longitudinal_acc =
     std::clamp(road_velocity / shift_time, 0.0, parameters_->max_acceleration);
 
   path_shifter.setShiftLines(future);
   path_shifter.setVelocity(getEgoSpeed());
   path_shifter.setLongitudinalAcceleration(longitudinal_acc);
-  path_shifter.setLateralAccelerationLimit(parameters_->max_lateral_acceleration);
+  path_shifter.setLateralAccelerationLimit(helper_.getLateralMaxAccelLimit());
 }
 
 AvoidLineArray AvoidanceModule::findNewShiftLine(const AvoidLineArray & candidates) const
@@ -2794,8 +2791,8 @@ AvoidLineArray AvoidanceModule::findNewShiftLine(const AvoidLineArray & candidat
   // check jerk limit.
   const auto is_large_jerk = [this](const auto & s) {
     const auto jerk = PathShifter::calcJerkFromLatLonDistance(
-      s.getRelativeLength(), s.getRelativeLongitudinal(), helper_.getSharpAvoidanceEgoSpeed());
-    return jerk > parameters_->max_lateral_jerk;
+      s.getRelativeLength(), s.getRelativeLongitudinal(), helper_.getAvoidanceEgoSpeed());
+    return jerk > helper_.getLateralMaxJerkLimit();
   };
 
   // check ignore or not.
@@ -3214,13 +3211,12 @@ double AvoidanceModule::calcDistanceToStopLine(const ObjectData & object) const
 
   const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
                             object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
-  const auto variable = helper_.getMinimumAvoidanceDistance(
+  const auto variable = helper_.getMinAvoidanceDistance(
     helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin));
   const auto constant = p->min_prepare_distance + object_parameter.safety_buffer_longitudinal +
                         base_link2front + p->stop_buffer;
 
-  return object.longitudinal -
-         std::clamp(variable + constant, p->stop_min_distance, p->stop_max_distance);
+  return object.longitudinal - std::min(variable + constant, p->stop_max_distance);
 }
 
 void AvoidanceModule::insertWaitPoint(
@@ -3363,11 +3359,10 @@ void AvoidanceModule::insertPrepareVelocity(ShiftedPath & shifted_path) const
     helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin);
 
   // check slow down feasibility
-  const auto min_avoid_distance = helper_.getMinimumAvoidanceDistance(shift_length);
+  const auto min_avoid_distance = helper_.getMinAvoidanceDistance(shift_length);
   const auto distance_to_object = object.longitudinal;
   const auto remaining_distance = distance_to_object - min_avoid_distance;
-  const auto decel_distance =
-    helper_.getFeasibleDecelDistance(parameters_->min_sharp_avoidance_speed);
+  const auto decel_distance = helper_.getFeasibleDecelDistance(parameters_->velocity_map.front());
   if (remaining_distance < decel_distance) {
     return;
   }
@@ -3388,7 +3383,7 @@ void AvoidanceModule::insertPrepareVelocity(ShiftedPath & shifted_path) const
 
     // target speed with nominal jerk limits.
     const double v_target = PathShifter::calcFeasibleVelocityFromJerk(
-      shift_length, parameters_->nominal_lateral_jerk, shift_longitudinal_distance);
+      shift_length, helper_.getLateralMinJerkLimit(), shift_longitudinal_distance);
     const double v_original = shifted_path.path.points.at(i).point.longitudinal_velocity_mps;
     const double v_insert = std::max(v_target - parameters_->buf_slow_down_speed, lower_speed);
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -165,11 +165,9 @@ AvoidanceModuleManager::AvoidanceModuleManager(
     std::string ns = "avoidance.avoidance.longitudinal.";
     p.prepare_time = get_parameter<double>(node, ns + "prepare_time");
     p.min_prepare_distance = get_parameter<double>(node, ns + "min_prepare_distance");
-    p.min_avoidance_distance = get_parameter<double>(node, ns + "min_avoidance_distance");
-    p.min_nominal_avoidance_speed = get_parameter<double>(node, ns + "min_nominal_avoidance_speed");
-    p.min_sharp_avoidance_speed = get_parameter<double>(node, ns + "min_sharp_avoidance_speed");
     p.min_slow_down_speed = get_parameter<double>(node, ns + "min_slow_down_speed");
     p.buf_slow_down_speed = get_parameter<double>(node, ns + "buf_slow_down_speed");
+    p.nominal_avoidance_speed = get_parameter<double>(node, ns + "nominal_avoidance_speed");
   }
 
   // yield
@@ -181,7 +179,6 @@ AvoidanceModuleManager::AvoidanceModuleManager(
   // stop
   {
     std::string ns = "avoidance.stop.";
-    p.stop_min_distance = get_parameter<double>(node, ns + "min_distance");
     p.stop_max_distance = get_parameter<double>(node, ns + "max_distance");
     p.stop_buffer = get_parameter<double>(node, ns + "stop_buffer");
   }
@@ -205,9 +202,26 @@ AvoidanceModuleManager::AvoidanceModuleManager(
   // constraints (lateral)
   {
     std::string ns = "avoidance.constraints.lateral.";
-    p.nominal_lateral_jerk = get_parameter<double>(node, ns + "nominal_lateral_jerk");
-    p.max_lateral_jerk = get_parameter<double>(node, ns + "max_lateral_jerk");
-    p.max_lateral_acceleration = get_parameter<double>(node, ns + "max_lateral_acceleration");
+    p.velocity_map = get_parameter<std::vector<double>>(node, ns + "velocity");
+    p.lateral_max_accel_map = get_parameter<std::vector<double>>(node, ns + "max_accel_values");
+    p.lateral_min_jerk_map = get_parameter<std::vector<double>>(node, ns + "min_jerk_values");
+    p.lateral_max_jerk_map = get_parameter<std::vector<double>>(node, ns + "max_jerk_values");
+
+    if (p.velocity_map.empty()) {
+      throw std::domain_error("invalid velocity map.");
+    }
+
+    if (p.velocity_map.size() != p.lateral_max_accel_map.size()) {
+      throw std::domain_error("inconsistency among the constraints map.");
+    }
+
+    if (p.velocity_map.size() != p.lateral_min_jerk_map.size()) {
+      throw std::domain_error("inconsistency among the constraints map.");
+    }
+
+    if (p.velocity_map.size() != p.lateral_max_jerk_map.size()) {
+      throw std::domain_error("inconsistency among the constraints map.");
+    }
   }
 
   // velocity matrix
@@ -302,15 +316,36 @@ void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parame
   {
     const std::string ns = "avoidance.stop.";
     updateParam<double>(parameters, ns + "max_distance", p->stop_max_distance);
-    updateParam<double>(parameters, ns + "min_distance", p->stop_min_distance);
     updateParam<double>(parameters, ns + "stop_buffer", p->stop_buffer);
   }
 
   {
     const std::string ns = "avoidance.constrains.lateral.";
-    updateParam<double>(parameters, ns + "nominal_lateral_jerk", p->nominal_lateral_jerk);
-    updateParam<double>(parameters, ns + "max_lateral_jerk", p->max_lateral_jerk);
-    updateParam<double>(parameters, ns + "max_lateral_acceleration", p->max_lateral_acceleration);
+
+    std::vector<double> velocity_map;
+    updateParam<std::vector<double>>(parameters, ns + "velocity", velocity_map);
+    std::vector<double> lateral_max_accel_map;
+    updateParam<std::vector<double>>(parameters, ns + "max_accel_values", lateral_max_accel_map);
+    std::vector<double> lateral_min_jerk_map;
+    updateParam<std::vector<double>>(parameters, ns + "min_jerk_values", lateral_min_jerk_map);
+    std::vector<double> lateral_max_jerk_map;
+    updateParam<std::vector<double>>(parameters, ns + "max_jerk_values", lateral_max_jerk_map);
+
+    if (!velocity_map.empty()) {
+      p->velocity_map = velocity_map;
+    }
+
+    if (!velocity_map.empty() && velocity_map.size() == lateral_max_accel_map.size()) {
+      p->lateral_max_accel_map = lateral_max_accel_map;
+    }
+
+    if (!velocity_map.empty() && velocity_map.size() == lateral_min_jerk_map.size()) {
+      p->lateral_min_jerk_map = lateral_min_jerk_map;
+    }
+
+    if (!velocity_map.empty() && velocity_map.size() == lateral_max_jerk_map.size()) {
+      p->lateral_max_jerk_map = lateral_max_jerk_map;
+    }
   }
 
   {


### PR DESCRIPTION
## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3970d8e</samp>

This pull request refactors the avoidance module of the behavior path planner to use speed-dependent parameters and functions for the avoidance behavior. It updates the `avoidance.param.yaml` file and the corresponding header and source files to remove unused or redundant variables and functions, and to improve the performance and robustness of the module.

## Description

Please approve :arrow_down: before this PR.
https://github.com/autowarefoundation/autoware_launch/pull/454

I would like to make it possible to set lateral jerk/accel limitaion independently for each speed range (low, mid, high).

```yaml
        # lateral constraints
        lateral:
          velocity: [0.0, 1.38, 11.1]                   # [m/s]
          max_accel_values: [0.5, 0.5, 0.5]             # [m/ss]
          min_jerk_values: [0.2, 0.2, 0.2]              # [m/sss]
          max_jerk_values: [2.0, 1.0, 0.5]             # [m/sss]
```

In above parameters, avoidance path is generated by following configuration:

| Speed Range  | Speed [m/s] | Lateral Accel [m/ss] | Lateral Minimum Jerk [m/sss] | Lateral Maximum Jerk [m/sss] |
| :------------------: | :----: | :----: | :--------------------------: | :-------------: |
| LOW | 0.0 ~ 1.38 | 0.5 | 0.2 | 2.0       |
| MID   | 1.38 ~ 11.1  | 0.5 | 0.2 | 1.0      |
| HIGH   | 11.1 ~  | 0.5 | 0.2 | 0.5      |

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/01eef87b-c9b6-57ab-8e15-a28d88a0392f?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Shorten the stop distance for avoidance target.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
