### PR TITLE
feat(gnss_poser): options for gnss pose pub method

### DIFF
--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -35,6 +35,7 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 | `map_frame`         | string | "map"            | frame id                                                                                                                   |
 | `coordinate_system` | int    | "4"              | coordinate system enumeration; 0: UTM, 1: MGRS, 2: Plane, 3: WGS84 Local Coordinate System, 4: UTM Local Coordinate System |
 | `plane_zone`        | int    | 9                | identification number of the plane rectangular coordinate systems.                                                         |
+| `gnss_pose_pub_method` | int | 0                | 0: Instant Value 1: Average Value 2: Median Value. If 0 is choosen buffer_epoch parameter loses affect.       |
 
 ## Assumptions / Known limits
 

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -35,7 +35,7 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 | `map_frame`            | string | "map"            | frame id                                                                                                                   |
 | `coordinate_system`    | int    | "4"              | coordinate system enumeration; 0: UTM, 1: MGRS, 2: Plane, 3: WGS84 Local Coordinate System, 4: UTM Local Coordinate System |
 | `plane_zone`           | int    | 9                | identification number of the plane rectangular coordinate systems.                                                         |
-| `gnss_pose_pub_method` | int    | 0                | 0: Instant Value 1: Average Value 2: Median Value. If 0 is choosen buffer_epoch parameter loses affect.                    |
+| `gnss_pose_pub_method` | int    | 0                | 0: Instant Value 1: Average Value 2: Median Value. If 0 is chosen buffer_epoch parameter loses affect.                    |
 
 ## Assumptions / Known limits
 

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -35,7 +35,7 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 | `map_frame`            | string | "map"            | frame id                                                                                                                   |
 | `coordinate_system`    | int    | "4"              | coordinate system enumeration; 0: UTM, 1: MGRS, 2: Plane, 3: WGS84 Local Coordinate System, 4: UTM Local Coordinate System |
 | `plane_zone`           | int    | 9                | identification number of the plane rectangular coordinate systems.                                                         |
-| `gnss_pose_pub_method` | int    | 0                | 0: Instant Value 1: Average Value 2: Median Value. If 0 is chosen buffer_epoch parameter loses affect.                    |
+| `gnss_pose_pub_method` | int    | 0                | 0: Instant Value 1: Average Value 2: Median Value. If 0 is chosen buffer_epoch parameter loses affect.                     |
 
 ## Assumptions / Known limits
 

--- a/sensing/gnss_poser/README.md
+++ b/sensing/gnss_poser/README.md
@@ -27,15 +27,15 @@ The `gnss_poser` is a node that subscribes gnss sensing messages and calculates 
 
 ### Core Parameters
 
-| Name                | Type   | Default Value    | Description                                                                                                                |
-| ------------------- | ------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `base_frame`        | string | "base_link"      | frame id                                                                                                                   |
-| `gnss_frame`        | string | "gnss"           | frame id                                                                                                                   |
-| `gnss_base_frame`   | string | "gnss_base_link" | frame id                                                                                                                   |
-| `map_frame`         | string | "map"            | frame id                                                                                                                   |
-| `coordinate_system` | int    | "4"              | coordinate system enumeration; 0: UTM, 1: MGRS, 2: Plane, 3: WGS84 Local Coordinate System, 4: UTM Local Coordinate System |
-| `plane_zone`        | int    | 9                | identification number of the plane rectangular coordinate systems.                                                         |
-| `gnss_pose_pub_method` | int | 0                | 0: Instant Value 1: Average Value 2: Median Value. If 0 is choosen buffer_epoch parameter loses affect.       |
+| Name                   | Type   | Default Value    | Description                                                                                                                |
+| ---------------------- | ------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `base_frame`           | string | "base_link"      | frame id                                                                                                                   |
+| `gnss_frame`           | string | "gnss"           | frame id                                                                                                                   |
+| `gnss_base_frame`      | string | "gnss_base_link" | frame id                                                                                                                   |
+| `map_frame`            | string | "map"            | frame id                                                                                                                   |
+| `coordinate_system`    | int    | "4"              | coordinate system enumeration; 0: UTM, 1: MGRS, 2: Plane, 3: WGS84 Local Coordinate System, 4: UTM Local Coordinate System |
+| `plane_zone`           | int    | 9                | identification number of the plane rectangular coordinate systems.                                                         |
+| `gnss_pose_pub_method` | int    | 0                | 0: Instant Value 1: Average Value 2: Median Value. If 0 is choosen buffer_epoch parameter loses affect.                    |
 
 ## Assumptions / Known limits
 

