### PR TITLE
feat(dynamic_avoidance): memorize previous object information

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -35,6 +35,12 @@
 
 namespace behavior_path_planner
 {
+struct MinMaxValue
+{
+  double min_value;
+  double max_value;
+};
+
 struct DynamicAvoidanceParameters
 {
   // common
@@ -83,14 +89,17 @@ public:
   {
     DynamicAvoidanceObject(
       const PredictedObject & predicted_object, const double arg_vel, const double arg_lat_vel,
-      const bool arg_is_collision_left, const double arg_time_to_collision)
+      const bool arg_is_collision_left, const double arg_time_to_collision,
+      const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid)
     : uuid(tier4_autoware_utils::toHexString(predicted_object.object_id)),
       pose(predicted_object.kinematics.initial_pose_with_covariance.pose),
       shape(predicted_object.shape),
       vel(arg_vel),
       lat_vel(arg_lat_vel),
       is_collision_left(arg_is_collision_left),
-      time_to_collision(arg_time_to_collision)
+      time_to_collision(arg_time_to_collision),
+      lon_offset_to_avoid(arg_lon_offset_to_avoid),
+      lat_offset_to_avoid(arg_lat_offset_to_avoid)
     {
       for (const auto & path : predicted_object.kinematics.predicted_paths) {
         predicted_paths.push_back(path);
@@ -104,6 +113,8 @@ public:
     double lat_vel;
     bool is_collision_left;
     double time_to_collision;
+    MinMaxValue lon_offset_to_avoid;
+    MinMaxValue lat_offset_to_avoid;
     std::vector<autoware_auto_perception_msgs::msg::PredictedPath> predicted_paths{};
   };
 
@@ -180,6 +191,20 @@ public:
       }
       return objects;
     }
+    std::optional<DynamicAvoidanceObject> getValidObject(const std::string & uuid) const
+    {
+      // add/update object
+      if (counter_map_.count(uuid) == 0) {
+        return std::nullopt;
+      }
+      if (counter_map_.at(uuid) < max_count_) {
+        return std::nullopt;
+      }
+      if (object_map_.count(uuid) == 0) {
+        return std::nullopt;
+      }
+      return object_map_.at(uuid);
+    }
 
     std::vector<std::string> current_uuids_;
     // NOTE: positive is for meeting entrying condition, and negative is for exiting.
@@ -221,6 +246,7 @@ private:
 
   bool isLabelTargetObstacle(const uint8_t label) const;
   void updateTargetObjects();
+  std::optional<std::vector<PathPointWithLaneId>> calcPathForObjectPolygon() const;
   bool willObjectCutIn(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
     const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const;
@@ -235,6 +261,14 @@ private:
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & obj_path) const;
   LatLonOffset getLateralLongitudinalOffset(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedObject & object) const;
+  MinMaxValue calcMinMaxLongitudinalOffsetToAvoid(
+    const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
+    const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,
+    const double time_to_collision) const;
+  MinMaxValue calcMinMaxLateralOffsetToAvoid(
+    const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
+    const Polygon2d & obj_points, const bool is_collision_left,
+    const std::optional<DynamicAvoidanceObject> & prev_object) const;
 
   std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> getAdjacentLanes(
     const double forward_distance, const double backward_distance) const;
@@ -245,46 +279,6 @@ private:
   // std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject> prev_target_objects_;
   std::shared_ptr<DynamicAvoidanceParameters> parameters_;
 
-  struct ObjectsVariable
-  {
-    void resetCurrentUuids() { current_uuids_.clear(); }
-    void addCurrentUuid(const std::string & uuid) { current_uuids_.push_back(uuid); }
-    void removeCounterUnlessUpdated()
-    {
-      std::vector<std::string> obsolete_uuids;
-      for (const auto & key_and_value : variable_) {
-        if (
-          std::find(current_uuids_.begin(), current_uuids_.end(), key_and_value.first) ==
-          current_uuids_.end()) {
-          obsolete_uuids.push_back(key_and_value.first);
-        }
-      }
-
-      for (const auto & obsolete_uuid : obsolete_uuids) {
-        variable_.erase(obsolete_uuid);
-      }
-    }
-
-    std::optional<double> get(const std::string & uuid) const
-    {
-      if (variable_.count(uuid) != 0) {
-        return variable_.at(uuid);
-      }
-      return std::nullopt;
-    }
-    void update(const std::string & uuid, const double new_variable)
-    {
-      if (variable_.count(uuid) != 0) {
-        variable_.at(uuid) = new_variable;
-      } else {
-        variable_.emplace(uuid, new_variable);
-      }
-    }
-
-    std::unordered_map<std::string, double> variable_;
-    std::vector<std::string> current_uuids_;
-  };
-  mutable ObjectsVariable prev_objects_min_bound_lat_offset_;
   TargetObjectsManager target_objects_manager_;
 };
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -41,13 +41,13 @@ geometry_msgs::msg::Point toGeometryPoint(const tier4_autoware_utils::Point2d & 
   return geom_obj_point;
 }
 
