### PR TITLE
feat(routing_no_drivable_lane_when_module_enabled): add solution for routing no_drivable_lane only when module enabled

### DIFF
--- a/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -23,4 +23,4 @@
       # behavior_velocity_planner::RunOutModulePlugin
       # behavior_velocity_planner::SpeedBumpModulePlugin
       - behavior_velocity_planner::OutOfLaneModulePlugin
-      # behavior_velocity_planner::NoDrivableLaneModulePlugin
+      - behavior_velocity_planner::NoDrivableLaneModulePlugin

--- a/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -23,4 +23,4 @@
       # behavior_velocity_planner::RunOutModulePlugin
       # behavior_velocity_planner::SpeedBumpModulePlugin
       - behavior_velocity_planner::OutOfLaneModulePlugin
-      - behavior_velocity_planner::NoDrivableLaneModulePlugin
+      # behavior_velocity_planner::NoDrivableLaneModulePlugin     # If enabled, set consider_no_drivable_lanes to true in mission_planner.param.yaml

--- a/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -23,4 +23,4 @@
       # behavior_velocity_planner::RunOutModulePlugin
       # behavior_velocity_planner::SpeedBumpModulePlugin
       - behavior_velocity_planner::OutOfLaneModulePlugin
-      # behavior_velocity_planner::NoDrivableLaneModulePlugin     # If enabled, set consider_no_drivable_lanes to true in mission_planner.param.yaml
+      # behavior_velocity_planner::NoDrivableLaneModulePlugin

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -14,16 +14,18 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 
 ### Parameters
 
-| Name                       | Type   | Description                                                                                                      |
-| -------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------- |
-| `map_frame`                | string | The frame name for map                                                                                           |
-| `arrival_check_angle_deg`  | double | Angle threshold for goal check                                                                                   |
-| `arrival_check_distance`   | double | Distance threshold for goal check                                                                                |
-| `arrival_check_duration`   | double | Duration threshold for goal check                                                                                |
-| `goal_angle_threshold`     | double | Max goal pose angle for goal approve                                                                             |
-| `enable_correct_goal_pose` | bool   | Enabling correction of goal pose according to the closest lanelet orientation                                    |
-| `reroute_time_threshold`   | double | If the time to the rerouting point at the current velocity is greater than this threshold, rerouting is possible |
-| `minimum_reroute_length`   | double | Minimum Length for publishing a new route                                                                        |
+| Name                        | Type   | Description                                                                                                      |
+| ----------------------------| ------ | ---------------------------------------------------------------------------------------------------------------- |
+| `map_frame`                 | string | The frame name for map                                                                                           |
+| `arrival_check_angle_deg`   | double | Angle threshold for goal check                                                                                   |
+| `arrival_check_distance`    | double | Distance threshold for goal check                                                                                |
+| `arrival_check_duration`    | double | Duration threshold for goal check                                                                                |
+| `goal_angle_threshold`      | double | Max goal pose angle for goal approve                                                                             |
+| `enable_correct_goal_pose`  | bool   | Enabling correction of goal pose according to the closest lanelet orientation                                    |
+| `reroute_time_threshold`    | double | If the time to the rerouting point at the current velocity is greater than this threshold, rerouting is possible |
+| `minimum_reroute_length`    | double | Minimum Length for publishing a new route                                                                        |
+| `consider_no_drivable_lanes`| bool   | This flag is for considering no_drivable_lanes in planning or not. Set to true when behavior_velocity_planner::NoDrivableLaneModulePlugin in uncommented in autoware_launch |
+
 
 ### Services
 

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -14,18 +14,17 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 
 ### Parameters
 
