### PR TITLE
fix(out_of_lane): prevent crash when current footprint is empty

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/src/debug.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/debug.cpp
@@ -64,7 +64,7 @@ void add_current_overlap_marker(
   debug_marker.points.clear();
   for (const auto & p : current_footprint)
     debug_marker.points.push_back(tier4_autoware_utils::createMarkerPosition(p.x(), p.y(), z));
-  debug_marker.points.push_back(debug_marker.points.front());
+  if (!debug_marker.points.empty()) debug_marker.points.push_back(debug_marker.points.front());
   if (current_overlapped_lanelets.empty())
     debug_marker.color = tier4_autoware_utils::createMarkerColor(0.1, 1.0, 0.1, 0.5);
   else


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
The `behavior_velocity_planner` can crash if the `out_of_lane` module cannot calculate its current footprint.
This PR removes this crash.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Prevents crashes of the `behavior_velocity_planner`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
