### PR TITLE
fix(obstacle_avoidance_planner): fix the bug of inserting stop point

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -441,8 +441,8 @@ void ObstacleAvoidancePlanner::insertZeroVelocityOutsideDrivableArea(
   if (first_outside_idx) {
     debug_data_ptr_->stop_pose_by_drivable_area = optimized_traj_points.at(*first_outside_idx).pose;
     const auto stop_idx = [&]() {
-      const auto dist = tier4_autoware_utils::calcDistance2d(
-        optimized_traj_points.at(0), optimized_traj_points.at(*first_outside_idx));
+      const auto dist =
+        motion_utils::calcSignedArcLength(optimized_traj_points, 0, *first_outside_idx);
       const auto dist_with_margin = dist - vehicle_stop_margin_outside_drivable_area_;
       const auto first_outside_idx_with_margin =
         motion_utils::insertTargetPoint(0, dist_with_margin, optimized_traj_points);


### PR DESCRIPTION
## Description

Fixed the bug which tries to calculate the length along the trajectory but actually calculates the length of two points.


![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/9e27fded-7025-44c6-a30b-d53800bd910d)



<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/2872e992-ca1b-49d8-b7ff-4b7a8474bc56)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
