### PR TITLE
[DO NOT MERGE] fix(map_tf_generator): remove default value from declare_parameter

### DIFF
--- a/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/pcd_map_tf_generator_node.cpp
@@ -36,8 +36,8 @@ public:
   explicit PcdMapTFGeneratorNode(const rclcpp::NodeOptions & options)
   : Node("pcd_map_tf_generator", options)
   {
-    map_frame_ = declare_parameter("map_frame", "map");
-    viewer_frame_ = declare_parameter("viewer_frame", "viewer");
+    map_frame_ = declare_parameter("map_frame");
+    viewer_frame_ = declare_parameter("viewer_frame");
 
     sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
       "pointcloud_map", rclcpp::QoS{1}.transient_local(),

--- a/map/map_tf_generator/src/vector_map_tf_generator_node.cpp
+++ b/map/map_tf_generator/src/vector_map_tf_generator_node.cpp
@@ -31,8 +31,8 @@ public:
   explicit VectorMapTFGeneratorNode(const rclcpp::NodeOptions & options)
   : Node("vector_map_tf_generator", options)
   {
-    map_frame_ = declare_parameter("map_frame", "map");
-    viewer_frame_ = declare_parameter("viewer_frame", "viewer");
+    map_frame_ = declare_parameter("map_frame");
+    viewer_frame_ = declare_parameter("viewer_frame");
 
     sub_ = create_subscription<autoware_auto_mapping_msgs::msg::HADMapBin>(
       "vector_map", rclcpp::QoS{1}.transient_local(),


### PR DESCRIPTION
## Description
This is a test pr to check chat gpt review feature for PRs from forked branch

PLEASE DO NOT MERGE THIS PR
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Release Notes:

- Refactor: Removed default values from the `declare_parameter` calls for the `map_frame` and `viewer_frame` parameters in the constructors of `PcdMapTFGeneratorNode` and `VectorMapTFGeneratorNode`.

> "Code refactored, defaults removed,
> Parameters declared, as they should.
> With cleaner code, bugs we'll evade,
> A better foundation has been laid."
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->