### PR TITLE
refactor(image_projection_based_fusion): update rois topic names definitions

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -5,7 +5,7 @@
   <arg name="output/objects" default="objects"/>
   <arg name="image_raw0" default="/image_raw" description="image raw topic name"/>
   <arg name="camera_info0" default="/camera_info" description="camera info topic name"/>
-  <arg name="detection_rois0" default="/perception/object_recognition/detection/rois0" description="detection rois output topi name"/>
+  <arg name="detection_rois0" default="/perception/object_recognition/detection/rois0" description="detection rois output topic name"/>
   <arg name="image_raw1" default="/image_raw1"/>
   <arg name="camera_info1" default="/camera_info1"/>
   <arg name="detection_rois1" default="/perception/object_recognition/detection/rois1"/>
@@ -191,21 +191,21 @@
     <push-ros-namespace namespace="pointpainting"/>
     <include file="$(find-pkg-share image_projection_based_fusion)/launch/pointpainting_fusion.launch.xml">
       <arg name="input/camera_info0" value="$(var camera_info0)"/>
-      <arg name="input/rois0" value="/perception/object_recognition/detection/rois0"/>
+      <arg name="input/rois0" value="$(var detection_rois0)"/>
       <arg name="input/camera_info1" value="$(var camera_info1)"/>
-      <arg name="input/rois1" value="/perception/object_recognition/detection/rois1"/>
+      <arg name="input/rois1" value="$(var detection_rois1)"/>
       <arg name="input/camera_info2" value="$(var camera_info2)"/>
-      <arg name="input/rois2" value="/perception/object_recognition/detection/rois2"/>
+      <arg name="input/rois2" value="$(var detection_rois2)"/>
       <arg name="input/camera_info3" value="$(var camera_info3)"/>
-      <arg name="input/rois3" value="/perception/object_recognition/detection/rois3"/>
+      <arg name="input/rois3" value="$(var detection_rois3)"/>
       <arg name="input/camera_info4" value="$(var camera_info4)"/>
-      <arg name="input/rois4" value="/perception/object_recognition/detection/rois4"/>
+      <arg name="input/rois4" value="$(var detection_rois4)"/>
       <arg name="input/camera_info5" value="$(var camera_info5)"/>
-      <arg name="input/rois5" value="/perception/object_recognition/detection/rois5"/>
+      <arg name="input/rois5" value="$(var detection_rois5)"/>
       <arg name="input/camera_info6" value="$(var camera_info6)"/>
-      <arg name="input/rois6" value="/perception/object_recognition/detection/rois6"/>
+      <arg name="input/rois6" value="$(var detection_rois6)"/>
       <arg name="input/camera_info7" value="$(var camera_info7)"/>
-      <arg name="input/rois7" value="/perception/object_recognition/detection/rois7"/>
+      <arg name="input/rois7" value="$(var detection_rois7)"/>
       <arg name="input/rois_number" value="$(var image_number)"/>
       <arg name="input/image0" value="$(var image_raw0)"/>
       <arg name="input/image1" value="$(var image_raw1)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -5,20 +5,28 @@
   <arg name="output/objects" default="objects"/>
   <arg name="image_raw0" default="/image_raw" description="image raw topic name"/>
   <arg name="camera_info0" default="/camera_info" description="camera info topic name"/>
+  <arg name="detection_rois0" default="/perception/object_recognition/detection/rois0" description="detection rois output topi name"/>
   <arg name="image_raw1" default="/image_raw1"/>
   <arg name="camera_info1" default="/camera_info1"/>
+  <arg name="detection_rois1" default="/perception/object_recognition/detection/rois1"/>
   <arg name="image_raw2" default="/image_raw2"/>
   <arg name="camera_info2" default="/camera_info2"/>
+  <arg name="detection_rois2" default="/perception/object_recognition/detection/rois2"/>
   <arg name="image_raw3" default="/image_raw3"/>
   <arg name="camera_info3" default="/camera_info3"/>
+  <arg name="detection_rois3" default="/perception/object_recognition/detection/rois3"/>
   <arg name="image_raw4" default="/image_raw4"/>
   <arg name="camera_info4" default="/camera_info4"/>
+  <arg name="detection_rois4" default="/perception/object_recognition/detection/rois4"/>
   <arg name="image_raw5" default="/image_raw5"/>
   <arg name="camera_info5" default="/camera_info5"/>
+  <arg name="detection_rois5" default="/perception/object_recognition/detection/rois5"/>
   <arg name="image_raw6" default="/image_raw6"/>
   <arg name="camera_info6" default="/camera_info6"/>
+  <arg name="detection_rois6" default="/perception/object_recognition/detection/rois6"/>
   <arg name="image_raw7" default="/image_raw7"/>
   <arg name="camera_info7" default="/camera_info7"/>
+  <arg name="detection_rois7" default="/perception/object_recognition/detection/rois7"/>
   <arg name="image_number" default="1" description="choose image raw number(1-8)"/>
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
@@ -82,21 +90,21 @@
       <group>
         <include file="$(find-pkg-share image_projection_based_fusion)/launch/roi_cluster_fusion.launch.xml">
           <arg name="input/camera_info0" value="$(var camera_info0)"/>
-          <arg name="input/rois0" value="/perception/object_recognition/detection/rois0"/>
+          <arg name="input/rois0" value="$(var detection_rois0)"/>
           <arg name="input/camera_info1" value="$(var camera_info1)"/>
