### PR TITLE
feat(dynamic_avoidance): plan path inside the module

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -16,6 +16,8 @@
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__DYNAMIC_AVOIDANCE_MODULE_HPP_
 
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+#include "obstacle_avoidance_planner/mpt_optimizer.hpp"
+#include "path_smoother/elastic_band.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -39,6 +41,7 @@ struct DynamicAvoidanceParameters
 {
   // common
   bool enable_debug_info{true};
+  bool enable_path_planning{false};
 
   // obstacle types to avoid
   bool avoid_car{true};
@@ -178,6 +181,9 @@ private:
   std::optional<tier4_autoware_utils::Polygon2d> calcDynamicObstaclePolygon(
     const DynamicAvoidanceObject & object) const;
 
+  PathWithLaneId planPath(
+    const PathWithLaneId & input_path, const DrivableAreaInfo & drivable_area_info);
+
   std::vector<DynamicAvoidanceModule::DynamicAvoidanceObjectCandidate>
     prev_target_objects_candidate_;
   std::vector<DynamicAvoidanceModule::DynamicAvoidanceObject> target_objects_;
@@ -224,6 +230,9 @@ private:
     std::vector<std::string> current_uuids_;
   };
   mutable ObjectsVariable prev_objects_min_bound_lat_offset_;
+
+  std::shared_ptr<path_smoother::EBPathSmoother> eb_path_smoother_;
+  std::shared_ptr<obstacle_avoidance_planner::MPTOptimizer> mpt_optimizer_;
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -15,9 +15,17 @@
 #ifndef BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__DYNAMIC_AVOIDANCE_MODULE_HPP_
 #define BEHAVIOR_PATH_PLANNER__SCENE_MODULE__DYNAMIC_AVOIDANCE__DYNAMIC_AVOIDANCE_MODULE_HPP_
 
+// NOTE: Since the cmake is too slow with the obstacle_avoidance_planner and path_smoother package,
+// ENABLE_PATH_PLANNING is set to false by default.
+
+// #define ENABLE_PATH_PLANNING
+
 #include "behavior_path_planner/scene_module/scene_module_interface.hpp"
+
+#ifdef ENABLE_PATH_PLANNING
 #include "obstacle_avoidance_planner/mpt_optimizer.hpp"
 #include "path_smoother/elastic_band.hpp"
+#endif
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -231,8 +239,10 @@ private:
   };
   mutable ObjectsVariable prev_objects_min_bound_lat_offset_;
 
+#ifdef ENABLE_PATH_PLANNING
   std::shared_ptr<path_smoother::EBPathSmoother> eb_path_smoother_;
   std::shared_ptr<obstacle_avoidance_planner::MPTOptimizer> mpt_optimizer_;
+#endif
 };
 }  // namespace behavior_path_planner
 

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -57,6 +57,8 @@
   <depend>magic_enum</depend>
   <depend>motion_utils</depend>
   <depend>object_recognition_utils</depend>
+  <depend>obstacle_avoidance_planner</depend>
+  <depend>path_smoother</depend>
   <depend>planning_test_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -57,8 +57,6 @@
   <depend>magic_enum</depend>
   <depend>motion_utils</depend>
   <depend>object_recognition_utils</depend>
-  <depend>obstacle_avoidance_planner</depend>
-  <depend>path_smoother</depend>
   <depend>planning_test_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
@@ -74,6 +72,10 @@
   <depend>tier4_planning_msgs</depend>
   <depend>vehicle_info_util</depend>
   <depend>visualization_msgs</depend>
+  <!-- Currently, uncommenting the following makes
+       the cmake of behavior_path_planner too slow -->
+  <!-- <depend>obstacle_avoidance_planner</depend> -->
+  <!-- <depend>path_smoother</depend> -->
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -32,6 +32,7 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
   {  // common
     std::string ns = "dynamic_avoidance.common.";
     p.enable_debug_info = node->declare_parameter<bool>(ns + "enable_debug_info");
+    p.enable_path_planning = node->declare_parameter<bool>(ns + "enable_path_planning");
   }
 
   {  // target object
@@ -101,6 +102,7 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
   {  // common
     const std::string ns = "dynamic_avoidance.common.";
     updateParam<bool>(parameters, ns + "enable_debug_info", p->enable_debug_info);
+    updateParam<bool>(parameters, ns + "enable_path_planning", p->enable_path_planning);
   }
 
   {  // target object

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/mpt_optimizer.hpp
@@ -106,8 +106,8 @@ public:
   MPTOptimizer(
     rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
     const vehicle_info_util::VehicleInfo & vehicle_info, const TrajectoryParam & traj_param,
-    const std::shared_ptr<DebugData> debug_data_ptr,
-    const std::shared_ptr<TimeKeeper> time_keeper_ptr);
+    const std::shared_ptr<DebugData> debug_data_ptr = std::make_shared<DebugData>(),
+    const std::shared_ptr<TimeKeeper> time_keeper_ptr = std::make_shared<TimeKeeper>());
 
   std::vector<TrajectoryPoint> optimizeTrajectory(
     const PlannerData & planner_data, const std::vector<TrajectoryPoint> & smoothed_points);

--- a/planning/path_smoother/include/path_smoother/elastic_band.hpp
+++ b/planning/path_smoother/include/path_smoother/elastic_band.hpp
@@ -34,7 +34,8 @@ class EBPathSmoother
 public:
   EBPathSmoother(
     rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
-    const CommonParam & common_param, const std::shared_ptr<TimeKeeper> time_keeper_ptr);
+    const CommonParam & common_param,
+    const std::shared_ptr<TimeKeeper> time_keeper_ptr = std::make_shared<TimeKeeper>());
 
   std::vector<TrajectoryPoint> smoothTrajectory(
     const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & ego_pose);


### PR DESCRIPTION
## Description

Use optimization path planner in dynamic_avoidance module by using the class of obstacle_avoidance_planner and path_smoother.
The feature is set to false by default.

NOTE:
CMake of behavior_path_planner with obstacle_avoidance_planner and path_smoother is too slow (around 5 mins only by CMake). 
Therefore, by using the macro in source files and commenting dependency out in package.xml, the path planning code is ignored by default.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
