### PR TITLE
fix(intersection): align pass judge line to peeking occlusion line

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -315,6 +315,10 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
     intersection_stop_lines.default_stop_line) {
     intersection_stop_lines.occlusion_peeking_stop_line = intersection_stop_lines.default_stop_line;
   }
+  if (
+    intersection_stop_lines.pass_judge_line < intersection_stop_lines.occlusion_peeking_stop_line) {
+    intersection_stop_lines.pass_judge_line = intersection_stop_lines.occlusion_peeking_stop_line
+  }
   return intersection_stop_lines;
 }
 


### PR DESCRIPTION
## Description

When the occlusion peeking offset is positive, it could exceed pass judge line index. In that case during the peeking ego would pass the pass judge line and peeking could be aborted.

## Related links

[TIER IV COMPANY INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-2844)

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
