### PR TITLE
feat(obstacle_avoidance_planner): make MPT's output not std::optional

### DIFF
--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -109,8 +109,9 @@ public:
     const std::shared_ptr<DebugData> debug_data_ptr,
     const std::shared_ptr<TimeKeeper> time_keeper_ptr);
 
-  std::optional<std::vector<TrajectoryPoint>> getModelPredictiveTrajectory(
+  std::vector<TrajectoryPoint> getModelPredictiveTrajectory(
     const PlannerData & planner_data, const std::vector<TrajectoryPoint> & smoothed_points);
+  std::optional<std::vector<TrajectoryPoint>> getPrevMPTTrajectoryPoints() const;
 
   void initialize(const bool enable_debug_info, const TrajectoryParam & traj_param);
   void resetPreviousData();
@@ -237,6 +238,7 @@ private:
   int prev_mat_n_ = 0;
   int prev_mat_m_ = 0;
   std::shared_ptr<std::vector<ReferencePoint>> prev_ref_points_ptr_{nullptr};
+  std::shared_ptr<std::vector<TrajectoryPoint>> prev_mpt_traj_points_ptr_{nullptr};
 
   void updateVehicleCircles();
 

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -109,9 +109,9 @@ public:
     const std::shared_ptr<DebugData> debug_data_ptr,
     const std::shared_ptr<TimeKeeper> time_keeper_ptr);
 
