### PR TITLE
feat(dynamic_avoidance): precise cut-out decision

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -91,18 +91,12 @@ public:
   {
     DynamicAvoidanceObject(
       const PredictedObject & predicted_object, const double arg_vel, const double arg_lat_vel,
-      const bool arg_is_collision_left, const double arg_time_to_collision,
-      const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid,
       const std::optional<rclcpp::Time> & arg_latest_time_inside_ego_path)
     : uuid(tier4_autoware_utils::toHexString(predicted_object.object_id)),
       pose(predicted_object.kinematics.initial_pose_with_covariance.pose),
       shape(predicted_object.shape),
       vel(arg_vel),
       lat_vel(arg_lat_vel),
-      is_collision_left(arg_is_collision_left),
-      time_to_collision(arg_time_to_collision),
-      lon_offset_to_avoid(arg_lon_offset_to_avoid),
-      lat_offset_to_avoid(arg_lat_offset_to_avoid),
       latest_time_inside_ego_path(arg_latest_time_inside_ego_path)
     {
       for (const auto & path : predicted_object.kinematics.predicted_paths) {
@@ -115,12 +109,21 @@ public:
     autoware_auto_perception_msgs::msg::Shape shape;
     double vel;
     double lat_vel;
-    bool is_collision_left;
-    double time_to_collision;
-    MinMaxValue lon_offset_to_avoid;
-    MinMaxValue lat_offset_to_avoid;
     std::optional<rclcpp::Time> latest_time_inside_ego_path{std::nullopt};
     std::vector<autoware_auto_perception_msgs::msg::PredictedPath> predicted_paths{};
+
+    MinMaxValue lon_offset_to_avoid;
+    MinMaxValue lat_offset_to_avoid;
+    bool is_collision_left;
+
+    void update(
+      const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid,
+      const bool arg_is_collision_left)
+    {
+      lon_offset_to_avoid = arg_lon_offset_to_avoid;
+      lat_offset_to_avoid = arg_lat_offset_to_avoid;
+      is_collision_left = arg_is_collision_left;
+    }
   };
 
   struct TargetObjectsManager
@@ -256,7 +259,7 @@ private:
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
     const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const;
   bool willObjectCutOut(
-    const double obj_tangent_vel, const double obj_normal_vel, const bool is_collision_left,
+    const double obj_tangent_vel, const double obj_normal_vel, const bool is_object_left,
     const std::optional<DynamicAvoidanceObject> & prev_object) const;
   bool isObjectFarFromPath(
     const PredictedObject & predicted_object, const double obj_dist_to_path) const;
@@ -266,7 +269,8 @@ private:
   std::optional<std::pair<size_t, size_t>> calcCollisionSection(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & obj_path) const;
   LatLonOffset getLateralLongitudinalOffset(
-    const std::vector<PathPointWithLaneId> & ego_path, const PredictedObject & object) const;
+    const std::vector<PathPointWithLaneId> & ego_path, const geometry_msgs::msg::Pose & obj_pose,
+    const autoware_auto_perception_msgs::msg::Shape & obj_shape) const;
   MinMaxValue calcMinMaxLongitudinalOffsetToAvoid(
     const std::vector<PathPointWithLaneId> & path_points_for_object_polygon,
     const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -218,6 +218,16 @@ public:
       }
       return object_map_.at(uuid);
     }
