### PR TITLE
feat(map based prediction): add support of sampling paths by lane width

### DIFF
--- a/perception/map_based_prediction/README.md
+++ b/perception/map_based_prediction/README.md
@@ -157,6 +157,7 @@ If the target object is inside the road or crosswalk, this module outputs one or
 | `prediction_sampling_delta_time`            | double | sampling time for points in predicted path [s]                                                               |
 | `min_velocity_for_map_based_prediction`     | double | apply map-based prediction to the objects with higher velocity than this value                               |
 | `min_crosswalk_user_velocity`               | double | minimum velocity use in path prediction for crosswalk users                                                  |
+| `num_sampling_path`                         | int    | The number of paths to be sampled.                                                                           |
 | `dist_threshold_for_searching_lanelet`      | double | The threshold of the angle used when searching for the lane to which the object belongs [rad]                |
 | `delta_yaw_threshold_for_searching_lanelet` | double | The threshold of the distance used when searching for the lane to which the object belongs [m]               |
 | `sigma_lateral_offset`                      | double | Standard deviation for lateral position of objects [m]                                                       |
@@ -167,6 +168,11 @@ If the target object is inside the road or crosswalk, this module outputs one or
 | `dist_ratio_threshold_to_right_bound`       | double | Conditions for using lane change detection of objects. Distance to the right bound of lanelet.               |
 | `diff_dist_threshold_to_left_bound`         | double | Conditions for using lane change detection of objects. Differential value of horizontal position of objects. |
 | `diff_dist_threshold_to_right_bound`        | double | Conditions for using lane change detection of objects. Differential value of horizontal position of objects. |
+| `path_cost_params.jerk`                     | double | Weight of jerk cost.                                                                                         |
+| `path_cost_params.time`                     | double | Weight of time cost.                                                                                         |
+| `path_cost_params.position`                 | double | Weight of position cost.                                                                                     |
+| `path_cost_params.lateral`                  | double | Weight of lateral cost.                                                                                      |
+| `path_cost_params.longitudinal`             | double | Weight of longitudinal cost.                                                                                 |
 
 ## Assumptions / Known limits
 

--- a/perception/map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/map_based_prediction/config/map_based_prediction.param.yaml
@@ -5,6 +5,7 @@
     prediction_sampling_delta_time: 0.5 #[s]
     min_velocity_for_map_based_prediction: 1.39 #[m/s]
     min_crosswalk_user_velocity: 1.39 #[m/s]
+    num_sampling_path: 5
     dist_threshold_for_searching_lanelet: 3.0 #[m]
     delta_yaw_threshold_for_searching_lanelet: 0.785 #[rad]
     sigma_lateral_offset: 0.5 #[m]

--- a/perception/map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/map_based_prediction/config/map_based_prediction.param.yaml
@@ -26,4 +26,11 @@
         diff_dist_threshold_to_right_bound: -0.29 #[m]
       num_continuous_state_transition: 3
 
+    path_cost_params:
+      jerk: 0.1
+      time: 0.1
+      position: 1.0
+      lateral: 1.0
+      longitudinal: 1.0
+
     reference_path_resolution: 0.5 #[m]

--- a/perception/map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/map_based_prediction/config/map_based_prediction.param.yaml
@@ -27,7 +27,7 @@
       num_continuous_state_transition: 3
 
     path_cost_params:
-      jerk: 0.1
+      jerk: 0.001
       time: 0.1
       position: 1.0
       lateral: 1.0

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -89,6 +89,7 @@ struct LaneletData
 
 struct PredictedRefPath
 {
+  double lane_width;
   float probability;
   PosePath path;
   Maneuver maneuver;
@@ -209,9 +210,12 @@ private:
 
   void addReferencePaths(
     const TrackedObject & object, const lanelet::routing::LaneletPaths & candidate_paths,
-    const float path_probability, const ManeuverProbability & maneuver_probability,
-    const Maneuver & maneuver, std::vector<PredictedRefPath> & reference_paths);
+    const double lane_width, const float path_probability,
+    const ManeuverProbability & maneuver_probability, const Maneuver & maneuver,
+    std::vector<PredictedRefPath> & reference_paths);
   std::vector<PosePath> convertPathType(const lanelet::routing::LaneletPaths & paths);
