### PR TITLE
fix(behavior_path_planner): fix getExtendedCurrentLanes

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -383,7 +383,7 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
 
 lanelet::ConstLanelets getExtendedCurrentLanes(
   const std::shared_ptr<const PlannerData> & planner_data, const double backward_length,
-  const double forward_length, const bool until_goal_lane);
+  const double forward_length, const bool forward_only_in_route);
 
 lanelet::ConstLanelets calcLaneAroundPose(
   const std::shared_ptr<RouteHandler> route_handler, const geometry_msgs::msg::Pose & pose,

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -154,7 +154,7 @@ void GoalPlannerModule::onTimer()
   const auto current_lanes = utils::getExtendedCurrentLanes(
     planner_data_, parameters_->backward_goal_search_length,
     parameters_->forward_goal_search_length,
-    /*until_goal_lane*/ false);
+    /*forward_only_in_route*/ false);
   std::vector<PullOverPath> path_candidates{};
   std::optional<Pose> closest_start_pose{};
   double min_start_arc_length = std::numeric_limits<double>::max();
@@ -592,7 +592,7 @@ void GoalPlannerModule::setLanes()
   status_.current_lanes = utils::getExtendedCurrentLanes(
     planner_data_, parameters_->backward_goal_search_length,
     parameters_->forward_goal_search_length,
-    /*until_goal_lane*/ false);
+    /*forward_only_in_route*/ false);
   status_.pull_over_lanes =
     goal_planner_utils::getPullOverLanes(*(planner_data_->route_handler), left_side_parking_);
   status_.lanes =

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -116,7 +116,7 @@ bool StartPlannerModule::isExecutionRequested() const
     planner_data_->parameters.backward_path_length + parameters_->max_back_distance;
   const auto current_lanes = utils::getExtendedCurrentLanes(
     planner_data_, backward_path_length, std::numeric_limits<double>::max(),
-    /*until_goal_lane*/ true);
+    /*forward_only_in_route*/ true);
   const auto pull_out_lanes =
     start_planner_utils::getPullOutLanes(planner_data_, backward_path_length);
   auto lanes = current_lanes;
@@ -328,7 +328,7 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
     planner_data_->parameters.backward_path_length + parameters_->max_back_distance;
   const auto current_lanes = utils::getExtendedCurrentLanes(
     planner_data_, backward_path_length, std::numeric_limits<double>::max(),
-    /*until_goal_lane*/ true);
+    /*forward_only_in_route*/ true);
 
   auto stop_path = status_.back_finished ? getCurrentPath() : status_.backward_path;
   const auto drivable_lanes = generateDrivableLanes(stop_path);

--- a/planning/behavior_path_planner/src/utils/goal_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/geometric_pull_over.cpp
@@ -46,7 +46,7 @@ boost::optional<PullOverPath> GeometricPullOver::plan(const Pose & goal_pose)
   // prepare road nad shoulder lanes
   const auto road_lanes = utils::getExtendedCurrentLanes(
     planner_data_, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length,
-    /*until_goal_lane*/ false);
+    /*forward_only_in_route*/ false);
   const auto shoulder_lanes =
     goal_planner_utils::getPullOverLanes(*route_handler, left_side_parking_);
   if (road_lanes.empty() || shoulder_lanes.empty()) {

--- a/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/goal_searcher.cpp
@@ -57,7 +57,7 @@ GoalCandidates GoalSearcher::search(const Pose & original_goal_pose)
     goal_planner_utils::getPullOverLanes(*route_handler, left_side_parking_);
   auto lanes = utils::getExtendedCurrentLanes(
     planner_data_, backward_length, forward_length,
-    /*until_goal_lane*/ false);
+    /*forward_only_in_route*/ false);
   lanes.insert(lanes.end(), pull_over_lanes.begin(), pull_over_lanes.end());
 
   const auto goal_arc_coords =