--- a/sensing/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
@@ -60,6 +60,8 @@ private:
   geometry_msgs::msg::Point getPosition(const GNSSStat & gnss_stat);
   geometry_msgs::msg::Point getMedianPosition(
     const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer);
+  geometry_msgs::msg::Point getAveragePosition(
+    const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer);
   geometry_msgs::msg::Quaternion getQuaternionByHeading(const int heading);
   geometry_msgs::msg::Quaternion getQuaternionByPositionDifference(
     const geometry_msgs::msg::Point & point, const geometry_msgs::msg::Point & prev_point);
@@ -103,6 +105,7 @@ private:
   autoware_sensing_msgs::msg::GnssInsOrientationStamped::SharedPtr
     msg_gnss_ins_orientation_stamped_;
   int height_system_;
+  int gnss_pose_pub_method;
 };
 }  // namespace gnss_poser
 

--- a/sensing/gnss_poser/launch/gnss_poser.launch.xml
+++ b/sensing/gnss_poser/launch/gnss_poser.launch.xml
@@ -18,6 +18,8 @@
   <arg name="use_gnss_ins_orientation" default="true"/>
   <arg name="plane_zone" default="9"/>
   <arg name="height_system" default="1" description="0:Orthometric Height 1:Ellipsoid Height"/>
+  <arg name="gnss_pose_pub_method" default="0" description="0: Instant Value 1: Average Value 2: Median Value"/>
+
 
   <node pkg="gnss_poser" exec="gnss_poser" name="gnss_poser" output="screen">
     <remap from="fix" to="$(var input_topic_fix)"/>
@@ -37,5 +39,7 @@
     <param name="use_gnss_ins_orientation" value="$(var use_gnss_ins_orientation)"/>
     <param from="$(var param_file)"/>
     <param name="height_system" value="$(var height_system)"/>
+    <param name="gnss_pose_pub_method" value="$(var gnss_pose_pub_method)"/>
+
   </node>
 </launch>

--- a/sensing/gnss_poser/launch/gnss_poser.launch.xml
+++ b/sensing/gnss_poser/launch/gnss_poser.launch.xml
@@ -20,7 +20,6 @@
   <arg name="height_system" default="1" description="0:Orthometric Height 1:Ellipsoid Height"/>
   <arg name="gnss_pose_pub_method" default="0" description="0: Instant Value 1: Average Value 2: Median Value"/>
 
-
   <node pkg="gnss_poser" exec="gnss_poser" name="gnss_poser" output="screen">
     <remap from="fix" to="$(var input_topic_fix)"/>
     <remap from="autoware_orientation" to="$(var input_topic_orientation)"/>
@@ -40,6 +39,5 @@
     <param from="$(var param_file)"/>
     <param name="height_system" value="$(var height_system)"/>
     <param name="gnss_pose_pub_method" value="$(var gnss_pose_pub_method)"/>
-
   </node>
 </launch>

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -36,7 +36,7 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
   msg_gnss_ins_orientation_stamped_(
     std::make_shared<autoware_sensing_msgs::msg::GnssInsOrientationStamped>()),
   height_system_(declare_parameter<int>("height_system", 1)),
