### PR TITLE
feat(mission_planner): add a guard for rerouting while not following lane

### DIFF
--- a/planning/mission_planner/package.xml
+++ b/planning/mission_planner/package.xml
@@ -33,6 +33,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
+  <depend>tier4_planning_msgs</depend>
   <depend>vehicle_info_util</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -27,6 +27,7 @@
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <tier4_planning_msgs/msg/reroute_availability.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -55,6 +56,7 @@ using NormalRoute = planning_interface::NormalRoute;
 using MrmRoute = planning_interface::MrmRoute;
 using RouteState = planning_interface::RouteState;
 using Odometry = nav_msgs::msg::Odometry;
+using RerouteAvailability = tier4_planning_msgs::msg::RerouteAvailability;
 
 class MissionPlanner : public rclcpp::Node
 {
@@ -72,8 +74,11 @@ private:
 
   rclcpp::Subscription<Odometry>::SharedPtr sub_odometry_;
   rclcpp::Subscription<HADMapBin>::SharedPtr vector_map_subscriber_;
+  rclcpp::Subscription<RerouteAvailability>::SharedPtr sub_reroute_availability_;
   Odometry::ConstSharedPtr odometry_;
+  RerouteAvailability::ConstSharedPtr reroute_availability_;
   void on_odometry(const Odometry::ConstSharedPtr msg);
+  void on_reroute_availability(const RerouteAvailability::ConstSharedPtr msg);
 
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
   void clear_route();


### PR DESCRIPTION
## Description
Add a guard for the mission planner to prevent it from rerouting while the behavior path planner is in lane change, avoidance, and other modules(start planner, goal planner and etc). This can also prevent the entire planner from generating an unsafe path. 
<!-- Write a brief description of this PR. -->
[Screencast from 2023年08月09日 00時25分00秒.webm](https://github.com/autowarefoundation/autoware.universe/assets/43805014/678c3f22-a397-45be-81a2-3182c223646a)

## Tests performed
PSim


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
