### PR TITLE
feat(intersection): extract occlusion contour as polygon

### DIFF
--- a/planning/behavior_velocity_intersection_module/CMakeLists.txt
+++ b/planning/behavior_velocity_intersection_module/CMakeLists.txt
@@ -5,12 +5,18 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 pluginlib_export_plugin_description_file(behavior_velocity_planner plugins.xml)
 
+find_package(OpenCV REQUIRED)
+
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/debug.cpp
   src/manager.cpp
   src/scene_intersection.cpp
   src/scene_merge_from_private_road.cpp
   src/util.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${OpenCV_LIBRARIES}
 )
 
 ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -46,7 +46,7 @@
         min_vehicle_brake_for_rss: -2.5 # [m/s^2]
         max_vehicle_velocity_for_rss: 16.66 # [m/s] == 60kmph
         denoise_kernel: 1.0 # [m]
-        pub_debug_grid: false
+        possible_object_bbox: [1.0, 2.0] # [m x m]
 
       enable_rtc: # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval
         intersection: true

--- a/planning/behavior_velocity_intersection_module/package.xml
+++ b/planning/behavior_velocity_intersection_module/package.xml
@@ -20,14 +20,9 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>behavior_velocity_planner_common</depend>
-  <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>
-  <depend>grid_map_cv</depend>
-  <depend>grid_map_ros</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
-  <depend>libboost-dev</depend>
-  <depend>libopencv-dev</depend>
   <depend>magic_enum</depend>
   <depend>motion_utils</depend>
   <depend>nav_msgs</depend>

--- a/planning/behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_intersection_module/src/debug.cpp
@@ -221,6 +221,14 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
       &debug_marker_array, now);
   }
 
+  size_t j{0};
+  for (const auto & p : debug_data_.occlusion_polygons) {
+    appendMarkerArray(
+      debug::createPolygonMarkerArray(
+        p, "occlusion_polygons", lane_id_ + j++, now, 0.3, 0.0, 0.0, 1.0, 0.0, 0.0),
+      &debug_marker_array, now);
+  }
+
   return debug_marker_array;
 }
 

--- a/planning/behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_intersection_module/src/debug.cpp
@@ -221,11 +221,11 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
       &debug_marker_array, now);
   }
 
-  size_t j{0};
-  for (const auto & p : debug_data_.occlusion_polygons) {
+  for (size_t j = 0; j < debug_data_.occlusion_polygons.size(); ++j) {
+    const auto & p = debug_data_.occlusion_polygons.at(j);
     appendMarkerArray(
       debug::createPolygonMarkerArray(
-        p, "occlusion_polygons", lane_id_ + j++, now, 0.3, 0.0, 0.0, 1.0, 0.0, 0.0),
+        p, "occlusion_polygons", lane_id_ + j, now, 0.3, 0.0, 0.0, 1.0, 0.0, 0.0),
       &debug_marker_array, now);
   }
 

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -113,7 +113,6 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
   ip.occlusion.max_vehicle_velocity_for_rss =
     node.declare_parameter<double>(ns + ".occlusion.max_vehicle_velocity_for_rss");
   ip.occlusion.denoise_kernel = node.declare_parameter<double>(ns + ".occlusion.denoise_kernel");
-  ip.occlusion.pub_debug_grid = node.declare_parameter<bool>(ns + ".occlusion.pub_debug_grid");
   ip.occlusion.possible_object_bbox =
     node.declare_parameter<std::vector<double>>(ns + ".occlusion.possible_object_bbox");
 }

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -114,6 +114,8 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
     node.declare_parameter<double>(ns + ".occlusion.max_vehicle_velocity_for_rss");
   ip.occlusion.denoise_kernel = node.declare_parameter<double>(ns + ".occlusion.denoise_kernel");
   ip.occlusion.pub_debug_grid = node.declare_parameter<bool>(ns + ".occlusion.pub_debug_grid");
