### PR TITLE
feat(vehicle_cmd_gate): improve transition filter for longitudinal

### DIFF
--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -529,15 +529,15 @@ AckermannControlCommand VehicleCmdGate::filterControlCommand(const AckermannCont
   // switching from manual to autonomous
   auto prev_values = (mode.mode == OperationModeState::AUTONOMOUS) ? out : current_status_cmd;
 
+  if (ego_is_stopped) {
+    prev_values.longitudinal = out.longitudinal;
+  }
+
   // TODO(Horibe): To prevent sudden acceleration/deceleration when switching from manual to
   // autonomous, the filter should be applied for actual speed and acceleration during manual
   // driving. However, this means that the output command from Gate will always be close to the
-  // driving state during manual driving. Since the Gate's output is checked by various modules as
-  // the intended value of Autoware, it should be closed to planned values. Conversely, it is
-  // undesirable for the target vehicle speed to be non-zero in a situation where the vehicle is
-  // supposed to stop. Until the appropriate handling will be done, previous value is used for the
-  // filter in manual mode.
-  prev_values.longitudinal = out.longitudinal;  // TODO(Horibe): to be removed
+  // driving state during manual driving. Here, let autoware publish the stop command when the ego
+  // is stopped to intend the autoware is trying to keep stopping.
 
   filter_.setPrevCmd(prev_values);
   filter_on_transition_.setPrevCmd(prev_values);


### PR DESCRIPTION
## Description

To enable longitudinal jerk filter when engaging. This PR modifies the control command output on MANUAL driving.

With this PR, the control command output will get a close value to the current ego velocity and acceleration, except for the case ego being stopped

## Related links

None

## Tests performed

tested on a real vehicle, and confirmed the filter works well.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

With this PR, the control command output will get a close value to the current ego velocity and acceleration, except for the case ego being stopped

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
