### PR TITLE
fix(traffic_light_arbiter): clear perception msg when the stamp is over the tolerance

### DIFF
--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -99,7 +99,7 @@ void TrafficLightArbiter::onExternalMsg(const TrafficSignalArray::ConstSharedPtr
   if (
     (rclcpp::Time(msg->stamp) - rclcpp::Time(latest_perception_msg_.stamp)).seconds() >
     perception_time_tolerance_) {
-    latest_external_msg_.signals.clear();
+    latest_perception_msg_.signals.clear();
   }
 
   arbitrateAndPublish(msg->stamp);


### PR DESCRIPTION
## Description

I think `latest_perception_msg_` should be cleared here instead of `latest_external_msg_`.
https://github.com/autowarefoundation/autoware.universe/pull/4464/files#diff-8488136a70c0a6c2330c7db712a8d69c5e2111f1b7f83477e67a99887933ca4dR102

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed that this node works by following these steps.

- launch traffic_signal_arbiter
```
ros2 launch traffic_light_arbiter traffic_light_arbiter.launch.xml
```
- publish traffic signal message to `/external/traffic_signals`
- check the output topic of this node.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