-          <arg name="input/rois1" value="/perception/object_recognition/detection/rois1"/>
+          <arg name="input/rois1" value="$(var detection_rois1)"/>
           <arg name="input/camera_info2" value="$(var camera_info2)"/>
-          <arg name="input/rois2" value="/perception/object_recognition/detection/rois2"/>
+          <arg name="input/rois2" value="$(var detection_rois2)"/>
           <arg name="input/camera_info3" value="$(var camera_info3)"/>
-          <arg name="input/rois3" value="/perception/object_recognition/detection/rois3"/>
+          <arg name="input/rois3" value="$(var detection_rois3)"/>
           <arg name="input/camera_info4" value="$(var camera_info4)"/>
-          <arg name="input/rois4" value="/perception/object_recognition/detection/rois4"/>
+          <arg name="input/rois4" value="$(var detection_rois4)"/>
           <arg name="input/camera_info5" value="$(var camera_info5)"/>
-          <arg name="input/rois5" value="/perception/object_recognition/detection/rois5"/>
+          <arg name="input/rois5" value="$(var detection_rois5)"/>
           <arg name="input/camera_info6" value="$(var camera_info6)"/>
-          <arg name="input/rois6" value="/perception/object_recognition/detection/rois6"/>
+          <arg name="input/rois6" value="$(var detection_rois6)"/>
           <arg name="input/camera_info7" value="$(var camera_info7)"/>
-          <arg name="input/rois7" value="/perception/object_recognition/detection/rois7"/>
+          <arg name="input/rois7" value="$(var detection_rois7)"/>
           <arg name="input/rois_number" value="$(var image_number)"/>
           <arg name="input/clusters" value="$(var input/clustering)"/>
           <arg name="input/image0" value="$(var image_raw0)"/>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -30,20 +30,28 @@
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
   <arg name="image_raw0" default="/sensing/camera/camera0/image_rect_color" description="image raw topic name"/>
   <arg name="camera_info0" default="/sensing/camera/camera0/camera_info" description="camera info topic name"/>
+  <arg name="detection_rois0" default="/perception/object_recognition/detection/rois0" description="detection rois output topi name"/>
   <arg name="image_raw1" default="/sensing/camera/camera1/image_rect_color"/>
   <arg name="camera_info1" default="/sensing/camera/camera1/camera_info"/>
+  <arg name="detection_rois1" default="/perception/object_recognition/detection/rois1"/>
   <arg name="image_raw2" default="/sensing/camera/camera2/image_rect_color"/>
   <arg name="camera_info2" default="/sensing/camera/camera2/camera_info"/>
+  <arg name="detection_rois2" default="/perception/object_recognition/detection/rois2"/>
   <arg name="image_raw3" default="/sensing/camera/camera3/image_rect_color"/>
   <arg name="camera_info3" default="/sensing/camera/camera3/camera_info"/>
+  <arg name="detection_rois3" default="/perception/object_recognition/detection/rois3"/>
   <arg name="image_raw4" default="/sensing/camera/camera4/image_rect_color"/>
   <arg name="camera_info4" default="/sensing/camera/camera4/camera_info"/>
+  <arg name="detection_rois4" default="/perception/object_recognition/detection/rois4"/>
   <arg name="image_raw5" default="/sensing/camera/camera5/image_rect_color"/>
   <arg name="camera_info5" default="/sensing/camera/camera5/camera_info"/>
+  <arg name="detection_rois5" default="/perception/object_recognition/detection/rois5"/>
   <arg name="image_raw6" default="/sensing/camera/camera6/image_rect_color"/>
   <arg name="camera_info6" default="/sensing/camera/camera6/camera_info"/>
+  <arg name="detection_rois6" default="/perception/object_recognition/detection/rois6"/>
   <arg name="image_raw7" default="/sensing/camera/camera7/image_rect_color"/>
   <arg name="camera_info7" default="/sensing/camera/camera7/camera_info"/>
+  <arg name="detection_rois7" default="/perception/object_recognition/detection/rois7"/>
   <arg name="image_number" default="6" description="choose image raw number(1-8)"/>
   <arg name="object_recognition_detection_fusion_sync_param_path" description="you need change the size of 'input_offset_ms' in the file in this path when you want to change image_number"/>
   <arg name="use_vector_map" default="true" description="use vector map in prediction"/>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -30,7 +30,7 @@
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
   <arg name="image_raw0" default="/sensing/camera/camera0/image_rect_color" description="image raw topic name"/>
   <arg name="camera_info0" default="/sensing/camera/camera0/camera_info" description="camera info topic name"/>
-  <arg name="detection_rois0" default="/perception/object_recognition/detection/rois0" description="detection rois output topi name"/>
+  <arg name="detection_rois0" default="/perception/object_recognition/detection/rois0" description="detection rois output topic name"/>
   <arg name="image_raw1" default="/sensing/camera/camera1/image_rect_color"/>
   <arg name="camera_info1" default="/sensing/camera/camera1/camera_info"/>
   <arg name="detection_rois1" default="/perception/object_recognition/detection/rois1"/>


### PR DESCRIPTION
## Description

This PR changes ```image_projection_based_fusion``` package input rois arguments workflow. After the this PR input rois topic names migrated from ```perception.launch.xml```.

releated: #4250 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
