### PR TITLE
feat(path_smoother): make EB's output not std::optional

### DIFF
--- a/planning/path_smoother/include/path_smoother/elastic_band.hpp
+++ b/planning/path_smoother/include/path_smoother/elastic_band.hpp
@@ -103,6 +103,7 @@ private:
   EBParam eb_param_;
   mutable std::shared_ptr<TimeKeeper> time_keeper_ptr_;
   rclcpp::Logger logger_;
+  rclcpp::Clock clock_;
 
   // publisher
   rclcpp::Publisher<Trajectory>::SharedPtr debug_eb_traj_pub_;

--- a/planning/path_smoother/include/path_smoother/elastic_band.hpp
+++ b/planning/path_smoother/include/path_smoother/elastic_band.hpp
@@ -36,8 +36,8 @@ public:
     rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
     const CommonParam & common_param, const std::shared_ptr<TimeKeeper> time_keeper_ptr);
 
-  std::optional<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>> getEBTrajectory(
-    const PlannerData & planner_data);
+  std::vector<TrajectoryPoint> smoothTrajectory(
+    const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & ego_pose);
 
   void initialize(const bool enable_debug_info, const CommonParam & common_param);
   void resetPreviousData();
@@ -118,13 +118,12 @@ private:
     const std::vector<TrajectoryPoint> & traj_points) const;
 
   void updateConstraint(
-    const std_msgs::msg::Header & header, const std::vector<TrajectoryPoint> & traj_points,
-    const bool is_goal_contained, const int pad_start_idx);
+    const std::vector<TrajectoryPoint> & traj_points, const bool is_goal_contained,
+    const int pad_start_idx);
 
-  std::optional<std::vector<double>> optimizeTrajectory();
+  std::optional<std::vector<double>> calcSmoothedTrajectory();
 
-  std::optional<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>
-  convertOptimizedPointsToTrajectory(
+  std::optional<std::vector<TrajectoryPoint>> convertOptimizedPointsToTrajectory(
     const std::vector<double> & optimized_points, const std::vector<TrajectoryPoint> & traj_points,
     const int pad_start_idx) const;
 };

--- a/planning/path_smoother/include/path_smoother/elastic_band_smoother.hpp
+++ b/planning/path_smoother/include/path_smoother/elastic_band_smoother.hpp
@@ -96,23 +96,13 @@ protected:
 
   // main functions
   bool isDataReady(const Path & path, rclcpp::Clock clock) const;
-  PlannerData createPlannerData(const Path & path) const;
-  std::vector<TrajectoryPoint> generateOptimizedTrajectory(const PlannerData & planner_data);
-  std::vector<TrajectoryPoint> extendTrajectory(
-    const std::vector<TrajectoryPoint> & traj_points,
-    const std::vector<TrajectoryPoint> & optimized_points) const;
-
-  // functions in generateOptimizedTrajectory
-  std::vector<TrajectoryPoint> optimizeTrajectory(const PlannerData & planner_data);
-  std::vector<TrajectoryPoint> getPrevOptimizedTrajectory(
-    const std::vector<TrajectoryPoint> & traj_points) const;
   void applyInputVelocity(
     std::vector<TrajectoryPoint> & output_traj_points,
     const std::vector<TrajectoryPoint> & input_traj_points,
     const geometry_msgs::msg::Pose & ego_pose) const;
-  void insertZeroVelocityOutsideDrivableArea(
-    const PlannerData & planner_data, std::vector<TrajectoryPoint> & traj_points) const;
-  void publishVirtualWall(const geometry_msgs::msg::Pose & stop_pose) const;
+  std::vector<TrajectoryPoint> extendTrajectory(
+    const std::vector<TrajectoryPoint> & traj_points,
+    const std::vector<TrajectoryPoint> & optimized_points) const;
 };
 }  // namespace path_smoother
 

--- a/planning/path_smoother/src/elastic_band.cpp
+++ b/planning/path_smoother/src/elastic_band.cpp
@@ -68,6 +68,13 @@ std::vector<double> toStdVector(const Eigen::VectorXd & eigen_vec)
 {
   return {eigen_vec.data(), eigen_vec.data() + eigen_vec.rows()};
 }
+
+std_msgs::msg::Header createHeader()
+{
+  std_msgs::msg::Header header;
+  header.frame_id = "map";
+  return header;
+}
 }  // namespace
 
 namespace path_smoother
@@ -179,25 +186,30 @@ void EBPathSmoother::resetPreviousData()
   prev_eb_traj_points_ptr_ = nullptr;
 }
 
