### PR TITLE
feat(dynamic_avoidance): calculate which side to avoid more accurately

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -82,13 +82,13 @@ public:
   {
     DynamicAvoidanceObject(
       const PredictedObject & predicted_object, const double arg_vel, const double arg_lat_vel,
-      const bool arg_is_left, const double arg_time_to_collision)
+      const bool arg_is_collision_left, const double arg_time_to_collision)
     : uuid(tier4_autoware_utils::toHexString(predicted_object.object_id)),
       pose(predicted_object.kinematics.initial_pose_with_covariance.pose),
       shape(predicted_object.shape),
       vel(arg_vel),
       lat_vel(arg_lat_vel),
-      is_left(arg_is_left),
+      is_collision_left(arg_is_collision_left),
       time_to_collision(arg_time_to_collision)
     {
       for (const auto & path : predicted_object.kinematics.predicted_paths) {
@@ -101,7 +101,7 @@ public:
     autoware_auto_perception_msgs::msg::Shape shape;
     double vel;
     double lat_vel;
-    bool is_left;
+    bool is_collision_left;
     double time_to_collision;
     std::vector<autoware_auto_perception_msgs::msg::PredictedPath> predicted_paths{};
   };
@@ -162,7 +162,7 @@ private:
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
     const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const;
   bool willObjectCutOut(
-    const double obj_tangent_vel, const double obj_normal_vel, const bool is_left) const;
+    const double obj_tangent_vel, const double obj_normal_vel, const bool is_collision_left) const;
   bool isObjectFarFromPath(
     const PredictedObject & predicted_object, const double obj_dist_to_path) const;
   double calcTimeToCollision(


### PR DESCRIPTION
## Description

Without this PR, which side to avoid is calculated by the ego's pose and object's pose.
This implementation cannot deal with the case where the ego's path and object's path will cross and which side to avoid is the opposite to the expected side.

With this PR, which side to avoid is calculated by the future ego's pose and object's pose when the collision will occur.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
