### PR TITLE
refactor(behavior_velocity_crosswalk_module): use std::optional instead of boost::optional

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/debug.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/debug.cpp
@@ -83,7 +83,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     auto marker = createDefaultMarker(
       "map", now, "attention range near", uid, Marker::POINTS, createMarkerScale(0.25, 0.25, 0.0),
       createMarkerColor(0.0, 0.0, 1.0, 0.999));
-    marker.points.push_back(debug_data.range_near_point.get());
+    marker.points.push_back(*debug_data.range_near_point);
     msg.markers.push_back(marker);
   }
 
@@ -91,7 +91,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     auto marker = createDefaultMarker(
       "map", now, "attention range far", uid, Marker::POINTS, createMarkerScale(0.25, 0.25, 0.0),
       createMarkerColor(1.0, 1.0, 1.0, 0.999));
-    marker.points.push_back(debug_data.range_far_point.get());
+    marker.points.push_back(*debug_data.range_far_point);
     msg.markers.push_back(marker);
   }
 

--- a/planning/behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/manager.cpp
@@ -143,7 +143,7 @@ void CrosswalkModuleManager::launchNewModules(const PathWithLaneId & path)
     opt_use_regulatory_element_ = checkRegulatoryElementExistence(rh->getLaneletMapPtr());
     std::ostringstream string_stream;
     string_stream << "use crosswalk regulatory element: ";
-    string_stream << std::boolalpha << opt_use_regulatory_element_.get();
+    string_stream << std::boolalpha << *opt_use_regulatory_element_;
     RCLCPP_INFO_STREAM(logger_, string_stream.str());
   }
 
@@ -157,12 +157,12 @@ void CrosswalkModuleManager::launchNewModules(const PathWithLaneId & path)
     const auto lanelet_map_ptr = planner_data_->route_handler_->getLaneletMapPtr();
 
     registerModule(std::make_shared<CrosswalkModule>(
-      id, lanelet_map_ptr, p, opt_use_regulatory_element_.get(), logger, clock_));
+      id, lanelet_map_ptr, p, *opt_use_regulatory_element_, logger, clock_));
     generateUUID(id);
     updateRTCStatus(getUUID(id), true, std::numeric_limits<double>::lowest(), path.header.stamp);
   };
 
