### PR TITLE
feat(avoidance): prevent smoother undershoot

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -3016,6 +3016,15 @@ void AvoidanceModule::insertPrepareVelocity(ShiftedPath & shifted_path) const
   const auto lower_speed = object.avoid_required ? 0.0 : parameters_->min_slow_down_speed;
 
   // insert slow down speed.
+  const double current_target_velocity = PathShifter::calcFeasibleVelocityFromJerk(
+    shift_length, helper_.getLateralMinJerkLimit(), distance_to_object);
+  if (current_target_velocity < getEgoSpeed() && decel_distance < remaining_distance) {
+    utils::avoidance::insertDecelPoint(
+      getEgoPosition(), decel_distance, parameters_->velocity_map.front(), shifted_path.path,
+      slow_pose_);
+    return;
+  }
+
   const auto start_idx = planner_data_->findEgoIndex(shifted_path.path.points);
   for (size_t i = start_idx; i < shifted_path.path.points.size(); ++i) {
     const auto distance_from_ego = calcSignedArcLength(shifted_path.path.points, start_idx, i);


### PR DESCRIPTION
## Description

The avoidance module inserts slow down section so that the ego vehicle can avoid object whenever the operator approves its maneuver. But sometimes current ego speed exceeds slow down target speed, which causes **undershoot** (Red line in following fig) in motion velocity smoother.



![Screenshot from 2023-08-07 14-59-58](https://github.com/autowarefoundation/autoware.universe/assets/44889564/f379519f-d344-4081-bdb3-d60d68906706)

https://github.com/autowarefoundation/autoware.universe/assets/44889564/0bcc4d24-1ec4-4cdd-8d48-bf2829b5ab92

In this PR, I added gurad in order to prevent undershoot. (If the current speed exceeds target slow down speed, it inserts feasible slow down point instead of slow down section.)

--- 

#### Nominal case (insert slow down section)

https://github.com/autowarefoundation/autoware.universe/assets/44889564/53f6811d-4de2-4848-9f47-e7b41c658104

#### High speed case (insert best effort slow down point)

https://github.com/autowarefoundation/autoware.universe/assets/44889564/29039f47-9b20-492d-97cc-a293d878f788

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [ ] [PASS TIER IV INTERNAL SCENARIOS
](https://evaluation.tier4.jp/evaluation/reports/1ec58c29-c2e5-5289-8e76-a8355cfc6b7e?project_id=prd_jt)
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Improve driving comfortability.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
