### PR TITLE
refactor(behavior_path_planner): clean up interface

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -51,7 +51,6 @@ public:
     const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map);
 
   ModuleStatus updateState() override;
-  ModuleStatus getNodeStatusWhileWaitingApproval() const override { return ModuleStatus::SUCCESS; }
   CandidateOutput planCandidate() const override;
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -132,7 +132,6 @@ public:
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
   ModuleStatus updateState() override;
-  ModuleStatus getNodeStatusWhileWaitingApproval() const override { return ModuleStatus::SUCCESS; }
   BehaviorModuleOutput plan() override;
   CandidateOutput planCandidate() const override;
   BehaviorModuleOutput planWaitingApproval() override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
@@ -101,7 +101,6 @@ public:
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
   ModuleStatus updateState() override;
-  ModuleStatus getNodeStatusWhileWaitingApproval() const override { return ModuleStatus::SUCCESS; }
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   void processOnEntry() override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -129,8 +129,8 @@ public:
     // for new architecture
     const auto lanes = utils::getLaneletsFromPath(*out.path, planner_data_->route_handler);
     const auto drivable_lanes = utils::generateDrivableLanes(lanes);
-    out.drivable_area_info.drivable_lanes =
-      getNonOverlappingExpandedLanes(*out.path, drivable_lanes);
+    out.drivable_area_info.drivable_lanes = utils::getNonOverlappingExpandedLanes(
+      *out.path, drivable_lanes, planner_data_->drivable_area_expansion_parameters);
 
     return out;
   }
@@ -437,18 +437,6 @@ protected:
   double getEgoSpeed() const
   {
     return std::abs(planner_data_->self_odometry->twist.twist.linear.x);
-  }
-
-  std::vector<DrivableLanes> getNonOverlappingExpandedLanes(
-    PathWithLaneId & path, const std::vector<DrivableLanes> & lanes) const
-  {
-    const auto & dp = planner_data_->drivable_area_expansion_parameters;
-
-    const auto shorten_lanes = utils::cutOverlappedLanes(path, lanes);
-    const auto expanded_lanes = utils::expandLanelets(
-      shorten_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
-      dp.drivable_area_types_to_skip);
-    return expanded_lanes;
   }
 
   bool is_simultaneously_executable_as_approved_module_{false};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -101,12 +101,6 @@ public:
   virtual void updateCurrentState() { current_state_ = updateState(); }
 
   /**
-   * @brief If the module plan customized reference path while waiting approval, it should output
-   * SUCCESS. Otherwise, it should output FAILURE to check execution request of next module.
-   */
-  virtual ModuleStatus getNodeStatusWhileWaitingApproval() const { return ModuleStatus::FAILURE; }
-
-  /**
    * @brief Return true if the module has request for execution (not necessarily feasible)
    */
   virtual bool isExecutionRequested() const = 0;
@@ -381,21 +375,6 @@ private:
   BehaviorModuleOutput previous_module_output_;
 
 protected:
-  // TODO(murooka) Remove this function when BT-based architecture will be removed
-  std::unordered_map<std::string, std::shared_ptr<RTCInterface>> createRTCInterfaceMap(
-    rclcpp::Node & node, const std::string & name, const std::vector<std::string> & rtc_types)
-  {
-    std::unordered_map<std::string, std::shared_ptr<RTCInterface>> rtc_interface_ptr_map;
-    for (const auto & rtc_type : rtc_types) {
-      const auto snake_case_name = utils::convertToSnakeCase(name);
-      const auto rtc_interface_name =
-        rtc_type.empty() ? snake_case_name : (snake_case_name + "_" + rtc_type);
-      rtc_interface_ptr_map.emplace(
-        rtc_type, std::make_shared<RTCInterface>(&node, rtc_interface_name));
-    }
-    return rtc_interface_ptr_map;
-  }
-
   virtual void updateRTCStatus(const double start_distance, const double finish_distance)
   {
     for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -51,7 +51,6 @@ public:
     const double & min_request_time_sec, bool override_requests = false) const noexcept;
   ModuleStatus updateState() override;
   void updateData() override;
-  ModuleStatus getNodeStatusWhileWaitingApproval() const override { return ModuleStatus::SUCCESS; }
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   CandidateOutput planCandidate() const override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -81,7 +81,6 @@ public:
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
   ModuleStatus updateState() override;
-  ModuleStatus getNodeStatusWhileWaitingApproval() const override { return ModuleStatus::SUCCESS; }
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   CandidateOutput planCandidate() const override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -70,6 +70,7 @@ using behavior_path_planner::utils::safety_check::ExtendedPredictedObject;
 using behavior_path_planner::utils::safety_check::PoseWithVelocityAndPolygonStamped;
 using behavior_path_planner::utils::safety_check::PoseWithVelocityStamped;
 using behavior_path_planner::utils::safety_check::PredictedPathWithPolygon;