-  gnss_pose_pub_method(declare_parameter<int>("gnss_pose_pub_method",0))
+  gnss_pose_pub_method(declare_parameter<int>("gnss_pose_pub_method", 0))
 {
   int coordinate_system =
     declare_parameter("coordinate_system", static_cast<int>(CoordinateSystem::MGRS));
@@ -88,10 +88,9 @@ void GNSSPoser::callbackNavSatFix(
   geometry_msgs::msg::Pose gnss_antenna_pose{};
 
   // publish pose immediately
-  if(!gnss_pose_pub_method){
-    gnss_antenna_pose.position=position;
-  }
-  else{
+  if (!gnss_pose_pub_method) {
+    gnss_antenna_pose.position = position;
+  } else {
     // fill position buffer
     position_buffer_.push_front(position);
     if (!position_buffer_.full()) {
@@ -101,7 +100,8 @@ void GNSSPoser::callbackNavSatFix(
       return;
     }
     // publish average pose or median pose of position buffer
-    gnss_antenna_pose.position = (gnss_pose_pub_method == 1) ? getAveragePosition(position_buffer_) : getMedianPosition(position_buffer_);
+    gnss_antenna_pose.position = (gnss_pose_pub_method == 1) ? getAveragePosition(position_buffer_)
+                                                             : getMedianPosition(position_buffer_);
   }
 
   // calc gnss antenna orientation
@@ -167,7 +167,6 @@ void GNSSPoser::callbackNavSatFix(
 
   // broadcast map to gnss_base_link
   publishTF(map_frame_, gnss_base_frame_, gnss_base_pose_msg);
-
 }
 
 void GNSSPoser::callbackGnssInsOrientationStamped(
@@ -250,7 +249,9 @@ geometry_msgs::msg::Point GNSSPoser::getMedianPosition(
   return median_point;
 }
 
-geometry_msgs::msg::Point GNSSPoser::getAveragePosition(const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer){
+geometry_msgs::msg::Point GNSSPoser::getAveragePosition(
+  const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer)
+{
   std::vector<double> array_x;
   std::vector<double> array_y;
   std::vector<double> array_z;
@@ -261,9 +262,12 @@ geometry_msgs::msg::Point GNSSPoser::getAveragePosition(const boost::circular_bu
   }
 
   geometry_msgs::msg::Point average_point;
-  average_point.x = std::reduce(array_x.begin(), array_x.end()) / static_cast<double>(array_x.size());
-  average_point.y = std::reduce(array_y.begin(), array_y.end()) / static_cast<double>(array_y.size());
-  average_point.z = std::reduce(array_z.begin(), array_z.end()) / static_cast<double>(array_z.size());
+  average_point.x =
+    std::reduce(array_x.begin(), array_x.end()) / static_cast<double>(array_x.size());
+  average_point.y =
+    std::reduce(array_y.begin(), array_y.end()) / static_cast<double>(array_y.size());
+  average_point.z =
+    std::reduce(array_z.begin(), array_z.end()) / static_cast<double>(array_z.size());
   return average_point;
 }
 

--- a/sensing/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/gnss_poser/src/gnss_poser_core.cpp
@@ -35,7 +35,8 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
   plane_zone_(declare_parameter<int>("plane_zone", 9)),
   msg_gnss_ins_orientation_stamped_(
     std::make_shared<autoware_sensing_msgs::msg::GnssInsOrientationStamped>()),
-  height_system_(declare_parameter<int>("height_system", 1))
+  height_system_(declare_parameter<int>("height_system", 1)),
+  gnss_pose_pub_method(declare_parameter<int>("gnss_pose_pub_method",0))
 {
   int coordinate_system =
     declare_parameter("coordinate_system", static_cast<int>(CoordinateSystem::MGRS));
@@ -84,37 +85,43 @@ void GNSSPoser::callbackNavSatFix(
   const auto gnss_stat = convert(*nav_sat_fix_msg_ptr, coordinate_system_, height_system_);
   const auto position = getPosition(gnss_stat);
 
-  // calc median position
-  position_buffer_.push_front(position);
-  if (!position_buffer_.full()) {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
-      "Buffering Position. Output Skipped.");
-    return;
+  geometry_msgs::msg::Pose gnss_antenna_pose{};
+
+  // publish pose immediately
+  if(!gnss_pose_pub_method){
+    gnss_antenna_pose.position=position;
   }
-  const auto median_position = getMedianPosition(position_buffer_);
+  else{
+    // fill position buffer
+    position_buffer_.push_front(position);
+    if (!position_buffer_.full()) {
+      RCLCPP_WARN_STREAM_THROTTLE(
+        this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+        "Buffering Position. Output Skipped.");
+      return;
+    }
+    // publish average pose or median pose of position buffer
+    gnss_antenna_pose.position = (gnss_pose_pub_method == 1) ? getAveragePosition(position_buffer_) : getMedianPosition(position_buffer_);
+  }
 
   // calc gnss antenna orientation
   geometry_msgs::msg::Quaternion orientation;
   if (use_gnss_ins_orientation_) {
     orientation = msg_gnss_ins_orientation_stamped_->orientation.orientation;
   } else {
-    static auto prev_position = median_position;
-    orientation = getQuaternionByPositionDifference(median_position, prev_position);
-    prev_position = median_position;
+    static auto prev_position = gnss_antenna_pose.position;
+    orientation = getQuaternionByPositionDifference(gnss_antenna_pose.position, prev_position);
+    prev_position = gnss_antenna_pose.position;
   }
 
-  // generate gnss_antenna_pose
-  geometry_msgs::msg::Pose gnss_antenna_pose{};
-  gnss_antenna_pose.position = median_position;
   gnss_antenna_pose.orientation = orientation;
 
-  // get TF from gnss_antenna to map
   tf2::Transform tf_map2gnss_antenna{};
   tf2::fromMsg(gnss_antenna_pose, tf_map2gnss_antenna);
 
   // get TF from base_link to gnss_antenna
   auto tf_gnss_antenna2base_link_msg_ptr = std::make_shared<geometry_msgs::msg::TransformStamped>();
+
   getStaticTransform(
     gnss_frame_, base_frame_, tf_gnss_antenna2base_link_msg_ptr, nav_sat_fix_msg_ptr->header.stamp);
   tf2::Transform tf_gnss_antenna2base_link{};
@@ -160,6 +167,7 @@ void GNSSPoser::callbackNavSatFix(
 
   // broadcast map to gnss_base_link
   publishTF(map_frame_, gnss_base_frame_, gnss_base_pose_msg);
+
 }
 
 void GNSSPoser::callbackGnssInsOrientationStamped(
@@ -240,6 +248,23 @@ geometry_msgs::msg::Point GNSSPoser::getMedianPosition(
   median_point.y = getMedian(array_y);
   median_point.z = getMedian(array_z);
   return median_point;
+}
+
+geometry_msgs::msg::Point GNSSPoser::getAveragePosition(const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer){
+  std::vector<double> array_x;
+  std::vector<double> array_y;
+  std::vector<double> array_z;
+  for (const auto & position : position_buffer) {
+    array_x.push_back(position.x);
+    array_y.push_back(position.y);
+    array_z.push_back(position.z);
+  }
+
+  geometry_msgs::msg::Point average_point;
+  average_point.x = std::reduce(array_x.begin(), array_x.end()) / static_cast<double>(array_x.size());
+  average_point.y = std::reduce(array_y.begin(), array_y.end()) / static_cast<double>(array_y.size());
+  average_point.z = std::reduce(array_z.begin(), array_z.end()) / static_cast<double>(array_z.size());
+  return average_point;
 }
 
 geometry_msgs::msg::Quaternion GNSSPoser::getQuaternionByHeading(const int heading)


### PR DESCRIPTION
## Description

Adding feature reffered: #4188

This PR offers three options for publishing gnss_pose:

1. Publish coming data immediately (buffer_epoch does not have effect on algorithm).
2. Publish median of the buffer (buffer_epoch setted by user).
3. Publish average value of the poses in the buffer (buffer_epoch setted by user).

## Tests performed

All added options runned through logging simulator. 

## Effects on system behavior

Different GNSS/INS sensors different accuracies, user should be able to choose the most suitable buffer size and gnss pose publish method for themselves.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/