### PR TITLE
fix(roi_cluster_fusion): use data type consistent with the header declaration

### DIFF
--- a/perception/image_projection_based_fusion/src/utils/geometry.cpp
+++ b/perception/image_projection_based_fusion/src/utils/geometry.cpp
@@ -164,7 +164,7 @@ void transformPoints(
 
 bool is_inside(
   const sensor_msgs::msg::RegionOfInterest & outer,
-  const sensor_msgs::msg::RegionOfInterest & inner, const double outer_offset_scale)
+  const sensor_msgs::msg::RegionOfInterest & inner, const float outer_offset_scale)
 {
   const double lower_scale = 1.0 - std::abs(outer_offset_scale - 1.0);
   return outer.x_offset * lower_scale <= inner.x_offset &&


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

This PR corrects a data type for a variable to make it consistent with its header declaration.
Without this consistency, it may cause an error, such as `undefined symbol: _ZN29image_projection_based_fusion9is_insideERKN11sensor_msgs3msg17RegionOfInterest_ISaIvEEES6_f`, in some environments.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

`ros2 launch image_projection_based_fusion roi_cluster_fusion.launch.xml`

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
