### PR TITLE
fix(dynamic_avoidance): minor changes with bug fix

### DIFF
--- a/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -3,6 +3,7 @@
     dynamic_avoidance:
       common:
         enable_debug_info: true
+        use_hatched_road_markings: true
 
       # avoidance is performed for the object type with true
       target_object:
@@ -18,6 +19,7 @@
         min_obstacle_vel: 0.0 # [m/s]
 
         successive_num_to_entry_dynamic_avoidance_condition: 5
+        successive_num_to_exit_dynamic_avoidance_condition: 1
 
         min_obj_lat_offset_to_ego_path: 0.0 # [m]
         max_obj_lat_offset_to_ego_path: 1.0 # [m]
@@ -26,26 +28,34 @@
           min_time_to_start_cut_in: 1.0 # [s]
           min_lon_offset_ego_to_object: 0.0 # [m]
 
+        cut_out_object:
+          max_time_from_outside_ego_path: 2.0 # [s]
+          min_object_lat_vel: 0.3 # [m/s]
+
         crossing_object:
-          min_object_vel: 1.0
-          max_object_angle: 1.05
+          min_overtaking_object_vel: 1.0
+          max_overtaking_object_angle: 1.05
+          min_oncoming_object_vel: 0.0
+          max_oncoming_object_angle: 0.523
 
         front_object:
           max_object_angle: 0.785
 
       drivable_area_generation:
-        lat_offset_from_obstacle: 1.0 # [m]
+        lat_offset_from_obstacle: 0.8 # [m]
         max_lat_offset_to_avoid: 0.5 # [m]
+        max_time_for_object_lat_shift: 2.0 # [s]
+        lpf_gain_for_lat_avoid_to_offset: 0.9 # [-]
 
         # for same directional object
         overtaking_object:
-          max_time_to_collision: 10.0 # [s]
+          max_time_to_collision: 40.0 # [s]
           start_duration_to_avoid: 2.0  # [s]
           end_duration_to_avoid: 4.0  # [s]
           duration_to_hold_avoidance: 3.0 # [s]
 
         # for opposite directional object
         oncoming_object:
