### PR TITLE
fix(start_planner): remove shift pull out enough distance check

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/shift_pull_out.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/shift_pull_out.hpp
@@ -45,10 +45,6 @@ public:
     const BehaviorPathPlannerParameters & common_parameter,
     const behavior_path_planner::StartPlannerParameters & parameter);
 
-  bool hasEnoughDistance(
-    const double pull_out_total_distance, const lanelet::ConstLanelets & current_lanes,
-    const Pose & current_pose, const bool isInGoalRouteSection, const Pose & goal_pose);
-
   double calcBeforeShiftedArcLength(
     const PathWithLaneId & path, const double target_after_arc_length, const double dr);
 

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -216,14 +216,6 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     const double before_shifted_pull_out_distance =
       std::max(pull_out_distance, pull_out_distance_converted);
 
-    // check has enough distance
-    const bool is_in_goal_route_section = route_handler.isInGoalRouteSection(road_lanes.back());
-    if (!hasEnoughDistance(
-          before_shifted_pull_out_distance, road_lanes, start_pose, is_in_goal_route_section,
-          goal_pose)) {
-      continue;
-    }
-
     // if before_shifted_pull_out_distance is too short, shifting path fails, so add non shifted
     if (before_shifted_pull_out_distance < RESAMPLE_INTERVAL && !has_non_shifted_path) {
       candidate_paths.push_back(non_shifted_path);
@@ -317,25 +309,6 @@ double ShiftPullOut::calcPullOutLongitudinalDistance(
     std::max(min_pull_out_distance_by_acc, min_pull_out_distance_by_curvature), min_distance);
 
   return min_pull_out_distance;
-}
-
-bool ShiftPullOut::hasEnoughDistance(
-  const double pull_out_total_distance, const lanelet::ConstLanelets & road_lanes,
-  const Pose & current_pose, const bool is_in_goal_route_section, const Pose & goal_pose)
-{
-  // the goal is far so current_lanes do not include goal's lane
-  if (pull_out_total_distance > utils::getDistanceToEndOfLane(current_pose, road_lanes)) {
-    return false;
-  }
-
-  // current_lanes include goal's lane
-  if (
-    is_in_goal_route_section &&
-    pull_out_total_distance > utils::getSignedDistance(current_pose, goal_pose, road_lanes)) {
-    return false;
-  }
-
-  return true;
 }
 
 double ShiftPullOut::calcBeforeShiftedArcLength(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

https://github.com/autowarefoundation/autoware.universe/pull/4418 surfaces potential bugs in loop route path generation.


![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/ef2b4c4a-571b-46f9-8a4c-d7cb844b7975)


this is because the extended road lanes has previous lanes of current lanes, and the goal and current pose arc corrdinates are caluculated wrongly. This lead to wrong hasEnoughDistance judgement.

In this PR remove the hasEnoghDistance because currently the distance is calculated validly like https://github.com/autowarefoundation/autoware.universe/pull/4005

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->


https://github.com/autowarefoundation/autoware.universe/pull/4418

## Tests performed

<!-- Describe how you have tested this PR. -->

[tier4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/bbc8f39a-8f83-59f3-a725-fa4771960e35?project_id=prd_jt) 1580/1588

base:
1577/1588([2023/07/30](https://evaluation.tier4.jp/evaluation/reports/d1ec5471-3332-5f7c-9203-6d40ef0f270e/?project_id=prd_jt))

psim

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/b527c59b-95cd-489f-b31a-6c7fe7ad57ba)


[teir4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/41cdb24f-f29e-56a6-badd-409da36988f0?project_id=prd_jt)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
