### PR TITLE
fix(planner_manager): don't back waiting approval besides last one in approved modules

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -145,7 +145,6 @@
         time_horizon: 10.0                               # [s]
         safety_check_backward_distance: 100.0            # [m]
         safety_check_hysteresis_factor: 2.0              # [-]
-        safety_check_ego_offset: 1.0                     # [m]
 
       # For avoidance maneuver
       avoidance:

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -126,10 +126,10 @@ public:
    */
   void reset()
   {
+    std::for_each(manager_ptrs_.begin(), manager_ptrs_.end(), [](const auto & m) { m->reset(); });
     approved_module_ptrs_.clear();
     candidate_module_ptrs_.clear();
     root_lanelet_ = boost::none;
-    std::for_each(manager_ptrs_.begin(), manager_ptrs_.end(), [](const auto & m) { m->reset(); });
     resetProcessingTime();
   }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -162,6 +162,7 @@ public:
     clearWaitingApproval();
     removeRTCStatus();
     unlockNewModuleLaunch();
+    unlockOutputPath();
     steering_factor_interface_ptr_->clearSteeringFactors();
 
     stop_reason_ = StopReason();
@@ -219,6 +220,10 @@ public:
    * @brief set planner data
    */
   virtual void setData(const std::shared_ptr<const PlannerData> & data) { planner_data_ = data; }
+
+  void lockOutputPath() { is_locked_output_path_ = true; }
+
+  void unlockOutputPath() { is_locked_output_path_ = false; }
 
   bool isWaitingApproval() const
   {
@@ -359,6 +364,8 @@ private:
   bool is_simultaneously_executable_as_candidate_module_{false};
 
   bool is_locked_new_module_launch_{false};
+
+  bool is_locked_output_path_{false};
 
 protected:
   /**
@@ -526,6 +533,8 @@ protected:
   }
 
   BehaviorModuleOutput getPreviousModuleOutput() const { return previous_module_output_; }
+
+  bool isOutputPathLocked() const { return is_locked_output_path_; }
 
   void lockNewModuleLaunch() { is_locked_new_module_launch_ = true; }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -161,6 +161,7 @@ public:
 
     clearWaitingApproval();
     removeRTCStatus();
+    publishRTCStatus();
     unlockNewModuleLaunch();
     unlockOutputPath();
     steering_factor_interface_ptr_->clearSteeringFactors();

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -201,9 +201,6 @@ struct AvoidanceParameters
   // transit hysteresis (unsafe to safe)
   double safety_check_hysteresis_factor;
 
-  // don't output new candidate path if the offset between ego and path is larger than this.
-  double safety_check_ego_offset;
-
   // keep target velocity in yield maneuver
   double yield_velocity;
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -480,18 +480,14 @@ void AvoidanceModule::fillEgoStatus(
 
   const auto can_yield_maneuver = canYieldManeuver(data);
 
-  const size_t ego_seg_idx =
-    planner_data_->findEgoSegmentIndex(helper_.getPreviousSplineShiftPath().path.points);
-  const auto offset = std::abs(motion_utils::calcLateralOffset(
-    helper_.getPreviousSplineShiftPath().path.points, getEgoPosition(), ego_seg_idx));
-
-  // don't output new candidate path if the offset between the ego and previous output path is
-  // larger than threshold.
-  // TODO(Satoshi OTA): remove this workaround
-  if (offset > parameters_->safety_check_ego_offset) {
+  /**
+   * If the output path is locked by outside of this module, don't update output path.
+   */
+  if (isOutputPathLocked()) {
     data.safe_new_sl.clear();
     data.candidate_path = helper_.getPreviousSplineShiftPath();
-    RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 500, "unsafe. canceling candidate path...");
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 500, "this module is locked now. keep current path.");
     return;
   }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2165,8 +2165,6 @@ BehaviorModuleOutput AvoidanceModule::plan()
   generateExtendedDrivableArea(output);
   setDrivableLanes(output.drivable_area_info.drivable_lanes);
 
-  // updateRegisteredRTCStatus(spline_shift_path.path);
-
   return output;
 }
 
@@ -2504,8 +2502,6 @@ void AvoidanceModule::initVariables()
 
 void AvoidanceModule::initRTCStatus()
 {
-  removeRTCStatus();
-  clearWaitingApproval();
   left_shift_array_.clear();
   right_shift_array_.clear();
   uuid_map_.at("left") = generateUUID();

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -151,7 +151,6 @@ AvoidanceModuleManager::AvoidanceModuleManager(
       get_parameter<double>(node, ns + "safety_check_backward_distance");
     p.safety_check_hysteresis_factor =
       get_parameter<double>(node, ns + "safety_check_hysteresis_factor");
-    p.safety_check_ego_offset = get_parameter<double>(node, ns + "safety_check_ego_offset");
   }
 
   // avoidance maneuver (lateral)


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1027c2</samp>

This pull request improves the behavior path planning by enhancing the scene module interface and refactoring the avoidance module. It adds functions and a flag to the interface to lock and unlock the output path of the scene modules, and publishes the RTC status before exiting. It updates the planner manager logic to handle the output path lock and the waiting approval modules. It simplifies the avoidance module code by using the interface functions and removing the redundant parameter `safety_check_ego_offset`. It also makes minor changes to the `planner_manager.hpp` and `avoidance_module_data.hpp` files to reorder and remove some statements.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] PASS TIER IV INTERNAL SCENARIOS

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
