### PR TITLE
fix(lane_change): add distance check for the lane change acceleration sampling

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -540,7 +540,7 @@ std::vector<double> NormalLaneChange::sampleLongitudinalAccValues(
     current_velocity, common_parameters,
     route_handler.getLateralIntervalsToPreferredLane(current_lanes.back()), max_acc);
 
-  if (max_lane_change_length > utils::getDistanceToEndOfLane(current_pose, target_lanes)) {
+  if (max_lane_change_length > utils::getDistanceToEndOfLane(current_pose, current_lanes)) {
     return utils::lane_change::getAccelerationValues(
       min_acc, max_acc, longitudinal_acc_sampling_num);
   }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -540,6 +540,10 @@ std::vector<double> NormalLaneChange::sampleLongitudinalAccValues(
     current_velocity, common_parameters,
     route_handler.getLateralIntervalsToPreferredLane(current_lanes.back()), max_acc);
 
+  if (max_lane_change_length > utils::getDistanceToEndOfLane(current_pose, target_lanes)) {
+    return utils::lane_change::getAccelerationValues(min_acc, max_acc, longitudinal_acc_sampling_num);
+  }
+
   // if maximum lane change length is less than length to goal or the end of target lanes, only
   // sample max acc
   if (route_handler.isInGoalRouteSection(target_lanes.back())) {

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -541,7 +541,8 @@ std::vector<double> NormalLaneChange::sampleLongitudinalAccValues(
     route_handler.getLateralIntervalsToPreferredLane(current_lanes.back()), max_acc);
 
   if (max_lane_change_length > utils::getDistanceToEndOfLane(current_pose, target_lanes)) {
-    return utils::lane_change::getAccelerationValues(min_acc, max_acc, longitudinal_acc_sampling_num);
+    return utils::lane_change::getAccelerationValues(
+      min_acc, max_acc, longitudinal_acc_sampling_num);
   }
 
   // if maximum lane change length is less than length to goal or the end of target lanes, only


### PR DESCRIPTION
## Description
The lane change module in the autoware samples longitudinal acceleration values based on the velocity of the ego vehicle and the distance to the current and target lanes. Even though it is supposed to check the distance to the end of current lanes, it does not have that check function. In this PR, I added a check function to measure the distance to the end of lane when sampling longitudinal acceleration.

Scenario test
1581/1588
[TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/ce9ba133-e2ae-5d87-b505-e93de53b6f81?project_id=prd_jt)
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