-          max_time_to_collision: 15.0 # [s]
+          max_time_to_collision: 40.0 # [s] This value should be the same as overtaking_object's one to suppress chattering of this value for parked vehicles
           start_duration_to_avoid: 12.0  # [s]
           end_duration_to_avoid: 0.0  # [s]

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -45,6 +45,7 @@ struct DynamicAvoidanceParameters
 {
   // common
   bool enable_debug_info{true};
+  bool use_hatched_road_markings{true};
 
   // obstacle types to avoid
   bool avoid_car{true};

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -120,8 +120,10 @@ public:
     std::optional<rclcpp::Time> latest_time_inside_ego_path{std::nullopt};
     std::vector<autoware_auto_perception_msgs::msg::PredictedPath> predicted_paths{};
 
-    MinMaxValue lon_offset_to_avoid;
-    MinMaxValue lat_offset_to_avoid;
+    // NOTE: Previous values of the following are used for low-pass filtering.
+    //       Therefore, they has to be initialized as nullopt.
+    std::optional<MinMaxValue> lon_offset_to_avoid{std::nullopt};
+    std::optional<MinMaxValue> lat_offset_to_avoid{std::nullopt};
     bool is_collision_left;
     bool should_be_avoided{false};
 
@@ -306,7 +308,6 @@ private:
 
   bool isLabelTargetObstacle(const uint8_t label) const;
   void updateTargetObjects();
-  std::optional<std::vector<PathPointWithLaneId>> calcPathForObjectPolygon() const;
   bool willObjectCutIn(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
     const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -76,6 +76,8 @@ struct DynamicAvoidanceParameters
   // drivable area generation
   double lat_offset_from_obstacle{0.0};
   double max_lat_offset_to_avoid{0.0};
+  double max_time_for_lat_shift{0.0};
+  double lpf_gain_for_lat_avoid_to_offset{0.0};
 
   double max_time_to_collision_overtaking_object{0.0};
   double start_duration_to_avoid_overtaking_object{0.0};

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -68,7 +68,7 @@ void appendExtractedPolygonMarker(
   auto marker = tier4_autoware_utils::createDefaultMarker(
     "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "extracted_polygons", marker_array.markers.size(),
     visualization_msgs::msg::Marker::LINE_STRIP,
-    tier4_autoware_utils::createMarkerScale(0.05, 0.0, 0.0),
+    tier4_autoware_utils::createMarkerScale(0.1, 0.0, 0.0),
     tier4_autoware_utils::createMarkerColor(1.0, 0.5, 0.6, 0.8));
 
   // NOTE: obj_poly.outer() has already duplicated points to close the polygon.
@@ -349,11 +349,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
   const auto prev_module_path = getPreviousModuleOutput().path;
   const auto & predicted_objects = planner_data_->dynamic_object->objects;
 
-  const auto path_points_for_object_polygon = calcPathForObjectPolygon();
-  if (!path_points_for_object_polygon) {
-    return;
-  }
-
+  const auto path_points_for_object_polygon = getPreviousModuleOutput().reference_path->points;
   const auto prev_objects = target_objects_manager_.getValidObjects();
 
   // 1. Rough filtering of target objects
@@ -508,39 +504,16 @@ void DynamicAvoidanceModule::updateTargetObjects()
 
     // 2.g. calculate longitudinal and lateral offset to avoid
     const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
+    std::cerr << obj_uuid << std::endl;
     const auto lon_offset_to_avoid = calcMinMaxLongitudinalOffsetToAvoid(
-      *path_points_for_object_polygon, object.pose, obj_points, object.vel, time_to_collision);
+      path_points_for_object_polygon, object.pose, obj_points, object.vel, time_to_collision);
     const auto lat_offset_to_avoid = calcMinMaxLateralOffsetToAvoid(
-      *path_points_for_object_polygon, obj_points, is_collision_left, object.lat_vel, prev_object);
+      path_points_for_object_polygon, obj_points, is_collision_left, object.lat_vel, prev_object);
 
     const bool should_be_avoided = true;
     target_objects_manager_.updateObject(
       obj_uuid, lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided);
   }
-}
-
-std::optional<std::vector<PathPointWithLaneId>> DynamicAvoidanceModule::calcPathForObjectPolygon()
-  const
-{
-  const auto & ego_pose = getEgoPose();
-  const auto & rh = planner_data_->route_handler;
-
-  // get path with backward margin
-  lanelet::ConstLanelet current_lane;
-  if (!rh->getClosestLaneletWithinRoute(ego_pose, &current_lane)) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("behavior_path_planner").get_child("dynamic_avoidance"),
-      "failed to find closest lanelet within route!!!");
-    return std::nullopt;
-  }
-
-  constexpr double forward_length = 100.0;
-  const double backward_length = 50.0;
-  const auto current_lanes =
-    rh->getLaneletSequence(current_lane, ego_pose, backward_length, forward_length);
-  const auto path = utils::getCenterLinePath(
-    *rh, current_lanes, ego_pose, backward_length, forward_length, planner_data_->parameters);
-  return path.points;
 }
 
 [[maybe_unused]] std::optional<std::pair<size_t, size_t>>