--- a/planning/behavior_path_planner/src/utils/goal_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/shift_pull_over.cpp
@@ -48,7 +48,7 @@ boost::optional<PullOverPath> ShiftPullOver::plan(const Pose & goal_pose)
   // get road and shoulder lanes
   const auto road_lanes = utils::getExtendedCurrentLanes(
     planner_data_, backward_search_length, forward_search_length,
-    /*until_goal_lane*/ false);
+    /*forward_only_in_route*/ false);
   const auto shoulder_lanes =
     goal_planner_utils::getPullOverLanes(*route_handler, left_side_parking_);
   if (road_lanes.empty() || shoulder_lanes.empty()) {

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -44,7 +44,7 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
     planner_data_->parameters.backward_path_length + parameters_.max_back_distance;
   const auto road_lanes = utils::getExtendedCurrentLanes(
     planner_data_, backward_path_length, std::numeric_limits<double>::max(),
-    /*until_goal_lane*/ true);
+    /*forward_only_in_route*/ true);
   const auto pull_out_lanes = getPullOutLanes(planner_data_, backward_path_length);
   auto lanes = road_lanes;
   for (const auto & pull_out_lane : pull_out_lanes) {

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -54,7 +54,7 @@ boost::optional<PullOutPath> ShiftPullOut::plan(Pose start_pose, Pose goal_pose)
 
   const auto road_lanes = utils::getExtendedCurrentLanes(
     planner_data_, backward_path_length, std::numeric_limits<double>::max(),
-    /*until_goal_lane*/ true);
+    /*forward_only_in_route*/ true);
   // find candidate paths
   auto pull_out_paths = calcPullOutPaths(
     *route_handler, road_lanes, start_pose, goal_pose, common_parameters, parameters_);

--- a/planning/behavior_path_planner/src/utils/start_planner/util.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/util.cpp
@@ -116,6 +116,6 @@ lanelet::ConstLanelets getPullOutLanes(
   return utils::getExtendedCurrentLanes(
     planner_data, backward_length,
     /*forward_length*/ std::numeric_limits<double>::max(),
-    /*until_goal_lane*/ true);
+    /*forward_only_in_route*/ true);
 }
 }  // namespace behavior_path_planner::start_planner_utils

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -2912,7 +2912,7 @@ lanelet::ConstLanelets extendLanes(
 
 lanelet::ConstLanelets getExtendedCurrentLanes(
   const std::shared_ptr<const PlannerData> & planner_data, const double backward_length,
-  const double forward_length, const bool until_goal_lane)
+  const double forward_length, const bool forward_only_in_route)
 {
   auto lanes = getCurrentLanes(planner_data);
   if (lanes.empty()) return lanes;
@@ -2942,15 +2942,6 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
   }
 
   while (forward_length_sum < forward_length) {
-    // stop extending when the goal route section is reached
-    // if forward_length is a very large value, set it to true,
-    // as it may continue to extend lanes outside the route ahead of goal forever.
-    if (until_goal_lane) {
-      if (planner_data->route_handler->isInGoalRouteSection(lanes.back())) {
-        return lanes;
-      }
-    }
-
     auto extended_lanes = extendNextLane(planner_data->route_handler, lanes);
     if (extended_lanes.empty()) {
       return lanes;
@@ -2967,6 +2958,16 @@ lanelet::ConstLanelets getExtendedCurrentLanes(
     } else {
       break;  // no more next lanes to add
     }
+
+    // stop extending when the lane outside of the route is reached
+    // if forward_length is a very large value, set it to true,
+    // as it may continue to extend forever.
+    if (forward_only_in_route) {
+      if (!planner_data->route_handler->isRouteLanelet(extended_lanes.back())) {
+        return lanes;
+      }
+    }
+
     lanes = extended_lanes;
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Fixed a problem where extending current lanes does not finish when a lane change is required to reach the goal.
In this PR, added an option to end extend in the lane of the route instead of reaching the goal section.

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/d69889fd-0468-49bb-aae8-609fc2760e29)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/93aa3462-a0ac-43a3-a929-23b1ee6e07d3)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware.universe/pull/4418

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/c8c9a422-88e7-440e-9736-2b3e0eb19a7f)


[tier4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/tables/new?catalog_id=cb497016-2e2f-4ce0-9ac8-68d77a27a55d&filter=&job_id=cfd6b8e3-7d3a-56d3-83f0-348bd44449da&project_id=prd_jt&table_config=date%2Chide&target_ids=14b338df-d76d-54d2-8865-bea25dc8742c%2C8f7055c2-4a51-56e3-8bc3-3a4a8da17310)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->


none


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Release Notes:

- Refactor: Renamed the `until_goal_lane` parameter to `forward_only_in_route` in the `getExtendedCurrentLanes` function for improved clarity and consistency across modules.

> "Code paths intertwine,
> Parameters align,
> Clarity refined,
> A smoother design."
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->