+
+  double calculate_lane_width(const lanelet::ConstLanelet & lane) const;
 
   void updateFuturePossibleLanelets(
     const TrackedObject & object, const lanelet::routing::LaneletPaths & paths);

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -144,6 +144,7 @@ private:
   double prediction_sampling_time_interval_;
   double min_velocity_for_map_based_prediction_;
   double min_crosswalk_user_velocity_;
+  int num_sampling_path_;
   double debug_accumulated_time_;
   double dist_threshold_for_searching_lanelet_;
   double delta_yaw_threshold_for_searching_lanelet_;

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -120,7 +120,7 @@ private:
   FrenetPoint getFrenetPoint(const TrackedObject & object, const PosePath & ref_path);
 
   // TODO(ktro2828): add support of max curvature threshold and collision
-  FrenetPath & get_best_path(
+  const FrenetPath & get_best_path(
     std::vector<FrenetPath> & frenet_paths, const double max_velocity,
     const double max_acceleration) const;
 };

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -66,7 +66,7 @@ class PathGenerator
 public:
   PathGenerator(
     const double time_horizon, const double sampling_time_interval,
-    const double min_crosswalk_user_velocity, const size_t num_sample = 5);
+    const double min_crosswalk_user_velocity, const int num_sampling_path);
 
   PredictedPath generatePathForNonVehicleObject(const TrackedObject & object);
 
@@ -88,7 +88,7 @@ private:
   double time_horizon_;
   double sampling_time_interval_;
   double min_crosswalk_user_velocity_;
-  size_t num_sample_;
+  int num_sampling_path_;
 
   static constexpr float KJ_ = 0.1, KT_ = 0.1, KD_ = 1.0, K_LAT_ = 1.0, K_LON_ = 1.0;
 

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -64,9 +64,15 @@ using PosePath = std::vector<geometry_msgs::msg::Pose>;
 class PathGenerator
 {
 public:
+  struct CostParams
+  {
+    double KJ, KT, KD, K_LAT, K_LON;
+  };  // struct CostParams
+
   PathGenerator(
     const double time_horizon, const double sampling_time_interval,
-    const double min_crosswalk_user_velocity, const int num_sampling_path);
+    const double min_crosswalk_user_velocity, const int num_sampling_path,
+    const CostParams & cost_params);
 
   PredictedPath generatePathForNonVehicleObject(const TrackedObject & object);
 
@@ -89,8 +95,7 @@ private:
   double sampling_time_interval_;
   double min_crosswalk_user_velocity_;
   int num_sampling_path_;
-
-  static constexpr float KJ_ = 0.1, KT_ = 0.1, KD_ = 1.0, K_LAT_ = 1.0, K_LON_ = 1.0;
+  CostParams cost_params_;
 
   // Member functions
   PredictedPath generateStraightPath(const TrackedObject & object) const;

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -66,7 +66,7 @@ class PathGenerator
 public:
   PathGenerator(
     const double time_horizon, const double sampling_time_interval,
-    const double min_crosswalk_user_velocity);
+    const double min_crosswalk_user_velocity, const size_t num_sample = 5);
 
   PredictedPath generatePathForNonVehicleObject(const TrackedObject & object);
 
@@ -75,7 +75,7 @@ public:
   PredictedPath generatePathForOffLaneVehicle(const TrackedObject & object);
 
   PredictedPath generatePathForOnLaneVehicle(
-    const TrackedObject & object, const PosePath & ref_paths);
+    const TrackedObject & object, const PosePath & ref_path, const double lane_width);
 
   PredictedPath generatePathForCrosswalkUser(
     const TrackedObject & object, const EntryPoint & reachable_crosswalk) const;
