### PR TITLE
feat(behavior_path_planner): output drivable lanes marker

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -296,6 +296,8 @@ public:
 
   MarkerArray getDebugMarkers() const { return debug_marker_; }
 
+  MarkerArray getDrivableLanesMarkers() const { return drivable_lanes_marker_; }
+
   virtual MarkerArray getModuleVirtualWall() { return MarkerArray(); }
 
   ModuleStatus getCurrentStatus() const { return current_state_; }
@@ -341,6 +343,12 @@ public:
     stop_pose_ = boost::none;
     slow_pose_ = boost::none;
     dead_pose_ = boost::none;
+  }
+
+  void setDrivableLanes(const std::vector<DrivableLanes> & drivable_lanes)
+  {
+    drivable_lanes_marker_ =
+      marker_utils::createDrivableLanesMarkerArray(drivable_lanes, "drivable_lanes");
   }
 
   rclcpp::Logger getLogger() const { return logger_; }
@@ -496,6 +504,8 @@ protected:
   mutable MarkerArray info_marker_;
 
   mutable MarkerArray debug_marker_;
+
+  mutable MarkerArray drivable_lanes_marker_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -68,6 +68,7 @@ public:
     pub_info_marker_ = node->create_publisher<MarkerArray>("~/info/" + name, 20);
     pub_debug_marker_ = node->create_publisher<MarkerArray>("~/debug/" + name, 20);
     pub_virtual_wall_ = node->create_publisher<MarkerArray>("~/virtual_wall/" + name, 20);
+    pub_drivable_lanes_ = node->create_publisher<MarkerArray>("~/drivable_lanes/" + name, 20);
   }
 
   virtual ~SceneModuleManagerInterface() = default;
@@ -170,6 +171,7 @@ public:
 
     MarkerArray info_markers{};
     MarkerArray debug_markers{};
+    MarkerArray drivable_lanes_markers{};
 
     const auto marker_offset = std::numeric_limits<uint8_t>::max();
 
@@ -185,16 +187,23 @@ public:
         debug_markers.markers.push_back(marker);
       }
 
+      for (auto & marker : m->getDrivableLanesMarkers().markers) {
+        marker.id += marker_id;
+        drivable_lanes_markers.markers.push_back(marker);
+      }
+
       marker_id += marker_offset;
     }
 
     if (registered_modules_.empty() && idling_module_ptr_ != nullptr) {
       appendMarkerArray(idling_module_ptr_->getInfoMarkers(), &info_markers);
       appendMarkerArray(idling_module_ptr_->getDebugMarkers(), &debug_markers);
+      appendMarkerArray(idling_module_ptr_->getDrivableLanesMarkers(), &drivable_lanes_markers);
     }
 
     pub_info_marker_->publish(info_markers);
     pub_debug_marker_->publish(debug_markers);
+    pub_drivable_lanes_->publish(drivable_lanes_markers);
   }
 
   bool exist(const SceneModulePtr & module_ptr) const
@@ -270,6 +279,8 @@ protected:
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_debug_marker_;
 
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_virtual_wall_;
+
+  rclcpp::Publisher<MarkerArray>::SharedPtr pub_drivable_lanes_;
 
   std::string name_;
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2512,6 +2512,7 @@ BehaviorModuleOutput AvoidanceModule::plan()
 
   // Drivable area generation.
   generateExtendedDrivableArea(output);
+  setDrivableLanes(output.drivable_area_info.drivable_lanes);
 
   updateRegisteredRTCStatus(spline_shift_path.path);
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7654cbb</samp>

This pull request adds a new feature to the behavior path planner that allows it to represent and publish the drivable lanes in each scene module using marker arrays. The `SceneModuleInterface` and `SceneModuleManagerInterface` classes are modified to support this feature, and the `AvoidanceModule` class is updated to use it. This feature can improve the visualization and debugging of the behavior path planner.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/f32aeeb5-e802-4d7d-8083-b938ab07e0a4)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
