### PR TITLE
feat(lane_change): add safety check flags for lane change

### DIFF
--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -47,7 +47,8 @@
       # collision check
       enable_prepare_segment_collision_check: true
       prepare_segment_ignore_object_velocity_thresh: 0.1 # [m/s]
-      use_predicted_path_outside_lanelet: true
+      check_objects_on_current_lanes: true
+      check_objects_on_other_lanes: true
       use_all_predicted_path: true
 
       # lane change cancel

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -104,7 +104,8 @@ struct LaneChangeParameters
   // collision check
   bool enable_prepare_segment_collision_check{true};
   double prepare_segment_ignore_object_velocity_thresh{0.1};
-  bool use_predicted_path_outside_lanelet{false};
+  bool check_objects_on_current_lanes{false};
+  bool check_objects_on_other_lanes{false};
   bool use_all_predicted_path{false};
 
   // true by default

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -104,7 +104,7 @@ struct LaneChangeParameters
   // collision check
   bool enable_prepare_segment_collision_check{true};
   double prepare_segment_ignore_object_velocity_thresh{0.1};
-  bool check_objects_on_current_lanes{false};
+  bool check_objects_on_current_lanes{true};
   bool check_objects_on_other_lanes{true};
   bool use_all_predicted_path{false};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -105,7 +105,7 @@ struct LaneChangeParameters
   bool enable_prepare_segment_collision_check{true};
   double prepare_segment_ignore_object_velocity_thresh{0.1};
   bool check_objects_on_current_lanes{false};
-  bool check_objects_on_other_lanes{false};
+  bool check_objects_on_other_lanes{true};
   bool use_all_predicted_path{false};
 
   // true by default

--- a/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
@@ -79,8 +79,10 @@ LaneChangeModuleManager::LaneChangeModuleManager(
     get_parameter<bool>(node, parameter("enable_prepare_segment_collision_check"));
   p.prepare_segment_ignore_object_velocity_thresh =
     get_parameter<double>(node, parameter("prepare_segment_ignore_object_velocity_thresh"));
-  p.use_predicted_path_outside_lanelet =
-    get_parameter<bool>(node, parameter("use_predicted_path_outside_lanelet"));
+  p.check_objects_on_current_lanes =
+    get_parameter<bool>(node, parameter("check_objects_on_current_lanes"));
+  p.check_objects_on_other_lanes =
+    get_parameter<bool>(node, parameter("check_objects_on_other_lanes"));
   p.use_all_predicted_path = get_parameter<bool>(node, parameter("use_all_predicted_path"));
 
   // target object

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -1148,11 +1148,14 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
     utils::lane_change::convertToPredictedPath(ego_predicted_path, time_resolution);
 
   auto collision_check_objects = target_objects.target_lane;
-  collision_check_objects.insert(
-    collision_check_objects.end(), target_objects.current_lane.begin(),
-    target_objects.current_lane.end());
 
-  if (lane_change_parameters_->use_predicted_path_outside_lanelet) {
+  if (lane_change_parameters_->check_objects_on_current_lanes) {
+    collision_check_objects.insert(
+      collision_check_objects.end(), target_objects.current_lane.begin(),
+      target_objects.current_lane.end());
+  }
+
+  if (lane_change_parameters_->check_objects_on_other_lanes) {
     collision_check_objects.insert(
       collision_check_objects.end(), target_objects.other_lane.begin(),
       target_objects.other_lane.end());


### PR DESCRIPTION
## Description
Add flags for the safety check in the lane change module to enable the user to select whether they want to use objects on the specific lanes.

[Launch PR](https://github.com/autowarefoundation/autoware_launch/pull/462)
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

PSim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No efffects

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
