### PR TITLE
fix(vehicle_cmd_gate): fix slow start

### DIFF
--- a/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
@@ -59,6 +59,8 @@ public:
   void filterAll(
     const double dt, const double current_steer_angle, AckermannControlCommand & input) const;
 
+  AckermannControlCommand getPrevCmd() { return prev_cmd_; }
+
 private:
   VehicleCmdFilterParam param_;
   AckermannControlCommand prev_cmd_;

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -514,8 +514,11 @@ AckermannControlCommand VehicleCmdGate::filterControlCommand(const AckermannCont
       auto prev_cmd = filter_.getPrevCmd();
       prev_cmd.longitudinal.acceleration =
         std::max(prev_cmd.longitudinal.acceleration, current_status_cmd.longitudinal.acceleration);
+      // consider reverse driving
       prev_cmd.longitudinal.speed =
-        std::max(prev_cmd.longitudinal.speed, current_status_cmd.longitudinal.speed);
+        std::fabs(prev_cmd.longitudinal.speed) > std::fabs(current_status_cmd.longitudinal.speed)
+          ? prev_cmd.longitudinal.speed
+          : current_status_cmd.longitudinal.speed;
       filter_.setPrevCmd(prev_cmd);
     }
     filter_.filterAll(dt, current_steer_, out);

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -17,6 +17,7 @@
 #include <rclcpp/logging.hpp>
 #include <tier4_api_utils/tier4_api_utils.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <functional>
 #include <memory>
@@ -504,10 +505,19 @@ AckermannControlCommand VehicleCmdGate::filterControlCommand(const AckermannCont
     filter_on_transition_.filterAll(dt, current_steer_, out);
   } else {
     // When ego is stopped and the input command is not stopping,
-    // use the actual vehicle longitudinal state for the filtering
+    // use the higher of actual vehicle longitudinal state
+    // and previous longitudinal command for the filtering
     // this is to prevent the jerk limits being applied and causing
     // a delay when restarting the vehicle.
-    if (ego_is_stopped && !input_cmd_is_stopping) filter_.setPrevCmd(current_status_cmd);
+
+    if (ego_is_stopped && !input_cmd_is_stopping) {
+      auto prev_cmd = filter_.getPrevCmd();
+      prev_cmd.longitudinal.acceleration =
+        std::max(prev_cmd.longitudinal.acceleration, current_status_cmd.longitudinal.acceleration);
+      prev_cmd.longitudinal.speed =
+        std::max(prev_cmd.longitudinal.speed, current_status_cmd.longitudinal.speed);
+      filter_.setPrevCmd(prev_cmd);
+    }
     filter_.filterAll(dt, current_steer_, out);
   }
 


### PR DESCRIPTION
## Description

In the "vehicle_cmd_gate" module, the current practice is to use the actual longitudinal state of the vehicle (accel=0, speed=0) as the previous command value during a stop. However, this can occasionally lead to a decrease in the commanded acceleration, resulting in a slower start. So, I have made a modification to utilize the larger of the previous command value or the actual longitudinal state of the vehicle as the previous command value.

Before:
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/fa958d11-f846-43ad-9bae-c665730128a0)

After:
The value of ```/control/command/control_cmd/longitudinal/acceleration``` has been improved to increase smoothly.

![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/5d1a7cd1-4d4c-494d-bdd5-ff569a6432d1)


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Tested by rosbag and logging_simulator (See description)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers
none
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
none
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
Improved departure delays

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
