### PR TITLE
feat(obstacle_avoidance_planner): bound search for overlapping drivable area

### DIFF
--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1322,8 +1322,10 @@ boost::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> 
 }
 
 std::vector<DrivableLanes> cutOverlappedLanes(
-  PathWithLaneId & path, const std::vector<DrivableLanes> & lanes)
+  [[maybe_unused]] PathWithLaneId & path, const std::vector<DrivableLanes> & lanes)
 {
+  return lanes;
+
   const auto overlapped_lanelet_idx = getOverlappedLaneletId(lanes);
   if (!overlapped_lanelet_idx) {
     return lanes;


### PR DESCRIPTION
## Description


- TODO
    - [ ] check if this works with intersection area
    - [ ] set search length 10m instead of 5m to find the far bound.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
