### PR TITLE
feat(map_based_prediction): enable prediction to/from shoulder lanelet (lanelet not in routing graph)

### DIFF
--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -139,6 +139,7 @@ private:
   // Parameters
   bool enable_delay_compensation_;
   double prediction_time_horizon_;
+  double prediction_time_horizon_rate_for_validate_lane_length_;
   double prediction_sampling_time_interval_;
   double min_velocity_for_map_based_prediction_;
   double min_crosswalk_user_velocity_;

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1272,10 +1272,9 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     if (!!opt_right) {
       right_paths = routing_graph_ptr_->possiblePaths(*opt_right, possible_params);
     } else if (!!adjacent_right) {
-      std::cout << adjacent_right->id() << std::endl;
       right_paths = routing_graph_ptr_->possiblePaths(*adjacent_right, possible_params);
     } else {
-      // if no right lanele in graph
+      // if no right lanelet in graph
       auto unconnected_rights =
         getRightLineSharingLanelets(current_lanelet_data.lanelet, lanelet_map_ptr_);
       // search for only first unconnected lanelet

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -1124,15 +1124,21 @@ std::vector<PredictedRefPath> MapBasedPredictionNode::getPredictedReferencePath(
     // Step1.1 Get the left lanelet
     lanelet::routing::LaneletPaths left_paths;
     auto opt_left = routing_graph_ptr_->left(current_lanelet_data.lanelet);
+    auto adjacent_left = routing_graph_ptr_->adjacentLeft(current_lanelet_data.lanelet);
     if (!!opt_left) {
       left_paths = routing_graph_ptr_->possiblePaths(*opt_left, possible_params);
+    } else if (!!adjacent_left) {
+      left_paths = routing_graph_ptr_->possiblePaths(*adjacent_left, possible_params);
     }
 
     // Step1.2 Get the right lanelet
     lanelet::routing::LaneletPaths right_paths;
     auto opt_right = routing_graph_ptr_->right(current_lanelet_data.lanelet);
+    auto adjacent_right = routing_graph_ptr_->adjacentRight(current_lanelet_data.lanelet);
     if (!!opt_right) {
       right_paths = routing_graph_ptr_->possiblePaths(*opt_right, possible_params);
+    } else if (!!adjacent_right) {
+      right_paths = routing_graph_ptr_->possiblePaths(*adjacent_right, possible_params);
     }
 
     // Step1.3 Get the centerline


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR is aiming to generate prediction path from/to a shoulder lanelet, which is unconnected in routing graph.

### Approaches

Implemented algorithm has following architecture:

- left/right shoulder lane prediction(center path prediction has similar architecture)
![image](https://github.com/autowarefoundation/autoware.universe/assets/20086766/a241bc94-fcf6-43a7-80d2-dd9a61985cc4)

#### shoulder lane detection

- when two lanelet shares left/right linestring, we judge these lanelets have neighbor relationships

#### lanelet isolation detection

- a lanelet is considered as "isolated" when it does not have any left/right/following lanelet

#### lanelet length validation

- when lanelet length is not enough, predicted path could be oddly curved
- validation tries to evaluate the lanelet has enough lane length
  - minimum lanelet length is calculated by `obj linear velocity * time_horizon * rate`
  - In default, time_horizon is `10` [s] and rate is `0.8`


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

- [ ] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/b4321154-eb72-584a-9194-53e81e8156d4?project_id=prd_jt)

## Tests performed

Tested in psim.
I'll show edge cases:

| cases |result image | 
|--|--|
| normal lane to shoulder|![Screenshot from 2023-07-21 17-25-12](https://github.com/autowarefoundation/autoware.universe/assets/20086766/2d76b945-8c08-432c-8490-49a55dc797d6)|
|shoulder lane to normal|![Screenshot from 2023-07-21 18-12-24](https://github.com/autowarefoundation/autoware.universe/assets/20086766/f22cfe5c-d005-438c-84b3-bffdb096480a)|
| normal lane to shoulder <br> (path discarded due to not enough lanelet length)|![image](https://github.com/autowarefoundation/autoware.universe/assets/20086766/a5eeb3f6-2a34-4c98-a78a-ea8fbe4332b2)|
|shoulder lane to normal <br> (path discarded due to not enough lanelet length)|![Screenshot from 2023-07-21 18-12-50](https://github.com/autowarefoundation/autoware.universe/assets/20086766/b382e46d-8331-4292-91f4-1b3cf6e372fe)|



<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
