### PR TITLE
refactor(interface): remove redundant member variables

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -49,7 +49,7 @@ class AvoidanceModule : public SceneModuleInterface
 public:
   AvoidanceModule(
     const std::string & name, rclcpp::Node & node, std::shared_ptr<AvoidanceParameters> parameters,
-    const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map);
+    const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map);
 
   ModuleStatus updateState() override;
   CandidateOutput planCandidate() const override;
@@ -62,9 +62,9 @@ public:
   void updateData() override;
   void acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const override;
 
-  void updateModuleParams(const std::shared_ptr<AvoidanceParameters> & parameters)
+  void updateModuleParams(const std::any & parameters) override
   {
-    parameters_ = parameters;
+    parameters_ = std::any_cast<std::shared_ptr<AvoidanceParameters>>(parameters);
   }
   std::shared_ptr<AvoidanceDebugMsgArray> get_debug_msg_array() const;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/manager.hpp
@@ -44,8 +44,6 @@ public:
 
 private:
   std::shared_ptr<AvoidanceParameters> parameters_;
-
-  std::vector<std::shared_ptr<AvoidanceModule>> registered_modules_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -129,9 +129,9 @@ public:
     std::shared_ptr<DynamicAvoidanceParameters> parameters,
     const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map);
 
-  void updateModuleParams(const std::shared_ptr<DynamicAvoidanceParameters> & parameters)
+  void updateModuleParams(const std::any & parameters) override
   {
-    parameters_ = parameters;
+    parameters_ = std::any_cast<std::shared_ptr<DynamicAvoidanceParameters>>(parameters);
   }
 
   bool isExecutionRequested() const override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/manager.hpp
@@ -44,7 +44,6 @@ public:
 
 private:
   std::shared_ptr<DynamicAvoidanceParameters> parameters_;
-  std::vector<std::shared_ptr<DynamicAvoidanceModule>> registered_modules_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/goal_planner_module.hpp
@@ -92,9 +92,9 @@ public:
     const std::shared_ptr<GoalPlannerParameters> & parameters,
     const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map);
 
-  void updateModuleParams(const std::shared_ptr<GoalPlannerParameters> & parameters)
+  void updateModuleParams(const std::any & parameters) override
   {
-    parameters_ = parameters;
+    parameters_ = std::any_cast<std::shared_ptr<GoalPlannerParameters>>(parameters);
   }
 
   BehaviorModuleOutput run() override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/goal_planner/manager.hpp
@@ -42,8 +42,6 @@ public:
 
 private:
   std::shared_ptr<GoalPlannerParameters> parameters_;
-
-  std::vector<std::shared_ptr<GoalPlannerModule>> registered_modules_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
@@ -87,7 +87,7 @@ public:
 
   void acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const override;
 
-  void updateModuleParams(const std::shared_ptr<LaneChangeParameters> & parameters);
+  void updateModuleParams(const std::any & parameters) override;
 
   void setData(const std::shared_ptr<const PlannerData> & data) override;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/manager.hpp
@@ -44,8 +44,6 @@ public:
 protected:
   std::shared_ptr<LaneChangeParameters> parameters_;
 
-  std::vector<std::shared_ptr<LaneChangeInterface>> registered_modules_;
-
   Direction direction_;
 
   LaneChangeModuleType type_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -37,6 +37,7 @@
 #include <visualization_msgs/msg/detail/marker_array__struct.hpp>
 
 #include <algorithm>
+#include <any>
 #include <limits>
 #include <memory>
 #include <random>
@@ -87,6 +88,8 @@ public:
   }
 
   virtual ~SceneModuleInterface() = default;