+using drivable_area_expansion::DrivableAreaExpansionParameters;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseArray;
@@ -229,6 +230,9 @@ boost::optional<lanelet::ConstLanelet> getLeftLanelet(
 std::vector<DrivableLanes> generateDrivableLanes(const lanelet::ConstLanelets & current_lanes);
 std::vector<DrivableLanes> generateDrivableLanesWithShoulderLanes(
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & shoulder_lanes);
+std::vector<DrivableLanes> getNonOverlappingExpandedLanes(
+  PathWithLaneId & path, const std::vector<DrivableLanes> & lanes,
+  const DrivableAreaExpansionParameters & parameters);
 std::vector<geometry_msgs::msg::Point> calcBound(
   const std::shared_ptr<RouteHandler> route_handler,
   const std::vector<DrivableLanes> & drivable_lanes,

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -664,7 +664,8 @@ void GoalPlannerModule::setDrivableAreaInfo(BehaviorModuleOutput & output) const
     output.drivable_area_info.drivable_margin =
       planner_data_->parameters.vehicle_width / 2.0 + drivable_area_margin;
   } else {
-    const auto target_drivable_lanes = getNonOverlappingExpandedLanes(*output.path, status_.lanes);
+    const auto target_drivable_lanes = utils::getNonOverlappingExpandedLanes(
+      *output.path, status_.lanes, planner_data_->drivable_area_expansion_parameters);
 
     DrivableAreaInfo current_drivable_area_info;
     current_drivable_area_info.drivable_lanes = target_drivable_lanes;
@@ -854,7 +855,8 @@ BehaviorModuleOutput GoalPlannerModule::planWaitingApprovalWithGoalModification(
     out.drivable_area_info.drivable_margin =
       planner_data_->parameters.vehicle_width / 2.0 + drivable_area_margin;
   } else {
-    const auto target_drivable_lanes = getNonOverlappingExpandedLanes(*out.path, status_.lanes);
+    const auto target_drivable_lanes = utils::getNonOverlappingExpandedLanes(
+      *out.path, status_.lanes, planner_data_->drivable_area_expansion_parameters);
 
     DrivableAreaInfo current_drivable_area_info;
     current_drivable_area_info.drivable_lanes = target_drivable_lanes;

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -207,7 +207,8 @@ BehaviorModuleOutput StartPlannerModule::plan()
     path = status_.backward_path;
   }
 
-  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(path, status_.lanes);
+  const auto target_drivable_lanes = utils::getNonOverlappingExpandedLanes(
+    path, status_.lanes, planner_data_->drivable_area_expansion_parameters);
 
   DrivableAreaInfo current_drivable_area_info;
   current_drivable_area_info.drivable_lanes = target_drivable_lanes;
@@ -535,7 +536,8 @@ PathWithLaneId StartPlannerModule::generateStopPath() const
   path.points.push_back(toPathPointWithLaneId(moved_pose));
 
   // generate drivable area
-  const auto target_drivable_lanes = getNonOverlappingExpandedLanes(path, status_.lanes);
+  const auto target_drivable_lanes = utils::getNonOverlappingExpandedLanes(
+    path, status_.lanes, planner_data_->drivable_area_expansion_parameters);
 
   return path;
 }

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1212,6 +1212,17 @@ std::vector<DrivableLanes> generateDrivableLanesWithShoulderLanes(
   return drivable_lanes;
 }
 
+std::vector<DrivableLanes> getNonOverlappingExpandedLanes(
+  PathWithLaneId & path, const std::vector<DrivableLanes> & lanes,
+  const DrivableAreaExpansionParameters & parameters)
+{
+  const auto shorten_lanes = utils::cutOverlappedLanes(path, lanes);
+  const auto expanded_lanes = utils::expandLanelets(
+    shorten_lanes, parameters.drivable_area_left_bound_offset,
+    parameters.drivable_area_right_bound_offset, parameters.drivable_area_types_to_skip);
+  return expanded_lanes;
+}
+
 boost::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes)
 {
   auto overlaps = [](const DrivableLanes & lanes, const DrivableLanes & target_lanes) {

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1217,10 +1217,9 @@ std::vector<DrivableLanes> getNonOverlappingExpandedLanes(
   const DrivableAreaExpansionParameters & parameters)
 {
   const auto shorten_lanes = utils::cutOverlappedLanes(path, lanes);
-  const auto expanded_lanes = utils::expandLanelets(
+  return utils::expandLanelets(
     shorten_lanes, parameters.drivable_area_left_bound_offset,
     parameters.drivable_area_right_bound_offset, parameters.drivable_area_types_to_skip);
-  return expanded_lanes;
 }
 
 boost::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & lanes)


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 940d4ab</samp>

Simplified the `SceneModuleInterface` class and removed unused functions. Added a new utility function `getNonOverlappingExpandedLanes` to handle drivable area expansion for different scene modules. Updated the `AvoidanceModule`, `GoalPlannerModule`, `StartPlannerModule`, and `DynamicAvoidanceModule` to use the new utility function.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
