### PR TITLE
feat(avoidance): output unconfortable path with unsafe state

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -175,16 +175,29 @@
         max_distance: 20.0                              # [m]
         stop_buffer: 1.0                                # [m]
 
-      constraints:
-        # vehicle slows down under longitudinal constraints
-        use_constraints_for_decel: false                # [-]
+      policy:
+        # policy for vehicle slow down behavior. select "best_effort" or "reliable".
+        # "best_effort": slow down deceleration & jerk are limited by constraints.
+        #                but there is a possibility that the vehicle can't stop in front of the vehicle.
+        # "reliable": insert stop or slow down point with ignoring decel/jerk constraints.
+        #             make it possible to increase chance to avoid but uncomfortable deceleration maybe happen.
+        deceleration: "best_effort"                     # [-]
+        # policy for avoidance lateral margin. select "best_effort" or "reliable".
+        # "best_effort": output avoidance path with shorten lateral margin when there is no enough longitudinal
+        #                margin to avoid.
+        # "reliable": module output avoidance path with safe (rtc cooperate) state only when the vehicle can avoid
+        #             with expected lateral margin.
+        lateral_margin: "best_effort"                   # [-]
+        # if true, module doesn't wait deceleration and outputs avoidance path by best effort margin.
+        use_shorten_margin_immediately: true            # [-]
 
+      constraints:
         # lateral constraints
         lateral:
           velocity: [1.0, 1.38, 11.1]                   # [m/s]
           max_accel_values: [0.5, 0.5, 0.5]             # [m/ss]
           min_jerk_values: [0.2, 0.2, 0.2]              # [m/sss]
-          max_jerk_values: [1.0, 1.0, 1.0]             # [m/sss]
+          max_jerk_values: [1.0, 1.0, 1.0]              # [m/sss]
 
         # longitudinal constraints
         longitudinal:

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -480,6 +480,15 @@ private:
    */
   bool isSafePath(ShiftedPath & shifted_path, DebugData & debug) const;
 
+  bool isComfortable(const AvoidLineArray & shift_lines) const
+  {
+    return std::all_of(shift_lines.begin(), shift_lines.end(), [&](const auto & line) {
+      return PathShifter::calcJerkFromLatLonDistance(
+               line.getRelativeLength(), line.getRelativeLongitudinal(),
+               helper_.getAvoidanceEgoSpeed()) < helper_.getLateralMaxJerkLimit();
+    });
+  }
+
   // post process
 
   /**

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -465,6 +465,8 @@ struct AvoidancePlanningData
 
   bool safe{false};
 
+  bool comfortable{false};
+
   bool avoid_required{false};
 
   bool yield_required{false};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -113,8 +113,11 @@ struct AvoidanceParameters
   // use intersection area for avoidance
   bool use_intersection_areas{false};
 
-  // constrains
-  bool use_constraints_for_decel{false};
+  // // constrains
+  // bool use_constraints_for_decel{false};
+
+  // // policy
+  // bool use_relaxed_margin_immediately{false};
 
   // max deceleration for
   double max_deceleration;
@@ -273,6 +276,15 @@ struct AvoidanceParameters
 
   // For shift line generation process. Remove sharp(=jerky) shift line.
   double sharp_shift_filter_threshold;
+
+  // policy
+  bool use_shorten_margin_immediately{false};
+
+  // policy
+  std::string policy_deceleration{"best_effort"};
+
+  // policy
+  std::string policy_lateral_margin{"best_effort"};
 
   // target velocity matrix
   std::vector<double> velocity_map;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -191,10 +191,21 @@ AvoidanceModuleManager::AvoidanceModuleManager(
     p.stop_buffer = get_parameter<double>(node, ns + "stop_buffer");
   }
 
-  // constraints
+  // policy
   {
-    std::string ns = "avoidance.constraints.";
-    p.use_constraints_for_decel = get_parameter<bool>(node, ns + "use_constraints_for_decel");
+    std::string ns = "avoidance.policy.";
+    p.policy_deceleration = get_parameter<std::string>(node, ns + "deceleration");
+    p.policy_lateral_margin = get_parameter<std::string>(node, ns + "lateral_margin");
+    p.use_shorten_margin_immediately =
+      get_parameter<bool>(node, ns + "use_shorten_margin_immediately");
+
+    if (p.policy_deceleration != "best_effort" && p.policy_deceleration != "reliable") {
+      throw std::domain_error("invalid policy. please select 'best_effort' or 'reliable'.");
+    }
+
+    if (p.policy_lateral_margin != "best_effort" && p.policy_lateral_margin != "reliable") {
+      throw std::domain_error("invalid policy. please select 'best_effort' or 'reliable'.");
+    }
   }
 
   // constraints (longitudinal)

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -725,7 +725,7 @@ void fillObjectStoppableJudge(
   ObjectData & object_data, const ObjectDataArray & registered_objects,
   const double feasible_stop_distance, const std::shared_ptr<AvoidanceParameters> & parameters)
 {
-  if (!parameters->use_constraints_for_decel) {
+  if (parameters->policy_deceleration == "reliable") {
     object_data.is_stoppable = true;
     return;
   }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 816a70f</samp>

Refactor `AvoidanceModule` class to improve shift line planning for obstacle avoidance. Add `isComfortable` function and `comfortable` flag to filter out uncomfortable shift lines.

---

Add some options to configurate avoidance policy.

```yaml
      policy:
        # policy for vehicle slow down behavior. select "best_effort" or "reliable".
        # "best_effort": slow down deceleration & jerk are limited by constraints.
        #                but there is a possibility that the vehicle can't stop in front of the vehicle.
        # "reliable": insert stop or slow down point with ignoring decel/jerk constraints.
        #             make it possible to increase chance to avoid but uncomfortable deceleration maybe happen.
        deceleration: "best_effort"                     # [-]
        # policy for avoidance lateral margin. select "best_effort" or "reliable".
        # "best_effort": output avoidance path with shorten lateral margin when there is no enough longitudinal
        #                margin to avoid.
        # "reliable": module output avoidance path with safe (rtc cooperate) state only when the vehicle can avoid
        #             with expected lateral margin.
        lateral_margin: "best_effort"                   # [-]
        # if true, module doesn't wait deceleration and outputs avoidance path by best effort margin.
        use_shorten_margin_immediately: true            # [-]
```

Additionally, make it possible to output unsafe (=lateral jerk exceeds limit value) path with unsafe state.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/0ba80eb7-dacf-40d7-aac1-bc7abd74d614

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/4b538983-5b7d-54fc-8f68-d0714f127fb6?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
