### PR TITLE
feat(behavior_velocity_crosswalk_module): suppress sudden stop for stuck vehicle

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
@@ -4,8 +4,8 @@
       common:
         show_processing_time: false # [-] whether to show processing time
         # param for input data
-        enable_rtc: true # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval
         traffic_light_state_timeout: 3.0 # [s] timeout threshold for traffic light signal
+        enable_rtc: true # if true, the scene modules should be approved by (request to cooperate)rtc function. if false, the module can be run without approval from rtc.
 
       # param for stop position
       stop_position:
@@ -30,6 +30,9 @@
         stuck_vehicle_velocity: 1.0 # [m/s] maximum velocity threshold whether the vehicle is stuck
         max_stuck_vehicle_lateral_offset: 2.0 # [m] maximum lateral offset for stuck vehicle position should be looked
         stuck_vehicle_attention_range: 10.0 # [m] the detection area is defined as X meters behind the crosswalk
+        min_acc: -1.0   # min acceleration [m/ss]
+        min_jerk: -1.0  # min jerk [m/sss]
+        max_jerk: 1.0   # max jerk [m/sss]
 
       # param for pass judge logic
       pass_judge:

--- a/planning/behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/manager.cpp
@@ -66,6 +66,9 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
     node.declare_parameter<double>(ns + ".stuck_vehicle.max_stuck_vehicle_lateral_offset");
   cp.stuck_vehicle_attention_range =
     node.declare_parameter<double>(ns + ".stuck_vehicle.stuck_vehicle_attention_range");
+  cp.min_acc_for_stuck_vehicle = node.declare_parameter<double>(ns + ".stuck_vehicle.min_acc");
+  cp.max_jerk_for_stuck_vehicle = node.declare_parameter<double>(ns + ".stuck_vehicle.max_jerk");
+  cp.min_jerk_for_stuck_vehicle = node.declare_parameter<double>(ns + ".stuck_vehicle.min_jerk");
 
   // param for pass judge logic
   cp.ego_pass_first_margin =

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -17,6 +17,7 @@
 #include <autoware_auto_tf2/tf2_autoware_auto_msgs.hpp>
 #include <behavior_velocity_planner_common/utilization/path_utilization.hpp>
 #include <behavior_velocity_planner_common/utilization/util.hpp>
+#include <motion_utils/distance/distance.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
@@ -30,6 +31,7 @@ namespace behavior_velocity_planner
 {
 namespace bg = boost::geometry;
 using motion_utils::calcArcLength;
+using motion_utils::calcDecelDistWithJerkAndAccConstraints;
 using motion_utils::calcLateralOffset;
 using motion_utils::calcLongitudinalOffsetPoint;
 using motion_utils::calcLongitudinalOffsetPose;
@@ -762,6 +764,8 @@ std::optional<StopFactor> CrosswalkModule::checkStopForStuckVehicles(
   const std::vector<geometry_msgs::msg::Point> & path_intersects,
   const std::optional<geometry_msgs::msg::Pose> & stop_pose) const
 {
+  const auto & p = planner_param_;
+
   if (path_intersects.size() < 2 || !stop_pose) {
     return {};
   }
@@ -772,26 +776,39 @@ std::optional<StopFactor> CrosswalkModule::checkStopForStuckVehicles(
     }
 
     const auto & obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
-    if (planner_param_.stuck_vehicle_velocity < std::hypot(obj_vel.x, obj_vel.y)) {
+    if (p.stuck_vehicle_velocity < std::hypot(obj_vel.x, obj_vel.y)) {
       continue;
     }
 
     const auto & obj_pos = object.kinematics.initial_pose_with_covariance.pose.position;
     const auto lateral_offset = calcLateralOffset(ego_path.points, obj_pos);
-    if (planner_param_.max_stuck_vehicle_lateral_offset < std::abs(lateral_offset)) {
+    if (p.max_stuck_vehicle_lateral_offset < std::abs(lateral_offset)) {
       continue;
     }
 
     const auto & ego_pos = planner_data_->current_odometry->pose.position;
+    const auto & ego_vel = planner_data_->current_velocity->twist.linear;
+    const auto ego_acc = planner_data_->current_acceleration->accel.accel.linear.x;
+
     const double near_attention_range =
       calcSignedArcLength(ego_path.points, ego_pos, path_intersects.back());
-    const double far_attention_range =
-      near_attention_range + planner_param_.stuck_vehicle_attention_range;
+    const double far_attention_range = near_attention_range + p.stuck_vehicle_attention_range;
 
     const auto dist_ego2obj = calcSignedArcLength(ego_path.points, ego_pos, obj_pos);
 
     if (near_attention_range < dist_ego2obj && dist_ego2obj < far_attention_range) {
-      return createStopFactor(*stop_pose, {obj_pos});
+      const double min_feasible_dist_to_stop = calcDecelDistWithJerkAndAccConstraints(
+        ego_vel, 0.0, ego_acc, p.min_acc_for_stuck_vehicle, p.max_jerk_for_stuck_vehicle,
+        p.min_jerk_for_stuck_vehicle);
+      const double dist_ego2stop =
+        calcSignedArcLength(ego_path.points, ego_pos, stop_pose->position);
+      const double feasible_dist_to_stop = std::max(min_feasible_dist_to_stop, dist_ego2stop);
+
+      const auto feasible_stop_pose =
+        calcLongitudinalOffsetPose(ego_path, 0, feasible_dist_to_stop);
+      if (feasible_stop_pose) {
+        return createStopFactor(*feasible_stop_pose, {obj_pos});
+      }
     }
   }
 

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -787,7 +787,7 @@ std::optional<StopFactor> CrosswalkModule::checkStopForStuckVehicles(
     }
 
     const auto & ego_pos = planner_data_->current_odometry->pose.position;
-    const auto & ego_vel = planner_data_->current_velocity->twist.linear;
+    const auto & ego_vel = planner_data_->current_velocity->twist.linear.x;
     const auto ego_acc = planner_data_->current_acceleration->accel.accel.linear.x;
 
     const double near_attention_range =

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -76,6 +76,9 @@ public:
     double stuck_vehicle_velocity;
     double max_stuck_vehicle_lateral_offset;
     double stuck_vehicle_attention_range;
+    double min_acc_for_stuck_vehicle;
+    double max_jerk_for_stuck_vehicle;
+    double min_jerk_for_stuck_vehicle;
     // param for pass judge logic
     double ego_pass_first_margin;
     double ego_pass_later_margin;


### PR DESCRIPTION
## Description

TIER IV internal ticket: https://tier4.atlassian.net/browse/RT1-3240

Suppress sudden stop for stuck vehicle detection in crosswalk module by adding min_acc, max_jerk and min_jerk.


Normal case.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/e4813d47-18a5-43e6-946b-b7f5a65af17c)


If the stop for stuck vehicle detection is required suddenly, the stop point is inserted forward.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/347f7746-9911-4ff0-bf4f-f308ff9ead1b)
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

suppress sudden stop for stuck vehicle detection in crosswalk module

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
