### PR TITLE
fix: freespace_planner issue#2353

### DIFF
--- a/planning/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
+++ b/planning/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
@@ -320,7 +320,7 @@ void FreespacePlannerNode::onRoute(const LaneletRoute::ConstSharedPtr msg)
 
   algo_->resetFindGoal();
   RCLCPP_INFO(get_logger(), "----------Trajectory is reseted because of onRoute().----------");
-  
+
   reset();
 }
 
@@ -427,7 +427,9 @@ void FreespacePlannerNode::onTimer()
 
   if (!isActive(scenario_)) {
     reset();
-    RCLCPP_INFO(get_logger(), "----------Trajectory is reseted because the scenario is not active.----------");
+    RCLCPP_INFO(
+      get_logger(),
+      "----------Trajectory is reseted because the scenario is not active.----------");
     return;
   }
 

--- a/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp
+++ b/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp
@@ -136,8 +136,8 @@ public:
   virtual bool hasObstacleOnTrajectory(const geometry_msgs::msg::PoseArray & trajectory) const;
   const PlannerWaypoints & getWaypoints() const { return waypoints_; }
 
-  void resetFindGoal(){success_to_find_goal_ = false;}
-  void successToFindGoal(){success_to_find_goal_ = true;}
+  void resetFindGoal() { success_to_find_goal_ = false; }
+  void successToFindGoal() { success_to_find_goal_ = true; }
 
   virtual ~AbstractPlanningAlgorithm() {}
 
@@ -191,7 +191,6 @@ protected:
 
   // Flag for finding goal
   bool success_to_find_goal_ = false;
-
 };
 
 }  // namespace freespace_planning_algorithms

--- a/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp
+++ b/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp
@@ -136,6 +136,9 @@ public:
   virtual bool hasObstacleOnTrajectory(const geometry_msgs::msg::PoseArray & trajectory) const;
   const PlannerWaypoints & getWaypoints() const { return waypoints_; }
 
+  void resetFindGoal(){success_to_find_goal_ = false;}
+  void successToFindGoal(){success_to_find_goal_ = true;}
+
   virtual ~AbstractPlanningAlgorithm() {}
 
 protected:
@@ -185,6 +188,10 @@ protected:
 
   // result path
   PlannerWaypoints waypoints_;
+
+  // Flag for finding goal
+  bool success_to_find_goal_ = false;
+
 };
 
 }  // namespace freespace_planning_algorithms

--- a/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#include <rclcpp/rclcpp.hpp>
 #include "freespace_planning_algorithms/abstract_algorithm.hpp"
 
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
@@ -207,14 +207,16 @@ bool AbstractPlanningAlgorithm::detectCollision(const IndexXYT & base_index) con
     return false;
   }
 
-  const auto & vertex_indexes_2d = vertex_indexes_table_[base_index.theta];
-  for (const auto & vertex_index_2d : vertex_indexes_2d) {
-    IndexXYT vertex_index{vertex_index_2d.x, vertex_index_2d.y, 0};
-    // must slide to current base position
-    vertex_index.x += base_index.x;
-    vertex_index.y += base_index.y;
-    if (isOutOfRange(vertex_index)) {
-      return true;
+  if (success_to_find_goal_ == false) {
+    const auto & vertex_indexes_2d = vertex_indexes_table_[base_index.theta];
+    for (const auto & vertex_index_2d : vertex_indexes_2d) {
+      IndexXYT vertex_index{vertex_index_2d.x, vertex_index_2d.y, 0};
+      // must slide to current base position
+      vertex_index.x += base_index.x;
+      vertex_index.y += base_index.y;
+      if (isOutOfRange(vertex_index)) {
+        return true;
+      }
     }
   }
 
@@ -226,8 +228,18 @@ bool AbstractPlanningAlgorithm::detectCollision(const IndexXYT & base_index) con
     coll_index.x += base_index.x;
     coll_index.y += base_index.y;
 
-    if (isObs(coll_index)) {
-      return true;
+    if (success_to_find_goal_ == true) {
+      if (0 <= coll_index.x && coll_index.x < costmap_.info.width &&
+          0 <= coll_index.y && coll_index.y < costmap_.info.height) {
+        if (isObs(coll_index)) {
+          return true;
+        }
+      }
+    }
+    else {
+      if (isObs(coll_index)) {
+        return true;
+      }
     }
   }
 

--- a/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -11,9 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <rclcpp/rclcpp.hpp>
 #include "freespace_planning_algorithms/abstract_algorithm.hpp"
 
+#include <rclcpp/rclcpp.hpp>
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <vector>
@@ -229,14 +229,14 @@ bool AbstractPlanningAlgorithm::detectCollision(const IndexXYT & base_index) con
     coll_index.y += base_index.y;
 
     if (success_to_find_goal_ == true) {
-      if (0 <= coll_index.x && coll_index.x < costmap_.info.width &&
-          0 <= coll_index.y && coll_index.y < costmap_.info.height) {
+      if (
+        0 <= coll_index.x && coll_index.x < costmap_.info.width && 0 <= coll_index.y &&
+        coll_index.y < costmap_.info.height) {
         if (isObs(coll_index)) {
           return true;
         }
       }
-    }
-    else {
+    } else {
       if (isObs(coll_index)) {
         return true;
       }


### PR DESCRIPTION
## Description

Fix of issue#2353
issueで言及されていた運転が停止してしまう問題は解決できた。
しかし何度も軌道が再計画されてしまう

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/2353
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers
一度ゴールを発見したら軌道追従中に範囲外に出ても走行を続けるようにしたい。
ゴール発見フラグ(AbstractPlanningAlgorithm.success_to_find_goal_)を追加して挙動を変えてみた

freespace_planner_node
- 新しいゴールが来たらゴール発見フラグをfalseに
- 計画の前にゴール発見フラグをfalseに
- 計画の後にゴール発見フラグをtrueに

abstract_algorithm.hpp
- フラグの追加
- フラグをtrue, falseにするpublicメソッドの追加

abstruct_algorithm.cpp
- detectCollision関数内の変更
　- フラグがtrueのときは軌道が範囲外にはずれた判定をしない
　- フラグがtrueのときは範囲外の障害物判定をしない（参照インデックスがおかしくなってしまうため）

## Interface changes


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
