### PR TITLE
fix(compare_map_segmentation): change to using kinematic_state topic

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/pointcloud_map_filter.launch.py
@@ -65,7 +65,7 @@ class PointcloudMapFilterPipeline:
                     ("map", "/map/pointcloud_map"),
                     ("output", LaunchConfiguration("output_topic")),
                     ("map_loader_service", "/map/get_differential_pointcloud_map"),
-                    ("pose_with_covariance", "/localization/pose_estimator/pose_with_covariance"),
+                    ("kinematic_state", "/localization/kinematic_state"),
                 ],
                 parameters=[
                     {
@@ -122,7 +122,7 @@ class PointcloudMapFilterPipeline:
                     ("map", "/map/pointcloud_map"),
                     ("output", LaunchConfiguration("output_topic")),
                     ("map_loader_service", "/map/get_differential_pointcloud_map"),
-                    ("pose_with_covariance", "/localization/pose_estimator/pose_with_covariance"),
+                    ("kinematic_state", "/localization/kinematic_state"),
                 ],
                 parameters=[
                     {

--- a/perception/compare_map_segmentation/CMakeLists.txt
+++ b/perception/compare_map_segmentation/CMakeLists.txt
@@ -46,8 +46,7 @@ ament_target_dependencies(compare_map_segmentation
   sensor_msgs
   tier4_autoware_utils
   autoware_map_msgs
-  component_interface_specs
-  component_interface_utils
+  nav_msgs
 )
 
 if(OPENMP_FOUND)

--- a/perception/compare_map_segmentation/README.md
+++ b/perception/compare_map_segmentation/README.md
@@ -61,12 +61,11 @@ This filter is a combination of the distance_based_compare_map_filter and voxel_
 
 #### Input
 
-| Name                                 | Type                                            | Description                                                    |
-| ------------------------------------ | ----------------------------------------------- | -------------------------------------------------------------- |
-| `~/input/points`                     | `sensor_msgs::msg::PointCloud2`                 | reference points                                               |
-| `~/input/map`                        | `sensor_msgs::msg::PointCloud2`                 | map (in case static map loading)                               |
-| `~/pose_with_covariance`             | `geometry_msgs::msg::PoseWithCovarianceStamped` | current ego-vehicle pose (in case dynamic map loading)         |
-| `/localization/initialization_state` | `localization_interface::InitializationState`   | Ego-vehicle pose initialization state (in dynamic map loading) |
+| Name                            | Type                            | Description                                            |
+| ------------------------------- | ------------------------------- | ------------------------------------------------------ |
+| `~/input/points`                | `sensor_msgs::msg::PointCloud2` | reference points                                       |
+| `~/input/map`                   | `sensor_msgs::msg::PointCloud2` | map (in case static map loading)                       |
+| `/localization/kinematic_state` | `nav_msgs::msg::Odometry`       | current ego-vehicle pose (in case dynamic map loading) |
 
 #### Output
 

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -15,12 +15,11 @@
 #ifndef COMPARE_MAP_SEGMENTATION__VOXEL_GRID_MAP_LOADER_HPP_
 #define COMPARE_MAP_SEGMENTATION__VOXEL_GRID_MAP_LOADER_HPP_
 
-#include <component_interface_specs/localization.hpp>
-#include <component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/srv/get_differential_point_cloud_map.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <pcl/filters/voxel_grid.h>
@@ -154,16 +153,11 @@ protected:
   };
 
   typedef typename std::map<std::string, struct MapGridVoxelInfo> VoxelGridDict;
-  using InitializationState = localization_interface::InitializationState;
 
   /** \brief Map to hold loaded map grid id and it's voxel filter */
   VoxelGridDict current_voxel_grid_dict_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_kinematic_state_;
 
-  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
-    sub_estimated_pose_;
-  component_interface_utils::Subscription<InitializationState>::SharedPtr
-    sub_pose_initializer_state_;
-  InitializationState::Message initialization_state_;
   std::optional<geometry_msgs::msg::Point> current_position_ = std::nullopt;
   std::optional<geometry_msgs::msg::Point> last_updated_position_ = std::nullopt;
   rclcpp::TimerBase::SharedPtr map_update_timer_;
@@ -200,8 +194,7 @@ public:
     rclcpp::Node * node, double leaf_size, double downsize_ratio_z_axis,
     std::string * tf_map_input_frame, std::mutex * mutex,
     rclcpp::CallbackGroup::SharedPtr main_callback_group);
-  void onEstimatedPoseCallback(geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr pose);
-  void onPoseInitializerCallback(const InitializationState::Message::ConstSharedPtr msg);
+  void onEstimatedPoseCallback(nav_msgs::msg::Odometry::ConstSharedPtr pose);
 
   void timer_callback();
   bool should_update_map() const;

--- a/perception/compare_map_segmentation/package.xml
+++ b/perception/compare_map_segmentation/package.xml
@@ -18,10 +18,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_map_msgs</depend>
-  <depend>component_interface_specs</depend>
-  <depend>component_interface_utils</depend>
   <depend>grid_map_pcl</depend>
   <depend>grid_map_ros</depend>
+  <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>pointcloud_preprocessor</depend>
   <depend>rclcpp</depend>

--- a/perception/euclidean_cluster/launch/euclidean_cluster.launch.py
+++ b/perception/euclidean_cluster/launch/euclidean_cluster.launch.py
@@ -57,7 +57,7 @@ def launch_setup(context, *args, **kwargs):
             ("map", LaunchConfiguration("input_map")),
             ("output", "compare_map_filtered/pointcloud"),
             ("map_loader_service", "/map/get_differential_pointcloud_map"),
-            ("pose_with_covariance", "/localization/pose_estimator/pose_with_covariance"),
+            ("kinematic_state", "/localization/kinematic_state"),
         ],
         parameters=[
             {

--- a/perception/euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.py
+++ b/perception/euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.py
@@ -47,7 +47,7 @@ def launch_setup(context, *args, **kwargs):
             ("map", LaunchConfiguration("input_map")),
             ("output", "map_filter/pointcloud"),
             ("map_loader_service", "/map/get_differential_pointcloud_map"),
-            ("pose_with_covariance", "/localization/pose_estimator/pose_with_covariance"),
+            ("kinematic_state", "/localization/kinematic_state"),
         ],
         parameters=[load_composable_node_param("compare_map_param_path")],
     )


### PR DESCRIPTION
## Description

- Change the topic to obtain ego-vehicle position in dynamic map loader mode of compare map segmentation.

## Related links 

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-3245)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- Confirm map comparing result using Logging_simulor.
![image](https://github.com/autowarefoundation/autoware.universe/assets/94814556/974a5da4-e205-4091-a55b-978cbc744ec3)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
