### PR TITLE
fix(start_planner): fix drivable lanes

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -51,11 +51,7 @@ struct PullOutStatus
   size_t current_path_idx{0};
   PlannerType planner_type{PlannerType::NONE};
   PathWithLaneId backward_path{};
-  lanelet::ConstLanelets current_lanes{};
   lanelet::ConstLanelets pull_out_lanes{};
-  std::vector<DrivableLanes> lanes{};
-  std::vector<uint64_t> lane_follow_lane_ids{};
-  std::vector<uint64_t> pull_out_lane_ids{};
   bool is_safe{false};
   bool back_finished{false};
   Pose pull_out_start_pose{};
@@ -139,6 +135,8 @@ private:
     const std::vector<Pose> & start_pose_candidates, const Pose & goal_pose,
     const std::string search_priority);
   PathWithLaneId generateStopPath() const;
+  lanelet::ConstLanelets getPathLanes(const PathWithLaneId & path) const;
+  std::vector<DrivableLanes> generateDrivableLanes(const PathWithLaneId & path) const;
   void updatePullOutStatus();
   static bool isOverlappedWithLane(
     const lanelet::ConstLanelet & candidate_lanelet,

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -547,7 +547,7 @@ lanelet::ConstLanelets StartPlannerModule::getPathLanes(const PathWithLaneId & p
   }
 
   const auto & lanelet_layer = planner_data_->route_handler->getLaneletMapPtr()->laneletLayer;
-  
+
   lanelet::ConstLanelets path_lanes;
   path_lanes.reserve(lane_ids.size());
   for (const auto & id : lane_ids) {

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -201,7 +201,7 @@ BehaviorModuleOutput StartPlannerModule::plan()
   }
 
   const auto target_drivable_lanes = utils::getNonOverlappingExpandedLanes(
-    path, status_.lanes, planner_data_->drivable_area_expansion_parameters);
+    path, generateDrivableLanes(path), planner_data_->drivable_area_expansion_parameters);
 
   DrivableAreaInfo current_drivable_area_info;
   current_drivable_area_info.drivable_lanes = target_drivable_lanes;
@@ -330,11 +330,8 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
     planner_data_, backward_path_length, std::numeric_limits<double>::max(),
     /*until_goal_lane*/ true);
 
-  const auto pull_out_lanes =
-    start_planner_utils::getPullOutLanes(planner_data_, backward_path_length);
   auto stop_path = status_.back_finished ? getCurrentPath() : status_.backward_path;
-  const auto drivable_lanes =
-    utils::generateDrivableLanesWithShoulderLanes(current_lanes, pull_out_lanes);
+  const auto drivable_lanes = generateDrivableLanes(stop_path);
   const auto & dp = planner_data_->drivable_area_expansion_parameters;
   const auto expanded_lanes = utils::expandLanelets(
     drivable_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
@@ -533,9 +530,36 @@ PathWithLaneId StartPlannerModule::generateStopPath() const
 
   // generate drivable area
   const auto target_drivable_lanes = utils::getNonOverlappingExpandedLanes(
-    path, status_.lanes, planner_data_->drivable_area_expansion_parameters);
+    path, generateDrivableLanes(path), planner_data_->drivable_area_expansion_parameters);
 
   return path;
+}
+
+lanelet::ConstLanelets StartPlannerModule::getPathLanes(const PathWithLaneId & path) const
+{
+  lanelet::ConstLanelets path_lanes;
+
+  const auto & lanelet_layer = planner_data_->route_handler->getLaneletMapPtr()->laneletLayer;
+
+  std::vector<lanelet::Id> lane_ids;
+  for (const auto & p : path.points) {
+    for (const auto & id : p.lane_ids) {
+      if (std::find(lane_ids.begin(), lane_ids.end(), id) == lane_ids.end()) {
+        lane_ids.push_back(id);
+      }
+    }
+  }
+  for (const auto & id : lane_ids) {
+    path_lanes.push_back(lanelet_layer.get(id));
+  }
+
+  return path_lanes;
+}
+
+std::vector<DrivableLanes> StartPlannerModule::generateDrivableLanes(
+  const PathWithLaneId & path) const
+{
+  return utils::generateDrivableLanesWithShoulderLanes(getPathLanes(path), status_.pull_out_lanes);
 }
 
 void StartPlannerModule::updatePullOutStatus()
@@ -561,17 +585,10 @@ void StartPlannerModule::updatePullOutStatus()
   const auto & current_pose = planner_data_->self_odometry->pose.pose;
   const auto & goal_pose = planner_data_->route_handler->getGoalPose();
 
