### PR TITLE
chore(tier4_simulator_launch): launch camera and V2X fusion module in simple planning simulator

### DIFF
--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -16,7 +16,8 @@
   <arg name="perception/enable_detection_failure" default="true" description="enable to simulate detection failure when using dummy perception"/>
   <arg name="perception/enable_object_recognition" default="false" description="enable object recognition"/>
   <arg name="perception/enable_elevation_map" default="false" description="enable elevation map loader"/>
-  <arg name="perception/enable_traffic_light" default="false" description="enable traffic light"/>
+  <arg name="perception/enable_traffic_light" default="true" description="enable traffic light"/>
+  <arg name="fusion_only" default="true" description="enable only camera and V2X fusion when enabling traffic light"/>
   <arg name="perception/use_base_link_z" default="true" description="dummy perception uses base_link z axis coordinate if it is true"/>
   <arg name="sensing/visible_range" default="300.0" description="visible range when using dummy perception"/>
 


### PR DESCRIPTION
## Description

Added args to launch camera and V2X fusion modules to test this feature in scenario simulator.
modules in red rectangles in below image is fusion modules.
![image](https://github.com/autowarefoundation/autoware.universe/assets/11865769/236b2176-b2b1-496e-b14b-426c74fd40f1)


Related issue:
- https://github.com/autowarefoundation/autoware.universe/issues/2567

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

### Before
Run simple planning simulator.
```
$ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/tmp/sample_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit 2>&1 | tee autoware.log
```

There are no nodes related to traffic light recognition.
```
$ ros2 node list | grep traffic_light

```
 ### After

Run simple planning simulator.
```
$ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/tmp/sample_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit 2>&1 | tee autoware.log
```

Modules to fusion camera and V2X are launched.
```
$ ros2 node list | grep traffic_light
/perception/traffic_light_recognition/camera6/classification/traffic_light_occlusion_predictor
/perception/traffic_light_recognition/camera6/classification/transform_listener_impl_564e2ac0bec8
/perception/traffic_light_recognition/traffic_light_arbiter/arbiter
/perception/traffic_light_recognition/traffic_light_arbiter/container
/perception/traffic_light_recognition/traffic_light_map_visualizer
/perception/traffic_light_recognition/traffic_light_multi_camera_fusion
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No effects because no traffic light recognition modules are launched in simple planning simulator.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
