### PR TITLE
refactor(mission_planner): use snake case instead of camel case

### DIFF
--- a/planning/mission_planner/package.xml
+++ b/planning/mission_planner/package.xml
@@ -33,6 +33,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
+  <depend>tier4_planning_msgs</depend>
   <depend>vehicle_info_util</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -27,6 +27,7 @@
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <tier4_planning_msgs/msg/reroute_availability.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -55,6 +56,7 @@ using NormalRoute = planning_interface::NormalRoute;
 using MrmRoute = planning_interface::MrmRoute;
 using RouteState = planning_interface::RouteState;
 using Odometry = nav_msgs::msg::Odometry;
+using RerouteAvailability = tier4_planning_msgs::msg::RerouteAvailability;
 
 class MissionPlanner : public rclcpp::Node
 {
@@ -72,8 +74,11 @@ private:
 
   rclcpp::Subscription<Odometry>::SharedPtr sub_odometry_;
   rclcpp::Subscription<HADMapBin>::SharedPtr vector_map_subscriber_;
+  rclcpp::Subscription<RerouteAvailability>::SharedPtr sub_reroute_availability_;
   Odometry::ConstSharedPtr odometry_;
+  RerouteAvailability::ConstSharedPtr reroute_availability_;
   void on_odometry(const Odometry::ConstSharedPtr msg);
+  void on_reroute_availability(const RerouteAvailability::ConstSharedPtr msg);
 
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
   void clear_route();

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -73,11 +73,13 @@ private:
   PoseStamped transform_pose(const PoseStamped & input);
 
   rclcpp::Subscription<Odometry>::SharedPtr sub_odometry_;
-  rclcpp::Subscription<HADMapBin>::SharedPtr vector_map_subscriber_;
+  rclcpp::Subscription<HADMapBin>::SharedPtr sub_vector_map_;
   rclcpp::Subscription<RerouteAvailability>::SharedPtr sub_reroute_availability_;
   Odometry::ConstSharedPtr odometry_;
+  HADMapBin::ConstSharedPtr map_ptr_;
   RerouteAvailability::ConstSharedPtr reroute_availability_;
   void on_odometry(const Odometry::ConstSharedPtr msg);
+  void on_map(const HADMapBin::ConstSharedPtr msg);
   void on_reroute_availability(const RerouteAvailability::ConstSharedPtr msg);
 
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
@@ -125,9 +127,6 @@ private:
   void on_clear_mrm_route(
     const ClearMrmRoute::Service::Request::SharedPtr req,
     const ClearMrmRoute::Service::Response::SharedPtr res);
-
-  HADMapBin::ConstSharedPtr map_ptr_{nullptr};
-  void onMap(const HADMapBin::ConstSharedPtr msg);
 
   component_interface_utils::Subscription<ModifiedGoal>::SharedPtr sub_modified_goal_;
   void on_modified_goal(const ModifiedGoal::Message::ConstSharedPtr msg);


### PR DESCRIPTION
## Description
Some functions in the mission planner use camel case, although it is supposed to use snake case. In this PR, I changed it to the snake case as well as some variable names to improve readability.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
