### PR TITLE
fix(dynamic_avoidance): avoid cut-in object close to the ego

### DIFF
--- a/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -22,6 +22,10 @@
         min_obj_lat_offset_to_ego_path: 0.0 # [m]
         max_obj_lat_offset_to_ego_path: 1.0 # [m]
 
+        cut_in_object:
+          min_time_to_start_cut_in: 1.0 # [s]
+          min_lon_offset_ego_to_object: 0.0 # [m]
+
         crossing_object:
           min_object_vel: 1.0
           max_object_angle: 1.05

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -55,6 +55,7 @@ struct DynamicAvoidanceParameters
   double min_obj_lat_offset_to_ego_path{0.0};
   double max_obj_lat_offset_to_ego_path{0.0};
 
+  double min_time_to_start_cut_in{0.0};
   double min_lon_offset_ego_to_cut_in_object{0.0};
   double max_front_object_angle{0.0};
   double min_crossing_object_vel{0.0};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -55,6 +55,7 @@ struct DynamicAvoidanceParameters
   double min_obj_lat_offset_to_ego_path{0.0};
   double max_obj_lat_offset_to_ego_path{0.0};
 
+  double min_lon_offset_ego_to_cut_in_object{0.0};
   double max_front_object_angle{0.0};
   double min_crossing_object_vel{0.0};
   double max_crossing_object_angle{0.0};
@@ -145,11 +146,20 @@ public:
   }
 
 private:
+  struct LatLonOffset
+  {
+    const size_t nearest_idx;
+    const double max_lat_offset;
+    const double min_lat_offset;
+    const double max_lon_offset;
+    const double min_lon_offset;
+  };
+
   bool isLabelTargetObstacle(const uint8_t label) const;
   std::vector<DynamicAvoidanceObjectCandidate> calcTargetObjectsCandidate();
   bool willObjectCutIn(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
-    const double obj_tangent_vel) const;
+    const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const;
   bool willObjectCutOut(
     const double obj_tangent_vel, const double obj_normal_vel, const bool is_left) const;
   bool isObjectFarFromPath(
@@ -159,6 +169,8 @@ private:
     const double obj_tangent_vel) const;
   std::optional<std::pair<size_t, size_t>> calcCollisionSection(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & obj_path) const;
