### PR TITLE
fix(start_planner): execute when curent pose is close to route start pose not receiving new route

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -122,7 +122,6 @@ private:
   std::unique_ptr<rclcpp::Time> last_route_received_time_;
   std::unique_ptr<rclcpp::Time> last_pull_out_start_update_time_;
   std::unique_ptr<Pose> last_approved_pose_;
-  mutable bool has_received_new_route_{false};
 
   std::shared_ptr<PullOutPlannerBase> getCurrentPlanner() const;
   PathWithLaneId getFullPath() const;

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -78,25 +78,25 @@ void StartPlannerModule::processOnExit()
 
 bool StartPlannerModule::isExecutionRequested() const
 {
+  // Execute when current pose is near route start pose
+  const Pose & start_pose = planner_data_->route_handler->getStartPose();
+  const Pose & current_pose = planner_data_->self_odometry->pose.pose;
+  if (
+    tier4_autoware_utils::calcDistance2d(start_pose.position, current_pose.position) >
+    parameters_->th_arrived_distance) {
+    return false;
+  }
+
   // Check if ego arrives at goal
   const Pose & goal_pose = planner_data_->route_handler->getGoalPose();
-  const Pose & current_pose = planner_data_->self_odometry->pose.pose;
   if (
     tier4_autoware_utils::calcDistance2d(goal_pose.position, current_pose.position) <
     parameters_->th_arrived_distance) {
     return false;
   }
 
-  has_received_new_route_ =
-    !planner_data_->prev_route_id ||
-    *planner_data_->prev_route_id != planner_data_->route_handler->getRouteUuid();
-
   if (current_state_ == ModuleStatus::RUNNING) {
     return true;
-  }
-
-  if (!has_received_new_route_) {
-    return false;
   }
 
   const bool is_stopped = utils::l2Norm(planner_data_->self_odometry->twist.twist.linear) <
@@ -540,13 +540,17 @@ PathWithLaneId StartPlannerModule::generateStopPath() const
 
 void StartPlannerModule::updatePullOutStatus()
 {
-  if (has_received_new_route_) {
+  const bool has_received_new_route =
+    !planner_data_->prev_route_id ||
+    *planner_data_->prev_route_id != planner_data_->route_handler->getRouteUuid();
+
+  if (has_received_new_route) {
     status_ = PullOutStatus();
   }
 
   // skip updating if enough time has not passed for preventing chattering between back and
   // start_planner
-  if (!has_received_new_route_ && !last_pull_out_start_update_time_ && !status_.back_finished) {
+  if (!has_received_new_route && !last_pull_out_start_update_time_ && !status_.back_finished) {
     if (!last_pull_out_start_update_time_) {
       last_pull_out_start_update_time_ = std::make_unique<rclcpp::Time>(clock_->now());
     }

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -96,6 +96,7 @@ public:
   // for goal
   bool isInGoalRouteSection(const lanelet::ConstLanelet & lanelet) const;
   Pose getGoalPose() const;
+  Pose getStartPose() const;
   lanelet::Id getGoalLaneId() const;
   bool getGoalLanelet(lanelet::ConstLanelet * goal_lanelet) const;
   std::vector<lanelet::ConstLanelet> getLanesBeforePose(

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -418,6 +418,15 @@ lanelet::ConstLanelets RouteHandler::getRouteLanelets() const
   return route_lanelets_;
 }
 
+Pose RouteHandler::getStartPose() const
+{
+  if (!route_ptr_) {
+    RCLCPP_WARN(logger_, "[Route Handler] getStartPose: Route has not been set yet");
+    Pose();
+  }
+  return route_ptr_->start_pose;
+}
+
 Pose RouteHandler::getGoalPose() const
 {
   if (!route_ptr_) {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Chage start planner isExecutionRequested condition.

before: recieving new route
after: curent pose is close to route start pose

This change fixes the issue that start_planner can not be executed blocked by goal planner when disabling auto approval.

1. Initially, the start_planner sends a request and gets registered as a candidate.
2. In the next loop, despite the start_planner's enable_simultaneous_execution_as_candidate_module being set to false, the goal_planner presents itself as a candidate and gets set as the highest_priority_module.
3. Since the goal_planner is not in the is_waiting_approval state, the goal_planner is set as the approved module.
4. After that, the manager clears all current candidates for re-evaluation.
5. In the second check of the while loop, the start_planner is seen as not having updated its route and doesn't send a request.
6. As the request_modules is empty, it returns. At this point, the goal_planner has already been registered as approved.

reference: [tier4 internal slack](https://star4.slack.com/archives/C03QW0GU6P7/p1689040009682709)

https://github.com/autowarefoundation/autoware.universe/assets/39142679/84c5dea5-f038-4bb0-a063-a79c36a40b31



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

[tier4 internal slack](https://star4.slack.com/archives/C03QW0GU6P7/p1689040009682709)

[tier4 intenal ticket](https://tier4.atlassian.net/browse/RT1-3068)

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

[tier4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/2f6ebe98-2a64-598e-b8b9-276dc253f5c6/?project_id=prd_jt)
1579/1588

base: 
1577/1588([2023/07/30](https://evaluation.tier4.jp/evaluation/reports/d1ec5471-3332-5f7c-9203-6d40ef0f270e/?project_id=prd_jt))


https://github.com/autowarefoundation/autoware.universe/assets/39142679/e935afc3-131d-4918-b7a9-9d28cca1cff7



## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