-std::pair<double, double> getMinMaxValues(const std::vector<double> & vec)
+MinMaxValue getMinMaxValues(const std::vector<double> & vec)
 {
   const size_t min_idx = std::distance(vec.begin(), std::min_element(vec.begin(), vec.end()));
 
   const size_t max_idx = std::distance(vec.begin(), std::max_element(vec.begin(), vec.end()));
 
-  return std::make_pair(vec.at(min_idx), vec.at(max_idx));
+  return MinMaxValue{vec.at(min_idx), vec.at(max_idx)};
 }
 
 void appendObjectMarker(MarkerArray & marker_array, const geometry_msgs::msg::Pose & obj_pose)
@@ -254,7 +254,6 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
 
   // create obstacles to avoid (= extract from the drivable area)
   std::vector<DrivableAreaInfo::Obstacle> obstacles_for_drivable_area;
-  prev_objects_min_bound_lat_offset_.resetCurrentUuids();
   for (const auto & object : target_objects_) {
     const auto obstacle_poly = calcDynamicObstaclePolygon(object);
     if (obstacle_poly) {
@@ -263,11 +262,8 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
 
       appendObjectMarker(info_marker_, object.pose);
       appendExtractedPolygonMarker(debug_marker_, obstacle_poly.value());
-
-      prev_objects_min_bound_lat_offset_.addCurrentUuid(object.uuid);
     }
   }
-  prev_objects_min_bound_lat_offset_.removeCounterUnlessUpdated();
 
   BehaviorModuleOutput output;
   output.path = prev_module_path;
@@ -327,6 +323,11 @@ void DynamicAvoidanceModule::updateTargetObjects()
   const auto prev_module_path = getPreviousModuleOutput().path;
   const auto & predicted_objects = planner_data_->dynamic_object->objects;
 
+  const auto path_points_for_object_polygon = calcPathForObjectPolygon();
+  if (!path_points_for_object_polygon) {
+    return;
+  }
+
   target_objects_manager_.initialize();
   for (const auto & predicted_object : predicted_objects) {
     const auto obj_uuid = tier4_autoware_utils::toHexString(predicted_object.object_id);
@@ -336,6 +337,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
       predicted_object.kinematics.predicted_paths.begin(),
       predicted_object.kinematics.predicted_paths.end(),
       [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
+    const auto prev_object = target_objects_manager_.getValidObject(obj_uuid);
 
     // 1. check label
     const bool is_label_target_obstacle =
@@ -427,6 +429,14 @@ void DynamicAvoidanceModule::updateTargetObjects()
         obj_uuid.c_str());
       continue;
     }
+    if (time_to_collision < -parameters_->duration_to_hold_avoidance_overtaking_object) {
+      RCLCPP_INFO_EXPRESSION(
+        getLogger(), parameters_->enable_debug_info,
+        "[DynamicAvoidance] Ignore obstacle (%s) since time to collision is a small negative "
+        "value.",
+        obj_uuid.c_str());
+      continue;
+    }
 
     // 9. calculate which side object will be against ego's path
     const auto future_obj_pose =
@@ -435,12 +445,44 @@ void DynamicAvoidanceModule::updateTargetObjects()
                                      ? isLeft(prev_module_path->points, future_obj_pose->position)
                                      : is_object_left;
 
+    // 10. calculate longitudinal and lateral offset to avoid
+    const auto obj_points = tier4_autoware_utils::toPolygon2d(obj_pose, predicted_object.shape);
+    const auto lon_offset_to_avoid = calcMinMaxLongitudinalOffsetToAvoid(
+      *path_points_for_object_polygon, obj_pose, obj_points, obj_tangent_vel, time_to_collision);
+    const auto lat_offset_to_avoid = calcMinMaxLateralOffsetToAvoid(
+      *path_points_for_object_polygon, obj_points, is_collision_left, prev_object);
+
     const auto target_object = DynamicAvoidanceObject(
-      predicted_object, obj_tangent_vel, obj_normal_vel, is_collision_left, time_to_collision);
+      predicted_object, obj_tangent_vel, obj_normal_vel, is_collision_left, time_to_collision,
+      lon_offset_to_avoid, lat_offset_to_avoid);
 
     target_objects_manager_.updateObject(obj_uuid, target_object);
   }
   target_objects_manager_.finalize();
