### PR TITLE
feat(dynamic_avoidance): object polygon based drivable area generation

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -74,6 +74,7 @@ struct DynamicAvoidanceParameters
   double max_oncoming_crossing_object_angle{0.0};
 
   // drivable area generation
+  std::string polygon_generation_method{};
   double lat_offset_from_obstacle{0.0};
   double max_lat_offset_to_avoid{0.0};
   double max_time_for_lat_shift{0.0};
@@ -335,7 +336,9 @@ private:
 
   std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> getAdjacentLanes(
     const double forward_distance, const double backward_distance) const;
-  std::optional<tier4_autoware_utils::Polygon2d> calcDynamicObstaclePolygon(
+  std::optional<tier4_autoware_utils::Polygon2d> calcEgoPathBasedDynamicObstaclePolygon(
+    const DynamicAvoidanceObject & object) const;
+  std::optional<tier4_autoware_utils::Polygon2d> calcObjectPathBasedDynamicObstaclePolygon(
     const DynamicAvoidanceObject & object) const;
 
   void printIgnoreReason(const std::string & obj_uuid, const std::string & reason)

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -81,6 +81,8 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
 
   {  // drivable_area_generation
     std::string ns = "dynamic_avoidance.drivable_area_generation.";
+    p.polygon_generation_method =
+      node->declare_parameter<std::string>(ns + "polygon_generation_method");
     p.lat_offset_from_obstacle = node->declare_parameter<double>(ns + "lat_offset_from_obstacle");
     p.max_lat_offset_to_avoid = node->declare_parameter<double>(ns + "max_lat_offset_to_avoid");
     p.max_time_for_lat_shift =
@@ -178,6 +180,8 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
   {  // drivable_area_generation
     const std::string ns = "dynamic_avoidance.drivable_area_generation.";
 
+    updateParam<std::string>(
+      parameters, ns + "polygon_generation_method", p->polygon_generation_method);
     updateParam<double>(parameters, ns + "lat_offset_from_obstacle", p->lat_offset_from_obstacle);
     updateParam<double>(parameters, ns + "max_lat_offset_to_avoid", p->max_lat_offset_to_avoid);
     updateParam<double>(


### PR DESCRIPTION
## Description

Dynamic obstacles' polygons to avoid are removed from the drivable area in the dynamic avoidance module.

Currently, the polygons are generated on the ego's path frame.
The method has a limitation case as follows.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/d0ce5103-69c3-465a-9f62-1adc4aab2962)

Ideally, the polygons should be generated on the object's path frame as follows, resulting in successful avoidance.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/d74b6e22-f3b6-4610-8dde-81e1488eb4ba)

By default, this PR's change is not used since the object path is unstable for now.
If it becomes stable, the polygon generation method will be the object path frame.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
