### PR TITLE
feat(tier4_autoware_utils): add intersect function

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -770,6 +770,28 @@ inline bool isTwistCovarianceValid(
   return false;
 }
 
+// NOTE: much faster than boost::geometry::intersects()
+inline std::optional<geometry_msgs::msg::Point> intersect(
+  const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2,
+  const geometry_msgs::msg::Point & p3, const geometry_msgs::msg::Point & p4)
+{
+  // calculate intersection point
+  const double det = (p1.x - p2.x) * (p4.y - p3.y) - (p4.x - p3.x) * (p1.y - p2.y);
+  if (det == 0.0) {
+    return std::nullopt;
+  }
+
+  const double t = ((p4.y - p3.y) * (p4.x - p2.x) + (p3.x - p4.x) * (p4.y - p2.y)) / det;
+  const double s = ((p2.y - p1.y) * (p4.x - p2.x) + (p1.x - p2.x) * (p4.y - p2.y)) / det;
+  if (t < 0 || 1 < t || s < 0 || 1 < s) {
+    return std::nullopt;
+  }
+
+  geometry_msgs::msg::Point intersect_point;
+  intersect_point.x = t * p1.x + (1.0 - t) * p2.x;
+  intersect_point.y = t * p1.y + (1.0 - t) * p2.y;
+  return intersect_point;
+}
 }  // namespace tier4_autoware_utils
 
 #endif  // TIER4_AUTOWARE_UTILS__GEOMETRY__GEOMETRY_HPP_

--- a/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
+++ b/common/tier4_autoware_utils/test/src/geometry/test_geometry.cpp
@@ -1689,3 +1689,108 @@ TEST(geometry, isTwistCovarianceValid)
   twist_with_covariance.covariance.at(0) = 1.0;
   EXPECT_EQ(tier4_autoware_utils::isTwistCovarianceValid(twist_with_covariance), true);
 }
+
+TEST(geometry, intersect)
+{
+  using tier4_autoware_utils::createPoint;
+  using tier4_autoware_utils::intersect;
+
+  {  // Normally crossing
+    const auto p1 = createPoint(0.0, -1.0, 0.0);
+    const auto p2 = createPoint(0.0, 1.0, 0.0);
+    const auto p3 = createPoint(-1.0, 0.0, 0.0);
+    const auto p4 = createPoint(1.0, 0.0, 0.0);
+    const auto result = intersect(p1, p2, p3, p4);
+
+    EXPECT_TRUE(result);
+    EXPECT_NEAR(result->x, 0.0, epsilon);
+    EXPECT_NEAR(result->y, 0.0, epsilon);
+    EXPECT_NEAR(result->z, 0.0, epsilon);
+  }
+
+  {  // No crossing
+    const auto p1 = createPoint(0.0, -1.0, 0.0);
+    const auto p2 = createPoint(0.0, 1.0, 0.0);
+    const auto p3 = createPoint(1.0, 0.0, 0.0);
+    const auto p4 = createPoint(3.0, 0.0, 0.0);
+    const auto result = intersect(p1, p2, p3, p4);
+
+    EXPECT_FALSE(result);
+  }
+
+  {  // One segment is the point on the other's segment
+    const auto p1 = createPoint(0.0, -1.0, 0.0);
+    const auto p2 = createPoint(0.0, 1.0, 0.0);
+    const auto p3 = createPoint(0.0, 0.0, 0.0);
+    const auto p4 = createPoint(0.0, 0.0, 0.0);
+    const auto result = intersect(p1, p2, p3, p4);
+
+    EXPECT_FALSE(result);
+  }
+
+  {  // One segment is the point not on the other's segment
+    const auto p1 = createPoint(0.0, -1.0, 0.0);
+    const auto p2 = createPoint(0.0, 1.0, 0.0);
+    const auto p3 = createPoint(1.0, 0.0, 0.0);
+    const auto p4 = createPoint(1.0, 0.0, 0.0);
+    const auto result = intersect(p1, p2, p3, p4);
+
+    EXPECT_FALSE(result);
+  }
+
+  {  // Both segments are the points which are the same position
+    const auto p1 = createPoint(0.0, 0.0, 0.0);
+    const auto p2 = createPoint(0.0, 0.0, 0.0);
+    const auto p3 = createPoint(0.0, 0.0, 0.0);
+    const auto p4 = createPoint(0.0, 0.0, 0.0);
+    const auto result = intersect(p1, p2, p3, p4);
+
+    EXPECT_FALSE(result);
+  }
+
+  {  // Both segments are the points which are different position
+    const auto p1 = createPoint(0.0, 1.0, 0.0);
+    const auto p2 = createPoint(0.0, 1.0, 0.0);
+    const auto p3 = createPoint(1.0, 0.0, 0.0);
+    const auto p4 = createPoint(1.0, 0.0, 0.0);
+    const auto result = intersect(p1, p2, p3, p4);
+
+    EXPECT_FALSE(result);
+  }
+
+  {  // Segments are the same
+    const auto p1 = createPoint(0.0, -1.0, 0.0);
+    const auto p2 = createPoint(0.0, 1.0, 0.0);
+    const auto p3 = createPoint(0.0, -1.0, 0.0);
+    const auto p4 = createPoint(0.0, 1.0, 0.0);
+    const auto result = intersect(p1, p2, p3, p4);
+
+    EXPECT_FALSE(result);
+  }
+
+  {  // One's edge is on the other's segment
+    const auto p1 = createPoint(0.0, -1.0, 0.0);
+    const auto p2 = createPoint(0.0, 1.0, 0.0);
+    const auto p3 = createPoint(0.0, 0.0, 0.0);
+    const auto p4 = createPoint(1.0, 0.0, 0.0);
+    const auto result = intersect(p1, p2, p3, p4);
+
+    EXPECT_TRUE(result);
+    EXPECT_NEAR(result->x, 0.0, epsilon);
+    EXPECT_NEAR(result->y, 0.0, epsilon);
+    EXPECT_NEAR(result->z, 0.0, epsilon);
+  }
+
+  {  // One's edge is the same as the other's edge.
+    const auto p1 = createPoint(0.0, -1.0, 0.0);
+    const auto p2 = createPoint(0.0, 1.0, 0.0);
+    const auto p3 = createPoint(0.0, -1.0, 0.0);
+    const auto p4 = createPoint(2.0, -1.0, 0.0);
+    const auto result = intersect(p1, p2, p3, p4);
+
+    EXPECT_TRUE(result);
+    EXPECT_NEAR(result->x, 0.0, epsilon);
+    EXPECT_NEAR(result->y, -1.0, epsilon);
+    EXPECT_NEAR(result->z, 0.0, epsilon);
+  }
+}


### PR DESCRIPTION
## Description

Added an intersect function that returns the intersection point from the two segments represented by four points.
This function is currently used in several packages since it is much faster than the boost one.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Unit test

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No behavior change

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