+}
+
+std::optional<std::vector<PathPointWithLaneId>> DynamicAvoidanceModule::calcPathForObjectPolygon()
+  const
+{
+  const auto & ego_pose = getEgoPose();
+  const auto & rh = planner_data_->route_handler;
+
+  // get path with backward margin
+  lanelet::ConstLanelet current_lane;
+  if (!rh->getClosestLaneletWithinRoute(ego_pose, &current_lane)) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("behavior_path_planner").get_child("dynamic_avoidance"),
+      "failed to find closest lanelet within route!!!");
+    return std::nullopt;
+  }
+
+  constexpr double forward_length = 100.0;
+  const double backward_length = 50.0;
+  const auto current_lanes =
+    rh->getLaneletSequence(current_lane, ego_pose, backward_length, forward_length);
+  const auto path = utils::getCenterLinePath(
+    *rh, current_lanes, ego_pose, backward_length, forward_length, planner_data_->parameters);
+  return path.points;
 }
 
 [[maybe_unused]] std::optional<std::pair<size_t, size_t>>
@@ -631,128 +673,85 @@ DynamicAvoidanceModule::LatLonOffset DynamicAvoidanceModule::getLateralLongitudi
   const auto obj_lon_min_max_offset = getMinMaxValues(obj_lon_offset_vec);
 
   return LatLonOffset{
-    obj_seg_idx, obj_lat_min_max_offset.second, obj_lat_min_max_offset.first,
-    obj_lon_min_max_offset.second, obj_lon_min_max_offset.first};
+    obj_seg_idx, obj_lat_min_max_offset.max_value, obj_lat_min_max_offset.min_value,
+    obj_lon_min_max_offset.max_value, obj_lon_min_max_offset.min_value};
 }
 
-// NOTE: object does not have const only to update min_bound_lat_offset.
-std::optional<tier4_autoware_utils::Polygon2d> DynamicAvoidanceModule::calcDynamicObstaclePolygon(
-  const DynamicAvoidanceObject & object) const
+MinMaxValue DynamicAvoidanceModule::calcMinMaxLongitudinalOffsetToAvoid(
+  const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
+  const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,
+  const double time_to_collision) const
 {
-  const auto ego_pose = getEgoPose();
-  const auto & rh = planner_data_->route_handler;
-
-  // get path with backward margin
-  lanelet::ConstLanelet current_lane;
-  if (!rh->getClosestLaneletWithinRoute(ego_pose, &current_lane)) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("behavior_path_planner").get_child("dynamic_avoidance"),
-      "failed to find closest lanelet within route!!!");
-    return std::nullopt;
-  }
-
-  auto path_with_backward_margin = [&]() {
-    constexpr double forward_length = 100.0;
-    const double backward_length = 50.0;
-    const auto current_lanes =
-      rh->getLaneletSequence(current_lane, ego_pose, backward_length, forward_length);
-    return utils::getCenterLinePath(
-      *rh, current_lanes, ego_pose, backward_length, forward_length, planner_data_->parameters);
-  }();
-
   const size_t obj_seg_idx =
-    motion_utils::findNearestSegmentIndex(path_with_backward_margin.points, object.pose.position);
-  const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
-
-  // calculate min/max lateral offset from object to path
-  const auto [min_obj_lat_abs_offset, max_obj_lat_abs_offset] = [&]() {
-    std::vector<double> obj_lat_abs_offset_vec;
-    for (size_t i = 0; i < obj_points.outer().size(); ++i) {
-      const auto geom_obj_point = toGeometryPoint(obj_points.outer().at(i));
-      const size_t obj_point_seg_idx =
-        motion_utils::findNearestSegmentIndex(path_with_backward_margin.points, geom_obj_point);
-      const double obj_point_lat_offset = motion_utils::calcLateralOffset(
-        path_with_backward_margin.points, geom_obj_point, obj_point_seg_idx);
-      obj_lat_abs_offset_vec.push_back(std::abs(obj_point_lat_offset));
-    }
-    return getMinMaxValues(obj_lat_abs_offset_vec);
-  }();
-  const double min_obj_lat_offset =
-    min_obj_lat_abs_offset * (object.is_collision_left ? 1.0 : -1.0);
-  const double max_obj_lat_offset =
-    max_obj_lat_abs_offset * (object.is_collision_left ? 1.0 : -1.0);
+    motion_utils::findNearestSegmentIndex(path_points_for_object_polygon, obj_pose.position);
 
   // calculate min/max longitudinal offset from object to path