+    void updateObject(
+      const std::string & uuid, const MinMaxValue & lon_offset_to_avoid,
+      const MinMaxValue & lat_offset_to_avoid, const bool is_collision_left,
+      const bool should_be_avoided)
+    {
+      if (object_map_.count(uuid) != 0) {
+        object_map_.at(uuid).update(
+          lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided);
+      }
+    }
 
     std::vector<std::string> current_uuids_;
     // NOTE: positive is for meeting entrying condition, and negative is for exiting.

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -91,12 +91,14 @@ public:
   {
     DynamicAvoidanceObject(
       const PredictedObject & predicted_object, const double arg_vel, const double arg_lat_vel,
+      const bool arg_is_object_on_ego_path,
       const std::optional<rclcpp::Time> & arg_latest_time_inside_ego_path)
     : uuid(tier4_autoware_utils::toHexString(predicted_object.object_id)),
       pose(predicted_object.kinematics.initial_pose_with_covariance.pose),
       shape(predicted_object.shape),
       vel(arg_vel),
       lat_vel(arg_lat_vel),
+      is_object_on_ego_path(arg_is_object_on_ego_path),
       latest_time_inside_ego_path(arg_latest_time_inside_ego_path)
     {
       for (const auto & path : predicted_object.kinematics.predicted_paths) {
@@ -109,20 +111,23 @@ public:
     autoware_auto_perception_msgs::msg::Shape shape;
     double vel;
     double lat_vel;
+    bool is_object_on_ego_path;
     std::optional<rclcpp::Time> latest_time_inside_ego_path{std::nullopt};
     std::vector<autoware_auto_perception_msgs::msg::PredictedPath> predicted_paths{};
 
     MinMaxValue lon_offset_to_avoid;
     MinMaxValue lat_offset_to_avoid;
     bool is_collision_left;
+    bool should_be_avoided{false};
 
     void update(
       const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid,
-      const bool arg_is_collision_left)
+      const bool arg_is_collision_left, const bool arg_should_be_avoided)
     {
       lon_offset_to_avoid = arg_lon_offset_to_avoid;
       lat_offset_to_avoid = arg_lat_offset_to_avoid;
       is_collision_left = arg_is_collision_left;
+      should_be_avoided = arg_should_be_avoided;
     }
   };
 

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -424,7 +424,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
   target_objects_manager_.finalize();
 
   // 2. Precise filtering of target objects and check if they should be avoided
-  for (auto & object : target_objects_manager_.getValidObjects()) {
+  for (const auto & object : target_objects_manager_.getValidObjects()) {
     const auto obj_uuid = object.uuid;
     const auto prev_object = getObstacleFromUuid(prev_objects, obj_uuid);
     const auto obj_path = *std::max_element(
@@ -505,7 +505,8 @@ void DynamicAvoidanceModule::updateTargetObjects()
       *path_points_for_object_polygon, obj_points, is_collision_left, prev_object);
 
     const bool should_be_avoided = true;
-    object.update(lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided);
+    target_objects_manager_.updateObject(
+      obj_uuid, lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided);
   }
 }
 

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -328,32 +328,31 @@ void DynamicAvoidanceModule::updateTargetObjects()
     return;
   }
 
