### PR TITLE
feat(behavior_path_planner): change straight turn signal condition

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -260,21 +260,24 @@ boost::optional<TurnSignalInfo> TurnSignalDecider::getIntersectionTurnSignalInfo
       continue;
     }
 
-    if (
-      (lane_attribute == "right" || lane_attribute == "left" || lane_attribute == "straight") &&
-      dist_to_front_point < search_distance) {
-      // update map if necessary
-      if (desired_start_point_map_.find(lane_id) == desired_start_point_map_.end()) {
-        desired_start_point_map_.emplace(lane_id, current_pose);
-      }
+    constexpr double stop_velocity_threshold = 0.1;
+    if (dist_to_front_point < search_distance) {
+      if (
+        lane_attribute == "right" || lane_attribute == "left" ||
+        (lane_attribute == "straight" && current_vel < stop_velocity_threshold)) {
+        // update map if necessary
+        if (desired_start_point_map_.find(lane_id) == desired_start_point_map_.end()) {
+          desired_start_point_map_.emplace(lane_id, current_pose);
+        }
 
-      TurnSignalInfo turn_signal_info{};
-      turn_signal_info.desired_start_point = desired_start_point_map_.at(lane_id);
-      turn_signal_info.required_start_point = lane_front_pose;
-      turn_signal_info.required_end_point = get_required_end_point(combined_lane.centerline3d());
-      turn_signal_info.desired_end_point = lane_back_pose;
-      turn_signal_info.turn_signal.command = signal_map.at(lane_attribute);
-      signal_queue.push(turn_signal_info);
+        TurnSignalInfo turn_signal_info{};
+        turn_signal_info.desired_start_point = desired_start_point_map_.at(lane_id);
+        turn_signal_info.required_start_point = lane_front_pose;
+        turn_signal_info.required_end_point = get_required_end_point(combined_lane.centerline3d());
+        turn_signal_info.desired_end_point = lane_back_pose;
+        turn_signal_info.turn_signal.command = signal_map.at(lane_attribute);
+        signal_queue.push(turn_signal_info);
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Turn signal decider disable the blinker when the ego vehicle runs on a straight line at intersections. However, this causes some serious problems for the lane change and avoidance module when it tries to change lanes or avoid objects near intersections. In this PR, I change the code by disabling the blinker only when the ego vehicle stops at the intersection.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Scenario Test 1575/1588
[TIRE IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/dd810336-efe4-52ec-ace6-190ff2f54c58?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
