### PR TITLE
fix(ndt_scan_matcher): update member variables properly in map_update_module

### DIFF
--- a/localization/ndt_scan_matcher/src/map_update_module.cpp
+++ b/localization/ndt_scan_matcher/src/map_update_module.cpp
@@ -131,6 +131,8 @@ void MapUpdateModule::update_map(const geometry_msgs::msg::Point & position)
     status = result.wait_for(std::chrono::seconds(1));
   }
   update_ndt(result.get()->new_pointcloud_with_ids, result.get()->ids_to_remove);
+
+  last_update_position_ = position;
 }
 
 void MapUpdateModule::update_ndt(

--- a/localization/ndt_scan_matcher/src/map_update_module.cpp
+++ b/localization/ndt_scan_matcher/src/map_update_module.cpp
@@ -131,7 +131,6 @@ void MapUpdateModule::update_map(const geometry_msgs::msg::Point & position)
     status = result.wait_for(std::chrono::seconds(1));
   }
   update_ndt(result.get()->new_pointcloud_with_ids, result.get()->ids_to_remove);
-
   last_update_position_ = position;
 }
 


### PR DESCRIPTION
## Description
In the previous PR, we erased 
```
 last_update_position_ = res->pose_with_covariance.pose.pose.position;
```
by mistake, which is necesssary to update the last position where the map is updated (which is used as a reference when to update the map)
([See this line](https://github.com/autowarefoundation/autoware.universe/pull/4165#discussion_r1266571196))

This PR is to add the line in appropriate function.
<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/4165
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Ran Logging Simulator with a split map and a sample rosbag from tutorial, and confirmed that the dynamic map loading is working properly from both RViz and log.
Here's a map I used: [sample-map-rosbag_split.zip](https://github.com/autowarefoundation/autoware.universe/files/12079389/sample-map-rosbag_split.zip)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers
Please check with the above rosbag to verify that the dynamic map loading is working properly. By visualizing `/localization/pose_estimator/debug/loaded_pointcloud_map`, you should be able to see the loaded map changes dynamically.
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
None
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
None (dynamic map loading functionality will work with this PR)
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
