### PR TITLE
perf(avoidance): improve avoidance path stability

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/helper.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/helper.hpp
@@ -43,15 +43,16 @@ public:
 
   void validate() const
   {
-    const auto reference_points_size = prev_reference_path_.points.size();
+    const auto linear_shift_path_size = prev_linear_shift_path_.path.points.size();
     const auto linear_shift_size = prev_linear_shift_path_.shift_length.size();
+    const auto spline_shift_path_size = prev_spline_shift_path_.path.points.size();
     const auto spline_shift_size = prev_spline_shift_path_.shift_length.size();
 
-    if (reference_points_size != linear_shift_size) {
+    if (linear_shift_path_size != linear_shift_size) {
       throw std::logic_error("there is an inconsistency among the previous data.");
     }
 
-    if (reference_points_size != spline_shift_size) {
+    if (spline_shift_path_size != spline_shift_size) {
       throw std::logic_error("there is an inconsistency among the previous data.");
     }
   }
@@ -129,28 +130,28 @@ public:
   double getEgoShift() const
   {
     validate();
-    const auto idx = data_->findEgoIndex(prev_reference_path_.points);
+    const auto idx = data_->findEgoIndex(prev_spline_shift_path_.path.points);
     return prev_spline_shift_path_.shift_length.at(idx);
   }
 
   double getEgoLinearShift() const
   {
     validate();
-    const auto idx = data_->findEgoIndex(prev_reference_path_.points);
+    const auto idx = data_->findEgoIndex(prev_linear_shift_path_.path.points);
     return prev_linear_shift_path_.shift_length.at(idx);
   }
 
   double getShift(const Point & p) const
   {
     validate();
-    const auto idx = findNearestIndex(prev_reference_path_.points, p);
+    const auto idx = findNearestIndex(prev_spline_shift_path_.path.points, p);
     return prev_spline_shift_path_.shift_length.at(idx);
   }
 
   double getLinearShift(const Point & p) const
   {
     validate();
-    const auto idx = findNearestIndex(prev_reference_path_.points, p);
+    const auto idx = findNearestIndex(prev_linear_shift_path_.path.points, p);
     return prev_linear_shift_path_.shift_length.at(idx);
   }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -296,7 +296,7 @@ TurnSignalInfo NormalLaneChange::updateOutputTurnSignal()
 
 lanelet::ConstLanelets NormalLaneChange::getCurrentLanes() const
 {
-  return utils::getCurrentLanesFromPath(prev_module_path_, planner_data_);
+  return utils::getCurrentLanesFromPath(prev_module_reference_path_, planner_data_);
 }
 
 lanelet::ConstLanelets NormalLaneChange::getLaneChangeLanes(

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -1622,7 +1622,8 @@ std::pair<PredictedObjects, PredictedObjects> separateObjectsByPath(
   double max_offset = 0.0;
   for (const auto & object_parameter : parameters->object_parameters) {
     const auto p = object_parameter.second;
-    const auto offset = p.envelope_buffer_margin + p.safety_buffer_lateral + p.avoid_margin_lateral;
+    const auto offset =
+      2.0 * p.envelope_buffer_margin + p.safety_buffer_lateral + p.avoid_margin_lateral;
     max_offset = std::max(max_offset, offset);
   }
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 678b2e2</samp>

Improved the behavior path planner's avoidance module and path shifter. Fixed some bugs and errors in the path validation and shift calculation, and removed unnecessary points from the shifted path. Updated some functions in `helper.hpp` to use the shifted path points.

https://github.com/autowarefoundation/autoware.universe/assets/44889564/2bac3cfa-5693-40a7-9032-23398fd873d9


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [ ] [PASS TIER IV INTERNAL SCENAIROS
](https://evaluation.tier4.jp/evaluation/reports/c45a9d52-f525-5e5f-b08f-461f17c18073?project_id=prd_jt)
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