-  std::vector<TrajectoryPoint> getModelPredictiveTrajectory(
+  std::vector<TrajectoryPoint> optimizeTrajectory(
     const PlannerData & planner_data, const std::vector<TrajectoryPoint> & smoothed_points);
-  std::optional<std::vector<TrajectoryPoint>> getPrevMPTTrajectoryPoints() const;
+  std::optional<std::vector<TrajectoryPoint>> getPrevOptimizedTrajectoryPoints() const;
 
   void initialize(const bool enable_debug_info, const TrajectoryParam & traj_param);
   void resetPreviousData();
@@ -238,7 +238,7 @@ private:
   int prev_mat_n_ = 0;
   int prev_mat_m_ = 0;
   std::shared_ptr<std::vector<ReferencePoint>> prev_ref_points_ptr_{nullptr};
-  std::shared_ptr<std::vector<TrajectoryPoint>> prev_mpt_traj_points_ptr_{nullptr};
+  std::shared_ptr<std::vector<TrajectoryPoint>> prev_optimized_traj_points_ptr_{nullptr};
 
   void updateVehicleCircles();
 

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/node.hpp
@@ -78,9 +78,6 @@ protected:  // for the static_centerline_optimizer package
   // variables for subscribers
   Odometry::SharedPtr ego_state_ptr_;
 
-  // variables for previous information
-  std::shared_ptr<std::vector<TrajectoryPoint>> prev_optimized_traj_points_ptr_;
-
   // interface publisher
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub_;
   rclcpp::Publisher<MarkerArray>::SharedPtr virtual_wall_pub_;

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -474,6 +474,7 @@ void MPTOptimizer::initialize(const bool enable_debug_info, const TrajectoryPara
 void MPTOptimizer::resetPreviousData()
 {
   prev_ref_points_ptr_ = nullptr;
+  prev_mpt_traj_points_ptr_ = nullptr;
 }
 
 void MPTOptimizer::onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -483,7 +484,7 @@ void MPTOptimizer::onParam(const std::vector<rclcpp::Parameter> & parameters)
   debug_data_ptr_->mpt_visualize_sampling_num = mpt_param_.mpt_visualize_sampling_num;
 }
 
-std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::getModelPredictiveTrajectory(
+std::vector<TrajectoryPoint> MPTOptimizer::getModelPredictiveTrajectory(
   const PlannerData & planner_data, const std::vector<TrajectoryPoint> & smoothed_points)
 {
   time_keeper_ptr_->tic(__func__);
@@ -491,12 +492,19 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::getModelPredictiveTraj
   const auto & p = planner_data;
   const auto & traj_points = p.traj_points;
 
+  const auto get_prev_mpt_traj_points = [&]() {
+    if (prev_mpt_traj_points_ptr_) {
+      return *prev_mpt_traj_points_ptr_;
+    }
+    return smoothed_points;
+  };
+
   // 1. calculate reference points
   auto ref_points = calcReferencePoints(planner_data, smoothed_points);
   if (ref_points.size() < 2) {
     RCLCPP_INFO_EXPRESSION(
       logger_, enable_debug_info_, "return std::nullopt since ref_points size is less than 2.");
-    return std::nullopt;
+    return get_prev_mpt_traj_points();
   }
 
   // 2. calculate B and W matrices where x = B u + W
@@ -516,14 +524,14 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::getModelPredictiveTraj
   if (!optimized_steer_angles) {
     RCLCPP_INFO_EXPRESSION(
       logger_, enable_debug_info_, "return std::nullopt since could not solve qp");
-    return std::nullopt;
+    return get_prev_mpt_traj_points();
   }
 
   // 7. convert to points with validation
   const auto mpt_traj_points = calcMPTPoints(ref_points, *optimized_steer_angles, mpt_mat);
   if (!mpt_traj_points) {
     RCLCPP_WARN(logger_, "return std::nullopt since lateral or yaw error is too large.");
-    return std::nullopt;
+    return get_prev_mpt_traj_points();
   }
 
   // 8. publish trajectories for debug
@@ -533,8 +541,17 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::getModelPredictiveTraj
 
   debug_data_ptr_->ref_points = ref_points;
   prev_ref_points_ptr_ = std::make_shared<std::vector<ReferencePoint>>(ref_points);
+  prev_mpt_traj_points_ptr_ = std::make_shared<std::vector<TrajectoryPoint>>(*mpt_traj_points);
 
   return *mpt_traj_points;
+}
+
+std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::getPrevMPTTrajectoryPoints() const
+{
+  if (prev_mpt_traj_points_ptr_) {
+    return *prev_mpt_traj_points_ptr_;
+  }
+  return std::nullopt;
 }
 
 std::vector<ReferencePoint> MPTOptimizer::calcReferencePoints(

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -187,8 +187,6 @@ void ObstacleAvoidancePlanner::initializePlanning()
 void ObstacleAvoidancePlanner::resetPreviousData()
 {
   mpt_optimizer_ptr_->resetPreviousData();
-
-  prev_optimized_traj_points_ptr_ = nullptr;
 }
 
 void ObstacleAvoidancePlanner::onPath(const Path::SharedPtr path_ptr)
@@ -337,24 +335,18 @@ std::vector<TrajectoryPoint> ObstacleAvoidancePlanner::optimizeTrajectory(
   //    with model predictive trajectory
   const auto mpt_traj =
     mpt_optimizer_ptr_->getModelPredictiveTrajectory(planner_data, p.traj_points);
-  if (!mpt_traj) {
-    return getPrevOptimizedTrajectory(p.traj_points);
-  }
-
-  // 3. make prev trajectories
-  prev_optimized_traj_points_ptr_ = std::make_shared<std::vector<TrajectoryPoint>>(*mpt_traj);
 
   time_keeper_ptr_->toc(__func__, "    ");
-  return *mpt_traj;
+  return mpt_traj;
 }
 
 std::vector<TrajectoryPoint> ObstacleAvoidancePlanner::getPrevOptimizedTrajectory(
   const std::vector<TrajectoryPoint> & traj_points) const
 {
-  if (prev_optimized_traj_points_ptr_) {
-    return *prev_optimized_traj_points_ptr_;
+  const auto prev_mpt_traj_points = mpt_optimizer_ptr_->getPrevMPTTrajectoryPoints();
+  if (prev_mpt_traj_points) {
+    return *prev_mpt_traj_points;
   }
-
   return traj_points;
 }
 

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -333,8 +333,7 @@ std::vector<TrajectoryPoint> ObstacleAvoidancePlanner::optimizeTrajectory(
 
   // 2. make trajectory kinematically-feasible and collision-free (= inside the drivable area)
   //    with model predictive trajectory
-  const auto mpt_traj =
-    mpt_optimizer_ptr_->getModelPredictiveTrajectory(planner_data, p.traj_points);
+  const auto mpt_traj = mpt_optimizer_ptr_->optimizeTrajectory(planner_data, p.traj_points);
 
   time_keeper_ptr_->toc(__func__, "    ");
   return mpt_traj;
@@ -343,9 +342,9 @@ std::vector<TrajectoryPoint> ObstacleAvoidancePlanner::optimizeTrajectory(
 std::vector<TrajectoryPoint> ObstacleAvoidancePlanner::getPrevOptimizedTrajectory(
   const std::vector<TrajectoryPoint> & traj_points) const
 {
-  const auto prev_mpt_traj_points = mpt_optimizer_ptr_->getPrevMPTTrajectoryPoints();
-  if (prev_mpt_traj_points) {
-    return *prev_mpt_traj_points;
+  const auto prev_optimized_traj_points = mpt_optimizer_ptr_->getPrevOptimizedTrajectoryPoints();
+  if (prev_optimized_traj_points) {
+    return *prev_optimized_traj_points;
   }
   return traj_points;
 }


### PR DESCRIPTION
## Description

In order to easily use optimization path planner in packages other than obstacle_avoidance_planner, this PR makes the output of MPT's output not std::optional by holding the previous optimized result not in the node itself but in the MPT class.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- planning simulator
- scenario simulator (no degradation)
    - https://evaluation.tier4.jp/evaluation/reports/e3283471-b1ad-5aa6-8411-3b60f12930fe?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