@@ -849,10 +822,10 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
 
   // filter min_bound_lat_offset
   const auto prev_min_lat_avoid_to_offset = [&]() -> std::optional<double> {
-    if (!prev_object) {
+    if (!prev_object || !prev_object->lat_offset_to_avoid) {
       return std::nullopt;
     }
-    return prev_object->lat_offset_to_avoid.min_value;
+    return prev_object->lat_offset_to_avoid->min_value;
   }();
   const double filtered_min_bound_lat_offset =
     prev_min_lat_avoid_to_offset ? signal_processing::lowpassFilter(
@@ -860,6 +833,12 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
                                      parameters_->lpf_gain_for_lat_avoid_to_offset)
                                  : min_bound_lat_offset;
 
+  if (prev_min_lat_avoid_to_offset) {
+    std::cerr << min_bound_lat_offset << " " << *prev_min_lat_avoid_to_offset << " then "
+              << filtered_min_bound_lat_offset << std::endl;
+  } else {
+    std::cerr << filtered_min_bound_lat_offset << std::endl;
+  }
   return MinMaxValue{filtered_min_bound_lat_offset, max_bound_lat_offset};
 }
 
@@ -867,22 +846,23 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
 std::optional<tier4_autoware_utils::Polygon2d> DynamicAvoidanceModule::calcDynamicObstaclePolygon(
   const DynamicAvoidanceObject & object) const
 {
-  auto path_points_for_object_polygon = calcPathForObjectPolygon();
-  if (!path_points_for_object_polygon) {
+  if (!object.lon_offset_to_avoid || !object.lat_offset_to_avoid) {
     return std::nullopt;
   }
 
+  auto path_points_for_object_polygon = getPreviousModuleOutput().reference_path->points;
+
   const size_t obj_seg_idx =
-    motion_utils::findNearestSegmentIndex(*path_points_for_object_polygon, object.pose.position);
+    motion_utils::findNearestSegmentIndex(path_points_for_object_polygon, object.pose.position);
   const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
 
   const auto lon_bound_start_idx_opt = motion_utils::insertTargetPoint(
-    obj_seg_idx, object.lon_offset_to_avoid.min_value, *path_points_for_object_polygon);
+    obj_seg_idx, object.lon_offset_to_avoid->min_value, path_points_for_object_polygon);
   const size_t updated_obj_seg_idx =
     (lon_bound_start_idx_opt && lon_bound_start_idx_opt.value() <= obj_seg_idx) ? obj_seg_idx + 1
                                                                                 : obj_seg_idx;
   const auto lon_bound_end_idx_opt = motion_utils::insertTargetPoint(
-    updated_obj_seg_idx, object.lon_offset_to_avoid.max_value, *path_points_for_object_polygon);
+    updated_obj_seg_idx, object.lon_offset_to_avoid->max_value, path_points_for_object_polygon);
 
   if (!lon_bound_start_idx_opt && !lon_bound_end_idx_opt) {
     // NOTE: The obstacle is longitudinally out of the ego's trajectory.
@@ -892,19 +872,19 @@ std::optional<tier4_autoware_utils::Polygon2d> DynamicAvoidanceModule::calcDynam
     lon_bound_start_idx_opt ? lon_bound_start_idx_opt.value() : static_cast<size_t>(0);
   const size_t lon_bound_end_idx =
     lon_bound_end_idx_opt ? lon_bound_end_idx_opt.value()
-                          : static_cast<size_t>(path_points_for_object_polygon->size() - 1);
+                          : static_cast<size_t>(path_points_for_object_polygon.size() - 1);
 
   // create inner/outer bound points
   std::vector<geometry_msgs::msg::Point> obj_inner_bound_points;
   std::vector<geometry_msgs::msg::Point> obj_outer_bound_points;
   for (size_t i = lon_bound_start_idx; i <= lon_bound_end_idx; ++i) {
     obj_inner_bound_points.push_back(tier4_autoware_utils::calcOffsetPose(
-                                       path_points_for_object_polygon->at(i).point.pose, 0.0,
-                                       object.lat_offset_to_avoid.min_value, 0.0)
+                                       path_points_for_object_polygon.at(i).point.pose, 0.0,
+                                       object.lat_offset_to_avoid->min_value, 0.0)
                                        .position);
     obj_outer_bound_points.push_back(tier4_autoware_utils::calcOffsetPose(
-                                       path_points_for_object_polygon->at(i).point.pose, 0.0,
-                                       object.lat_offset_to_avoid.max_value, 0.0)
+                                       path_points_for_object_polygon.at(i).point.pose, 0.0,
+                                       object.lat_offset_to_avoid->max_value, 0.0)
                                        .position);
   }
 

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -270,7 +270,6 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
   debug_marker_.markers.clear();
 
   const auto prev_module_path = getPreviousModuleOutput().path;