+
+  virtual void updateModuleParams(const std::any & parameters) = 0;
 
   /**
    * @brief Return SUCCESS if plan is not needed or plan is successfully finished,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/manager.hpp
@@ -43,8 +43,6 @@ public:
 
 private:
   std::shared_ptr<SideShiftParameters> parameters_;
-
-  std::vector<std::shared_ptr<SideShiftModule>> registered_modules_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/side_shift/side_shift_module.hpp
@@ -43,7 +43,7 @@ public:
   SideShiftModule(
     const std::string & name, rclcpp::Node & node,
     const std::shared_ptr<SideShiftParameters> & parameters,
-    const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map);
+    const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map);
 
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
@@ -59,9 +59,9 @@ public:
 
   void setParameters(const std::shared_ptr<SideShiftParameters> & parameters);
 
-  void updateModuleParams(const std::shared_ptr<SideShiftParameters> & parameters)
+  void updateModuleParams(const std::any & parameters) override
   {
-    parameters_ = parameters;
+    parameters_ = std::any_cast<std::shared_ptr<SideShiftParameters>>(parameters);
   }
 
   void acceptVisitor(

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/manager.hpp
@@ -42,8 +42,6 @@ public:
 
 private:
   std::shared_ptr<StartPlannerParameters> parameters_;
-
-  std::vector<std::shared_ptr<StartPlannerModule>> registered_modules_;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/start_planner/start_planner_module.hpp
@@ -71,9 +71,9 @@ public:
     const std::shared_ptr<StartPlannerParameters> & parameters,
     const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map);
 
-  void updateModuleParams(const std::shared_ptr<StartPlannerParameters> & parameters)
+  void updateModuleParams(const std::any & parameters) override
   {
-    parameters_ = parameters;
+    parameters_ = std::any_cast<std::shared_ptr<StartPlannerParameters>>(parameters);
   }
 
   BehaviorModuleOutput run() override;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -36,7 +36,7 @@ using utils::lane_change::assignToCandidate;
 
 LaneChangeInterface::LaneChangeInterface(
   const std::string & name, rclcpp::Node & node, std::shared_ptr<LaneChangeParameters> parameters,
-  const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map,
+  const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map,
   std::unique_ptr<LaneChangeBase> && module_type)
 : SceneModuleInterface{name, node, rtc_interface_ptr_map},
   parameters_{std::move(parameters)},
@@ -278,10 +278,9 @@ CandidateOutput LaneChangeInterface::planCandidate() const
   return output;
 }
 
-void LaneChangeInterface::updateModuleParams(
-  const std::shared_ptr<LaneChangeParameters> & parameters)
+void LaneChangeInterface::updateModuleParams(const std::any & parameters)
 {
-  parameters_ = parameters;
+  parameters_ = std::any_cast<std::shared_ptr<LaneChangeParameters>>(parameters);
 }
 
 void LaneChangeInterface::setData(const std::shared_ptr<const PlannerData> & data)
@@ -507,7 +506,7 @@ AvoidanceByLaneChangeInterface::AvoidanceByLaneChangeInterface(
   const std::string & name, rclcpp::Node & node,
   const std::shared_ptr<LaneChangeParameters> & parameters,
   const std::shared_ptr<AvoidanceByLCParameters> & avoidance_by_lane_change_parameters,
-  const std::unordered_map<std::string, std::shared_ptr<RTCInterface> > & rtc_interface_ptr_map)
+  const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map)
 : LaneChangeInterface{
     name, node, parameters, rtc_interface_ptr_map,
     std::make_unique<AvoidanceByLaneChange>(parameters, avoidance_by_lane_change_parameters)}

--- a/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
@@ -100,10 +100,11 @@ void StartPlannerModuleManager::updateModuleParams(
   [[maybe_unused]] std::string ns = name_ + ".";
 
   std::for_each(registered_modules_.begin(), registered_modules_.end(), [&](const auto & m) {
-    m->updateModuleParams(p);
-    m->setInitialIsSimultaneousExecutableAsApprovedModule(
+    const auto start_planner_ptr = std::dynamic_pointer_cast<StartPlannerModule>(m);
+    start_planner_ptr->updateModuleParams(p);
+    start_planner_ptr->setInitialIsSimultaneousExecutableAsApprovedModule(
       enable_simultaneous_execution_as_approved_module_);
-    m->setInitialIsSimultaneousExecutableAsCandidateModule(
+    start_planner_ptr->setInitialIsSimultaneousExecutableAsCandidateModule(
       enable_simultaneous_execution_as_candidate_module_);
   });
 }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d1d34a</samp>

Refactor the scene module interface to support different parameter types for different scene modules. Move the registered_modules_ member variable from the scene module manager classes to the base SceneModuleManagerInterface class. Update the updateModuleParams methods of the scene module classes to use std::any_cast and std::dynamic_pointer_cast as needed. Improve the code style of some scene module classes.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/479bd0ce-0e1c-5e50-957f-8fd02571d403?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
