### PR TITLE
fix(avoidance): fix dying with empty lanes

### DIFF
--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -855,6 +855,10 @@ void filterTargetObjects(
   using lanelet::geometry::toArcCoordinates;
   using lanelet::utils::to2D;
 
+  if (data.current_lanelets.empty()) {
+    return;
+  }
+
   const auto & rh = planner_data->route_handler;
   const auto & path_points = data.reference_path_rough.points;
   const auto & ego_pos = planner_data->self_odometry->pose.pose.position;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->


fix avoidance_by_lc dying with empty lanes.

```
(gdb) bt
#0  lanelet::ConstPrimitive<lanelet::LaneletData>::id (this=0xffffffffffffffe8) at /usr/include/c++/11/bits/shared_ptr_base.h:1295
#1  route_handler::RouteHandler::isInGoalRouteSection (this=0x7f462005cf70, lanelet=...) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/route_handler/src/route_handler.cpp:474
#2  0x00007f464758a8b4 in behavior_path_planner::utils::avoidance::filterTargetObjects (objects=std::vector of length 0, capacity 0, data=..., debug=..., planner_data=std::shared_ptr<const behavior_path_planner::PlannerData> (use count 16, weak count 0) = {...},
    parameters=std::shared_ptr<behavior_path_planner::AvoidanceParameters> (use count 4, weak count 0) = {...}) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/utils/avoidance/utils.cpp:866
#3  0x00007f46474d6544 in behavior_path_planner::AvoidanceByLaneChange::fillAvoidanceTargetObjects (this=0x7f45dc0fd000, data=..., debug=...) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp:172
#4  0x00007f46474d68df in behavior_path_planner::AvoidanceByLaneChange::calcAvoidancePlanningData (this=0x7f45dc0fd000, debug=...) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp:128
#5  0x00007f46474d69c0 in behavior_path_planner::AvoidanceByLaneChange::updateSpecialData (this=0x7f45dc0fd000) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp:92
#6  0x00007f4647341fa2 in behavior_path_planner::SceneModuleManagerInterface::isExecutionRequested (this=0x7f46202eb230, previous_module_output=...) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp:91
#7  0x00007f464733326a in behavior_path_planner::PlannerManager::getRequestModules (this=0x7f46200b7950, previous_module_output=...) at /usr/include/c++/11/bits/shared_ptr_base.h:1295
#8  0x00007f46473380a6 in operator() (__closure=0x7f4647ff58e0) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/planner_manager.cpp:91
#9  0x00007f4647338bbb in behavior_path_planner::PlannerManager::run (this=this@entry=0x7f46200b7950, data=std::shared_ptr<behavior_path_planner::PlannerData> (use count 16, weak count 0) = {...}) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/planner_manager.cpp:51
#10 0x00007f464736901e in behavior_path_planner::BehaviorPathPlannerNode::run (this=0x7f462004aed0) at /usr/include/c++/11/bits/shared_ptr_base.h:1295
#11 0x00007f464736dd25 in std::__invoke_impl<void, void (behavior_path_planner::BehaviorPathPlannerNode::*&)(), behavior_path_planner::BehaviorPathPlannerNode*&> (__t=@0x7f46203210d0: 0x7f462004aed0,
    __f=@0x7f46203210c0: (void (behavior_path_planner::BehaviorPathPlannerNode::*)(behavior_path_planner::BehaviorPathPlannerNode * const)) 0x7f4647368bf0 <behavior_path_planner::BehaviorPathPlannerNode::run()>) at /usr/include/c++/11/bits/invoke.h:71
#12 std::__invoke<void (behavior_path_planner::BehaviorPathPlannerNode::*&)(), behavior_path_planner::BehaviorPathPlannerNode*&> (
    __fn=@0x7f46203210c0: (void (behavior_path_planner::BehaviorPathPlannerNode::*)(behavior_path_planner::BehaviorPathPlannerNode * const)) 0x7f4647368bf0 <behavior_path_planner::BehaviorPathPlannerNode::run()>) at /usr/include/c++/11/bits/invoke.h:96
#13 std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (__args=..., this=0x7f46203210c0) at /usr/include/c++/11/functional:420
#14 std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>::operator()<, void>() (this=0x7f46203210c0) at /usr/include/c++/11/functional:503
#15 rclcpp::GenericTimer<std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>, (void*)0>::execute_callback_delegate<std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>, (void*)0>() (
    this=0x7f4620321090) at /opt/ros/humble/include/rclcpp/rclcpp/timer.hpp:244
#16 rclcpp::GenericTimer<std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>, (void*)0>::execute_callback() (this=0x7f4620321090) at /opt/ros/humble/include/rclcpp/rclcpp/timer.hpp:230
#17 0x00007f46678dade1 in rclcpp::Executor::execute_any_executable(rclcpp::AnyExecutable&) () from /opt/ros/humble/lib/librclcpp.so
#18 0x00007f46678e209a in rclcpp::executors::MultiThreadedExecutor::run(unsigned long) () from /opt/ros/humble/lib/librclcpp.so
#19 0x00007f46674dc253 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#20 0x00007f4667094b43 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#21 0x00007f4667126a00 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
(gdb) f 2
#2  0x00007f464758a8b4 in behavior_path_planner::utils::avoidance::filterTargetObjects (objects=std::vector of length 0, capacity 0, data=..., debug=..., planner_data=std::shared_ptr<const behavior_path_planner::PlannerData> (use count 16, weak count 0) = {...},
    parameters=std::shared_ptr<behavior_path_planner::AvoidanceParameters> (use count 4, weak count 0) = {...}) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_path_planner/src/utils/avoidance/utils.cpp:866
866       const auto dist_to_goal = rh->isInGoalRouteSection(data.current_lanelets.back())
(gdb) p data.current_lanelets
$9 = std::vector of length 0, capacity 0
```


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