+  ip.occlusion.possible_object_bbox =
+    node.declare_parameter<std::vector<double>>(ns + ".occlusion.possible_object_bbox");
 }
 
 void IntersectionModuleManager::launchNewModules(

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -12,33 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <grid_map_cv/grid_map_cv.hpp>
-#include <grid_map_ros/grid_map_ros.hpp>
-#include <lanelet2_extension/regulatory_elements/road_marking.hpp>
-#include <lanelet2_extension/utility/message_conversion.hpp>
-#include <lanelet2_extension/utility/query.hpp>
-#include <lanelet2_extension/utility/utilities.hpp>
-
-#if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
-#else
-#include <cv_bridge/cv_bridge.h>
-#endif
-// #include <sensor_msgs/image_encodings.h>
-// #include <opencv2/highgui/highgui.hpp>
 #include "scene_intersection.hpp"
+
 #include "util.hpp"
 
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <behavior_velocity_planner_common/utilization/path_utilization.hpp>
 #include <behavior_velocity_planner_common/utilization/util.hpp>
+#include <lanelet2_extension/regulatory_elements/road_marking.hpp>
+#include <lanelet2_extension/utility/message_conversion.hpp>
+#include <lanelet2_extension/utility/query.hpp>
+#include <lanelet2_extension/utility/utilities.hpp>
 #include <magic_enum.hpp>
 #include <opencv2/imgproc.hpp>
-
-#include <boost/geometry/algorithms/area.hpp>
-#include <boost/geometry/algorithms/simplify.hpp>
-#include <boost/geometry/core/cs.hpp>
-#include <boost/geometry/geometries/register/point.hpp>
 
 #include <lanelet2_core/geometry/Polygon.h>
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
@@ -48,8 +34,6 @@
 #include <memory>
 #include <tuple>
 #include <vector>
-
-BOOST_GEOMETRY_REGISTER_POINT_2D(cv::Point, int, cs::cartesian, x, y)  // NOLINT
 
 namespace behavior_velocity_planner
 {
@@ -100,10 +84,6 @@ IntersectionModule::IntersectionModule(
     planner_param_.collision_detection.state_transit_margin_time);
   before_creep_state_machine_.setMarginTime(planner_param_.occlusion.before_creep_stop_time);
   before_creep_state_machine_.setState(StateMachine::State::STOP);
-  if (enable_occlusion_detection) {
-    occlusion_grid_pub_ = node_.create_publisher<grid_map_msgs::msg::GridMap>(
-      "~/debug/intersection/occlusion_grid", rclcpp::QoS(1).transient_local());
-  }
   stuck_private_area_timeout_.setMarginTime(planner_param_.stuck_vehicle.timeout_private_area);
   stuck_private_area_timeout_.setState(StateMachine::State::STOP);
 }
@@ -1111,9 +1091,6 @@ bool IntersectionModule::checkCollision(
   return collision_detected;
 }
 
-using CvPolygon = boost::geometry::model::polygon<cv::Point>;
-using CvLineString = boost::geometry::model::linestring<cv::Point>;
-
 bool IntersectionModule::isOcclusionCleared(
   const nav_msgs::msg::OccupancyGrid & occ_grid,
   const std::vector<lanelet::CompoundPolygon3d> & attention_areas,
@@ -1355,10 +1332,20 @@ bool IntersectionModule::isOcclusionCleared(
   cv::findContours(occlusion_mask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
   std::vector<std::vector<cv::Point>> valid_contours;
   for (const auto & contour : contours) {
+    std::vector<cv::Point> valid_contour;
+    for (const auto & p : contour) {
+      if (distance_grid.at<unsigned char>(p.y, p.x) == undef_pixel) {
+        continue;
+      }
+      valid_contour.push_back(p);
+    }
+    if (valid_contour.size() <= 2) {
+      continue;
+    }
     std::vector<cv::Point> approx_contour;
     cv::approxPolyDP(
-      contour, approx_contour,
-      std::round(std::min(possible_object_bbox_x, possible_object_bbox_y) / resolution), true);
+      valid_contour, approx_contour,
+      std::round(std::min(possible_object_bbox_x, possible_object_bbox_y) / std::sqrt(2.0)), true);
     if (approx_contour.size() <= 1) continue;
     // check area
     const double poly_area = cv::contourArea(approx_contour);
@@ -1378,59 +1365,29 @@ bool IntersectionModule::isOcclusionCleared(
     debug_data_.occlusion_polygons.push_back(polygon_msg);
   }
 
-  // clean-up and find nearest risk
   const int min_cost_thr = dist2pixel(occlusion_dist_thr);
   int min_cost = undef_pixel - 1;
-  int max_cost = 0;
-  std::optional<int> min_cost_projection_ind = std::nullopt;
   geometry_msgs::msg::Point nearest_occlusion_point;
-  for (int i = 0; i < width; ++i) {
-    for (int j = 0; j < height; ++j) {
-      const int pixel = static_cast<int>(distance_grid.at<unsigned char>(height - 1 - j, i));
-      const bool occluded = (occlusion_mask.at<unsigned char>(height - 1 - j, i) == 255);
+  for (const auto & occlusion_contour : valid_contours) {
+    for (const auto & p : occlusion_contour) {
+      const int pixel = static_cast<int>(distance_grid.at<unsigned char>(p.y, p.x));
+      const bool occluded = (occlusion_mask.at<unsigned char>(p.y, p.x) == 255);
       if (pixel == undef_pixel || !occluded) {
-        // ignore outside of cropped
-        // some cell maybe undef still
-        distance_grid.at<unsigned char>(height - 1 - j, i) = 0;
         continue;
       }
-      if (max_cost < pixel) {
-        max_cost = pixel;
-      }
-      const int projection_ind = projection_ind_grid.at<int>(height - 1 - j, i);
       if (pixel < min_cost) {
-        assert(projection_ind >= 0);
         min_cost = pixel;
-        min_cost_projection_ind = projection_ind;
-        nearest_occlusion_point.x = origin.x + i * resolution;
-        nearest_occlusion_point.y = origin.y + j * resolution;
-        nearest_occlusion_point.z = origin.z + distance_max * pixel / max_cost_pixel;
+        nearest_occlusion_point.x = origin.x + p.x * resolution;
+        nearest_occlusion_point.y = origin.y + (height - 1 - p.y) * resolution;
+        nearest_occlusion_point.z = origin.z;
       }
     }
   }
-  debug_data_.nearest_occlusion_point = nearest_occlusion_point;
 
-  if (planner_param_.occlusion.pub_debug_grid) {
-    cv::Mat distance_grid_heatmap;
-    cv::applyColorMap(distance_grid, distance_grid_heatmap, cv::COLORMAP_JET);
-    grid_map::GridMap occlusion_grid({"elevation"});
-    occlusion_grid.setFrameId("map");
-    occlusion_grid.setGeometry(
-      grid_map::Length(width * resolution, height * resolution), resolution,
-      grid_map::Position(origin.x + width * resolution / 2, origin.y + height * resolution / 2));
-    cv::rotate(distance_grid, distance_grid, cv::ROTATE_90_COUNTERCLOCKWISE);
-    cv::rotate(distance_grid_heatmap, distance_grid_heatmap, cv::ROTATE_90_COUNTERCLOCKWISE);
-    grid_map::GridMapCvConverter::addLayerFromImage<unsigned char, 1>(
-      distance_grid, "elevation", occlusion_grid, origin.z /* elevation for 0 */,
-      origin.z + distance_max /* elevation for 255 */);
-    grid_map::GridMapCvConverter::addColorLayerFromImage<unsigned char, 3>(
-      distance_grid_heatmap, "color", occlusion_grid);
-    occlusion_grid_pub_->publish(grid_map::GridMapRosConverter::toMessage(occlusion_grid));
-  }
-
-  if (min_cost > min_cost_thr || !min_cost_projection_ind.has_value()) {
+  if (min_cost > min_cost_thr) {
     return true;
   } else {
+    debug_data_.nearest_occlusion_point = nearest_occlusion_point;
     return false;
   }
 }

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -1236,13 +1236,16 @@ bool IntersectionModule::isOcclusionCleared(
     occlusion_mask_raw, occlusion_mask, cv::MORPH_OPEN,
     cv::getStructuringElement(cv::MORPH_RECT, cv::Size(morph_size, morph_size)));
   {
+    const auto & possible_object_bbox = planner_param_.occlusion.possible_object_bbox;
+    const double possible_object_area = possible_object_bbox.at(0) * possible_object_bbox.at(1);
     std::vector<std::vector<cv::Point>> contours;
     cv::findContours(occlusion_mask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
     for (const auto & contour : contours) {
       // std::vector<cv::Point> approx_contour;
       // cv::approxPolyDP(contour, approx_contour, 0.05 * cv::arcLength(contour, true), true);
       Polygon2d polygon;
-      // [[maybe_unused]] const double poly_area = cv::contourArea(contour);
+      const double poly_area = cv::contourArea(contour);
+      if (poly_area < possible_object_area) continue;
       for (const auto & p : contour) {
         const double glob_x = (p.x + 0.5) * resolution + origin.x;
         const double glob_y = (height - 0.5 - p.y) * resolution + origin.y;

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -35,6 +35,11 @@
 #include <magic_enum.hpp>
 #include <opencv2/imgproc.hpp>
 
+#include <boost/geometry/algorithms/area.hpp>
+#include <boost/geometry/algorithms/simplify.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/geometries/register/point.hpp>
+
 #include <lanelet2_core/geometry/Polygon.h>
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
@@ -43,6 +48,8 @@
 #include <memory>
 #include <tuple>
 #include <vector>
+
+BOOST_GEOMETRY_REGISTER_POINT_2D(cv::Point, int, cs::cartesian, x, y)  // NOLINT
 
 namespace behavior_velocity_planner
 {
@@ -1104,6 +1111,8 @@ bool IntersectionModule::checkCollision(
   return collision_detected;
 }
 
+using CvPolygon = boost::geometry::model::polygon<cv::Point>;
+
 bool IntersectionModule::isOcclusionCleared(
   const nav_msgs::msg::OccupancyGrid & occ_grid,
   const std::vector<lanelet::CompoundPolygon3d> & attention_areas,
@@ -1346,23 +1355,26 @@ bool IntersectionModule::isOcclusionCleared(
     // std::vector<cv::Point> approx_contour;
     // cv::approxPolyDP(contour, approx_contour, 0.05 * cv::arcLength(contour, true), true);
 
-    // check size
-    const double poly_area = cv::contourArea(contour);
-    if (poly_area < possible_object_area) continue;
-
     // check if distance is positive
-    std::vector<cv::Point> positive_contour;
+    CvPolygon positive_contour;
     for (const auto & p : contour) {
       const int i = p.x, j = p.y;
       if (distance_grid.at<unsigned char>(j, i) != undef_pixel) {
-        positive_contour.push_back(p);
+        positive_contour.outer().emplace_back(i, j);
       }
     }
-    if (positive_contour.empty()) continue;
+    if (positive_contour.outer().empty()) continue;
+    // bg::correct(positive_contour);
+    CvPolygon simplified_contour;
+    bg::simplify(positive_contour, simplified_contour, 0.5);
 
-    valid_contours.push_back(positive_contour);
+    // check size
+    const double poly_area = bg::area(simplified_contour);
+    if (poly_area < possible_object_area) continue;
+
+    valid_contours.push_back(simplified_contour.outer());
     Polygon2d polygon;
-    for (const auto & p : contour) {
+    for (const auto & p : simplified_contour.outer()) {
       const double glob_x = (p.x + 0.5) * resolution + origin.x;
       const double glob_y = (height - 0.5 - p.y) * resolution + origin.y;
       polygon.outer().emplace_back(glob_x, glob_y);

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -20,13 +20,11 @@
 #include <behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <behavior_velocity_planner_common/utilization/state_machine.hpp>
-#include <grid_map_core/grid_map_core.hpp>
 #include <motion_utils/motion_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
-#include <grid_map_msgs/msg/grid_map.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -108,7 +106,6 @@ public:
       double min_vehicle_brake_for_rss;
       double max_vehicle_velocity_for_rss;
       double denoise_kernel;
-      bool pub_debug_grid;
       std::vector<double> possible_object_bbox;
     } occlusion;
   };
@@ -275,7 +272,6 @@ private:
   */
 
   util::DebugData debug_data_;
-  rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr occlusion_grid_pub_;
 };
 
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -109,6 +109,7 @@ public:
       double max_vehicle_velocity_for_rss;
       double denoise_kernel;
       bool pub_debug_grid;
+      std::vector<double> possible_object_bbox;
     } occlusion;
   };
 

--- a/planning/behavior_velocity_intersection_module/src/util_type.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util_type.hpp
@@ -49,6 +49,7 @@ struct DebugData
   autoware_auto_perception_msgs::msg::PredictedObjects stuck_targets;
   std::optional<geometry_msgs::msg::Point> nearest_occlusion_point = std::nullopt;
   std::optional<geometry_msgs::msg::Point> nearest_occlusion_projection_point = std::nullopt;
+  std::vector<geometry_msgs::msg::Polygon> occlusion_polygons;
 };
 
 struct InterpolatedPathInfo


### PR DESCRIPTION
## Description

This feature replaces the occlusion grid with occlusion polygon and filtering based on its size.

## Related links

[Tier IV COMPANY INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-2754)
launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/485

## Tests performed

Psim

https://github.com/autowarefoundation/autoware.universe/assets/28677420/f44e87d0-6919-4fac-a1e2-2e4d37771f93

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