-  if (opt_use_regulatory_element_.get()) {
+  if (*opt_use_regulatory_element_) {
     const auto crosswalk_leg_elem_map = planning_utils::getRegElemMapOnPath<Crosswalk>(
       path, rh->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
@@ -187,7 +187,7 @@ CrosswalkModuleManager::getModuleExpiredFunction(const PathWithLaneId & path)
 
   std::set<int64_t> crosswalk_id_set;
 
-  if (opt_use_regulatory_element_.get()) {
+  if (*opt_use_regulatory_element_) {
     const auto crosswalk_leg_elem_map = planning_utils::getRegElemMapOnPath<Crosswalk>(
       path, rh->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
@@ -239,10 +239,10 @@ void WalkwayModuleManager::launchNewModules(const PathWithLaneId & path)
     const auto lanelet_map_ptr = planner_data_->route_handler_->getLaneletMapPtr();
 
     registerModule(std::make_shared<WalkwayModule>(
-      lanelet.id(), lanelet_map_ptr, p, opt_use_regulatory_element_.get(), logger, clock_));
+      lanelet.id(), lanelet_map_ptr, p, *opt_use_regulatory_element_, logger, clock_));
   };
 
-  if (opt_use_regulatory_element_.get()) {
+  if (*opt_use_regulatory_element_) {
     const auto crosswalk_leg_elem_map = planning_utils::getRegElemMapOnPath<Crosswalk>(
       path, rh->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
@@ -267,7 +267,7 @@ WalkwayModuleManager::getModuleExpiredFunction(const PathWithLaneId & path)
 
   std::set<int64_t> walkway_id_set;
 
-  if (opt_use_regulatory_element_.get()) {
+  if (*opt_use_regulatory_element_) {
     const auto crosswalk_leg_elem_map = planning_utils::getRegElemMapOnPath<Crosswalk>(
       path, rh->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 

--- a/planning/behavior_velocity_crosswalk_module/src/manager.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/manager.hpp
@@ -29,6 +29,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <set>
 #include <vector>
 
@@ -52,7 +53,7 @@ private:
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const PathWithLaneId & path) override;
 
-  boost::optional<bool> opt_use_regulatory_element_{boost::none};
+  std::optional<bool> opt_use_regulatory_element_{std::nullopt};
 };
 
 class WalkwayModuleManager : public SceneModuleManagerInterface
@@ -70,7 +71,7 @@ private:
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const PathWithLaneId & path) override;
 
-  boost::optional<bool> opt_use_regulatory_element_{boost::none};
+  std::optional<bool> opt_use_regulatory_element_{std::nullopt};
 };
 
 class CrosswalkModulePlugin : public PluginWrapper<CrosswalkModuleManager>

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -38,6 +38,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -98,7 +99,7 @@ public:
     // NOTE: FULLY_STOPPED means stopped object which can be ignored.
     enum class State { STOPPED = 0, FULLY_STOPPED, OTHER };
     State state{State::OTHER};
-    boost::optional<rclcpp::Time> time_to_start_stopped{boost::none};
+    std::optional<rclcpp::Time> time_to_start_stopped{std::nullopt};
 
     void updateState(
       const rclcpp::Time & now, const double obj_vel, const bool is_ego_yielding,
@@ -123,7 +124,7 @@ public:
           state = State::STOPPED;
         }
       } else {
-        time_to_start_stopped = boost::none;
+        time_to_start_stopped = std::nullopt;
         state = State::OTHER;
       }
     }
@@ -182,35 +183,35 @@ private:
   void applySafetySlowDownSpeed(
     PathWithLaneId & output, const std::vector<geometry_msgs::msg::Point> & path_intersects);
 
-  boost::optional<std::pair<geometry_msgs::msg::Point, double>> getStopPointWithMargin(
+  std::optional<std::pair<geometry_msgs::msg::Point, double>> getStopPointWithMargin(
     const PathWithLaneId & ego_path,
     const std::vector<geometry_msgs::msg::Point> & path_intersects) const;
 
-  boost::optional<StopFactor> checkStopForCrosswalkUsers(
+  std::optional<StopFactor> checkStopForCrosswalkUsers(
     const PathWithLaneId & ego_path, const PathWithLaneId & sparse_resample_path,
-    const boost::optional<std::pair<geometry_msgs::msg::Point, double>> & p_stop_line,
+    const std::optional<std::pair<geometry_msgs::msg::Point, double>> & p_stop_line,
     const std::vector<geometry_msgs::msg::Point> & path_intersects,
-    const boost::optional<geometry_msgs::msg::Pose> & default_stop_pose);
+    const std::optional<geometry_msgs::msg::Pose> & default_stop_pose);
 
-  boost::optional<StopFactor> checkStopForStuckedVehicles(
+  std::optional<StopFactor> checkStopForStuckedVehicles(
     const PathWithLaneId & ego_path, const std::vector<PredictedObject> & objects,
     const std::vector<geometry_msgs::msg::Point> & path_intersects,
-    const boost::optional<geometry_msgs::msg::Pose> & stop_pose) const;
+    const std::optional<geometry_msgs::msg::Pose> & stop_pose) const;
 
   std::vector<CollisionPoint> getCollisionPoints(
     const PathWithLaneId & ego_path, const PredictedObject & object,
     const Polygon2d & attention_area, const std::pair<double, double> & crosswalk_attention_range);
 
-  boost::optional<StopFactor> getNearestStopFactor(
+  std::optional<StopFactor> getNearestStopFactor(
     const PathWithLaneId & ego_path,
-    const boost::optional<StopFactor> & stop_factor_for_crosswalk_users,
-    const boost::optional<StopFactor> & stop_factor_for_stucked_vehicles);
+    const std::optional<StopFactor> & stop_factor_for_crosswalk_users,
+    const std::optional<StopFactor> & stop_factor_for_stucked_vehicles);
 
-  void planGo(PathWithLaneId & ego_path, const boost::optional<StopFactor> & stop_factor);
+  void planGo(PathWithLaneId & ego_path, const std::optional<StopFactor> & stop_factor);
 
   void planStop(
-    PathWithLaneId & ego_path, const boost::optional<StopFactor> & nearest_stop_factor,
-    const boost::optional<geometry_msgs::msg::Pose> & default_stop_pose, StopReason * stop_reason);
+    PathWithLaneId & ego_path, const std::optional<StopFactor> & nearest_stop_factor,
+    const std::optional<geometry_msgs::msg::Pose> & default_stop_pose, StopReason * stop_reason);
 
   // minor functions
   std::pair<double, double> getAttentionRange(

--- a/planning/behavior_velocity_crosswalk_module/src/scene_walkway.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_walkway.cpp
@@ -48,13 +48,13 @@ WalkwayModule::WalkwayModule(
   } else {
     const auto stop_line = getStopLineFromMap(module_id_, lanelet_map_ptr, "crosswalk_id");
     if (!!stop_line) {
-      stop_lines_.push_back(stop_line.get());
+      stop_lines_.push_back(*stop_line);
     }
     walkway_ = lanelet_map_ptr->laneletLayer.get(module_id);
   }
 }
 
-boost::optional<std::pair<double, geometry_msgs::msg::Point>> WalkwayModule::getStopLine(
+std::optional<std::pair<double, geometry_msgs::msg::Point>> WalkwayModule::getStopLine(
   const PathWithLaneId & ego_path, bool & exist_stopline_in_map,
   const std::vector<geometry_msgs::msg::Point> & path_intersects) const
 {
@@ -111,7 +111,7 @@ bool WalkwayModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_
       return false;
     }
 
-    const auto & p_stop = p_stop_line.get().second;
+    const auto & p_stop = p_stop_line->second;
     const auto stop_line_distance = exist_stopline_in_map ? 0.0 : planner_param_.stop_line_distance;
     const auto margin = stop_line_distance + base_link2front;
     const auto stop_pose = calcLongitudinalOffsetPose(input.points, p_stop, -margin);
@@ -120,7 +120,7 @@ bool WalkwayModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_
       return false;
     }
 
-    const auto inserted_pose = planning_utils::insertStopPoint(stop_pose.get().position, *path);
+    const auto inserted_pose = planning_utils::insertStopPoint(stop_pose->position, *path);
     if (inserted_pose) {
       debug_data_.stop_poses.push_back(inserted_pose.get());
     }
@@ -136,7 +136,7 @@ bool WalkwayModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_
 
     // use arc length to identify if ego vehicle is in front of walkway stop or not.
     const double signed_arc_dist_to_stop_point =
-      calcSignedArcLength(input.points, ego_pos, stop_pose.get().position);
+      calcSignedArcLength(input.points, ego_pos, stop_pose->position);
 
     const double distance_threshold = 1.0;
     debug_data_.stop_judge_range = distance_threshold;

--- a/planning/behavior_velocity_crosswalk_module/src/scene_walkway.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_walkway.hpp
@@ -30,6 +30,7 @@
 #include <lanelet2_routing/RoutingGraphContainer.h>
 
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -57,7 +58,7 @@ public:
 private:
   const int64_t module_id_;
 
-  [[nodiscard]] boost::optional<std::pair<double, geometry_msgs::msg::Point>> getStopLine(
+  [[nodiscard]] std::optional<std::pair<double, geometry_msgs::msg::Point>> getStopLine(
     const PathWithLaneId & ego_path, bool & exist_stopline_in_map,
     const std::vector<geometry_msgs::msg::Point> & path_intersects) const;
 

--- a/planning/behavior_velocity_crosswalk_module/src/util.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/util.cpp
@@ -146,7 +146,7 @@ std::vector<geometry_msgs::msg::Point> getLinestringIntersects(
   return geometry_points;
 }
 
-lanelet::Optional<lanelet::ConstLineString3d> getStopLineFromMap(
+std::optional<lanelet::ConstLineString3d> getStopLineFromMap(
   const int lane_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   const std::string & attribute_name)
 {

--- a/planning/behavior_velocity_crosswalk_module/src/util.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/util.hpp
@@ -23,6 +23,7 @@
 
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -68,8 +69,8 @@ struct DebugData
   geometry_msgs::msg::Pose first_stop_pose;
   geometry_msgs::msg::Point nearest_collision_point;
 
-  boost::optional<geometry_msgs::msg::Point> range_near_point{boost::none};
-  boost::optional<geometry_msgs::msg::Point> range_far_point{boost::none};
+  std::optional<geometry_msgs::msg::Point> range_near_point{std::nullopt};
+  std::optional<geometry_msgs::msg::Point> range_far_point{std::nullopt};
 
   std::vector<std::pair<CollisionPoint, CollisionState>> collision_points;
 
@@ -89,7 +90,7 @@ std::vector<geometry_msgs::msg::Point> getLinestringIntersects(
   const PathWithLaneId & ego_path, const lanelet::BasicLineString2d & linestring,
   const geometry_msgs::msg::Point & ego_pos, const size_t max_num);
 
-lanelet::Optional<lanelet::ConstLineString3d> getStopLineFromMap(
+std::optional<lanelet::ConstLineString3d> getStopLineFromMap(
   const int lane_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   const std::string & attribute_name);
 }  // namespace behavior_velocity_planner


### PR DESCRIPTION
## Description

Depends on https://github.com/autowarefoundation/autoware.universe/pull/4284

use std::optional instead of boost::optional
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