+  const auto prev_objects = target_objects_manager_.getValidObjects();
+
+  // 1. Rough filtering of target objects
   target_objects_manager_.initialize();
   for (const auto & predicted_object : predicted_objects) {
     const auto obj_uuid = tier4_autoware_utils::toHexString(predicted_object.object_id);
     const auto & obj_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
     const double obj_vel = predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x;
-    const auto obj_path = *std::max_element(
-      predicted_object.kinematics.predicted_paths.begin(),
-      predicted_object.kinematics.predicted_paths.end(),
-      [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
     const auto prev_object = target_objects_manager_.getValidObject(obj_uuid);
 
-    // 1. check label
+    // 1.a. check label
     const bool is_label_target_obstacle =
       isLabelTargetObstacle(predicted_object.classification.front().label);
     if (!is_label_target_obstacle) {
       continue;
     }
 
-    // 2. check if velocity is large enough
+    // 1.b. check if velocity is large enough
     const auto [obj_tangent_vel, obj_normal_vel] =
       projectObstacleVelocityToTrajectory(prev_module_path->points, predicted_object);
     if (std::abs(obj_tangent_vel) < parameters_->min_obstacle_vel) {
       continue;
     }
 
-    // 3. check if object is not crossing ego's path
+    // 1.c. check if object is not crossing ego's path
     const double obj_angle = calcDiffAngleAgainstPath(prev_module_path->points, obj_pose);
     const bool is_obstacle_crossing_path =
       parameters_->max_crossing_object_angle < std::abs(obj_angle) &&
@@ -368,7 +367,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
       continue;
     }
 
-    // 4. check if object is not to be followed by ego
+    // 1.d. check if object is not to be followed by ego
     const double obj_dist_to_path = calcDistanceToPath(prev_module_path->points, obj_pose.position);
     const bool is_object_on_ego_path =
       obj_dist_to_path <
@@ -383,7 +382,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
       continue;
     }
 
-    // 5. check if object lateral offset to ego's path is large enough
+    // 1.e. check if object lateral offset to ego's path is small enough
     const bool is_object_far_from_path = isObjectFarFromPath(predicted_object, obj_dist_to_path);
     if (is_object_far_from_path) {
       RCLCPP_INFO_EXPRESSION(
@@ -392,22 +391,52 @@ void DynamicAvoidanceModule::updateTargetObjects()
       continue;
     }
 
-    // 6. calculate which side object exists against ego's path
-    const bool is_object_left = isLeft(prev_module_path->points, obj_pose.position);
-    const auto lat_lon_offset =
-      getLateralLongitudinalOffset(prev_module_path->points, predicted_object);
+    // 1.f. calculate latest time inside ego's path
+    const auto latest_time_inside_ego_path = [&]() -> std::optional<rclcpp::Time> {
+      if (!prev_object || !prev_object->latest_time_inside_ego_path) {
+        if (is_object_on_ego_path) {
+          return clock_->now();
+        }
+        return std::nullopt;
+      }
+      if (is_object_on_ego_path) {
+        return clock_->now();
+      }
+      return *prev_object->latest_time_inside_ego_path;
+    }();
 
-    // 7. check if object will not cut in or cut out
+    const auto target_object = DynamicAvoidanceObject(
+      predicted_object, obj_tangent_vel, obj_normal_vel, latest_time_inside_ego_path);
+    target_objects_manager_.updateObject(obj_uuid, target_object);
+  }
+  target_objects_manager_.finalize();
+
+  // 2. Precise filtering of target objects and update offset to avoid
+  for (auto & object : target_objects_manager_.getValidObjects()) {
+    const auto obj_uuid = object.uuid;
+    const auto prev_object = target_objects_manager_.getValidObject(obj_uuid);
+    const auto obj_path = *std::max_element(
+      object.predicted_paths.begin(), object.predicted_paths.end(),
+      [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
+
+    // 2.a. calculate which side object exists against ego's path
+    const bool is_object_left = isLeft(prev_module_path->points, object.pose.position);
+    const auto lat_lon_offset =
+      getLateralLongitudinalOffset(prev_module_path->points, object.pose, object.shape);
+
+    // 2.b. check if object will not cut in
     const bool will_object_cut_in =
-      willObjectCutIn(prev_module_path->points, obj_path, obj_tangent_vel, lat_lon_offset);
-    const bool will_object_cut_out =
-      willObjectCutOut(obj_tangent_vel, obj_normal_vel, is_object_left, prev_object);
+      willObjectCutIn(prev_module_path->points, obj_path, object.vel, lat_lon_offset);
     if (will_object_cut_in) {
       RCLCPP_INFO_EXPRESSION(
         getLogger(), parameters_->enable_debug_info,
         "[DynamicAvoidance] Ignore obstacle (%s) since it will cut in.", obj_uuid.c_str());
       continue;
     }
+
+    // 2.c. check if object will not cut out
+    const bool will_object_cut_out =
+      willObjectCutOut(object.vel, object.lat_vel, is_object_left, prev_object);
     if (will_object_cut_out) {
       RCLCPP_INFO_EXPRESSION(
         getLogger(), parameters_->enable_debug_info,
@@ -415,14 +444,13 @@ void DynamicAvoidanceModule::updateTargetObjects()
       continue;
     }
 
-    // 8. check if time to collision
+    // 2.d. check if time to collision
     const double time_to_collision =
-      calcTimeToCollision(prev_module_path->points, obj_pose, obj_tangent_vel);
+      calcTimeToCollision(prev_module_path->points, object.pose, object.vel);
     if (
-      (0 <= obj_tangent_vel &&
+      (0 <= object.vel &&
        parameters_->max_time_to_collision_overtaking_object < time_to_collision) ||
-      (obj_tangent_vel <= 0 &&
-       parameters_->max_time_to_collision_oncoming_object < time_to_collision)) {
+      (object.vel <= 0 && parameters_->max_time_to_collision_oncoming_object < time_to_collision)) {
       RCLCPP_INFO_EXPRESSION(
         getLogger(), parameters_->enable_debug_info,
         "[DynamicAvoidance] Ignore obstacle (%s) since time to collision is large.",
@@ -438,39 +466,22 @@ void DynamicAvoidanceModule::updateTargetObjects()
       continue;
     }
 
-    // 9. calculate which side object will be against ego's path
+    // 2.e. calculate which side object will be against ego's path
     const auto future_obj_pose =
       object_recognition_utils::calcInterpolatedPose(obj_path, time_to_collision);
     const bool is_collision_left = future_obj_pose
                                      ? isLeft(prev_module_path->points, future_obj_pose->position)
                                      : is_object_left;
 
-    // 10. calculate longitudinal and lateral offset to avoid
-    const auto obj_points = tier4_autoware_utils::toPolygon2d(obj_pose, predicted_object.shape);
+    // 2.f. calculate longitudinal and lateral offset to avoid
+    const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
     const auto lon_offset_to_avoid = calcMinMaxLongitudinalOffsetToAvoid(
-      *path_points_for_object_polygon, obj_pose, obj_points, obj_tangent_vel, time_to_collision);
+      *path_points_for_object_polygon, object.pose, obj_points, object.vel, time_to_collision);
     const auto lat_offset_to_avoid = calcMinMaxLateralOffsetToAvoid(
       *path_points_for_object_polygon, obj_points, is_collision_left, prev_object);
 
-    const auto latest_time_inside_ego_path = [&]() -> std::optional<rclcpp::Time> {
-      if (!prev_object || !prev_object->latest_time_inside_ego_path) {
-        if (is_object_on_ego_path) {
-          return clock_->now();
-        }
-        return std::nullopt;
-      }
-      if (is_object_on_ego_path) {
-        return clock_->now();
-      }
-      return *prev_object->latest_time_inside_ego_path;
-    }();
-    const auto target_object = DynamicAvoidanceObject(
-      predicted_object, obj_tangent_vel, obj_normal_vel, is_collision_left, time_to_collision,
-      lon_offset_to_avoid, lat_offset_to_avoid, latest_time_inside_ego_path);
-
-    target_objects_manager_.updateObject(obj_uuid, target_object);
+    object.update(lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left);
   }
-  target_objects_manager_.finalize();
 }
 
 std::optional<std::vector<PathPointWithLaneId>> DynamicAvoidanceModule::calcPathForObjectPolygon()
@@ -594,7 +605,7 @@ bool DynamicAvoidanceModule::willObjectCutIn(
 }
 
 bool DynamicAvoidanceModule::willObjectCutOut(
-  const double obj_tangent_vel, const double obj_normal_vel, const bool is_collision_left,
+  const double obj_tangent_vel, const double obj_normal_vel, const bool is_object_left,
   const std::optional<DynamicAvoidanceObject> & prev_object) const
 {
   // Ignore oncoming object
@@ -610,7 +621,7 @@ bool DynamicAvoidanceModule::willObjectCutOut(
     }
   }
 
-  if (is_collision_left) {
+  if (is_object_left) {
     if (parameters_->min_cut_out_object_lat_vel < obj_normal_vel) {
       return true;
     }
@@ -663,12 +674,11 @@ std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> DynamicAvoidanceModule
 }
 
 DynamicAvoidanceModule::LatLonOffset DynamicAvoidanceModule::getLateralLongitudinalOffset(
-  const std::vector<PathPointWithLaneId> & ego_path, const PredictedObject & object) const
+  const std::vector<PathPointWithLaneId> & ego_path, const geometry_msgs::msg::Pose & obj_pose,
+  const autoware_auto_perception_msgs::msg::Shape & obj_shape) const
 {
-  const auto & obj_pose = object.kinematics.initial_pose_with_covariance.pose;
-
   const size_t obj_seg_idx = motion_utils::findNearestSegmentIndex(ego_path, obj_pose.position);
-  const auto obj_points = tier4_autoware_utils::toPolygon2d(obj_pose, object.shape);
+  const auto obj_points = tier4_autoware_utils::toPolygon2d(obj_pose, obj_shape);
 
   // TODO(murooka) calculation is not so accurate.
   std::vector<double> obj_lat_offset_vec;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -60,6 +60,11 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
     p.min_lon_offset_ego_to_cut_in_object =
       node->declare_parameter<double>(ns + "cut_in_object.min_lon_offset_ego_to_object");
 
+    p.max_time_from_outside_ego_path_for_cut_out =
+      node->declare_parameter<double>(ns + "cut_out_object.max_time_from_outside_ego_path");
+    p.min_cut_out_object_lat_vel =
+      node->declare_parameter<double>(ns + "cut_out_object.min_object_lat_vel");
+
     p.max_front_object_angle =
       node->declare_parameter<double>(ns + "front_object.max_object_angle");
 
@@ -136,6 +141,12 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
     updateParam<double>(
       parameters, ns + "cut_in_object.min_lon_offset_ego_to_object",
       p->min_lon_offset_ego_to_cut_in_object);
+
+    updateParam<double>(
+      parameters, ns + "cut_out_object.max_time_from_outside_ego_path",
+      p->max_time_from_outside_ego_path_for_cut_out);
+    updateParam<double>(
+      parameters, ns + "cut_out_object.min_object_lat_vel", p->min_cut_out_object_lat_vel);
 
     updateParam<double>(
       parameters, ns + "front_object.max_object_angle", p->max_front_object_angle);


### PR DESCRIPTION
## Description

More precise cut out decision of target objects for dynamic avoidance.
This PR checks if the object to cut out was inside the ego's path a few seconds before cutting out.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Precise cut out decision of target objects for dynamic avoidance

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Release Notes:
- New Feature: Added two new parameters to control cut-out decision for target objects in dynamic avoidance.
- Refactor: Updated data structures and methods in the `DynamicAvoidanceModule` and `TargetObjectsManager` classes.

> "In the realm of dynamic avoidance,
> Parameters now grant precision.
> Cut-out decisions, under control,
> Target objects dance with a new role.
> Refactored structures, methods refined,
> Codebase shines, complexity declined."
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->