### PR TITLE
fix(start_planner): fix path generation for separated lanes and extended loop lanes

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -379,7 +379,7 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
 
 lanelet::ConstLanelets getExtendedCurrentLanes(
   const std::shared_ptr<const PlannerData> & planner_data, const double backward_length,
-  const double forward_length);
+  const double forward_length, const bool until_goal_lane);
 
 lanelet::ConstLanelets calcLaneAroundPose(
   const std::shared_ptr<RouteHandler> route_handler, const geometry_msgs::msg::Pose & pose,

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -153,7 +153,8 @@ void GoalPlannerModule::onTimer()
   // generate valid pull over path candidates and calculate closest start pose
   const auto current_lanes = utils::getExtendedCurrentLanes(
     planner_data_, parameters_->backward_goal_search_length,
-    parameters_->forward_goal_search_length);
+    parameters_->forward_goal_search_length,
+    /*until_goal_lane*/ false);
   std::vector<PullOverPath> path_candidates{};
   std::optional<Pose> closest_start_pose{};
   double min_start_arc_length = std::numeric_limits<double>::max();
@@ -590,7 +591,8 @@ void GoalPlannerModule::setLanes()
 {
   status_.current_lanes = utils::getExtendedCurrentLanes(
     planner_data_, parameters_->backward_goal_search_length,
-    parameters_->forward_goal_search_length);
+    parameters_->forward_goal_search_length,
+    /*until_goal_lane*/ false);
   status_.pull_over_lanes =
     goal_planner_utils::getPullOverLanes(*(planner_data_->route_handler), left_side_parking_);
   status_.lanes =

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -115,7 +115,8 @@ bool StartPlannerModule::isExecutionRequested() const
   const double backward_path_length =
     planner_data_->parameters.backward_path_length + parameters_->max_back_distance;
   const auto current_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, backward_path_length, std::numeric_limits<double>::max());
+    planner_data_, backward_path_length, std::numeric_limits<double>::max(),
+    /*until_goal_lane*/ true);
   const auto pull_out_lanes =
     start_planner_utils::getPullOutLanes(planner_data_, backward_path_length);
   auto lanes = current_lanes;
@@ -331,7 +332,8 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
   const double backward_path_length =
     planner_data_->parameters.backward_path_length + parameters_->max_back_distance;
   const auto current_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, backward_path_length, std::numeric_limits<double>::max());
+    planner_data_, backward_path_length, std::numeric_limits<double>::max(),
+    /*until_goal_lane*/ true);
 
   const auto pull_out_lanes =
     start_planner_utils::getPullOutLanes(planner_data_, backward_path_length);
@@ -566,7 +568,8 @@ void StartPlannerModule::updatePullOutStatus()
   const double backward_path_length =
     planner_data_->parameters.backward_path_length + parameters_->max_back_distance;
   status_.current_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, backward_path_length, std::numeric_limits<double>::max());
+    planner_data_, backward_path_length, std::numeric_limits<double>::max(),
+    /*until_goal_lane*/ true);
   status_.pull_out_lanes =
     start_planner_utils::getPullOutLanes(planner_data_, backward_path_length);
 

--- a/planning/behavior_path_planner/src/utils/goal_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/geometric_pull_over.cpp
@@ -45,7 +45,8 @@ boost::optional<PullOverPath> GeometricPullOver::plan(const Pose & goal_pose)
 
   // prepare road nad shoulder lanes
   const auto road_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length);