-  const double backward_path_length =
-    planner_data_->parameters.backward_path_length + parameters_->max_back_distance;
-  status_.current_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, backward_path_length, std::numeric_limits<double>::max(),
-    /*until_goal_lane*/ true);
-  status_.pull_out_lanes =
-    start_planner_utils::getPullOutLanes(planner_data_, backward_path_length);
-
-  // combine road and shoulder lanes
-  status_.lanes =
-    utils::generateDrivableLanesWithShoulderLanes(status_.current_lanes, status_.pull_out_lanes);
+  // save pull out lanes which is generated using current pose before starting pull out
+  // (before approval)
+  status_.pull_out_lanes = start_planner_utils::getPullOutLanes(
+    planner_data_, planner_data_->parameters.backward_path_length + parameters_->max_back_distance);
 
   // search pull out start candidates backward
   std::vector<Pose> start_pose_candidates = searchPullOutStartPoses();
@@ -583,10 +600,6 @@ void StartPlannerModule::updatePullOutStatus()
       *route_handler, status_.pull_out_lanes, current_pose, status_.pull_out_start_pose,
       parameters_->backward_velocity);
   }
-
-  // Update status
-  status_.lane_follow_lane_ids = utils::getIds(status_.current_lanes);
-  status_.pull_out_lane_ids = utils::getIds(status_.pull_out_lanes);
 }
 
 std::vector<Pose> StartPlannerModule::searchPullOutStartPoses()
@@ -677,10 +690,10 @@ bool StartPlannerModule::hasFinishedPullOut() const
   const auto current_pose = planner_data_->self_odometry->pose.pose;
 
   // check that ego has passed pull out end point
-  const auto arclength_current =
-    lanelet::utils::getArcCoordinates(status_.current_lanes, current_pose);
+  const auto path_lanes = getPathLanes(getFullPath());
+  const auto arclength_current = lanelet::utils::getArcCoordinates(path_lanes, current_pose);
   const auto arclength_pull_out_end =
-    lanelet::utils::getArcCoordinates(status_.current_lanes, status_.pull_out_path.end_pose);
+    lanelet::utils::getArcCoordinates(path_lanes, status_.pull_out_path.end_pose);
 
   // offset to not finish the module before engage
   constexpr double offset = 0.1;
@@ -877,7 +890,7 @@ BehaviorModuleOutput StartPlannerModule::generateStopOutput()
   output.path = std::make_shared<PathWithLaneId>(stop_path);
 
   DrivableAreaInfo current_drivable_area_info;
-  current_drivable_area_info.drivable_lanes = status_.lanes;
+  current_drivable_area_info.drivable_lanes = generateDrivableLanes(*output.path);
   output.drivable_area_info = utils::combineDrivableAreaInfo(
     current_drivable_area_info, getPreviousModuleOutput().drivable_area_info);
 

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -537,10 +537,6 @@ PathWithLaneId StartPlannerModule::generateStopPath() const
 
 lanelet::ConstLanelets StartPlannerModule::getPathLanes(const PathWithLaneId & path) const
 {
-  lanelet::ConstLanelets path_lanes;
-
-  const auto & lanelet_layer = planner_data_->route_handler->getLaneletMapPtr()->laneletLayer;
-
   std::vector<lanelet::Id> lane_ids;
   for (const auto & p : path.points) {
     for (const auto & id : p.lane_ids) {
@@ -549,6 +545,11 @@ lanelet::ConstLanelets StartPlannerModule::getPathLanes(const PathWithLaneId & p
       }
     }
   }
+
+  const auto & lanelet_layer = planner_data_->route_handler->getLaneletMapPtr()->laneletLayer;
+  
+  lanelet::ConstLanelets path_lanes;
+  path_lanes.reserve(lane_ids.size());
   for (const auto & id : lane_ids) {
     path_lanes.push_back(lanelet_layer.get(id));
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

backward extended lanes are added to drivable lanes and this causes unintentional cut overlapped path

```
[component_container_mt-27] target_drivable_lanes: right: 179452left: 179452middle :
[component_container_mt-27] right: 179280left: 179280middle :
[component_container_mt-27] right: 190756left: 190757middle :
[component_container_mt-27] right: 179382left: 190720middle :
[component_container_mt-27] right: 179398left: 190609middle :
[component_container_mt-27] right: 179416left: 179443middle :
[component_container_mt-27] right: 190784left: 190785middle :
[component_container_mt-27] right: 190797left: 190794middle :
[component_container_mt-27] right: 190802left: 190801middle :
[component_container_mt-27] right: 177680left: 190615middle :
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/ce8171a6-a4ad-44e1-9300-b1497be23eea)


In this PR, use path point lane ids to generate drivable lanes.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

[tier4 internal ticket](https://tier4.atlassian.net/browse/RT1-3159)

## Tests performed

<!-- Describe how you have tested this PR. -->


[tier4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/493f7a18-76e4-5602-ba25-4ad7e516c652/?project_id=prd_jt)

psim

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/089f7c78-3280-4d7b-b732-417ed3e86b1b)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/10f2d7c0-1982-4140-accb-d8877c6d53bd)




## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
