### PR TITLE
fix(behavior_path_planner): update root lanele if it is not in route lanelet

### DIFF
--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -636,15 +636,21 @@ void PlannerManager::resetRootLanelet(const std::shared_ptr<PlannerData> & data)
 
   const auto root_lanelet = updateRootLanelet(data);
 
+  // if root_lanelet is not route lanelets, reset root lanelet.
+  // this can be caused by rerouting.
+  const auto route_handler = data->route_handler;
+  if (!route_handler->isRouteLanelet(root_lanelet_.get())) {
+    root_lanelet_ = root_lanelet;
+    return;
+  }
+
   // check ego is in same lane
   if (root_lanelet_.get().id() == root_lanelet.id()) {
     return;
   }
 
-  const auto route_handler = data->route_handler;
-  const auto next_lanelets = route_handler->getRoutingGraphPtr()->following(root_lanelet_.get());
-
   // check ego is in next lane
+  const auto next_lanelets = route_handler->getRoutingGraphPtr()->following(root_lanelet_.get());
   for (const auto & next : next_lanelets) {
     if (next.id() == root_lanelet.id()) {
       return;

--- a/planning/behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/src/planner_manager.cpp
@@ -638,7 +638,7 @@ void PlannerManager::resetRootLanelet(const std::shared_ptr<PlannerData> & data)
 
   // if root_lanelet is not route lanelets, reset root lanelet.
   // this can be caused by rerouting.
-  const auto route_handler = data->route_handler;
+  const auto & route_handler = data->route_handler;
   if (!route_handler->isRouteLanelet(root_lanelet_.get())) {
     root_lanelet_ = root_lanelet;
     return;

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -325,6 +325,7 @@ public:
     const lanelet::ConstLanelet & prev_lane, const lanelet::ConstLanelet & next_lane) const;
   lanelet::ConstLanelets getShoulderLanelets() const;
   bool isShoulderLanelet(const lanelet::ConstLanelet & lanelet) const;
+  bool isRouteLanelet(const lanelet::ConstLanelet & lanelet) const;
 
   // for path
   PathWithLaneId getCenterLinePath(

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -1800,6 +1800,11 @@ bool RouteHandler::isShoulderLanelet(const lanelet::ConstLanelet & lanelet) cons
   return lanelet::utils::contains(shoulder_lanelets_, lanelet);
 }
 
+bool RouteHandler::isRouteLanelet(const lanelet::ConstLanelet & lanelet) const
+{
+  return lanelet::utils::contains(route_lanelets_, lanelet);
+}
+
 lanelet::ConstLanelets RouteHandler::getPreviousLaneletSequence(
   const lanelet::ConstLanelets & lanelet_sequence) const
 {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Update root_lanelet_ if it is not in route lanelet.


Rerouging with modified goal update route_laneles, but if following lanes of previous root_lalet contains new root_lanelet_, that is not updated.  This is happen when the previos root_lanelet is before new root lanelets.

```
  // check ego is in next lane
  const auto next_lanelets = route_handler->getRoutingGraphPtr()->following(root_lanelet_.get());
  for (const auto & next : next_lanelets) {
    if (next.id() == root_lanelet.id()) {
      return;
    }
  }
```

In a result root_lanelet is not in route_lanels and this causes empty lanelet sequence in 

```
    const auto lanelet_sequence = route_handler->getLaneletSequence(
      root_lanelet_.get(), pose, backward_length, std::numeric_limits<double>::max());
```
https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp#L281-L282

and generate empty reference path. In result a module (e.g. avoidance) uses the null previous output and dies.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

tier4 interanl scenario test 

https://evaluation.tier4.jp/evaluation/reports/0e24127b-f63f-56af-88af-880fddcce8c9?project_id=prd_jt
1568/1588

compare
https://evaluation.tier4.jp/evaluation/reports/tables/new?catalog_id=cb497016-2e2f-4ce0-9ac8-68d77a27a55d&filter=&job_id=0e24127b-f63f-56af-88af-880fddcce8c9&project_id=prd_jt&table_config=date%2Chide&target_ids=769105c1-379c-5291-96ef-a1906180cb37

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
none
## Interface changes

none

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