-  const auto obj_lon_offset = [&]() -> std::optional<std::pair<double, double>> {
+  const auto obj_lon_offset = [&]() {
     std::vector<double> obj_lon_offset_vec;
     for (size_t i = 0; i < obj_points.outer().size(); ++i) {
       const auto geom_obj_point = toGeometryPoint(obj_points.outer().at(i));
       const double lon_offset = motion_utils::calcLongitudinalOffsetToSegment(
-        path_with_backward_margin.points, obj_seg_idx, geom_obj_point);
+        path_points_for_object_polygon, obj_seg_idx, geom_obj_point);
       obj_lon_offset_vec.push_back(lon_offset);
     }
 
-    const auto [raw_min_obj_lon_offset, raw_max_obj_lon_offset] =
-      getMinMaxValues(obj_lon_offset_vec);
-    if (object.time_to_collision < -parameters_->duration_to_hold_avoidance_overtaking_object) {
-      return std::nullopt;
-    }
+    const auto raw_obj_lon_offset = getMinMaxValues(obj_lon_offset_vec);
 
-    if (object.vel < 0) {
-      return std::make_pair(
-        raw_min_obj_lon_offset + object.vel * object.time_to_collision, raw_max_obj_lon_offset);
+    if (obj_vel < 0) {
+      return MinMaxValue{
+        raw_obj_lon_offset.min_value + obj_vel * time_to_collision, raw_obj_lon_offset.max_value};
     }
 
     // NOTE: If time to collision is considered here, the ego is close to the object when starting
     // avoidance.
     //       The ego should start avoidance before overtaking.
-    return std::make_pair(raw_min_obj_lon_offset, raw_max_obj_lon_offset);
+    return raw_obj_lon_offset;
   }();
 
-  if (!obj_lon_offset) {
-    return std::nullopt;
-  }
-  const double min_obj_lon_offset = obj_lon_offset->first;
-  const double max_obj_lon_offset = obj_lon_offset->second;
-
   // calculate bound start and end index
-  const bool is_object_overtaking = (0.0 <= object.vel);
-  // TODO(murooka) use getEgoSpeed() instead of object.vel
+  const bool is_object_overtaking = (0.0 <= obj_vel);
+  // TODO(murooka) use getEgoSpeed() instead of obj_vel
   const double start_length_to_avoid =
-    std::abs(object.vel) * (is_object_overtaking
-                              ? parameters_->start_duration_to_avoid_overtaking_object
-                              : parameters_->start_duration_to_avoid_oncoming_object);
+    std::abs(obj_vel) * (is_object_overtaking
+                           ? parameters_->start_duration_to_avoid_overtaking_object
+                           : parameters_->start_duration_to_avoid_oncoming_object);
   const double end_length_to_avoid =
-    std::abs(object.vel) * (is_object_overtaking
-                              ? parameters_->end_duration_to_avoid_overtaking_object
-                              : parameters_->end_duration_to_avoid_oncoming_object);
-  const auto lon_bound_start_idx_opt = motion_utils::insertTargetPoint(
-    obj_seg_idx, min_obj_lon_offset - start_length_to_avoid, path_with_backward_margin.points);
-  const size_t updated_obj_seg_idx =
-    (lon_bound_start_idx_opt && lon_bound_start_idx_opt.value() <= obj_seg_idx) ? obj_seg_idx + 1
-                                                                                : obj_seg_idx;
-  const auto lon_bound_end_idx_opt = motion_utils::insertTargetPoint(
-    updated_obj_seg_idx, max_obj_lon_offset + end_length_to_avoid,
-    path_with_backward_margin.points);
+    std::abs(obj_vel) * (is_object_overtaking ? parameters_->end_duration_to_avoid_overtaking_object
+                                              : parameters_->end_duration_to_avoid_oncoming_object);
 
-  if (!lon_bound_start_idx_opt && !lon_bound_end_idx_opt) {
-    // NOTE: The obstacle is longitudinally out of the ego's trajectory.
-    return std::nullopt;
-  }
-  const size_t lon_bound_start_idx =
-    lon_bound_start_idx_opt ? lon_bound_start_idx_opt.value() : static_cast<size_t>(0);
-  const size_t lon_bound_end_idx =
-    lon_bound_end_idx_opt ? lon_bound_end_idx_opt.value()
-                          : static_cast<size_t>(path_with_backward_margin.points.size() - 1);
+  return MinMaxValue{
+    obj_lon_offset.min_value - start_length_to_avoid,
+    obj_lon_offset.max_value + end_length_to_avoid};
+}
+
+MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
+  const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
+  const Polygon2d & obj_points, const bool is_collision_left,
+  const std::optional<DynamicAvoidanceObject> & prev_object) const
+{
+  // calculate min/max lateral offset from object to path
+  const auto obj_lat_abs_offset = [&]() {
+    std::vector<double> obj_lat_abs_offset_vec;
+    for (size_t i = 0; i < obj_points.outer().size(); ++i) {
+      const auto geom_obj_point = toGeometryPoint(obj_points.outer().at(i));
+      const size_t obj_point_seg_idx =
+        motion_utils::findNearestSegmentIndex(path_points_for_object_polygon, geom_obj_point);
+      const double obj_point_lat_offset = motion_utils::calcLateralOffset(
+        path_points_for_object_polygon, geom_obj_point, obj_point_seg_idx);
+      obj_lat_abs_offset_vec.push_back(std::abs(obj_point_lat_offset));
+    }
+    return getMinMaxValues(obj_lat_abs_offset_vec);
+  }();
+  const double min_obj_lat_offset = obj_lat_abs_offset.min_value * (is_collision_left ? 1.0 : -1.0);
+  const double max_obj_lat_offset = obj_lat_abs_offset.max_value * (is_collision_left ? 1.0 : -1.0);
 
   // calculate bound min and max lateral offset
   const double min_bound_lat_offset = [&]() {
     const double raw_min_bound_lat_offset =
-      min_obj_lat_offset -
-      parameters_->lat_offset_from_obstacle * (object.is_collision_left ? 1.0 : -1.0);
+      min_obj_lat_offset - parameters_->lat_offset_from_obstacle * (is_collision_left ? 1.0 : -1.0);
     const double min_bound_lat_abs_offset_limit =
       planner_data_->parameters.vehicle_width / 2.0 - parameters_->max_lat_offset_to_avoid;
-    if (object.is_collision_left) {
+    if (is_collision_left) {
       if (raw_min_bound_lat_offset < min_bound_lat_abs_offset_limit) {
         return min_bound_lat_abs_offset_limit;
       }
@@ -764,29 +763,66 @@ std::optional<tier4_autoware_utils::Polygon2d> DynamicAvoidanceModule::calcDynam
     return raw_min_bound_lat_offset;
   }();
   const double max_bound_lat_offset =
-    max_obj_lat_offset +
-    parameters_->lat_offset_from_obstacle * (object.is_collision_left ? 1.0 : -1.0);
+    max_obj_lat_offset + parameters_->lat_offset_from_obstacle * (is_collision_left ? 1.0 : -1.0);
 
   // filter min_bound_lat_offset
-  const auto prev_min_bound_lat_offset = prev_objects_min_bound_lat_offset_.get(object.uuid);
+  const auto prev_min_lat_avoid_to_offset = [&]() -> std::optional<double> {
+    if (!prev_object) {
+      return std::nullopt;
+    }
+    return prev_object->lat_offset_to_avoid.min_value;
+  }();
   const double filtered_min_bound_lat_offset =
-    prev_min_bound_lat_offset
-      ? signal_processing::lowpassFilter(min_bound_lat_offset, *prev_min_bound_lat_offset, 0.3)
+    prev_min_lat_avoid_to_offset
+      ? signal_processing::lowpassFilter(min_bound_lat_offset, *prev_min_lat_avoid_to_offset, 0.3)
       : min_bound_lat_offset;
-  prev_objects_min_bound_lat_offset_.update(object.uuid, filtered_min_bound_lat_offset);
+
+  return MinMaxValue{filtered_min_bound_lat_offset, max_bound_lat_offset};
+}
+
+// NOTE: object does not have const only to update min_bound_lat_offset.
+std::optional<tier4_autoware_utils::Polygon2d> DynamicAvoidanceModule::calcDynamicObstaclePolygon(
+  const DynamicAvoidanceObject & object) const
+{
+  auto path_points_for_object_polygon = calcPathForObjectPolygon();
+  if (!path_points_for_object_polygon) {
+    return std::nullopt;
+  }
+
+  const size_t obj_seg_idx =
+    motion_utils::findNearestSegmentIndex(*path_points_for_object_polygon, object.pose.position);
+  const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
+
+  const auto lon_bound_start_idx_opt = motion_utils::insertTargetPoint(
+    obj_seg_idx, object.lon_offset_to_avoid.min_value, *path_points_for_object_polygon);
+  const size_t updated_obj_seg_idx =
+    (lon_bound_start_idx_opt && lon_bound_start_idx_opt.value() <= obj_seg_idx) ? obj_seg_idx + 1
+                                                                                : obj_seg_idx;
+  const auto lon_bound_end_idx_opt = motion_utils::insertTargetPoint(
+    updated_obj_seg_idx, object.lon_offset_to_avoid.max_value, *path_points_for_object_polygon);
+
+  if (!lon_bound_start_idx_opt && !lon_bound_end_idx_opt) {
+    // NOTE: The obstacle is longitudinally out of the ego's trajectory.
+    return std::nullopt;
+  }
+  const size_t lon_bound_start_idx =
+    lon_bound_start_idx_opt ? lon_bound_start_idx_opt.value() : static_cast<size_t>(0);
+  const size_t lon_bound_end_idx =
+    lon_bound_end_idx_opt ? lon_bound_end_idx_opt.value()
+                          : static_cast<size_t>(path_points_for_object_polygon->size() - 1);
 
   // create inner/outer bound points
   std::vector<geometry_msgs::msg::Point> obj_inner_bound_points;
   std::vector<geometry_msgs::msg::Point> obj_outer_bound_points;
   for (size_t i = lon_bound_start_idx; i <= lon_bound_end_idx; ++i) {
-    obj_inner_bound_points.push_back(
-      tier4_autoware_utils::calcOffsetPose(
-        path_with_backward_margin.points.at(i).point.pose, 0.0, filtered_min_bound_lat_offset, 0.0)
-        .position);
-    obj_outer_bound_points.push_back(
-      tier4_autoware_utils::calcOffsetPose(
-        path_with_backward_margin.points.at(i).point.pose, 0.0, max_bound_lat_offset, 0.0)
-        .position);
+    obj_inner_bound_points.push_back(tier4_autoware_utils::calcOffsetPose(
+                                       path_points_for_object_polygon->at(i).point.pose, 0.0,
+                                       object.lat_offset_to_avoid.min_value, 0.0)
+                                       .position);
+    obj_outer_bound_points.push_back(tier4_autoware_utils::calcOffsetPose(
+                                       path_points_for_object_polygon->at(i).point.pose, 0.0,
+                                       object.lat_offset_to_avoid.max_value, 0.0)
+                                       .position);
   }
 
   // create obj_polygon from inner/outer bound points

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -47,6 +47,8 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
     p.min_obstacle_vel = node->declare_parameter<double>(ns + "min_obstacle_vel");
     p.successive_num_to_entry_dynamic_avoidance_condition =
       node->declare_parameter<int>(ns + "successive_num_to_entry_dynamic_avoidance_condition");
+    p.successive_num_to_exit_dynamic_avoidance_condition =
+      node->declare_parameter<int>(ns + "successive_num_to_exit_dynamic_avoidance_condition");
 
     p.min_obj_lat_offset_to_ego_path =
       node->declare_parameter<double>(ns + "min_obj_lat_offset_to_ego_path");
@@ -120,6 +122,9 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
     updateParam<int>(
       parameters, ns + "successive_num_to_entry_dynamic_avoidance_condition",
       p->successive_num_to_entry_dynamic_avoidance_condition);
+    updateParam<int>(
+      parameters, ns + "successive_num_to_exit_dynamic_avoidance_condition",
+      p->successive_num_to_exit_dynamic_avoidance_condition);
 
     updateParam<double>(
       parameters, ns + "min_obj_lat_offset_to_ego_path", p->min_obj_lat_offset_to_ego_path);


### PR DESCRIPTION
## Description

To suppress the chattering of objects appearing/disappearing, whether object's variable (e.g. velocity) is lower/higher than the threshold, the previous object information is memorized with this change.

The meaning of the `counter` for each object is, if the value is positive, the object appears `counter` times in a raw, and if negative, the object disappears `counter` times in a raw.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
