### PR TITLE
ci: add prevent-no-label-execution for openai-pr-reviewer

### DIFF
--- a/.github/workflows/openai-pr-reviewer.yaml
+++ b/.github/workflows/openai-pr-reviewer.yaml
@@ -16,7 +16,13 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'pull_request_review_comment' }}
 
 jobs:
+  prevent-no-label-execution:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/prevent-no-label-execution.yaml@v1
+    with:
+      label: openai-pr-review
   review:
+    needs: prevent-no-label-execution
+    if: ${{ needs.prevent-no-label-execution.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: fluxninja/openai-pr-reviewer@latest

--- a/.github/workflows/openai-pr-reviewer.yaml
+++ b/.github/workflows/openai-pr-reviewer.yaml
@@ -23,7 +23,7 @@ jobs:
   prevent-no-label-execution:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/prevent-no-label-execution.yaml@v1
     with:
-      label: openai-pr-review
+      label: openai-pr-reviewer
   review:
     needs: prevent-no-label-execution
     if: ${{ needs.prevent-no-label-execution.outputs.run == 'true' }}

--- a/.github/workflows/openai-pr-reviewer.yaml
+++ b/.github/workflows/openai-pr-reviewer.yaml
@@ -6,6 +6,10 @@ permissions:
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
   pull_request_review_comment:
     types: [created]
 


### PR DESCRIPTION
## Description
Add label check to run Open AI PR reviewer

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Bug fix: Added label check to run Open AI PR reviewer in `.github/workflows/openai-pr-reviewer.yaml`.

> "A bug was found, a fix was made,
> Now labels are checked, no more mistakes.
> Open AI PR reviewer, diligent and wise,
> Ensuring code quality, reaching for the skies."
<!-- end of auto-generated comment: release notes by openai -->