@@ -88,13 +88,15 @@ private:
   double time_horizon_;
   double sampling_time_interval_;
   double min_crosswalk_user_velocity_;
+  size_t num_sample_;
 
   static constexpr float KJ_ = 0.1, KT_ = 0.1, KD_ = 1.0, K_LAT_ = 1.0, K_LON_ = 1.0;
 
   // Member functions
   PredictedPath generateStraightPath(const TrackedObject & object) const;
 
-  PredictedPath generatePolynomialPath(const TrackedObject & object, const PosePath & ref_path);
+  PredictedPath generatePolynomialPath(
+    const TrackedObject & object, const PosePath & ref_path, const double lane_width);
 
   FrenetPath generateFrenetPath(
     const FrenetPoint & current_point, const FrenetPoint & target_point, const double max_length);

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -47,10 +47,18 @@ struct FrenetPoint
   float d_vel;
   float s_acc;
   float d_acc;
-};
+};  // struct FrenetPoint
+
+struct FrenetPath
+{
+  std::vector<FrenetPoint> path;
+  double cost;
+
+  size_t size() const { return path.size(); }
+  FrenetPoint at(const size_t idx) const { return path.at(idx); }
+};  // struct FrenetPath
 
 using EntryPoint = std::pair<Eigen::Vector2d /*in*/, Eigen::Vector2d /*out*/>;
-using FrenetPath = std::vector<FrenetPoint>;
 using PosePath = std::vector<geometry_msgs::msg::Pose>;
 
 class PathGenerator
@@ -80,6 +88,8 @@ private:
   double time_horizon_;
   double sampling_time_interval_;
   double min_crosswalk_user_velocity_;
+
+  static constexpr float KJ_ = 0.1, KT_ = 0.1, KD_ = 1.0, K_LAT_ = 1.0, K_LON_ = 1.0;
 
   // Member functions
   PredictedPath generateStraightPath(const TrackedObject & object) const;

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -111,6 +111,11 @@ private:
     const PosePath & ref_path);
 
   FrenetPoint getFrenetPoint(const TrackedObject & object, const PosePath & ref_path);
+
+  // TODO(ktro2828): add support of max curvature threshold and collision
+  size_t get_best_path_index(
+    std::vector<FrenetPath> & frenet_paths, const double max_velocity,
+    const double max_acceleration) const;
 };
 }  // namespace map_based_prediction
 

--- a/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -113,7 +113,7 @@ private:
   FrenetPoint getFrenetPoint(const TrackedObject & object, const PosePath & ref_path);
 
   // TODO(ktro2828): add support of max curvature threshold and collision
