### PR TITLE
docs(traffic_light_multi_camera_fusion): fix broken table display

### DIFF
--- a/perception/traffic_light_multi_camera_fusion/README.md
+++ b/perception/traffic_light_multi_camera_fusion/README.md
@@ -11,11 +11,11 @@
 
 For every camera, the following three topics are subscribed:
 
-| Name | Type | Description |
-| ---------------------------------------| -------------------------------------------------------|----------------------------------------------------|
-| `~/<camera_namespace>/camera_info` | sensor_msgs::CameraInfo |camera info from traffic_light_map_based_detector |
-| `~/<camera_namespace>/rois` | tier4_perception_msgs::TrafficLightRoiArray |detection roi from traffic_light_fine_detector |
-| `~/<camera_namespace>/traffic_signals` | tier4_perception_msgs::TrafficLightSignalArray |classification result from traffic_light_classifier |
+| Name                                   | Type                                           | Description                                         |
+| -------------------------------------- | ---------------------------------------------- | --------------------------------------------------- |
+| `~/<camera_namespace>/camera_info`     | sensor_msgs::CameraInfo                        | camera info from traffic_light_map_based_detector   |
+| `~/<camera_namespace>/rois`            | tier4_perception_msgs::TrafficLightRoiArray    | detection roi from traffic_light_fine_detector      |
+| `~/<camera_namespace>/traffic_signals` | tier4_perception_msgs::TrafficLightSignalArray | classification result from traffic_light_classifier |
 
 You don't need to configure these topics manually. Just provide the `camera_namespaces` parameter and the node will automatically extract the `<camera_namespace>` and create the subscribers.
 

--- a/perception/traffic_light_multi_camera_fusion/README.md
+++ b/perception/traffic_light_multi_camera_fusion/README.md
@@ -9,8 +9,9 @@
 
 ## Input topics
 
-For every camera, the following three topics are subscribed:  
-| Name | Type | |
+For every camera, the following three topics are subscribed:
+
+| Name | Type | Description |
 | ---------------------------------------| -------------------------------------------------------|----------------------------------------------------|
 | `~/<camera_namespace>/camera_info` | sensor_msgs::CameraInfo |camera info from traffic_light_map_based_detector |
 | `~/<camera_namespace>/rois` | tier4_perception_msgs::TrafficLightRoiArray |detection roi from traffic_light_fine_detector |


### PR DESCRIPTION
## Description

Fixed broken table display in the documentation.
https://autowarefoundation.github.io/autoware.universe/main/perception/traffic_light_multi_camera_fusion/
![image](https://github.com/autowarefoundation/autoware.universe/assets/11865769/4b272398-f1a1-47f5-a86c-c97f29c620fc)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
