### PR TITLE
fix(euclidean_cluster): add disuse downsample in clustering pipeline

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -22,6 +22,7 @@
   <arg name="image_number" default="1" description="choose image raw number(1-8)"/>
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
+  <arg name="use_downsample_pointcloud" default="true" description="use use downsample pointcloud in perception"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg name="use_pointcloud_container" default="false" description="use pointcloud container for detection preprocessor"/>
   <arg name="container_name" default="pointcloud_container"/>
@@ -65,6 +66,7 @@
         <arg name="input_pointcloud" value="$(var clustering/input/pointcloud)"/>
         <arg name="output_clusters" value="clusters"/>
         <arg name="use_pointcloud_map" value="false"/>
+        <arg name="use_downsample_pointcloud" value="$(var use_downsample_pointcloud)"/>
       </include>
     </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -22,7 +22,7 @@
   <arg name="image_number" default="1" description="choose image raw number(1-8)"/>
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
-  <arg name="use_downsample_pointcloud" default="true" description="use use downsample pointcloud in perception"/>
+  <arg name="use_downsample_pointcloud" default="true" description="use downsample pointcloud in perception"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg name="use_pointcloud_container" default="false" description="use pointcloud container for detection preprocessor"/>
   <arg name="container_name" default="pointcloud_container"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
@@ -4,7 +4,7 @@
   <arg name="input/pointcloud"/>
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `clustering`"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
-  <arg name="use_downsample_pointcloud" default="true" description="use use downsample pointcloud in perception"/>
+  <arg name="use_downsample_pointcloud" default="true" description="use downsample pointcloud in perception"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg name="use_pointcloud_container" default="false" description="use pointcloud container for detection preprocessor"/>
   <arg name="container_name" default="pointcloud_container"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
@@ -4,6 +4,7 @@
   <arg name="input/pointcloud"/>
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `clustering`"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
+  <arg name="use_downsample_pointcloud" default="true" description="use use downsample pointcloud in perception"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg name="use_pointcloud_container" default="false" description="use pointcloud container for detection preprocessor"/>
   <arg name="container_name" default="pointcloud_container"/>
@@ -56,6 +57,7 @@
       <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
       <arg name="container_name" value="$(var container_name)"/>
       <arg name="score_threshold" value="$(var score_threshold)"/>
+      <arg name="use_downsample_pointcloud" value="$(var use_downsample_pointcloud)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -5,7 +5,7 @@
   <arg name="output/objects" default="objects"/>
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `clustering`"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
-  <arg name="use_downsample_pointcloud" default="true" description="use use downsample pointcloud in perception"/>
+  <arg name="use_downsample_pointcloud" default="true" description="use downsample pointcloud in perception"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg name="use_pointcloud_container" default="false" description="use pointcloud container for detection preprocessor"/>
   <arg name="container_name" default="pointcloud_container"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -5,6 +5,7 @@
   <arg name="output/objects" default="objects"/>
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `clustering`"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
+  <arg name="use_downsample_pointcloud" default="true" description="use use downsample pointcloud in perception"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg name="use_pointcloud_container" default="false" description="use pointcloud container for detection preprocessor"/>
   <arg name="container_name" default="pointcloud_container"/>
@@ -33,6 +34,7 @@
         <arg name="input_pointcloud" value="$(var clustering/input/pointcloud)"/>
         <arg name="output_clusters" value="clusters"/>
         <arg name="use_pointcloud_map" value="false"/>
+        <arg name="use_downsample_pointcloud" value="$(var use_downsample_pointcloud)"/>
       </include>
     </group>
 

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -48,6 +48,7 @@
   <arg name="object_recognition_detection_fusion_sync_param_path" description="you need change the size of 'input_offset_ms' in the file in this path when you want to change image_number"/>
   <arg name="use_vector_map" default="true" description="use vector map in prediction"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
+  <arg name="use_downsample_pointcloud" default="false" description="use use downsample pointcloud in perception"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg
     name="use_empty_dynamic_object_publisher"
