### PR TITLE
refactor(yabloc): replace deprecated rosidl API

### DIFF
--- a/localization/yabloc/yabloc_particle_filter/CMakeLists.txt
+++ b/localization/yabloc/yabloc_particle_filter/CMakeLists.txt
@@ -49,7 +49,6 @@ ament_auto_add_library(
 )
 target_include_directories(abstract_corrector SYSTEM PRIVATE ${PCL_INCLUDE_DIRS})
 target_link_libraries(abstract_corrector Sophus::Sophus ${PCL_LIBRARIES})
-rosidl_target_interfaces(abstract_corrector ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 # Prediction library
 ament_auto_add_library(predictor
@@ -60,7 +59,16 @@ ament_auto_add_library(predictor
 )
 target_include_directories(predictor SYSTEM PRIVATE ${PCL_INCLUDE_DIRS})
 target_link_libraries(predictor Sophus::Sophus ${PCL_LIBRARIES})
-rosidl_target_interfaces(predictor ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+# ros2idl typesupport
+if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)
+  rosidl_target_interfaces(abstract_corrector ${PROJECT_NAME} "rosidl_typesupport_cpp")
+  rosidl_target_interfaces(predictor ${PROJECT_NAME} "rosidl_typesupport_cpp")
+else()
+  rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+  target_link_libraries(abstract_corrector "${cpp_typesupport_target}")
+  target_link_libraries(predictor "${cpp_typesupport_target}")
+endif()
 
 # Cost map Library
 ament_auto_add_library(ll2_cost_map

--- a/localization/yabloc/yabloc_pose_initializer/CMakeLists.txt
+++ b/localization/yabloc/yabloc_pose_initializer/CMakeLists.txt
@@ -44,8 +44,15 @@ ament_auto_add_executable(${TARGET}
   src/camera/camera_pose_initializer_node.cpp)
 target_include_directories(${TARGET} PUBLIC include)
 target_include_directories(${TARGET} SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS})
-rosidl_target_interfaces(${TARGET} ${PROJECT_NAME} "rosidl_typesupport_cpp")
 target_link_libraries(${TARGET} ${PCL_LIBRARIES} Sophus::Sophus)
+
+# ros2idl typesupport
+if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)
+  rosidl_target_interfaces(${TARGET} ${PROJECT_NAME} "rosidl_typesupport_cpp")
+else()
+  rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+  target_link_libraries(${TARGET} "${cpp_typesupport_target}")
+endif()
 
 # Semantic segmentation
 install(PROGRAMS


### PR DESCRIPTION
## Description

From ROS 2 humble, `rosidl_target_interfaces` is deprecated: ref. https://github.com/ros2/rosidl/pull/606
Some packages adapt this changes by using `rosidl_get_typesupport_target` + version checking like [this](https://github.com/autowarefoundation/autoware.universe/blob/main/control/control_performance_analysis/CMakeLists.txt#L41-L52), but yabloc does not.

This PR introduce `rosidl_get_typesupport_target` + version checking to yabloc packages.

## Tests performed

Not applicable for behavior. Build succeeded.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
