### PR TITLE
fix(behavior_velocity_crosswalk_module): prevent to access null stop_factor

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -1051,6 +1051,11 @@ void CrosswalkModule::planStop(
     return std::nullopt;
   }();
 
+  if (!stop_factor) {
+    RCLCPP_ERROR_STREAM_THROTTLE(logger_, *clock_, 5000, "stop_factor is null");
+    return;
+  }
+
   // Plan stop
   insertDecelPointWithDebugInfo(stop_factor->stop_pose.position, 0.0, ego_path);
   planning_utils::appendStopReason(*stop_factor, stop_reason);


### PR DESCRIPTION
## Description

In the planStop function of the crosswalk module, the ```stop_factor``` variable can be accessed even if it is null_opt.


I fixed it.

(TIERIV Internal Link:
https://evaluation.tier4.jp/evaluation/reports/007f6767-d452-53c3-b7ad-0da9a5909d3c/tests/f68cf39a-69b5-53eb-944b-6d84f37d58eb/2e1d61f5-e9d4-5576-a887-aede118ddf0e?project_id=prd_jt 
In scenarios, the behavior module died with following error.
```
[component_container_mt-61] terminate called after throwing an instance of 'std::bad_array_new_length'
[component_container_mt-61]   what():  std::bad_array_new_length
```
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/756894ed-0412-49d3-8a6c-ee8f027bf7f8)

)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested on Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

See description.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
