### PR TITLE
refactor(interface): use `weak_ptr` or `unique_ptr` instead of `shared_ptr`

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -105,9 +105,9 @@ public:
    */
   void registerSceneModuleManager(const SceneModuleManagerPtr & manager_ptr)
   {
-    RCLCPP_INFO(logger_, "register %s module", manager_ptr->getModuleName().c_str());
+    RCLCPP_INFO(logger_, "register %s module", manager_ptr->name().c_str());
     manager_ptrs_.push_back(manager_ptr);
-    processing_time_.emplace(manager_ptr->getModuleName(), 0.0);
+    processing_time_.emplace(manager_ptr->name(), 0.0);
   }
 
   /**
@@ -301,8 +301,9 @@ private:
    */
   void deleteExpiredModules(SceneModulePtr & module_ptr) const
   {
-    const auto manager = getManager(module_ptr);
-    manager->deleteModules(module_ptr);
+    module_ptr->onExit();
+    module_ptr->publishRTCStatus();
+    module_ptr.reset();
   }
 
   /**
@@ -376,7 +377,7 @@ private:
   {
     const auto itr = std::find_if(
       manager_ptrs_.begin(), manager_ptrs_.end(),
-      [&module_ptr](const auto & m) { return m->getModuleName() == module_ptr->name(); });
+      [&module_ptr](const auto & m) { return m->name() == module_ptr->name(); });
 
     if (itr == manager_ptrs_.end()) {
       throw std::domain_error("unknown manager name.");

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
@@ -35,9 +35,9 @@ public:
   AvoidanceModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<AvoidanceModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
+    return std::make_unique<AvoidanceModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
@@ -34,9 +34,9 @@ public:
   DynamicAvoidanceModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<DynamicAvoidanceModule>(
+    return std::make_unique<DynamicAvoidanceModule>(
       name_, *node_, parameters_, rtc_interface_ptr_map_);
   }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/manager.hpp
@@ -33,9 +33,9 @@ public:
   GoalPlannerModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<GoalPlannerModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
+    return std::make_unique<GoalPlannerModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
@@ -37,7 +37,7 @@ public:
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config,
     const Direction direction, const LaneChangeModuleType type);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override;
+  std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override;
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
@@ -55,7 +55,7 @@ public:
   AvoidanceByLaneChangeModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override;
+  std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override;
 
   // void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
@@ -34,9 +34,9 @@ public:
   SideShiftModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<SideShiftModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
+    return std::make_unique<SideShiftModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/manager.hpp
@@ -33,9 +33,9 @@ public:
   StartPlannerModuleManager(
     rclcpp::Node * node, const std::string & name, const ModuleConfigParameters & config);
 
-  std::shared_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
+  std::unique_ptr<SceneModuleInterface> createNewSceneModuleInstance() override
   {
-    return std::make_shared<StartPlannerModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
+    return std::make_unique<StartPlannerModule>(name_, *node_, parameters_, rtc_interface_ptr_map_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -366,8 +366,8 @@ void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parame
       parameters, ns + "trim.sharp_shift_filter_threshold", p->sharp_shift_filter_threshold);
   }
 
-  std::for_each(registered_modules_.begin(), registered_modules_.end(), [&p](const auto & m) {
-    m->updateModuleParams(p);
+  std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
+    if (!observer.expired()) observer.lock()->updateModuleParams(p);
   });
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -171,8 +171,8 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
       p->end_duration_to_avoid_oncoming_object);
   }
 
-  std::for_each(registered_modules_.begin(), registered_modules_.end(), [&p](const auto & m) {
-    m->updateModuleParams(p);
+  std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
+    if (!observer.expired()) observer.lock()->updateModuleParams(p);
   });
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
@@ -246,8 +246,8 @@ void GoalPlannerModuleManager::updateModuleParams(
 
   [[maybe_unused]] std::string ns = name_ + ".";
 
-  std::for_each(registered_modules_.begin(), registered_modules_.end(), [&p](const auto & m) {
-    m->updateModuleParams(p);
+  std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
+    if (!observer.expired()) observer.lock()->updateModuleParams(p);
   });
 }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
@@ -133,14 +133,14 @@ LaneChangeModuleManager::LaneChangeModuleManager(
   parameters_ = std::make_shared<LaneChangeParameters>(p);
 }
 
-std::shared_ptr<SceneModuleInterface> LaneChangeModuleManager::createNewSceneModuleInstance()
+std::unique_ptr<SceneModuleInterface> LaneChangeModuleManager::createNewSceneModuleInstance()
 {
   if (type_ == LaneChangeModuleType::NORMAL) {
-    return std::make_shared<LaneChangeInterface>(
+    return std::make_unique<LaneChangeInterface>(
       name_, *node_, parameters_, rtc_interface_ptr_map_,
       std::make_unique<NormalLaneChange>(parameters_, LaneChangeModuleType::NORMAL, direction_));
   }
-  return std::make_shared<LaneChangeInterface>(
+  return std::make_unique<LaneChangeInterface>(
     name_, *node_, parameters_, rtc_interface_ptr_map_,
     std::make_unique<ExternalRequestLaneChange>(parameters_, direction_));
 }
@@ -155,8 +155,8 @@ void LaneChangeModuleManager::updateModuleParams(const std::vector<rclcpp::Param
   updateParam<double>(
     parameters, ns + "finish_judge_lateral_threshold", p->finish_judge_lateral_threshold);
 
-  std::for_each(registered_modules_.begin(), registered_modules_.end(), [&p](const auto & m) {
-    m->updateModuleParams(p);
+  std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
+    if (!observer.expired()) observer.lock()->updateModuleParams(p);
   });
 }
 
@@ -271,10 +271,10 @@ AvoidanceByLaneChangeModuleManager::AvoidanceByLaneChangeModuleManager(
   avoidance_parameters_ = std::make_shared<AvoidanceByLCParameters>(p);
 }
 
-std::shared_ptr<SceneModuleInterface>
+std::unique_ptr<SceneModuleInterface>
 AvoidanceByLaneChangeModuleManager::createNewSceneModuleInstance()
 {
-  return std::make_shared<AvoidanceByLaneChangeInterface>(
+  return std::make_unique<AvoidanceByLaneChangeInterface>(
     name_, *node_, parameters_, avoidance_parameters_, rtc_interface_ptr_map_);
 }
 

--- a/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/manager.cpp
@@ -51,8 +51,8 @@ void SideShiftModuleManager::updateModuleParams(
   [[maybe_unused]] std::string ns = "side_shift.";
   // updateParam<bool>(parameters, ns + ..., ...);
 
-  std::for_each(registered_modules_.begin(), registered_modules_.end(), [&p](const auto & m) {
-    m->updateModuleParams(p);
+  std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
+    if (!observer.expired()) observer.lock()->updateModuleParams(p);
   });
 }
 

--- a/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
@@ -99,13 +99,17 @@ void StartPlannerModuleManager::updateModuleParams(
 
   [[maybe_unused]] std::string ns = name_ + ".";
 
-  std::for_each(registered_modules_.begin(), registered_modules_.end(), [&](const auto & m) {
-    const auto start_planner_ptr = std::dynamic_pointer_cast<StartPlannerModule>(m);
-    start_planner_ptr->updateModuleParams(p);
-    start_planner_ptr->setInitialIsSimultaneousExecutableAsApprovedModule(
-      enable_simultaneous_execution_as_approved_module_);
-    start_planner_ptr->setInitialIsSimultaneousExecutableAsCandidateModule(
-      enable_simultaneous_execution_as_candidate_module_);
+  std::for_each(observers_.begin(), observers_.end(), [&](const auto & observer) {
+    if (!observer.expired()) {
+      const auto start_planner_ptr = std::dynamic_pointer_cast<StartPlannerModule>(observer.lock());
+      if (start_planner_ptr) {
+        start_planner_ptr->updateModuleParams(p);
+        start_planner_ptr->setInitialIsSimultaneousExecutableAsApprovedModule(
+          enable_simultaneous_execution_as_approved_module_);
+        start_planner_ptr->setInitialIsSimultaneousExecutableAsCandidateModule(
+          enable_simultaneous_execution_as_candidate_module_);
+      }
+    }
   });
 }
 }  // namespace behavior_path_planner


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6780cf4</samp>

Refactor the scene module system in the behavior path planner to use unique and weak pointers instead of shared pointers, and to support dynamic parameter updates. Rename and simplify some methods and variables for clarity and consistency. Fix some code style and type issues in various files.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/479bd0ce-0e1c-5e50-957f-8fd02571d403?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
