### PR TITLE
refactor(behavior_path_planner): scene module interface clang-tidy

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -34,7 +34,6 @@
 #include <tier4_planning_msgs/msg/stop_reason.hpp>
 #include <tier4_planning_msgs/msg/stop_reason_array.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
-#include <utility>
 #include <visualization_msgs/msg/detail/marker_array__struct.hpp>
 
 #include <algorithm>
@@ -76,7 +75,7 @@ class SceneModuleInterface
 public:
   SceneModuleInterface(
     const std::string & name, rclcpp::Node & node,
-    std::unordered_map<std::string, std::shared_ptr<RTCInterface>>  rtc_interface_ptr_map)
+    std::unordered_map<std::string, std::shared_ptr<RTCInterface>> rtc_interface_ptr_map)
   : name_{name},
     logger_{node.get_logger().get_child(name)},
     clock_{node.get_clock()},

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -34,6 +34,7 @@
 #include <tier4_planning_msgs/msg/stop_reason.hpp>
 #include <tier4_planning_msgs/msg/stop_reason_array.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
+#include <utility>
 #include <visualization_msgs/msg/detail/marker_array__struct.hpp>
 
 #include <algorithm>
@@ -50,12 +51,8 @@ namespace behavior_path_planner
 {
 using autoware_adapi_v1_msgs::msg::SteeringFactor;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
-using motion_utils::createDeadLineVirtualWallMarker;
-using motion_utils::createSlowDownVirtualWallMarker;
-using motion_utils::createStopVirtualWallMarker;
 using rtc_interface::RTCInterface;
 using steering_factor_interface::SteeringFactorInterface;
-using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcOffsetPose;
 using tier4_autoware_utils::generateUUID;
 using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
@@ -79,16 +76,16 @@ class SceneModuleInterface
 public:
   SceneModuleInterface(
     const std::string & name, rclcpp::Node & node,
-    const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map)
+    std::unordered_map<std::string, std::shared_ptr<RTCInterface>>  rtc_interface_ptr_map)
   : name_{name},
     logger_{node.get_logger().get_child(name)},
     clock_{node.get_clock()},
-    rtc_interface_ptr_map_(rtc_interface_ptr_map),
+    rtc_interface_ptr_map_(std::move(rtc_interface_ptr_map)),
     steering_factor_interface_ptr_(
       std::make_unique<SteeringFactorInterface>(&node, utils::convertToSnakeCase(name)))
   {
-    for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
-      uuid_map_.emplace(itr->first, generateUUID());
+    for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
+      uuid_map_.emplace(module_name, generateUUID());
     }
   }
 
@@ -176,9 +173,9 @@ public:
    */
   void publishRTCStatus()
   {
-    for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
-      if (itr->second) {
-        itr->second->publishCooperateStatus(clock_->now());
+    for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
+      if (ptr) {
+        ptr->publishCooperateStatus(clock_->now());
       }
     }
   }
@@ -193,18 +190,18 @@ public:
 
   void lockRTCCommand()
   {
-    for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
-      if (itr->second) {
-        itr->second->lockCommandUpdate();
+    for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
+      if (ptr) {
+        ptr->lockCommandUpdate();
       }
     }
   }
 
   void unlockRTCCommand()
   {
-    for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
-      if (itr->second) {
-        itr->second->unlockCommandUpdate();
+    for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
+      if (ptr) {
+        ptr->unlockCommandUpdate();
       }
     }
   }
@@ -398,10 +395,10 @@ protected:
 
   virtual void updateRTCStatus(const double start_distance, const double finish_distance)
   {
-    for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
-      if (itr->second) {
-        itr->second->updateCooperateStatus(
-          uuid_map_.at(itr->first), isExecutionReady(), start_distance, finish_distance,
+    for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
+      if (ptr) {
+        ptr->updateCooperateStatus(
+          uuid_map_.at(module_name), isExecutionReady(), start_distance, finish_distance,
           clock_->now());
       }
     }
@@ -483,9 +480,9 @@ protected:
 
   void removeRTCStatus()
   {
-    for (auto itr = rtc_interface_ptr_map_.begin(); itr != rtc_interface_ptr_map_.end(); ++itr) {
-      if (itr->second) {
-        itr->second->clearCooperateStatus();
+    for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {
+      if (ptr) {
+        ptr->clearCooperateStatus();
       }
     }
   }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -49,6 +49,7 @@ using motion_utils::calcLongitudinalOffsetPose;
 using motion_utils::calcSignedArcLength;
 using motion_utils::findNearestIndex;
 using motion_utils::findNearestSegmentIndex;
+using tier4_autoware_utils::appendMarkerArray;
 using tier4_autoware_utils::calcDistance2d;
 using tier4_autoware_utils::calcInterpolatedPose;
 using tier4_autoware_utils::calcLateralDeviation;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -31,6 +31,7 @@
 
 namespace behavior_path_planner
 {
+using tier4_autoware_utils::appendMarkerArray;
 using utils::lane_change::assignToCandidate;
 
 LaneChangeInterface::LaneChangeInterface(


### PR DESCRIPTION
## Description

This pull request refactors the `SceneModuleInterface` class to improve code quality based on clang-tidy's report, and due to `using` declarations for the `appendMarkerArray` function is not exactly used anywhere in `scene_module_interface.hpp`, they are moved to the respective scene module files.

## Tests performed

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