-  const auto drivable_lanes = getPreviousModuleOutput().drivable_area_info.drivable_lanes;
 
   // create obstacles to avoid (= extract from the drivable area)
   std::vector<DrivableAreaInfo::Obstacle> obstacles_for_drivable_area;
@@ -285,11 +284,18 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
     }
   }
 
+  DrivableAreaInfo current_drivable_area_info;
+  current_drivable_area_info.drivable_lanes =
+    getPreviousModuleOutput().drivable_area_info.drivable_lanes;
+  current_drivable_area_info.obstacles = obstacles_for_drivable_area;
+  current_drivable_area_info.enable_expanding_hatched_road_markings =
+    parameters_->use_hatched_road_markings;
+
   BehaviorModuleOutput output;
   output.path = prev_module_path;
+  output.drivable_area_info = utils::combineDrivableAreaInfo(
+    current_drivable_area_info, getPreviousModuleOutput().drivable_area_info);
   output.reference_path = getPreviousModuleOutput().reference_path;
-  output.drivable_area_info.drivable_lanes = drivable_lanes;
-  output.drivable_area_info.obstacles = obstacles_for_drivable_area;
   output.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
 
   return output;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -855,11 +855,10 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
     return prev_object->lat_offset_to_avoid.min_value;
   }();
   const double filtered_min_bound_lat_offset =
-    prev_min_lat_avoid_to_offset
-      ? signal_processing::lowpassFilter(
-          min_bound_lat_offset, *prev_min_lat_avoid_to_offset,
-          parameters_->lpf_gain_for_lat_avoid_to_offset)  // TODO(murooka) use rosparam
-      : min_bound_lat_offset;
+    prev_min_lat_avoid_to_offset ? signal_processing::lowpassFilter(
+                                     min_bound_lat_offset, *prev_min_lat_avoid_to_offset,
+                                     parameters_->lpf_gain_for_lat_avoid_to_offset)
+                                 : min_bound_lat_offset;
 
   return MinMaxValue{filtered_min_bound_lat_offset, max_bound_lat_offset};
 }

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -833,10 +833,9 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
 
   // calculate bound min and max lateral offset
   const double min_bound_lat_offset = [&]() {
-    constexpr double object_time_to_shift = 2.0;
     const double lat_abs_offset_to_shift =
       std::max(0.0, obj_normal_vel * (is_collision_left ? -1.0 : 1.0)) *
-      object_time_to_shift;  // TODO(murooka) use rosparam
+      parameters_->max_time_for_lat_shift;
     const double raw_min_bound_lat_offset =
       min_obj_lat_abs_offset - parameters_->lat_offset_from_obstacle - lat_abs_offset_to_shift;
     const double min_bound_lat_abs_offset_limit =
@@ -858,7 +857,8 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
   const double filtered_min_bound_lat_offset =
     prev_min_lat_avoid_to_offset
       ? signal_processing::lowpassFilter(
-          min_bound_lat_offset, *prev_min_lat_avoid_to_offset, 0.5)  // TODO(murooka) use rosparam
+          min_bound_lat_offset, *prev_min_lat_avoid_to_offset,
+          parameters_->lpf_gain_for_lat_avoid_to_offset)  // TODO(murooka) use rosparam
       : min_bound_lat_offset;
 
   return MinMaxValue{filtered_min_bound_lat_offset, max_bound_lat_offset};

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -504,7 +504,6 @@ void DynamicAvoidanceModule::updateTargetObjects()
 
     // 2.g. calculate longitudinal and lateral offset to avoid
     const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
