### PR TITLE
fix(behavior_path_planner): fix straight turn signal end point

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/turn_signal_decider.hpp
@@ -107,6 +107,8 @@ private:
     const double nearest_dist_threshold, const double nearest_yaw_threshold);
 
   geometry_msgs::msg::Pose get_required_end_point(const lanelet::ConstLineString3d & centerline);
+  geometry_msgs::msg::Pose get_straight_lane_required_end_point(
+    const lanelet::ConstLineString3d & centerline);
 
   bool use_prior_turn_signal(
     const double dist_to_prior_required_start, const double dist_to_prior_required_end,


### PR DESCRIPTION
## Description
Usually, the end point of the straight lane has not big angle difference from other points on the lane. Therefore, the required endpoint becomes the start point of the lane, which makes the required section disappear. In this PR, I made the required position at the center of the lane.

![image](https://github.com/autowarefoundation/autoware.universe/assets/43805014/a833f646-6a4f-45bd-872d-221111cc9f0d)
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