+  LatLonOffset getLateralLongitudinalOffset(
+    const std::vector<PathPointWithLaneId> & ego_path, const PredictedObject & object) const;
 
   std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> getAdjacentLanes(
     const double forward_distance, const double backward_distance) const;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -529,11 +529,15 @@ bool DynamicAvoidanceModule::willObjectCutIn(
 
   // Ignore object close to the ego
   const size_t ego_seg_idx = planner_data_->findEgoSegmentIndex(ego_path);
+  const double relative_velocity = getEgoSpeed() - obj_tangent_vel;
   const double lon_offset_ego_to_obj =
     motion_utils::calcSignedArcLength(
       ego_path, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx) +
     lat_lon_offset.min_lon_offset;
-  if (lon_offset_ego_to_obj < parameters_->min_lon_offset_ego_to_cut_in_object) {
+  if (
+    lon_offset_ego_to_obj < std::max(
+                              parameters_->min_lon_offset_ego_to_cut_in_object,
+                              relative_velocity * parameters_->min_time_to_start_cut_in)) {
     return false;
   }
 

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -399,10 +399,12 @@ DynamicAvoidanceModule::calcTargetObjectsCandidate()
     // TODO(murooka) use obj_path.back() instead of obj_pose for the case where the object crosses
     // the ego's path
     const bool is_left = isLeft(prev_module_path->points, obj_path.path.back().position);
+    const auto lat_lon_offset =
+      getLateralLongitudinalOffset(prev_module_path->points, predicted_object);
 
     // 6. check if object will not cut in or cut out
     const bool will_object_cut_in =
-      willObjectCutIn(prev_module_path->points, obj_path, obj_tangent_vel);
+      willObjectCutIn(prev_module_path->points, obj_path, obj_tangent_vel, lat_lon_offset);
     const bool will_object_cut_out = willObjectCutOut(obj_tangent_vel, obj_normal_vel, is_left);
     if (will_object_cut_in) {
       RCLCPP_INFO_EXPRESSION(
@@ -516,12 +518,22 @@ bool DynamicAvoidanceModule::isObjectFarFromPath(
 
 bool DynamicAvoidanceModule::willObjectCutIn(
   const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
-  const double obj_tangent_vel) const
+  const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const
 {
   constexpr double epsilon_path_lat_diff = 0.3;
 
   // Ignore oncoming object
   if (obj_tangent_vel < 0) {
+    return false;
+  }
+
+  // Ignore object close to the ego
+  const size_t ego_seg_idx = planner_data_->findEgoSegmentIndex(ego_path);
+  const double lon_offset_ego_to_obj =
+    motion_utils::calcSignedArcLength(
+      ego_path, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx) +
+    lat_lon_offset.min_lon_offset;
+  if (lon_offset_ego_to_obj < parameters_->min_lon_offset_ego_to_cut_in_object) {
     return false;
   }
 
@@ -594,6 +606,41 @@ std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> DynamicAvoidanceModule
   }
 
   return std::make_pair(right_lanes, left_lanes);
+}
+
+DynamicAvoidanceModule::LatLonOffset DynamicAvoidanceModule::getLateralLongitudinalOffset(
+  const std::vector<PathPointWithLaneId> & ego_path, const PredictedObject & object) const
+{
+  const auto & obj_pose = object.kinematics.initial_pose_with_covariance.pose;
+
+  const size_t obj_seg_idx = motion_utils::findNearestSegmentIndex(ego_path, obj_pose.position);
+  const auto obj_points = tier4_autoware_utils::toPolygon2d(obj_pose, object.shape);
+
+  // TODO(murooka) calculation is not so accurate.
+  std::vector<double> obj_lat_offset_vec;
+  std::vector<double> obj_lon_offset_vec;
+  for (size_t i = 0; i < obj_points.outer().size(); ++i) {
+    const auto geom_obj_point = toGeometryPoint(obj_points.outer().at(i));
+    const size_t obj_point_seg_idx =
+      motion_utils::findNearestSegmentIndex(ego_path, geom_obj_point);
+
+    // calculate lateral offset
+    const double obj_point_lat_offset =
+      motion_utils::calcLateralOffset(ego_path, geom_obj_point, obj_point_seg_idx);
+    obj_lat_offset_vec.push_back(obj_point_lat_offset);
+
+    // calculate longitudinal offset
+    const double lon_offset =
+      motion_utils::calcLongitudinalOffsetToSegment(ego_path, obj_seg_idx, geom_obj_point);
+    obj_lon_offset_vec.push_back(lon_offset);
+  }
+
+  const auto obj_lat_min_max_offset = getMinMaxValues(obj_lat_offset_vec);
+  const auto obj_lon_min_max_offset = getMinMaxValues(obj_lon_offset_vec);
+
+  return LatLonOffset{
+    obj_seg_idx, obj_lat_min_max_offset.second, obj_lat_min_max_offset.first,
+    obj_lon_min_max_offset.second, obj_lon_min_max_offset.first};
 }
 
 // NOTE: object does not have const only to update min_bound_lat_offset.

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -53,6 +53,9 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
     p.max_obj_lat_offset_to_ego_path =
       node->declare_parameter<double>(ns + "max_obj_lat_offset_to_ego_path");
 
+    p.min_lon_offset_ego_to_cut_in_object =
+      node->declare_parameter<double>(ns + "cut_in_object.min_lon_offset_ego_to_object");
+
     p.max_front_object_angle =
       node->declare_parameter<double>(ns + "front_object.max_object_angle");
 
@@ -120,6 +123,10 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
       parameters, ns + "min_obj_lat_offset_to_ego_path", p->min_obj_lat_offset_to_ego_path);
     updateParam<double>(
       parameters, ns + "max_obj_lat_offset_to_ego_path", p->max_obj_lat_offset_to_ego_path);
+
+    updateParam<double>(
+      parameters, ns + "cut_in_object.min_lon_offset_ego_to_object",
+      p->min_lon_offset_ego_to_cut_in_object);
 
     updateParam<double>(
       parameters, ns + "front_object.max_object_angle", p->max_front_object_angle);

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -53,6 +53,8 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
     p.max_obj_lat_offset_to_ego_path =
       node->declare_parameter<double>(ns + "max_obj_lat_offset_to_ego_path");
 
+    p.min_time_to_start_cut_in =
+      node->declare_parameter<double>(ns + "cut_in_object.min_time_to_start_cut_in");
     p.min_lon_offset_ego_to_cut_in_object =
       node->declare_parameter<double>(ns + "cut_in_object.min_lon_offset_ego_to_object");
 
@@ -124,6 +126,8 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
     updateParam<double>(
       parameters, ns + "max_obj_lat_offset_to_ego_path", p->max_obj_lat_offset_to_ego_path);
 
+    updateParam<double>(
+      parameters, ns + "cut_in_object.min_time_to_start_cut_in", p->min_time_to_start_cut_in);
     updateParam<double>(
       parameters, ns + "cut_in_object.min_lon_offset_ego_to_object",
       p->min_lon_offset_ego_to_cut_in_object);


### PR DESCRIPTION
## Description

Depends on https://github.com/autowarefoundation/autoware.universe/pull/4390
Avoid cut-in objects if they are close to the ego.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