@@ -134,6 +135,7 @@
           <arg name="voxel_grid_param_path" value="$(var object_recognition_detection_voxel_grid_based_euclidean_param_path)"/>
           <arg name="voxel_grid_based_euclidean_param_path" value="$(var object_recognition_detection_voxel_grid_based_euclidean_cluster_param_path)"/>
           <arg name="use_pointcloud_map" value="$(var use_pointcloud_map)"/>
+          <arg name="use_downsample_pointcloud" value="$(var use_downsample_pointcloud)"/>
           <arg name="use_object_filter" value="$(var use_object_filter)"/>
           <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
           <arg name="container_name" value="$(var pointcloud_container_name)"/>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -48,7 +48,7 @@
   <arg name="object_recognition_detection_fusion_sync_param_path" description="you need change the size of 'input_offset_ms' in the file in this path when you want to change image_number"/>
   <arg name="use_vector_map" default="true" description="use vector map in prediction"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
-  <arg name="use_downsample_pointcloud" default="false" description="use use downsample pointcloud in perception"/>
+  <arg name="use_downsample_pointcloud" default="false" description="use downsample pointcloud in perception"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg
     name="use_empty_dynamic_object_publisher"

--- a/perception/euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.xml
+++ b/perception/euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.xml
@@ -4,6 +4,7 @@
   <arg name="input_map" default="/map/pointcloud_map"/>
   <arg name="output_clusters" default="clusters"/>
   <arg name="use_pointcloud_map" default="false"/>
+  <arg name="use_downsample_pointcloud" default="false"/>
   <arg name="voxel_grid_param_path" default="$(find-pkg-share euclidean_cluster)/config/voxel_grid.param.yaml"/>
   <arg name="compare_map_param_path" default="$(find-pkg-share euclidean_cluster)/config/compare_map.param.yaml"/>
   <arg name="outlier_param_path" default="$(find-pkg-share euclidean_cluster)/config/outlier.param.yaml"/>
@@ -14,6 +15,7 @@
     <arg name="input_map" value="$(var input_map)"/>
     <arg name="output_clusters" value="$(var output_clusters)"/>
     <arg name="use_pointcloud_map" value="$(var use_pointcloud_map)"/>
+    <arg name="use_downsample_pointcloud" value="$(var use_downsample_pointcloud)"/>
     <arg name="voxel_grid_param_path" value="$(var voxel_grid_param_path)"/>
     <arg name="compare_map_param_path" value="$(var compare_map_param_path)"/>
     <arg name="outlier_param_path" value="$(var outlier_param_path)"/>


### PR DESCRIPTION
## Description

This PR to add option of unuse downsampling pointcloud to improve density of Euclidean Cluter (EC) input pointcloud. 
In the result, small object detection perfomance could be improved. 

| Pipeline before update | Pipeline after update|
| --- | --- |
|![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/a18fe328-7fec-49b5-b379-0a025366e556)|![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/45f20731-7b15-4908-b9fc-306eb53f3747)|

## Related links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-3051)

## Tests performed

In spire of number of pointcloud input into Euclidean Cluster is increased, the simplified pipeline after change shows no increase of delay time between Ground_segmentation node and Euclidean Cluster node. The result was confirmed by logging_simulator.

| Before update | After update |
| -- | ---|
| pilot-auto, sample rosbag | |
| Topics delay compared with header stamp| Topics delay compared with header stamp|
| ![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/13992fa6-be55-4b1c-855c-347f796bf38f)|![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/1d13a75b-ad62-4b55-abe8-1332750d5cf5)|
| Delay time between EC and Ground_segmentation| Delay time between EC and Ground_segmentation |
|![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/45d5bc05-a0a3-427e-bb00-1630e7d34913)|![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/eebf541b-1e24-40b9-8d9c-26264b8bc279)|
| Internal rosbag | |
| Topics delay compared with header stamp|Topics delay compared with header stamp|
| ![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/9280721f-55dd-4710-b51b-c7aa0763c1f1)| ![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/fa30ef41-ea9c-4595-b171-03ca29ee1a65)|
| Delay time between EC and Ground_segmentation|  Delay time between EC and Ground_segmentation|
|![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/04087924-ae8e-4abc-97a2-97e6d9208b7c)| ![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/db60f4a7-a8af-48a9-96b1-48006042a27c)|



## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