-std::optional<std::vector<autoware_auto_planning_msgs::msg::TrajectoryPoint>>
-EBPathSmoother::getEBTrajectory(const PlannerData & planner_data)
+std::vector<TrajectoryPoint> EBPathSmoother::smoothTrajectory(
+  const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & ego_pose)
 {
   time_keeper_ptr_->tic(__func__);
 
-  const auto & p = planner_data;
+  const auto get_prev_eb_traj_points = [&]() {
+    if (prev_eb_traj_points_ptr_) {
+      return *prev_eb_traj_points_ptr_;
+    }
+    return traj_points;
+  };
 
   // 1. crop trajectory
   const double forward_traj_length = eb_param_.num_points * eb_param_.delta_arc_length;
   const double backward_traj_length = common_param_.output_backward_traj_length;
 
   const size_t ego_seg_idx =
-    trajectory_utils::findEgoSegmentIndex(p.traj_points, p.ego_pose, ego_nearest_param_);
+    trajectory_utils::findEgoSegmentIndex(traj_points, ego_pose, ego_nearest_param_);
   const auto cropped_traj_points = motion_utils::cropPoints(
-    p.traj_points, p.ego_pose.position, ego_seg_idx, forward_traj_length, backward_traj_length);
+    traj_points, ego_pose.position, ego_seg_idx, forward_traj_length, backward_traj_length);
 
   // check if goal is contained in cropped_traj_points
   const bool is_goal_contained =
-    geometry_utils::isSamePoint(cropped_traj_points.back(), planner_data.traj_points.back());
+    geometry_utils::isSamePoint(cropped_traj_points.back(), traj_points.back());
 
   // 2. insert fixed point
   // NOTE: This should be after cropping trajectory so that fixed point will not be cropped.
@@ -221,14 +233,14 @@ EBPathSmoother::getEBTrajectory(const PlannerData & planner_data)
   const auto [padded_traj_points, pad_start_idx] = getPaddedTrajectoryPoints(resampled_traj_points);
 
   // 5. update constraint for elastic band's QP
-  updateConstraint(p.header, padded_traj_points, is_goal_contained, pad_start_idx);
+  updateConstraint(padded_traj_points, is_goal_contained, pad_start_idx);
 
   // 6. get optimization result
-  const auto optimized_points = optimizeTrajectory();
+  const auto optimized_points = calcSmoothedTrajectory();
   if (!optimized_points) {
     RCLCPP_INFO_EXPRESSION(
       logger_, enable_debug_info_, "return std::nullopt since smoothing failed");
-    return std::nullopt;
+    return get_prev_eb_traj_points();
   }
 
   // 7. convert optimization result to trajectory
@@ -236,13 +248,13 @@ EBPathSmoother::getEBTrajectory(const PlannerData & planner_data)
     convertOptimizedPointsToTrajectory(*optimized_points, padded_traj_points, pad_start_idx);
   if (!eb_traj_points) {
     RCLCPP_WARN(logger_, "return std::nullopt since x or y error is too large");
-    return std::nullopt;
+    return get_prev_eb_traj_points();
   }
 
   prev_eb_traj_points_ptr_ = std::make_shared<std::vector<TrajectoryPoint>>(*eb_traj_points);
 
   // 8. publish eb trajectory
-  const auto eb_traj = trajectory_utils::createTrajectory(p.header, *eb_traj_points);
+  const auto eb_traj = trajectory_utils::createTrajectory(createHeader(), *eb_traj_points);
   debug_eb_traj_pub_->publish(eb_traj);
 
   time_keeper_ptr_->toc(__func__, "      ");
@@ -287,8 +299,8 @@ std::tuple<std::vector<TrajectoryPoint>, size_t> EBPathSmoother::getPaddedTrajec
 }
 
 void EBPathSmoother::updateConstraint(
-  const std_msgs::msg::Header & header, const std::vector<TrajectoryPoint> & traj_points,
-  const bool is_goal_contained, const int pad_start_idx)
+  const std::vector<TrajectoryPoint> & traj_points, const bool is_goal_contained,
+  const int pad_start_idx)
 {
   time_keeper_ptr_->tic(__func__);
 
@@ -365,13 +377,14 @@ void EBPathSmoother::updateConstraint(
   }
 
   // publish fixed trajectory
-  const auto eb_fixed_traj = trajectory_utils::createTrajectory(header, debug_fixed_traj_points);
+  const auto eb_fixed_traj =
+    trajectory_utils::createTrajectory(createHeader(), debug_fixed_traj_points);
   debug_eb_fixed_traj_pub_->publish(eb_fixed_traj);
 
   time_keeper_ptr_->toc(__func__, "        ");
 }
 
-std::optional<std::vector<double>> EBPathSmoother::optimizeTrajectory()
+std::optional<std::vector<double>> EBPathSmoother::calcSmoothedTrajectory()
 {
   time_keeper_ptr_->tic(__func__);
 


### PR DESCRIPTION
## Description

- In order to easily use optimization path smoother in packages other than path_planner,
    - make EB's output not std::optional by holding the previous optimized result not in the node itself but in the EB class.
    - remove PlannerData struct
- minor refactoring

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- planning simulator
- scenario simulator (no degradation)
    - https://evaluation.tier4.jp/evaluation/reports/e3283471-b1ad-5aa6-8411-3b60f12930fe?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
