### PR TITLE
TESTING CI 3: DO NOT MERGE

### DIFF
--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// thisisanintendedtypo (This is an intended typo)
+// This is not a typo
 
 #ifndef GNSS_POSER__CONVERT_HPP_
 #define GNSS_POSER__CONVERT_HPP_

--- a/sensing/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/convert.hpp
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// thisisanintendedtypo (This is an intended typo)
+
 #ifndef GNSS_POSER__CONVERT_HPP_
 #define GNSS_POSER__CONVERT_HPP_
 


### PR DESCRIPTION
PR **without** a typo in disabled components that includes a typo already
Expected spell-check-partial behavior: pass
Expected spell-check-differential behavior: fail