### PR TITLE
feat!: rename map_projector_type

### DIFF
--- a/common/component_interface_specs/include/component_interface_specs/map.hpp
+++ b/common/component_interface_specs/include/component_interface_specs/map.hpp
@@ -25,7 +25,7 @@ namespace map_interface
 struct MapProjectorInfo
 {
   using Message = tier4_map_msgs::msg::MapProjectorInfo;
-  static constexpr char name[] = "/map/map_projector_type";
+  static constexpr char name[] = "/map/map_projector_info";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;

--- a/map/map_loader/README.md
+++ b/map/map_loader/README.md
@@ -140,7 +140,7 @@ Please see [the description of `GetSelectedPointCloudMap.srv`](https://github.co
 ### Feature
 
 lanelet2_map_loader loads Lanelet2 file and publishes the map data as autoware_auto_mapping_msgs/HADMapBin message.
-The node projects lan/lon coordinates into arbitrary coordinates defined in `/map/map_projector_type` from `map_projection_loader`.
+The node projects lan/lon coordinates into arbitrary coordinates defined in `/map/map_projector_info` from `map_projection_loader`.
 The node supports the following three types of coordinate systems:
 
 - MGRS

--- a/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
+++ b/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
@@ -43,7 +43,7 @@ public:
 private:
   void on_map_projector_info(const MapProjectorInfo::ConstSharedPtr msg);
 
-  rclcpp::Subscription<MapProjectorInfo>::SharedPtr sub_map_projector_type_;
+  rclcpp::Subscription<MapProjectorInfo>::SharedPtr sub_map_projector_info_;
   rclcpp::Publisher<HADMapBin>::SharedPtr pub_map_bin_;
 };
 

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
@@ -52,7 +52,7 @@ Lanelet2MapLoaderNode::Lanelet2MapLoaderNode(const rclcpp::NodeOptions & options
 : Node("lanelet2_map_loader", options)
 {
   // subscription
-  sub_map_projector_type_ = create_subscription<MapProjectorInfo>(
+  sub_map_projector_info_ = create_subscription<MapProjectorInfo>(
     "input/map_projector_info", rclcpp::QoS{1}.transient_local(),
     [this](const MapProjectorInfo::ConstSharedPtr msg) { on_map_projector_info(msg); });
 }

--- a/map/map_projection_loader/launch/map_projection_loader.launch.xml
+++ b/map/map_projection_loader/launch/map_projection_loader.launch.xml
@@ -3,7 +3,7 @@
   <arg name="lanelet2_map_path" description="Path to the lanelet2 map file"/>
 
   <node pkg="map_projection_loader" exec="map_projection_loader" name="map_projection_loader" output="screen">
-    <remap from="~/map_projector_info" to="/map/map_projector_type"/>
+    <remap from="~/map_projector_info" to="/map/map_projector_info"/>
     <param name="map_projector_info_path" value="$(var map_projector_info_path)"/>
     <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>
   </node>


### PR DESCRIPTION
## Description
Change the name of the topic /map/map_projector_type, since it mismatches with the type of the topic MapProjectorInfo.


<!-- Write a brief description of this PR. -->

## Related links
N/A
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
TO BE FILLED
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
N/A
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
Yes
/map/map_projector_type will be renamed to /map/map_projector_info
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
N/A
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