-  size_t get_best_path_index(
+  FrenetPath & get_best_path(
     std::vector<FrenetPath> & frenet_paths, const double max_velocity,
     const double max_acceleration) const;
 };

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -550,7 +550,7 @@ ObjectClassification::_label_type changeLabelForPrediction(
     label == ObjectClassification::MOTORCYCLE || label == ObjectClassification::BICYCLE) {
     // if object is within road lanelet and satisfies yaw constraints
     const bool within_road_lanelet = withinRoadLanelet(object, lanelet_map_ptr_, true);
-    const float high_speed_threshold = 25.0 / 18.0 * 5.0;  // High speed bycicle 25 km/h
+    const float high_speed_threshold = 25.0 / 18.0 * 5.0;  // High speed bicycle 25 km/h
     const bool high_speed_object =
       object.kinematics.twist_with_covariance.twist.linear.x > high_speed_threshold;
 

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -595,6 +595,7 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
   min_velocity_for_map_based_prediction_ =
     declare_parameter("min_velocity_for_map_based_prediction", 1.0);
   min_crosswalk_user_velocity_ = declare_parameter("min_crosswalk_user_velocity", 1.0);
+  num_sampling_path_ = declare_parameter<int>("num_sampling_path", 5);
   dist_threshold_for_searching_lanelet_ =
     declare_parameter("dist_threshold_for_searching_lanelet", 3.0);
   delta_yaw_threshold_for_searching_lanelet_ =
@@ -637,7 +638,8 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
     declare_parameter("prediction_time_horizon_rate_for_validate_lane_length", 0.8);
 
   path_generator_ = std::make_shared<PathGenerator>(
-    prediction_time_horizon_, prediction_sampling_time_interval_, min_crosswalk_user_velocity_);
+    prediction_time_horizon_, prediction_sampling_time_interval_, min_crosswalk_user_velocity_,
+    num_sampling_path_);
 
   sub_objects_ = this->create_subscription<TrackedObjects>(
     "/perception/object_recognition/tracking/objects", 1,

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1365,15 +1365,15 @@ double MapBasedPredictionNode::calculate_lane_width(const lanelet::ConstLanelet 
   std::vector<double> spline_y = interpolation::spline(base_keys, base_bound_y, query_keys);
 
   const size_t num_interpolate = query_bound.size();
-  double max_width = 0.0;
+  double min_width = 1e9;
   for (size_t i = 0; i < num_interpolate; ++i) {
     if (const auto ith_width =
           std::hypot(spline_x.at(i) - query_bound[i].x(), spline_y.at(i) - query_bound[i].y());
-        max_width < ith_width) {
-      max_width = ith_width;
+        ith_width < min_width) {
+      min_width = ith_width;
     }
   }
-  return max_width;
+  return min_width != 1e9 ? min_width : 0.0;
 }
 
 /**

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -596,7 +596,7 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
   min_velocity_for_map_based_prediction_ =
     declare_parameter("min_velocity_for_map_based_prediction", 1.0);
   min_crosswalk_user_velocity_ = declare_parameter("min_crosswalk_user_velocity", 1.0);
-  num_sampling_path_ = declare_parameter<int>("num_sampling_path", 5);
+  num_sampling_path_ = declare_parameter<int>("num_sampling_path");
   dist_threshold_for_searching_lanelet_ =
     declare_parameter("dist_threshold_for_searching_lanelet", 3.0);
   delta_yaw_threshold_for_searching_lanelet_ =
@@ -636,11 +636,11 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
   // weights of path generation cost
   PathGenerator::CostParams cost_params;
   {
-    cost_params.KJ = declare_parameter<double>("path_cost_params.jerk", 0.001);
-    cost_params.KT = declare_parameter<double>("path_cost_params.time", 0.1);
-    cost_params.KD = declare_parameter<double>("path_cost_params.position", 1.0);
-    cost_params.K_LAT = declare_parameter<double>("path_cost_params.lateral", 1.0);
-    cost_params.K_LON = declare_parameter<double>("path_cost_params.longitudinal", 1.0);
+    cost_params.KJ = declare_parameter<double>("path_cost_params.jerk");
+    cost_params.KT = declare_parameter<double>("path_cost_params.time");
+    cost_params.KD = declare_parameter<double>("path_cost_params.position");
+    cost_params.K_LAT = declare_parameter<double>("path_cost_params.lateral");
+    cost_params.K_LON = declare_parameter<double>("path_cost_params.longitudinal");
   }
 
   reference_path_resolution_ = declare_parameter("reference_path_resolution", 0.5);

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -631,6 +631,17 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
     num_continuous_state_transition_ =
       declare_parameter<int>("lane_change_detection.num_continuous_state_transition");
   }
+
+  // weights of path generation cost
+  PathGenerator::CostParams cost_params;
+  {
+    cost_params.KJ = declare_parameter<double>("path_cost_params.jerk", 0.1);
+    cost_params.KT = declare_parameter<double>("path_cost_params.time", 0.1);
+    cost_params.KD = declare_parameter<double>("path_cost_params.position", 1.0);
+    cost_params.K_LAT = declare_parameter<double>("path_cost_params.lateral", 1.0);
+    cost_params.K_LON = declare_parameter<double>("path_cost_params.longitudinal", 1.0);
+  }
+
   reference_path_resolution_ = declare_parameter("reference_path_resolution", 0.5);
   /* prediction path will disabled when the estimated path length exceeds lanelet length. This
    * parameter control the estimated path length = vx * th * (rate)  */
@@ -639,7 +650,7 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
 
   path_generator_ = std::make_shared<PathGenerator>(
     prediction_time_horizon_, prediction_sampling_time_interval_, min_crosswalk_user_velocity_,
-    num_sampling_path_);
+    num_sampling_path_, cost_params);
 
   sub_objects_ = this->create_subscription<TrackedObjects>(
     "/perception/object_recognition/tracking/objects", 1,

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -635,7 +635,7 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
   // weights of path generation cost
   PathGenerator::CostParams cost_params;
   {
-    cost_params.KJ = declare_parameter<double>("path_cost_params.jerk", 0.1);
+    cost_params.KJ = declare_parameter<double>("path_cost_params.jerk", 0.001);
     cost_params.KT = declare_parameter<double>("path_cost_params.time", 0.1);
     cost_params.KD = declare_parameter<double>("path_cost_params.position", 1.0);
     cost_params.K_LAT = declare_parameter<double>("path_cost_params.lateral", 1.0);

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -37,6 +37,7 @@
 #include <functional>
 #include <limits>
 
+// cspell: ignore leftbound, rightbound, constlanelets
 namespace map_based_prediction
 {
 

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -207,7 +207,7 @@ PredictedPath PathGenerator::generatePolynomialPath(
   // TODO(ktro2828): check whether path is valid (collision, speed, acceleration, curvature)
   const double max_acceleration = current_point.s_acc;
   const double max_velocity = current_point.s_vel + max_acceleration * time_horizon_;
-  const auto frenet_predicted_path = get_best_path(frenet_paths, max_velocity, max_acceleration);
+  const auto & frenet_predicted_path = get_best_path(frenet_paths, max_velocity, max_acceleration);
 
   // Step3. Interpolate Reference Path for converting predicted path coordinate
   const auto interpolated_ref_path = interpolateReferencePath(ref_path, frenet_predicted_path);
@@ -444,7 +444,7 @@ FrenetPoint PathGenerator::getFrenetPoint(const TrackedObject & object, const Po
   return frenet_point;
 }
 
-FrenetPath & PathGenerator::get_best_path(
+const FrenetPath & PathGenerator::get_best_path(
   std::vector<FrenetPath> & frenet_paths, const double max_velocity,
   const double max_acceleration) const
 {

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -25,11 +25,11 @@ namespace map_based_prediction
 {
 PathGenerator::PathGenerator(
   const double time_horizon, const double sampling_time_interval,
-  const double min_crosswalk_user_velocity, const size_t num_sample)
+  const double min_crosswalk_user_velocity, const int num_sampling_path)
 : time_horizon_(time_horizon),
   sampling_time_interval_(sampling_time_interval),
   min_crosswalk_user_velocity_(min_crosswalk_user_velocity),
-  num_sample_(num_sample)
+  num_sampling_path_(num_sampling_path)
 {
 }
 
@@ -184,10 +184,9 @@ PredictedPath PathGenerator::generatePolynomialPath(
   const double ref_path_len = motion_utils::calcArcLength(ref_path);
   const auto current_point = getFrenetPoint(object, ref_path);
 
-  const double min_width = -0.5 * lane_width, max_width = 0.5 * lane_width;
-  const double sample_width = lane_width / num_sample_;
   std::vector<FrenetPath> frenet_paths;
-  for (double terminal_d = min_width; terminal_d <= max_width; terminal_d += sample_width) {
+  for (int n = -num_sampling_path_ / 2; n < num_sampling_path_ / 2 + 1; ++n) {
+    const double terminal_d = n * lane_width / num_sampling_path_;
     // Step1. Set Target Frenet Point
     // Note that we do not set position s,
     // since we don't know the target longitudinal position

--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -25,11 +25,13 @@ namespace map_based_prediction
 {
 PathGenerator::PathGenerator(
   const double time_horizon, const double sampling_time_interval,
-  const double min_crosswalk_user_velocity, const int num_sampling_path)
+  const double min_crosswalk_user_velocity, const int num_sampling_path,
+  const CostParams & cost_params)
 : time_horizon_(time_horizon),
   sampling_time_interval_(sampling_time_interval),
   min_crosswalk_user_velocity_(min_crosswalk_user_velocity),
-  num_sampling_path_(num_sampling_path)
+  num_sampling_path_(num_sampling_path),
+  cost_params_(cost_params)
 {
 }
 
@@ -268,9 +270,11 @@ FrenetPath PathGenerator::generateFrenetPath(
   const double last_d_cost = path.empty() ? 0.0 : std::pow(path.back().d, 2);
   const double last_s_cost =
     path.empty() ? 0.0 : std::pow(current_point.s_vel - path.back().s_vel, 2);
-  const double cost_d = KJ_ * sum_d_jerk + KT_ * duration + KD_ * last_d_cost;
-  const double cost_s = KJ_ * sum_s_jerk + KT_ * duration + KD_ * last_s_cost;
-  const double cost = K_LAT_ * cost_d + K_LON_ * cost_s;
+  const double cost_d =
+    cost_params_.KJ * sum_d_jerk + cost_params_.KT * duration + cost_params_.KD * last_d_cost;
+  const double cost_s =
+    cost_params_.KJ * sum_s_jerk + cost_params_.KT * duration + cost_params_.KD * last_s_cost;
+  const double cost = cost_params_.K_LAT * cost_d + cost_params_.K_LON * cost_s;
   return {path, cost};
 }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Add support of sampling paths by its lane width and select best path that has minimum cost.

![map_based_prediction](https://github.com/autowarefoundation/autoware.universe/assets/60615504/65d390c4-cadf-43a5-9819-f15e4c46fedf)

Finally, the path which has minimum cost will be selected. The cost function is shown as below.

$$
C = K_{lat}C_d + K_{lon}C_s
$$

For the details about cost and the other information see [the original paper](https://www.researchgate.net/profile/Moritz-Werling/publication/224156269_Optimal_Trajectory_Generation_for_Dynamic_Street_Scenarios_in_a_Frenet_Frame/links/54f749df0cf210398e9277af/Optimal-Trajectory-Generation-for-Dynamic-Street-Scenarios-in-a-Frenet-Frame.pdf).

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

[TEST PERFORMANCES](https://evaluation.tier4.jp/evaluation/reports/0d20ba0a-af18-5d63-83f7-c4c4169e045a?project_id=prd_jt)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

|Name|Type|Description|
|:--|:--:|:--|
| `num_sampling_path`                         | int    | number of paths to be sampled.                                                                               |
| `path_cost_params.jerk`                     | double | Weight of jerk cost.                                                                                         |
| `path_cost_params.time`                     | double | Weight of time cost.                                                                                         |
| `path_cost_params.position`                 | double | Weight of position cost.                                                                                     |
| `path_cost_params.lateral`                  | double | Weight of lateral cost.                                                                                      |
| `path_cost_params.longitudinal`             | double | Weight of longitudinal cost.                                                                                 |

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Release Notes:
- New Feature: Introduced support for sampling paths by lane width and selecting the best path based on cost in the map-based prediction module.
- Refactor: Added a new parameter and struct to control path sampling and cost weights, respectively.
- Refactor: Modified data structures and functions to accommodate the new changes.

> "Paths by lane width,
> Cost components now defined.
> Predict with precision."
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->