### PR TITLE
feat(planning_debug_tools): manage time of perception_replayer by slider

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
@@ -59,11 +59,16 @@ class PerceptionReplayer(PerceptionReplayerCommon):
             self.pointcloud_pub.publish(pointcloud_msg)
 
         # step timestamp
-        print(self.widget.slider.value())
-        # self.bag_timestamp = self.widget.slider.value()
+        # get timestamp from slider
+        self.bag_timestamp = self.rosbag_objects_data[0][
+            0
+        ] + self.widget.slider.value() / 1000000 * (
+            self.rosbag_objects_data[-1][0] - self.rosbag_objects_data[0][0]
+        )
         if not self.is_pause:
             self.bag_timestamp += self.rate * self.delta_time * 1e9  # seconds to timestamp
-        # self.widget.slider.setValue(self.bag_timestamp)
+        # update slider value from the updated timestamp
+        self.widget.slider.setValue(self.widget.timestamp_to_value(self.bag_timestamp))
 
         # extract message by the timestamp
         msgs = copy.deepcopy(self.find_topics_by_timestamp(self.bag_timestamp))

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
@@ -36,7 +36,9 @@ class PerceptionReplayer(PerceptionReplayerCommon):
         self.rate = 1.0
 
         # initialize widget
-        self.widget = TimeManagerWidget()
+        self.widget = TimeManagerWidget(
+            self.rosbag_objects_data[0][0], self.rosbag_objects_data[-1][0]
+        )
         self.widget.show()
         self.widget.button.clicked.connect(self.onPushed)
         for button in self.widget.rate_button:
@@ -57,8 +59,11 @@ class PerceptionReplayer(PerceptionReplayerCommon):
             self.pointcloud_pub.publish(pointcloud_msg)
 
         # step timestamp
+        print(self.widget.slider.value())
+        # self.bag_timestamp = self.widget.slider.value()
         if not self.is_pause:
             self.bag_timestamp += self.rate * self.delta_time * 1e9  # seconds to timestamp
+        # self.widget.slider.setValue(self.bag_timestamp)
 
         # extract message by the timestamp
         msgs = copy.deepcopy(self.find_topics_by_timestamp(self.bag_timestamp))

--- a/planning/planning_debug_tools/scripts/perception_replayer/time_manager_widget.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/time_manager_widget.py
@@ -19,13 +19,17 @@ from PyQt5.QtWidgets import QGridLayout
 from PyQt5.QtWidgets import QMainWindow
 from PyQt5.QtWidgets import QPushButton
 from PyQt5.QtWidgets import QSizePolicy
+from PyQt5.QtWidgets import QSlider
 from PyQt5.QtWidgets import QWidget
 
 
 class TimeManagerWidget(QMainWindow):
-    def __init__(self):
+    def __init__(self, start_timestamp, end_timestamp):
         super(self.__class__, self).__init__()
         self.setupUI()
+
+        self.start_timestamp = start_timestamp
+        self.end_timestamp = end_timestamp
 
     def setupUI(self):
         self.setObjectName("PerceptionReplayer")
@@ -39,6 +43,7 @@ class TimeManagerWidget(QMainWindow):
         self.grid_layout.setContentsMargins(10, 10, 10, 10)
         self.grid_layout.setObjectName("grid_layout")
 
+        # rate button
         self.rate_button = []
         for i, rate in enumerate([0.1, 0.5, 1.0, 2.0, 5.0, 10.0]):
             button = QPushButton(str(rate))
@@ -46,9 +51,18 @@ class TimeManagerWidget(QMainWindow):
             self.rate_button.append(button)
             self.grid_layout.addWidget(self.rate_button[-1], 0, i, 1, 1)
 
+        # pause button
         self.button = QPushButton("pause")
         self.button.setCheckable(True)
         self.button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-
         self.grid_layout.addWidget(self.button, 1, 0, 1, -1)
+
+        # slider
+        self.slider = QSlider(QtCore.Qt.Horizontal)
+        self.slider.setMinimum(self.start_timestamp)
+        self.slider.setMaximum(self.end_timestamp)
+        self.slider.setValue(self.start_timestamp)
+        self.slider.valueChanged.connect(self.value_change)
+        self.grid_layout.addWidget(self.slider, 2, 0, 1, -1)
+
         self.setCentralWidget(self.central_widget)

--- a/planning/planning_debug_tools/scripts/perception_replayer/time_manager_widget.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/time_manager_widget.py
@@ -26,10 +26,12 @@ from PyQt5.QtWidgets import QWidget
 class TimeManagerWidget(QMainWindow):
     def __init__(self, start_timestamp, end_timestamp):
         super(self.__class__, self).__init__()
-        self.setupUI()
 
         self.start_timestamp = start_timestamp
         self.end_timestamp = end_timestamp
+        self.max_value = 1000000
+
+        self.setupUI()
 
     def setupUI(self):
         self.setObjectName("PerceptionReplayer")
@@ -59,10 +61,21 @@ class TimeManagerWidget(QMainWindow):
 
         # slider
         self.slider = QSlider(QtCore.Qt.Horizontal)
-        self.slider.setMinimum(self.start_timestamp)
-        self.slider.setMaximum(self.end_timestamp)
-        self.slider.setValue(self.start_timestamp)
-        self.slider.valueChanged.connect(self.value_change)
+        self.slider.setMinimum(0)
+        self.slider.setMaximum(self.max_value)
+        self.slider.setValue(0)
         self.grid_layout.addWidget(self.slider, 2, 0, 1, -1)
 
         self.setCentralWidget(self.central_widget)
+
+    def timestamp_to_value(self, timestamp):
+        return int(
+            (timestamp - self.start_timestamp)
+            / (self.end_timestamp - self.start_timestamp)
+            * self.max_value
+        )
+
+    def value_to_timestamp(self, value):
+        return self.start_timestamp + self.slider.value() / self.max_value * (
+            self.end_value - self.start_value
+        )


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Added a slider GUI to move the timestamp of rosbag forward/backward for perception_replayer

The following is the video of `planning simulator` with `ros2 run planning_debug_tools  perception_replayer.py -b <bag-files>`

https://github.com/autowarefoundation/autoware.universe/assets/20228327/5a808760-e7ca-4992-8bc6-b8dcac7237f4



## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
