### PR TITLE
fix(perception_utils): fix `-Werror=reorder`

### DIFF
--- a/common/perception_utils/include/perception_utils/prime_synchronizer.hpp
+++ b/common/perception_utils/include/perception_utils/prime_synchronizer.hpp
@@ -76,7 +76,7 @@ public:
       const typename PrimeMsgT::ConstSharedPtr, const typename SecondaryMsgT::ConstSharedPtr...)>
       callback,
     StampT max_delay_t = 0.2, StampT max_wait_t = 0.1)
-  : node_ptr_(node_ptr), callback_(callback), max_delay_t_(max_delay_t), max_wait_t_(max_wait_t)
+  : node_ptr_(node_ptr), callback_(callback), max_wait_t_(max_wait_t), max_delay_t_(max_delay_t)
   {
     assert((topics.size() == sizeof...(SecondaryMsgT) + 1) && "Incorrect topic number");
     assert(topics.size() == qos.size() && "topic size not equal to qos size!");


### PR DESCRIPTION
## Description

```
/home/satoshi/pilot-auto/install/perception_utils/include/perception_utils/prime_synchronizer.hpp:348:10: error: ‘perception_utils::PrimeSynchronizer<tier4_perception_msgs::msg::TrafficSignalArray_<std::allocator<void> >, tier4_perception_msgs::msg::TrafficLightRoiArray_<std::allocator<void> >, sensor_msgs::msg::CameraInfo_<std::allocator<void> >, sensor_msgs::msg::PointCloud2_<std::allocator<void> > >::max_delay
_t_’ will be initialized after [-Werror=reorder]                                                                                                                                                                                                                                                                                                                                                                                
  348 |   double max_delay_t_;                                                                                                                                                                                                                                                                                                                                                                                                  
      |          ^~~~~~~~~~~~                                                                                                                                                                                                                                                                                                                                                                                                   
/home/satoshi/pilot-auto/install/perception_utils/include/perception_utils/prime_synchronizer.hpp:344:10: error:   ‘double perception_utils::PrimeSynchronizer<tier4_perception_msgs::msg::TrafficSignalArray_<std::allocator<void> >, tier4_perception_msgs::msg::TrafficLightRoiArray_<std::allocator<void> >, sensor_msgs::msg::CameraInfo_<std::allocator<void> >, sensor_msgs::msg::PointCloud2_<std::allocator<void> > >::
max_wait_t_’ [-Werror=reorder]                                                                                                                                                                                                                                                                                                                                                                                                  
  344 |   double max_wait_t_;                                                                                                                                                                                                                                                                                                                                                                                                   
      |          ^~~~~~~~~~~                                                                                                                                                                                                                                                                                                                                                                                                    
/home/satoshi/pilot-auto/install/perception_utils/include/perception_utils/prime_synchronizer.hpp:72:3: error:   when initialized here [-Werror=reorder]                                                                                                                                                                                                                                                                        
   72 |   PrimeSynchronizer(                                                                                                                                                                                                                                                                                                                                                                                                    
      |   ^~~~~~~~~~~~~~~~~
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Nothing.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