-| Name                        | Type   | Description                                                                                                      |
-| ----------------------------| ------ | ---------------------------------------------------------------------------------------------------------------- |
-| `map_frame`                 | string | The frame name for map                                                                                           |
-| `arrival_check_angle_deg`   | double | Angle threshold for goal check                                                                                   |
-| `arrival_check_distance`    | double | Distance threshold for goal check                                                                                |
-| `arrival_check_duration`    | double | Duration threshold for goal check                                                                                |
-| `goal_angle_threshold`      | double | Max goal pose angle for goal approve                                                                             |
-| `enable_correct_goal_pose`  | bool   | Enabling correction of goal pose according to the closest lanelet orientation                                    |
-| `reroute_time_threshold`    | double | If the time to the rerouting point at the current velocity is greater than this threshold, rerouting is possible |
-| `minimum_reroute_length`    | double | Minimum Length for publishing a new route                                                                        |
-| `consider_no_drivable_lanes`| bool   | This flag is for considering no_drivable_lanes in planning or not.                                               |
-
+| Name                         | Type   | Description                                                                                                      |
+| ---------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------- |
+| `map_frame`                  | string | The frame name for map                                                                                           |
+| `arrival_check_angle_deg`    | double | Angle threshold for goal check                                                                                   |
+| `arrival_check_distance`     | double | Distance threshold for goal check                                                                                |
+| `arrival_check_duration`     | double | Duration threshold for goal check                                                                                |
+| `goal_angle_threshold`       | double | Max goal pose angle for goal approve                                                                             |
+| `enable_correct_goal_pose`   | bool   | Enabling correction of goal pose according to the closest lanelet orientation                                    |
+| `reroute_time_threshold`     | double | If the time to the rerouting point at the current velocity is greater than this threshold, rerouting is possible |
+| `minimum_reroute_length`     | double | Minimum Length for publishing a new route                                                                        |
+| `consider_no_drivable_lanes` | bool   | This flag is for considering no_drivable_lanes in planning or not.                                               |
 
 ### Services
 

--- a/planning/mission_planner/README.md
+++ b/planning/mission_planner/README.md
@@ -24,7 +24,7 @@ In current Autoware.universe, only Lanelet2 map format is supported.
 | `enable_correct_goal_pose`  | bool   | Enabling correction of goal pose according to the closest lanelet orientation                                    |
 | `reroute_time_threshold`    | double | If the time to the rerouting point at the current velocity is greater than this threshold, rerouting is possible |
 | `minimum_reroute_length`    | double | Minimum Length for publishing a new route                                                                        |
-| `consider_no_drivable_lanes`| bool   | This flag is for considering no_drivable_lanes in planning or not. Set to true when behavior_velocity_planner::NoDrivableLaneModulePlugin in uncommented in autoware_launch |
+| `consider_no_drivable_lanes`| bool   | This flag is for considering no_drivable_lanes in planning or not.                                               |
 
 
 ### Services

--- a/planning/mission_planner/config/mission_planner.param.yaml
+++ b/planning/mission_planner/config/mission_planner.param.yaml
@@ -9,4 +9,3 @@
     reroute_time_threshold: 10.0
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
-

--- a/planning/mission_planner/config/mission_planner.param.yaml
+++ b/planning/mission_planner/config/mission_planner.param.yaml
@@ -9,4 +9,4 @@
     reroute_time_threshold: 10.0
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
-    
+

--- a/planning/mission_planner/config/mission_planner.param.yaml
+++ b/planning/mission_planner/config/mission_planner.param.yaml
@@ -9,4 +9,4 @@
     reroute_time_threshold: 10.0
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
-                                      # Set to true when behavior_velocity_planner::NoDrivableLaneModulePlugin in uncommented in autoware_launch
+    

--- a/planning/mission_planner/config/mission_planner.param.yaml
+++ b/planning/mission_planner/config/mission_planner.param.yaml
@@ -8,3 +8,5 @@
     enable_correct_goal_pose: false
     reroute_time_threshold: 10.0
     minimum_reroute_length: 30.0
