### PR TITLE
fix(accel_brake_map_calibrator_button_panel): fix calibration service name

### DIFF
--- a/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.cpp
+++ b/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.cpp
@@ -135,7 +135,7 @@ void AccelBrakeMapCalibratorButtonPanel::pushCalibrationButton()
 
     // wait 3 second
     after_calib_ = true;
-    rclcpp::Rate(0.33).sleep();
+    rclcpp::Rate(1.0 / 3.0).sleep();
     after_calib_ = false;
 
     // unlock button

--- a/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.cpp
+++ b/common/tier4_calibration_rviz_plugin/src/accel_brake_map_calibrator_button_panel.cpp
@@ -75,7 +75,7 @@ void AccelBrakeMapCalibratorButtonPanel::onInitialize()
       &AccelBrakeMapCalibratorButtonPanel::callbackUpdateSuggest, this, std::placeholders::_1));
 
   client_ = raw_node->create_client<tier4_vehicle_msgs::srv::UpdateAccelBrakeMap>(
-    "/accel_brake_map_calibrator/update_map_dir");
+    "/vehicle/calibration/accel_brake_map_calibrator/update_map_dir");
 }
 
 void AccelBrakeMapCalibratorButtonPanel::callbackUpdateSuggest(
@@ -118,25 +118,28 @@ void AccelBrakeMapCalibratorButtonPanel::pushCalibrationButton()
   status_label_->setText("executing calibration...");
 
   std::thread thread([this] {
-    auto req = std::make_shared<tier4_vehicle_msgs::srv::UpdateAccelBrakeMap::Request>();
-    req->path = "";
+    if (!client_->wait_for_service(std::chrono::seconds(1))) {
+      status_label_->setStyleSheet("QLabel { background-color : red;}");
+      status_label_->setText("service server not found");
 
-    client_->async_send_request(
-      req,
-      [this](
-        [[maybe_unused]] rclcpp::Client<tier4_vehicle_msgs::srv::UpdateAccelBrakeMap>::SharedFuture
-          result) {
-        status_label_->setStyleSheet("QLabel { background-color : lightgreen;}");
-        status_label_->setText("OK!!!");
+    } else {
+      auto req = std::make_shared<tier4_vehicle_msgs::srv::UpdateAccelBrakeMap::Request>();
+      req->path = "";
+      client_->async_send_request(
+        req, [this]([[maybe_unused]] rclcpp::Client<
+                    tier4_vehicle_msgs::srv::UpdateAccelBrakeMap>::SharedFuture result) {});
 
-        // wait 3 second
-        after_calib_ = true;
-        rclcpp::Rate(3.0).sleep();
-        after_calib_ = false;
+      status_label_->setStyleSheet("QLabel { background-color : lightgreen;}");
+      status_label_->setText("OK!!!");
+    }
 
-        // unlock button
-        calibration_button_->setEnabled(true);
-      });
+    // wait 3 second
+    after_calib_ = true;
+    rclcpp::Rate(0.33).sleep();
+    after_calib_ = false;
+
+    // unlock button
+    calibration_button_->setEnabled(true);
   });
 
   thread.detach();


### PR DESCRIPTION
## Description
fix the name of calibration service server, ```accel_brake_map_calibrator/update_map_dir``` to ```/vehicle/calibration/accel_brake_map_calibrator/update_map_dir```.

Also I changed to output information as below when the service server does not exist
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/c74a380e-9ec3-41e0-92a6-ff0e54068c10)

<!-- Write a brief description of this PR. -->

## Tests performed
I confirmed that it works fine both when the service exists and when it does not exist

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
It does not affect automous driving behavior

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
