### PR TITLE
fix(avoidance): overwrite backward path velocity

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2433,7 +2433,7 @@ PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & orig
     planner_data_->parameters.backward_path_length, longest_dist_to_shift_point + extra_margin);
   const auto previous_path = helper_.getPreviousReferencePath();
 
-  const size_t orig_ego_idx = findNearestIndex(original_path.points, getEgoPosition());
+  const size_t orig_ego_idx = planner_data_->findEgoIndex(original_path.points);
   const size_t prev_ego_idx =
     findNearestSegmentIndex(previous_path.points, getPoint(original_path.points.at(orig_ego_idx)));
 
@@ -2451,6 +2451,12 @@ PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & orig
       extended_path.points.end(), previous_path.points.begin() + clip_idx,
       previous_path.points.begin() + prev_ego_idx);
   }
+
+  // overwrite backward path velocity by latest one.
+  std::for_each(extended_path.points.begin(), extended_path.points.end(), [&](auto & p) {
+    p.point.longitudinal_velocity_mps =
+      original_path.points.at(orig_ego_idx).point.longitudinal_velocity_mps;
+  });
 
   {
     extended_path.points.insert(


### PR DESCRIPTION
## Description

Since avoidance module keeps previous path and extend backward path length so that it inserts backward shift line, it needs to update backward path velocity.

Before this PR, ego tries keeping previous path velocity (=10km/h) unexpectedly even when lanelet's velocity limit is 15km/h.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/176df641-0024-4fed-a42f-446c80774231

After this PR, ego can accelerate when the lanelet's velocity limit gets higher.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/41e055b1-00b4-4bf5-87bf-26977c16551a

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/3075df56-c1a7-55ea-a1e9-603f8592e7f6?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