+    consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
+                                      # Set to true when behavior_velocity_planner::NoDrivableLaneModulePlugin in uncommented in autoware_launch

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -147,6 +147,7 @@ void DefaultPlanner::initialize_common(rclcpp::Node * node)
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*node_).getVehicleInfo();
   param_.goal_angle_threshold_deg = node_->declare_parameter<double>("goal_angle_threshold_deg");
   param_.enable_correct_goal_pose = node_->declare_parameter<bool>("enable_correct_goal_pose");
+  param_.consider_no_drivable_lanes = node_->declare_parameter<bool>("consider_no_drivable_lanes");
 }
 
 void DefaultPlanner::initialize(rclcpp::Node * node)
@@ -401,7 +402,7 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
     const auto goal_check_point = points.at(i);
     lanelet::ConstLanelets path_lanelets;
     if (!route_handler_.planPathLaneletsBetweenCheckpoints(
-          start_check_point, goal_check_point, &path_lanelets)) {
+          start_check_point, goal_check_point, &path_lanelets, param_.consider_no_drivable_lanes)) {
       RCLCPP_WARN(logger, "Failed to plan route.");
       return route_msg;
     }

--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.hpp
@@ -37,6 +37,7 @@ struct DefaultPlannerParameters
 {
   double goal_angle_threshold_deg;
   bool enable_correct_goal_pose;
+  bool consider_no_drivable_lanes;
 };
 
 class DefaultPlanner : public mission_planner::PlannerPlugin

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -89,7 +89,7 @@ public:
   // for routing
   bool planPathLaneletsBetweenCheckpoints(
     const Pose & start_checkpoint, const Pose & goal_checkpoint,
-    lanelet::ConstLanelets * path_lanelets) const;
+    lanelet::ConstLanelets * path_lanelets, const bool consider_no_drivable_lanes = false) const;
   std::vector<LaneletSegment> createMapSegments(const lanelet::ConstLanelets & path_lanelets) const;
   static bool isRouteLooped(const RouteSections & route_sections);
 

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1974,7 +1974,7 @@ lanelet::ConstLanelets RouteHandler::getNextLaneSequence(
 
 bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   const Pose & start_checkpoint, const Pose & goal_checkpoint,
-  lanelet::ConstLanelets * path_lanelets) const
+  lanelet::ConstLanelets * path_lanelets, const bool consider_no_drivable_lanes) const
 {
   // Find lanelets for start point. First, find all lanelets containing the start point to calculate
   // all possible route later. It fails when the point is not located on any road_lanelet (e.g. the
@@ -2038,15 +2038,19 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   }
 
   if (is_route_found) {
-    bool shortest_path_has_no_drivable_lane = hasNoDrivableLaneInPath(shortest_path);
-    if (shortest_path_has_no_drivable_lane) {
-      drivable_lane_path_found =
-        findDrivableLanePath(start_lanelet, goal_lanelet, drivable_lane_path);
-    }
-
     lanelet::routing::LaneletPath path;
-    if (drivable_lane_path_found) {
-      path = drivable_lane_path;
+    if (consider_no_drivable_lanes) {
+      bool shortest_path_has_no_drivable_lane = hasNoDrivableLaneInPath(shortest_path);
+      if (shortest_path_has_no_drivable_lane) {
+        drivable_lane_path_found =
+          findDrivableLanePath(start_lanelet, goal_lanelet, drivable_lane_path);
+      }
+
+      if (drivable_lane_path_found) {
+        path = drivable_lane_path;
+      } else {
+        path = shortest_path;
+      }
     } else {
       path = shortest_path;
     }


### PR DESCRIPTION
## Description
This PR is to add as solution for routing `no_drivable_lane(s)` only when the module is enabled.
<!-- Write a brief description of this PR. -->

## Related links
fixes #4307 
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Using planning simulator :
- When `no_drivable_lane` is disabled, the routing for `no_drivable_lane(s)` is not considered
- When When `no_drivable_lane` is enabled, routing for `no_drivable_lane(s)` is considered
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
:exclamation: **_Must be merged with this [autoware_launch PR](https://github.com/autowarefoundation/autoware_launch/pull/457)_** :exclamation:
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