+    planner_data_, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length,
+    /*until_goal_lane*/ false);
   const auto shoulder_lanes =
     goal_planner_utils::getPullOverLanes(*route_handler, left_side_parking_);
   if (road_lanes.empty() || shoulder_lanes.empty()) {

--- a/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
@@ -54,7 +54,9 @@ GoalCandidates GoalSearcher::search(const Pose & original_goal_pose)
 
   const auto pull_over_lanes =
     goal_planner_utils::getPullOverLanes(*route_handler, left_side_parking_);
-  auto lanes = utils::getExtendedCurrentLanes(planner_data_, backward_length, forward_length);
+  auto lanes = utils::getExtendedCurrentLanes(
+    planner_data_, backward_length, forward_length,
+    /*until_goal_lane*/ false);
   lanes.insert(lanes.end(), pull_over_lanes.begin(), pull_over_lanes.end());
 
   const auto goal_arc_coords =

--- a/planning/behavior_path_planner/src/utils/goal_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/shift_pull_over.cpp
@@ -46,8 +46,9 @@ boost::optional<PullOverPath> ShiftPullOver::plan(const Pose & goal_pose)
   const double jerk_resolution = std::abs(max_jerk - min_jerk) / shift_sampling_num;
 
   // get road and shoulder lanes
-  const auto road_lanes =
-    utils::getExtendedCurrentLanes(planner_data_, backward_search_length, forward_search_length);
+  const auto road_lanes = utils::getExtendedCurrentLanes(
+    planner_data_, backward_search_length, forward_search_length,
+    /*until_goal_lane*/ false);
   const auto shoulder_lanes =
     goal_planner_utils::getPullOverLanes(*route_handler, left_side_parking_);
   if (road_lanes.empty() || shoulder_lanes.empty()) {

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -43,7 +43,8 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
   const double backward_path_length =
     planner_data_->parameters.backward_path_length + parameters_.max_back_distance;
   const auto road_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, backward_path_length, std::numeric_limits<double>::max());
+    planner_data_, backward_path_length, std::numeric_limits<double>::max(),
+    /*until_goal_lane*/ true);
   const auto pull_out_lanes = getPullOutLanes(planner_data_, backward_path_length);
   auto lanes = road_lanes;
   for (const auto & pull_out_lane : pull_out_lanes) {

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -53,8 +53,8 @@ boost::optional<PullOutPath> ShiftPullOut::plan(Pose start_pose, Pose goal_pose)
   }
 
   const auto road_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, backward_path_length, std::numeric_limits<double>::max());
-
+    planner_data_, backward_path_length, std::numeric_limits<double>::max(),
+    /*until_goal_lane*/ true);
   // find candidate paths
   auto pull_out_paths = calcPullOutPaths(
     *route_handler, road_lanes, start_pose, goal_pose, common_parameters, parameters_);

