### PR TITLE
fix(obstacle_avoidance_planner): stop point insertion in looped path

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -389,11 +389,18 @@ void ObstacleAvoidancePlanner::applyInputVelocity(
   const auto stop_idx = motion_utils::searchZeroVelocityIndex(forward_cropped_input_traj_points);
   if (stop_idx) {
     const auto input_stop_pose = forward_cropped_input_traj_points.at(stop_idx.get()).pose;
-    const size_t stop_seg_idx = trajectory_utils::findEgoSegmentIndex(
-      output_traj_points, input_stop_pose, ego_nearest_param_);
+    // NOTE: motion_utils::findNearestSegmentIndex is used instead of
+    // trajectory_utils::findEgoSegmentIndex
+    //       for the case where input_traj_points is much longer than output_traj_points, and the
+    //       former has a stop point but the latter will not have.
+    const auto stop_seg_idx = motion_utils::findNearestSegmentIndex(
+      output_traj_points, input_stop_pose, ego_nearest_param_.dist_threshold,
+      ego_nearest_param_.yaw_threshold);
 
     // calculate and insert stop pose on output trajectory
-    trajectory_utils::insertStopPoint(output_traj_points, input_stop_pose, stop_seg_idx);
+    if (stop_seg_idx) {
+      trajectory_utils::insertStopPoint(output_traj_points, input_stop_pose, *stop_seg_idx);
+    }
   }
 
   time_keeper_ptr_->toc(__func__, "    ");


### PR DESCRIPTION
## Description

The optimization in obstacle_avoidance_planner is not executed every time.
Therefore, the internal path and the new input path's length may be not the same at all due to the path cut feature for overlapping lanes in behavior_path_planner.
This means, the stop point in the new input path may not be found in the internal path when the internal path is much shorter than the new input path.

This PR considers it to get nearest index not as `size_t` but as `std::optional<size_t>`.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator
scenario simulator (https://evaluation.tier4.jp/evaluation/reports/0c700b2d-2055-5391-8279-ae445b699cad?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
