### PR TITLE
feat(obstacle_cruise_planner): single slow down virtual wall

### DIFF
--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/common_structs.hpp
@@ -217,6 +217,7 @@ struct DebugData
   std::vector<StopObstacle> obstacles_to_stop;
   std::vector<CruiseObstacle> obstacles_to_cruise;
   std::vector<SlowDownObstacle> obstacles_to_slow_down;
+  MarkerArray slow_down_debug_wall_marker;
   MarkerArray stop_wall_marker;
   MarkerArray cruise_wall_marker;
   MarkerArray slow_down_wall_marker;

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -1342,6 +1342,10 @@ void ObstacleCruisePlannerNode::publishDebugMarker() const
     debug_marker.markers.push_back(marker);
   }
 
+  // slow down debug wall marker
+  tier4_autoware_utils::appendMarkerArray(
+    debug_data_ptr_->slow_down_debug_wall_marker, &debug_marker);
+
   debug_marker_pub_->publish(debug_marker);
 
   // 2. publish virtual wall for cruise and stop

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -411,17 +411,6 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
     }
     return std::nullopt;
   };
-  const auto add_slow_down_marker =
-    [&](const size_t obstacle_idx, const auto slow_down_traj_idx, const bool is_start) {
-      if (!slow_down_traj_idx) return;
-
-      const int id = obstacle_idx * 2 + (is_start ? 0 : 1);
-      const auto text = is_start ? "obstacle slow down start" : "obstacle slow down end";
-      const auto pose = slow_down_traj_points.at(*slow_down_traj_idx).pose;
-      const auto markers = motion_utils::createSlowDownVirtualWallMarker(
-        pose, text, planner_data.current_time, id, abs_ego_offset);
-      tier4_autoware_utils::appendMarkerArray(markers, &debug_data_ptr_->slow_down_wall_marker);
-    };
 
   std::vector<SlowDownOutput> new_prev_slow_down_output;
   for (size_t i = 0; i < obstacles.size(); ++i) {
@@ -433,7 +422,7 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
       planner_data, slow_down_traj_points, obstacle, prev_output, dist_to_ego);
     if (!dist_vec_to_slow_down) {
       RCLCPP_INFO_EXPRESSION(
-        rclcpp::get_logger("ObstacleCruisePlanner::Plannerinterface"), enable_debug_info_,
+        rclcpp::get_logger("ObstacleCruisePlanner::PlannerInterface"), enable_debug_info_,
         "[SlowDown] Ignore obstacle (%s) since distance to slow down is not valid",
         obstacle.uuid.c_str());
       continue;
@@ -495,14 +484,20 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
     }
 
     // add debug virtual wall
-    /*
     if (slow_down_start_idx) {
-      add_slow_down_marker(i, slow_down_start_idx, true);
+      const auto markers = motion_utils::createSlowDownVirtualWallMarker(
+        slow_down_traj_points.at(*slow_down_start_idx).pose, "obstacle slow down start",
+        planner_data.current_time, i * 2, abs_ego_offset);
+      tier4_autoware_utils::appendMarkerArray(
+        markers, &debug_data_ptr_->slow_down_debug_wall_marker);
     }
     if (slow_down_end_idx) {
-      add_slow_down_marker(i, slow_down_end_idx, false);
+      const auto markers = motion_utils::createSlowDownVirtualWallMarker(
+        slow_down_traj_points.at(*slow_down_end_idx).pose, "obstacle slow down end",
+        planner_data.current_time, i * 2 + 1, abs_ego_offset);
+      tier4_autoware_utils::appendMarkerArray(
+        markers, &debug_data_ptr_->slow_down_debug_wall_marker);
     }
-    */
 
     debug_data_ptr_->obstacles_to_slow_down.push_back(obstacle);
 


### PR DESCRIPTION
## Description

Without this PR, the start/end virtual walls are visualized for slow down, which becomes messy with a lot of obstacles.
This PR makes the slow down virtual wall single as follows.

**Before this PR**
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/cc3df50f-f74f-4e9f-ab91-377c07cd6c79)

**After this PR**
Before reaching the slow down start position, the virtual wall is visualized at the slow down start position.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/0791c621-d219-4479-99f9-3692c2912f56)
While planning slow down, the virtual wall is visualized at the front of the ego position.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/8d3e4035-32c2-468e-a283-154d8e00abf5)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