-    std::cerr << obj_uuid << std::endl;
     const auto lon_offset_to_avoid = calcMinMaxLongitudinalOffsetToAvoid(
       path_points_for_object_polygon, object.pose, obj_points, object.vel, time_to_collision);
     const auto lat_offset_to_avoid = calcMinMaxLateralOffsetToAvoid(
@@ -833,12 +832,6 @@ MinMaxValue DynamicAvoidanceModule::calcMinMaxLateralOffsetToAvoid(
                                      parameters_->lpf_gain_for_lat_avoid_to_offset)
                                  : min_bound_lat_offset;
 
-  if (prev_min_lat_avoid_to_offset) {
-    std::cerr << min_bound_lat_offset << " " << *prev_min_lat_avoid_to_offset << " then "
-              << filtered_min_bound_lat_offset << std::endl;
-  } else {
-    std::cerr << filtered_min_bound_lat_offset << std::endl;
-  }
   return MinMaxValue{filtered_min_bound_lat_offset, max_bound_lat_offset};
 }
 

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -32,6 +32,7 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
   {  // common
     std::string ns = "dynamic_avoidance.common.";
     p.enable_debug_info = node->declare_parameter<bool>(ns + "enable_debug_info");
+    p.use_hatched_road_markings = node->declare_parameter<bool>(ns + "use_hatched_road_markings");
   }
 
   {  // target object
@@ -112,6 +113,7 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
   {  // common
     const std::string ns = "dynamic_avoidance.common.";
     updateParam<bool>(parameters, ns + "enable_debug_info", p->enable_debug_info);
+    updateParam<bool>(parameters, ns + "use_hatched_road_markings", p->use_hatched_road_markings);
   }
 
   {  // target object

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -83,6 +83,10 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
     std::string ns = "dynamic_avoidance.drivable_area_generation.";
     p.lat_offset_from_obstacle = node->declare_parameter<double>(ns + "lat_offset_from_obstacle");
     p.max_lat_offset_to_avoid = node->declare_parameter<double>(ns + "max_lat_offset_to_avoid");
+    p.max_time_for_lat_shift =
+      node->declare_parameter<double>(ns + "max_time_for_object_lat_shift");
+    p.lpf_gain_for_lat_avoid_to_offset =
+      node->declare_parameter<double>(ns + "lpf_gain_for_lat_avoid_to_offset");
 
     p.max_time_to_collision_overtaking_object =
       node->declare_parameter<double>(ns + "overtaking_object.max_time_to_collision");
@@ -176,6 +180,10 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
 
     updateParam<double>(parameters, ns + "lat_offset_from_obstacle", p->lat_offset_from_obstacle);
     updateParam<double>(parameters, ns + "max_lat_offset_to_avoid", p->max_lat_offset_to_avoid);
+    updateParam<double>(
+      parameters, ns + "max_time_for_object_lat_shift", p->max_time_for_lat_shift);
+    updateParam<double>(
+      parameters, ns + "lpf_gain_for_lat_avoid_to_offset", p->lpf_gain_for_lat_avoid_to_offset);
 
     updateParam<double>(
       parameters, ns + "overtaking_object.max_time_to_collision",


### PR DESCRIPTION
## Description

Depends on https://github.com/autowarefoundation/autoware.universe/pull/4566

- Fixed a bug of uninitialized previous lat_offset_to_avoid
    - If an object is memorized but lat_offset_to_avoid is not updated, the initial value is 0, and low-pass filter uses it as a previous value, resulting in filtered lat_offset_to_avoid being almost 0.
- Remove calcPathForObjectPolygon because if the ego does the lane change, the calculated path will change and the result of low-pass filter of lat_offset_to_avoid will be wrong.
    - Reference path in previous module's output can be used instead.
- modify debug marker for better visibility
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
minor bug fix of dynamic_avoidance

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
