### PR TITLE
fix(traffic_light_occlusion_predictor): bug fix

### DIFF
--- a/perception/traffic_light_occlusion_predictor/src/nodelet.cpp
+++ b/perception/traffic_light_occlusion_predictor/src/nodelet.cpp
@@ -117,7 +117,7 @@ void TrafficLightOcclusionPredictorNodelet::syncCallback(
   if (
     in_cloud_msg == nullptr || in_cam_info_msg == nullptr || in_roi_msg == nullptr ||
     in_roi_msg->rois.size() != in_signal_msg->signals.size()) {
-    occlusion_ratios.resize(in_roi_msg->rois.size(), 0);
+    occlusion_ratios.resize(out_msg.signals.size(), 0);
   } else {
     cloud_occlusion_predictor_->predict(
       in_cam_info_msg, in_roi_msg, in_cloud_msg, tf_buffer_, traffic_light_position_map_,


### PR DESCRIPTION
## Description

- Fix the bug that causes traffic_light_occlusion_predictor to fall

Considering in_roi_msg could be nullptr, it would cause break down when it's called
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Nothing.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/