### PR TITLE
fix(roi_cluster_fusion): fix roi_cluster_fusion died bug

### DIFF
--- a/perception/image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
@@ -191,38 +191,39 @@ void RoiClusterFusionNode::fuseOnSingleImage(
         max_iou = iou + iou_x + iou_y;
       }
     }
-    bool is_roi_label_known = feature_obj.object.classification.front().label !=
-                              autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
-    bool is_roi_existence_prob_higher =
-      output_cluster_msg.feature_objects.at(index).object.existence_probability <=
-      feature_obj.object.existence_probability;
-    if (iou_threshold_ < max_iou && is_roi_existence_prob_higher && is_roi_label_known) {
-      output_cluster_msg.feature_objects.at(index).object.classification =
-        feature_obj.object.classification;
+    if (!output_cluster_msg.feature_objects.empty()) {
+      bool is_roi_label_known = feature_obj.object.classification.front().label !=
+                                autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
+      bool is_roi_existence_prob_higher =
+        output_cluster_msg.feature_objects.at(index).object.existence_probability <=
+        feature_obj.object.existence_probability;
+      if (iou_threshold_ < max_iou && is_roi_existence_prob_higher && is_roi_label_known) {
+        output_cluster_msg.feature_objects.at(index).object.classification =
+          feature_obj.object.classification;
 
-      // Update existence_probability for fused objects
-      if (
-        output_cluster_msg.feature_objects.at(index).object.existence_probability <
-        min_roi_existence_prob_) {
-        output_cluster_msg.feature_objects.at(index).object.existence_probability =
-          min_roi_existence_prob_;
+        // Update existence_probability for fused objects
+        if (
+          output_cluster_msg.feature_objects.at(index).object.existence_probability <
+          min_roi_existence_prob_) {
+          output_cluster_msg.feature_objects.at(index).object.existence_probability =
+            min_roi_existence_prob_;
+        }
+      }
+
+      // fuse with unknown roi
+
+      if (unknown_iou_threshold_ < max_iou && is_roi_existence_prob_higher && !is_roi_label_known) {
+        output_cluster_msg.feature_objects.at(index).object.classification =
+          feature_obj.object.classification;
+        // Update existence_probability for fused objects
+        if (
+          output_cluster_msg.feature_objects.at(index).object.existence_probability <
+          min_roi_existence_prob_) {
+          output_cluster_msg.feature_objects.at(index).object.existence_probability =
+            min_roi_existence_prob_;
+        }
       }
     }
-
-    // fuse with unknown roi
-
-    if (unknown_iou_threshold_ < max_iou && is_roi_existence_prob_higher && !is_roi_label_known) {
-      output_cluster_msg.feature_objects.at(index).object.classification =
-        feature_obj.object.classification;
-      // Update existence_probability for fused objects
-      if (
-        output_cluster_msg.feature_objects.at(index).object.existence_probability <
-        min_roi_existence_prob_) {
-        output_cluster_msg.feature_objects.at(index).object.existence_probability =
-          min_roi_existence_prob_;
-      }
-    }
-
     debug_image_rois.push_back(feature_obj.feature.roi);
   }
 


### PR DESCRIPTION
## Description

This PR to fix bug of roi_cluster_fusion node died when empty pointcloud is published.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
