### PR TITLE
feat(tier4_perception_launch): add radar tracking node to launcher

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/tracking/tracking.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/tracking/tracking.launch.xml
@@ -2,12 +2,28 @@
 <launch>
   <arg name="publish_rate" default="10.0"/>
   <arg name="enable_delay_compensation" default="true"/>
+  <arg name="radar_tracker_input" default="/perception/object_recognition/detection/radar/far_objects"/>
+  <arg name="radar_tracker_output" default="/perception/object_recognition/tracking/radar/far_objects"/>
+  <arg name="use_radar_object_tracker" default="true"/>
 
   <group>
+    <!--multi object tracking-->
     <include file="$(find-pkg-share multi_object_tracker)/launch/multi_object_tracker.launch.xml">
       <arg name="data_association_matrix_path" value="$(var object_recognition_tracking_multi_object_tracker_data_association_matrix_param_path)"/>
       <arg name="publish_rate" value="$(var publish_rate)"/>
       <arg name="enable_delay_compensation" value="$(var enable_delay_compensation)"/>
     </include>
+
+    <!--radar long range dynamic object tracking if needed-->
+    <group if="$(var use_radar_object_tracker)">
+      <include file="$(find-pkg-share radar_object_tracker)/launch/radar_object_tracker.launch.xml">
+        <arg name="publish_rate" value="$(var publish_rate)"/>
+        <arg name="enable_delay_compensation" value="$(var enable_delay_compensation)"/>
+        <arg name="input" value="$(var radar_tracker_input)"/>
+        <arg name="output" value="$(var radar_tracker_output)"/>
+        <arg name="data_association_matrix_path" value="$(var object_recognition_tracking_radar_object_tracker_data_association_matrix_param_path)"/>
+        <arg name="tracker_setting_path" value="$(var object_recognition_tracking_radar_object_tracker_tracking_setting_param_path)"/>
+      </include>
+    </group>
   </group>
 </launch>

--- a/launch/tier4_perception_launch/launch/object_recognition/tracking/tracking.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/tracking/tracking.launch.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="mode" default="lidar" description="options: `camera_lidar_radar_fusion`, `camera_lidar_fusion`, `lidar_radar_fusion`, `lidar` or `radar`"/>
   <arg name="publish_rate" default="10.0"/>
   <arg name="enable_delay_compensation" default="true"/>
   <arg name="radar_tracker_input" default="/perception/object_recognition/detection/radar/far_objects"/>
   <arg name="radar_tracker_output" default="/perception/object_recognition/tracking/radar/far_objects"/>
-  <arg name="use_radar_object_tracker" default="true"/>
 
   <group>
     <!--multi object tracking-->
@@ -14,8 +14,8 @@
       <arg name="enable_delay_compensation" value="$(var enable_delay_compensation)"/>
     </include>
 
-    <!--radar long range dynamic object tracking if needed-->
-    <group if="$(var use_radar_object_tracker)">
+    <!--radar long range dynamic object tracking if mode contains radar input-->
+    <group if="$(eval '&quot;$(var mode)&quot;==&quot;radar&quot; or &quot;$(var mode)&quot;==&quot;lidar_radar_fusion&quot; or &quot;$(var mode)&quot;==&quot;camera_lidar_radar_fusion&quot;')">
       <include file="$(find-pkg-share radar_object_tracker)/launch/radar_object_tracker.launch.xml">
         <arg name="publish_rate" value="$(var publish_rate)"/>
         <arg name="enable_delay_compensation" value="$(var enable_delay_compensation)"/>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -12,6 +12,8 @@
   <arg name="object_recognition_detection_object_merger_data_association_matrix_param_path"/>
   <arg name="object_recognition_detection_object_merger_distance_threshold_list_path"/>
   <arg name="object_recognition_tracking_multi_object_tracker_data_association_matrix_param_path"/>
+  <arg name="object_recognition_tracking_radar_object_tracker_data_association_matrix_param_path"/>
+  <arg name="object_recognition_tracking_radar_object_tracker_tracking_setting_param_path"/>
   <arg name="obstacle_segmentation_ground_segmentation_param_path"/>
   <arg name="obstacle_segmentation_ground_segmentation_elevation_map_param_path"/>
   <arg name="occupancy_grid_map_method"/>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -147,7 +147,9 @@
       <!-- tracking module -->
       <group>
         <push-ros-namespace namespace="tracking"/>
-        <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/tracking/tracking.launch.xml"/>
+        <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/tracking/tracking.launch.xml">
+          <arg name="mode" value="$(var mode)"/>
+        </include>
       </group>
       <!-- prediction module -->
       <group>

--- a/launch/tier4_perception_launch/package.xml
+++ b/launch/tier4_perception_launch/package.xml
@@ -34,6 +34,7 @@
   <exec_depend>radar_crossing_objects_noise_filter</exec_depend>
   <exec_depend>radar_fusion_to_detected_object</exec_depend>
   <exec_depend>radar_object_clustering</exec_depend>
+  <exec_depend>radar_object_tracker</exec_depend>
   <exec_depend>shape_estimation</exec_depend>
   <exec_depend>tensorrt_yolo</exec_depend>
   <exec_depend>topic_tools</exec_depend>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

This PR provides tracking for far objects with radar sensor input generated with https://github.com/autowarefoundation/autoware.universe/pull/4330.

To launch radar object tracking node, be sure to set `object_recognition_tracking_radar_object_tracker_data_association_matrix_param_path` and 
  `object_recognition_tracking_radar_object_tracker_tracking_setting_param_path`, which represent association settings and tracking settings.


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested in sample rosbag.
Remember to merge https://github.com/autowarefoundation/autoware_launch/pull/470 at the same time.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Default logsim will try to publish radar tracking results.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
