### PR TITLE
fix(traffic_light_arbiter): publish traffic light info even when a map without traffic lights is subscribed

### DIFF
--- a/perception/traffic_light_arbiter/include/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/traffic_light_arbiter/include/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -22,6 +22,7 @@
 
 #include <lanelet2_core/Forward.h>
 
+#include <memory>
 #include <unordered_set>
 
 class TrafficLightArbiter : public rclcpp::Node
@@ -45,7 +46,7 @@ private:
   void onExternalMsg(const TrafficSignalArray::ConstSharedPtr msg);
   void arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp);
 
-  std::unordered_set<lanelet::Id> map_regulatory_elements_set_;
+  std::shared_ptr<std::unordered_set<lanelet::Id>> map_regulatory_elements_set_;
 
   double external_time_tolerance_;
   double perception_time_tolerance_;

--- a/perception/traffic_light_arbiter/include/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/traffic_light_arbiter/include/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -46,7 +46,7 @@ private:
   void onExternalMsg(const TrafficSignalArray::ConstSharedPtr msg);
   void arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp);
 
-  std::shared_ptr<std::unordered_set<lanelet::Id>> map_regulatory_elements_set_;
+  std::unique_ptr<std::unordered_set<lanelet::Id>> map_regulatory_elements_set_;
 
   double external_time_tolerance_;
   double perception_time_tolerance_;

--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -115,6 +115,14 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
     return;
   }
 
+  TrafficSignalArray output_signals_msg;
+  output_signals_msg.stamp = stamp;
+
+  if (map_regulatory_elements_set_->empty()) {
+    pub_->publish(output_signals_msg);
+    return;
+  }
+
   auto add_signal_function = [&](const auto & signal, bool priority) {
     const auto id = signal.traffic_signal_id;
     if (!map_regulatory_elements_set_->count(id)) {
@@ -166,8 +174,6 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
       return highest_score_elements_vector;
     };
 
-  TrafficSignalArray output_signals_msg;
-  output_signals_msg.stamp = stamp;
   output_signals_msg.signals.reserve(regulatory_element_signals_map.size());
 
   for (const auto & [regulatory_element_id, elements] : regulatory_element_signals_map) {

--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -72,7 +72,7 @@ void TrafficLightArbiter::onMap(const LaneletMapBin::ConstSharedPtr msg)
   lanelet::utils::conversion::fromBinMsg(*msg, map);
 
   const auto signals = lanelet::filter_traffic_signals(map);
-  map_regulatory_elements_set_ = std::make_shared<std::unordered_set<lanelet::Id>>();
+  map_regulatory_elements_set_ = std::make_unique<std::unordered_set<lanelet::Id>>();
 
   for (const auto & signal : signals) {
     map_regulatory_elements_set_->emplace(signal->id());

--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -72,9 +72,10 @@ void TrafficLightArbiter::onMap(const LaneletMapBin::ConstSharedPtr msg)
   lanelet::utils::conversion::fromBinMsg(*msg, map);
 
   const auto signals = lanelet::filter_traffic_signals(map);
-  map_regulatory_elements_set_.clear();
+  map_regulatory_elements_set_ = std::make_shared<std::unordered_set<lanelet::Id>>();
+
   for (const auto & signal : signals) {
-    map_regulatory_elements_set_.emplace(signal->id());
+    map_regulatory_elements_set_->emplace(signal->id());
   }
 }
 
@@ -109,14 +110,14 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
   using ElementAndPriority = std::pair<Element, bool>;
   std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> regulatory_element_signals_map;
 
-  if (map_regulatory_elements_set_.empty()) {
+  if (map_regulatory_elements_set_ == nullptr) {
     RCLCPP_WARN(get_logger(), "Received traffic signal messages before a map");
     return;
   }
 
   auto add_signal_function = [&](const auto & signal, bool priority) {
     const auto id = signal.traffic_signal_id;
-    if (!map_regulatory_elements_set_.count(id)) {
+    if (!map_regulatory_elements_set_->count(id)) {
       RCLCPP_WARN(
         get_logger(), "Received a traffic signal not present in the current map (%lu)", id);
       return;


### PR DESCRIPTION
## Description
 publish traffic light info even when a map without traffic lights is subscribed

<!-- Write a brief description of this PR. -->

## Tests performed
I tested as below.
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- launch traffic_light_arbiter
```
$ros2 launch traffic_light_arbiter traffic_light_arbiter.launch.xml 
```

- publish map without traffic lights

- publish /external/traffic_light_recognition/traffic_signals 
```
$ros2 topic pub /external/traffic_light_recognition/traffic_signals autoware_perception_msgs/msg/TrafficSignalArray {}
```

- confirm that traffic_signals messages are published by traffic_light_arbiter
```
$ ros2 topic echo /perception/traffic_light_arbiter/traffic_signals
```

## Effects on system behavior
Even when you use a map without traffic light, traffic_light_arbiter will publish traffic light info.
( When you use a map with traffic light, this PR has no effects on system behavior. )

<!-- Describe how this PR affects the system behavior. -->


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
