### PR TITLE
fix(scnenario_selector): prevent changing scneario when same uuid route is received

### DIFF
--- a/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -197,8 +197,13 @@ void ScenarioSelectorNode::onMap(
 void ScenarioSelectorNode::onRoute(
   const autoware_planning_msgs::msg::LaneletRoute::ConstSharedPtr msg)
 {
+  // When the route id is the same (e.g. reporting with modified goal) keep the current scenario.
+  // Otherwise, reset the scenario.
+  if (!route_handler_ || route_handler_->getRouteUuid() != msg->uuid) {
+    current_scenario_ = tier4_planning_msgs::msg::Scenario::EMPTY;
+  }
+
   route_ = msg;
-  current_scenario_ = tier4_planning_msgs::msg::Scenario::EMPTY;
 }
 
 void ScenarioSelectorNode::onOdom(const nav_msgs::msg::Odometry::ConstSharedPtr msg)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

 prevent changing scneario when same uuid route is received

e.g.

If the goal is modified during a freespace pull over, it is rerouted. If ego is already out of lane at this time, the scenario may change unintentionally.

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/25f2f00a-dbfd-4e36-a082-b24f5f1cacbc)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