--- a/planning/behavior_path_planner/src/utils/start_planner/util.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/util.cpp
@@ -114,6 +114,8 @@ lanelet::ConstLanelets getPullOutLanes(
 
   // pull out from road lane
   return utils::getExtendedCurrentLanes(
-    planner_data, backward_length, /*forward_length*/ std::numeric_limits<double>::max());
+    planner_data, backward_length,
+    /*forward_length*/ std::numeric_limits<double>::max(),
+    /*until_goal_lane*/ true);
 }
 }  // namespace behavior_path_planner::start_planner_utils

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2854,7 +2854,14 @@ lanelet::ConstLanelets extendNextLane(
   // Add next lane
   const auto next_lanes = route_handler->getNextLanelets(extended_lanes.back());
   if (!next_lanes.empty()) {
-    extended_lanes.push_back(next_lanes.front());
+    // use the next lane in route if it exists
+    auto target_next_lane = next_lanes.front();
+    for (const auto & next_lane : next_lanes) {
+      if (route_handler->isRouteLanelet(next_lane)) {
+        target_next_lane = next_lane;
+      }
+    }
+    extended_lanes.push_back(target_next_lane);
   }
 
   return extended_lanes;
@@ -2868,9 +2875,15 @@ lanelet::ConstLanelets extendPrevLane(
   // Add previous lane
   const auto prev_lanes = route_handler->getPreviousLanelets(extended_lanes.front());
   if (!prev_lanes.empty()) {
-    extended_lanes.insert(extended_lanes.begin(), prev_lanes.front());
+    // use the previous lane in route if it exists
+    auto target_prev_lane = prev_lanes.front();
+    for (const auto & prev_lane : prev_lanes) {
+      if (route_handler->isRouteLanelet(prev_lane)) {
+        target_prev_lane = prev_lane;
+      }
+    }
+    extended_lanes.insert(extended_lanes.begin(), target_prev_lane);
   }
-
   return extended_lanes;
 }
 
@@ -2889,22 +2902,18 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
 {
   auto lanes = getCurrentLanes(planner_data);
   if (lanes.empty()) return lanes;
+  const auto start_lane = lanes.front();
 
   double forward_length_sum = 0.0;
   double backward_length_sum = 0.0;
 
-  const auto is_loop = [&](const auto & target_lane) {
-    auto it = std::find_if(lanes.begin(), lanes.end(), [&](const lanelet::ConstLanelet & lane) {
-      return lane.id() == target_lane.id();
-    });
-
-    return it != lanes.end();
-  };
-
   while (backward_length_sum < backward_length) {
     auto extended_lanes = extendPrevLane(planner_data->route_handler, lanes);
-
-    if (extended_lanes.empty() || is_loop(extended_lanes.front())) {
+    if (extended_lanes.empty()) {
+      return lanes;
+    }
+    // loop check
+    if (extended_lanes.front().id() == start_lane.id()) {
       return lanes;
     }
 
@@ -2918,8 +2927,11 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
 
   while (forward_length_sum < forward_length) {
     auto extended_lanes = extendNextLane(planner_data->route_handler, lanes);
-
-    if (extended_lanes.empty() || is_loop(extended_lanes.back())) {
+    if (extended_lanes.empty()) {
+      return lanes;
+    }
+    // loop check
+    if (extended_lanes.back().id() == start_lane.id()) {
       return lanes;
     }
 

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2898,7 +2898,7 @@ lanelet::ConstLanelets extendLanes(
 
 lanelet::ConstLanelets getExtendedCurrentLanes(
   const std::shared_ptr<const PlannerData> & planner_data, const double backward_length,
-  const double forward_length)
+  const double forward_length, const bool until_goal_lane)
 {
   auto lanes = getCurrentLanes(planner_data);
   if (lanes.empty()) return lanes;
@@ -2926,6 +2926,15 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
   }
 
   while (forward_length_sum < forward_length) {
+    // stop extending if the goal lane is included
+    if (until_goal_lane) {
+      lanelet::ConstLanelet goal_lane;
+      planner_data->route_handler->getGoalLanelet(&goal_lane);
+      if (lanes.back().id() == goal_lane.id()) {
+        return lanes;
+      }
+    }
+
     auto extended_lanes = extendNextLane(planner_data->route_handler, lanes);
     if (extended_lanes.empty()) {
       return lanes;

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2913,6 +2913,8 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
       return lanes;
     }
     // loop check
+    // if current map lanes is looping and has a very large value for backward_length,
+    // the extending process will not finish.
     if (extended_lanes.front().id() == start_lane.id()) {
       return lanes;
     }
@@ -2927,6 +2929,8 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
 
   while (forward_length_sum < forward_length) {
     // stop extending if the goal lane is included
+    // if forward_length is a very large value, set it to true,
+    // as it may continue to extend lanes outside the route ahead of goal forever.
     if (until_goal_lane) {
       lanelet::ConstLanelet goal_lane;
       planner_data->route_handler->getGoalLanelet(&goal_lane);
@@ -2940,6 +2944,8 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
       return lanes;
     }
     // loop check
+    // if current map lanes is looping and has a very large value for forward_length,
+    // the extending process will not finish.
     if (extended_lanes.back().id() == start_lane.id()) {
       return lanes;
     }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

solve https://github.com/autowarefoundation/autoware.universe/issues/4391

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/25d1e98c-c5ef-4aad-9597-69f707bcaaec)

The current_lanes variable currently only includes lanes within a forward_path_length of 300m, and next lanes are determined by extendNextLane. However, if there is more than one candidate for the next lane, and if an incorrect lane is added, the arc coordinates of the goal cannot be calculated correctly. In this PR, we've added the next lane in route_lanes to the extended lanes, if that lane exists. We've also fixed the loop check to only verify start lanes rather than all extended lanes. This is because sometimes the target next lane for extension is the same as the previously extended lanes, which causes a failure in adding the lane. This same issue can result in goal arc coordinates not being calculated correctly.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

solve https://github.com/autowarefoundation/autoware.universe/issues/4391

## Tests performed

<!-- Describe how you have tested this PR. -->


[tier4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/bbc8f39a-8f83-59f3-a725-fa4771960e35?project_id=prd_jt) 1580/1588

base:
1577/1588([2023/07/30](https://evaluation.tier4.jp/evaluation/reports/d1ec5471-3332-5f7c-9203-6d40ef0f270e/?project_id=prd_jt))

psim

the issues separated next lanes case 

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/aeba23a0-f339-4c5b-a674-1d25457eae6b)


long overlapped route lanes case (extended previous lanes are same to candidate of extended next lanes)

before

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/7099cdea-d322-4508-9bea-99350b6e41b4)

after 

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/f502ac10-ed38-4246-b89b-b3549682a369)



## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
none
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
