### PR TITLE
feat(avoidance): reduce road shoulder margin if lateral distance is not enough to avoid

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -154,7 +154,8 @@
           lateral_execution_threshold: 0.499            # [m]
           lateral_small_shift_threshold: 0.101          # [m]
           lateral_avoid_check_threshold: 0.1            # [m]
-          road_shoulder_safety_margin: 0.3              # [m]
+          soft_road_shoulder_margin: 0.8                # [m]
+          hard_road_shoulder_margin: 0.3                # [m]
           max_right_shift_length: 5.0
           max_left_shift_length: 5.0
         # avoidance distance parameters

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -233,7 +233,11 @@ struct AvoidanceParameters
 
   // The margin is configured so that the generated avoidance trajectory does not come near to the
   // road shoulder.
-  double road_shoulder_safety_margin{1.0};
+  double soft_road_shoulder_margin{1.0};
+
+  // The margin is configured so that the generated avoidance trajectory does not come near to the
+  // road shoulder.
+  double hard_road_shoulder_margin{1.0};
 
   // Even if the obstacle is very large, it will not avoid more than this length for right direction
   double max_right_shift_length;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -157,7 +157,8 @@ AvoidanceModuleManager::AvoidanceModuleManager(
   // avoidance maneuver (lateral)
   {
     std::string ns = "avoidance.avoidance.lateral.";
-    p.road_shoulder_safety_margin = get_parameter<double>(node, ns + "road_shoulder_safety_margin");
+    p.soft_road_shoulder_margin = get_parameter<double>(node, ns + "soft_road_shoulder_margin");
+    p.hard_road_shoulder_margin = get_parameter<double>(node, ns + "hard_road_shoulder_margin");
     p.lateral_execution_threshold = get_parameter<double>(node, ns + "lateral_execution_threshold");
     p.lateral_small_shift_threshold =
       get_parameter<double>(node, ns + "lateral_small_shift_threshold");
@@ -316,8 +317,8 @@ void AvoidanceModuleManager::updateModuleParams(const std::vector<rclcpp::Parame
       parameters, ns + "lateral_small_shift_threshold", p->lateral_small_shift_threshold);
     updateParam<double>(
       parameters, ns + "lateral_avoid_check_threshold", p->lateral_avoid_check_threshold);
-    updateParam<double>(
-      parameters, ns + "road_shoulder_safety_margin", p->road_shoulder_safety_margin);
+    updateParam<double>(parameters, ns + "soft_road_shoulder_margin", p->soft_road_shoulder_margin);
+    updateParam<double>(parameters, ns + "hard_road_shoulder_margin", p->hard_road_shoulder_margin);
   }
 
   {

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -1008,7 +1008,7 @@ void filterTargetObjects(
 
       // Step2. check if it should expand road shoulder margin.
       if (soft_lateral_distance_limit < min_avoid_margin) {
-        return std::min(hard_lateral_distance_limit, min_avoid_margin);
+        return min_avoid_margin;
       }
 
       // Step3. nominal case. avoid margin is limited by soft constraint.

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -992,18 +992,27 @@ void filterTargetObjects(
 
     // calculate avoid_margin dynamically
     // NOTE: This calculation must be after calculating to_road_shoulder_distance.
-    const double max_avoid_margin = object_parameter.safety_buffer_lateral * o.distance_factor +
-                                    object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
-    const double min_safety_lateral_distance =
-      object_parameter.safety_buffer_lateral + 0.5 * vehicle_width;
-    const auto max_allowable_lateral_distance =
-      o.to_road_shoulder_distance - parameters->road_shoulder_safety_margin - 0.5 * vehicle_width;
+    const auto max_avoid_margin = object_parameter.safety_buffer_lateral * o.distance_factor +
+                                  object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
+    const auto min_avoid_margin = object_parameter.safety_buffer_lateral + 0.5 * vehicle_width;
+    const auto soft_lateral_distance_limit =
+      o.to_road_shoulder_distance - parameters->soft_road_shoulder_margin - 0.5 * vehicle_width;
+    const auto hard_lateral_distance_limit =
+      o.to_road_shoulder_distance - parameters->hard_road_shoulder_margin - 0.5 * vehicle_width;
 
     const auto avoid_margin = [&]() -> boost::optional<double> {
-      if (max_allowable_lateral_distance < min_safety_lateral_distance) {
+      // Step1. check avoidable or not.
+      if (hard_lateral_distance_limit < min_avoid_margin) {
         return boost::none;
       }
-      return std::min(max_allowable_lateral_distance, max_avoid_margin);
+
+      // Step2. check if it should expand road shoulder margin.
+      if (soft_lateral_distance_limit < min_avoid_margin) {
+        return std::min(hard_lateral_distance_limit, min_avoid_margin);
+      }
+
+      // Step3. nominal case. avoid margin is limited by soft constraint.
+      return std::min(soft_lateral_distance_limit, max_avoid_margin);
     }();
 
     if (!!avoid_margin) {


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39afdae</samp>

This pull request modifies the `AvoidanceModuleManager` class and related files to use two parameters for the road shoulder margins instead of one. This allows the avoidance module to adjust the lateral distance to the road shoulder when avoiding obstacles, improving the robustness and safety of the behavior path planning.

Please approve :arrow_down: before this PR.
https://github.com/autowarefoundation/autoware_launch/pull/513

Add following new params:

```yaml
          soft_road_shoulder_margin: 0.8                # [m]
          hard_road_shoulder_margin: 0.3                # [m]
```

Then, there are four lateral margin params in avoidance config:

```yaml
safety_buffer_lateral
avoid_buffer_lateral
soft_road_shoulder_margin
hard_road_shoulder_margin
```

- the distance between the ego and object
  - max: `safety_buffer_lateral + avoid_buffer_lateral`
  - min: `safety_buffer_lateral`
- the distance between the ego and road shoulder
  - max: `soft_road_shoulder_margin`
  - min: `hard_road_shoulder_margin`

1. At first, it expands lateral margin as much as possible with `soft_road_shoulder_margin`
2. lateral margin can be reduced and minimum value is `safety_buffer_lateral`
3. if there is no enough distance between ego and object, the road shoulder margin can be reduced to `hard_road_shoulder_margin`

https://github.com/autowarefoundation/autoware.universe/assets/44889564/71d0ecfb-3606-4822-a35d-e7dc838c0016


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/6d16b9a3-1d27-523c-a82b-59d9aabd8739?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
