### PR TITLE
feat(planning_debug_tools): capture slider handle independently of mouse cursor

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -32,7 +32,7 @@ class PerceptionReproducer(PerceptionReplayerCommon):
         self.prev_traffic_signals_msg = None
 
         # start timer callback
-        self.timer = self.create_timer(0.01, self.on_timer)
+        self.timer = self.create_timer(0.1, self.on_timer)
         print("Start timer callback")
 
     def on_timer(self):

--- a/planning/planning_debug_tools/scripts/perception_replayer/time_manager_widget.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/time_manager_widget.py
@@ -23,6 +23,37 @@ from PyQt5.QtWidgets import QSlider
 from PyQt5.QtWidgets import QWidget
 
 
+# With QSlider, the slider's handle cannot be captured if the mouse cursor is not the handle position when pressing the mouse.
+class QJumpSlider(QSlider):
+    def __init__(self, slider_direction, max_value):
+        super(self.__class__, self).__init__(slider_direction)
+
+        self.max_value = max_value
+        self.is_mouse_pressed = False
+
+    def mouse_to_value(self, event):
+        x = event.pos().x()
+        return int(self.max_value * x / self.width())
+
+    def mousePressEvent(self, event):
+        super(self.__class__, self).mousePressEvent(event)
+
+        if event.button() == QtCore.Qt.LeftButton:
+            self.setValue(self.mouse_to_value(event))
+            self.is_mouse_pressed = True
+
+    def mouseMoveEvent(self, event):
+        super(self.__class__, self).mouseMoveEvent(event)
+        if self.is_mouse_pressed:
+            self.setValue(self.mouse_to_value(event))
+
+    def mouseReleaseEvent(self, event):
+        super(self.__class__, self).mouseReleaseEvent(event)
+
+        if event.button() == QtCore.Qt.LeftButton:
+            self.is_mouse_pressed = False
+
+
 class TimeManagerWidget(QMainWindow):
     def __init__(self, start_timestamp, end_timestamp):
         super(self.__class__, self).__init__()
@@ -60,7 +91,7 @@ class TimeManagerWidget(QMainWindow):
         self.grid_layout.addWidget(self.button, 1, 0, 1, -1)
 
         # slider
-        self.slider = QSlider(QtCore.Qt.Horizontal)
+        self.slider = QJumpSlider(QtCore.Qt.Horizontal, self.max_value)
         self.slider.setMinimum(0)
         self.slider.setMaximum(self.max_value)
         self.slider.setValue(0)
@@ -77,5 +108,5 @@ class TimeManagerWidget(QMainWindow):
 
     def value_to_timestamp(self, value):
         return self.start_timestamp + self.slider.value() / self.max_value * (
-            self.end_value - self.start_value
+            self.end_timestamp - self.start_timestamp
         )


### PR DESCRIPTION
## Description

- With QSlider, the slider's handle cannot be captured if the mouse cursor is not the handle position when pressing the mouse.
    - For better usability, by using the event of mouse press/move/release, the above feature not supported in QSlider is implemented in the new QJumpSlider class.

**without the PR**
Even when the mouse is pressed, the handle position does not move to the cursor position.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/5f2b7cd7-f00b-4414-9d1f-025fec6bf572)
**with the PR**
When the mouse is pressed, the handle position moves to the cursor position.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/0addf050-be44-4265-8502-47812a25ff6d)

- Make perception_reproduer 10Hz the same as Autoware's perception frequency.
    - The current setting results in the too high CPU usage.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
