### PR TITLE
fix(avoidance): add gurard to generateTotalShiftLine

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1097,1955 +1097,1973 @@ void AvoidanceModule::generateTotalShiftLine(
   for (size_t i = 0; i <= avoidance_data_.ego_closest_path_index; ++i) {
     if (sl.shift_line.size() <= i) {
       break;
-  for (size_t i = 0; i < sl.shift_line.size(); ++i) {
-    if (avoidance_data_.ego_closest_path_index < i) {
-      break;
+      for (size_t i = 0; i < sl.shift_line.size(); ++i) {
+        if (avoidance_data_.ego_closest_path_index < i) {
+          break;
+        }
+        sl.shift_line.at(i) = current_shift;
+        sl.shift_line_grad.at(i) = 0.0;
+      }
+      sl.shift_line.at(i) = current_shift;
+      sl.shift_line_grad.at(i) = 0.0;
     }
-    sl.shift_line.at(i) = current_shift;
-    sl.shift_line_grad.at(i) = 0.0;
-  }
-    sl.shift_line.at(i) = current_shift;
-    sl.shift_line_grad.at(i) = 0.0;
-  }
 
-  // If the shift point does not have an associated object,
-  // use previous value.
-  for (size_t i = 1; i < N; ++i) {
-    bool has_object = false;
-    for (const auto & al : avoid_lines) {
-      if (al.start_idx <= i && i <= al.end_idx) {
-        has_object = true;
-        break;
+    // If the shift point does not have an associated object,
+    // use previous value.
+    for (size_t i = 1; i < N; ++i) {
+      bool has_object = false;
+      for (const auto & al : avoid_lines) {
+        if (al.start_idx <= i && i <= al.end_idx) {
+          has_object = true;
+          break;
+        }
+      }
+      if (!has_object) {
+        sl.shift_line.at(i) = sl.shift_line.at(i - 1);
       }
     }
-    if (!has_object) {
-      sl.shift_line.at(i) = sl.shift_line.at(i - 1);
-    }
-  }
 
-  if (avoid_lines.empty()) {
+    if (avoid_lines.empty()) {
+      sl.shift_line_history.push_back(sl.shift_line);
+      return;
+    }
+
+    const auto grad_first_shift_line = (avoid_lines.front().start_shift_length - current_shift) /
+                                       avoid_lines.front().start_longitudinal;
+
+    for (size_t i = avoidance_data_.ego_closest_path_index; i <= avoid_lines.front().start_idx;
+         ++i) {
+      sl.shift_line.at(i) = helper_.getLinearShift(getPoint(path.points.at(i)));
+      sl.shift_line_grad.at(i) = grad_first_shift_line;
+    }
+
     sl.shift_line_history.push_back(sl.shift_line);
-    return;
   }
 
-  const auto grad_first_shift_line = (avoid_lines.front().start_shift_length - current_shift) /
-                                     avoid_lines.front().start_longitudinal;
+  AvoidLineArray AvoidanceModule::extractShiftLinesFromLine(ShiftLineData & shift_line_data) const
+  {
+    using utils::avoidance::setEndData;
+    using utils::avoidance::setStartData;
 
-  for (size_t i = avoidance_data_.ego_closest_path_index; i <= avoid_lines.front().start_idx; ++i) {
-    sl.shift_line.at(i) = helper_.getLinearShift(getPoint(path.points.at(i)));
-    sl.shift_line_grad.at(i) = grad_first_shift_line;
-  }
+    const auto & path = avoidance_data_.reference_path;
+    const auto & arcs = avoidance_data_.arclength_from_ego;
+    const auto N = path.points.size();
 
-  sl.shift_line_history.push_back(sl.shift_line);
-}
+    auto & sl = shift_line_data;
 
-AvoidLineArray AvoidanceModule::extractShiftLinesFromLine(ShiftLineData & shift_line_data) const
-{
-  using utils::avoidance::setEndData;
-  using utils::avoidance::setStartData;
+    const auto backward_grad = [&](const size_t i) {
+      if (i == 0) {
+        return sl.shift_line_grad.at(i);
+      }
+      const double ds = arcs.at(i) - arcs.at(i - 1);
+      if (ds < 1.0e-5) {
+        return sl.shift_line_grad.at(i);
+      }  // use theoretical value when ds is too small.
+      return (sl.shift_line.at(i) - sl.shift_line.at(i - 1)) / ds;
+    };
 
-  const auto & path = avoidance_data_.reference_path;
-  const auto & arcs = avoidance_data_.arclength_from_ego;
-  const auto N = path.points.size();
+    const auto forward_grad = [&](const size_t i) {
+      if (i == arcs.size() - 1) {
+        return sl.shift_line_grad.at(i);
+      }
+      const double ds = arcs.at(i + 1) - arcs.at(i);
+      if (ds < 1.0e-5) {
+        return sl.shift_line_grad.at(i);
+      }  // use theoretical value when ds is too small.
+      return (sl.shift_line.at(i + 1) - sl.shift_line.at(i)) / ds;
+    };
 
-  auto & sl = shift_line_data;
-
-  const auto backward_grad = [&](const size_t i) {
-    if (i == 0) {
-      return sl.shift_line_grad.at(i);
-    }
-    const double ds = arcs.at(i) - arcs.at(i - 1);
-    if (ds < 1.0e-5) {
-      return sl.shift_line_grad.at(i);
-    }  // use theoretical value when ds is too small.
-    return (sl.shift_line.at(i) - sl.shift_line.at(i - 1)) / ds;
-  };
-
-  const auto forward_grad = [&](const size_t i) {
-    if (i == arcs.size() - 1) {
-      return sl.shift_line_grad.at(i);
-    }
-    const double ds = arcs.at(i + 1) - arcs.at(i);
-    if (ds < 1.0e-5) {
-      return sl.shift_line_grad.at(i);
-    }  // use theoretical value when ds is too small.
-    return (sl.shift_line.at(i + 1) - sl.shift_line.at(i)) / ds;
-  };
-
-  // calculate forward and backward gradient of the shift length.
-  // This will be used for grad-change-point check.
-  sl.forward_grad = std::vector<double>(N, 0.0);
-  sl.backward_grad = std::vector<double>(N, 0.0);
-  for (size_t i = 0; i < N - 1; ++i) {
-    sl.forward_grad.at(i) = forward_grad(i);
-    sl.backward_grad.at(i) = backward_grad(i);
-  }
-
-  AvoidLineArray merged_avoid_lines;
-  AvoidLine al{};
-  bool found_first_start = false;
-  constexpr auto CREATE_SHIFT_GRAD_THR = 0.001;
-  constexpr auto IS_ALREADY_SHIFTING_THR = 0.001;
-  for (size_t i = avoidance_data_.ego_closest_path_index; i < N - 1; ++i) {
-    const auto & p = path.points.at(i).point.pose;
-    const auto shift = sl.shift_line.at(i);
-
-    // If the vehicle is already on the avoidance (checked by the first point has shift),
-    // set a start point at the first path point.
-    if (!found_first_start && std::abs(shift) > IS_ALREADY_SHIFTING_THR) {
-      setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
-      found_first_start = true;
-      DEBUG_PRINT("shift (= %f) is not zero at i = %lu. set start shift here.", shift, i);
+    // calculate forward and backward gradient of the shift length.
+    // This will be used for grad-change-point check.
+    sl.forward_grad = std::vector<double>(N, 0.0);
+    sl.backward_grad = std::vector<double>(N, 0.0);
+    for (size_t i = 0; i < N - 1; ++i) {
+      sl.forward_grad.at(i) = forward_grad(i);
+      sl.backward_grad.at(i) = backward_grad(i);
     }
 
-    // find the point where the gradient of the shift is changed
-    const bool set_shift_line_flag =
-      std::abs(sl.forward_grad.at(i) - sl.backward_grad.at(i)) > CREATE_SHIFT_GRAD_THR;
+    AvoidLineArray merged_avoid_lines;
+    AvoidLine al{};
+    bool found_first_start = false;
+    constexpr auto CREATE_SHIFT_GRAD_THR = 0.001;
+    constexpr auto IS_ALREADY_SHIFTING_THR = 0.001;
+    for (size_t i = avoidance_data_.ego_closest_path_index; i < N - 1; ++i) {
+      const auto & p = path.points.at(i).point.pose;
+      const auto shift = sl.shift_line.at(i);
 
-    if (!set_shift_line_flag) {
-      continue;
+      // If the vehicle is already on the avoidance (checked by the first point has shift),
+      // set a start point at the first path point.
+      if (!found_first_start && std::abs(shift) > IS_ALREADY_SHIFTING_THR) {
+        setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
+        found_first_start = true;
+        DEBUG_PRINT("shift (= %f) is not zero at i = %lu. set start shift here.", shift, i);
+      }
+
+      // find the point where the gradient of the shift is changed
+      const bool set_shift_line_flag =
+        std::abs(sl.forward_grad.at(i) - sl.backward_grad.at(i)) > CREATE_SHIFT_GRAD_THR;
+
+      if (!set_shift_line_flag) {
+        continue;
+      }
+
+      if (!found_first_start) {
+        setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
+        found_first_start = true;
+        DEBUG_PRINT("grad change detected. start at i = %lu", i);
+      } else {
+        setEndData(al, shift, p, i, arcs.at(i));
+        al.id = getOriginalShiftLineUniqueId();
+        merged_avoid_lines.push_back(al);
+        setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
+        DEBUG_PRINT("end and start point found at i = %lu", i);
+      }
     }
 
-    if (!found_first_start) {
-      setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
-      found_first_start = true;
-      DEBUG_PRINT("grad change detected. start at i = %lu", i);
-    } else {
-      setEndData(al, shift, p, i, arcs.at(i));
+    if (std::abs(backward_grad(N - 1)) > CREATE_SHIFT_GRAD_THR) {
+      const auto & p = path.points.at(N - 1).point.pose;
+      const auto shift = sl.shift_line.at(N - 1);
+      setEndData(al, shift, p, N - 1, arcs.at(N - 1));
       al.id = getOriginalShiftLineUniqueId();
       merged_avoid_lines.push_back(al);
-      setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
-      DEBUG_PRINT("end and start point found at i = %lu", i);
     }
+
+    return merged_avoid_lines;
   }
 
-  if (std::abs(backward_grad(N - 1)) > CREATE_SHIFT_GRAD_THR) {
-    const auto & p = path.points.at(N - 1).point.pose;
-    const auto shift = sl.shift_line.at(N - 1);
-    setEndData(al, shift, p, N - 1, arcs.at(N - 1));
-    al.id = getOriginalShiftLineUniqueId();
-    merged_avoid_lines.push_back(al);
-  }
+  void AvoidanceModule::fillShiftLineGap(AvoidLineArray & shift_lines) const
+  {
+    using utils::avoidance::setEndData;
 
-  return merged_avoid_lines;
-}
-
-void AvoidanceModule::fillShiftLineGap(AvoidLineArray & shift_lines) const
-{
-  using utils::avoidance::setEndData;
-
-  if (shift_lines.empty()) {
-    return;
-  }
-
-  const auto & data = avoidance_data_;
-
-  helper_.alignShiftLinesOrder(shift_lines, false);
-
-  const auto fill_gap = [&shift_lines, this](const auto & front_line, const auto & back_line) {
-    const auto has_gap = back_line.start_longitudinal - front_line.end_longitudinal > 0.0;
-    if (!has_gap) {
+    if (shift_lines.empty()) {
       return;
     }
 
-    AvoidLine new_line{};
-    new_line.start_shift_length = front_line.end_shift_length;
-    new_line.start_longitudinal = front_line.end_longitudinal;
-    new_line.end_shift_length = back_line.start_shift_length;
-    new_line.end_longitudinal = back_line.start_longitudinal;
-    new_line.id = getOriginalShiftLineUniqueId();
+    const auto & data = avoidance_data_;
 
-    shift_lines.push_back(new_line);
-  };
+    helper_.alignShiftLinesOrder(shift_lines, false);
 
-  // fill gap between ego and nearest shift line.
-  {
-    AvoidLine ego_line{};
-    setEndData(
-      ego_line, helper_.getEgoLinearShift(), data.reference_pose, data.ego_closest_path_index, 0.0);
-
-    fill_gap(ego_line, shift_lines.front());
-  }
-
-  // fill gap among shift lines.
-  for (size_t i = 0; i < shift_lines.size() - 1; ++i) {
-    fill_gap(shift_lines.at(i), shift_lines.at(i + 1));
-  }
-
-  utils::avoidance::fillAdditionalInfoFromLongitudinal(data, shift_lines);
-
-  helper_.alignShiftLinesOrder(shift_lines, false);
-}
-
-AvoidLineArray AvoidanceModule::mergeShiftLines(
-  const AvoidLineArray & raw_shift_lines, DebugData & debug) const
-{
-  // Generate shift line by merging raw_shift_lines.
-  ShiftLineData shift_line_data;
-  generateTotalShiftLine(raw_shift_lines, shift_line_data);
-
-  // Re-generate shift points by detecting gradient-change point of the shift line.
-  auto merged_shift_lines = extractShiftLinesFromLine(shift_line_data);
-
-  // set parent id
-  for (auto & al : merged_shift_lines) {
-    al.parent_ids = utils::avoidance::calcParentIds(raw_shift_lines, al);
-  }
-
-  // sort by distance from ego.
-  helper_.alignShiftLinesOrder(merged_shift_lines);
-
-  // debug visualize
-  {
-    debug.pos_shift = shift_line_data.pos_shift_line;
-    debug.neg_shift = shift_line_data.neg_shift_line;
-    debug.total_shift = shift_line_data.shift_line;
-    debug.pos_shift_grad = shift_line_data.pos_shift_line_grad;
-    debug.neg_shift_grad = shift_line_data.neg_shift_line_grad;
-    debug.total_forward_grad = shift_line_data.forward_grad;
-    debug.total_backward_grad = shift_line_data.backward_grad;
-  }
-
-  // debug print
-  {
-    const auto & arc = avoidance_data_.arclength_from_ego;
-    const auto & closest = avoidance_data_.ego_closest_path_index;
-    const auto & sl = shift_line_data.shift_line;
-    const auto & sg = shift_line_data.shift_line_grad;
-    const auto & fg = shift_line_data.forward_grad;
-    const auto & bg = shift_line_data.backward_grad;
-    using std::setw;
-    std::stringstream ss;
-    ss << std::fixed << std::setprecision(3);
-    ss << "\n[idx, arc, shift (for each shift points, filtered | total), grad (ideal, bwd, fwd)]: "
-          "closest = "
-       << closest << ", raw_shift_lines size = " << raw_shift_lines.size() << std::endl;
-    for (size_t i = 0; i < arc.size(); ++i) {
-      ss << "i = " << i << " | arc: " << arc.at(i) << " | shift: (";
-      for (const auto & p : shift_line_data.shift_line_history) {
-        ss << setw(5) << p.at(i) << ", ";
-      }
-      ss << "| total: " << setw(5) << sl.at(i) << ") | grad: (" << sg.at(i) << ", " << fg.at(i)
-         << ", " << bg.at(i) << ")" << std::endl;
-    }
-    DEBUG_PRINT("%s", ss.str().c_str());
-  }
-
-  printShiftLines(merged_shift_lines, "merged_shift_lines");
-
-  return merged_shift_lines;
-}
-
-AvoidLineArray AvoidanceModule::trimShiftLine(
-  const AvoidLineArray & shift_lines, DebugData & debug) const
-{
-  if (shift_lines.empty()) {
-    return shift_lines;
-  }
-
-  AvoidLineArray sl_array_trimmed = shift_lines;
-
-  // sort shift points from front to back.
-  helper_.alignShiftLinesOrder(sl_array_trimmed);
-
-  // - Change the shift length to the previous one if the deviation is small.
-  {
-    constexpr double SHIFT_DIFF_THRES = 1.0;
-    trimSmallShiftLine(sl_array_trimmed, SHIFT_DIFF_THRES);
-  }
-
-  // - Combine avoid points that have almost same gradient.
-  // this is to remove the noise.
-  {
-    const auto THRESHOLD = parameters_->same_grad_filter_1_threshold;
-    trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
-    debug.trim_similar_grad_shift = sl_array_trimmed;
-    printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift");
-  }
-
-  // - Quantize the shift length to reduce the shift point noise
-  // This is to remove the noise coming from detection accuracy, interpolation, resampling, etc.
-  {
-    const auto THRESHOLD = parameters_->quantize_filter_threshold;
-    quantizeShiftLine(sl_array_trimmed, THRESHOLD);
-    printShiftLines(sl_array_trimmed, "after sl_array_trimmed");
-    debug.quantized = sl_array_trimmed;
-  }
-
-  // - Change the shift length to the previous one if the deviation is small.
-  {
-    constexpr double SHIFT_DIFF_THRES = 1.0;
-    trimSmallShiftLine(sl_array_trimmed, SHIFT_DIFF_THRES);
-    debug.trim_small_shift = sl_array_trimmed;
-    printShiftLines(sl_array_trimmed, "after trim_small_shift");
-  }
-
-  // - Combine avoid points that have almost same gradient (again)
-  {
-    const auto THRESHOLD = parameters_->same_grad_filter_2_threshold;
-    trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
-    debug.trim_similar_grad_shift_second = sl_array_trimmed;
-    printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
-  }
-
-  // - trimTooSharpShift
-  // Check if it is not too sharp for the return-to-center shift point.
-  // If the shift is sharp, it is combined with the next shift point until it gets non-sharp.
-  {
-    const auto THRESHOLD = parameters_->sharp_shift_filter_threshold;
-    trimSharpReturn(sl_array_trimmed, THRESHOLD);
-    debug.trim_too_sharp_shift = sl_array_trimmed;
-    printShiftLines(sl_array_trimmed, "after trimSharpReturn");
-  }
-
-  // - Combine avoid points that have almost same gradient (again)
-  {
-    const auto THRESHOLD = parameters_->same_grad_filter_3_threshold;
-    trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
-    debug.trim_similar_grad_shift_third = sl_array_trimmed;
-    printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
-  }
-
-  return sl_array_trimmed;
-}
-
-void AvoidanceModule::quantizeShiftLine(AvoidLineArray & shift_lines, const double threshold) const
-{
-  if (threshold < 1.0e-5) {
-    return;  // no need to process
-  }
-
-  for (auto & sl : shift_lines) {
-    sl.end_shift_length = std::round(sl.end_shift_length / threshold) * threshold;
-  }
-
-  helper_.alignShiftLinesOrder(shift_lines);
-}
-
-void AvoidanceModule::trimSmallShiftLine(AvoidLineArray & shift_lines, const double threshold) const
-{
-  if (shift_lines.empty()) {
-    return;
-  }
-
-  AvoidLineArray input = shift_lines;
-  shift_lines.clear();
-
-  for (const auto & s : input) {
-    if (s.getRelativeLongitudinal() < threshold) {
-      continue;
-    }
-
-    shift_lines.push_back(s);
-  }
-}
-
-void AvoidanceModule::trimSimilarGradShiftLine(
-  AvoidLineArray & avoid_lines, const double threshold) const
-{
-  if (avoid_lines.empty()) {
-    return;
-  }
-
-  AvoidLineArray input = avoid_lines;
-  avoid_lines.clear();
-  avoid_lines.push_back(input.front());  // Take the first one anyway (think later)
-
-  AvoidLine base_line = input.front();
-
-  AvoidLineArray combine_buffer;
-  combine_buffer.push_back(input.front());
-
-  constexpr auto SHIFT_THR = 1e-3;
-  const auto is_negative_shift = [&](const auto & s) {
-    return s.getRelativeLength() < -1.0 * SHIFT_THR;
-  };
-
-  const auto is_positive_shift = [&](const auto & s) { return s.getRelativeLength() > SHIFT_THR; };
-
-  for (size_t i = 1; i < input.size(); ++i) {
-    AvoidLine combine{};
-
-    utils::avoidance::setStartData(
-      combine, base_line.start_shift_length, base_line.start, base_line.start_idx,
-      base_line.start_longitudinal);
-    utils::avoidance::setEndData(
-      combine, input.at(i).end_shift_length, input.at(i).end, input.at(i).end_idx,
-      input.at(i).end_longitudinal);
-
-    combine_buffer.push_back(input.at(i));
-
-    const auto violates = [&]() {
-      if (is_negative_shift(input.at(i)) && is_positive_shift(base_line)) {
-        return true;
-      }
-
-      if (is_negative_shift(base_line) && is_positive_shift(input.at(i))) {
-        return true;
-      }
-
-      const auto lon_combine = combine.getRelativeLongitudinal();
-      const auto base_length = base_line.getGradient() * lon_combine;
-      return std::abs(combine.getRelativeLength() - base_length) > threshold;
-    }();
-
-    if (violates) {
-      avoid_lines.push_back(input.at(i));
-      base_line = input.at(i);
-      combine_buffer.clear();
-      combine_buffer.push_back(input.at(i));
-    } else {
-      avoid_lines.back() = combine;
-    }
-  }
-
-  helper_.alignShiftLinesOrder(avoid_lines);
-
-  DEBUG_PRINT("size %lu -> %lu", input.size(), avoid_lines.size());
-}
-
-void AvoidanceModule::trimSharpReturn(AvoidLineArray & shift_lines, const double threshold) const
-{
-  AvoidLineArray shift_lines_orig = shift_lines;
-  shift_lines.clear();
-
-  const auto isZero = [](double v) { return std::abs(v) < 0.01; };
-
-  // check if the shift point is positive (avoiding) shift
-  const auto isPositive = [&](const auto & sl) {
-    constexpr auto POSITIVE_SHIFT_THR = 0.1;
-    return std::abs(sl.end_shift_length) - std::abs(sl.start_shift_length) > POSITIVE_SHIFT_THR;
-  };
-
-  // check if the shift point is negative (returning) shift
-  const auto isNegative = [&](const auto & sl) {
-    constexpr auto NEGATIVE_SHIFT_THR = -0.1;
-    return std::abs(sl.end_shift_length) - std::abs(sl.start_shift_length) < NEGATIVE_SHIFT_THR;
-  };
-
-  // combine two shift points. Be careful the order of "now" and "next".
-  const auto combineShiftLine = [this](const auto & sl_next, const auto & sl_now) {
-    auto sl_modified = sl_now;
-    utils::avoidance::setEndData(
-      sl_modified, sl_next.end_shift_length, sl_next.end, sl_next.end_idx,
-      sl_next.end_longitudinal);
-    sl_modified.parent_ids =
-      utils::avoidance::concatParentIds(sl_modified.parent_ids, sl_now.parent_ids);
-    return sl_modified;
-  };
-
-  // Check if the merged shift has a conflict with the original shifts.
-  const auto hasViolation = [&threshold](const auto & combined, const auto & combined_src) {
-    for (const auto & sl : combined_src) {
-      const auto combined_shift =
-        utils::avoidance::lerpShiftLengthOnArc(sl.end_longitudinal, combined);
-      if (sl.end_shift_length < -0.01 && combined_shift > sl.end_shift_length + threshold) {
-        return true;
-      }
-      if (sl.end_shift_length > 0.01 && combined_shift < sl.end_shift_length - threshold) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  // check for all shift points
-  for (size_t i = 0; i < shift_lines_orig.size(); ++i) {
-    auto sl_now = shift_lines_orig.at(i);
-    sl_now.start_shift_length =
-      shift_lines.empty() ? helper_.getEgoLinearShift() : shift_lines.back().end_shift_length;
-
-    if (sl_now.end_shift_length * sl_now.start_shift_length < -0.01) {
-      DEBUG_PRINT("i = %lu, This is avoid shift for opposite direction. take this one", i);
-      continue;
-    }
-
-    // Do nothing for non-reduce shift point
-    if (!isNegative(sl_now)) {
-      shift_lines.push_back(sl_now);
-      DEBUG_PRINT(
-        "i = %lu, positive shift. take this one. sl_now.length * sl_now.start_length = %f", i,
-        sl_now.end_shift_length * sl_now.start_shift_length);
-      continue;
-    }
-
-    // The last point is out of target of this function.
-    if (i == shift_lines_orig.size() - 1) {
-      shift_lines.push_back(sl_now);
-      DEBUG_PRINT("i = %lu, last shift. take this one.", i);
-      continue;
-    }
-
-    // -----------------------------------------------------------------------
-    // ------------ From here, the shift point is "negative" -----------------
-    // -----------------------------------------------------------------------
-
-    // if next shift is negative, combine them. loop until combined shift line
-    // exceeds merged shift point.
-    DEBUG_PRINT("i = %lu, found negative dist. search.", i);
-    {
-      auto sl_combined = sl_now;
-      auto sl_combined_prev = sl_combined;
-      AvoidLineArray sl_combined_array{sl_now};
-      size_t j = i + 1;
-      for (; i < shift_lines_orig.size(); ++j) {
-        const auto sl_combined = combineShiftLine(shift_lines_orig.at(j), sl_now);
-
-        {
-          std::stringstream ss;
-          ss << "i = " << i << ", j = " << j << ": sl_combined = " << toStrInfo(sl_combined);
-          DEBUG_PRINT("%s", ss.str().c_str());
-        }
-
-        // it gets positive. Finish merging.
-        if (isPositive(sl_combined)) {
-          shift_lines.push_back(sl_combined);
-          DEBUG_PRINT("reach positive.");
-          break;
-        }
-
-        // Still negative, but it violates the original shift points.
-        // Finish with the previous merge result.
-        if (hasViolation(sl_combined, sl_combined_array)) {
-          shift_lines.push_back(sl_combined_prev);
-          DEBUG_PRINT("violation found.");
-          --j;
-          break;
-        }
-
-        // Still negative, but it has an enough long distance. Finish merging.
-        const auto nominal_distance =
-          helper_.getMaxAvoidanceDistance(sl_combined.getRelativeLength());
-        const auto long_distance =
-          isZero(sl_combined.end_shift_length) ? nominal_distance : nominal_distance * 5.0;
-        if (sl_combined.getRelativeLongitudinal() > long_distance) {
-          shift_lines.push_back(sl_combined);
-          DEBUG_PRINT("still negative, but long enough. Threshold = %f", long_distance);
-          break;
-        }
-
-        // It reaches the last point. Still the shift is sharp, but merge with the current result.
-        if (j == shift_lines_orig.size() - 1) {
-          shift_lines.push_back(sl_combined);
-          DEBUG_PRINT("reach end point.");
-          break;
-        }
-
-        // Still negative shift, and the distance is not enough. Search next.
-        sl_combined_prev = sl_combined;
-        sl_combined_array.push_back(shift_lines_orig.at(j));
-      }
-      i = j;
-      continue;
-    }
-  }
-
-  helper_.alignShiftLinesOrder(shift_lines);
-
-  DEBUG_PRINT("trimSharpReturn: size %lu -> %lu", shift_lines_orig.size(), shift_lines.size());
-}
-
-void AvoidanceModule::addReturnShiftLineFromEgo(AvoidLineArray & sl_candidates) const
-{
-  constexpr double ep = 1.0e-3;
-  const auto & data = avoidance_data_;
-  const bool has_candidate_point = !sl_candidates.empty();
-  const bool has_registered_point = !path_shifter_.getShiftLines().empty();
-
-  // If the return-to-center shift points are already registered, do nothing.
-  if (!has_registered_point && std::fabs(getCurrentBaseShift()) < ep) {
-    DEBUG_PRINT("No shift points, not base offset. Do not have to add return-shift.");
-    return;
-  }
-
-  constexpr double RETURN_SHIFT_THRESHOLD = 0.1;
-  DEBUG_PRINT("registered last shift = %f", path_shifter_.getLastShiftLength());
-  if (std::abs(path_shifter_.getLastShiftLength()) < RETURN_SHIFT_THRESHOLD) {
-    DEBUG_PRINT("Return shift is already registered. do nothing.");
-    return;
-  }
-
-  // From here, the return-to-center is not registered. But perhaps the candidate is
-  // already generated.
-
-  // If it has a shift point, add return shift from the existing last shift point.
-  // If not, add return shift from ego point. (prepare distance is considered for both.)
-  ShiftLine last_sl;  // the return-shift will be generated after the last shift point.
-  {
-    // avoidance points: Yes, shift points: No -> select last avoidance point.
-    if (has_candidate_point && !has_registered_point) {
-      helper_.alignShiftLinesOrder(sl_candidates, false);
-      last_sl = sl_candidates.back();
-    }
-
-    // avoidance points: No, shift points: Yes -> select last shift point.
-    if (!has_candidate_point && has_registered_point) {
-      last_sl = utils::avoidance::fillAdditionalInfo(
-        data, AvoidLine{path_shifter_.getLastShiftLine().get()});
-    }
-
-    // avoidance points: Yes, shift points: Yes -> select the last one from both.
-    if (has_candidate_point && has_registered_point) {
-      helper_.alignShiftLinesOrder(sl_candidates, false);
-      const auto & al = sl_candidates.back();
-      const auto & sl = utils::avoidance::fillAdditionalInfo(
-        data, AvoidLine{path_shifter_.getLastShiftLine().get()});
-      last_sl = (sl.end_longitudinal > al.end_longitudinal) ? sl : al;
-    }
-
-    // avoidance points: No, shift points: No -> set the ego position to the last shift point
-    // so that the return-shift will be generated from ego position.
-    if (!has_candidate_point && !has_registered_point) {
-      last_sl.end_idx = avoidance_data_.ego_closest_path_index;
-      last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
-      last_sl.end_shift_length = getCurrentBaseShift();
-    }
-  }
-  printShiftLines(ShiftLineArray{last_sl}, "last shift point");
-
-  // There already is a shift point candidates to go back to center line, but it could be too sharp
-  // due to detection noise or timing.
-  // Here the return-shift from ego is added for the in case.
-  if (std::fabs(last_sl.end_shift_length) < RETURN_SHIFT_THRESHOLD) {
-    const auto current_base_shift = helper_.getEgoShift();
-    if (std::abs(current_base_shift) < ep) {
-      DEBUG_PRINT("last shift almost is zero, and current base_shift is zero. do nothing.");
-      return;
-    }
-
-    // Is there a shift point in the opposite direction of the current_base_shift?
-    //   No  -> we can overwrite the return shift, because the other shift points that decrease
-    //          the shift length are for return-shift.
-    //   Yes -> we can NOT overwrite, because it might be not a return-shift, but a avoiding
-    //          shift to the opposite direction which can not be overwritten by the return-shift.
-    for (const auto & sl : sl_candidates) {
-      if (
-        (current_base_shift > 0.0 && sl.end_shift_length < -ep) ||
-        (current_base_shift < 0.0 && sl.end_shift_length > ep)) {
-        DEBUG_PRINT(
-          "try to put overwrite return shift, but there is shift for opposite direction. Skip "
-          "adding return shift.");
+    const auto fill_gap = [&shift_lines, this](const auto & front_line, const auto & back_line) {
+      const auto has_gap = back_line.start_longitudinal - front_line.end_longitudinal > 0.0;
+      if (!has_gap) {
         return;
       }
+
+      AvoidLine new_line{};
+      new_line.start_shift_length = front_line.end_shift_length;
+      new_line.start_longitudinal = front_line.end_longitudinal;
+      new_line.end_shift_length = back_line.start_shift_length;
+      new_line.end_longitudinal = back_line.start_longitudinal;
+      new_line.id = getOriginalShiftLineUniqueId();
+
+      shift_lines.push_back(new_line);
+    };
+
+    // fill gap between ego and nearest shift line.
+    {
+      AvoidLine ego_line{};
+      setEndData(
+        ego_line, helper_.getEgoLinearShift(), data.reference_pose, data.ego_closest_path_index,
+        0.0);
+
+      fill_gap(ego_line, shift_lines.front());
     }
 
-    // If return shift already exists in candidate or registered shift lines, skip adding return
-    // shift.
-    if (has_candidate_point || has_registered_point) {
+    // fill gap among shift lines.
+    for (size_t i = 0; i < shift_lines.size() - 1; ++i) {
+      fill_gap(shift_lines.at(i), shift_lines.at(i + 1));
+    }
+
+    utils::avoidance::fillAdditionalInfoFromLongitudinal(data, shift_lines);
+
+    helper_.alignShiftLinesOrder(shift_lines, false);
+  }
+
+  AvoidLineArray AvoidanceModule::mergeShiftLines(
+    const AvoidLineArray & raw_shift_lines, DebugData & debug) const
+  {
+    // Generate shift line by merging raw_shift_lines.
+    ShiftLineData shift_line_data;
+    generateTotalShiftLine(raw_shift_lines, shift_line_data);
+
+    // Re-generate shift points by detecting gradient-change point of the shift line.
+    auto merged_shift_lines = extractShiftLinesFromLine(shift_line_data);
+
+    // set parent id
+    for (auto & al : merged_shift_lines) {
+      al.parent_ids = utils::avoidance::calcParentIds(raw_shift_lines, al);
+    }
+
+    // sort by distance from ego.
+    helper_.alignShiftLinesOrder(merged_shift_lines);
+
+    // debug visualize
+    {
+      debug.pos_shift = shift_line_data.pos_shift_line;
+      debug.neg_shift = shift_line_data.neg_shift_line;
+      debug.total_shift = shift_line_data.shift_line;
+      debug.pos_shift_grad = shift_line_data.pos_shift_line_grad;
+      debug.neg_shift_grad = shift_line_data.neg_shift_line_grad;
+      debug.total_forward_grad = shift_line_data.forward_grad;
+      debug.total_backward_grad = shift_line_data.backward_grad;
+    }
+
+    // debug print
+    {
+      const auto & arc = avoidance_data_.arclength_from_ego;
+      const auto & closest = avoidance_data_.ego_closest_path_index;
+      const auto & sl = shift_line_data.shift_line;
+      const auto & sg = shift_line_data.shift_line_grad;
+      const auto & fg = shift_line_data.forward_grad;
+      const auto & bg = shift_line_data.backward_grad;
+      using std::setw;
+      std::stringstream ss;
+      ss << std::fixed << std::setprecision(3);
+      ss
+        << "\n[idx, arc, shift (for each shift points, filtered | total), grad (ideal, bwd, fwd)]: "
+           "closest = "
+        << closest << ", raw_shift_lines size = " << raw_shift_lines.size() << std::endl;
+      for (size_t i = 0; i < arc.size(); ++i) {
+        ss << "i = " << i << " | arc: " << arc.at(i) << " | shift: (";
+        for (const auto & p : shift_line_data.shift_line_history) {
+          ss << setw(5) << p.at(i) << ", ";
+        }
+        ss << "| total: " << setw(5) << sl.at(i) << ") | grad: (" << sg.at(i) << ", " << fg.at(i)
+           << ", " << bg.at(i) << ")" << std::endl;
+      }
+      DEBUG_PRINT("%s", ss.str().c_str());
+    }
+
+    printShiftLines(merged_shift_lines, "merged_shift_lines");
+
+    return merged_shift_lines;
+  }
+
+  AvoidLineArray AvoidanceModule::trimShiftLine(
+    const AvoidLineArray & shift_lines, DebugData & debug) const
+  {
+    if (shift_lines.empty()) {
+      return shift_lines;
+    }
+
+    AvoidLineArray sl_array_trimmed = shift_lines;
+
+    // sort shift points from front to back.
+    helper_.alignShiftLinesOrder(sl_array_trimmed);
+
+    // - Change the shift length to the previous one if the deviation is small.
+    {
+      constexpr double SHIFT_DIFF_THRES = 1.0;
+      trimSmallShiftLine(sl_array_trimmed, SHIFT_DIFF_THRES);
+    }
+
+    // - Combine avoid points that have almost same gradient.
+    // this is to remove the noise.
+    {
+      const auto THRESHOLD = parameters_->same_grad_filter_1_threshold;
+      trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
+      debug.trim_similar_grad_shift = sl_array_trimmed;
+      printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift");
+    }
+
+    // - Quantize the shift length to reduce the shift point noise
+    // This is to remove the noise coming from detection accuracy, interpolation, resampling, etc.
+    {
+      const auto THRESHOLD = parameters_->quantize_filter_threshold;
+      quantizeShiftLine(sl_array_trimmed, THRESHOLD);
+      printShiftLines(sl_array_trimmed, "after sl_array_trimmed");
+      debug.quantized = sl_array_trimmed;
+    }
+
+    // - Change the shift length to the previous one if the deviation is small.
+    {
+      constexpr double SHIFT_DIFF_THRES = 1.0;
+      trimSmallShiftLine(sl_array_trimmed, SHIFT_DIFF_THRES);
+      debug.trim_small_shift = sl_array_trimmed;
+      printShiftLines(sl_array_trimmed, "after trim_small_shift");
+    }
+
+    // - Combine avoid points that have almost same gradient (again)
+    {
+      const auto THRESHOLD = parameters_->same_grad_filter_2_threshold;
+      trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
+      debug.trim_similar_grad_shift_second = sl_array_trimmed;
+      printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
+    }
+
+    // - trimTooSharpShift
+    // Check if it is not too sharp for the return-to-center shift point.
+    // If the shift is sharp, it is combined with the next shift point until it gets non-sharp.
+    {
+      const auto THRESHOLD = parameters_->sharp_shift_filter_threshold;
+      trimSharpReturn(sl_array_trimmed, THRESHOLD);
+      debug.trim_too_sharp_shift = sl_array_trimmed;
+      printShiftLines(sl_array_trimmed, "after trimSharpReturn");
+    }
+
+    // - Combine avoid points that have almost same gradient (again)
+    {
+      const auto THRESHOLD = parameters_->same_grad_filter_3_threshold;
+      trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
+      debug.trim_similar_grad_shift_third = sl_array_trimmed;
+      printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
+    }
+
+    return sl_array_trimmed;
+  }
+
+  void AvoidanceModule::quantizeShiftLine(AvoidLineArray & shift_lines, const double threshold)
+    const
+  {
+    if (threshold < 1.0e-5) {
+      return;  // no need to process
+    }
+
+    for (auto & sl : shift_lines) {
+      sl.end_shift_length = std::round(sl.end_shift_length / threshold) * threshold;
+    }
+
+    helper_.alignShiftLinesOrder(shift_lines);
+  }
+
+  void AvoidanceModule::trimSmallShiftLine(AvoidLineArray & shift_lines, const double threshold)
+    const
+  {
+    if (shift_lines.empty()) {
       return;
     }
 
-    // set the return-shift from ego.
-    DEBUG_PRINT(
-      "return shift already exists, but they are all candidates. Add return shift for overwrite.");
-    last_sl.end_idx = avoidance_data_.ego_closest_path_index;
-    last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
-    last_sl.end_shift_length = current_base_shift;
-  }
+    AvoidLineArray input = shift_lines;
+    shift_lines.clear();
 
-  const auto & arclength_from_ego = avoidance_data_.arclength_from_ego;
-
-  const auto nominal_prepare_distance = helper_.getNominalPrepareDistance();
-  const auto nominal_avoid_distance = helper_.getMaxAvoidanceDistance(last_sl.end_shift_length);
-
-  if (arclength_from_ego.empty()) {
-    return;
-  }
-
-  const auto remaining_distance = arclength_from_ego.back() - parameters_->remain_buffer_distance;
-
-  // If the avoidance point has already been set, the return shift must be set after the point.
-  const auto last_sl_distance = avoidance_data_.arclength_from_ego.at(last_sl.end_idx);
-
-  // check if there is enough distance for return.
-  if (last_sl_distance > remaining_distance) {  // tmp: add some small number (+1.0)
-    RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 1000, "No enough distance for return.");
-    return;
-  }
-
-  // If the remaining distance is not enough, the return shift needs to be shrunk.
-  // (or another option is just to ignore the return-shift.)
-  // But we do not want to change the last shift point, so we will shrink the distance after
-  // the last shift point.
-  //
-  //  The line "===" is fixed, "---" is scaled.
-  //
-  // [Before Scaling]
-  //  ego              last_sl_end             prepare_end            path_end    avoid_end
-  // ==o====================o----------------------o----------------------o------------o
-  //   |            prepare_dist                   |          avoid_dist               |
-  //
-  // [After Scaling]
-  // ==o====================o------------------o--------------------------o
-  //   |        prepare_dist_scaled            |    avoid_dist_scaled     |
-  //
-  const double variable_prepare_distance =
-    std::max(nominal_prepare_distance - last_sl_distance, 0.0);
-
-  double prepare_distance_scaled = std::max(nominal_prepare_distance, last_sl_distance);
-  double avoid_distance_scaled = nominal_avoid_distance;
-  if (remaining_distance < prepare_distance_scaled + avoid_distance_scaled) {
-    const auto scale = (remaining_distance - last_sl_distance) /
-                       std::max(nominal_avoid_distance + variable_prepare_distance, 0.1);
-    prepare_distance_scaled = last_sl_distance + scale * nominal_prepare_distance;
-    avoid_distance_scaled *= scale;
-    DEBUG_PRINT(
-      "last_sl_distance = %f, nominal_prepare_distance = %f, nominal_avoid_distance = %f, "
-      "remaining_distance = %f, variable_prepare_distance = %f, scale = %f, "
-      "prepare_distance_scaled = %f,avoid_distance_scaled = %f",
-      last_sl_distance, nominal_prepare_distance, nominal_avoid_distance, remaining_distance,
-      variable_prepare_distance, scale, prepare_distance_scaled, avoid_distance_scaled);
-  } else {
-    DEBUG_PRINT("there is enough distance. Use nominal for prepare & avoidance.");
-  }
-
-  // shift point for prepare distance: from last shift to return-start point.
-  if (nominal_prepare_distance > last_sl_distance) {
-    AvoidLine al;
-    al.id = getOriginalShiftLineUniqueId();
-    al.start_idx = last_sl.end_idx;
-    al.start = last_sl.end;
-    al.start_longitudinal = arclength_from_ego.at(al.start_idx);
-    al.end_idx =
-      utils::avoidance::findPathIndexFromArclength(arclength_from_ego, prepare_distance_scaled);
-    al.end = avoidance_data_.reference_path.points.at(al.end_idx).point.pose;
-    al.end_longitudinal = arclength_from_ego.at(al.end_idx);
-    al.end_shift_length = last_sl.end_shift_length;
-    al.start_shift_length = last_sl.end_shift_length;
-    sl_candidates.push_back(al);
-    printShiftLines(AvoidLineArray{al}, "prepare for return");
-    debug_data_.extra_return_shift.push_back(al);
-  }
-
-  // shift point for return to center line
-  {
-    AvoidLine al;
-    al.id = getOriginalShiftLineUniqueId();
-    al.start_idx =
-      utils::avoidance::findPathIndexFromArclength(arclength_from_ego, prepare_distance_scaled);
-    al.start = avoidance_data_.reference_path.points.at(al.start_idx).point.pose;
-    al.start_longitudinal = arclength_from_ego.at(al.start_idx);
-    al.end_idx = utils::avoidance::findPathIndexFromArclength(
-      arclength_from_ego, prepare_distance_scaled + avoid_distance_scaled);
-    al.end = avoidance_data_.reference_path.points.at(al.end_idx).point.pose;
-    al.end_longitudinal = arclength_from_ego.at(al.end_idx);
-    al.end_shift_length = 0.0;
-    al.start_shift_length = last_sl.end_shift_length;
-    sl_candidates.push_back(al);
-    printShiftLines(AvoidLineArray{al}, "return point");
-    debug_data_.extra_return_shift.push_back(al);
-  }
-
-  DEBUG_PRINT("Return Shift is added.");
-}
-
-bool AvoidanceModule::isSafePath(
-  ShiftedPath & shifted_path, [[maybe_unused]] DebugData & debug) const
-{
-  const auto & p = planner_data_->parameters;
-
-  if (!parameters_->enable_safety_check) {
-    return true;  // if safety check is disabled, it always return safe.
-  }
-
-  const auto ego_predicted_path =
-    utils::avoidance::convertToPredictedPath(shifted_path.path, planner_data_, parameters_);
-
-  const auto ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
-  const auto is_right_shift = [&]() -> std::optional<bool> {
-    for (size_t i = ego_idx; i < shifted_path.shift_length.size(); i++) {
-      const auto length = shifted_path.shift_length.at(i);
-
-      if (parameters_->lateral_avoid_check_threshold < length) {
-        return false;
+    for (const auto & s : input) {
+      if (s.getRelativeLongitudinal() < threshold) {
+        continue;
       }
 
-      if (parameters_->lateral_avoid_check_threshold < -1.0 * length) {
-        return true;
+      shift_lines.push_back(s);
+    }
+  }
+
+  void AvoidanceModule::trimSimilarGradShiftLine(
+    AvoidLineArray & avoid_lines, const double threshold) const
+  {
+    if (avoid_lines.empty()) {
+      return;
+    }
+
+    AvoidLineArray input = avoid_lines;
+    avoid_lines.clear();
+    avoid_lines.push_back(input.front());  // Take the first one anyway (think later)
+
+    AvoidLine base_line = input.front();
+
+    AvoidLineArray combine_buffer;
+    combine_buffer.push_back(input.front());
+
+    constexpr auto SHIFT_THR = 1e-3;
+    const auto is_negative_shift = [&](const auto & s) {
+      return s.getRelativeLength() < -1.0 * SHIFT_THR;
+    };
+
+    const auto is_positive_shift = [&](const auto & s) {
+      return s.getRelativeLength() > SHIFT_THR;
+    };
+
+    for (size_t i = 1; i < input.size(); ++i) {
+      AvoidLine combine{};
+
+      utils::avoidance::setStartData(
+        combine, base_line.start_shift_length, base_line.start, base_line.start_idx,
+        base_line.start_longitudinal);
+      utils::avoidance::setEndData(
+        combine, input.at(i).end_shift_length, input.at(i).end, input.at(i).end_idx,
+        input.at(i).end_longitudinal);
+
+      combine_buffer.push_back(input.at(i));
+
+      const auto violates = [&]() {
+        if (is_negative_shift(input.at(i)) && is_positive_shift(base_line)) {
+          return true;
+        }
+
+        if (is_negative_shift(base_line) && is_positive_shift(input.at(i))) {
+          return true;
+        }
+
+        const auto lon_combine = combine.getRelativeLongitudinal();
+        const auto base_length = base_line.getGradient() * lon_combine;
+        return std::abs(combine.getRelativeLength() - base_length) > threshold;
+      }();
+
+      if (violates) {
+        avoid_lines.push_back(input.at(i));
+        base_line = input.at(i);
+        combine_buffer.clear();
+        combine_buffer.push_back(input.at(i));
+      } else {
+        avoid_lines.back() = combine;
       }
     }
 
-    return std::nullopt;
-  }();
+    helper_.alignShiftLinesOrder(avoid_lines);
 
-  if (!is_right_shift.has_value()) {
+    DEBUG_PRINT("size %lu -> %lu", input.size(), avoid_lines.size());
+  }
+
+  void AvoidanceModule::trimSharpReturn(AvoidLineArray & shift_lines, const double threshold) const
+  {
+    AvoidLineArray shift_lines_orig = shift_lines;
+    shift_lines.clear();
+
+    const auto isZero = [](double v) { return std::abs(v) < 0.01; };
+
+    // check if the shift point is positive (avoiding) shift
+    const auto isPositive = [&](const auto & sl) {
+      constexpr auto POSITIVE_SHIFT_THR = 0.1;
+      return std::abs(sl.end_shift_length) - std::abs(sl.start_shift_length) > POSITIVE_SHIFT_THR;
+    };
+
+    // check if the shift point is negative (returning) shift
+    const auto isNegative = [&](const auto & sl) {
+      constexpr auto NEGATIVE_SHIFT_THR = -0.1;
+      return std::abs(sl.end_shift_length) - std::abs(sl.start_shift_length) < NEGATIVE_SHIFT_THR;
+    };
+
+    // combine two shift points. Be careful the order of "now" and "next".
+    const auto combineShiftLine = [this](const auto & sl_next, const auto & sl_now) {
+      auto sl_modified = sl_now;
+      utils::avoidance::setEndData(
+        sl_modified, sl_next.end_shift_length, sl_next.end, sl_next.end_idx,
+        sl_next.end_longitudinal);
+      sl_modified.parent_ids =
+        utils::avoidance::concatParentIds(sl_modified.parent_ids, sl_now.parent_ids);
+      return sl_modified;
+    };
+
+    // Check if the merged shift has a conflict with the original shifts.
+    const auto hasViolation = [&threshold](const auto & combined, const auto & combined_src) {
+      for (const auto & sl : combined_src) {
+        const auto combined_shift =
+          utils::avoidance::lerpShiftLengthOnArc(sl.end_longitudinal, combined);
+        if (sl.end_shift_length < -0.01 && combined_shift > sl.end_shift_length + threshold) {
+          return true;
+        }
+        if (sl.end_shift_length > 0.01 && combined_shift < sl.end_shift_length - threshold) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    // check for all shift points
+    for (size_t i = 0; i < shift_lines_orig.size(); ++i) {
+      auto sl_now = shift_lines_orig.at(i);
+      sl_now.start_shift_length =
+        shift_lines.empty() ? helper_.getEgoLinearShift() : shift_lines.back().end_shift_length;
+
+      if (sl_now.end_shift_length * sl_now.start_shift_length < -0.01) {
+        DEBUG_PRINT("i = %lu, This is avoid shift for opposite direction. take this one", i);
+        continue;
+      }
+
+      // Do nothing for non-reduce shift point
+      if (!isNegative(sl_now)) {
+        shift_lines.push_back(sl_now);
+        DEBUG_PRINT(
+          "i = %lu, positive shift. take this one. sl_now.length * sl_now.start_length = %f", i,
+          sl_now.end_shift_length * sl_now.start_shift_length);
+        continue;
+      }
+
+      // The last point is out of target of this function.
+      if (i == shift_lines_orig.size() - 1) {
+        shift_lines.push_back(sl_now);
+        DEBUG_PRINT("i = %lu, last shift. take this one.", i);
+        continue;
+      }
+
+      // -----------------------------------------------------------------------
+      // ------------ From here, the shift point is "negative" -----------------
+      // -----------------------------------------------------------------------
+
+      // if next shift is negative, combine them. loop until combined shift line
+      // exceeds merged shift point.
+      DEBUG_PRINT("i = %lu, found negative dist. search.", i);
+      {
+        auto sl_combined = sl_now;
+        auto sl_combined_prev = sl_combined;
+        AvoidLineArray sl_combined_array{sl_now};
+        size_t j = i + 1;
+        for (; i < shift_lines_orig.size(); ++j) {
+          const auto sl_combined = combineShiftLine(shift_lines_orig.at(j), sl_now);
+
+          {
+            std::stringstream ss;
+            ss << "i = " << i << ", j = " << j << ": sl_combined = " << toStrInfo(sl_combined);
+            DEBUG_PRINT("%s", ss.str().c_str());
+          }
+
+          // it gets positive. Finish merging.
+          if (isPositive(sl_combined)) {
+            shift_lines.push_back(sl_combined);
+            DEBUG_PRINT("reach positive.");
+            break;
+          }
+
+          // Still negative, but it violates the original shift points.
+          // Finish with the previous merge result.
+          if (hasViolation(sl_combined, sl_combined_array)) {
+            shift_lines.push_back(sl_combined_prev);
+            DEBUG_PRINT("violation found.");
+            --j;
+            break;
+          }
+
+          // Still negative, but it has an enough long distance. Finish merging.
+          const auto nominal_distance =
+            helper_.getMaxAvoidanceDistance(sl_combined.getRelativeLength());
+          const auto long_distance =
+            isZero(sl_combined.end_shift_length) ? nominal_distance : nominal_distance * 5.0;
+          if (sl_combined.getRelativeLongitudinal() > long_distance) {
+            shift_lines.push_back(sl_combined);
+            DEBUG_PRINT("still negative, but long enough. Threshold = %f", long_distance);
+            break;
+          }
+
+          // It reaches the last point. Still the shift is sharp, but merge with the current result.
+          if (j == shift_lines_orig.size() - 1) {
+            shift_lines.push_back(sl_combined);
+            DEBUG_PRINT("reach end point.");
+            break;
+          }
+
+          // Still negative shift, and the distance is not enough. Search next.
+          sl_combined_prev = sl_combined;
+          sl_combined_array.push_back(shift_lines_orig.at(j));
+        }
+        i = j;
+        continue;
+      }
+    }
+
+    helper_.alignShiftLinesOrder(shift_lines);
+
+    DEBUG_PRINT("trimSharpReturn: size %lu -> %lu", shift_lines_orig.size(), shift_lines.size());
+  }
+
+  void AvoidanceModule::addReturnShiftLineFromEgo(AvoidLineArray & sl_candidates) const
+  {
+    constexpr double ep = 1.0e-3;
+    const auto & data = avoidance_data_;
+    const bool has_candidate_point = !sl_candidates.empty();
+    const bool has_registered_point = !path_shifter_.getShiftLines().empty();
+
+    // If the return-to-center shift points are already registered, do nothing.
+    if (!has_registered_point && std::fabs(getCurrentBaseShift()) < ep) {
+      DEBUG_PRINT("No shift points, not base offset. Do not have to add return-shift.");
+      return;
+    }
+
+    constexpr double RETURN_SHIFT_THRESHOLD = 0.1;
+    DEBUG_PRINT("registered last shift = %f", path_shifter_.getLastShiftLength());
+    if (std::abs(path_shifter_.getLastShiftLength()) < RETURN_SHIFT_THRESHOLD) {
+      DEBUG_PRINT("Return shift is already registered. do nothing.");
+      return;
+    }
+
+    // From here, the return-to-center is not registered. But perhaps the candidate is
+    // already generated.
+
+    // If it has a shift point, add return shift from the existing last shift point.
+    // If not, add return shift from ego point. (prepare distance is considered for both.)
+    ShiftLine last_sl;  // the return-shift will be generated after the last shift point.
+    {
+      // avoidance points: Yes, shift points: No -> select last avoidance point.
+      if (has_candidate_point && !has_registered_point) {
+        helper_.alignShiftLinesOrder(sl_candidates, false);
+        last_sl = sl_candidates.back();
+      }
+
+      // avoidance points: No, shift points: Yes -> select last shift point.
+      if (!has_candidate_point && has_registered_point) {
+        last_sl = utils::avoidance::fillAdditionalInfo(
+          data, AvoidLine{path_shifter_.getLastShiftLine().get()});
+      }
+
+      // avoidance points: Yes, shift points: Yes -> select the last one from both.
+      if (has_candidate_point && has_registered_point) {
+        helper_.alignShiftLinesOrder(sl_candidates, false);
+        const auto & al = sl_candidates.back();
+        const auto & sl = utils::avoidance::fillAdditionalInfo(
+          data, AvoidLine{path_shifter_.getLastShiftLine().get()});
+        last_sl = (sl.end_longitudinal > al.end_longitudinal) ? sl : al;
+      }
+
+      // avoidance points: No, shift points: No -> set the ego position to the last shift point
+      // so that the return-shift will be generated from ego position.
+      if (!has_candidate_point && !has_registered_point) {
+        last_sl.end_idx = avoidance_data_.ego_closest_path_index;
+        last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
+        last_sl.end_shift_length = getCurrentBaseShift();
+      }
+    }
+    printShiftLines(ShiftLineArray{last_sl}, "last shift point");
+
+    // There already is a shift point candidates to go back to center line, but it could be too
+    // sharp due to detection noise or timing. Here the return-shift from ego is added for the in
+    // case.
+    if (std::fabs(last_sl.end_shift_length) < RETURN_SHIFT_THRESHOLD) {
+      const auto current_base_shift = helper_.getEgoShift();
+      if (std::abs(current_base_shift) < ep) {
+        DEBUG_PRINT("last shift almost is zero, and current base_shift is zero. do nothing.");
+        return;
+      }
+
+      // Is there a shift point in the opposite direction of the current_base_shift?
+      //   No  -> we can overwrite the return shift, because the other shift points that decrease
+      //          the shift length are for return-shift.
+      //   Yes -> we can NOT overwrite, because it might be not a return-shift, but a avoiding
+      //          shift to the opposite direction which can not be overwritten by the return-shift.
+      for (const auto & sl : sl_candidates) {
+        if (
+          (current_base_shift > 0.0 && sl.end_shift_length < -ep) ||
+          (current_base_shift < 0.0 && sl.end_shift_length > ep)) {
+          DEBUG_PRINT(
+            "try to put overwrite return shift, but there is shift for opposite direction. Skip "
+            "adding return shift.");
+          return;
+        }
+      }
+
+      // If return shift already exists in candidate or registered shift lines, skip adding return
+      // shift.
+      if (has_candidate_point || has_registered_point) {
+        return;
+      }
+
+      // set the return-shift from ego.
+      DEBUG_PRINT(
+        "return shift already exists, but they are all candidates. Add return shift for "
+        "overwrite.");
+      last_sl.end_idx = avoidance_data_.ego_closest_path_index;
+      last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
+      last_sl.end_shift_length = current_base_shift;
+    }
+
+    const auto & arclength_from_ego = avoidance_data_.arclength_from_ego;
+
+    const auto nominal_prepare_distance = helper_.getNominalPrepareDistance();
+    const auto nominal_avoid_distance = helper_.getMaxAvoidanceDistance(last_sl.end_shift_length);
+
+    if (arclength_from_ego.empty()) {
+      return;
+    }
+
+    const auto remaining_distance = arclength_from_ego.back() - parameters_->remain_buffer_distance;
+
+    // If the avoidance point has already been set, the return shift must be set after the point.
+    const auto last_sl_distance = avoidance_data_.arclength_from_ego.at(last_sl.end_idx);
+
+    // check if there is enough distance for return.
+    if (last_sl_distance > remaining_distance) {  // tmp: add some small number (+1.0)
+      RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 1000, "No enough distance for return.");
+      return;
+    }
+
+    // If the remaining distance is not enough, the return shift needs to be shrunk.
+    // (or another option is just to ignore the return-shift.)
+    // But we do not want to change the last shift point, so we will shrink the distance after
+    // the last shift point.
+    //
+    //  The line "===" is fixed, "---" is scaled.
+    //
+    // [Before Scaling]
+    //  ego              last_sl_end             prepare_end            path_end    avoid_end
+    // ==o====================o----------------------o----------------------o------------o
+    //   |            prepare_dist                   |          avoid_dist               |
+    //
+    // [After Scaling]
+    // ==o====================o------------------o--------------------------o
+    //   |        prepare_dist_scaled            |    avoid_dist_scaled     |
+    //
+    const double variable_prepare_distance =
+      std::max(nominal_prepare_distance - last_sl_distance, 0.0);
+
+    double prepare_distance_scaled = std::max(nominal_prepare_distance, last_sl_distance);
+    double avoid_distance_scaled = nominal_avoid_distance;
+    if (remaining_distance < prepare_distance_scaled + avoid_distance_scaled) {
+      const auto scale = (remaining_distance - last_sl_distance) /
+                         std::max(nominal_avoid_distance + variable_prepare_distance, 0.1);
+      prepare_distance_scaled = last_sl_distance + scale * nominal_prepare_distance;
+      avoid_distance_scaled *= scale;
+      DEBUG_PRINT(
+        "last_sl_distance = %f, nominal_prepare_distance = %f, nominal_avoid_distance = %f, "
+        "remaining_distance = %f, variable_prepare_distance = %f, scale = %f, "
+        "prepare_distance_scaled = %f,avoid_distance_scaled = %f",
+        last_sl_distance, nominal_prepare_distance, nominal_avoid_distance, remaining_distance,
+        variable_prepare_distance, scale, prepare_distance_scaled, avoid_distance_scaled);
+    } else {
+      DEBUG_PRINT("there is enough distance. Use nominal for prepare & avoidance.");
+    }
+
+    // shift point for prepare distance: from last shift to return-start point.
+    if (nominal_prepare_distance > last_sl_distance) {
+      AvoidLine al;
+      al.id = getOriginalShiftLineUniqueId();
+      al.start_idx = last_sl.end_idx;
+      al.start = last_sl.end;
+      al.start_longitudinal = arclength_from_ego.at(al.start_idx);
+      al.end_idx =
+        utils::avoidance::findPathIndexFromArclength(arclength_from_ego, prepare_distance_scaled);
+      al.end = avoidance_data_.reference_path.points.at(al.end_idx).point.pose;
+      al.end_longitudinal = arclength_from_ego.at(al.end_idx);
+      al.end_shift_length = last_sl.end_shift_length;
+      al.start_shift_length = last_sl.end_shift_length;
+      sl_candidates.push_back(al);
+      printShiftLines(AvoidLineArray{al}, "prepare for return");
+      debug_data_.extra_return_shift.push_back(al);
+    }
+
+    // shift point for return to center line
+    {
+      AvoidLine al;
+      al.id = getOriginalShiftLineUniqueId();
+      al.start_idx =
+        utils::avoidance::findPathIndexFromArclength(arclength_from_ego, prepare_distance_scaled);
+      al.start = avoidance_data_.reference_path.points.at(al.start_idx).point.pose;
+      al.start_longitudinal = arclength_from_ego.at(al.start_idx);
+      al.end_idx = utils::avoidance::findPathIndexFromArclength(
+        arclength_from_ego, prepare_distance_scaled + avoid_distance_scaled);
+      al.end = avoidance_data_.reference_path.points.at(al.end_idx).point.pose;
+      al.end_longitudinal = arclength_from_ego.at(al.end_idx);
+      al.end_shift_length = 0.0;
+      al.start_shift_length = last_sl.end_shift_length;
+      sl_candidates.push_back(al);
+      printShiftLines(AvoidLineArray{al}, "return point");
+      debug_data_.extra_return_shift.push_back(al);
+    }
+
+    DEBUG_PRINT("Return Shift is added.");
+  }
+
+  bool AvoidanceModule::isSafePath(ShiftedPath & shifted_path, [[maybe_unused]] DebugData & debug)
+    const
+  {
+    const auto & p = planner_data_->parameters;
+
+    if (!parameters_->enable_safety_check) {
+      return true;  // if safety check is disabled, it always return safe.
+    }
+
+    const auto ego_predicted_path =
+      utils::avoidance::convertToPredictedPath(shifted_path.path, planner_data_, parameters_);
+
+    const auto ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
+    const auto is_right_shift = [&]() -> std::optional<bool> {
+      for (size_t i = ego_idx; i < shifted_path.shift_length.size(); i++) {
+        const auto length = shifted_path.shift_length.at(i);
+
+        if (parameters_->lateral_avoid_check_threshold < length) {
+          return false;
+        }
+
+        if (parameters_->lateral_avoid_check_threshold < -1.0 * length) {
+          return true;
+        }
+      }
+
+      return std::nullopt;
+    }();
+
+    if (!is_right_shift.has_value()) {
+      return true;
+    }
+
+    const auto safety_check_target_objects = utils::avoidance::getSafetyCheckTargetObjects(
+      avoidance_data_, planner_data_, parameters_, is_right_shift.value());
+
+    for (const auto & object : safety_check_target_objects) {
+      const auto obj_predicted_paths =
+        utils::getPredictedPathFromObj(object, parameters_->check_all_predicted_path);
+      for (const auto & obj_path : obj_predicted_paths) {
+        CollisionCheckDebug collision{};
+        if (!utils::safety_check::checkCollision(
+              shifted_path.path, ego_predicted_path, object, obj_path, p,
+              p.expected_front_deceleration, p.expected_rear_deceleration, collision)) {
+          return false;
+        }
+      }
+    }
+
     return true;
   }
 
-  const auto safety_check_target_objects = utils::avoidance::getSafetyCheckTargetObjects(
-    avoidance_data_, planner_data_, parameters_, is_right_shift.value());
-
-  for (const auto & object : safety_check_target_objects) {
-    const auto obj_predicted_paths =
-      utils::getPredictedPathFromObj(object, parameters_->check_all_predicted_path);
-    for (const auto & obj_path : obj_predicted_paths) {
-      CollisionCheckDebug collision{};
-      if (!utils::safety_check::checkCollision(
-            shifted_path.path, ego_predicted_path, object, obj_path, p,
-            p.expected_front_deceleration, p.expected_rear_deceleration, collision)) {
-        return false;
-      }
-    }
-  }
-
-  return true;
-}
-
-void AvoidanceModule::generateExtendedDrivableArea(BehaviorModuleOutput & output) const
-{
-  const auto has_same_lane =
-    [](const lanelet::ConstLanelets lanes, const lanelet::ConstLanelet & lane) {
-      if (lanes.empty()) return false;
-      const auto has_same = [&](const auto & ll) { return ll.id() == lane.id(); };
-      return std::find_if(lanes.begin(), lanes.end(), has_same) != lanes.end();
-    };
-
-  const auto & route_handler = planner_data_->route_handler;
-  const auto & current_lanes = avoidance_data_.current_lanelets;
-  const auto & enable_opposite = parameters_->use_opposite_lane;
-  std::vector<DrivableLanes> drivable_lanes;
-
-  for (const auto & current_lane : current_lanes) {
-    DrivableLanes current_drivable_lanes;
-    current_drivable_lanes.left_lane = current_lane;
-    current_drivable_lanes.right_lane = current_lane;
-
-    if (!parameters_->use_adjacent_lane) {
-      drivable_lanes.push_back(current_drivable_lanes);
-      continue;
-    }
-
-    // 1. get left/right side lanes
-    const auto update_left_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
-      const auto all_left_lanelets =
-        route_handler->getAllLeftSharedLinestringLanelets(target_lane, enable_opposite, true);
-      if (!all_left_lanelets.empty()) {
-        current_drivable_lanes.left_lane = all_left_lanelets.back();  // leftmost lanelet
-        pushUniqueVector(
-          current_drivable_lanes.middle_lanes,
-          lanelet::ConstLanelets(all_left_lanelets.begin(), all_left_lanelets.end() - 1));
-      }
-    };
-    const auto update_right_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
-      const auto all_right_lanelets =
-        route_handler->getAllRightSharedLinestringLanelets(target_lane, enable_opposite, true);
-      if (!all_right_lanelets.empty()) {
-        current_drivable_lanes.right_lane = all_right_lanelets.back();  // rightmost lanelet
-        pushUniqueVector(
-          current_drivable_lanes.middle_lanes,
-          lanelet::ConstLanelets(all_right_lanelets.begin(), all_right_lanelets.end() - 1));
-      }
-    };
-
-    update_left_lanelets(current_lane);
-    update_right_lanelets(current_lane);
-
-    // 2.1 when there are multiple lanes whose previous lanelet is the same
-    const auto get_next_lanes_from_same_previous_lane =
-      [&route_handler](const lanelet::ConstLanelet & lane) {
-        // get previous lane, and return false if previous lane does not exist
-        lanelet::ConstLanelets prev_lanes;
-        if (!route_handler->getPreviousLaneletsWithinRoute(lane, &prev_lanes)) {
-          return lanelet::ConstLanelets{};
-        }
-
-        lanelet::ConstLanelets next_lanes;
-        for (const auto & prev_lane : prev_lanes) {
-          const auto next_lanes_from_prev = route_handler->getNextLanelets(prev_lane);
-          pushUniqueVector(next_lanes, next_lanes_from_prev);
-        }
-        return next_lanes;
+  void AvoidanceModule::generateExtendedDrivableArea(BehaviorModuleOutput & output) const
+  {
+    const auto has_same_lane =
+      [](const lanelet::ConstLanelets lanes, const lanelet::ConstLanelet & lane) {
+        if (lanes.empty()) return false;
+        const auto has_same = [&](const auto & ll) { return ll.id() == lane.id(); };
+        return std::find_if(lanes.begin(), lanes.end(), has_same) != lanes.end();
       };
 
-    const auto next_lanes_for_right =
-      get_next_lanes_from_same_previous_lane(current_drivable_lanes.right_lane);
-    const auto next_lanes_for_left =
-      get_next_lanes_from_same_previous_lane(current_drivable_lanes.left_lane);
+    const auto & route_handler = planner_data_->route_handler;
+    const auto & current_lanes = avoidance_data_.current_lanelets;
+    const auto & enable_opposite = parameters_->use_opposite_lane;
+    std::vector<DrivableLanes> drivable_lanes;
 
-    // 2.2 look for neighbor lane recursively, where end line of the lane is connected to end line
-    // of the original lane
-    const auto update_drivable_lanes =
-      [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
-        for (const auto & next_lane : next_lanes) {
-          const auto & edge_lane =
-            is_left ? current_drivable_lanes.left_lane : current_drivable_lanes.right_lane;
-          if (next_lane.id() == edge_lane.id()) {
-            continue;
+    for (const auto & current_lane : current_lanes) {
+      DrivableLanes current_drivable_lanes;
+      current_drivable_lanes.left_lane = current_lane;
+      current_drivable_lanes.right_lane = current_lane;
+
+      if (!parameters_->use_adjacent_lane) {
+        drivable_lanes.push_back(current_drivable_lanes);
+        continue;
+      }
+
+      // 1. get left/right side lanes
+      const auto update_left_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
+        const auto all_left_lanelets =
+          route_handler->getAllLeftSharedLinestringLanelets(target_lane, enable_opposite, true);
+        if (!all_left_lanelets.empty()) {
+          current_drivable_lanes.left_lane = all_left_lanelets.back();  // leftmost lanelet
+          pushUniqueVector(
+            current_drivable_lanes.middle_lanes,
+            lanelet::ConstLanelets(all_left_lanelets.begin(), all_left_lanelets.end() - 1));
+        }
+      };
+      const auto update_right_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
+        const auto all_right_lanelets =
+          route_handler->getAllRightSharedLinestringLanelets(target_lane, enable_opposite, true);
+        if (!all_right_lanelets.empty()) {
+          current_drivable_lanes.right_lane = all_right_lanelets.back();  // rightmost lanelet
+          pushUniqueVector(
+            current_drivable_lanes.middle_lanes,
+            lanelet::ConstLanelets(all_right_lanelets.begin(), all_right_lanelets.end() - 1));
+        }
+      };
+
+      update_left_lanelets(current_lane);
+      update_right_lanelets(current_lane);
+
+      // 2.1 when there are multiple lanes whose previous lanelet is the same
+      const auto get_next_lanes_from_same_previous_lane =
+        [&route_handler](const lanelet::ConstLanelet & lane) {
+          // get previous lane, and return false if previous lane does not exist
+          lanelet::ConstLanelets prev_lanes;
+          if (!route_handler->getPreviousLaneletsWithinRoute(lane, &prev_lanes)) {
+            return lanelet::ConstLanelets{};
           }
 
-          const auto & left_lane = is_left ? next_lane : edge_lane;
-          const auto & right_lane = is_left ? edge_lane : next_lane;
-          if (!isEndPointsConnected(left_lane, right_lane)) {
-            continue;
+          lanelet::ConstLanelets next_lanes;
+          for (const auto & prev_lane : prev_lanes) {
+            const auto next_lanes_from_prev = route_handler->getNextLanelets(prev_lane);
+            pushUniqueVector(next_lanes, next_lanes_from_prev);
           }
+          return next_lanes;
+        };
 
-          if (is_left) {
-            current_drivable_lanes.left_lane = next_lane;
-          } else {
-            current_drivable_lanes.right_lane = next_lane;
-          }
+      const auto next_lanes_for_right =
+        get_next_lanes_from_same_previous_lane(current_drivable_lanes.right_lane);
+      const auto next_lanes_for_left =
+        get_next_lanes_from_same_previous_lane(current_drivable_lanes.left_lane);
 
-          if (!has_same_lane(current_drivable_lanes.middle_lanes, edge_lane)) {
+      // 2.2 look for neighbor lane recursively, where end line of the lane is connected to end line
+      // of the original lane
+      const auto update_drivable_lanes =
+        [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
+          for (const auto & next_lane : next_lanes) {
+            const auto & edge_lane =
+              is_left ? current_drivable_lanes.left_lane : current_drivable_lanes.right_lane;
+            if (next_lane.id() == edge_lane.id()) {
+              continue;
+            }
+
+            const auto & left_lane = is_left ? next_lane : edge_lane;
+            const auto & right_lane = is_left ? edge_lane : next_lane;
+            if (!isEndPointsConnected(left_lane, right_lane)) {
+              continue;
+            }
+
             if (is_left) {
-              if (current_drivable_lanes.right_lane.id() != edge_lane.id()) {
-                current_drivable_lanes.middle_lanes.push_back(edge_lane);
-              }
+              current_drivable_lanes.left_lane = next_lane;
             } else {
-              if (current_drivable_lanes.left_lane.id() != edge_lane.id()) {
-                current_drivable_lanes.middle_lanes.push_back(edge_lane);
+              current_drivable_lanes.right_lane = next_lane;
+            }
+
+            if (!has_same_lane(current_drivable_lanes.middle_lanes, edge_lane)) {
+              if (is_left) {
+                if (current_drivable_lanes.right_lane.id() != edge_lane.id()) {
+                  current_drivable_lanes.middle_lanes.push_back(edge_lane);
+                }
+              } else {
+                if (current_drivable_lanes.left_lane.id() != edge_lane.id()) {
+                  current_drivable_lanes.middle_lanes.push_back(edge_lane);
+                }
               }
             }
+
+            return true;
+          }
+          return false;
+        };
+
+      const auto expand_drivable_area_recursively =
+        [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
+          // NOTE: set max search num to avoid infinity loop for drivable area expansion
+          constexpr size_t max_recursive_search_num = 3;
+          for (size_t i = 0; i < max_recursive_search_num; ++i) {
+            const bool is_update_kept = update_drivable_lanes(next_lanes, is_left);
+            if (!is_update_kept) {
+              break;
+            }
+            if (i == max_recursive_search_num - 1) {
+              RCLCPP_ERROR(
+                rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
+                "Drivable area expansion reaches max iteration.");
+            }
+          }
+        };
+      expand_drivable_area_recursively(next_lanes_for_right, false);
+      expand_drivable_area_recursively(next_lanes_for_left, true);
+
+      // 3. update again for new left/right lanes
+      update_left_lanelets(current_drivable_lanes.left_lane);
+      update_right_lanelets(current_drivable_lanes.right_lane);
+
+      // 4. compensate that current_lane is in either of left_lane, right_lane or middle_lanes.
+      if (
+        current_drivable_lanes.left_lane.id() != current_lane.id() &&
+        current_drivable_lanes.right_lane.id() != current_lane.id()) {
+        current_drivable_lanes.middle_lanes.push_back(current_lane);
+      }
+
+      drivable_lanes.push_back(current_drivable_lanes);
+    }
+
+    {  // for new architecture
+      DrivableAreaInfo current_drivable_area_info;
+      // generate drivable lanes
+      current_drivable_area_info.drivable_lanes = drivable_lanes;
+      // generate obstacle polygons
+      current_drivable_area_info.obstacles =
+        utils::avoidance::generateObstaclePolygonsForDrivableArea(
+          avoidance_data_.target_objects, parameters_,
+          planner_data_->parameters.vehicle_width / 2.0);
+      // expand hatched road markings
+      current_drivable_area_info.enable_expanding_hatched_road_markings =
+        parameters_->use_hatched_road_markings;
+      // expand intersection areas
+      current_drivable_area_info.enable_expanding_intersection_areas =
+        parameters_->use_intersection_areas;
+
+      output.drivable_area_info = utils::combineDrivableAreaInfo(
+        current_drivable_area_info, getPreviousModuleOutput().drivable_area_info);
+    }
+  }
+
+  PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & original_path) const
+  {
+    // special for avoidance: take behind distance upt ot shift-start-point if it exist.
+    const auto longest_dist_to_shift_point = [&]() {
+      double max_dist = 0.0;
+      for (const auto & pnt : path_shifter_.getShiftLines()) {
+        max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), pnt.start));
+      }
+      for (const auto & sp : registered_raw_shift_lines_) {
+        max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), sp.start));
+      }
+      return max_dist;
+    }();
+
+    const auto extra_margin = 10.0;  // Since distance does not consider arclength, but just line.
+    const auto backward_length = std::max(
+      planner_data_->parameters.backward_path_length, longest_dist_to_shift_point + extra_margin);
+    const auto previous_path = helper_.getPreviousReferencePath();
+
+    const size_t orig_ego_idx = planner_data_->findEgoIndex(original_path.points);
+    const size_t prev_ego_idx = findNearestSegmentIndex(
+      previous_path.points, getPoint(original_path.points.at(orig_ego_idx)));
+
+    size_t clip_idx = 0;
+    for (size_t i = 0; i < prev_ego_idx; ++i) {
+      if (backward_length > calcSignedArcLength(previous_path.points, clip_idx, prev_ego_idx)) {
+        break;
+      }
+      clip_idx = i;
+    }
+
+    PathWithLaneId extended_path{};
+    {
+      extended_path.points.insert(
+        extended_path.points.end(), previous_path.points.begin() + clip_idx,
+        previous_path.points.begin() + prev_ego_idx);
+    }
+
+    // overwrite backward path velocity by latest one.
+    std::for_each(extended_path.points.begin(), extended_path.points.end(), [&](auto & p) {
+      p.point.longitudinal_velocity_mps =
+        original_path.points.at(orig_ego_idx).point.longitudinal_velocity_mps;
+    });
+
+    {
+      extended_path.points.insert(
+        extended_path.points.end(), original_path.points.begin() + orig_ego_idx,
+        original_path.points.end());
+    }
+
+    return extended_path;
+  }
+
+  BehaviorModuleOutput AvoidanceModule::plan()
+  {
+    const auto & data = avoidance_data_;
+
+    resetPathCandidate();
+    resetPathReference();
+
+    updatePathShifter(data.safe_new_sl);
+
+    // generate path with shift points that have been inserted.
+    ShiftedPath linear_shift_path = utils::avoidance::toShiftedPath(data.reference_path);
+    ShiftedPath spline_shift_path = utils::avoidance::toShiftedPath(data.reference_path);
+    const auto success_spline_path_generation =
+      path_shifter_.generate(&spline_shift_path, true, SHIFT_TYPE::SPLINE);
+    const auto success_linear_path_generation =
+      path_shifter_.generate(&linear_shift_path, true, SHIFT_TYPE::LINEAR);
+
+    // set previous data
+    if (success_spline_path_generation && success_linear_path_generation) {
+      helper_.setPreviousLinearShiftPath(linear_shift_path);
+      helper_.setPreviousSplineShiftPath(spline_shift_path);
+      helper_.setPreviousReferencePath(data.reference_path);
+    } else {
+      spline_shift_path = helper_.getPreviousSplineShiftPath();
+    }
+
+    // post processing
+    {
+      postProcess();  // remove old shift points
+    }
+
+    BehaviorModuleOutput output;
+
+    // turn signal info
+    {
+      const auto original_signal = getPreviousModuleOutput().turn_signal_info;
+      const auto new_signal = calcTurnSignalInfo(spline_shift_path);
+      const auto current_seg_idx =
+        planner_data_->findEgoSegmentIndex(spline_shift_path.path.points);
+      output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
+        spline_shift_path.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
+        planner_data_->parameters.ego_nearest_dist_threshold,
+        planner_data_->parameters.ego_nearest_yaw_threshold);
+    }
+
+    // sparse resampling for computational cost
+    {
+      spline_shift_path.path = utils::resamplePathWithSpline(
+        spline_shift_path.path, parameters_->resample_interval_for_output);
+    }
+
+    avoidance_data_.state = updateEgoState(data);
+
+    // update output data
+    {
+      updateEgoBehavior(data, spline_shift_path);
+      updateInfoMarker(avoidance_data_);
+      updateDebugMarker(avoidance_data_, path_shifter_, debug_data_);
+    }
+
+    output.path = std::make_shared<PathWithLaneId>(spline_shift_path.path);
+    output.reference_path = getPreviousModuleOutput().reference_path;
+    path_reference_ = getPreviousModuleOutput().reference_path;
+
+    const size_t ego_idx = planner_data_->findEgoIndex(output.path->points);
+    utils::clipPathLength(*output.path, ego_idx, planner_data_->parameters);
+
+    // Drivable area generation.
+    generateExtendedDrivableArea(output);
+    setDrivableLanes(output.drivable_area_info.drivable_lanes);
+
+    // updateRegisteredRTCStatus(spline_shift_path.path);
+
+    return output;
+  }
+
+  CandidateOutput AvoidanceModule::planCandidate() const
+  {
+    const auto & data = avoidance_data_;
+
+    CandidateOutput output;
+
+    auto shifted_path = data.candidate_path;
+
+    if (!data.safe_new_sl.empty()) {  // clip from shift start index for visualize
+      utils::clipPathLength(
+        shifted_path.path, data.safe_new_sl.front().start_idx, std::numeric_limits<double>::max(),
+        0.0);
+
+      const auto sl = helper_.getMainShiftLine(data.safe_new_sl);
+      const auto sl_front = data.safe_new_sl.front();
+      const auto sl_back = data.safe_new_sl.back();
+
+      output.lateral_shift = helper_.getRelativeShiftToPath(sl);
+      output.start_distance_to_path_change = sl_front.start_longitudinal;
+      output.finish_distance_to_path_change = sl_back.end_longitudinal;
+
+      const uint16_t steering_factor_direction = std::invoke([&output]() {
+        if (output.lateral_shift > 0.0) {
+          return SteeringFactor::LEFT;
+        }
+        return SteeringFactor::RIGHT;
+      });
+      steering_factor_interface_ptr_->updateSteeringFactor(
+        {sl_front.start, sl_back.end},
+        {output.start_distance_to_path_change, output.finish_distance_to_path_change},
+        SteeringFactor::AVOIDANCE_PATH_CHANGE, steering_factor_direction,
+        SteeringFactor::APPROACHING, "");
+    }
+
+    const size_t ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
+    utils::clipPathLength(shifted_path.path, ego_idx, planner_data_->parameters);
+
+    output.path_candidate = shifted_path.path;
+
+    return output;
+  }
+
+  BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
+  {
+    BehaviorModuleOutput out = plan();
+
+    if (path_shifter_.getShiftLines().empty()) {
+      out.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
+    }
+
+    path_candidate_ = std::make_shared<PathWithLaneId>(planCandidate().path_candidate);
+    path_reference_ = getPreviousModuleOutput().reference_path;
+
+    return out;
+  }
+
+  void AvoidanceModule::updatePathShifter(const AvoidLineArray & shift_lines)
+  {
+    if (parameters_->disable_path_update) {
+      return;
+    }
+
+    if (shift_lines.empty()) {
+      return;
+    }
+
+    if (!isActivated()) {
+      return;
+    }
+
+    addNewShiftLines(path_shifter_, shift_lines);
+
+    current_raw_shift_lines_ = avoidance_data_.unapproved_raw_sl;
+
+    registerRawShiftLines(shift_lines);
+
+    const auto sl = helper_.getMainShiftLine(shift_lines);
+    const auto sl_front = shift_lines.front();
+    const auto sl_back = shift_lines.back();
+
+    if (helper_.getRelativeShiftToPath(sl) > 0.0) {
+      left_shift_array_.push_back({uuid_map_.at("left"), sl_front.start, sl_back.end});
+    } else if (helper_.getRelativeShiftToPath(sl) < 0.0) {
+      right_shift_array_.push_back({uuid_map_.at("right"), sl_front.start, sl_back.end});
+    }
+
+    uuid_map_.at("left") = generateUUID();
+    uuid_map_.at("right") = generateUUID();
+    candidate_uuid_ = generateUUID();
+
+    lockNewModuleLaunch();
+  }
+
+  /**
+   * set new shift points. remove old shift points if it has a conflict.
+   */
+  void AvoidanceModule::addNewShiftLines(
+    PathShifter & path_shifter, const AvoidLineArray & new_shift_lines) const
+  {
+    ShiftLineArray future = utils::avoidance::toShiftLineArray(new_shift_lines);
+
+    size_t min_start_idx = std::numeric_limits<size_t>::max();
+    for (const auto & sl : new_shift_lines) {
+      min_start_idx = std::min(min_start_idx, sl.start_idx);
+    }
+
+    const auto current_shift_lines = path_shifter.getShiftLines();
+    const auto front_new_shift_line = new_shift_lines.front();
+    const auto new_shift_length = front_new_shift_line.end_shift_length;
+    const auto new_shift_end_idx = front_new_shift_line.end_idx;
+
+    DEBUG_PRINT("min_start_idx = %lu", min_start_idx);
+
+    // Remove shift points that starts later than the new_shift_line from path_shifter.
+    //
+    // Why? Because shifter sorts by start position and applies shift points, so if there is a
+    // shift point that starts after the one you are going to put in, new one will be affected
+    // by the old one.
+    //
+    // Is it ok? This is a situation where the vehicle was originally going to avoid at the farther
+    // point, but decided to avoid it at a closer point. In this case, it is reasonable to cancel
+    // the farther avoidance.
+    for (const auto & sl : current_shift_lines) {
+      if (sl.start_idx >= min_start_idx) {
+        DEBUG_PRINT(
+          "sl.start_idx = %lu, this sl starts after new proposal. remove this one.", sl.start_idx);
+        continue;
+      }
+
+      if (sl.end_idx >= new_shift_end_idx) {
+        if (
+          sl.end_shift_length > -1e-3 && new_shift_length > -1e-3 &&
+          sl.end_shift_length < new_shift_length) {
+          continue;
+        }
+
+        if (
+          sl.end_shift_length < 1e-3 && new_shift_length < 1e-3 &&
+          sl.end_shift_length > new_shift_length) {
+          continue;
+        }
+      }
+
+      DEBUG_PRINT("sl.start_idx = %lu, no conflict. keep this one.", sl.start_idx);
+      future.push_back(sl);
+    }
+
+    const double road_velocity =
+      avoidance_data_.reference_path.points.at(front_new_shift_line.start_idx)
+        .point.longitudinal_velocity_mps;
+    const double shift_time = PathShifter::calcShiftTimeFromJerk(
+      front_new_shift_line.getRelativeLength(), helper_.getLateralMaxJerkLimit(),
+      helper_.getLateralMaxAccelLimit());
+    const double longitudinal_acc =
+      std::clamp(road_velocity / shift_time, 0.0, parameters_->max_acceleration);
+
+    path_shifter.setShiftLines(future);
+    path_shifter.setVelocity(getEgoSpeed());
+    path_shifter.setLongitudinalAcceleration(longitudinal_acc);
+    path_shifter.setLateralAccelerationLimit(helper_.getLateralMaxAccelLimit());
+  }
+
+  AvoidLineArray AvoidanceModule::findNewShiftLine(const AvoidLineArray & candidates) const
+  {
+    if (candidates.empty()) {
+      return {};
+    }
+
+    // add small shift lines.
+    const auto add_straight_shift =
+      [&, this](auto & subsequent, bool has_large_shift, const size_t start_idx) {
+        for (size_t i = start_idx; i < candidates.size(); ++i) {
+          if (
+            std::abs(candidates.at(i).getRelativeLength()) >
+            parameters_->lateral_small_shift_threshold) {
+            if (has_large_shift) {
+              break;
+            }
+
+            has_large_shift = true;
           }
 
-          return true;
+          subsequent.push_back(candidates.at(i));
         }
+      };
+
+    // get subsequent shift lines.
+    const auto get_subsequent_shift = [&, this](size_t i) {
+      AvoidLineArray subsequent{candidates.at(i)};
+
+      if (candidates.size() == i + 1) {
+        return subsequent;
+      }
+
+      if (
+        std::abs(candidates.at(i).getRelativeLength()) <
+        parameters_->lateral_small_shift_threshold) {
+        const auto has_large_shift =
+          candidates.at(i + 1).getRelativeLength() > parameters_->lateral_small_shift_threshold;
+
+        // candidate.at(i) is small length shift line. add large length shift line.
+        subsequent.push_back(candidates.at(i + 1));
+        add_straight_shift(subsequent, has_large_shift, i + 2);
+      } else {
+        // candidate.at(i) is large length shift line. add small length shift lines.
+        add_straight_shift(subsequent, true, i + 1);
+      }
+
+      return subsequent;
+    };
+
+    // check ignore or not.
+    const auto is_ignore_shift = [this](const auto & s) {
+      return std::abs(helper_.getRelativeShiftToPath(s)) < parameters_->lateral_execution_threshold;
+    };
+
+    for (size_t i = 0; i < candidates.size(); ++i) {
+      const auto & candidate = candidates.at(i);
+
+      // new shift points must exist in front of Ego
+      // this value should be larger than -eps consider path shifter calculation error.
+      const double eps = 0.01;
+      if (candidate.start_longitudinal < -eps) {
+        break;
+      }
+
+      if (!is_ignore_shift(candidate)) {
+        return get_subsequent_shift(i);
+      }
+    }
+
+    DEBUG_PRINT("No new shift point exists.");
+    return {};
+  }
+
+  bool AvoidanceModule::isValidShiftLine(
+    const AvoidLineArray & shift_lines, const PathShifter & shifter) const
+  {
+    if (shift_lines.empty()) {
+      return false;
+    }
+
+    auto shifter_for_validate = shifter;
+
+    addNewShiftLines(shifter_for_validate, shift_lines);
+
+    ShiftedPath proposed_shift_path;
+    shifter_for_validate.generate(&proposed_shift_path);
+
+    // check offset between new shift path and ego position.
+    {
+      const auto new_idx = planner_data_->findEgoIndex(proposed_shift_path.path.points);
+      const auto new_shift_length = proposed_shift_path.shift_length.at(new_idx);
+
+      constexpr double THRESHOLD = 0.1;
+      const auto offset = std::abs(new_shift_length - helper_.getEgoShift());
+      if (offset > THRESHOLD) {
+        RCLCPP_WARN_THROTTLE(
+          getLogger(), *clock_, 1000, "new shift line is invalid. [HUGE OFFSET (%.2f)]", offset);
         return false;
-      };
-
-    const auto expand_drivable_area_recursively =
-      [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
-        // NOTE: set max search num to avoid infinity loop for drivable area expansion
-        constexpr size_t max_recursive_search_num = 3;
-        for (size_t i = 0; i < max_recursive_search_num; ++i) {
-          const bool is_update_kept = update_drivable_lanes(next_lanes, is_left);
-          if (!is_update_kept) {
-            break;
-          }
-          if (i == max_recursive_search_num - 1) {
-            RCLCPP_ERROR(
-              rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
-              "Drivable area expansion reaches max iteration.");
-          }
-        }
-      };
-    expand_drivable_area_recursively(next_lanes_for_right, false);
-    expand_drivable_area_recursively(next_lanes_for_left, true);
-
-    // 3. update again for new left/right lanes
-    update_left_lanelets(current_drivable_lanes.left_lane);
-    update_right_lanelets(current_drivable_lanes.right_lane);
-
-    // 4. compensate that current_lane is in either of left_lane, right_lane or middle_lanes.
-    if (
-      current_drivable_lanes.left_lane.id() != current_lane.id() &&
-      current_drivable_lanes.right_lane.id() != current_lane.id()) {
-      current_drivable_lanes.middle_lanes.push_back(current_lane);
+      }
     }
 
-    drivable_lanes.push_back(current_drivable_lanes);
+    debug_data_.proposed_spline_shift = proposed_shift_path.shift_length;
+
+    return true;  // valid shift line.
   }
 
-  {  // for new architecture
-    DrivableAreaInfo current_drivable_area_info;
-    // generate drivable lanes
-    current_drivable_area_info.drivable_lanes = drivable_lanes;
-    // generate obstacle polygons
-    current_drivable_area_info.obstacles =
-      utils::avoidance::generateObstaclePolygonsForDrivableArea(
-        avoidance_data_.target_objects, parameters_, planner_data_->parameters.vehicle_width / 2.0);
-    // expand hatched road markings
-    current_drivable_area_info.enable_expanding_hatched_road_markings =
-      parameters_->use_hatched_road_markings;
-    // expand intersection areas
-    current_drivable_area_info.enable_expanding_intersection_areas =
-      parameters_->use_intersection_areas;
+  void AvoidanceModule::updateData()
+  {
+    using utils::avoidance::toShiftedPath;
 
-    output.drivable_area_info = utils::combineDrivableAreaInfo(
-      current_drivable_area_info, getPreviousModuleOutput().drivable_area_info);
-  }
-}
+    helper_.setData(planner_data_);
 
-PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & original_path) const
-{
-  // special for avoidance: take behind distance upt ot shift-start-point if it exist.
-  const auto longest_dist_to_shift_point = [&]() {
-    double max_dist = 0.0;
-    for (const auto & pnt : path_shifter_.getShiftLines()) {
-      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), pnt.start));
+    if (!helper_.isInitialized()) {
+      helper_.setPreviousSplineShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
+      helper_.setPreviousLinearShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
+      helper_.setPreviousReferencePath(*getPreviousModuleOutput().path);
+      helper_.setPreviousDrivingLanes(utils::avoidance::getCurrentLanesFromPath(
+        *getPreviousModuleOutput().reference_path, planner_data_));
     }
-    for (const auto & sp : registered_raw_shift_lines_) {
-      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), sp.start));
+
+    debug_data_ = DebugData();
+    avoidance_data_ = calcAvoidancePlanningData(debug_data_);
+
+    utils::avoidance::updateRegisteredObject(
+      registered_objects_, avoidance_data_.target_objects, parameters_);
+    utils::avoidance::compensateDetectionLost(
+      registered_objects_, avoidance_data_.target_objects, avoidance_data_.other_objects);
+
+    std::sort(
+      avoidance_data_.target_objects.begin(), avoidance_data_.target_objects.end(),
+      [](auto a, auto b) { return a.longitudinal < b.longitudinal; });
+
+    path_shifter_.setPath(avoidance_data_.reference_path);
+
+    // update registered shift point for new reference path & remove past objects
+    updateRegisteredRawShiftLines();
+
+    fillShiftLine(avoidance_data_, debug_data_);
+    fillEgoStatus(avoidance_data_, debug_data_);
+    fillDebugData(avoidance_data_, debug_data_);
+
+    updateRTCData();
+  }
+
+  void AvoidanceModule::processOnEntry()
+  {
+    initVariables();
+  }
+
+  void AvoidanceModule::processOnExit()
+  {
+    initVariables();
+    initRTCStatus();
+  }
+
+  void AvoidanceModule::initVariables()
+  {
+    helper_.reset();
+    path_shifter_ = PathShifter{};
+
+    debug_data_ = DebugData();
+    debug_marker_.markers.clear();
+    resetPathCandidate();
+    resetPathReference();
+    registered_raw_shift_lines_ = {};
+    current_raw_shift_lines_ = {};
+    original_unique_id = 0;
+    is_avoidance_maneuver_starts = false;
+    arrived_path_end_ = false;
+  }
+
+  void AvoidanceModule::initRTCStatus()
+  {
+    removeRTCStatus();
+    clearWaitingApproval();
+    left_shift_array_.clear();
+    right_shift_array_.clear();
+    uuid_map_.at("left") = generateUUID();
+    uuid_map_.at("right") = generateUUID();
+    candidate_uuid_ = generateUUID();
+  }
+
+  void AvoidanceModule::updateRTCData()
+  {
+    const auto & data = avoidance_data_;
+
+    updateRegisteredRTCStatus(helper_.getPreviousSplineShiftPath().path);
+
+    if (data.safe_new_sl.empty()) {
+      removeCandidateRTCStatus();
+      return;
     }
-    return max_dist;
-  }();
 
-  const auto extra_margin = 10.0;  // Since distance does not consider arclength, but just line.
-  const auto backward_length = std::max(
-    planner_data_->parameters.backward_path_length, longest_dist_to_shift_point + extra_margin);
-  const auto previous_path = helper_.getPreviousReferencePath();
-
-  const size_t orig_ego_idx = planner_data_->findEgoIndex(original_path.points);
-  const size_t prev_ego_idx =
-    findNearestSegmentIndex(previous_path.points, getPoint(original_path.points.at(orig_ego_idx)));
-
-  size_t clip_idx = 0;
-  for (size_t i = 0; i < prev_ego_idx; ++i) {
-    if (backward_length > calcSignedArcLength(previous_path.points, clip_idx, prev_ego_idx)) {
-      break;
+    const auto shift_line = helper_.getMainShiftLine(data.safe_new_sl);
+    if (helper_.getRelativeShiftToPath(shift_line) > 0.0) {
+      removePreviousRTCStatusRight();
+    } else if (helper_.getRelativeShiftToPath(shift_line) < 0.0) {
+      removePreviousRTCStatusLeft();
+    } else {
+      RCLCPP_WARN_STREAM(getLogger(), "Direction is UNKNOWN");
     }
-    clip_idx = i;
-  }
 
-  PathWithLaneId extended_path{};
-  {
-    extended_path.points.insert(
-      extended_path.points.end(), previous_path.points.begin() + clip_idx,
-      previous_path.points.begin() + prev_ego_idx);
-  }
+    CandidateOutput output;
 
-  // overwrite backward path velocity by latest one.
-  std::for_each(extended_path.points.begin(), extended_path.points.end(), [&](auto & p) {
-    p.point.longitudinal_velocity_mps =
-      original_path.points.at(orig_ego_idx).point.longitudinal_velocity_mps;
-  });
-
-  {
-    extended_path.points.insert(
-      extended_path.points.end(), original_path.points.begin() + orig_ego_idx,
-      original_path.points.end());
-  }
-
-  return extended_path;
-}
-
-BehaviorModuleOutput AvoidanceModule::plan()
-{
-  const auto & data = avoidance_data_;
-
-  resetPathCandidate();
-  resetPathReference();
-
-  updatePathShifter(data.safe_new_sl);
-
-  // generate path with shift points that have been inserted.
-  ShiftedPath linear_shift_path = utils::avoidance::toShiftedPath(data.reference_path);
-  ShiftedPath spline_shift_path = utils::avoidance::toShiftedPath(data.reference_path);
-  const auto success_spline_path_generation =
-    path_shifter_.generate(&spline_shift_path, true, SHIFT_TYPE::SPLINE);
-  const auto success_linear_path_generation =
-    path_shifter_.generate(&linear_shift_path, true, SHIFT_TYPE::LINEAR);
-
-  // set previous data
-  if (success_spline_path_generation && success_linear_path_generation) {
-    helper_.setPreviousLinearShiftPath(linear_shift_path);
-    helper_.setPreviousSplineShiftPath(spline_shift_path);
-    helper_.setPreviousReferencePath(data.reference_path);
-  } else {
-    spline_shift_path = helper_.getPreviousSplineShiftPath();
-  }
-
-  // post processing
-  {
-    postProcess();  // remove old shift points
-  }
-
-  BehaviorModuleOutput output;
-
-  // turn signal info
-  {
-    const auto original_signal = getPreviousModuleOutput().turn_signal_info;
-    const auto new_signal = calcTurnSignalInfo(spline_shift_path);
-    const auto current_seg_idx = planner_data_->findEgoSegmentIndex(spline_shift_path.path.points);
-    output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
-      spline_shift_path.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
-      planner_data_->parameters.ego_nearest_dist_threshold,
-      planner_data_->parameters.ego_nearest_yaw_threshold);
-  }
-
-  // sparse resampling for computational cost
-  {
-    spline_shift_path.path = utils::resamplePathWithSpline(
-      spline_shift_path.path, parameters_->resample_interval_for_output);
-  }
-
-  avoidance_data_.state = updateEgoState(data);
-
-  // update output data
-  {
-    updateEgoBehavior(data, spline_shift_path);
-    updateInfoMarker(avoidance_data_);
-    updateDebugMarker(avoidance_data_, path_shifter_, debug_data_);
-  }
-
-  output.path = std::make_shared<PathWithLaneId>(spline_shift_path.path);
-  output.reference_path = getPreviousModuleOutput().reference_path;
-  path_reference_ = getPreviousModuleOutput().reference_path;
-
-  const size_t ego_idx = planner_data_->findEgoIndex(output.path->points);
-  utils::clipPathLength(*output.path, ego_idx, planner_data_->parameters);
-
-  // Drivable area generation.
-  generateExtendedDrivableArea(output);
-  setDrivableLanes(output.drivable_area_info.drivable_lanes);
-
-  // updateRegisteredRTCStatus(spline_shift_path.path);
-
-  return output;
-}
-
-CandidateOutput AvoidanceModule::planCandidate() const
-{
-  const auto & data = avoidance_data_;
-
-  CandidateOutput output;
-
-  auto shifted_path = data.candidate_path;
-
-  if (!data.safe_new_sl.empty()) {  // clip from shift start index for visualize
-    utils::clipPathLength(
-      shifted_path.path, data.safe_new_sl.front().start_idx, std::numeric_limits<double>::max(),
-      0.0);
-
-    const auto sl = helper_.getMainShiftLine(data.safe_new_sl);
     const auto sl_front = data.safe_new_sl.front();
     const auto sl_back = data.safe_new_sl.back();
 
-    output.lateral_shift = helper_.getRelativeShiftToPath(sl);
+    output.path_candidate = data.candidate_path.path;
+    output.lateral_shift = helper_.getRelativeShiftToPath(shift_line);
     output.start_distance_to_path_change = sl_front.start_longitudinal;
     output.finish_distance_to_path_change = sl_back.end_longitudinal;
 
-    const uint16_t steering_factor_direction = std::invoke([&output]() {
-      if (output.lateral_shift > 0.0) {
-        return SteeringFactor::LEFT;
-      }
-      return SteeringFactor::RIGHT;
-    });
-    steering_factor_interface_ptr_->updateSteeringFactor(
-      {sl_front.start, sl_back.end},
-      {output.start_distance_to_path_change, output.finish_distance_to_path_change},
-      SteeringFactor::AVOIDANCE_PATH_CHANGE, steering_factor_direction, SteeringFactor::APPROACHING,
-      "");
+    updateCandidateRTCStatus(output);
   }
 
-  const size_t ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
-  utils::clipPathLength(shifted_path.path, ego_idx, planner_data_->parameters);
-
-  output.path_candidate = shifted_path.path;
-
-  return output;
-}
-
-BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
-{
-  BehaviorModuleOutput out = plan();
-
-  if (path_shifter_.getShiftLines().empty()) {
-    out.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
-  }
-
-  path_candidate_ = std::make_shared<PathWithLaneId>(planCandidate().path_candidate);
-  path_reference_ = getPreviousModuleOutput().reference_path;
-
-  return out;
-}
-
-void AvoidanceModule::updatePathShifter(const AvoidLineArray & shift_lines)
-{
-  if (parameters_->disable_path_update) {
-    return;
-  }
-
-  if (shift_lines.empty()) {
-    return;
-  }
-
-  if (!isActivated()) {
-    return;
-  }
-
-  addNewShiftLines(path_shifter_, shift_lines);
-
-  current_raw_shift_lines_ = avoidance_data_.unapproved_raw_sl;
-
-  registerRawShiftLines(shift_lines);
-
-  const auto sl = helper_.getMainShiftLine(shift_lines);
-  const auto sl_front = shift_lines.front();
-  const auto sl_back = shift_lines.back();
-
-  if (helper_.getRelativeShiftToPath(sl) > 0.0) {
-    left_shift_array_.push_back({uuid_map_.at("left"), sl_front.start, sl_back.end});
-  } else if (helper_.getRelativeShiftToPath(sl) < 0.0) {
-    right_shift_array_.push_back({uuid_map_.at("right"), sl_front.start, sl_back.end});
-  }
-
-  uuid_map_.at("left") = generateUUID();
-  uuid_map_.at("right") = generateUUID();
-  candidate_uuid_ = generateUUID();
-
-  lockNewModuleLaunch();
-}
-
-/**
- * set new shift points. remove old shift points if it has a conflict.
- */
-void AvoidanceModule::addNewShiftLines(
-  PathShifter & path_shifter, const AvoidLineArray & new_shift_lines) const
-{
-  ShiftLineArray future = utils::avoidance::toShiftLineArray(new_shift_lines);
-
-  size_t min_start_idx = std::numeric_limits<size_t>::max();
-  for (const auto & sl : new_shift_lines) {
-    min_start_idx = std::min(min_start_idx, sl.start_idx);
-  }
-
-  const auto current_shift_lines = path_shifter.getShiftLines();
-  const auto front_new_shift_line = new_shift_lines.front();
-  const auto new_shift_length = front_new_shift_line.end_shift_length;
-  const auto new_shift_end_idx = front_new_shift_line.end_idx;
-
-  DEBUG_PRINT("min_start_idx = %lu", min_start_idx);
-
-  // Remove shift points that starts later than the new_shift_line from path_shifter.
-  //
-  // Why? Because shifter sorts by start position and applies shift points, so if there is a
-  // shift point that starts after the one you are going to put in, new one will be affected
-  // by the old one.
-  //
-  // Is it ok? This is a situation where the vehicle was originally going to avoid at the farther
-  // point, but decided to avoid it at a closer point. In this case, it is reasonable to cancel the
-  // farther avoidance.
-  for (const auto & sl : current_shift_lines) {
-    if (sl.start_idx >= min_start_idx) {
-      DEBUG_PRINT(
-        "sl.start_idx = %lu, this sl starts after new proposal. remove this one.", sl.start_idx);
-      continue;
+  TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) const
+  {
+    const auto shift_lines = path_shifter_.getShiftLines();
+    if (shift_lines.empty()) {
+      return {};
     }
 
-    if (sl.end_idx >= new_shift_end_idx) {
-      if (
-        sl.end_shift_length > -1e-3 && new_shift_length > -1e-3 &&
-        sl.end_shift_length < new_shift_length) {
-        continue;
-      }
+    const auto front_shift_line = shift_lines.front();
+    const size_t start_idx = front_shift_line.start_idx;
+    const size_t end_idx = front_shift_line.end_idx;
 
-      if (
-        sl.end_shift_length < 1e-3 && new_shift_length < 1e-3 &&
-        sl.end_shift_length > new_shift_length) {
-        continue;
-      }
+    const auto current_shift_length = helper_.getEgoShift();
+    const double start_shift_length = path.shift_length.at(start_idx);
+    const double end_shift_length = path.shift_length.at(end_idx);
+    const double segment_shift_length = end_shift_length - start_shift_length;
+
+    const double turn_signal_shift_length_threshold =
+      planner_data_->parameters.turn_signal_shift_length_threshold;
+    const double turn_signal_search_time = planner_data_->parameters.turn_signal_search_time;
+    const double turn_signal_minimum_search_distance =
+      planner_data_->parameters.turn_signal_minimum_search_distance;
+
+    // If shift length is shorter than the threshold, it does not need to turn on blinkers
+    if (std::fabs(segment_shift_length) < turn_signal_shift_length_threshold) {
+      return {};
     }
 
-    DEBUG_PRINT("sl.start_idx = %lu, no conflict. keep this one.", sl.start_idx);
-    future.push_back(sl);
-  }
+    // If the vehicle does not shift anymore, we turn off the blinker
+    if (std::fabs(end_shift_length - current_shift_length) < 0.1) {
+      return {};
+    }
 
-  const double road_velocity =
-    avoidance_data_.reference_path.points.at(front_new_shift_line.start_idx)
-      .point.longitudinal_velocity_mps;
-  const double shift_time = PathShifter::calcShiftTimeFromJerk(
-    front_new_shift_line.getRelativeLength(), helper_.getLateralMaxJerkLimit(),
-    helper_.getLateralMaxAccelLimit());
-  const double longitudinal_acc =
-    std::clamp(road_velocity / shift_time, 0.0, parameters_->max_acceleration);
-
-  path_shifter.setShiftLines(future);
-  path_shifter.setVelocity(getEgoSpeed());
-  path_shifter.setLongitudinalAcceleration(longitudinal_acc);
-  path_shifter.setLateralAccelerationLimit(helper_.getLateralMaxAccelLimit());
-}
-
-AvoidLineArray AvoidanceModule::findNewShiftLine(const AvoidLineArray & candidates) const
-{
-  if (candidates.empty()) {
-    return {};
-  }
-
-  // add small shift lines.
-  const auto add_straight_shift =
-    [&, this](auto & subsequent, bool has_large_shift, const size_t start_idx) {
-      for (size_t i = start_idx; i < candidates.size(); ++i) {
-        if (
-          std::abs(candidates.at(i).getRelativeLength()) >
-          parameters_->lateral_small_shift_threshold) {
-          if (has_large_shift) {
-            break;
-          }
-
-          has_large_shift = true;
+    // compute blinker start idx and end idx
+    size_t blinker_start_idx = [&]() {
+      for (size_t idx = start_idx; idx <= end_idx; ++idx) {
+        const double current_shift_length = path.shift_length.at(idx);
+        if (current_shift_length > 0.1) {
+          return idx;
         }
-
-        subsequent.push_back(candidates.at(i));
       }
-    };
+      return start_idx;
+    }();
+    size_t blinker_end_idx = end_idx;
 
-  // get subsequent shift lines.
-  const auto get_subsequent_shift = [&, this](size_t i) {
-    AvoidLineArray subsequent{candidates.at(i)};
+    // prevent invalid access for out-of-range
+    blinker_start_idx =
+      std::min(std::max(std::size_t(0), blinker_start_idx), path.path.points.size() - 1);
+    blinker_end_idx =
+      std::min(std::max(blinker_start_idx, blinker_end_idx), path.path.points.size() - 1);
 
-    if (candidates.size() == i + 1) {
-      return subsequent;
+    const auto blinker_start_pose = path.path.points.at(blinker_start_idx).point.pose;
+    const auto blinker_end_pose = path.path.points.at(blinker_end_idx).point.pose;
+
+    const double ego_vehicle_offset =
+      planner_data_->parameters.vehicle_info.max_longitudinal_offset_m;
+    const auto signal_prepare_distance =
+      std::max(getEgoSpeed() * turn_signal_search_time, turn_signal_minimum_search_distance);
+    const auto ego_front_to_shift_start =
+      calcSignedArcLength(path.path.points, getEgoPosition(), blinker_start_pose.position) -
+      ego_vehicle_offset;
+
+    if (signal_prepare_distance < ego_front_to_shift_start) {
+      return {};
     }
 
-    if (
-      std::abs(candidates.at(i).getRelativeLength()) < parameters_->lateral_small_shift_threshold) {
-      const auto has_large_shift =
-        candidates.at(i + 1).getRelativeLength() > parameters_->lateral_small_shift_threshold;
+    bool turn_signal_on_swerving = planner_data_->parameters.turn_signal_on_swerving;
 
-      // candidate.at(i) is small length shift line. add large length shift line.
-      subsequent.push_back(candidates.at(i + 1));
-      add_straight_shift(subsequent, has_large_shift, i + 2);
-    } else {
-      // candidate.at(i) is large length shift line. add small length shift lines.
-      add_straight_shift(subsequent, true, i + 1);
-    }
-
-    return subsequent;
-  };
-
-  // check ignore or not.
-  const auto is_ignore_shift = [this](const auto & s) {
-    return std::abs(helper_.getRelativeShiftToPath(s)) < parameters_->lateral_execution_threshold;
-  };
-
-  for (size_t i = 0; i < candidates.size(); ++i) {
-    const auto & candidate = candidates.at(i);
-
-    // new shift points must exist in front of Ego
-    // this value should be larger than -eps consider path shifter calculation error.
-    const double eps = 0.01;
-    if (candidate.start_longitudinal < -eps) {
-      break;
-    }
-
-    if (!is_ignore_shift(candidate)) {
-      return get_subsequent_shift(i);
-    }
-  }
-
-  DEBUG_PRINT("No new shift point exists.");
-  return {};
-}
-
-bool AvoidanceModule::isValidShiftLine(
-  const AvoidLineArray & shift_lines, const PathShifter & shifter) const
-{
-  if (shift_lines.empty()) {
-    return false;
-  }
-
-  auto shifter_for_validate = shifter;
-
-  addNewShiftLines(shifter_for_validate, shift_lines);
-
-  ShiftedPath proposed_shift_path;
-  shifter_for_validate.generate(&proposed_shift_path);
-
-  // check offset between new shift path and ego position.
-  {
-    const auto new_idx = planner_data_->findEgoIndex(proposed_shift_path.path.points);
-    const auto new_shift_length = proposed_shift_path.shift_length.at(new_idx);
-
-    constexpr double THRESHOLD = 0.1;
-    const auto offset = std::abs(new_shift_length - helper_.getEgoShift());
-    if (offset > THRESHOLD) {
-      RCLCPP_WARN_THROTTLE(
-        getLogger(), *clock_, 1000, "new shift line is invalid. [HUGE OFFSET (%.2f)]", offset);
-      return false;
-    }
-  }
-
-  debug_data_.proposed_spline_shift = proposed_shift_path.shift_length;
-
-  return true;  // valid shift line.
-}
-
-void AvoidanceModule::updateData()
-{
-  using utils::avoidance::toShiftedPath;
-
-  helper_.setData(planner_data_);
-
-  if (!helper_.isInitialized()) {
-    helper_.setPreviousSplineShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
-    helper_.setPreviousLinearShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
-    helper_.setPreviousReferencePath(*getPreviousModuleOutput().path);
-    helper_.setPreviousDrivingLanes(utils::avoidance::getCurrentLanesFromPath(
-      *getPreviousModuleOutput().reference_path, planner_data_));
-  }
-
-  debug_data_ = DebugData();
-  avoidance_data_ = calcAvoidancePlanningData(debug_data_);
-
-  utils::avoidance::updateRegisteredObject(
-    registered_objects_, avoidance_data_.target_objects, parameters_);
-  utils::avoidance::compensateDetectionLost(
-    registered_objects_, avoidance_data_.target_objects, avoidance_data_.other_objects);
-
-  std::sort(
-    avoidance_data_.target_objects.begin(), avoidance_data_.target_objects.end(),
-    [](auto a, auto b) { return a.longitudinal < b.longitudinal; });
-
-  path_shifter_.setPath(avoidance_data_.reference_path);
-
-  // update registered shift point for new reference path & remove past objects
-  updateRegisteredRawShiftLines();
-
-  fillShiftLine(avoidance_data_, debug_data_);
-  fillEgoStatus(avoidance_data_, debug_data_);
-  fillDebugData(avoidance_data_, debug_data_);
-
-  updateRTCData();
-}
-
-void AvoidanceModule::processOnEntry()
-{
-  initVariables();
-}
-
-void AvoidanceModule::processOnExit()
-{
-  initVariables();
-  initRTCStatus();
-}
-
-void AvoidanceModule::initVariables()
-{
-  helper_.reset();
-  path_shifter_ = PathShifter{};
-
-  debug_data_ = DebugData();
-  debug_marker_.markers.clear();
-  resetPathCandidate();
-  resetPathReference();
-  registered_raw_shift_lines_ = {};
-  current_raw_shift_lines_ = {};
-  original_unique_id = 0;
-  is_avoidance_maneuver_starts = false;
-  arrived_path_end_ = false;
-}
-
-void AvoidanceModule::initRTCStatus()
-{
-  removeRTCStatus();
-  clearWaitingApproval();
-  left_shift_array_.clear();
-  right_shift_array_.clear();
-  uuid_map_.at("left") = generateUUID();
-  uuid_map_.at("right") = generateUUID();
-  candidate_uuid_ = generateUUID();
-}
-
-void AvoidanceModule::updateRTCData()
-{
-  const auto & data = avoidance_data_;
-
-  updateRegisteredRTCStatus(helper_.getPreviousSplineShiftPath().path);
-
-  if (data.safe_new_sl.empty()) {
-    removeCandidateRTCStatus();
-    return;
-  }
-
-  const auto shift_line = helper_.getMainShiftLine(data.safe_new_sl);
-  if (helper_.getRelativeShiftToPath(shift_line) > 0.0) {
-    removePreviousRTCStatusRight();
-  } else if (helper_.getRelativeShiftToPath(shift_line) < 0.0) {
-    removePreviousRTCStatusLeft();
-  } else {
-    RCLCPP_WARN_STREAM(getLogger(), "Direction is UNKNOWN");
-  }
-
-  CandidateOutput output;
-
-  const auto sl_front = data.safe_new_sl.front();
-  const auto sl_back = data.safe_new_sl.back();
-
-  output.path_candidate = data.candidate_path.path;
-  output.lateral_shift = helper_.getRelativeShiftToPath(shift_line);
-  output.start_distance_to_path_change = sl_front.start_longitudinal;
-  output.finish_distance_to_path_change = sl_back.end_longitudinal;
-
-  updateCandidateRTCStatus(output);
-}
-
-TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) const
-{
-  const auto shift_lines = path_shifter_.getShiftLines();
-  if (shift_lines.empty()) {
-    return {};
-  }
-
-  const auto front_shift_line = shift_lines.front();
-  const size_t start_idx = front_shift_line.start_idx;
-  const size_t end_idx = front_shift_line.end_idx;
-
-  const auto current_shift_length = helper_.getEgoShift();
-  const double start_shift_length = path.shift_length.at(start_idx);
-  const double end_shift_length = path.shift_length.at(end_idx);
-  const double segment_shift_length = end_shift_length - start_shift_length;
-
-  const double turn_signal_shift_length_threshold =
-    planner_data_->parameters.turn_signal_shift_length_threshold;
-  const double turn_signal_search_time = planner_data_->parameters.turn_signal_search_time;
-  const double turn_signal_minimum_search_distance =
-    planner_data_->parameters.turn_signal_minimum_search_distance;
-
-  // If shift length is shorter than the threshold, it does not need to turn on blinkers
-  if (std::fabs(segment_shift_length) < turn_signal_shift_length_threshold) {
-    return {};
-  }
-
-  // If the vehicle does not shift anymore, we turn off the blinker
-  if (std::fabs(end_shift_length - current_shift_length) < 0.1) {
-    return {};
-  }
-
-  // compute blinker start idx and end idx
-  size_t blinker_start_idx = [&]() {
-    for (size_t idx = start_idx; idx <= end_idx; ++idx) {
-      const double current_shift_length = path.shift_length.at(idx);
-      if (current_shift_length > 0.1) {
-        return idx;
+    TurnSignalInfo turn_signal_info{};
+    if (turn_signal_on_swerving) {
+      if (segment_shift_length > 0.0) {
+        turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+      } else {
+        turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
       }
-    }
-    return start_idx;
-  }();
-  size_t blinker_end_idx = end_idx;
-
-  // prevent invalid access for out-of-range
-  blinker_start_idx =
-    std::min(std::max(std::size_t(0), blinker_start_idx), path.path.points.size() - 1);
-  blinker_end_idx =
-    std::min(std::max(blinker_start_idx, blinker_end_idx), path.path.points.size() - 1);
-
-  const auto blinker_start_pose = path.path.points.at(blinker_start_idx).point.pose;
-  const auto blinker_end_pose = path.path.points.at(blinker_end_idx).point.pose;
-
-  const double ego_vehicle_offset =
-    planner_data_->parameters.vehicle_info.max_longitudinal_offset_m;
-  const auto signal_prepare_distance =
-    std::max(getEgoSpeed() * turn_signal_search_time, turn_signal_minimum_search_distance);
-  const auto ego_front_to_shift_start =
-    calcSignedArcLength(path.path.points, getEgoPosition(), blinker_start_pose.position) -
-    ego_vehicle_offset;
-
-  if (signal_prepare_distance < ego_front_to_shift_start) {
-    return {};
-  }
-
-  bool turn_signal_on_swerving = planner_data_->parameters.turn_signal_on_swerving;
-
-  TurnSignalInfo turn_signal_info{};
-  if (turn_signal_on_swerving) {
-    if (segment_shift_length > 0.0) {
-      turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
     } else {
-      turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
+      turn_signal_info.turn_signal.command = TurnIndicatorsCommand::DISABLE;
     }
-  } else {
-    turn_signal_info.turn_signal.command = TurnIndicatorsCommand::DISABLE;
+
+    if (ego_front_to_shift_start > 0.0) {
+      turn_signal_info.desired_start_point = planner_data_->self_odometry->pose.pose;
+    } else {
+      turn_signal_info.desired_start_point = blinker_start_pose;
+    }
+    turn_signal_info.desired_end_point = blinker_end_pose;
+    turn_signal_info.required_start_point = blinker_start_pose;
+    turn_signal_info.required_end_point = blinker_end_pose;
+
+    return turn_signal_info;
   }
 
-  if (ego_front_to_shift_start > 0.0) {
-    turn_signal_info.desired_start_point = planner_data_->self_odometry->pose.pose;
-  } else {
-    turn_signal_info.desired_start_point = blinker_start_pose;
-  }
-  turn_signal_info.desired_end_point = blinker_end_pose;
-  turn_signal_info.required_start_point = blinker_start_pose;
-  turn_signal_info.required_end_point = blinker_end_pose;
+  void AvoidanceModule::updateInfoMarker(const AvoidancePlanningData & data) const
+  {
+    using marker_utils::avoidance_marker::createTargetObjectsMarkerArray;
 
-  return turn_signal_info;
-}
-
-void AvoidanceModule::updateInfoMarker(const AvoidancePlanningData & data) const
-{
-  using marker_utils::avoidance_marker::createTargetObjectsMarkerArray;
-
-  info_marker_.markers.clear();
-  appendMarkerArray(
-    createTargetObjectsMarkerArray(data.target_objects, "target_objects"), &info_marker_);
-}
-
-void AvoidanceModule::updateDebugMarker(
-  const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug) const
-{
-  using marker_utils::createLaneletsAreaMarkerArray;
-  using marker_utils::createObjectsMarkerArray;
-  using marker_utils::createPathMarkerArray;
-  using marker_utils::createPoseMarkerArray;
-  using marker_utils::createShiftGradMarkerArray;
-  using marker_utils::createShiftLengthMarkerArray;
-  using marker_utils::createShiftLineMarkerArray;
-  using marker_utils::avoidance_marker::createAvoidLineMarkerArray;
-  using marker_utils::avoidance_marker::createEgoStatusMarkerArray;
-  using marker_utils::avoidance_marker::createOtherObjectsMarkerArray;
-  using marker_utils::avoidance_marker::createOverhangFurthestLineStringMarkerArray;
-  using marker_utils::avoidance_marker::createPredictedVehiclePositions;
-  using marker_utils::avoidance_marker::createSafetyCheckMarkerArray;
-  using marker_utils::avoidance_marker::createUnsafeObjectsMarkerArray;
-  using marker_utils::avoidance_marker::makeOverhangToRoadShoulderMarkerArray;
-  using tier4_autoware_utils::appendMarkerArray;
-
-  debug_marker_.markers.clear();
-
-  if (!parameters_->publish_debug_marker) {
-    return;
+    info_marker_.markers.clear();
+    appendMarkerArray(
+      createTargetObjectsMarkerArray(data.target_objects, "target_objects"), &info_marker_);
   }
 
-  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+  void AvoidanceModule::updateDebugMarker(
+    const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug) const
+  {
+    using marker_utils::createLaneletsAreaMarkerArray;
+    using marker_utils::createObjectsMarkerArray;
+    using marker_utils::createPathMarkerArray;
+    using marker_utils::createPoseMarkerArray;
+    using marker_utils::createShiftGradMarkerArray;
+    using marker_utils::createShiftLengthMarkerArray;
+    using marker_utils::createShiftLineMarkerArray;
+    using marker_utils::avoidance_marker::createAvoidLineMarkerArray;
+    using marker_utils::avoidance_marker::createEgoStatusMarkerArray;
+    using marker_utils::avoidance_marker::createOtherObjectsMarkerArray;
+    using marker_utils::avoidance_marker::createOverhangFurthestLineStringMarkerArray;
+    using marker_utils::avoidance_marker::createPredictedVehiclePositions;
+    using marker_utils::avoidance_marker::createSafetyCheckMarkerArray;
+    using marker_utils::avoidance_marker::createUnsafeObjectsMarkerArray;
+    using marker_utils::avoidance_marker::makeOverhangToRoadShoulderMarkerArray;
+    using tier4_autoware_utils::appendMarkerArray;
 
-  const auto add = [this](const MarkerArray & added) { appendMarkerArray(added, &debug_marker_); };
+    debug_marker_.markers.clear();
 
-  const auto addAvoidLine =
-    [&](const AvoidLineArray & al_arr, const auto & ns, auto r, auto g, auto b, double w = 0.05) {
-      add(createAvoidLineMarkerArray(al_arr, ns, r, g, b, w));
+    if (!parameters_->publish_debug_marker) {
+      return;
+    }
+
+    const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+
+    const auto add = [this](const MarkerArray & added) {
+      appendMarkerArray(added, &debug_marker_);
     };
 
-  const auto addShiftLine =
-    [&](const ShiftLineArray & sl_arr, const auto & ns, auto r, auto g, auto b, double w = 0.1) {
-      add(createShiftLineMarkerArray(sl_arr, shifter.getBaseOffset(), ns, r, g, b, w));
-    };
+    const auto addAvoidLine =
+      [&](const AvoidLineArray & al_arr, const auto & ns, auto r, auto g, auto b, double w = 0.05) {
+        add(createAvoidLineMarkerArray(al_arr, ns, r, g, b, w));
+      };
 
-  add(createEgoStatusMarkerArray(data, getEgoPose(), "ego_status"));
-  add(createPredictedVehiclePositions(
-    debug.path_with_planned_velocity, "predicted_vehicle_positions"));
+    const auto addShiftLine =
+      [&](const ShiftLineArray & sl_arr, const auto & ns, auto r, auto g, auto b, double w = 0.1) {
+        add(createShiftLineMarkerArray(sl_arr, shifter.getBaseOffset(), ns, r, g, b, w));
+      };
 
-  const auto & path = data.reference_path;
-  add(createPathMarkerArray(debug.center_line, "centerline", 0, 0.0, 0.5, 0.9));
-  add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
-  add(createPathMarkerArray(
-    helper_.getPreviousLinearShiftPath().path, "prev_linear_shift", 0, 0.5, 0.4, 0.6));
-  add(createPoseMarkerArray(data.reference_pose, "reference_pose", 0, 0.9, 0.3, 0.3));
+    add(createEgoStatusMarkerArray(data, getEgoPose(), "ego_status"));
+    add(createPredictedVehiclePositions(
+      debug.path_with_planned_velocity, "predicted_vehicle_positions"));
 
-  add(createSafetyCheckMarkerArray(data.state, getEgoPose(), debug));
+    const auto & path = data.reference_path;
+    add(createPathMarkerArray(debug.center_line, "centerline", 0, 0.0, 0.5, 0.9));
+    add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
+    add(createPathMarkerArray(
+      helper_.getPreviousLinearShiftPath().path, "prev_linear_shift", 0, 0.5, 0.4, 0.6));
+    add(createPoseMarkerArray(data.reference_pose, "reference_pose", 0, 0.9, 0.3, 0.3));
 
-  add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
-  add(createLaneletsAreaMarkerArray(*debug.expanded_lanelets, "expanded_lanelet", 0.8, 0.8, 0.0));
+    add(createSafetyCheckMarkerArray(data.state, getEgoPose(), debug));
 
-  add(createOtherObjectsMarkerArray(
-    data.other_objects, AvoidanceDebugFactor::OBJECT_IS_BEHIND_THRESHOLD));
-  add(createOtherObjectsMarkerArray(
-    data.other_objects, AvoidanceDebugFactor::OBJECT_IS_IN_FRONT_THRESHOLD));
-  add(createOtherObjectsMarkerArray(
-    data.other_objects, AvoidanceDebugFactor::OBJECT_BEHIND_PATH_GOAL));
-  add(createOtherObjectsMarkerArray(
-    data.other_objects, AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE));
-  add(createOtherObjectsMarkerArray(data.other_objects, AvoidanceDebugFactor::OBJECT_IS_NOT_TYPE));
-  add(createOtherObjectsMarkerArray(data.other_objects, AvoidanceDebugFactor::NOT_PARKING_OBJECT));
-  add(createOtherObjectsMarkerArray(data.other_objects, std::string("MovingObject")));
-  add(createOtherObjectsMarkerArray(data.other_objects, std::string("CrosswalkUser")));
-  add(createOtherObjectsMarkerArray(data.other_objects, std::string("OutOfTargetArea")));
-  add(createOtherObjectsMarkerArray(data.other_objects, std::string("NotNeedAvoidance")));
-  add(createOtherObjectsMarkerArray(data.other_objects, std::string("LessThanExecutionThreshold")));
+    add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
+    add(createLaneletsAreaMarkerArray(*debug.expanded_lanelets, "expanded_lanelet", 0.8, 0.8, 0.0));
 
-  add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
-  add(createOverhangFurthestLineStringMarkerArray(debug.bounds, "bounds", 1.0, 0.0, 1.0));
-
-  add(createUnsafeObjectsMarkerArray(debug.unsafe_objects, "unsafe_objects"));
-
-  // parent object info
-  addAvoidLine(debug.registered_raw_shift, "p_registered_shift", 0.8, 0.8, 0.0);
-  addAvoidLine(debug.current_raw_shift, "p_current_raw_shift", 0.5, 0.2, 0.2);
-  addAvoidLine(debug.extra_return_shift, "p_extra_return_shift", 0.0, 0.5, 0.8);
-
-  // shift length
-  {
-    const std::string ns = "shift_length";
-    add(createShiftLengthMarkerArray(debug.pos_shift, path, ns + "_pos", 0.0, 0.7, 0.5));
-    add(createShiftLengthMarkerArray(debug.neg_shift, path, ns + "_neg", 0.0, 0.5, 0.7));
-    add(createShiftLengthMarkerArray(debug.total_shift, path, ns + "_total", 0.99, 0.4, 0.2));
-  }
-
-  // shift grad
-  {
-    const std::string ns = "shift_grad";
-    add(createShiftGradMarkerArray(
-      debug.pos_shift_grad, debug.pos_shift, path, ns + "_pos", 0.0, 0.7, 0.5));
-    add(createShiftGradMarkerArray(
-      debug.neg_shift_grad, debug.neg_shift, path, ns + "_neg", 0.0, 0.5, 0.7));
-    add(createShiftGradMarkerArray(
-      debug.total_forward_grad, debug.total_shift, path, ns + "_total_forward", 0.99, 0.4, 0.2));
-    add(createShiftGradMarkerArray(
-      debug.total_backward_grad, debug.total_shift, path, ns + "_total_backward", 0.4, 0.2, 0.99));
-  }
-
-  // shift path
-  {
-    const std::string ns = "shift_line";
-    add(createShiftLengthMarkerArray(
-      helper_.getPreviousLinearShiftPath().shift_length, path, ns + "_linear_registered", 0.9, 0.3,
-      0.3));
-    add(createShiftLengthMarkerArray(
-      debug.proposed_spline_shift, path, ns + "_spline_proposed", 1.0, 1.0, 1.0));
-  }
-
-  // child shift points
-  {
-    const std::string ns = "pipeline";
-    add(createAvoidLineMarkerArray(debug.gap_filled, ns + "_1_gap_filled", 0.5, 0.8, 1.0, 0.05));
-    add(createAvoidLineMarkerArray(debug.merged, ns + "_2_merge", 0.345, 0.968, 1.0, 0.05));
-    add(createAvoidLineMarkerArray(
-      debug.trim_similar_grad_shift, ns + "_3_concat_by_grad", 0.976, 0.328, 0.910, 0.05));
+    add(createOtherObjectsMarkerArray(
+      data.other_objects, AvoidanceDebugFactor::OBJECT_IS_BEHIND_THRESHOLD));
+    add(createOtherObjectsMarkerArray(
+      data.other_objects, AvoidanceDebugFactor::OBJECT_IS_IN_FRONT_THRESHOLD));
+    add(createOtherObjectsMarkerArray(
+      data.other_objects, AvoidanceDebugFactor::OBJECT_BEHIND_PATH_GOAL));
+    add(createOtherObjectsMarkerArray(
+      data.other_objects, AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE));
     add(
-      createAvoidLineMarkerArray(debug.quantized, ns + "_4_quantized", 0.505, 0.745, 0.969, 0.05));
-    add(createAvoidLineMarkerArray(
-      debug.trim_small_shift, ns + "_5_trim_small_shift", 0.663, 0.525, 0.941, 0.05));
-    add(createAvoidLineMarkerArray(
-      debug.trim_similar_grad_shift_second, ns + "_6_concat_by_grad", 0.97, 0.32, 0.91, 0.05));
-    add(createAvoidLineMarkerArray(
-      debug.trim_momentary_return, ns + "_7_trim_momentary_return", 0.976, 0.078, 0.878, 0.05));
-    add(createAvoidLineMarkerArray(
-      debug.trim_too_sharp_shift, ns + "_8_trim_sharp_shift", 0.576, 0.0, 0.978, 0.05));
-    add(createAvoidLineMarkerArray(
-      debug.trim_similar_grad_shift_third, ns + "_9_concat_by_grad", 1.0, 0.0, 0.0, 0.05));
-  }
+      createOtherObjectsMarkerArray(data.other_objects, AvoidanceDebugFactor::OBJECT_IS_NOT_TYPE));
+    add(
+      createOtherObjectsMarkerArray(data.other_objects, AvoidanceDebugFactor::NOT_PARKING_OBJECT));
+    add(createOtherObjectsMarkerArray(data.other_objects, std::string("MovingObject")));
+    add(createOtherObjectsMarkerArray(data.other_objects, std::string("CrosswalkUser")));
+    add(createOtherObjectsMarkerArray(data.other_objects, std::string("OutOfTargetArea")));
+    add(createOtherObjectsMarkerArray(data.other_objects, std::string("NotNeedAvoidance")));
+    add(
+      createOtherObjectsMarkerArray(data.other_objects, std::string("LessThanExecutionThreshold")));
 
-  addShiftLine(shifter.getShiftLines(), "path_shifter_registered_points", 0.99, 0.99, 0.0, 0.5);
-  addAvoidLine(debug.new_shift_lines, "path_shifter_proposed_points", 0.99, 0.0, 0.0, 0.5);
-}
+    add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
+    add(createOverhangFurthestLineStringMarkerArray(debug.bounds, "bounds", 1.0, 0.0, 1.0));
 
-void AvoidanceModule::updateAvoidanceDebugData(
-  std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const
-{
-  debug_data_.avoidance_debug_msg_array.avoidance_info.clear();
-  auto & debug_data_avoidance = debug_data_.avoidance_debug_msg_array.avoidance_info;
-  debug_data_avoidance = avoidance_debug_msg_array;
-  if (!debug_avoidance_initializer_for_shift_line_.empty()) {
-    const bool is_info_old_ =
-      (clock_->now() - debug_avoidance_initializer_for_shift_line_time_).seconds() > 0.1;
-    if (!is_info_old_) {
-      debug_data_avoidance.insert(
-        debug_data_avoidance.end(), debug_avoidance_initializer_for_shift_line_.begin(),
-        debug_avoidance_initializer_for_shift_line_.end());
+    add(createUnsafeObjectsMarkerArray(debug.unsafe_objects, "unsafe_objects"));
+
+    // parent object info
+    addAvoidLine(debug.registered_raw_shift, "p_registered_shift", 0.8, 0.8, 0.0);
+    addAvoidLine(debug.current_raw_shift, "p_current_raw_shift", 0.5, 0.2, 0.2);
+    addAvoidLine(debug.extra_return_shift, "p_extra_return_shift", 0.0, 0.5, 0.8);
+
+    // shift length
+    {
+      const std::string ns = "shift_length";
+      add(createShiftLengthMarkerArray(debug.pos_shift, path, ns + "_pos", 0.0, 0.7, 0.5));
+      add(createShiftLengthMarkerArray(debug.neg_shift, path, ns + "_neg", 0.0, 0.5, 0.7));
+      add(createShiftLengthMarkerArray(debug.total_shift, path, ns + "_total", 0.99, 0.4, 0.2));
     }
-  }
-}
 
-double AvoidanceModule::calcDistanceToStopLine(const ObjectData & object) const
-{
-  const auto & p = parameters_;
-  const auto & base_link2front = planner_data_->parameters.base_link2front;
-  const auto & vehicle_width = planner_data_->parameters.vehicle_width;
+    // shift grad
+    {
+      const std::string ns = "shift_grad";
+      add(createShiftGradMarkerArray(
+        debug.pos_shift_grad, debug.pos_shift, path, ns + "_pos", 0.0, 0.7, 0.5));
+      add(createShiftGradMarkerArray(
+        debug.neg_shift_grad, debug.neg_shift, path, ns + "_neg", 0.0, 0.5, 0.7));
+      add(createShiftGradMarkerArray(
+        debug.total_forward_grad, debug.total_shift, path, ns + "_total_forward", 0.99, 0.4, 0.2));
+      add(createShiftGradMarkerArray(
+        debug.total_backward_grad, debug.total_shift, path, ns + "_total_backward", 0.4, 0.2,
+        0.99));
+    }
 
-  //         D5
-  //      |<---->|                               D4
-  //      |<----------------------------------------------------------------------->|
-  // +-----------+            D1                 D2                      D3         +-----------+
-  // |           |        |<------->|<------------------------->|<----------------->|           |
-  // |    ego    |======= x ======= x ========================= x ==================|    obj    |
-  // |           |    stop_point  avoid                       avoid                 |           |
-  // +-----------+                start                        end                  +-----------+
-  //
-  // D1: p.min_prepare_distance
-  // D2: min_avoid_distance
-  // D3: longitudinal_avoid_margin_front (margin + D5)
-  // D4: o_front.longitudinal
-  // D5: base_link2front
+    // shift path
+    {
+      const std::string ns = "shift_line";
+      add(createShiftLengthMarkerArray(
+        helper_.getPreviousLinearShiftPath().shift_length, path, ns + "_linear_registered", 0.9,
+        0.3, 0.3));
+      add(createShiftLengthMarkerArray(
+        debug.proposed_spline_shift, path, ns + "_spline_proposed", 1.0, 1.0, 1.0));
+    }
 
-  const auto object_type = utils::getHighestProbLabel(object.object.classification);
-  const auto object_parameter = parameters_->object_parameters.at(object_type);
+    // child shift points
+    {
+      const std::string ns = "pipeline";
+      add(createAvoidLineMarkerArray(debug.gap_filled, ns + "_1_gap_filled", 0.5, 0.8, 1.0, 0.05));
+      add(createAvoidLineMarkerArray(debug.merged, ns + "_2_merge", 0.345, 0.968, 1.0, 0.05));
+      add(createAvoidLineMarkerArray(
+        debug.trim_similar_grad_shift, ns + "_3_concat_by_grad", 0.976, 0.328, 0.910, 0.05));
+      add(createAvoidLineMarkerArray(
+        debug.quantized, ns + "_4_quantized", 0.505, 0.745, 0.969, 0.05));
+      add(createAvoidLineMarkerArray(
+        debug.trim_small_shift, ns + "_5_trim_small_shift", 0.663, 0.525, 0.941, 0.05));
+      add(createAvoidLineMarkerArray(
+        debug.trim_similar_grad_shift_second, ns + "_6_concat_by_grad", 0.97, 0.32, 0.91, 0.05));
+      add(createAvoidLineMarkerArray(
+        debug.trim_momentary_return, ns + "_7_trim_momentary_return", 0.976, 0.078, 0.878, 0.05));
+      add(createAvoidLineMarkerArray(
+        debug.trim_too_sharp_shift, ns + "_8_trim_sharp_shift", 0.576, 0.0, 0.978, 0.05));
+      add(createAvoidLineMarkerArray(
+        debug.trim_similar_grad_shift_third, ns + "_9_concat_by_grad", 1.0, 0.0, 0.0, 0.05));
+    }
 
-  const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
-                            object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
-  const auto variable = helper_.getMinAvoidanceDistance(
-    helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin));
-  const auto constant = p->min_prepare_distance + object_parameter.safety_buffer_longitudinal +
-                        base_link2front + p->stop_buffer;
-
-  return object.longitudinal - std::min(variable + constant, p->stop_max_distance);
-}
-
-void AvoidanceModule::insertWaitPoint(
-  const bool use_constraints_for_decel, ShiftedPath & shifted_path) const
-{
-  const auto & data = avoidance_data_;
-
-  if (!data.stop_target_object) {
-    return;
-  }
-
-  if (helper_.isShifted()) {
-    return;
-  }
-
-  // If we don't need to consider deceleration constraints, insert a deceleration point
-  // and return immediately
-  if (!use_constraints_for_decel) {
-    utils::avoidance::insertDecelPoint(
-      getEgoPosition(), data.to_stop_line, 0.0, shifted_path.path, stop_pose_);
-    return;
+    addShiftLine(shifter.getShiftLines(), "path_shifter_registered_points", 0.99, 0.99, 0.0, 0.5);
+    addAvoidLine(debug.new_shift_lines, "path_shifter_proposed_points", 0.99, 0.0, 0.0, 0.5);
   }
 
-  // If the stop distance is not enough for comfortable stop, don't insert wait point.
-  const auto is_comfortable_stop = helper_.getFeasibleDecelDistance(0.0) < data.to_stop_line;
-  const auto is_slow_speed = getEgoSpeed() < parameters_->min_slow_down_speed;
-  if (!is_comfortable_stop && !is_slow_speed) {
-    RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 500, "not execute uncomfortable deceleration.");
-    return;
-  }
-
-  // If target object can be stopped for, insert a deceleration point and return
-  if (data.stop_target_object.get().is_stoppable) {
-    utils::avoidance::insertDecelPoint(
-      getEgoPosition(), data.to_stop_line, 0.0, shifted_path.path, stop_pose_);
-    return;
-  }
-
-  // If the object cannot be stopped for, calculate a "mild" deceleration distance
-  // and insert a deceleration point at that distance
-  const auto stop_distance = helper_.getFeasibleDecelDistance(0.0, false);
-  utils::avoidance::insertDecelPoint(
-    getEgoPosition(), stop_distance, 0.0, shifted_path.path, stop_pose_);
-}
-
-void AvoidanceModule::insertStopPoint(
-  const bool use_constraints_for_decel, ShiftedPath & shifted_path) const
-{
-  const auto & data = avoidance_data_;
-
-  if (data.safe) {
-    return;
-  }
-
-  if (!parameters_->enable_yield_maneuver_during_shifting) {
-    return;
-  }
-
-  const auto stop_idx = [&]() {
-    const auto ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
-    for (size_t idx = ego_idx; idx < shifted_path.path.points.size(); ++idx) {
-      const auto & estimated_pose = shifted_path.path.points.at(idx).point.pose;
-      if (!utils::isEgoWithinOriginalLane(
-            data.current_lanelets, estimated_pose, planner_data_->parameters)) {
-        return idx - 1;
+  void AvoidanceModule::updateAvoidanceDebugData(
+    std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const
+  {
+    debug_data_.avoidance_debug_msg_array.avoidance_info.clear();
+    auto & debug_data_avoidance = debug_data_.avoidance_debug_msg_array.avoidance_info;
+    debug_data_avoidance = avoidance_debug_msg_array;
+    if (!debug_avoidance_initializer_for_shift_line_.empty()) {
+      const bool is_info_old_ =
+        (clock_->now() - debug_avoidance_initializer_for_shift_line_time_).seconds() > 0.1;
+      if (!is_info_old_) {
+        debug_data_avoidance.insert(
+          debug_data_avoidance.end(), debug_avoidance_initializer_for_shift_line_.begin(),
+          debug_avoidance_initializer_for_shift_line_.end());
       }
     }
+  }
 
-    return shifted_path.path.points.size() - 1;
-  }();
+  double AvoidanceModule::calcDistanceToStopLine(const ObjectData & object) const
+  {
+    const auto & p = parameters_;
+    const auto & base_link2front = planner_data_->parameters.base_link2front;
+    const auto & vehicle_width = planner_data_->parameters.vehicle_width;
 
-  const auto stop_distance =
-    calcSignedArcLength(shifted_path.path.points, getEgoPosition(), stop_idx);
+    //         D5
+    //      |<---->|                               D4
+    //      |<----------------------------------------------------------------------->|
+    // +-----------+            D1                 D2                      D3         +-----------+
+    // |           |        |<------->|<------------------------->|<----------------->|           |
+    // |    ego    |======= x ======= x ========================= x ==================|    obj    |
+    // |           |    stop_point  avoid                       avoid                 |           |
+    // +-----------+                start                        end                  +-----------+
+    //
+    // D1: p.min_prepare_distance
+    // D2: min_avoid_distance
+    // D3: longitudinal_avoid_margin_front (margin + D5)
+    // D4: o_front.longitudinal
+    // D5: base_link2front
 
-  // If we don't need to consider deceleration constraints, insert a deceleration point
-  // and return immediately
-  if (!use_constraints_for_decel) {
+    const auto object_type = utils::getHighestProbLabel(object.object.classification);
+    const auto object_parameter = parameters_->object_parameters.at(object_type);
+
+    const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
+                              object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
+    const auto variable = helper_.getMinAvoidanceDistance(
+      helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin));
+    const auto constant = p->min_prepare_distance + object_parameter.safety_buffer_longitudinal +
+                          base_link2front + p->stop_buffer;
+
+    return object.longitudinal - std::min(variable + constant, p->stop_max_distance);
+  }
+
+  void AvoidanceModule::insertWaitPoint(
+    const bool use_constraints_for_decel, ShiftedPath & shifted_path) const
+  {
+    const auto & data = avoidance_data_;
+
+    if (!data.stop_target_object) {
+      return;
+    }
+
+    if (helper_.isShifted()) {
+      return;
+    }
+
+    // If we don't need to consider deceleration constraints, insert a deceleration point
+    // and return immediately
+    if (!use_constraints_for_decel) {
+      utils::avoidance::insertDecelPoint(
+        getEgoPosition(), data.to_stop_line, 0.0, shifted_path.path, stop_pose_);
+      return;
+    }
+
+    // If the stop distance is not enough for comfortable stop, don't insert wait point.
+    const auto is_comfortable_stop = helper_.getFeasibleDecelDistance(0.0) < data.to_stop_line;
+    const auto is_slow_speed = getEgoSpeed() < parameters_->min_slow_down_speed;
+    if (!is_comfortable_stop && !is_slow_speed) {
+      RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 500, "not execute uncomfortable deceleration.");
+      return;
+    }
+
+    // If target object can be stopped for, insert a deceleration point and return
+    if (data.stop_target_object.get().is_stoppable) {
+      utils::avoidance::insertDecelPoint(
+        getEgoPosition(), data.to_stop_line, 0.0, shifted_path.path, stop_pose_);
+      return;
+    }
+
+    // If the object cannot be stopped for, calculate a "mild" deceleration distance
+    // and insert a deceleration point at that distance
+    const auto stop_distance = helper_.getFeasibleDecelDistance(0.0, false);
     utils::avoidance::insertDecelPoint(
       getEgoPosition(), stop_distance, 0.0, shifted_path.path, stop_pose_);
-    return;
   }
 
-  // Otherwise, consider deceleration constraints before inserting deceleration point
-  const auto decel_distance = helper_.getFeasibleDecelDistance(0.0, false);
-  if (stop_distance < decel_distance) {
-    return;
-  }
+  void AvoidanceModule::insertStopPoint(
+    const bool use_constraints_for_decel, ShiftedPath & shifted_path) const
+  {
+    const auto & data = avoidance_data_;
 
-  constexpr double MARGIN = 1.0;
-  utils::avoidance::insertDecelPoint(
-    getEgoPosition(), stop_distance - MARGIN, 0.0, shifted_path.path, stop_pose_);
-}
-
-void AvoidanceModule::insertYieldVelocity(ShiftedPath & shifted_path) const
-{
-  const auto & p = parameters_;
-  const auto & data = avoidance_data_;
-
-  if (data.target_objects.empty()) {
-    return;
-  }
-
-  if (helper_.isShifted()) {
-    return;
-  }
-
-  const auto decel_distance = helper_.getFeasibleDecelDistance(p->yield_velocity, false);
-  utils::avoidance::insertDecelPoint(
-    getEgoPosition(), decel_distance, p->yield_velocity, shifted_path.path, slow_pose_);
-}
-
-void AvoidanceModule::insertPrepareVelocity(ShiftedPath & shifted_path) const
-{
-  const auto & data = avoidance_data_;
-
-  // do nothing if there is no avoidance target.
-  if (data.target_objects.empty()) {
-    return;
-  }
-
-  // insert slow down speed only when the avoidance maneuver is not initiated.
-  if (helper_.isShifted()) {
-    return;
-  }
-
-  // insert slow down speed only when no shift line is approved.
-  if (!path_shifter_.getShiftLines().empty()) {
-    return;
-  }
-
-  const auto object = data.target_objects.front();
-
-  // calculate shift length for front object.
-  const auto & vehicle_width = planner_data_->parameters.vehicle_width;
-  const auto object_type = utils::getHighestProbLabel(object.object.classification);
-  const auto object_parameter = parameters_->object_parameters.at(object_type);
-  const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
-                            object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
-  const auto shift_length =
-    helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin);
-
-  // check slow down feasibility
-  const auto min_avoid_distance = helper_.getMinAvoidanceDistance(shift_length);
-  const auto distance_to_object = object.longitudinal;
-  const auto remaining_distance = distance_to_object - min_avoid_distance;
-  const auto decel_distance = helper_.getFeasibleDecelDistance(parameters_->velocity_map.front());
-  if (remaining_distance < decel_distance) {
-    return;
-  }
-
-  // decide slow down lower limit.
-  const auto lower_speed = object.avoid_required ? 0.0 : parameters_->min_slow_down_speed;
-
-  // insert slow down speed.
-  const double current_target_velocity = PathShifter::calcFeasibleVelocityFromJerk(
-    shift_length, helper_.getLateralMinJerkLimit(), distance_to_object);
-  if (current_target_velocity < getEgoSpeed() && decel_distance < remaining_distance) {
-    utils::avoidance::insertDecelPoint(
-      getEgoPosition(), decel_distance, parameters_->velocity_map.front(), shifted_path.path,
-      slow_pose_);
-    return;
-  }
-
-  const auto start_idx = planner_data_->findEgoIndex(shifted_path.path.points);
-  for (size_t i = start_idx; i < shifted_path.path.points.size(); ++i) {
-    const auto distance_from_ego = calcSignedArcLength(shifted_path.path.points, start_idx, i);
-
-    // slow down speed is inserted only in front of the object.
-    const auto shift_longitudinal_distance = distance_to_object - distance_from_ego;
-    if (shift_longitudinal_distance < min_avoid_distance) {
-      break;
+    if (data.safe) {
+      return;
     }
 
-    // target speed with nominal jerk limits.
-    const double v_target = PathShifter::calcFeasibleVelocityFromJerk(
-      shift_length, helper_.getLateralMinJerkLimit(), shift_longitudinal_distance);
-    const double v_original = shifted_path.path.points.at(i).point.longitudinal_velocity_mps;
-    const double v_insert = std::max(v_target - parameters_->buf_slow_down_speed, lower_speed);
+    if (!parameters_->enable_yield_maneuver_during_shifting) {
+      return;
+    }
 
-    shifted_path.path.points.at(i).point.longitudinal_velocity_mps = std::min(v_original, v_insert);
+    const auto stop_idx = [&]() {
+      const auto ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
+      for (size_t idx = ego_idx; idx < shifted_path.path.points.size(); ++idx) {
+        const auto & estimated_pose = shifted_path.path.points.at(idx).point.pose;
+        if (!utils::isEgoWithinOriginalLane(
+              data.current_lanelets, estimated_pose, planner_data_->parameters)) {
+          return idx - 1;
+        }
+      }
+
+      return shifted_path.path.points.size() - 1;
+    }();
+
+    const auto stop_distance =
+      calcSignedArcLength(shifted_path.path.points, getEgoPosition(), stop_idx);
+
+    // If we don't need to consider deceleration constraints, insert a deceleration point
+    // and return immediately
+    if (!use_constraints_for_decel) {
+      utils::avoidance::insertDecelPoint(
+        getEgoPosition(), stop_distance, 0.0, shifted_path.path, stop_pose_);
+      return;
+    }
+
+    // Otherwise, consider deceleration constraints before inserting deceleration point
+    const auto decel_distance = helper_.getFeasibleDecelDistance(0.0, false);
+    if (stop_distance < decel_distance) {
+      return;
+    }
+
+    constexpr double MARGIN = 1.0;
+    utils::avoidance::insertDecelPoint(
+      getEgoPosition(), stop_distance - MARGIN, 0.0, shifted_path.path, stop_pose_);
   }
 
-  slow_pose_ = motion_utils::calcLongitudinalOffsetPose(
-    shifted_path.path.points, start_idx, distance_to_object);
-}
+  void AvoidanceModule::insertYieldVelocity(ShiftedPath & shifted_path) const
+  {
+    const auto & p = parameters_;
+    const auto & data = avoidance_data_;
 
-std::shared_ptr<AvoidanceDebugMsgArray> AvoidanceModule::get_debug_msg_array() const
-{
-  debug_data_.avoidance_debug_msg_array.header.stamp = clock_->now();
-  return std::make_shared<AvoidanceDebugMsgArray>(debug_data_.avoidance_debug_msg_array);
-}
+    if (data.target_objects.empty()) {
+      return;
+    }
 
-void AvoidanceModule::acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const
-{
-  if (visitor) {
-    visitor->visitAvoidanceModule(this);
+    if (helper_.isShifted()) {
+      return;
+    }
+
+    const auto decel_distance = helper_.getFeasibleDecelDistance(p->yield_velocity, false);
+    utils::avoidance::insertDecelPoint(
+      getEgoPosition(), decel_distance, p->yield_velocity, shifted_path.path, slow_pose_);
   }
-}
 
-void SceneModuleVisitor::visitAvoidanceModule(const AvoidanceModule * module) const
-{
-  avoidance_visitor_ = module->get_debug_msg_array();
-}
+  void AvoidanceModule::insertPrepareVelocity(ShiftedPath & shifted_path) const
+  {
+    const auto & data = avoidance_data_;
+
+    // do nothing if there is no avoidance target.
+    if (data.target_objects.empty()) {
+      return;
+    }
+
+    // insert slow down speed only when the avoidance maneuver is not initiated.
+    if (helper_.isShifted()) {
+      return;
+    }
+
+    // insert slow down speed only when no shift line is approved.
+    if (!path_shifter_.getShiftLines().empty()) {
+      return;
+    }
+
+    const auto object = data.target_objects.front();
+
+    // calculate shift length for front object.
+    const auto & vehicle_width = planner_data_->parameters.vehicle_width;
+    const auto object_type = utils::getHighestProbLabel(object.object.classification);
+    const auto object_parameter = parameters_->object_parameters.at(object_type);
+    const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
+                              object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
+    const auto shift_length =
+      helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin);
+
+    // check slow down feasibility
+    const auto min_avoid_distance = helper_.getMinAvoidanceDistance(shift_length);
+    const auto distance_to_object = object.longitudinal;
+    const auto remaining_distance = distance_to_object - min_avoid_distance;
+    const auto decel_distance = helper_.getFeasibleDecelDistance(parameters_->velocity_map.front());
+    if (remaining_distance < decel_distance) {
+      return;
+    }
+
+    // decide slow down lower limit.
+    const auto lower_speed = object.avoid_required ? 0.0 : parameters_->min_slow_down_speed;
+
+    // insert slow down speed.
+    const double current_target_velocity = PathShifter::calcFeasibleVelocityFromJerk(
+      shift_length, helper_.getLateralMinJerkLimit(), distance_to_object);
+    if (current_target_velocity < getEgoSpeed() && decel_distance < remaining_distance) {
+      utils::avoidance::insertDecelPoint(
+        getEgoPosition(), decel_distance, parameters_->velocity_map.front(), shifted_path.path,
+        slow_pose_);
+      return;
+    }
+
+    const auto start_idx = planner_data_->findEgoIndex(shifted_path.path.points);
+    for (size_t i = start_idx; i < shifted_path.path.points.size(); ++i) {
+      const auto distance_from_ego = calcSignedArcLength(shifted_path.path.points, start_idx, i);
+
+      // slow down speed is inserted only in front of the object.
+      const auto shift_longitudinal_distance = distance_to_object - distance_from_ego;
+      if (shift_longitudinal_distance < min_avoid_distance) {
+        break;
+      }
+
+      // target speed with nominal jerk limits.
+      const double v_target = PathShifter::calcFeasibleVelocityFromJerk(
+        shift_length, helper_.getLateralMinJerkLimit(), shift_longitudinal_distance);
+      const double v_original = shifted_path.path.points.at(i).point.longitudinal_velocity_mps;
+      const double v_insert = std::max(v_target - parameters_->buf_slow_down_speed, lower_speed);
+
+      shifted_path.path.points.at(i).point.longitudinal_velocity_mps =
+        std::min(v_original, v_insert);
+    }
+
+    slow_pose_ = motion_utils::calcLongitudinalOffsetPose(
+      shifted_path.path.points, start_idx, distance_to_object);
+  }
+
+  std::shared_ptr<AvoidanceDebugMsgArray> AvoidanceModule::get_debug_msg_array() const
+  {
+    debug_data_.avoidance_debug_msg_array.header.stamp = clock_->now();
+    return std::make_shared<AvoidanceDebugMsgArray>(debug_data_.avoidance_debug_msg_array);
+  }
+
+  void AvoidanceModule::acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const
+  {
+    if (visitor) {
+      visitor->visitAvoidanceModule(this);
+    }
+  }
+
+  void SceneModuleVisitor::visitAvoidanceModule(const AvoidanceModule * module) const
+  {
+    avoidance_visitor_ = module->get_debug_msg_array();
+  }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1097,13 +1097,7 @@ void AvoidanceModule::generateTotalShiftLine(
   for (size_t i = 0; i <= avoidance_data_.ego_closest_path_index; ++i) {
     if (sl.shift_line.size() <= i) {
       break;
-  for (size_t i = 0; i < sl.shift_line.size(); ++i) {
-    if (avoidance_data_.ego_closest_path_index < i) {
-      break;
     }
-    sl.shift_line.at(i) = current_shift;
-    sl.shift_line_grad.at(i) = 0.0;
-  }
     sl.shift_line.at(i) = current_shift;
     sl.shift_line_grad.at(i) = 0.0;
   }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1097,1973 +1097,1955 @@ void AvoidanceModule::generateTotalShiftLine(
   for (size_t i = 0; i <= avoidance_data_.ego_closest_path_index; ++i) {
     if (sl.shift_line.size() <= i) {
       break;
-      for (size_t i = 0; i < sl.shift_line.size(); ++i) {
-        if (avoidance_data_.ego_closest_path_index < i) {
-          break;
-        }
-        sl.shift_line.at(i) = current_shift;
-        sl.shift_line_grad.at(i) = 0.0;
-      }
-      sl.shift_line.at(i) = current_shift;
-      sl.shift_line_grad.at(i) = 0.0;
+  for (size_t i = 0; i < sl.shift_line.size(); ++i) {
+    if (avoidance_data_.ego_closest_path_index < i) {
+      break;
     }
-
-    // If the shift point does not have an associated object,
-    // use previous value.
-    for (size_t i = 1; i < N; ++i) {
-      bool has_object = false;
-      for (const auto & al : avoid_lines) {
-        if (al.start_idx <= i && i <= al.end_idx) {
-          has_object = true;
-          break;
-        }
-      }
-      if (!has_object) {
-        sl.shift_line.at(i) = sl.shift_line.at(i - 1);
-      }
-    }
-
-    if (avoid_lines.empty()) {
-      sl.shift_line_history.push_back(sl.shift_line);
-      return;
-    }
-
-    const auto grad_first_shift_line = (avoid_lines.front().start_shift_length - current_shift) /
-                                       avoid_lines.front().start_longitudinal;
-
-    for (size_t i = avoidance_data_.ego_closest_path_index; i <= avoid_lines.front().start_idx;
-         ++i) {
-      sl.shift_line.at(i) = helper_.getLinearShift(getPoint(path.points.at(i)));
-      sl.shift_line_grad.at(i) = grad_first_shift_line;
-    }
-
-    sl.shift_line_history.push_back(sl.shift_line);
+    sl.shift_line.at(i) = current_shift;
+    sl.shift_line_grad.at(i) = 0.0;
+  }
+    sl.shift_line.at(i) = current_shift;
+    sl.shift_line_grad.at(i) = 0.0;
   }
 
-  AvoidLineArray AvoidanceModule::extractShiftLinesFromLine(ShiftLineData & shift_line_data) const
-  {
-    using utils::avoidance::setEndData;
-    using utils::avoidance::setStartData;
-
-    const auto & path = avoidance_data_.reference_path;
-    const auto & arcs = avoidance_data_.arclength_from_ego;
-    const auto N = path.points.size();
-
-    auto & sl = shift_line_data;
-
-    const auto backward_grad = [&](const size_t i) {
-      if (i == 0) {
-        return sl.shift_line_grad.at(i);
-      }
-      const double ds = arcs.at(i) - arcs.at(i - 1);
-      if (ds < 1.0e-5) {
-        return sl.shift_line_grad.at(i);
-      }  // use theoretical value when ds is too small.
-      return (sl.shift_line.at(i) - sl.shift_line.at(i - 1)) / ds;
-    };
-
-    const auto forward_grad = [&](const size_t i) {
-      if (i == arcs.size() - 1) {
-        return sl.shift_line_grad.at(i);
-      }
-      const double ds = arcs.at(i + 1) - arcs.at(i);
-      if (ds < 1.0e-5) {
-        return sl.shift_line_grad.at(i);
-      }  // use theoretical value when ds is too small.
-      return (sl.shift_line.at(i + 1) - sl.shift_line.at(i)) / ds;
-    };
-
-    // calculate forward and backward gradient of the shift length.
-    // This will be used for grad-change-point check.
-    sl.forward_grad = std::vector<double>(N, 0.0);
-    sl.backward_grad = std::vector<double>(N, 0.0);
-    for (size_t i = 0; i < N - 1; ++i) {
-      sl.forward_grad.at(i) = forward_grad(i);
-      sl.backward_grad.at(i) = backward_grad(i);
-    }
-
-    AvoidLineArray merged_avoid_lines;
-    AvoidLine al{};
-    bool found_first_start = false;
-    constexpr auto CREATE_SHIFT_GRAD_THR = 0.001;
-    constexpr auto IS_ALREADY_SHIFTING_THR = 0.001;
-    for (size_t i = avoidance_data_.ego_closest_path_index; i < N - 1; ++i) {
-      const auto & p = path.points.at(i).point.pose;
-      const auto shift = sl.shift_line.at(i);
-
-      // If the vehicle is already on the avoidance (checked by the first point has shift),
-      // set a start point at the first path point.
-      if (!found_first_start && std::abs(shift) > IS_ALREADY_SHIFTING_THR) {
-        setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
-        found_first_start = true;
-        DEBUG_PRINT("shift (= %f) is not zero at i = %lu. set start shift here.", shift, i);
-      }
-
-      // find the point where the gradient of the shift is changed
-      const bool set_shift_line_flag =
-        std::abs(sl.forward_grad.at(i) - sl.backward_grad.at(i)) > CREATE_SHIFT_GRAD_THR;
-
-      if (!set_shift_line_flag) {
-        continue;
-      }
-
-      if (!found_first_start) {
-        setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
-        found_first_start = true;
-        DEBUG_PRINT("grad change detected. start at i = %lu", i);
-      } else {
-        setEndData(al, shift, p, i, arcs.at(i));
-        al.id = getOriginalShiftLineUniqueId();
-        merged_avoid_lines.push_back(al);
-        setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
-        DEBUG_PRINT("end and start point found at i = %lu", i);
+  // If the shift point does not have an associated object,
+  // use previous value.
+  for (size_t i = 1; i < N; ++i) {
+    bool has_object = false;
+    for (const auto & al : avoid_lines) {
+      if (al.start_idx <= i && i <= al.end_idx) {
+        has_object = true;
+        break;
       }
     }
+    if (!has_object) {
+      sl.shift_line.at(i) = sl.shift_line.at(i - 1);
+    }
+  }
 
-    if (std::abs(backward_grad(N - 1)) > CREATE_SHIFT_GRAD_THR) {
-      const auto & p = path.points.at(N - 1).point.pose;
-      const auto shift = sl.shift_line.at(N - 1);
-      setEndData(al, shift, p, N - 1, arcs.at(N - 1));
+  if (avoid_lines.empty()) {
+    sl.shift_line_history.push_back(sl.shift_line);
+    return;
+  }
+
+  const auto grad_first_shift_line = (avoid_lines.front().start_shift_length - current_shift) /
+                                     avoid_lines.front().start_longitudinal;
+
+  for (size_t i = avoidance_data_.ego_closest_path_index; i <= avoid_lines.front().start_idx; ++i) {
+    sl.shift_line.at(i) = helper_.getLinearShift(getPoint(path.points.at(i)));
+    sl.shift_line_grad.at(i) = grad_first_shift_line;
+  }
+
+  sl.shift_line_history.push_back(sl.shift_line);
+}
+
+AvoidLineArray AvoidanceModule::extractShiftLinesFromLine(ShiftLineData & shift_line_data) const
+{
+  using utils::avoidance::setEndData;
+  using utils::avoidance::setStartData;
+
+  const auto & path = avoidance_data_.reference_path;
+  const auto & arcs = avoidance_data_.arclength_from_ego;
+  const auto N = path.points.size();
+
+  auto & sl = shift_line_data;
+
+  const auto backward_grad = [&](const size_t i) {
+    if (i == 0) {
+      return sl.shift_line_grad.at(i);
+    }
+    const double ds = arcs.at(i) - arcs.at(i - 1);
+    if (ds < 1.0e-5) {
+      return sl.shift_line_grad.at(i);
+    }  // use theoretical value when ds is too small.
+    return (sl.shift_line.at(i) - sl.shift_line.at(i - 1)) / ds;
+  };
+
+  const auto forward_grad = [&](const size_t i) {
+    if (i == arcs.size() - 1) {
+      return sl.shift_line_grad.at(i);
+    }
+    const double ds = arcs.at(i + 1) - arcs.at(i);
+    if (ds < 1.0e-5) {
+      return sl.shift_line_grad.at(i);
+    }  // use theoretical value when ds is too small.
+    return (sl.shift_line.at(i + 1) - sl.shift_line.at(i)) / ds;
+  };
+
+  // calculate forward and backward gradient of the shift length.
+  // This will be used for grad-change-point check.
+  sl.forward_grad = std::vector<double>(N, 0.0);
+  sl.backward_grad = std::vector<double>(N, 0.0);
+  for (size_t i = 0; i < N - 1; ++i) {
+    sl.forward_grad.at(i) = forward_grad(i);
+    sl.backward_grad.at(i) = backward_grad(i);
+  }
+
+  AvoidLineArray merged_avoid_lines;
+  AvoidLine al{};
+  bool found_first_start = false;
+  constexpr auto CREATE_SHIFT_GRAD_THR = 0.001;
+  constexpr auto IS_ALREADY_SHIFTING_THR = 0.001;
+  for (size_t i = avoidance_data_.ego_closest_path_index; i < N - 1; ++i) {
+    const auto & p = path.points.at(i).point.pose;
+    const auto shift = sl.shift_line.at(i);
+
+    // If the vehicle is already on the avoidance (checked by the first point has shift),
+    // set a start point at the first path point.
+    if (!found_first_start && std::abs(shift) > IS_ALREADY_SHIFTING_THR) {
+      setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
+      found_first_start = true;
+      DEBUG_PRINT("shift (= %f) is not zero at i = %lu. set start shift here.", shift, i);
+    }
+
+    // find the point where the gradient of the shift is changed
+    const bool set_shift_line_flag =
+      std::abs(sl.forward_grad.at(i) - sl.backward_grad.at(i)) > CREATE_SHIFT_GRAD_THR;
+
+    if (!set_shift_line_flag) {
+      continue;
+    }
+
+    if (!found_first_start) {
+      setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
+      found_first_start = true;
+      DEBUG_PRINT("grad change detected. start at i = %lu", i);
+    } else {
+      setEndData(al, shift, p, i, arcs.at(i));
       al.id = getOriginalShiftLineUniqueId();
       merged_avoid_lines.push_back(al);
+      setStartData(al, 0.0, p, i, arcs.at(i));  // start length is overwritten later.
+      DEBUG_PRINT("end and start point found at i = %lu", i);
     }
-
-    return merged_avoid_lines;
   }
 
-  void AvoidanceModule::fillShiftLineGap(AvoidLineArray & shift_lines) const
-  {
-    using utils::avoidance::setEndData;
+  if (std::abs(backward_grad(N - 1)) > CREATE_SHIFT_GRAD_THR) {
+    const auto & p = path.points.at(N - 1).point.pose;
+    const auto shift = sl.shift_line.at(N - 1);
+    setEndData(al, shift, p, N - 1, arcs.at(N - 1));
+    al.id = getOriginalShiftLineUniqueId();
+    merged_avoid_lines.push_back(al);
+  }
 
-    if (shift_lines.empty()) {
+  return merged_avoid_lines;
+}
+
+void AvoidanceModule::fillShiftLineGap(AvoidLineArray & shift_lines) const
+{
+  using utils::avoidance::setEndData;
+
+  if (shift_lines.empty()) {
+    return;
+  }
+
+  const auto & data = avoidance_data_;
+
+  helper_.alignShiftLinesOrder(shift_lines, false);
+
+  const auto fill_gap = [&shift_lines, this](const auto & front_line, const auto & back_line) {
+    const auto has_gap = back_line.start_longitudinal - front_line.end_longitudinal > 0.0;
+    if (!has_gap) {
       return;
     }
 
-    const auto & data = avoidance_data_;
+    AvoidLine new_line{};
+    new_line.start_shift_length = front_line.end_shift_length;
+    new_line.start_longitudinal = front_line.end_longitudinal;
+    new_line.end_shift_length = back_line.start_shift_length;
+    new_line.end_longitudinal = back_line.start_longitudinal;
+    new_line.id = getOriginalShiftLineUniqueId();
 
-    helper_.alignShiftLinesOrder(shift_lines, false);
+    shift_lines.push_back(new_line);
+  };
 
-    const auto fill_gap = [&shift_lines, this](const auto & front_line, const auto & back_line) {
-      const auto has_gap = back_line.start_longitudinal - front_line.end_longitudinal > 0.0;
-      if (!has_gap) {
-        return;
-      }
+  // fill gap between ego and nearest shift line.
+  {
+    AvoidLine ego_line{};
+    setEndData(
+      ego_line, helper_.getEgoLinearShift(), data.reference_pose, data.ego_closest_path_index, 0.0);
 
-      AvoidLine new_line{};
-      new_line.start_shift_length = front_line.end_shift_length;
-      new_line.start_longitudinal = front_line.end_longitudinal;
-      new_line.end_shift_length = back_line.start_shift_length;
-      new_line.end_longitudinal = back_line.start_longitudinal;
-      new_line.id = getOriginalShiftLineUniqueId();
-
-      shift_lines.push_back(new_line);
-    };
-
-    // fill gap between ego and nearest shift line.
-    {
-      AvoidLine ego_line{};
-      setEndData(
-        ego_line, helper_.getEgoLinearShift(), data.reference_pose, data.ego_closest_path_index,
-        0.0);
-
-      fill_gap(ego_line, shift_lines.front());
-    }
-
-    // fill gap among shift lines.
-    for (size_t i = 0; i < shift_lines.size() - 1; ++i) {
-      fill_gap(shift_lines.at(i), shift_lines.at(i + 1));
-    }
-
-    utils::avoidance::fillAdditionalInfoFromLongitudinal(data, shift_lines);
-
-    helper_.alignShiftLinesOrder(shift_lines, false);
+    fill_gap(ego_line, shift_lines.front());
   }
 
-  AvoidLineArray AvoidanceModule::mergeShiftLines(
-    const AvoidLineArray & raw_shift_lines, DebugData & debug) const
-  {
-    // Generate shift line by merging raw_shift_lines.
-    ShiftLineData shift_line_data;
-    generateTotalShiftLine(raw_shift_lines, shift_line_data);
-
-    // Re-generate shift points by detecting gradient-change point of the shift line.
-    auto merged_shift_lines = extractShiftLinesFromLine(shift_line_data);
-
-    // set parent id
-    for (auto & al : merged_shift_lines) {
-      al.parent_ids = utils::avoidance::calcParentIds(raw_shift_lines, al);
-    }
-
-    // sort by distance from ego.
-    helper_.alignShiftLinesOrder(merged_shift_lines);
-
-    // debug visualize
-    {
-      debug.pos_shift = shift_line_data.pos_shift_line;
-      debug.neg_shift = shift_line_data.neg_shift_line;
-      debug.total_shift = shift_line_data.shift_line;
-      debug.pos_shift_grad = shift_line_data.pos_shift_line_grad;
-      debug.neg_shift_grad = shift_line_data.neg_shift_line_grad;
-      debug.total_forward_grad = shift_line_data.forward_grad;
-      debug.total_backward_grad = shift_line_data.backward_grad;
-    }
-
-    // debug print
-    {
-      const auto & arc = avoidance_data_.arclength_from_ego;
-      const auto & closest = avoidance_data_.ego_closest_path_index;
-      const auto & sl = shift_line_data.shift_line;
-      const auto & sg = shift_line_data.shift_line_grad;
-      const auto & fg = shift_line_data.forward_grad;
-      const auto & bg = shift_line_data.backward_grad;
-      using std::setw;
-      std::stringstream ss;
-      ss << std::fixed << std::setprecision(3);
-      ss
-        << "\n[idx, arc, shift (for each shift points, filtered | total), grad (ideal, bwd, fwd)]: "
-           "closest = "
-        << closest << ", raw_shift_lines size = " << raw_shift_lines.size() << std::endl;
-      for (size_t i = 0; i < arc.size(); ++i) {
-        ss << "i = " << i << " | arc: " << arc.at(i) << " | shift: (";
-        for (const auto & p : shift_line_data.shift_line_history) {
-          ss << setw(5) << p.at(i) << ", ";
-        }
-        ss << "| total: " << setw(5) << sl.at(i) << ") | grad: (" << sg.at(i) << ", " << fg.at(i)
-           << ", " << bg.at(i) << ")" << std::endl;
-      }
-      DEBUG_PRINT("%s", ss.str().c_str());
-    }
-
-    printShiftLines(merged_shift_lines, "merged_shift_lines");
-
-    return merged_shift_lines;
+  // fill gap among shift lines.
+  for (size_t i = 0; i < shift_lines.size() - 1; ++i) {
+    fill_gap(shift_lines.at(i), shift_lines.at(i + 1));
   }
 
-  AvoidLineArray AvoidanceModule::trimShiftLine(
-    const AvoidLineArray & shift_lines, DebugData & debug) const
-  {
-    if (shift_lines.empty()) {
-      return shift_lines;
-    }
+  utils::avoidance::fillAdditionalInfoFromLongitudinal(data, shift_lines);
 
-    AvoidLineArray sl_array_trimmed = shift_lines;
+  helper_.alignShiftLinesOrder(shift_lines, false);
+}
 
-    // sort shift points from front to back.
-    helper_.alignShiftLinesOrder(sl_array_trimmed);
+AvoidLineArray AvoidanceModule::mergeShiftLines(
+  const AvoidLineArray & raw_shift_lines, DebugData & debug) const
+{
+  // Generate shift line by merging raw_shift_lines.
+  ShiftLineData shift_line_data;
+  generateTotalShiftLine(raw_shift_lines, shift_line_data);
 
-    // - Change the shift length to the previous one if the deviation is small.
-    {
-      constexpr double SHIFT_DIFF_THRES = 1.0;
-      trimSmallShiftLine(sl_array_trimmed, SHIFT_DIFF_THRES);
-    }
+  // Re-generate shift points by detecting gradient-change point of the shift line.
+  auto merged_shift_lines = extractShiftLinesFromLine(shift_line_data);
 
-    // - Combine avoid points that have almost same gradient.
-    // this is to remove the noise.
-    {
-      const auto THRESHOLD = parameters_->same_grad_filter_1_threshold;
-      trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
-      debug.trim_similar_grad_shift = sl_array_trimmed;
-      printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift");
-    }
-
-    // - Quantize the shift length to reduce the shift point noise
-    // This is to remove the noise coming from detection accuracy, interpolation, resampling, etc.
-    {
-      const auto THRESHOLD = parameters_->quantize_filter_threshold;
-      quantizeShiftLine(sl_array_trimmed, THRESHOLD);
-      printShiftLines(sl_array_trimmed, "after sl_array_trimmed");
-      debug.quantized = sl_array_trimmed;
-    }
-
-    // - Change the shift length to the previous one if the deviation is small.
-    {
-      constexpr double SHIFT_DIFF_THRES = 1.0;
-      trimSmallShiftLine(sl_array_trimmed, SHIFT_DIFF_THRES);
-      debug.trim_small_shift = sl_array_trimmed;
-      printShiftLines(sl_array_trimmed, "after trim_small_shift");
-    }
-
-    // - Combine avoid points that have almost same gradient (again)
-    {
-      const auto THRESHOLD = parameters_->same_grad_filter_2_threshold;
-      trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
-      debug.trim_similar_grad_shift_second = sl_array_trimmed;
-      printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
-    }
-
-    // - trimTooSharpShift
-    // Check if it is not too sharp for the return-to-center shift point.
-    // If the shift is sharp, it is combined with the next shift point until it gets non-sharp.
-    {
-      const auto THRESHOLD = parameters_->sharp_shift_filter_threshold;
-      trimSharpReturn(sl_array_trimmed, THRESHOLD);
-      debug.trim_too_sharp_shift = sl_array_trimmed;
-      printShiftLines(sl_array_trimmed, "after trimSharpReturn");
-    }
-
-    // - Combine avoid points that have almost same gradient (again)
-    {
-      const auto THRESHOLD = parameters_->same_grad_filter_3_threshold;
-      trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
-      debug.trim_similar_grad_shift_third = sl_array_trimmed;
-      printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
-    }
-
-    return sl_array_trimmed;
+  // set parent id
+  for (auto & al : merged_shift_lines) {
+    al.parent_ids = utils::avoidance::calcParentIds(raw_shift_lines, al);
   }
 
-  void AvoidanceModule::quantizeShiftLine(AvoidLineArray & shift_lines, const double threshold)
-    const
+  // sort by distance from ego.
+  helper_.alignShiftLinesOrder(merged_shift_lines);
+
+  // debug visualize
   {
-    if (threshold < 1.0e-5) {
-      return;  // no need to process
-    }
-
-    for (auto & sl : shift_lines) {
-      sl.end_shift_length = std::round(sl.end_shift_length / threshold) * threshold;
-    }
-
-    helper_.alignShiftLinesOrder(shift_lines);
+    debug.pos_shift = shift_line_data.pos_shift_line;
+    debug.neg_shift = shift_line_data.neg_shift_line;
+    debug.total_shift = shift_line_data.shift_line;
+    debug.pos_shift_grad = shift_line_data.pos_shift_line_grad;
+    debug.neg_shift_grad = shift_line_data.neg_shift_line_grad;
+    debug.total_forward_grad = shift_line_data.forward_grad;
+    debug.total_backward_grad = shift_line_data.backward_grad;
   }
 
-  void AvoidanceModule::trimSmallShiftLine(AvoidLineArray & shift_lines, const double threshold)
-    const
+  // debug print
   {
-    if (shift_lines.empty()) {
-      return;
-    }
-
-    AvoidLineArray input = shift_lines;
-    shift_lines.clear();
-
-    for (const auto & s : input) {
-      if (s.getRelativeLongitudinal() < threshold) {
-        continue;
+    const auto & arc = avoidance_data_.arclength_from_ego;
+    const auto & closest = avoidance_data_.ego_closest_path_index;
+    const auto & sl = shift_line_data.shift_line;
+    const auto & sg = shift_line_data.shift_line_grad;
+    const auto & fg = shift_line_data.forward_grad;
+    const auto & bg = shift_line_data.backward_grad;
+    using std::setw;
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(3);
+    ss << "\n[idx, arc, shift (for each shift points, filtered | total), grad (ideal, bwd, fwd)]: "
+          "closest = "
+       << closest << ", raw_shift_lines size = " << raw_shift_lines.size() << std::endl;
+    for (size_t i = 0; i < arc.size(); ++i) {
+      ss << "i = " << i << " | arc: " << arc.at(i) << " | shift: (";
+      for (const auto & p : shift_line_data.shift_line_history) {
+        ss << setw(5) << p.at(i) << ", ";
       }
-
-      shift_lines.push_back(s);
+      ss << "| total: " << setw(5) << sl.at(i) << ") | grad: (" << sg.at(i) << ", " << fg.at(i)
+         << ", " << bg.at(i) << ")" << std::endl;
     }
+    DEBUG_PRINT("%s", ss.str().c_str());
   }
 
-  void AvoidanceModule::trimSimilarGradShiftLine(
-    AvoidLineArray & avoid_lines, const double threshold) const
-  {
-    if (avoid_lines.empty()) {
-      return;
-    }
+  printShiftLines(merged_shift_lines, "merged_shift_lines");
 
-    AvoidLineArray input = avoid_lines;
-    avoid_lines.clear();
-    avoid_lines.push_back(input.front());  // Take the first one anyway (think later)
+  return merged_shift_lines;
+}
 
-    AvoidLine base_line = input.front();
-
-    AvoidLineArray combine_buffer;
-    combine_buffer.push_back(input.front());
-
-    constexpr auto SHIFT_THR = 1e-3;
-    const auto is_negative_shift = [&](const auto & s) {
-      return s.getRelativeLength() < -1.0 * SHIFT_THR;
-    };
-
-    const auto is_positive_shift = [&](const auto & s) {
-      return s.getRelativeLength() > SHIFT_THR;
-    };
-
-    for (size_t i = 1; i < input.size(); ++i) {
-      AvoidLine combine{};
-
-      utils::avoidance::setStartData(
-        combine, base_line.start_shift_length, base_line.start, base_line.start_idx,
-        base_line.start_longitudinal);
-      utils::avoidance::setEndData(
-        combine, input.at(i).end_shift_length, input.at(i).end, input.at(i).end_idx,
-        input.at(i).end_longitudinal);
-
-      combine_buffer.push_back(input.at(i));
-
-      const auto violates = [&]() {
-        if (is_negative_shift(input.at(i)) && is_positive_shift(base_line)) {
-          return true;
-        }
-
-        if (is_negative_shift(base_line) && is_positive_shift(input.at(i))) {
-          return true;
-        }
-
-        const auto lon_combine = combine.getRelativeLongitudinal();
-        const auto base_length = base_line.getGradient() * lon_combine;
-        return std::abs(combine.getRelativeLength() - base_length) > threshold;
-      }();
-
-      if (violates) {
-        avoid_lines.push_back(input.at(i));
-        base_line = input.at(i);
-        combine_buffer.clear();
-        combine_buffer.push_back(input.at(i));
-      } else {
-        avoid_lines.back() = combine;
-      }
-    }
-
-    helper_.alignShiftLinesOrder(avoid_lines);
-
-    DEBUG_PRINT("size %lu -> %lu", input.size(), avoid_lines.size());
+AvoidLineArray AvoidanceModule::trimShiftLine(
+  const AvoidLineArray & shift_lines, DebugData & debug) const
+{
+  if (shift_lines.empty()) {
+    return shift_lines;
   }
 
-  void AvoidanceModule::trimSharpReturn(AvoidLineArray & shift_lines, const double threshold) const
+  AvoidLineArray sl_array_trimmed = shift_lines;
+
+  // sort shift points from front to back.
+  helper_.alignShiftLinesOrder(sl_array_trimmed);
+
+  // - Change the shift length to the previous one if the deviation is small.
   {
-    AvoidLineArray shift_lines_orig = shift_lines;
-    shift_lines.clear();
-
-    const auto isZero = [](double v) { return std::abs(v) < 0.01; };
-
-    // check if the shift point is positive (avoiding) shift
-    const auto isPositive = [&](const auto & sl) {
-      constexpr auto POSITIVE_SHIFT_THR = 0.1;
-      return std::abs(sl.end_shift_length) - std::abs(sl.start_shift_length) > POSITIVE_SHIFT_THR;
-    };
-
-    // check if the shift point is negative (returning) shift
-    const auto isNegative = [&](const auto & sl) {
-      constexpr auto NEGATIVE_SHIFT_THR = -0.1;
-      return std::abs(sl.end_shift_length) - std::abs(sl.start_shift_length) < NEGATIVE_SHIFT_THR;
-    };
-
-    // combine two shift points. Be careful the order of "now" and "next".
-    const auto combineShiftLine = [this](const auto & sl_next, const auto & sl_now) {
-      auto sl_modified = sl_now;
-      utils::avoidance::setEndData(
-        sl_modified, sl_next.end_shift_length, sl_next.end, sl_next.end_idx,
-        sl_next.end_longitudinal);
-      sl_modified.parent_ids =
-        utils::avoidance::concatParentIds(sl_modified.parent_ids, sl_now.parent_ids);
-      return sl_modified;
-    };
-
-    // Check if the merged shift has a conflict with the original shifts.
-    const auto hasViolation = [&threshold](const auto & combined, const auto & combined_src) {
-      for (const auto & sl : combined_src) {
-        const auto combined_shift =
-          utils::avoidance::lerpShiftLengthOnArc(sl.end_longitudinal, combined);
-        if (sl.end_shift_length < -0.01 && combined_shift > sl.end_shift_length + threshold) {
-          return true;
-        }
-        if (sl.end_shift_length > 0.01 && combined_shift < sl.end_shift_length - threshold) {
-          return true;
-        }
-      }
-      return false;
-    };
-
-    // check for all shift points
-    for (size_t i = 0; i < shift_lines_orig.size(); ++i) {
-      auto sl_now = shift_lines_orig.at(i);
-      sl_now.start_shift_length =
-        shift_lines.empty() ? helper_.getEgoLinearShift() : shift_lines.back().end_shift_length;
-
-      if (sl_now.end_shift_length * sl_now.start_shift_length < -0.01) {
-        DEBUG_PRINT("i = %lu, This is avoid shift for opposite direction. take this one", i);
-        continue;
-      }
-
-      // Do nothing for non-reduce shift point
-      if (!isNegative(sl_now)) {
-        shift_lines.push_back(sl_now);
-        DEBUG_PRINT(
-          "i = %lu, positive shift. take this one. sl_now.length * sl_now.start_length = %f", i,
-          sl_now.end_shift_length * sl_now.start_shift_length);
-        continue;
-      }
-
-      // The last point is out of target of this function.
-      if (i == shift_lines_orig.size() - 1) {
-        shift_lines.push_back(sl_now);
-        DEBUG_PRINT("i = %lu, last shift. take this one.", i);
-        continue;
-      }
-
-      // -----------------------------------------------------------------------
-      // ------------ From here, the shift point is "negative" -----------------
-      // -----------------------------------------------------------------------
-
-      // if next shift is negative, combine them. loop until combined shift line
-      // exceeds merged shift point.
-      DEBUG_PRINT("i = %lu, found negative dist. search.", i);
-      {
-        auto sl_combined = sl_now;
-        auto sl_combined_prev = sl_combined;
-        AvoidLineArray sl_combined_array{sl_now};
-        size_t j = i + 1;
-        for (; i < shift_lines_orig.size(); ++j) {
-          const auto sl_combined = combineShiftLine(shift_lines_orig.at(j), sl_now);
-
-          {
-            std::stringstream ss;
-            ss << "i = " << i << ", j = " << j << ": sl_combined = " << toStrInfo(sl_combined);
-            DEBUG_PRINT("%s", ss.str().c_str());
-          }
-
-          // it gets positive. Finish merging.
-          if (isPositive(sl_combined)) {
-            shift_lines.push_back(sl_combined);
-            DEBUG_PRINT("reach positive.");
-            break;
-          }
-
-          // Still negative, but it violates the original shift points.
-          // Finish with the previous merge result.
-          if (hasViolation(sl_combined, sl_combined_array)) {
-            shift_lines.push_back(sl_combined_prev);
-            DEBUG_PRINT("violation found.");
-            --j;
-            break;
-          }
-
-          // Still negative, but it has an enough long distance. Finish merging.
-          const auto nominal_distance =
-            helper_.getMaxAvoidanceDistance(sl_combined.getRelativeLength());
-          const auto long_distance =
-            isZero(sl_combined.end_shift_length) ? nominal_distance : nominal_distance * 5.0;
-          if (sl_combined.getRelativeLongitudinal() > long_distance) {
-            shift_lines.push_back(sl_combined);
-            DEBUG_PRINT("still negative, but long enough. Threshold = %f", long_distance);
-            break;
-          }
-
-          // It reaches the last point. Still the shift is sharp, but merge with the current result.
-          if (j == shift_lines_orig.size() - 1) {
-            shift_lines.push_back(sl_combined);
-            DEBUG_PRINT("reach end point.");
-            break;
-          }
-
-          // Still negative shift, and the distance is not enough. Search next.
-          sl_combined_prev = sl_combined;
-          sl_combined_array.push_back(shift_lines_orig.at(j));
-        }
-        i = j;
-        continue;
-      }
-    }
-
-    helper_.alignShiftLinesOrder(shift_lines);
-
-    DEBUG_PRINT("trimSharpReturn: size %lu -> %lu", shift_lines_orig.size(), shift_lines.size());
+    constexpr double SHIFT_DIFF_THRES = 1.0;
+    trimSmallShiftLine(sl_array_trimmed, SHIFT_DIFF_THRES);
   }
 
-  void AvoidanceModule::addReturnShiftLineFromEgo(AvoidLineArray & sl_candidates) const
+  // - Combine avoid points that have almost same gradient.
+  // this is to remove the noise.
   {
-    constexpr double ep = 1.0e-3;
-    const auto & data = avoidance_data_;
-    const bool has_candidate_point = !sl_candidates.empty();
-    const bool has_registered_point = !path_shifter_.getShiftLines().empty();
-
-    // If the return-to-center shift points are already registered, do nothing.
-    if (!has_registered_point && std::fabs(getCurrentBaseShift()) < ep) {
-      DEBUG_PRINT("No shift points, not base offset. Do not have to add return-shift.");
-      return;
-    }
-
-    constexpr double RETURN_SHIFT_THRESHOLD = 0.1;
-    DEBUG_PRINT("registered last shift = %f", path_shifter_.getLastShiftLength());
-    if (std::abs(path_shifter_.getLastShiftLength()) < RETURN_SHIFT_THRESHOLD) {
-      DEBUG_PRINT("Return shift is already registered. do nothing.");
-      return;
-    }
-
-    // From here, the return-to-center is not registered. But perhaps the candidate is
-    // already generated.
-
-    // If it has a shift point, add return shift from the existing last shift point.
-    // If not, add return shift from ego point. (prepare distance is considered for both.)
-    ShiftLine last_sl;  // the return-shift will be generated after the last shift point.
-    {
-      // avoidance points: Yes, shift points: No -> select last avoidance point.
-      if (has_candidate_point && !has_registered_point) {
-        helper_.alignShiftLinesOrder(sl_candidates, false);
-        last_sl = sl_candidates.back();
-      }
-
-      // avoidance points: No, shift points: Yes -> select last shift point.
-      if (!has_candidate_point && has_registered_point) {
-        last_sl = utils::avoidance::fillAdditionalInfo(
-          data, AvoidLine{path_shifter_.getLastShiftLine().get()});
-      }
-
-      // avoidance points: Yes, shift points: Yes -> select the last one from both.
-      if (has_candidate_point && has_registered_point) {
-        helper_.alignShiftLinesOrder(sl_candidates, false);
-        const auto & al = sl_candidates.back();
-        const auto & sl = utils::avoidance::fillAdditionalInfo(
-          data, AvoidLine{path_shifter_.getLastShiftLine().get()});
-        last_sl = (sl.end_longitudinal > al.end_longitudinal) ? sl : al;
-      }
-
-      // avoidance points: No, shift points: No -> set the ego position to the last shift point
-      // so that the return-shift will be generated from ego position.
-      if (!has_candidate_point && !has_registered_point) {
-        last_sl.end_idx = avoidance_data_.ego_closest_path_index;
-        last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
-        last_sl.end_shift_length = getCurrentBaseShift();
-      }
-    }
-    printShiftLines(ShiftLineArray{last_sl}, "last shift point");
-
-    // There already is a shift point candidates to go back to center line, but it could be too
-    // sharp due to detection noise or timing. Here the return-shift from ego is added for the in
-    // case.
-    if (std::fabs(last_sl.end_shift_length) < RETURN_SHIFT_THRESHOLD) {
-      const auto current_base_shift = helper_.getEgoShift();
-      if (std::abs(current_base_shift) < ep) {
-        DEBUG_PRINT("last shift almost is zero, and current base_shift is zero. do nothing.");
-        return;
-      }
-
-      // Is there a shift point in the opposite direction of the current_base_shift?
-      //   No  -> we can overwrite the return shift, because the other shift points that decrease
-      //          the shift length are for return-shift.
-      //   Yes -> we can NOT overwrite, because it might be not a return-shift, but a avoiding
-      //          shift to the opposite direction which can not be overwritten by the return-shift.
-      for (const auto & sl : sl_candidates) {
-        if (
-          (current_base_shift > 0.0 && sl.end_shift_length < -ep) ||
-          (current_base_shift < 0.0 && sl.end_shift_length > ep)) {
-          DEBUG_PRINT(
-            "try to put overwrite return shift, but there is shift for opposite direction. Skip "
-            "adding return shift.");
-          return;
-        }
-      }
-
-      // If return shift already exists in candidate or registered shift lines, skip adding return
-      // shift.
-      if (has_candidate_point || has_registered_point) {
-        return;
-      }
-
-      // set the return-shift from ego.
-      DEBUG_PRINT(
-        "return shift already exists, but they are all candidates. Add return shift for "
-        "overwrite.");
-      last_sl.end_idx = avoidance_data_.ego_closest_path_index;
-      last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
-      last_sl.end_shift_length = current_base_shift;
-    }
-
-    const auto & arclength_from_ego = avoidance_data_.arclength_from_ego;
-
-    const auto nominal_prepare_distance = helper_.getNominalPrepareDistance();
-    const auto nominal_avoid_distance = helper_.getMaxAvoidanceDistance(last_sl.end_shift_length);
-
-    if (arclength_from_ego.empty()) {
-      return;
-    }
-
-    const auto remaining_distance = arclength_from_ego.back() - parameters_->remain_buffer_distance;
-
-    // If the avoidance point has already been set, the return shift must be set after the point.
-    const auto last_sl_distance = avoidance_data_.arclength_from_ego.at(last_sl.end_idx);
-
-    // check if there is enough distance for return.
-    if (last_sl_distance > remaining_distance) {  // tmp: add some small number (+1.0)
-      RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 1000, "No enough distance for return.");
-      return;
-    }
-
-    // If the remaining distance is not enough, the return shift needs to be shrunk.
-    // (or another option is just to ignore the return-shift.)
-    // But we do not want to change the last shift point, so we will shrink the distance after
-    // the last shift point.
-    //
-    //  The line "===" is fixed, "---" is scaled.
-    //
-    // [Before Scaling]
-    //  ego              last_sl_end             prepare_end            path_end    avoid_end
-    // ==o====================o----------------------o----------------------o------------o
-    //   |            prepare_dist                   |          avoid_dist               |
-    //
-    // [After Scaling]
-    // ==o====================o------------------o--------------------------o
-    //   |        prepare_dist_scaled            |    avoid_dist_scaled     |
-    //
-    const double variable_prepare_distance =
-      std::max(nominal_prepare_distance - last_sl_distance, 0.0);
-
-    double prepare_distance_scaled = std::max(nominal_prepare_distance, last_sl_distance);
-    double avoid_distance_scaled = nominal_avoid_distance;
-    if (remaining_distance < prepare_distance_scaled + avoid_distance_scaled) {
-      const auto scale = (remaining_distance - last_sl_distance) /
-                         std::max(nominal_avoid_distance + variable_prepare_distance, 0.1);
-      prepare_distance_scaled = last_sl_distance + scale * nominal_prepare_distance;
-      avoid_distance_scaled *= scale;
-      DEBUG_PRINT(
-        "last_sl_distance = %f, nominal_prepare_distance = %f, nominal_avoid_distance = %f, "
-        "remaining_distance = %f, variable_prepare_distance = %f, scale = %f, "
-        "prepare_distance_scaled = %f,avoid_distance_scaled = %f",
-        last_sl_distance, nominal_prepare_distance, nominal_avoid_distance, remaining_distance,
-        variable_prepare_distance, scale, prepare_distance_scaled, avoid_distance_scaled);
-    } else {
-      DEBUG_PRINT("there is enough distance. Use nominal for prepare & avoidance.");
-    }
-
-    // shift point for prepare distance: from last shift to return-start point.
-    if (nominal_prepare_distance > last_sl_distance) {
-      AvoidLine al;
-      al.id = getOriginalShiftLineUniqueId();
-      al.start_idx = last_sl.end_idx;
-      al.start = last_sl.end;
-      al.start_longitudinal = arclength_from_ego.at(al.start_idx);
-      al.end_idx =
-        utils::avoidance::findPathIndexFromArclength(arclength_from_ego, prepare_distance_scaled);
-      al.end = avoidance_data_.reference_path.points.at(al.end_idx).point.pose;
-      al.end_longitudinal = arclength_from_ego.at(al.end_idx);
-      al.end_shift_length = last_sl.end_shift_length;
-      al.start_shift_length = last_sl.end_shift_length;
-      sl_candidates.push_back(al);
-      printShiftLines(AvoidLineArray{al}, "prepare for return");
-      debug_data_.extra_return_shift.push_back(al);
-    }
-
-    // shift point for return to center line
-    {
-      AvoidLine al;
-      al.id = getOriginalShiftLineUniqueId();
-      al.start_idx =
-        utils::avoidance::findPathIndexFromArclength(arclength_from_ego, prepare_distance_scaled);
-      al.start = avoidance_data_.reference_path.points.at(al.start_idx).point.pose;
-      al.start_longitudinal = arclength_from_ego.at(al.start_idx);
-      al.end_idx = utils::avoidance::findPathIndexFromArclength(
-        arclength_from_ego, prepare_distance_scaled + avoid_distance_scaled);
-      al.end = avoidance_data_.reference_path.points.at(al.end_idx).point.pose;
-      al.end_longitudinal = arclength_from_ego.at(al.end_idx);
-      al.end_shift_length = 0.0;
-      al.start_shift_length = last_sl.end_shift_length;
-      sl_candidates.push_back(al);
-      printShiftLines(AvoidLineArray{al}, "return point");
-      debug_data_.extra_return_shift.push_back(al);
-    }
-
-    DEBUG_PRINT("Return Shift is added.");
+    const auto THRESHOLD = parameters_->same_grad_filter_1_threshold;
+    trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
+    debug.trim_similar_grad_shift = sl_array_trimmed;
+    printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift");
   }
 
-  bool AvoidanceModule::isSafePath(ShiftedPath & shifted_path, [[maybe_unused]] DebugData & debug)
-    const
+  // - Quantize the shift length to reduce the shift point noise
+  // This is to remove the noise coming from detection accuracy, interpolation, resampling, etc.
   {
-    const auto & p = planner_data_->parameters;
+    const auto THRESHOLD = parameters_->quantize_filter_threshold;
+    quantizeShiftLine(sl_array_trimmed, THRESHOLD);
+    printShiftLines(sl_array_trimmed, "after sl_array_trimmed");
+    debug.quantized = sl_array_trimmed;
+  }
 
-    if (!parameters_->enable_safety_check) {
-      return true;  // if safety check is disabled, it always return safe.
+  // - Change the shift length to the previous one if the deviation is small.
+  {
+    constexpr double SHIFT_DIFF_THRES = 1.0;
+    trimSmallShiftLine(sl_array_trimmed, SHIFT_DIFF_THRES);
+    debug.trim_small_shift = sl_array_trimmed;
+    printShiftLines(sl_array_trimmed, "after trim_small_shift");
+  }
+
+  // - Combine avoid points that have almost same gradient (again)
+  {
+    const auto THRESHOLD = parameters_->same_grad_filter_2_threshold;
+    trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
+    debug.trim_similar_grad_shift_second = sl_array_trimmed;
+    printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
+  }
+
+  // - trimTooSharpShift
+  // Check if it is not too sharp for the return-to-center shift point.
+  // If the shift is sharp, it is combined with the next shift point until it gets non-sharp.
+  {
+    const auto THRESHOLD = parameters_->sharp_shift_filter_threshold;
+    trimSharpReturn(sl_array_trimmed, THRESHOLD);
+    debug.trim_too_sharp_shift = sl_array_trimmed;
+    printShiftLines(sl_array_trimmed, "after trimSharpReturn");
+  }
+
+  // - Combine avoid points that have almost same gradient (again)
+  {
+    const auto THRESHOLD = parameters_->same_grad_filter_3_threshold;
+    trimSimilarGradShiftLine(sl_array_trimmed, THRESHOLD);
+    debug.trim_similar_grad_shift_third = sl_array_trimmed;
+    printShiftLines(sl_array_trimmed, "after trim_similar_grad_shift_second");
+  }
+
+  return sl_array_trimmed;
+}
+
+void AvoidanceModule::quantizeShiftLine(AvoidLineArray & shift_lines, const double threshold) const
+{
+  if (threshold < 1.0e-5) {
+    return;  // no need to process
+  }
+
+  for (auto & sl : shift_lines) {
+    sl.end_shift_length = std::round(sl.end_shift_length / threshold) * threshold;
+  }
+
+  helper_.alignShiftLinesOrder(shift_lines);
+}
+
+void AvoidanceModule::trimSmallShiftLine(AvoidLineArray & shift_lines, const double threshold) const
+{
+  if (shift_lines.empty()) {
+    return;
+  }
+
+  AvoidLineArray input = shift_lines;
+  shift_lines.clear();
+
+  for (const auto & s : input) {
+    if (s.getRelativeLongitudinal() < threshold) {
+      continue;
     }
 
-    const auto ego_predicted_path =
-      utils::avoidance::convertToPredictedPath(shifted_path.path, planner_data_, parameters_);
+    shift_lines.push_back(s);
+  }
+}
 
-    const auto ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
-    const auto is_right_shift = [&]() -> std::optional<bool> {
-      for (size_t i = ego_idx; i < shifted_path.shift_length.size(); i++) {
-        const auto length = shifted_path.shift_length.at(i);
+void AvoidanceModule::trimSimilarGradShiftLine(
+  AvoidLineArray & avoid_lines, const double threshold) const
+{
+  if (avoid_lines.empty()) {
+    return;
+  }
 
-        if (parameters_->lateral_avoid_check_threshold < length) {
-          return false;
-        }
+  AvoidLineArray input = avoid_lines;
+  avoid_lines.clear();
+  avoid_lines.push_back(input.front());  // Take the first one anyway (think later)
 
-        if (parameters_->lateral_avoid_check_threshold < -1.0 * length) {
-          return true;
-        }
+  AvoidLine base_line = input.front();
+
+  AvoidLineArray combine_buffer;
+  combine_buffer.push_back(input.front());
+
+  constexpr auto SHIFT_THR = 1e-3;
+  const auto is_negative_shift = [&](const auto & s) {
+    return s.getRelativeLength() < -1.0 * SHIFT_THR;
+  };
+
+  const auto is_positive_shift = [&](const auto & s) { return s.getRelativeLength() > SHIFT_THR; };
+
+  for (size_t i = 1; i < input.size(); ++i) {
+    AvoidLine combine{};
+
+    utils::avoidance::setStartData(
+      combine, base_line.start_shift_length, base_line.start, base_line.start_idx,
+      base_line.start_longitudinal);
+    utils::avoidance::setEndData(
+      combine, input.at(i).end_shift_length, input.at(i).end, input.at(i).end_idx,
+      input.at(i).end_longitudinal);
+
+    combine_buffer.push_back(input.at(i));
+
+    const auto violates = [&]() {
+      if (is_negative_shift(input.at(i)) && is_positive_shift(base_line)) {
+        return true;
       }
 
-      return std::nullopt;
+      if (is_negative_shift(base_line) && is_positive_shift(input.at(i))) {
+        return true;
+      }
+
+      const auto lon_combine = combine.getRelativeLongitudinal();
+      const auto base_length = base_line.getGradient() * lon_combine;
+      return std::abs(combine.getRelativeLength() - base_length) > threshold;
     }();
 
-    if (!is_right_shift.has_value()) {
-      return true;
+    if (violates) {
+      avoid_lines.push_back(input.at(i));
+      base_line = input.at(i);
+      combine_buffer.clear();
+      combine_buffer.push_back(input.at(i));
+    } else {
+      avoid_lines.back() = combine;
+    }
+  }
+
+  helper_.alignShiftLinesOrder(avoid_lines);
+
+  DEBUG_PRINT("size %lu -> %lu", input.size(), avoid_lines.size());
+}
+
+void AvoidanceModule::trimSharpReturn(AvoidLineArray & shift_lines, const double threshold) const
+{
+  AvoidLineArray shift_lines_orig = shift_lines;
+  shift_lines.clear();
+
+  const auto isZero = [](double v) { return std::abs(v) < 0.01; };
+
+  // check if the shift point is positive (avoiding) shift
+  const auto isPositive = [&](const auto & sl) {
+    constexpr auto POSITIVE_SHIFT_THR = 0.1;
+    return std::abs(sl.end_shift_length) - std::abs(sl.start_shift_length) > POSITIVE_SHIFT_THR;
+  };
+
+  // check if the shift point is negative (returning) shift
+  const auto isNegative = [&](const auto & sl) {
+    constexpr auto NEGATIVE_SHIFT_THR = -0.1;
+    return std::abs(sl.end_shift_length) - std::abs(sl.start_shift_length) < NEGATIVE_SHIFT_THR;
+  };
+
+  // combine two shift points. Be careful the order of "now" and "next".
+  const auto combineShiftLine = [this](const auto & sl_next, const auto & sl_now) {
+    auto sl_modified = sl_now;
+    utils::avoidance::setEndData(
+      sl_modified, sl_next.end_shift_length, sl_next.end, sl_next.end_idx,
+      sl_next.end_longitudinal);
+    sl_modified.parent_ids =
+      utils::avoidance::concatParentIds(sl_modified.parent_ids, sl_now.parent_ids);
+    return sl_modified;
+  };
+
+  // Check if the merged shift has a conflict with the original shifts.
+  const auto hasViolation = [&threshold](const auto & combined, const auto & combined_src) {
+    for (const auto & sl : combined_src) {
+      const auto combined_shift =
+        utils::avoidance::lerpShiftLengthOnArc(sl.end_longitudinal, combined);
+      if (sl.end_shift_length < -0.01 && combined_shift > sl.end_shift_length + threshold) {
+        return true;
+      }
+      if (sl.end_shift_length > 0.01 && combined_shift < sl.end_shift_length - threshold) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // check for all shift points
+  for (size_t i = 0; i < shift_lines_orig.size(); ++i) {
+    auto sl_now = shift_lines_orig.at(i);
+    sl_now.start_shift_length =
+      shift_lines.empty() ? helper_.getEgoLinearShift() : shift_lines.back().end_shift_length;
+
+    if (sl_now.end_shift_length * sl_now.start_shift_length < -0.01) {
+      DEBUG_PRINT("i = %lu, This is avoid shift for opposite direction. take this one", i);
+      continue;
     }
 
-    const auto safety_check_target_objects = utils::avoidance::getSafetyCheckTargetObjects(
-      avoidance_data_, planner_data_, parameters_, is_right_shift.value());
+    // Do nothing for non-reduce shift point
+    if (!isNegative(sl_now)) {
+      shift_lines.push_back(sl_now);
+      DEBUG_PRINT(
+        "i = %lu, positive shift. take this one. sl_now.length * sl_now.start_length = %f", i,
+        sl_now.end_shift_length * sl_now.start_shift_length);
+      continue;
+    }
 
-    for (const auto & object : safety_check_target_objects) {
-      const auto obj_predicted_paths =
-        utils::getPredictedPathFromObj(object, parameters_->check_all_predicted_path);
-      for (const auto & obj_path : obj_predicted_paths) {
-        CollisionCheckDebug collision{};
-        if (!utils::safety_check::checkCollision(
-              shifted_path.path, ego_predicted_path, object, obj_path, p,
-              p.expected_front_deceleration, p.expected_rear_deceleration, collision)) {
-          return false;
+    // The last point is out of target of this function.
+    if (i == shift_lines_orig.size() - 1) {
+      shift_lines.push_back(sl_now);
+      DEBUG_PRINT("i = %lu, last shift. take this one.", i);
+      continue;
+    }
+
+    // -----------------------------------------------------------------------
+    // ------------ From here, the shift point is "negative" -----------------
+    // -----------------------------------------------------------------------
+
+    // if next shift is negative, combine them. loop until combined shift line
+    // exceeds merged shift point.
+    DEBUG_PRINT("i = %lu, found negative dist. search.", i);
+    {
+      auto sl_combined = sl_now;
+      auto sl_combined_prev = sl_combined;
+      AvoidLineArray sl_combined_array{sl_now};
+      size_t j = i + 1;
+      for (; i < shift_lines_orig.size(); ++j) {
+        const auto sl_combined = combineShiftLine(shift_lines_orig.at(j), sl_now);
+
+        {
+          std::stringstream ss;
+          ss << "i = " << i << ", j = " << j << ": sl_combined = " << toStrInfo(sl_combined);
+          DEBUG_PRINT("%s", ss.str().c_str());
         }
+
+        // it gets positive. Finish merging.
+        if (isPositive(sl_combined)) {
+          shift_lines.push_back(sl_combined);
+          DEBUG_PRINT("reach positive.");
+          break;
+        }
+
+        // Still negative, but it violates the original shift points.
+        // Finish with the previous merge result.
+        if (hasViolation(sl_combined, sl_combined_array)) {
+          shift_lines.push_back(sl_combined_prev);
+          DEBUG_PRINT("violation found.");
+          --j;
+          break;
+        }
+
+        // Still negative, but it has an enough long distance. Finish merging.
+        const auto nominal_distance =
+          helper_.getMaxAvoidanceDistance(sl_combined.getRelativeLength());
+        const auto long_distance =
+          isZero(sl_combined.end_shift_length) ? nominal_distance : nominal_distance * 5.0;
+        if (sl_combined.getRelativeLongitudinal() > long_distance) {
+          shift_lines.push_back(sl_combined);
+          DEBUG_PRINT("still negative, but long enough. Threshold = %f", long_distance);
+          break;
+        }
+
+        // It reaches the last point. Still the shift is sharp, but merge with the current result.
+        if (j == shift_lines_orig.size() - 1) {
+          shift_lines.push_back(sl_combined);
+          DEBUG_PRINT("reach end point.");
+          break;
+        }
+
+        // Still negative shift, and the distance is not enough. Search next.
+        sl_combined_prev = sl_combined;
+        sl_combined_array.push_back(shift_lines_orig.at(j));
+      }
+      i = j;
+      continue;
+    }
+  }
+
+  helper_.alignShiftLinesOrder(shift_lines);
+
+  DEBUG_PRINT("trimSharpReturn: size %lu -> %lu", shift_lines_orig.size(), shift_lines.size());
+}
+
+void AvoidanceModule::addReturnShiftLineFromEgo(AvoidLineArray & sl_candidates) const
+{
+  constexpr double ep = 1.0e-3;
+  const auto & data = avoidance_data_;
+  const bool has_candidate_point = !sl_candidates.empty();
+  const bool has_registered_point = !path_shifter_.getShiftLines().empty();
+
+  // If the return-to-center shift points are already registered, do nothing.
+  if (!has_registered_point && std::fabs(getCurrentBaseShift()) < ep) {
+    DEBUG_PRINT("No shift points, not base offset. Do not have to add return-shift.");
+    return;
+  }
+
+  constexpr double RETURN_SHIFT_THRESHOLD = 0.1;
+  DEBUG_PRINT("registered last shift = %f", path_shifter_.getLastShiftLength());
+  if (std::abs(path_shifter_.getLastShiftLength()) < RETURN_SHIFT_THRESHOLD) {
+    DEBUG_PRINT("Return shift is already registered. do nothing.");
+    return;
+  }
+
+  // From here, the return-to-center is not registered. But perhaps the candidate is
+  // already generated.
+
+  // If it has a shift point, add return shift from the existing last shift point.
+  // If not, add return shift from ego point. (prepare distance is considered for both.)
+  ShiftLine last_sl;  // the return-shift will be generated after the last shift point.
+  {
+    // avoidance points: Yes, shift points: No -> select last avoidance point.
+    if (has_candidate_point && !has_registered_point) {
+      helper_.alignShiftLinesOrder(sl_candidates, false);
+      last_sl = sl_candidates.back();
+    }
+
+    // avoidance points: No, shift points: Yes -> select last shift point.
+    if (!has_candidate_point && has_registered_point) {
+      last_sl = utils::avoidance::fillAdditionalInfo(
+        data, AvoidLine{path_shifter_.getLastShiftLine().get()});
+    }
+
+    // avoidance points: Yes, shift points: Yes -> select the last one from both.
+    if (has_candidate_point && has_registered_point) {
+      helper_.alignShiftLinesOrder(sl_candidates, false);
+      const auto & al = sl_candidates.back();
+      const auto & sl = utils::avoidance::fillAdditionalInfo(
+        data, AvoidLine{path_shifter_.getLastShiftLine().get()});
+      last_sl = (sl.end_longitudinal > al.end_longitudinal) ? sl : al;
+    }
+
+    // avoidance points: No, shift points: No -> set the ego position to the last shift point
+    // so that the return-shift will be generated from ego position.
+    if (!has_candidate_point && !has_registered_point) {
+      last_sl.end_idx = avoidance_data_.ego_closest_path_index;
+      last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
+      last_sl.end_shift_length = getCurrentBaseShift();
+    }
+  }
+  printShiftLines(ShiftLineArray{last_sl}, "last shift point");
+
+  // There already is a shift point candidates to go back to center line, but it could be too sharp
+  // due to detection noise or timing.
+  // Here the return-shift from ego is added for the in case.
+  if (std::fabs(last_sl.end_shift_length) < RETURN_SHIFT_THRESHOLD) {
+    const auto current_base_shift = helper_.getEgoShift();
+    if (std::abs(current_base_shift) < ep) {
+      DEBUG_PRINT("last shift almost is zero, and current base_shift is zero. do nothing.");
+      return;
+    }
+
+    // Is there a shift point in the opposite direction of the current_base_shift?
+    //   No  -> we can overwrite the return shift, because the other shift points that decrease
+    //          the shift length are for return-shift.
+    //   Yes -> we can NOT overwrite, because it might be not a return-shift, but a avoiding
+    //          shift to the opposite direction which can not be overwritten by the return-shift.
+    for (const auto & sl : sl_candidates) {
+      if (
+        (current_base_shift > 0.0 && sl.end_shift_length < -ep) ||
+        (current_base_shift < 0.0 && sl.end_shift_length > ep)) {
+        DEBUG_PRINT(
+          "try to put overwrite return shift, but there is shift for opposite direction. Skip "
+          "adding return shift.");
+        return;
       }
     }
 
+    // If return shift already exists in candidate or registered shift lines, skip adding return
+    // shift.
+    if (has_candidate_point || has_registered_point) {
+      return;
+    }
+
+    // set the return-shift from ego.
+    DEBUG_PRINT(
+      "return shift already exists, but they are all candidates. Add return shift for overwrite.");
+    last_sl.end_idx = avoidance_data_.ego_closest_path_index;
+    last_sl.end = avoidance_data_.reference_path.points.at(last_sl.end_idx).point.pose;
+    last_sl.end_shift_length = current_base_shift;
+  }
+
+  const auto & arclength_from_ego = avoidance_data_.arclength_from_ego;
+
+  const auto nominal_prepare_distance = helper_.getNominalPrepareDistance();
+  const auto nominal_avoid_distance = helper_.getMaxAvoidanceDistance(last_sl.end_shift_length);
+
+  if (arclength_from_ego.empty()) {
+    return;
+  }
+
+  const auto remaining_distance = arclength_from_ego.back() - parameters_->remain_buffer_distance;
+
+  // If the avoidance point has already been set, the return shift must be set after the point.
+  const auto last_sl_distance = avoidance_data_.arclength_from_ego.at(last_sl.end_idx);
+
+  // check if there is enough distance for return.
+  if (last_sl_distance > remaining_distance) {  // tmp: add some small number (+1.0)
+    RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 1000, "No enough distance for return.");
+    return;
+  }
+
+  // If the remaining distance is not enough, the return shift needs to be shrunk.
+  // (or another option is just to ignore the return-shift.)
+  // But we do not want to change the last shift point, so we will shrink the distance after
+  // the last shift point.
+  //
+  //  The line "===" is fixed, "---" is scaled.
+  //
+  // [Before Scaling]
+  //  ego              last_sl_end             prepare_end            path_end    avoid_end
+  // ==o====================o----------------------o----------------------o------------o
+  //   |            prepare_dist                   |          avoid_dist               |
+  //
+  // [After Scaling]
+  // ==o====================o------------------o--------------------------o
+  //   |        prepare_dist_scaled            |    avoid_dist_scaled     |
+  //
+  const double variable_prepare_distance =
+    std::max(nominal_prepare_distance - last_sl_distance, 0.0);
+
+  double prepare_distance_scaled = std::max(nominal_prepare_distance, last_sl_distance);
+  double avoid_distance_scaled = nominal_avoid_distance;
+  if (remaining_distance < prepare_distance_scaled + avoid_distance_scaled) {
+    const auto scale = (remaining_distance - last_sl_distance) /
+                       std::max(nominal_avoid_distance + variable_prepare_distance, 0.1);
+    prepare_distance_scaled = last_sl_distance + scale * nominal_prepare_distance;
+    avoid_distance_scaled *= scale;
+    DEBUG_PRINT(
+      "last_sl_distance = %f, nominal_prepare_distance = %f, nominal_avoid_distance = %f, "
+      "remaining_distance = %f, variable_prepare_distance = %f, scale = %f, "
+      "prepare_distance_scaled = %f,avoid_distance_scaled = %f",
+      last_sl_distance, nominal_prepare_distance, nominal_avoid_distance, remaining_distance,
+      variable_prepare_distance, scale, prepare_distance_scaled, avoid_distance_scaled);
+  } else {
+    DEBUG_PRINT("there is enough distance. Use nominal for prepare & avoidance.");
+  }
+
+  // shift point for prepare distance: from last shift to return-start point.
+  if (nominal_prepare_distance > last_sl_distance) {
+    AvoidLine al;
+    al.id = getOriginalShiftLineUniqueId();
+    al.start_idx = last_sl.end_idx;
+    al.start = last_sl.end;
+    al.start_longitudinal = arclength_from_ego.at(al.start_idx);
+    al.end_idx =
+      utils::avoidance::findPathIndexFromArclength(arclength_from_ego, prepare_distance_scaled);
+    al.end = avoidance_data_.reference_path.points.at(al.end_idx).point.pose;
+    al.end_longitudinal = arclength_from_ego.at(al.end_idx);
+    al.end_shift_length = last_sl.end_shift_length;
+    al.start_shift_length = last_sl.end_shift_length;
+    sl_candidates.push_back(al);
+    printShiftLines(AvoidLineArray{al}, "prepare for return");
+    debug_data_.extra_return_shift.push_back(al);
+  }
+
+  // shift point for return to center line
+  {
+    AvoidLine al;
+    al.id = getOriginalShiftLineUniqueId();
+    al.start_idx =
+      utils::avoidance::findPathIndexFromArclength(arclength_from_ego, prepare_distance_scaled);
+    al.start = avoidance_data_.reference_path.points.at(al.start_idx).point.pose;
+    al.start_longitudinal = arclength_from_ego.at(al.start_idx);
+    al.end_idx = utils::avoidance::findPathIndexFromArclength(
+      arclength_from_ego, prepare_distance_scaled + avoid_distance_scaled);
+    al.end = avoidance_data_.reference_path.points.at(al.end_idx).point.pose;
+    al.end_longitudinal = arclength_from_ego.at(al.end_idx);
+    al.end_shift_length = 0.0;
+    al.start_shift_length = last_sl.end_shift_length;
+    sl_candidates.push_back(al);
+    printShiftLines(AvoidLineArray{al}, "return point");
+    debug_data_.extra_return_shift.push_back(al);
+  }
+
+  DEBUG_PRINT("Return Shift is added.");
+}
+
+bool AvoidanceModule::isSafePath(
+  ShiftedPath & shifted_path, [[maybe_unused]] DebugData & debug) const
+{
+  const auto & p = planner_data_->parameters;
+
+  if (!parameters_->enable_safety_check) {
+    return true;  // if safety check is disabled, it always return safe.
+  }
+
+  const auto ego_predicted_path =
+    utils::avoidance::convertToPredictedPath(shifted_path.path, planner_data_, parameters_);
+
+  const auto ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
+  const auto is_right_shift = [&]() -> std::optional<bool> {
+    for (size_t i = ego_idx; i < shifted_path.shift_length.size(); i++) {
+      const auto length = shifted_path.shift_length.at(i);
+
+      if (parameters_->lateral_avoid_check_threshold < length) {
+        return false;
+      }
+
+      if (parameters_->lateral_avoid_check_threshold < -1.0 * length) {
+        return true;
+      }
+    }
+
+    return std::nullopt;
+  }();
+
+  if (!is_right_shift.has_value()) {
     return true;
   }
 
-  void AvoidanceModule::generateExtendedDrivableArea(BehaviorModuleOutput & output) const
-  {
-    const auto has_same_lane =
-      [](const lanelet::ConstLanelets lanes, const lanelet::ConstLanelet & lane) {
-        if (lanes.empty()) return false;
-        const auto has_same = [&](const auto & ll) { return ll.id() == lane.id(); };
-        return std::find_if(lanes.begin(), lanes.end(), has_same) != lanes.end();
-      };
-
-    const auto & route_handler = planner_data_->route_handler;
-    const auto & current_lanes = avoidance_data_.current_lanelets;
-    const auto & enable_opposite = parameters_->use_opposite_lane;
-    std::vector<DrivableLanes> drivable_lanes;
-
-    for (const auto & current_lane : current_lanes) {
-      DrivableLanes current_drivable_lanes;
-      current_drivable_lanes.left_lane = current_lane;
-      current_drivable_lanes.right_lane = current_lane;
-
-      if (!parameters_->use_adjacent_lane) {
-        drivable_lanes.push_back(current_drivable_lanes);
-        continue;
-      }
-
-      // 1. get left/right side lanes
-      const auto update_left_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
-        const auto all_left_lanelets =
-          route_handler->getAllLeftSharedLinestringLanelets(target_lane, enable_opposite, true);
-        if (!all_left_lanelets.empty()) {
-          current_drivable_lanes.left_lane = all_left_lanelets.back();  // leftmost lanelet
-          pushUniqueVector(
-            current_drivable_lanes.middle_lanes,
-            lanelet::ConstLanelets(all_left_lanelets.begin(), all_left_lanelets.end() - 1));
-        }
-      };
-      const auto update_right_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
-        const auto all_right_lanelets =
-          route_handler->getAllRightSharedLinestringLanelets(target_lane, enable_opposite, true);
-        if (!all_right_lanelets.empty()) {
-          current_drivable_lanes.right_lane = all_right_lanelets.back();  // rightmost lanelet
-          pushUniqueVector(
-            current_drivable_lanes.middle_lanes,
-            lanelet::ConstLanelets(all_right_lanelets.begin(), all_right_lanelets.end() - 1));
-        }
-      };
-
-      update_left_lanelets(current_lane);
-      update_right_lanelets(current_lane);
-
-      // 2.1 when there are multiple lanes whose previous lanelet is the same
-      const auto get_next_lanes_from_same_previous_lane =
-        [&route_handler](const lanelet::ConstLanelet & lane) {
-          // get previous lane, and return false if previous lane does not exist
-          lanelet::ConstLanelets prev_lanes;
-          if (!route_handler->getPreviousLaneletsWithinRoute(lane, &prev_lanes)) {
-            return lanelet::ConstLanelets{};
-          }
-
-          lanelet::ConstLanelets next_lanes;
-          for (const auto & prev_lane : prev_lanes) {
-            const auto next_lanes_from_prev = route_handler->getNextLanelets(prev_lane);
-            pushUniqueVector(next_lanes, next_lanes_from_prev);
-          }
-          return next_lanes;
-        };
-
-      const auto next_lanes_for_right =
-        get_next_lanes_from_same_previous_lane(current_drivable_lanes.right_lane);
-      const auto next_lanes_for_left =
-        get_next_lanes_from_same_previous_lane(current_drivable_lanes.left_lane);
-
-      // 2.2 look for neighbor lane recursively, where end line of the lane is connected to end line
-      // of the original lane
-      const auto update_drivable_lanes =
-        [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
-          for (const auto & next_lane : next_lanes) {
-            const auto & edge_lane =
-              is_left ? current_drivable_lanes.left_lane : current_drivable_lanes.right_lane;
-            if (next_lane.id() == edge_lane.id()) {
-              continue;
-            }
-
-            const auto & left_lane = is_left ? next_lane : edge_lane;
-            const auto & right_lane = is_left ? edge_lane : next_lane;
-            if (!isEndPointsConnected(left_lane, right_lane)) {
-              continue;
-            }
-
-            if (is_left) {
-              current_drivable_lanes.left_lane = next_lane;
-            } else {
-              current_drivable_lanes.right_lane = next_lane;
-            }
-
-            if (!has_same_lane(current_drivable_lanes.middle_lanes, edge_lane)) {
-              if (is_left) {
-                if (current_drivable_lanes.right_lane.id() != edge_lane.id()) {
-                  current_drivable_lanes.middle_lanes.push_back(edge_lane);
-                }
-              } else {
-                if (current_drivable_lanes.left_lane.id() != edge_lane.id()) {
-                  current_drivable_lanes.middle_lanes.push_back(edge_lane);
-                }
-              }
-            }
-
-            return true;
-          }
-          return false;
-        };
-
-      const auto expand_drivable_area_recursively =
-        [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
-          // NOTE: set max search num to avoid infinity loop for drivable area expansion
-          constexpr size_t max_recursive_search_num = 3;
-          for (size_t i = 0; i < max_recursive_search_num; ++i) {
-            const bool is_update_kept = update_drivable_lanes(next_lanes, is_left);
-            if (!is_update_kept) {
-              break;
-            }
-            if (i == max_recursive_search_num - 1) {
-              RCLCPP_ERROR(
-                rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
-                "Drivable area expansion reaches max iteration.");
-            }
-          }
-        };
-      expand_drivable_area_recursively(next_lanes_for_right, false);
-      expand_drivable_area_recursively(next_lanes_for_left, true);
-
-      // 3. update again for new left/right lanes
-      update_left_lanelets(current_drivable_lanes.left_lane);
-      update_right_lanelets(current_drivable_lanes.right_lane);
-
-      // 4. compensate that current_lane is in either of left_lane, right_lane or middle_lanes.
-      if (
-        current_drivable_lanes.left_lane.id() != current_lane.id() &&
-        current_drivable_lanes.right_lane.id() != current_lane.id()) {
-        current_drivable_lanes.middle_lanes.push_back(current_lane);
-      }
-
-      drivable_lanes.push_back(current_drivable_lanes);
-    }
-
-    {  // for new architecture
-      DrivableAreaInfo current_drivable_area_info;
-      // generate drivable lanes
-      current_drivable_area_info.drivable_lanes = drivable_lanes;
-      // generate obstacle polygons
-      current_drivable_area_info.obstacles =
-        utils::avoidance::generateObstaclePolygonsForDrivableArea(
-          avoidance_data_.target_objects, parameters_,
-          planner_data_->parameters.vehicle_width / 2.0);
-      // expand hatched road markings
-      current_drivable_area_info.enable_expanding_hatched_road_markings =
-        parameters_->use_hatched_road_markings;
-      // expand intersection areas
-      current_drivable_area_info.enable_expanding_intersection_areas =
-        parameters_->use_intersection_areas;
-
-      output.drivable_area_info = utils::combineDrivableAreaInfo(
-        current_drivable_area_info, getPreviousModuleOutput().drivable_area_info);
-    }
-  }
-
-  PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & original_path) const
-  {
-    // special for avoidance: take behind distance upt ot shift-start-point if it exist.
-    const auto longest_dist_to_shift_point = [&]() {
-      double max_dist = 0.0;
-      for (const auto & pnt : path_shifter_.getShiftLines()) {
-        max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), pnt.start));
-      }
-      for (const auto & sp : registered_raw_shift_lines_) {
-        max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), sp.start));
-      }
-      return max_dist;
-    }();
-
-    const auto extra_margin = 10.0;  // Since distance does not consider arclength, but just line.
-    const auto backward_length = std::max(
-      planner_data_->parameters.backward_path_length, longest_dist_to_shift_point + extra_margin);
-    const auto previous_path = helper_.getPreviousReferencePath();
-
-    const size_t orig_ego_idx = planner_data_->findEgoIndex(original_path.points);
-    const size_t prev_ego_idx = findNearestSegmentIndex(
-      previous_path.points, getPoint(original_path.points.at(orig_ego_idx)));
-
-    size_t clip_idx = 0;
-    for (size_t i = 0; i < prev_ego_idx; ++i) {
-      if (backward_length > calcSignedArcLength(previous_path.points, clip_idx, prev_ego_idx)) {
-        break;
-      }
-      clip_idx = i;
-    }
-
-    PathWithLaneId extended_path{};
-    {
-      extended_path.points.insert(
-        extended_path.points.end(), previous_path.points.begin() + clip_idx,
-        previous_path.points.begin() + prev_ego_idx);
-    }
-
-    // overwrite backward path velocity by latest one.
-    std::for_each(extended_path.points.begin(), extended_path.points.end(), [&](auto & p) {
-      p.point.longitudinal_velocity_mps =
-        original_path.points.at(orig_ego_idx).point.longitudinal_velocity_mps;
-    });
-
-    {
-      extended_path.points.insert(
-        extended_path.points.end(), original_path.points.begin() + orig_ego_idx,
-        original_path.points.end());
-    }
-
-    return extended_path;
-  }
-
-  BehaviorModuleOutput AvoidanceModule::plan()
-  {
-    const auto & data = avoidance_data_;
-
-    resetPathCandidate();
-    resetPathReference();
-
-    updatePathShifter(data.safe_new_sl);
-
-    // generate path with shift points that have been inserted.
-    ShiftedPath linear_shift_path = utils::avoidance::toShiftedPath(data.reference_path);
-    ShiftedPath spline_shift_path = utils::avoidance::toShiftedPath(data.reference_path);
-    const auto success_spline_path_generation =
-      path_shifter_.generate(&spline_shift_path, true, SHIFT_TYPE::SPLINE);
-    const auto success_linear_path_generation =
-      path_shifter_.generate(&linear_shift_path, true, SHIFT_TYPE::LINEAR);
-
-    // set previous data
-    if (success_spline_path_generation && success_linear_path_generation) {
-      helper_.setPreviousLinearShiftPath(linear_shift_path);
-      helper_.setPreviousSplineShiftPath(spline_shift_path);
-      helper_.setPreviousReferencePath(data.reference_path);
-    } else {
-      spline_shift_path = helper_.getPreviousSplineShiftPath();
-    }
-
-    // post processing
-    {
-      postProcess();  // remove old shift points
-    }
-
-    BehaviorModuleOutput output;
-
-    // turn signal info
-    {
-      const auto original_signal = getPreviousModuleOutput().turn_signal_info;
-      const auto new_signal = calcTurnSignalInfo(spline_shift_path);
-      const auto current_seg_idx =
-        planner_data_->findEgoSegmentIndex(spline_shift_path.path.points);
-      output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
-        spline_shift_path.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
-        planner_data_->parameters.ego_nearest_dist_threshold,
-        planner_data_->parameters.ego_nearest_yaw_threshold);
-    }
-
-    // sparse resampling for computational cost
-    {
-      spline_shift_path.path = utils::resamplePathWithSpline(
-        spline_shift_path.path, parameters_->resample_interval_for_output);
-    }
-
-    avoidance_data_.state = updateEgoState(data);
-
-    // update output data
-    {
-      updateEgoBehavior(data, spline_shift_path);
-      updateInfoMarker(avoidance_data_);
-      updateDebugMarker(avoidance_data_, path_shifter_, debug_data_);
-    }
-
-    output.path = std::make_shared<PathWithLaneId>(spline_shift_path.path);
-    output.reference_path = getPreviousModuleOutput().reference_path;
-    path_reference_ = getPreviousModuleOutput().reference_path;
-
-    const size_t ego_idx = planner_data_->findEgoIndex(output.path->points);
-    utils::clipPathLength(*output.path, ego_idx, planner_data_->parameters);
-
-    // Drivable area generation.
-    generateExtendedDrivableArea(output);
-    setDrivableLanes(output.drivable_area_info.drivable_lanes);
-
-    // updateRegisteredRTCStatus(spline_shift_path.path);
-
-    return output;
-  }
-
-  CandidateOutput AvoidanceModule::planCandidate() const
-  {
-    const auto & data = avoidance_data_;
-
-    CandidateOutput output;
-
-    auto shifted_path = data.candidate_path;
-
-    if (!data.safe_new_sl.empty()) {  // clip from shift start index for visualize
-      utils::clipPathLength(
-        shifted_path.path, data.safe_new_sl.front().start_idx, std::numeric_limits<double>::max(),
-        0.0);
-
-      const auto sl = helper_.getMainShiftLine(data.safe_new_sl);
-      const auto sl_front = data.safe_new_sl.front();
-      const auto sl_back = data.safe_new_sl.back();
-
-      output.lateral_shift = helper_.getRelativeShiftToPath(sl);
-      output.start_distance_to_path_change = sl_front.start_longitudinal;
-      output.finish_distance_to_path_change = sl_back.end_longitudinal;
-
-      const uint16_t steering_factor_direction = std::invoke([&output]() {
-        if (output.lateral_shift > 0.0) {
-          return SteeringFactor::LEFT;
-        }
-        return SteeringFactor::RIGHT;
-      });
-      steering_factor_interface_ptr_->updateSteeringFactor(
-        {sl_front.start, sl_back.end},
-        {output.start_distance_to_path_change, output.finish_distance_to_path_change},
-        SteeringFactor::AVOIDANCE_PATH_CHANGE, steering_factor_direction,
-        SteeringFactor::APPROACHING, "");
-    }
-
-    const size_t ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
-    utils::clipPathLength(shifted_path.path, ego_idx, planner_data_->parameters);
-
-    output.path_candidate = shifted_path.path;
-
-    return output;
-  }
-
-  BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
-  {
-    BehaviorModuleOutput out = plan();
-
-    if (path_shifter_.getShiftLines().empty()) {
-      out.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
-    }
-
-    path_candidate_ = std::make_shared<PathWithLaneId>(planCandidate().path_candidate);
-    path_reference_ = getPreviousModuleOutput().reference_path;
-
-    return out;
-  }
-
-  void AvoidanceModule::updatePathShifter(const AvoidLineArray & shift_lines)
-  {
-    if (parameters_->disable_path_update) {
-      return;
-    }
-
-    if (shift_lines.empty()) {
-      return;
-    }
-
-    if (!isActivated()) {
-      return;
-    }
-
-    addNewShiftLines(path_shifter_, shift_lines);
-
-    current_raw_shift_lines_ = avoidance_data_.unapproved_raw_sl;
-
-    registerRawShiftLines(shift_lines);
-
-    const auto sl = helper_.getMainShiftLine(shift_lines);
-    const auto sl_front = shift_lines.front();
-    const auto sl_back = shift_lines.back();
-
-    if (helper_.getRelativeShiftToPath(sl) > 0.0) {
-      left_shift_array_.push_back({uuid_map_.at("left"), sl_front.start, sl_back.end});
-    } else if (helper_.getRelativeShiftToPath(sl) < 0.0) {
-      right_shift_array_.push_back({uuid_map_.at("right"), sl_front.start, sl_back.end});
-    }
-
-    uuid_map_.at("left") = generateUUID();
-    uuid_map_.at("right") = generateUUID();
-    candidate_uuid_ = generateUUID();
-
-    lockNewModuleLaunch();
-  }
-
-  /**
-   * set new shift points. remove old shift points if it has a conflict.
-   */
-  void AvoidanceModule::addNewShiftLines(
-    PathShifter & path_shifter, const AvoidLineArray & new_shift_lines) const
-  {
-    ShiftLineArray future = utils::avoidance::toShiftLineArray(new_shift_lines);
-
-    size_t min_start_idx = std::numeric_limits<size_t>::max();
-    for (const auto & sl : new_shift_lines) {
-      min_start_idx = std::min(min_start_idx, sl.start_idx);
-    }
-
-    const auto current_shift_lines = path_shifter.getShiftLines();
-    const auto front_new_shift_line = new_shift_lines.front();
-    const auto new_shift_length = front_new_shift_line.end_shift_length;
-    const auto new_shift_end_idx = front_new_shift_line.end_idx;
-
-    DEBUG_PRINT("min_start_idx = %lu", min_start_idx);
-
-    // Remove shift points that starts later than the new_shift_line from path_shifter.
-    //
-    // Why? Because shifter sorts by start position and applies shift points, so if there is a
-    // shift point that starts after the one you are going to put in, new one will be affected
-    // by the old one.
-    //
-    // Is it ok? This is a situation where the vehicle was originally going to avoid at the farther
-    // point, but decided to avoid it at a closer point. In this case, it is reasonable to cancel
-    // the farther avoidance.
-    for (const auto & sl : current_shift_lines) {
-      if (sl.start_idx >= min_start_idx) {
-        DEBUG_PRINT(
-          "sl.start_idx = %lu, this sl starts after new proposal. remove this one.", sl.start_idx);
-        continue;
-      }
-
-      if (sl.end_idx >= new_shift_end_idx) {
-        if (
-          sl.end_shift_length > -1e-3 && new_shift_length > -1e-3 &&
-          sl.end_shift_length < new_shift_length) {
-          continue;
-        }
-
-        if (
-          sl.end_shift_length < 1e-3 && new_shift_length < 1e-3 &&
-          sl.end_shift_length > new_shift_length) {
-          continue;
-        }
-      }
-
-      DEBUG_PRINT("sl.start_idx = %lu, no conflict. keep this one.", sl.start_idx);
-      future.push_back(sl);
-    }
-
-    const double road_velocity =
-      avoidance_data_.reference_path.points.at(front_new_shift_line.start_idx)
-        .point.longitudinal_velocity_mps;
-    const double shift_time = PathShifter::calcShiftTimeFromJerk(
-      front_new_shift_line.getRelativeLength(), helper_.getLateralMaxJerkLimit(),
-      helper_.getLateralMaxAccelLimit());
-    const double longitudinal_acc =
-      std::clamp(road_velocity / shift_time, 0.0, parameters_->max_acceleration);
-
-    path_shifter.setShiftLines(future);
-    path_shifter.setVelocity(getEgoSpeed());
-    path_shifter.setLongitudinalAcceleration(longitudinal_acc);
-    path_shifter.setLateralAccelerationLimit(helper_.getLateralMaxAccelLimit());
-  }
-
-  AvoidLineArray AvoidanceModule::findNewShiftLine(const AvoidLineArray & candidates) const
-  {
-    if (candidates.empty()) {
-      return {};
-    }
-
-    // add small shift lines.
-    const auto add_straight_shift =
-      [&, this](auto & subsequent, bool has_large_shift, const size_t start_idx) {
-        for (size_t i = start_idx; i < candidates.size(); ++i) {
-          if (
-            std::abs(candidates.at(i).getRelativeLength()) >
-            parameters_->lateral_small_shift_threshold) {
-            if (has_large_shift) {
-              break;
-            }
-
-            has_large_shift = true;
-          }
-
-          subsequent.push_back(candidates.at(i));
-        }
-      };
-
-    // get subsequent shift lines.
-    const auto get_subsequent_shift = [&, this](size_t i) {
-      AvoidLineArray subsequent{candidates.at(i)};
-
-      if (candidates.size() == i + 1) {
-        return subsequent;
-      }
-
-      if (
-        std::abs(candidates.at(i).getRelativeLength()) <
-        parameters_->lateral_small_shift_threshold) {
-        const auto has_large_shift =
-          candidates.at(i + 1).getRelativeLength() > parameters_->lateral_small_shift_threshold;
-
-        // candidate.at(i) is small length shift line. add large length shift line.
-        subsequent.push_back(candidates.at(i + 1));
-        add_straight_shift(subsequent, has_large_shift, i + 2);
-      } else {
-        // candidate.at(i) is large length shift line. add small length shift lines.
-        add_straight_shift(subsequent, true, i + 1);
-      }
-
-      return subsequent;
-    };
-
-    // check ignore or not.
-    const auto is_ignore_shift = [this](const auto & s) {
-      return std::abs(helper_.getRelativeShiftToPath(s)) < parameters_->lateral_execution_threshold;
-    };
-
-    for (size_t i = 0; i < candidates.size(); ++i) {
-      const auto & candidate = candidates.at(i);
-
-      // new shift points must exist in front of Ego
-      // this value should be larger than -eps consider path shifter calculation error.
-      const double eps = 0.01;
-      if (candidate.start_longitudinal < -eps) {
-        break;
-      }
-
-      if (!is_ignore_shift(candidate)) {
-        return get_subsequent_shift(i);
-      }
-    }
-
-    DEBUG_PRINT("No new shift point exists.");
-    return {};
-  }
-
-  bool AvoidanceModule::isValidShiftLine(
-    const AvoidLineArray & shift_lines, const PathShifter & shifter) const
-  {
-    if (shift_lines.empty()) {
-      return false;
-    }
-
-    auto shifter_for_validate = shifter;
-
-    addNewShiftLines(shifter_for_validate, shift_lines);
-
-    ShiftedPath proposed_shift_path;
-    shifter_for_validate.generate(&proposed_shift_path);
-
-    // check offset between new shift path and ego position.
-    {
-      const auto new_idx = planner_data_->findEgoIndex(proposed_shift_path.path.points);
-      const auto new_shift_length = proposed_shift_path.shift_length.at(new_idx);
-
-      constexpr double THRESHOLD = 0.1;
-      const auto offset = std::abs(new_shift_length - helper_.getEgoShift());
-      if (offset > THRESHOLD) {
-        RCLCPP_WARN_THROTTLE(
-          getLogger(), *clock_, 1000, "new shift line is invalid. [HUGE OFFSET (%.2f)]", offset);
+  const auto safety_check_target_objects = utils::avoidance::getSafetyCheckTargetObjects(
+    avoidance_data_, planner_data_, parameters_, is_right_shift.value());
+
+  for (const auto & object : safety_check_target_objects) {
+    const auto obj_predicted_paths =
+      utils::getPredictedPathFromObj(object, parameters_->check_all_predicted_path);
+    for (const auto & obj_path : obj_predicted_paths) {
+      CollisionCheckDebug collision{};
+      if (!utils::safety_check::checkCollision(
+            shifted_path.path, ego_predicted_path, object, obj_path, p,
+            p.expected_front_deceleration, p.expected_rear_deceleration, collision)) {
         return false;
       }
     }
-
-    debug_data_.proposed_spline_shift = proposed_shift_path.shift_length;
-
-    return true;  // valid shift line.
   }
 
-  void AvoidanceModule::updateData()
-  {
-    using utils::avoidance::toShiftedPath;
+  return true;
+}
 
-    helper_.setData(planner_data_);
+void AvoidanceModule::generateExtendedDrivableArea(BehaviorModuleOutput & output) const
+{
+  const auto has_same_lane =
+    [](const lanelet::ConstLanelets lanes, const lanelet::ConstLanelet & lane) {
+      if (lanes.empty()) return false;
+      const auto has_same = [&](const auto & ll) { return ll.id() == lane.id(); };
+      return std::find_if(lanes.begin(), lanes.end(), has_same) != lanes.end();
+    };
 
-    if (!helper_.isInitialized()) {
-      helper_.setPreviousSplineShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
-      helper_.setPreviousLinearShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
-      helper_.setPreviousReferencePath(*getPreviousModuleOutput().path);
-      helper_.setPreviousDrivingLanes(utils::avoidance::getCurrentLanesFromPath(
-        *getPreviousModuleOutput().reference_path, planner_data_));
+  const auto & route_handler = planner_data_->route_handler;
+  const auto & current_lanes = avoidance_data_.current_lanelets;
+  const auto & enable_opposite = parameters_->use_opposite_lane;
+  std::vector<DrivableLanes> drivable_lanes;
+
+  for (const auto & current_lane : current_lanes) {
+    DrivableLanes current_drivable_lanes;
+    current_drivable_lanes.left_lane = current_lane;
+    current_drivable_lanes.right_lane = current_lane;
+
+    if (!parameters_->use_adjacent_lane) {
+      drivable_lanes.push_back(current_drivable_lanes);
+      continue;
     }
 
-    debug_data_ = DebugData();
-    avoidance_data_ = calcAvoidancePlanningData(debug_data_);
+    // 1. get left/right side lanes
+    const auto update_left_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
+      const auto all_left_lanelets =
+        route_handler->getAllLeftSharedLinestringLanelets(target_lane, enable_opposite, true);
+      if (!all_left_lanelets.empty()) {
+        current_drivable_lanes.left_lane = all_left_lanelets.back();  // leftmost lanelet
+        pushUniqueVector(
+          current_drivable_lanes.middle_lanes,
+          lanelet::ConstLanelets(all_left_lanelets.begin(), all_left_lanelets.end() - 1));
+      }
+    };
+    const auto update_right_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
+      const auto all_right_lanelets =
+        route_handler->getAllRightSharedLinestringLanelets(target_lane, enable_opposite, true);
+      if (!all_right_lanelets.empty()) {
+        current_drivable_lanes.right_lane = all_right_lanelets.back();  // rightmost lanelet
+        pushUniqueVector(
+          current_drivable_lanes.middle_lanes,
+          lanelet::ConstLanelets(all_right_lanelets.begin(), all_right_lanelets.end() - 1));
+      }
+    };
 
-    utils::avoidance::updateRegisteredObject(
-      registered_objects_, avoidance_data_.target_objects, parameters_);
-    utils::avoidance::compensateDetectionLost(
-      registered_objects_, avoidance_data_.target_objects, avoidance_data_.other_objects);
+    update_left_lanelets(current_lane);
+    update_right_lanelets(current_lane);
 
-    std::sort(
-      avoidance_data_.target_objects.begin(), avoidance_data_.target_objects.end(),
-      [](auto a, auto b) { return a.longitudinal < b.longitudinal; });
+    // 2.1 when there are multiple lanes whose previous lanelet is the same
+    const auto get_next_lanes_from_same_previous_lane =
+      [&route_handler](const lanelet::ConstLanelet & lane) {
+        // get previous lane, and return false if previous lane does not exist
+        lanelet::ConstLanelets prev_lanes;
+        if (!route_handler->getPreviousLaneletsWithinRoute(lane, &prev_lanes)) {
+          return lanelet::ConstLanelets{};
+        }
 
-    path_shifter_.setPath(avoidance_data_.reference_path);
+        lanelet::ConstLanelets next_lanes;
+        for (const auto & prev_lane : prev_lanes) {
+          const auto next_lanes_from_prev = route_handler->getNextLanelets(prev_lane);
+          pushUniqueVector(next_lanes, next_lanes_from_prev);
+        }
+        return next_lanes;
+      };
 
-    // update registered shift point for new reference path & remove past objects
-    updateRegisteredRawShiftLines();
+    const auto next_lanes_for_right =
+      get_next_lanes_from_same_previous_lane(current_drivable_lanes.right_lane);
+    const auto next_lanes_for_left =
+      get_next_lanes_from_same_previous_lane(current_drivable_lanes.left_lane);
 
-    fillShiftLine(avoidance_data_, debug_data_);
-    fillEgoStatus(avoidance_data_, debug_data_);
-    fillDebugData(avoidance_data_, debug_data_);
+    // 2.2 look for neighbor lane recursively, where end line of the lane is connected to end line
+    // of the original lane
+    const auto update_drivable_lanes =
+      [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
+        for (const auto & next_lane : next_lanes) {
+          const auto & edge_lane =
+            is_left ? current_drivable_lanes.left_lane : current_drivable_lanes.right_lane;
+          if (next_lane.id() == edge_lane.id()) {
+            continue;
+          }
 
-    updateRTCData();
-  }
+          const auto & left_lane = is_left ? next_lane : edge_lane;
+          const auto & right_lane = is_left ? edge_lane : next_lane;
+          if (!isEndPointsConnected(left_lane, right_lane)) {
+            continue;
+          }
 
-  void AvoidanceModule::processOnEntry()
-  {
-    initVariables();
-  }
+          if (is_left) {
+            current_drivable_lanes.left_lane = next_lane;
+          } else {
+            current_drivable_lanes.right_lane = next_lane;
+          }
 
-  void AvoidanceModule::processOnExit()
-  {
-    initVariables();
-    initRTCStatus();
-  }
+          if (!has_same_lane(current_drivable_lanes.middle_lanes, edge_lane)) {
+            if (is_left) {
+              if (current_drivable_lanes.right_lane.id() != edge_lane.id()) {
+                current_drivable_lanes.middle_lanes.push_back(edge_lane);
+              }
+            } else {
+              if (current_drivable_lanes.left_lane.id() != edge_lane.id()) {
+                current_drivable_lanes.middle_lanes.push_back(edge_lane);
+              }
+            }
+          }
 
-  void AvoidanceModule::initVariables()
-  {
-    helper_.reset();
-    path_shifter_ = PathShifter{};
+          return true;
+        }
+        return false;
+      };
 
-    debug_data_ = DebugData();
-    debug_marker_.markers.clear();
-    resetPathCandidate();
-    resetPathReference();
-    registered_raw_shift_lines_ = {};
-    current_raw_shift_lines_ = {};
-    original_unique_id = 0;
-    is_avoidance_maneuver_starts = false;
-    arrived_path_end_ = false;
-  }
+    const auto expand_drivable_area_recursively =
+      [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
+        // NOTE: set max search num to avoid infinity loop for drivable area expansion
+        constexpr size_t max_recursive_search_num = 3;
+        for (size_t i = 0; i < max_recursive_search_num; ++i) {
+          const bool is_update_kept = update_drivable_lanes(next_lanes, is_left);
+          if (!is_update_kept) {
+            break;
+          }
+          if (i == max_recursive_search_num - 1) {
+            RCLCPP_ERROR(
+              rclcpp::get_logger("behavior_path_planner").get_child("avoidance"),
+              "Drivable area expansion reaches max iteration.");
+          }
+        }
+      };
+    expand_drivable_area_recursively(next_lanes_for_right, false);
+    expand_drivable_area_recursively(next_lanes_for_left, true);
 
-  void AvoidanceModule::initRTCStatus()
-  {
-    removeRTCStatus();
-    clearWaitingApproval();
-    left_shift_array_.clear();
-    right_shift_array_.clear();
-    uuid_map_.at("left") = generateUUID();
-    uuid_map_.at("right") = generateUUID();
-    candidate_uuid_ = generateUUID();
-  }
+    // 3. update again for new left/right lanes
+    update_left_lanelets(current_drivable_lanes.left_lane);
+    update_right_lanelets(current_drivable_lanes.right_lane);
 
-  void AvoidanceModule::updateRTCData()
-  {
-    const auto & data = avoidance_data_;
-
-    updateRegisteredRTCStatus(helper_.getPreviousSplineShiftPath().path);
-
-    if (data.safe_new_sl.empty()) {
-      removeCandidateRTCStatus();
-      return;
+    // 4. compensate that current_lane is in either of left_lane, right_lane or middle_lanes.
+    if (
+      current_drivable_lanes.left_lane.id() != current_lane.id() &&
+      current_drivable_lanes.right_lane.id() != current_lane.id()) {
+      current_drivable_lanes.middle_lanes.push_back(current_lane);
     }
 
-    const auto shift_line = helper_.getMainShiftLine(data.safe_new_sl);
-    if (helper_.getRelativeShiftToPath(shift_line) > 0.0) {
-      removePreviousRTCStatusRight();
-    } else if (helper_.getRelativeShiftToPath(shift_line) < 0.0) {
-      removePreviousRTCStatusLeft();
-    } else {
-      RCLCPP_WARN_STREAM(getLogger(), "Direction is UNKNOWN");
+    drivable_lanes.push_back(current_drivable_lanes);
+  }
+
+  {  // for new architecture
+    DrivableAreaInfo current_drivable_area_info;
+    // generate drivable lanes
+    current_drivable_area_info.drivable_lanes = drivable_lanes;
+    // generate obstacle polygons
+    current_drivable_area_info.obstacles =
+      utils::avoidance::generateObstaclePolygonsForDrivableArea(
+        avoidance_data_.target_objects, parameters_, planner_data_->parameters.vehicle_width / 2.0);
+    // expand hatched road markings
+    current_drivable_area_info.enable_expanding_hatched_road_markings =
+      parameters_->use_hatched_road_markings;
+    // expand intersection areas
+    current_drivable_area_info.enable_expanding_intersection_areas =
+      parameters_->use_intersection_areas;
+
+    output.drivable_area_info = utils::combineDrivableAreaInfo(
+      current_drivable_area_info, getPreviousModuleOutput().drivable_area_info);
+  }
+}
+
+PathWithLaneId AvoidanceModule::extendBackwardLength(const PathWithLaneId & original_path) const
+{
+  // special for avoidance: take behind distance upt ot shift-start-point if it exist.
+  const auto longest_dist_to_shift_point = [&]() {
+    double max_dist = 0.0;
+    for (const auto & pnt : path_shifter_.getShiftLines()) {
+      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), pnt.start));
     }
+    for (const auto & sp : registered_raw_shift_lines_) {
+      max_dist = std::max(max_dist, calcDistance2d(getEgoPose(), sp.start));
+    }
+    return max_dist;
+  }();
 
-    CandidateOutput output;
+  const auto extra_margin = 10.0;  // Since distance does not consider arclength, but just line.
+  const auto backward_length = std::max(
+    planner_data_->parameters.backward_path_length, longest_dist_to_shift_point + extra_margin);
+  const auto previous_path = helper_.getPreviousReferencePath();
 
+  const size_t orig_ego_idx = planner_data_->findEgoIndex(original_path.points);
+  const size_t prev_ego_idx =
+    findNearestSegmentIndex(previous_path.points, getPoint(original_path.points.at(orig_ego_idx)));
+
+  size_t clip_idx = 0;
+  for (size_t i = 0; i < prev_ego_idx; ++i) {
+    if (backward_length > calcSignedArcLength(previous_path.points, clip_idx, prev_ego_idx)) {
+      break;
+    }
+    clip_idx = i;
+  }
+
+  PathWithLaneId extended_path{};
+  {
+    extended_path.points.insert(
+      extended_path.points.end(), previous_path.points.begin() + clip_idx,
+      previous_path.points.begin() + prev_ego_idx);
+  }
+
+  // overwrite backward path velocity by latest one.
+  std::for_each(extended_path.points.begin(), extended_path.points.end(), [&](auto & p) {
+    p.point.longitudinal_velocity_mps =
+      original_path.points.at(orig_ego_idx).point.longitudinal_velocity_mps;
+  });
+
+  {
+    extended_path.points.insert(
+      extended_path.points.end(), original_path.points.begin() + orig_ego_idx,
+      original_path.points.end());
+  }
+
+  return extended_path;
+}
+
+BehaviorModuleOutput AvoidanceModule::plan()
+{
+  const auto & data = avoidance_data_;
+
+  resetPathCandidate();
+  resetPathReference();
+
+  updatePathShifter(data.safe_new_sl);
+
+  // generate path with shift points that have been inserted.
+  ShiftedPath linear_shift_path = utils::avoidance::toShiftedPath(data.reference_path);
+  ShiftedPath spline_shift_path = utils::avoidance::toShiftedPath(data.reference_path);
+  const auto success_spline_path_generation =
+    path_shifter_.generate(&spline_shift_path, true, SHIFT_TYPE::SPLINE);
+  const auto success_linear_path_generation =
+    path_shifter_.generate(&linear_shift_path, true, SHIFT_TYPE::LINEAR);
+
+  // set previous data
+  if (success_spline_path_generation && success_linear_path_generation) {
+    helper_.setPreviousLinearShiftPath(linear_shift_path);
+    helper_.setPreviousSplineShiftPath(spline_shift_path);
+    helper_.setPreviousReferencePath(data.reference_path);
+  } else {
+    spline_shift_path = helper_.getPreviousSplineShiftPath();
+  }
+
+  // post processing
+  {
+    postProcess();  // remove old shift points
+  }
+
+  BehaviorModuleOutput output;
+
+  // turn signal info
+  {
+    const auto original_signal = getPreviousModuleOutput().turn_signal_info;
+    const auto new_signal = calcTurnSignalInfo(spline_shift_path);
+    const auto current_seg_idx = planner_data_->findEgoSegmentIndex(spline_shift_path.path.points);
+    output.turn_signal_info = planner_data_->turn_signal_decider.use_prior_turn_signal(
+      spline_shift_path.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
+      planner_data_->parameters.ego_nearest_dist_threshold,
+      planner_data_->parameters.ego_nearest_yaw_threshold);
+  }
+
+  // sparse resampling for computational cost
+  {
+    spline_shift_path.path = utils::resamplePathWithSpline(
+      spline_shift_path.path, parameters_->resample_interval_for_output);
+  }
+
+  avoidance_data_.state = updateEgoState(data);
+
+  // update output data
+  {
+    updateEgoBehavior(data, spline_shift_path);
+    updateInfoMarker(avoidance_data_);
+    updateDebugMarker(avoidance_data_, path_shifter_, debug_data_);
+  }
+
+  output.path = std::make_shared<PathWithLaneId>(spline_shift_path.path);
+  output.reference_path = getPreviousModuleOutput().reference_path;
+  path_reference_ = getPreviousModuleOutput().reference_path;
+
+  const size_t ego_idx = planner_data_->findEgoIndex(output.path->points);
+  utils::clipPathLength(*output.path, ego_idx, planner_data_->parameters);
+
+  // Drivable area generation.
+  generateExtendedDrivableArea(output);
+  setDrivableLanes(output.drivable_area_info.drivable_lanes);
+
+  // updateRegisteredRTCStatus(spline_shift_path.path);
+
+  return output;
+}
+
+CandidateOutput AvoidanceModule::planCandidate() const
+{
+  const auto & data = avoidance_data_;
+
+  CandidateOutput output;
+
+  auto shifted_path = data.candidate_path;
+
+  if (!data.safe_new_sl.empty()) {  // clip from shift start index for visualize
+    utils::clipPathLength(
+      shifted_path.path, data.safe_new_sl.front().start_idx, std::numeric_limits<double>::max(),
+      0.0);
+
+    const auto sl = helper_.getMainShiftLine(data.safe_new_sl);
     const auto sl_front = data.safe_new_sl.front();
     const auto sl_back = data.safe_new_sl.back();
 
-    output.path_candidate = data.candidate_path.path;
-    output.lateral_shift = helper_.getRelativeShiftToPath(shift_line);
+    output.lateral_shift = helper_.getRelativeShiftToPath(sl);
     output.start_distance_to_path_change = sl_front.start_longitudinal;
     output.finish_distance_to_path_change = sl_back.end_longitudinal;
 
-    updateCandidateRTCStatus(output);
+    const uint16_t steering_factor_direction = std::invoke([&output]() {
+      if (output.lateral_shift > 0.0) {
+        return SteeringFactor::LEFT;
+      }
+      return SteeringFactor::RIGHT;
+    });
+    steering_factor_interface_ptr_->updateSteeringFactor(
+      {sl_front.start, sl_back.end},
+      {output.start_distance_to_path_change, output.finish_distance_to_path_change},
+      SteeringFactor::AVOIDANCE_PATH_CHANGE, steering_factor_direction, SteeringFactor::APPROACHING,
+      "");
   }
 
-  TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) const
-  {
-    const auto shift_lines = path_shifter_.getShiftLines();
-    if (shift_lines.empty()) {
-      return {};
+  const size_t ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
+  utils::clipPathLength(shifted_path.path, ego_idx, planner_data_->parameters);
+
+  output.path_candidate = shifted_path.path;
+
+  return output;
+}
+
+BehaviorModuleOutput AvoidanceModule::planWaitingApproval()
+{
+  BehaviorModuleOutput out = plan();
+
+  if (path_shifter_.getShiftLines().empty()) {
+    out.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
+  }
+
+  path_candidate_ = std::make_shared<PathWithLaneId>(planCandidate().path_candidate);
+  path_reference_ = getPreviousModuleOutput().reference_path;
+
+  return out;
+}
+
+void AvoidanceModule::updatePathShifter(const AvoidLineArray & shift_lines)
+{
+  if (parameters_->disable_path_update) {
+    return;
+  }
+
+  if (shift_lines.empty()) {
+    return;
+  }
+
+  if (!isActivated()) {
+    return;
+  }
+
+  addNewShiftLines(path_shifter_, shift_lines);
+
+  current_raw_shift_lines_ = avoidance_data_.unapproved_raw_sl;
+
+  registerRawShiftLines(shift_lines);
+
+  const auto sl = helper_.getMainShiftLine(shift_lines);
+  const auto sl_front = shift_lines.front();
+  const auto sl_back = shift_lines.back();
+
+  if (helper_.getRelativeShiftToPath(sl) > 0.0) {
+    left_shift_array_.push_back({uuid_map_.at("left"), sl_front.start, sl_back.end});
+  } else if (helper_.getRelativeShiftToPath(sl) < 0.0) {
+    right_shift_array_.push_back({uuid_map_.at("right"), sl_front.start, sl_back.end});
+  }
+
+  uuid_map_.at("left") = generateUUID();
+  uuid_map_.at("right") = generateUUID();
+  candidate_uuid_ = generateUUID();
+
+  lockNewModuleLaunch();
+}
+
+/**
+ * set new shift points. remove old shift points if it has a conflict.
+ */
+void AvoidanceModule::addNewShiftLines(
+  PathShifter & path_shifter, const AvoidLineArray & new_shift_lines) const
+{
+  ShiftLineArray future = utils::avoidance::toShiftLineArray(new_shift_lines);
+
+  size_t min_start_idx = std::numeric_limits<size_t>::max();
+  for (const auto & sl : new_shift_lines) {
+    min_start_idx = std::min(min_start_idx, sl.start_idx);
+  }
+
+  const auto current_shift_lines = path_shifter.getShiftLines();
+  const auto front_new_shift_line = new_shift_lines.front();
+  const auto new_shift_length = front_new_shift_line.end_shift_length;
+  const auto new_shift_end_idx = front_new_shift_line.end_idx;
+
+  DEBUG_PRINT("min_start_idx = %lu", min_start_idx);
+
+  // Remove shift points that starts later than the new_shift_line from path_shifter.
+  //
+  // Why? Because shifter sorts by start position and applies shift points, so if there is a
+  // shift point that starts after the one you are going to put in, new one will be affected
+  // by the old one.
+  //
+  // Is it ok? This is a situation where the vehicle was originally going to avoid at the farther
+  // point, but decided to avoid it at a closer point. In this case, it is reasonable to cancel the
+  // farther avoidance.
+  for (const auto & sl : current_shift_lines) {
+    if (sl.start_idx >= min_start_idx) {
+      DEBUG_PRINT(
+        "sl.start_idx = %lu, this sl starts after new proposal. remove this one.", sl.start_idx);
+      continue;
     }
 
-    const auto front_shift_line = shift_lines.front();
-    const size_t start_idx = front_shift_line.start_idx;
-    const size_t end_idx = front_shift_line.end_idx;
+    if (sl.end_idx >= new_shift_end_idx) {
+      if (
+        sl.end_shift_length > -1e-3 && new_shift_length > -1e-3 &&
+        sl.end_shift_length < new_shift_length) {
+        continue;
+      }
 
-    const auto current_shift_length = helper_.getEgoShift();
-    const double start_shift_length = path.shift_length.at(start_idx);
-    const double end_shift_length = path.shift_length.at(end_idx);
-    const double segment_shift_length = end_shift_length - start_shift_length;
-
-    const double turn_signal_shift_length_threshold =
-      planner_data_->parameters.turn_signal_shift_length_threshold;
-    const double turn_signal_search_time = planner_data_->parameters.turn_signal_search_time;
-    const double turn_signal_minimum_search_distance =
-      planner_data_->parameters.turn_signal_minimum_search_distance;
-
-    // If shift length is shorter than the threshold, it does not need to turn on blinkers
-    if (std::fabs(segment_shift_length) < turn_signal_shift_length_threshold) {
-      return {};
+      if (
+        sl.end_shift_length < 1e-3 && new_shift_length < 1e-3 &&
+        sl.end_shift_length > new_shift_length) {
+        continue;
+      }
     }
 
-    // If the vehicle does not shift anymore, we turn off the blinker
-    if (std::fabs(end_shift_length - current_shift_length) < 0.1) {
-      return {};
-    }
+    DEBUG_PRINT("sl.start_idx = %lu, no conflict. keep this one.", sl.start_idx);
+    future.push_back(sl);
+  }
 
-    // compute blinker start idx and end idx
-    size_t blinker_start_idx = [&]() {
-      for (size_t idx = start_idx; idx <= end_idx; ++idx) {
-        const double current_shift_length = path.shift_length.at(idx);
-        if (current_shift_length > 0.1) {
-          return idx;
+  const double road_velocity =
+    avoidance_data_.reference_path.points.at(front_new_shift_line.start_idx)
+      .point.longitudinal_velocity_mps;
+  const double shift_time = PathShifter::calcShiftTimeFromJerk(
+    front_new_shift_line.getRelativeLength(), helper_.getLateralMaxJerkLimit(),
+    helper_.getLateralMaxAccelLimit());
+  const double longitudinal_acc =
+    std::clamp(road_velocity / shift_time, 0.0, parameters_->max_acceleration);
+
+  path_shifter.setShiftLines(future);
+  path_shifter.setVelocity(getEgoSpeed());
+  path_shifter.setLongitudinalAcceleration(longitudinal_acc);
+  path_shifter.setLateralAccelerationLimit(helper_.getLateralMaxAccelLimit());
+}
+
+AvoidLineArray AvoidanceModule::findNewShiftLine(const AvoidLineArray & candidates) const
+{
+  if (candidates.empty()) {
+    return {};
+  }
+
+  // add small shift lines.
+  const auto add_straight_shift =
+    [&, this](auto & subsequent, bool has_large_shift, const size_t start_idx) {
+      for (size_t i = start_idx; i < candidates.size(); ++i) {
+        if (
+          std::abs(candidates.at(i).getRelativeLength()) >
+          parameters_->lateral_small_shift_threshold) {
+          if (has_large_shift) {
+            break;
+          }
+
+          has_large_shift = true;
         }
+
+        subsequent.push_back(candidates.at(i));
       }
-      return start_idx;
-    }();
-    size_t blinker_end_idx = end_idx;
-
-    // prevent invalid access for out-of-range
-    blinker_start_idx =
-      std::min(std::max(std::size_t(0), blinker_start_idx), path.path.points.size() - 1);
-    blinker_end_idx =
-      std::min(std::max(blinker_start_idx, blinker_end_idx), path.path.points.size() - 1);
-
-    const auto blinker_start_pose = path.path.points.at(blinker_start_idx).point.pose;
-    const auto blinker_end_pose = path.path.points.at(blinker_end_idx).point.pose;
-
-    const double ego_vehicle_offset =
-      planner_data_->parameters.vehicle_info.max_longitudinal_offset_m;
-    const auto signal_prepare_distance =
-      std::max(getEgoSpeed() * turn_signal_search_time, turn_signal_minimum_search_distance);
-    const auto ego_front_to_shift_start =
-      calcSignedArcLength(path.path.points, getEgoPosition(), blinker_start_pose.position) -
-      ego_vehicle_offset;
-
-    if (signal_prepare_distance < ego_front_to_shift_start) {
-      return {};
-    }
-
-    bool turn_signal_on_swerving = planner_data_->parameters.turn_signal_on_swerving;
-
-    TurnSignalInfo turn_signal_info{};
-    if (turn_signal_on_swerving) {
-      if (segment_shift_length > 0.0) {
-        turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
-      } else {
-        turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
-      }
-    } else {
-      turn_signal_info.turn_signal.command = TurnIndicatorsCommand::DISABLE;
-    }
-
-    if (ego_front_to_shift_start > 0.0) {
-      turn_signal_info.desired_start_point = planner_data_->self_odometry->pose.pose;
-    } else {
-      turn_signal_info.desired_start_point = blinker_start_pose;
-    }
-    turn_signal_info.desired_end_point = blinker_end_pose;
-    turn_signal_info.required_start_point = blinker_start_pose;
-    turn_signal_info.required_end_point = blinker_end_pose;
-
-    return turn_signal_info;
-  }
-
-  void AvoidanceModule::updateInfoMarker(const AvoidancePlanningData & data) const
-  {
-    using marker_utils::avoidance_marker::createTargetObjectsMarkerArray;
-
-    info_marker_.markers.clear();
-    appendMarkerArray(
-      createTargetObjectsMarkerArray(data.target_objects, "target_objects"), &info_marker_);
-  }
-
-  void AvoidanceModule::updateDebugMarker(
-    const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug) const
-  {
-    using marker_utils::createLaneletsAreaMarkerArray;
-    using marker_utils::createObjectsMarkerArray;
-    using marker_utils::createPathMarkerArray;
-    using marker_utils::createPoseMarkerArray;
-    using marker_utils::createShiftGradMarkerArray;
-    using marker_utils::createShiftLengthMarkerArray;
-    using marker_utils::createShiftLineMarkerArray;
-    using marker_utils::avoidance_marker::createAvoidLineMarkerArray;
-    using marker_utils::avoidance_marker::createEgoStatusMarkerArray;
-    using marker_utils::avoidance_marker::createOtherObjectsMarkerArray;
-    using marker_utils::avoidance_marker::createOverhangFurthestLineStringMarkerArray;
-    using marker_utils::avoidance_marker::createPredictedVehiclePositions;
-    using marker_utils::avoidance_marker::createSafetyCheckMarkerArray;
-    using marker_utils::avoidance_marker::createUnsafeObjectsMarkerArray;
-    using marker_utils::avoidance_marker::makeOverhangToRoadShoulderMarkerArray;
-    using tier4_autoware_utils::appendMarkerArray;
-
-    debug_marker_.markers.clear();
-
-    if (!parameters_->publish_debug_marker) {
-      return;
-    }
-
-    const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
-
-    const auto add = [this](const MarkerArray & added) {
-      appendMarkerArray(added, &debug_marker_);
     };
 
-    const auto addAvoidLine =
-      [&](const AvoidLineArray & al_arr, const auto & ns, auto r, auto g, auto b, double w = 0.05) {
-        add(createAvoidLineMarkerArray(al_arr, ns, r, g, b, w));
-      };
+  // get subsequent shift lines.
+  const auto get_subsequent_shift = [&, this](size_t i) {
+    AvoidLineArray subsequent{candidates.at(i)};
 
-    const auto addShiftLine =
-      [&](const ShiftLineArray & sl_arr, const auto & ns, auto r, auto g, auto b, double w = 0.1) {
-        add(createShiftLineMarkerArray(sl_arr, shifter.getBaseOffset(), ns, r, g, b, w));
-      };
-
-    add(createEgoStatusMarkerArray(data, getEgoPose(), "ego_status"));
-    add(createPredictedVehiclePositions(
-      debug.path_with_planned_velocity, "predicted_vehicle_positions"));
-
-    const auto & path = data.reference_path;
-    add(createPathMarkerArray(debug.center_line, "centerline", 0, 0.0, 0.5, 0.9));
-    add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
-    add(createPathMarkerArray(
-      helper_.getPreviousLinearShiftPath().path, "prev_linear_shift", 0, 0.5, 0.4, 0.6));
-    add(createPoseMarkerArray(data.reference_pose, "reference_pose", 0, 0.9, 0.3, 0.3));
-
-    add(createSafetyCheckMarkerArray(data.state, getEgoPose(), debug));
-
-    add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
-    add(createLaneletsAreaMarkerArray(*debug.expanded_lanelets, "expanded_lanelet", 0.8, 0.8, 0.0));
-
-    add(createOtherObjectsMarkerArray(
-      data.other_objects, AvoidanceDebugFactor::OBJECT_IS_BEHIND_THRESHOLD));
-    add(createOtherObjectsMarkerArray(
-      data.other_objects, AvoidanceDebugFactor::OBJECT_IS_IN_FRONT_THRESHOLD));
-    add(createOtherObjectsMarkerArray(
-      data.other_objects, AvoidanceDebugFactor::OBJECT_BEHIND_PATH_GOAL));
-    add(createOtherObjectsMarkerArray(
-      data.other_objects, AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE));
-    add(
-      createOtherObjectsMarkerArray(data.other_objects, AvoidanceDebugFactor::OBJECT_IS_NOT_TYPE));
-    add(
-      createOtherObjectsMarkerArray(data.other_objects, AvoidanceDebugFactor::NOT_PARKING_OBJECT));
-    add(createOtherObjectsMarkerArray(data.other_objects, std::string("MovingObject")));
-    add(createOtherObjectsMarkerArray(data.other_objects, std::string("CrosswalkUser")));
-    add(createOtherObjectsMarkerArray(data.other_objects, std::string("OutOfTargetArea")));
-    add(createOtherObjectsMarkerArray(data.other_objects, std::string("NotNeedAvoidance")));
-    add(
-      createOtherObjectsMarkerArray(data.other_objects, std::string("LessThanExecutionThreshold")));
-
-    add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
-    add(createOverhangFurthestLineStringMarkerArray(debug.bounds, "bounds", 1.0, 0.0, 1.0));
-
-    add(createUnsafeObjectsMarkerArray(debug.unsafe_objects, "unsafe_objects"));
-
-    // parent object info
-    addAvoidLine(debug.registered_raw_shift, "p_registered_shift", 0.8, 0.8, 0.0);
-    addAvoidLine(debug.current_raw_shift, "p_current_raw_shift", 0.5, 0.2, 0.2);
-    addAvoidLine(debug.extra_return_shift, "p_extra_return_shift", 0.0, 0.5, 0.8);
-
-    // shift length
-    {
-      const std::string ns = "shift_length";
-      add(createShiftLengthMarkerArray(debug.pos_shift, path, ns + "_pos", 0.0, 0.7, 0.5));
-      add(createShiftLengthMarkerArray(debug.neg_shift, path, ns + "_neg", 0.0, 0.5, 0.7));
-      add(createShiftLengthMarkerArray(debug.total_shift, path, ns + "_total", 0.99, 0.4, 0.2));
+    if (candidates.size() == i + 1) {
+      return subsequent;
     }
 
-    // shift grad
-    {
-      const std::string ns = "shift_grad";
-      add(createShiftGradMarkerArray(
-        debug.pos_shift_grad, debug.pos_shift, path, ns + "_pos", 0.0, 0.7, 0.5));
-      add(createShiftGradMarkerArray(
-        debug.neg_shift_grad, debug.neg_shift, path, ns + "_neg", 0.0, 0.5, 0.7));
-      add(createShiftGradMarkerArray(
-        debug.total_forward_grad, debug.total_shift, path, ns + "_total_forward", 0.99, 0.4, 0.2));
-      add(createShiftGradMarkerArray(
-        debug.total_backward_grad, debug.total_shift, path, ns + "_total_backward", 0.4, 0.2,
-        0.99));
+    if (
+      std::abs(candidates.at(i).getRelativeLength()) < parameters_->lateral_small_shift_threshold) {
+      const auto has_large_shift =
+        candidates.at(i + 1).getRelativeLength() > parameters_->lateral_small_shift_threshold;
+
+      // candidate.at(i) is small length shift line. add large length shift line.
+      subsequent.push_back(candidates.at(i + 1));
+      add_straight_shift(subsequent, has_large_shift, i + 2);
+    } else {
+      // candidate.at(i) is large length shift line. add small length shift lines.
+      add_straight_shift(subsequent, true, i + 1);
     }
 
-    // shift path
-    {
-      const std::string ns = "shift_line";
-      add(createShiftLengthMarkerArray(
-        helper_.getPreviousLinearShiftPath().shift_length, path, ns + "_linear_registered", 0.9,
-        0.3, 0.3));
-      add(createShiftLengthMarkerArray(
-        debug.proposed_spline_shift, path, ns + "_spline_proposed", 1.0, 1.0, 1.0));
+    return subsequent;
+  };
+
+  // check ignore or not.
+  const auto is_ignore_shift = [this](const auto & s) {
+    return std::abs(helper_.getRelativeShiftToPath(s)) < parameters_->lateral_execution_threshold;
+  };
+
+  for (size_t i = 0; i < candidates.size(); ++i) {
+    const auto & candidate = candidates.at(i);
+
+    // new shift points must exist in front of Ego
+    // this value should be larger than -eps consider path shifter calculation error.
+    const double eps = 0.01;
+    if (candidate.start_longitudinal < -eps) {
+      break;
     }
 
-    // child shift points
-    {
-      const std::string ns = "pipeline";
-      add(createAvoidLineMarkerArray(debug.gap_filled, ns + "_1_gap_filled", 0.5, 0.8, 1.0, 0.05));
-      add(createAvoidLineMarkerArray(debug.merged, ns + "_2_merge", 0.345, 0.968, 1.0, 0.05));
-      add(createAvoidLineMarkerArray(
-        debug.trim_similar_grad_shift, ns + "_3_concat_by_grad", 0.976, 0.328, 0.910, 0.05));
-      add(createAvoidLineMarkerArray(
-        debug.quantized, ns + "_4_quantized", 0.505, 0.745, 0.969, 0.05));
-      add(createAvoidLineMarkerArray(
-        debug.trim_small_shift, ns + "_5_trim_small_shift", 0.663, 0.525, 0.941, 0.05));
-      add(createAvoidLineMarkerArray(
-        debug.trim_similar_grad_shift_second, ns + "_6_concat_by_grad", 0.97, 0.32, 0.91, 0.05));
-      add(createAvoidLineMarkerArray(
-        debug.trim_momentary_return, ns + "_7_trim_momentary_return", 0.976, 0.078, 0.878, 0.05));
-      add(createAvoidLineMarkerArray(
-        debug.trim_too_sharp_shift, ns + "_8_trim_sharp_shift", 0.576, 0.0, 0.978, 0.05));
-      add(createAvoidLineMarkerArray(
-        debug.trim_similar_grad_shift_third, ns + "_9_concat_by_grad", 1.0, 0.0, 0.0, 0.05));
+    if (!is_ignore_shift(candidate)) {
+      return get_subsequent_shift(i);
     }
-
-    addShiftLine(shifter.getShiftLines(), "path_shifter_registered_points", 0.99, 0.99, 0.0, 0.5);
-    addAvoidLine(debug.new_shift_lines, "path_shifter_proposed_points", 0.99, 0.0, 0.0, 0.5);
   }
 
-  void AvoidanceModule::updateAvoidanceDebugData(
-    std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const
+  DEBUG_PRINT("No new shift point exists.");
+  return {};
+}
+
+bool AvoidanceModule::isValidShiftLine(
+  const AvoidLineArray & shift_lines, const PathShifter & shifter) const
+{
+  if (shift_lines.empty()) {
+    return false;
+  }
+
+  auto shifter_for_validate = shifter;
+
+  addNewShiftLines(shifter_for_validate, shift_lines);
+
+  ShiftedPath proposed_shift_path;
+  shifter_for_validate.generate(&proposed_shift_path);
+
+  // check offset between new shift path and ego position.
   {
-    debug_data_.avoidance_debug_msg_array.avoidance_info.clear();
-    auto & debug_data_avoidance = debug_data_.avoidance_debug_msg_array.avoidance_info;
-    debug_data_avoidance = avoidance_debug_msg_array;
-    if (!debug_avoidance_initializer_for_shift_line_.empty()) {
-      const bool is_info_old_ =
-        (clock_->now() - debug_avoidance_initializer_for_shift_line_time_).seconds() > 0.1;
-      if (!is_info_old_) {
-        debug_data_avoidance.insert(
-          debug_data_avoidance.end(), debug_avoidance_initializer_for_shift_line_.begin(),
-          debug_avoidance_initializer_for_shift_line_.end());
+    const auto new_idx = planner_data_->findEgoIndex(proposed_shift_path.path.points);
+    const auto new_shift_length = proposed_shift_path.shift_length.at(new_idx);
+
+    constexpr double THRESHOLD = 0.1;
+    const auto offset = std::abs(new_shift_length - helper_.getEgoShift());
+    if (offset > THRESHOLD) {
+      RCLCPP_WARN_THROTTLE(
+        getLogger(), *clock_, 1000, "new shift line is invalid. [HUGE OFFSET (%.2f)]", offset);
+      return false;
+    }
+  }
+
+  debug_data_.proposed_spline_shift = proposed_shift_path.shift_length;
+
+  return true;  // valid shift line.
+}
+
+void AvoidanceModule::updateData()
+{
+  using utils::avoidance::toShiftedPath;
+
+  helper_.setData(planner_data_);
+
+  if (!helper_.isInitialized()) {
+    helper_.setPreviousSplineShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
+    helper_.setPreviousLinearShiftPath(toShiftedPath(*getPreviousModuleOutput().path));
+    helper_.setPreviousReferencePath(*getPreviousModuleOutput().path);
+    helper_.setPreviousDrivingLanes(utils::avoidance::getCurrentLanesFromPath(
+      *getPreviousModuleOutput().reference_path, planner_data_));
+  }
+
+  debug_data_ = DebugData();
+  avoidance_data_ = calcAvoidancePlanningData(debug_data_);
+
+  utils::avoidance::updateRegisteredObject(
+    registered_objects_, avoidance_data_.target_objects, parameters_);
+  utils::avoidance::compensateDetectionLost(
+    registered_objects_, avoidance_data_.target_objects, avoidance_data_.other_objects);
+
+  std::sort(
+    avoidance_data_.target_objects.begin(), avoidance_data_.target_objects.end(),
+    [](auto a, auto b) { return a.longitudinal < b.longitudinal; });
+
+  path_shifter_.setPath(avoidance_data_.reference_path);
+
+  // update registered shift point for new reference path & remove past objects
+  updateRegisteredRawShiftLines();
+
+  fillShiftLine(avoidance_data_, debug_data_);
+  fillEgoStatus(avoidance_data_, debug_data_);
+  fillDebugData(avoidance_data_, debug_data_);
+
+  updateRTCData();
+}
+
+void AvoidanceModule::processOnEntry()
+{
+  initVariables();
+}
+
+void AvoidanceModule::processOnExit()
+{
+  initVariables();
+  initRTCStatus();
+}
+
+void AvoidanceModule::initVariables()
+{
+  helper_.reset();
+  path_shifter_ = PathShifter{};
+
+  debug_data_ = DebugData();
+  debug_marker_.markers.clear();
+  resetPathCandidate();
+  resetPathReference();
+  registered_raw_shift_lines_ = {};
+  current_raw_shift_lines_ = {};
+  original_unique_id = 0;
+  is_avoidance_maneuver_starts = false;
+  arrived_path_end_ = false;
+}
+
+void AvoidanceModule::initRTCStatus()
+{
+  removeRTCStatus();
+  clearWaitingApproval();
+  left_shift_array_.clear();
+  right_shift_array_.clear();
+  uuid_map_.at("left") = generateUUID();
+  uuid_map_.at("right") = generateUUID();
+  candidate_uuid_ = generateUUID();
+}
+
+void AvoidanceModule::updateRTCData()
+{
+  const auto & data = avoidance_data_;
+
+  updateRegisteredRTCStatus(helper_.getPreviousSplineShiftPath().path);
+
+  if (data.safe_new_sl.empty()) {
+    removeCandidateRTCStatus();
+    return;
+  }
+
+  const auto shift_line = helper_.getMainShiftLine(data.safe_new_sl);
+  if (helper_.getRelativeShiftToPath(shift_line) > 0.0) {
+    removePreviousRTCStatusRight();
+  } else if (helper_.getRelativeShiftToPath(shift_line) < 0.0) {
+    removePreviousRTCStatusLeft();
+  } else {
+    RCLCPP_WARN_STREAM(getLogger(), "Direction is UNKNOWN");
+  }
+
+  CandidateOutput output;
+
+  const auto sl_front = data.safe_new_sl.front();
+  const auto sl_back = data.safe_new_sl.back();
+
+  output.path_candidate = data.candidate_path.path;
+  output.lateral_shift = helper_.getRelativeShiftToPath(shift_line);
+  output.start_distance_to_path_change = sl_front.start_longitudinal;
+  output.finish_distance_to_path_change = sl_back.end_longitudinal;
+
+  updateCandidateRTCStatus(output);
+}
+
+TurnSignalInfo AvoidanceModule::calcTurnSignalInfo(const ShiftedPath & path) const
+{
+  const auto shift_lines = path_shifter_.getShiftLines();
+  if (shift_lines.empty()) {
+    return {};
+  }
+
+  const auto front_shift_line = shift_lines.front();
+  const size_t start_idx = front_shift_line.start_idx;
+  const size_t end_idx = front_shift_line.end_idx;
+
+  const auto current_shift_length = helper_.getEgoShift();
+  const double start_shift_length = path.shift_length.at(start_idx);
+  const double end_shift_length = path.shift_length.at(end_idx);
+  const double segment_shift_length = end_shift_length - start_shift_length;
+
+  const double turn_signal_shift_length_threshold =
+    planner_data_->parameters.turn_signal_shift_length_threshold;
+  const double turn_signal_search_time = planner_data_->parameters.turn_signal_search_time;
+  const double turn_signal_minimum_search_distance =
+    planner_data_->parameters.turn_signal_minimum_search_distance;
+
+  // If shift length is shorter than the threshold, it does not need to turn on blinkers
+  if (std::fabs(segment_shift_length) < turn_signal_shift_length_threshold) {
+    return {};
+  }
+
+  // If the vehicle does not shift anymore, we turn off the blinker
+  if (std::fabs(end_shift_length - current_shift_length) < 0.1) {
+    return {};
+  }
+
+  // compute blinker start idx and end idx
+  size_t blinker_start_idx = [&]() {
+    for (size_t idx = start_idx; idx <= end_idx; ++idx) {
+      const double current_shift_length = path.shift_length.at(idx);
+      if (current_shift_length > 0.1) {
+        return idx;
       }
     }
+    return start_idx;
+  }();
+  size_t blinker_end_idx = end_idx;
+
+  // prevent invalid access for out-of-range
+  blinker_start_idx =
+    std::min(std::max(std::size_t(0), blinker_start_idx), path.path.points.size() - 1);
+  blinker_end_idx =
+    std::min(std::max(blinker_start_idx, blinker_end_idx), path.path.points.size() - 1);
+
+  const auto blinker_start_pose = path.path.points.at(blinker_start_idx).point.pose;
+  const auto blinker_end_pose = path.path.points.at(blinker_end_idx).point.pose;
+
+  const double ego_vehicle_offset =
+    planner_data_->parameters.vehicle_info.max_longitudinal_offset_m;
+  const auto signal_prepare_distance =
+    std::max(getEgoSpeed() * turn_signal_search_time, turn_signal_minimum_search_distance);
+  const auto ego_front_to_shift_start =
+    calcSignedArcLength(path.path.points, getEgoPosition(), blinker_start_pose.position) -
+    ego_vehicle_offset;
+
+  if (signal_prepare_distance < ego_front_to_shift_start) {
+    return {};
   }
 
-  double AvoidanceModule::calcDistanceToStopLine(const ObjectData & object) const
-  {
-    const auto & p = parameters_;
-    const auto & base_link2front = planner_data_->parameters.base_link2front;
-    const auto & vehicle_width = planner_data_->parameters.vehicle_width;
+  bool turn_signal_on_swerving = planner_data_->parameters.turn_signal_on_swerving;
 
-    //         D5
-    //      |<---->|                               D4
-    //      |<----------------------------------------------------------------------->|
-    // +-----------+            D1                 D2                      D3         +-----------+
-    // |           |        |<------->|<------------------------->|<----------------->|           |
-    // |    ego    |======= x ======= x ========================= x ==================|    obj    |
-    // |           |    stop_point  avoid                       avoid                 |           |
-    // +-----------+                start                        end                  +-----------+
-    //
-    // D1: p.min_prepare_distance
-    // D2: min_avoid_distance
-    // D3: longitudinal_avoid_margin_front (margin + D5)
-    // D4: o_front.longitudinal
-    // D5: base_link2front
-
-    const auto object_type = utils::getHighestProbLabel(object.object.classification);
-    const auto object_parameter = parameters_->object_parameters.at(object_type);
-
-    const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
-                              object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
-    const auto variable = helper_.getMinAvoidanceDistance(
-      helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin));
-    const auto constant = p->min_prepare_distance + object_parameter.safety_buffer_longitudinal +
-                          base_link2front + p->stop_buffer;
-
-    return object.longitudinal - std::min(variable + constant, p->stop_max_distance);
+  TurnSignalInfo turn_signal_info{};
+  if (turn_signal_on_swerving) {
+    if (segment_shift_length > 0.0) {
+      turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+    } else {
+      turn_signal_info.turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
+    }
+  } else {
+    turn_signal_info.turn_signal.command = TurnIndicatorsCommand::DISABLE;
   }
 
-  void AvoidanceModule::insertWaitPoint(
-    const bool use_constraints_for_decel, ShiftedPath & shifted_path) const
+  if (ego_front_to_shift_start > 0.0) {
+    turn_signal_info.desired_start_point = planner_data_->self_odometry->pose.pose;
+  } else {
+    turn_signal_info.desired_start_point = blinker_start_pose;
+  }
+  turn_signal_info.desired_end_point = blinker_end_pose;
+  turn_signal_info.required_start_point = blinker_start_pose;
+  turn_signal_info.required_end_point = blinker_end_pose;
+
+  return turn_signal_info;
+}
+
+void AvoidanceModule::updateInfoMarker(const AvoidancePlanningData & data) const
+{
+  using marker_utils::avoidance_marker::createTargetObjectsMarkerArray;
+
+  info_marker_.markers.clear();
+  appendMarkerArray(
+    createTargetObjectsMarkerArray(data.target_objects, "target_objects"), &info_marker_);
+}
+
+void AvoidanceModule::updateDebugMarker(
+  const AvoidancePlanningData & data, const PathShifter & shifter, const DebugData & debug) const
+{
+  using marker_utils::createLaneletsAreaMarkerArray;
+  using marker_utils::createObjectsMarkerArray;
+  using marker_utils::createPathMarkerArray;
+  using marker_utils::createPoseMarkerArray;
+  using marker_utils::createShiftGradMarkerArray;
+  using marker_utils::createShiftLengthMarkerArray;
+  using marker_utils::createShiftLineMarkerArray;
+  using marker_utils::avoidance_marker::createAvoidLineMarkerArray;
+  using marker_utils::avoidance_marker::createEgoStatusMarkerArray;
+  using marker_utils::avoidance_marker::createOtherObjectsMarkerArray;
+  using marker_utils::avoidance_marker::createOverhangFurthestLineStringMarkerArray;
+  using marker_utils::avoidance_marker::createPredictedVehiclePositions;
+  using marker_utils::avoidance_marker::createSafetyCheckMarkerArray;
+  using marker_utils::avoidance_marker::createUnsafeObjectsMarkerArray;
+  using marker_utils::avoidance_marker::makeOverhangToRoadShoulderMarkerArray;
+  using tier4_autoware_utils::appendMarkerArray;
+
+  debug_marker_.markers.clear();
+
+  if (!parameters_->publish_debug_marker) {
+    return;
+  }
+
+  const auto current_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+
+  const auto add = [this](const MarkerArray & added) { appendMarkerArray(added, &debug_marker_); };
+
+  const auto addAvoidLine =
+    [&](const AvoidLineArray & al_arr, const auto & ns, auto r, auto g, auto b, double w = 0.05) {
+      add(createAvoidLineMarkerArray(al_arr, ns, r, g, b, w));
+    };
+
+  const auto addShiftLine =
+    [&](const ShiftLineArray & sl_arr, const auto & ns, auto r, auto g, auto b, double w = 0.1) {
+      add(createShiftLineMarkerArray(sl_arr, shifter.getBaseOffset(), ns, r, g, b, w));
+    };
+
+  add(createEgoStatusMarkerArray(data, getEgoPose(), "ego_status"));
+  add(createPredictedVehiclePositions(
+    debug.path_with_planned_velocity, "predicted_vehicle_positions"));
+
+  const auto & path = data.reference_path;
+  add(createPathMarkerArray(debug.center_line, "centerline", 0, 0.0, 0.5, 0.9));
+  add(createPathMarkerArray(path, "centerline_resampled", 0, 0.0, 0.9, 0.5));
+  add(createPathMarkerArray(
+    helper_.getPreviousLinearShiftPath().path, "prev_linear_shift", 0, 0.5, 0.4, 0.6));
+  add(createPoseMarkerArray(data.reference_pose, "reference_pose", 0, 0.9, 0.3, 0.3));
+
+  add(createSafetyCheckMarkerArray(data.state, getEgoPose(), debug));
+
+  add(createLaneletsAreaMarkerArray(*debug.current_lanelets, "current_lanelet", 0.0, 1.0, 0.0));
+  add(createLaneletsAreaMarkerArray(*debug.expanded_lanelets, "expanded_lanelet", 0.8, 0.8, 0.0));
+
+  add(createOtherObjectsMarkerArray(
+    data.other_objects, AvoidanceDebugFactor::OBJECT_IS_BEHIND_THRESHOLD));
+  add(createOtherObjectsMarkerArray(
+    data.other_objects, AvoidanceDebugFactor::OBJECT_IS_IN_FRONT_THRESHOLD));
+  add(createOtherObjectsMarkerArray(
+    data.other_objects, AvoidanceDebugFactor::OBJECT_BEHIND_PATH_GOAL));
+  add(createOtherObjectsMarkerArray(
+    data.other_objects, AvoidanceDebugFactor::TOO_NEAR_TO_CENTERLINE));
+  add(createOtherObjectsMarkerArray(data.other_objects, AvoidanceDebugFactor::OBJECT_IS_NOT_TYPE));
+  add(createOtherObjectsMarkerArray(data.other_objects, AvoidanceDebugFactor::NOT_PARKING_OBJECT));
+  add(createOtherObjectsMarkerArray(data.other_objects, std::string("MovingObject")));
+  add(createOtherObjectsMarkerArray(data.other_objects, std::string("CrosswalkUser")));
+  add(createOtherObjectsMarkerArray(data.other_objects, std::string("OutOfTargetArea")));
+  add(createOtherObjectsMarkerArray(data.other_objects, std::string("NotNeedAvoidance")));
+  add(createOtherObjectsMarkerArray(data.other_objects, std::string("LessThanExecutionThreshold")));
+
+  add(makeOverhangToRoadShoulderMarkerArray(data.target_objects, "overhang"));
+  add(createOverhangFurthestLineStringMarkerArray(debug.bounds, "bounds", 1.0, 0.0, 1.0));
+
+  add(createUnsafeObjectsMarkerArray(debug.unsafe_objects, "unsafe_objects"));
+
+  // parent object info
+  addAvoidLine(debug.registered_raw_shift, "p_registered_shift", 0.8, 0.8, 0.0);
+  addAvoidLine(debug.current_raw_shift, "p_current_raw_shift", 0.5, 0.2, 0.2);
+  addAvoidLine(debug.extra_return_shift, "p_extra_return_shift", 0.0, 0.5, 0.8);
+
+  // shift length
   {
-    const auto & data = avoidance_data_;
+    const std::string ns = "shift_length";
+    add(createShiftLengthMarkerArray(debug.pos_shift, path, ns + "_pos", 0.0, 0.7, 0.5));
+    add(createShiftLengthMarkerArray(debug.neg_shift, path, ns + "_neg", 0.0, 0.5, 0.7));
+    add(createShiftLengthMarkerArray(debug.total_shift, path, ns + "_total", 0.99, 0.4, 0.2));
+  }
 
-    if (!data.stop_target_object) {
-      return;
+  // shift grad
+  {
+    const std::string ns = "shift_grad";
+    add(createShiftGradMarkerArray(
+      debug.pos_shift_grad, debug.pos_shift, path, ns + "_pos", 0.0, 0.7, 0.5));
+    add(createShiftGradMarkerArray(
+      debug.neg_shift_grad, debug.neg_shift, path, ns + "_neg", 0.0, 0.5, 0.7));
+    add(createShiftGradMarkerArray(
+      debug.total_forward_grad, debug.total_shift, path, ns + "_total_forward", 0.99, 0.4, 0.2));
+    add(createShiftGradMarkerArray(
+      debug.total_backward_grad, debug.total_shift, path, ns + "_total_backward", 0.4, 0.2, 0.99));
+  }
+
+  // shift path
+  {
+    const std::string ns = "shift_line";
+    add(createShiftLengthMarkerArray(
+      helper_.getPreviousLinearShiftPath().shift_length, path, ns + "_linear_registered", 0.9, 0.3,
+      0.3));
+    add(createShiftLengthMarkerArray(
+      debug.proposed_spline_shift, path, ns + "_spline_proposed", 1.0, 1.0, 1.0));
+  }
+
+  // child shift points
+  {
+    const std::string ns = "pipeline";
+    add(createAvoidLineMarkerArray(debug.gap_filled, ns + "_1_gap_filled", 0.5, 0.8, 1.0, 0.05));
+    add(createAvoidLineMarkerArray(debug.merged, ns + "_2_merge", 0.345, 0.968, 1.0, 0.05));
+    add(createAvoidLineMarkerArray(
+      debug.trim_similar_grad_shift, ns + "_3_concat_by_grad", 0.976, 0.328, 0.910, 0.05));
+    add(
+      createAvoidLineMarkerArray(debug.quantized, ns + "_4_quantized", 0.505, 0.745, 0.969, 0.05));
+    add(createAvoidLineMarkerArray(
+      debug.trim_small_shift, ns + "_5_trim_small_shift", 0.663, 0.525, 0.941, 0.05));
+    add(createAvoidLineMarkerArray(
+      debug.trim_similar_grad_shift_second, ns + "_6_concat_by_grad", 0.97, 0.32, 0.91, 0.05));
+    add(createAvoidLineMarkerArray(
+      debug.trim_momentary_return, ns + "_7_trim_momentary_return", 0.976, 0.078, 0.878, 0.05));
+    add(createAvoidLineMarkerArray(
+      debug.trim_too_sharp_shift, ns + "_8_trim_sharp_shift", 0.576, 0.0, 0.978, 0.05));
+    add(createAvoidLineMarkerArray(
+      debug.trim_similar_grad_shift_third, ns + "_9_concat_by_grad", 1.0, 0.0, 0.0, 0.05));
+  }
+
+  addShiftLine(shifter.getShiftLines(), "path_shifter_registered_points", 0.99, 0.99, 0.0, 0.5);
+  addAvoidLine(debug.new_shift_lines, "path_shifter_proposed_points", 0.99, 0.0, 0.0, 0.5);
+}
+
+void AvoidanceModule::updateAvoidanceDebugData(
+  std::vector<AvoidanceDebugMsg> & avoidance_debug_msg_array) const
+{
+  debug_data_.avoidance_debug_msg_array.avoidance_info.clear();
+  auto & debug_data_avoidance = debug_data_.avoidance_debug_msg_array.avoidance_info;
+  debug_data_avoidance = avoidance_debug_msg_array;
+  if (!debug_avoidance_initializer_for_shift_line_.empty()) {
+    const bool is_info_old_ =
+      (clock_->now() - debug_avoidance_initializer_for_shift_line_time_).seconds() > 0.1;
+    if (!is_info_old_) {
+      debug_data_avoidance.insert(
+        debug_data_avoidance.end(), debug_avoidance_initializer_for_shift_line_.begin(),
+        debug_avoidance_initializer_for_shift_line_.end());
+    }
+  }
+}
+
+double AvoidanceModule::calcDistanceToStopLine(const ObjectData & object) const
+{
+  const auto & p = parameters_;
+  const auto & base_link2front = planner_data_->parameters.base_link2front;
+  const auto & vehicle_width = planner_data_->parameters.vehicle_width;
+
+  //         D5
+  //      |<---->|                               D4
+  //      |<----------------------------------------------------------------------->|
+  // +-----------+            D1                 D2                      D3         +-----------+
+  // |           |        |<------->|<------------------------->|<----------------->|           |
+  // |    ego    |======= x ======= x ========================= x ==================|    obj    |
+  // |           |    stop_point  avoid                       avoid                 |           |
+  // +-----------+                start                        end                  +-----------+
+  //
+  // D1: p.min_prepare_distance
+  // D2: min_avoid_distance
+  // D3: longitudinal_avoid_margin_front (margin + D5)
+  // D4: o_front.longitudinal
+  // D5: base_link2front
+
+  const auto object_type = utils::getHighestProbLabel(object.object.classification);
+  const auto object_parameter = parameters_->object_parameters.at(object_type);
+
+  const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
+                            object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
+  const auto variable = helper_.getMinAvoidanceDistance(
+    helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin));
+  const auto constant = p->min_prepare_distance + object_parameter.safety_buffer_longitudinal +
+                        base_link2front + p->stop_buffer;
+
+  return object.longitudinal - std::min(variable + constant, p->stop_max_distance);
+}
+
+void AvoidanceModule::insertWaitPoint(
+  const bool use_constraints_for_decel, ShiftedPath & shifted_path) const
+{
+  const auto & data = avoidance_data_;
+
+  if (!data.stop_target_object) {
+    return;
+  }
+
+  if (helper_.isShifted()) {
+    return;
+  }
+
+  // If we don't need to consider deceleration constraints, insert a deceleration point
+  // and return immediately
+  if (!use_constraints_for_decel) {
+    utils::avoidance::insertDecelPoint(
+      getEgoPosition(), data.to_stop_line, 0.0, shifted_path.path, stop_pose_);
+    return;
+  }
+
+  // If the stop distance is not enough for comfortable stop, don't insert wait point.
+  const auto is_comfortable_stop = helper_.getFeasibleDecelDistance(0.0) < data.to_stop_line;
+  const auto is_slow_speed = getEgoSpeed() < parameters_->min_slow_down_speed;
+  if (!is_comfortable_stop && !is_slow_speed) {
+    RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 500, "not execute uncomfortable deceleration.");
+    return;
+  }
+
+  // If target object can be stopped for, insert a deceleration point and return
+  if (data.stop_target_object.get().is_stoppable) {
+    utils::avoidance::insertDecelPoint(
+      getEgoPosition(), data.to_stop_line, 0.0, shifted_path.path, stop_pose_);
+    return;
+  }
+
+  // If the object cannot be stopped for, calculate a "mild" deceleration distance
+  // and insert a deceleration point at that distance
+  const auto stop_distance = helper_.getFeasibleDecelDistance(0.0, false);
+  utils::avoidance::insertDecelPoint(
+    getEgoPosition(), stop_distance, 0.0, shifted_path.path, stop_pose_);
+}
+
+void AvoidanceModule::insertStopPoint(
+  const bool use_constraints_for_decel, ShiftedPath & shifted_path) const
+{
+  const auto & data = avoidance_data_;
+
+  if (data.safe) {
+    return;
+  }
+
+  if (!parameters_->enable_yield_maneuver_during_shifting) {
+    return;
+  }
+
+  const auto stop_idx = [&]() {
+    const auto ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
+    for (size_t idx = ego_idx; idx < shifted_path.path.points.size(); ++idx) {
+      const auto & estimated_pose = shifted_path.path.points.at(idx).point.pose;
+      if (!utils::isEgoWithinOriginalLane(
+            data.current_lanelets, estimated_pose, planner_data_->parameters)) {
+        return idx - 1;
+      }
     }
 
-    if (helper_.isShifted()) {
-      return;
-    }
+    return shifted_path.path.points.size() - 1;
+  }();
 
-    // If we don't need to consider deceleration constraints, insert a deceleration point
-    // and return immediately
-    if (!use_constraints_for_decel) {
-      utils::avoidance::insertDecelPoint(
-        getEgoPosition(), data.to_stop_line, 0.0, shifted_path.path, stop_pose_);
-      return;
-    }
+  const auto stop_distance =
+    calcSignedArcLength(shifted_path.path.points, getEgoPosition(), stop_idx);
 
-    // If the stop distance is not enough for comfortable stop, don't insert wait point.
-    const auto is_comfortable_stop = helper_.getFeasibleDecelDistance(0.0) < data.to_stop_line;
-    const auto is_slow_speed = getEgoSpeed() < parameters_->min_slow_down_speed;
-    if (!is_comfortable_stop && !is_slow_speed) {
-      RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 500, "not execute uncomfortable deceleration.");
-      return;
-    }
-
-    // If target object can be stopped for, insert a deceleration point and return
-    if (data.stop_target_object.get().is_stoppable) {
-      utils::avoidance::insertDecelPoint(
-        getEgoPosition(), data.to_stop_line, 0.0, shifted_path.path, stop_pose_);
-      return;
-    }
-
-    // If the object cannot be stopped for, calculate a "mild" deceleration distance
-    // and insert a deceleration point at that distance
-    const auto stop_distance = helper_.getFeasibleDecelDistance(0.0, false);
+  // If we don't need to consider deceleration constraints, insert a deceleration point
+  // and return immediately
+  if (!use_constraints_for_decel) {
     utils::avoidance::insertDecelPoint(
       getEgoPosition(), stop_distance, 0.0, shifted_path.path, stop_pose_);
+    return;
   }
 
-  void AvoidanceModule::insertStopPoint(
-    const bool use_constraints_for_decel, ShiftedPath & shifted_path) const
-  {
-    const auto & data = avoidance_data_;
+  // Otherwise, consider deceleration constraints before inserting deceleration point
+  const auto decel_distance = helper_.getFeasibleDecelDistance(0.0, false);
+  if (stop_distance < decel_distance) {
+    return;
+  }
 
-    if (data.safe) {
-      return;
-    }
+  constexpr double MARGIN = 1.0;
+  utils::avoidance::insertDecelPoint(
+    getEgoPosition(), stop_distance - MARGIN, 0.0, shifted_path.path, stop_pose_);
+}
 
-    if (!parameters_->enable_yield_maneuver_during_shifting) {
-      return;
-    }
+void AvoidanceModule::insertYieldVelocity(ShiftedPath & shifted_path) const
+{
+  const auto & p = parameters_;
+  const auto & data = avoidance_data_;
 
-    const auto stop_idx = [&]() {
-      const auto ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
-      for (size_t idx = ego_idx; idx < shifted_path.path.points.size(); ++idx) {
-        const auto & estimated_pose = shifted_path.path.points.at(idx).point.pose;
-        if (!utils::isEgoWithinOriginalLane(
-              data.current_lanelets, estimated_pose, planner_data_->parameters)) {
-          return idx - 1;
-        }
-      }
+  if (data.target_objects.empty()) {
+    return;
+  }
 
-      return shifted_path.path.points.size() - 1;
-    }();
+  if (helper_.isShifted()) {
+    return;
+  }
 
-    const auto stop_distance =
-      calcSignedArcLength(shifted_path.path.points, getEgoPosition(), stop_idx);
+  const auto decel_distance = helper_.getFeasibleDecelDistance(p->yield_velocity, false);
+  utils::avoidance::insertDecelPoint(
+    getEgoPosition(), decel_distance, p->yield_velocity, shifted_path.path, slow_pose_);
+}
 
-    // If we don't need to consider deceleration constraints, insert a deceleration point
-    // and return immediately
-    if (!use_constraints_for_decel) {
-      utils::avoidance::insertDecelPoint(
-        getEgoPosition(), stop_distance, 0.0, shifted_path.path, stop_pose_);
-      return;
-    }
+void AvoidanceModule::insertPrepareVelocity(ShiftedPath & shifted_path) const
+{
+  const auto & data = avoidance_data_;
 
-    // Otherwise, consider deceleration constraints before inserting deceleration point
-    const auto decel_distance = helper_.getFeasibleDecelDistance(0.0, false);
-    if (stop_distance < decel_distance) {
-      return;
-    }
+  // do nothing if there is no avoidance target.
+  if (data.target_objects.empty()) {
+    return;
+  }
 
-    constexpr double MARGIN = 1.0;
+  // insert slow down speed only when the avoidance maneuver is not initiated.
+  if (helper_.isShifted()) {
+    return;
+  }
+
+  // insert slow down speed only when no shift line is approved.
+  if (!path_shifter_.getShiftLines().empty()) {
+    return;
+  }
+
+  const auto object = data.target_objects.front();
+
+  // calculate shift length for front object.
+  const auto & vehicle_width = planner_data_->parameters.vehicle_width;
+  const auto object_type = utils::getHighestProbLabel(object.object.classification);
+  const auto object_parameter = parameters_->object_parameters.at(object_type);
+  const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
+                            object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
+  const auto shift_length =
+    helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin);
+
+  // check slow down feasibility
+  const auto min_avoid_distance = helper_.getMinAvoidanceDistance(shift_length);
+  const auto distance_to_object = object.longitudinal;
+  const auto remaining_distance = distance_to_object - min_avoid_distance;
+  const auto decel_distance = helper_.getFeasibleDecelDistance(parameters_->velocity_map.front());
+  if (remaining_distance < decel_distance) {
+    return;
+  }
+
+  // decide slow down lower limit.
+  const auto lower_speed = object.avoid_required ? 0.0 : parameters_->min_slow_down_speed;
+
+  // insert slow down speed.
+  const double current_target_velocity = PathShifter::calcFeasibleVelocityFromJerk(
+    shift_length, helper_.getLateralMinJerkLimit(), distance_to_object);
+  if (current_target_velocity < getEgoSpeed() && decel_distance < remaining_distance) {
     utils::avoidance::insertDecelPoint(
-      getEgoPosition(), stop_distance - MARGIN, 0.0, shifted_path.path, stop_pose_);
+      getEgoPosition(), decel_distance, parameters_->velocity_map.front(), shifted_path.path,
+      slow_pose_);
+    return;
   }
 
-  void AvoidanceModule::insertYieldVelocity(ShiftedPath & shifted_path) const
-  {
-    const auto & p = parameters_;
-    const auto & data = avoidance_data_;
+  const auto start_idx = planner_data_->findEgoIndex(shifted_path.path.points);
+  for (size_t i = start_idx; i < shifted_path.path.points.size(); ++i) {
+    const auto distance_from_ego = calcSignedArcLength(shifted_path.path.points, start_idx, i);
 
-    if (data.target_objects.empty()) {
-      return;
+    // slow down speed is inserted only in front of the object.
+    const auto shift_longitudinal_distance = distance_to_object - distance_from_ego;
+    if (shift_longitudinal_distance < min_avoid_distance) {
+      break;
     }
 
-    if (helper_.isShifted()) {
-      return;
-    }
+    // target speed with nominal jerk limits.
+    const double v_target = PathShifter::calcFeasibleVelocityFromJerk(
+      shift_length, helper_.getLateralMinJerkLimit(), shift_longitudinal_distance);
+    const double v_original = shifted_path.path.points.at(i).point.longitudinal_velocity_mps;
+    const double v_insert = std::max(v_target - parameters_->buf_slow_down_speed, lower_speed);
 
-    const auto decel_distance = helper_.getFeasibleDecelDistance(p->yield_velocity, false);
-    utils::avoidance::insertDecelPoint(
-      getEgoPosition(), decel_distance, p->yield_velocity, shifted_path.path, slow_pose_);
+    shifted_path.path.points.at(i).point.longitudinal_velocity_mps = std::min(v_original, v_insert);
   }
 
-  void AvoidanceModule::insertPrepareVelocity(ShiftedPath & shifted_path) const
-  {
-    const auto & data = avoidance_data_;
+  slow_pose_ = motion_utils::calcLongitudinalOffsetPose(
+    shifted_path.path.points, start_idx, distance_to_object);
+}
 
-    // do nothing if there is no avoidance target.
-    if (data.target_objects.empty()) {
-      return;
-    }
+std::shared_ptr<AvoidanceDebugMsgArray> AvoidanceModule::get_debug_msg_array() const
+{
+  debug_data_.avoidance_debug_msg_array.header.stamp = clock_->now();
+  return std::make_shared<AvoidanceDebugMsgArray>(debug_data_.avoidance_debug_msg_array);
+}
 
-    // insert slow down speed only when the avoidance maneuver is not initiated.
-    if (helper_.isShifted()) {
-      return;
-    }
-
-    // insert slow down speed only when no shift line is approved.
-    if (!path_shifter_.getShiftLines().empty()) {
-      return;
-    }
-
-    const auto object = data.target_objects.front();
-
-    // calculate shift length for front object.
-    const auto & vehicle_width = planner_data_->parameters.vehicle_width;
-    const auto object_type = utils::getHighestProbLabel(object.object.classification);
-    const auto object_parameter = parameters_->object_parameters.at(object_type);
-    const auto avoid_margin = object_parameter.safety_buffer_lateral * object.distance_factor +
-                              object_parameter.avoid_margin_lateral + 0.5 * vehicle_width;
-    const auto shift_length =
-      helper_.getShiftLength(object, utils::avoidance::isOnRight(object), avoid_margin);
-
-    // check slow down feasibility
-    const auto min_avoid_distance = helper_.getMinAvoidanceDistance(shift_length);
-    const auto distance_to_object = object.longitudinal;
-    const auto remaining_distance = distance_to_object - min_avoid_distance;
-    const auto decel_distance = helper_.getFeasibleDecelDistance(parameters_->velocity_map.front());
-    if (remaining_distance < decel_distance) {
-      return;
-    }
-
-    // decide slow down lower limit.
-    const auto lower_speed = object.avoid_required ? 0.0 : parameters_->min_slow_down_speed;
-
-    // insert slow down speed.
-    const double current_target_velocity = PathShifter::calcFeasibleVelocityFromJerk(
-      shift_length, helper_.getLateralMinJerkLimit(), distance_to_object);
-    if (current_target_velocity < getEgoSpeed() && decel_distance < remaining_distance) {
-      utils::avoidance::insertDecelPoint(
-        getEgoPosition(), decel_distance, parameters_->velocity_map.front(), shifted_path.path,
-        slow_pose_);
-      return;
-    }
-
-    const auto start_idx = planner_data_->findEgoIndex(shifted_path.path.points);
-    for (size_t i = start_idx; i < shifted_path.path.points.size(); ++i) {
-      const auto distance_from_ego = calcSignedArcLength(shifted_path.path.points, start_idx, i);
-
-      // slow down speed is inserted only in front of the object.
-      const auto shift_longitudinal_distance = distance_to_object - distance_from_ego;
-      if (shift_longitudinal_distance < min_avoid_distance) {
-        break;
-      }
-
-      // target speed with nominal jerk limits.
-      const double v_target = PathShifter::calcFeasibleVelocityFromJerk(
-        shift_length, helper_.getLateralMinJerkLimit(), shift_longitudinal_distance);
-      const double v_original = shifted_path.path.points.at(i).point.longitudinal_velocity_mps;
-      const double v_insert = std::max(v_target - parameters_->buf_slow_down_speed, lower_speed);
-
-      shifted_path.path.points.at(i).point.longitudinal_velocity_mps =
-        std::min(v_original, v_insert);
-    }
-
-    slow_pose_ = motion_utils::calcLongitudinalOffsetPose(
-      shifted_path.path.points, start_idx, distance_to_object);
+void AvoidanceModule::acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const
+{
+  if (visitor) {
+    visitor->visitAvoidanceModule(this);
   }
+}
 
-  std::shared_ptr<AvoidanceDebugMsgArray> AvoidanceModule::get_debug_msg_array() const
-  {
-    debug_data_.avoidance_debug_msg_array.header.stamp = clock_->now();
-    return std::make_shared<AvoidanceDebugMsgArray>(debug_data_.avoidance_debug_msg_array);
-  }
-
-  void AvoidanceModule::acceptVisitor(const std::shared_ptr<SceneModuleVisitor> & visitor) const
-  {
-    if (visitor) {
-      visitor->visitAvoidanceModule(this);
-    }
-  }
-
-  void SceneModuleVisitor::visitAvoidanceModule(const AvoidanceModule * module) const
-  {
-    avoidance_visitor_ = module->get_debug_msg_array();
-  }
+void SceneModuleVisitor::visitAvoidanceModule(const AvoidanceModule * module) const
+{
+  avoidance_visitor_ = module->get_debug_msg_array();
+}
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1094,8 +1094,8 @@ void AvoidanceModule::generateTotalShiftLine(
 
   // overwrite shift with current_ego_shift until ego pose.
   const auto current_shift = helper_.getEgoLinearShift();
-  for (size_t i = 0; i <= avoidance_data_.ego_closest_path_index; ++i) {
-    if (sl.shift_line.size() <= i) {
+  for (size_t i = 0; i < sl.shift_line.size(); ++i) {
+    if (avoidance_data_.ego_closest_path_index < i) {
       break;
     }
     sl.shift_line.at(i) = current_shift;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1097,7 +1097,13 @@ void AvoidanceModule::generateTotalShiftLine(
   for (size_t i = 0; i <= avoidance_data_.ego_closest_path_index; ++i) {
     if (sl.shift_line.size() <= i) {
       break;
+  for (size_t i = 0; i < sl.shift_line.size(); ++i) {
+    if (avoidance_data_.ego_closest_path_index < i) {
+      break;
     }
+    sl.shift_line.at(i) = current_shift;
+    sl.shift_line_grad.at(i) = 0.0;
+  }
     sl.shift_line.at(i) = current_shift;
     sl.shift_line_grad.at(i) = 0.0;
   }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1095,6 +1095,9 @@ void AvoidanceModule::generateTotalShiftLine(
   // overwrite shift with current_ego_shift until ego pose.
   const auto current_shift = helper_.getEgoLinearShift();
   for (size_t i = 0; i <= avoidance_data_.ego_closest_path_index; ++i) {
+    if (sl.shift_line.size() <= i) {
+      break;
+    }
     sl.shift_line.at(i) = current_shift;
     sl.shift_line_grad.at(i) = 0.0;
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
add gurard to generateTotalShiftLine

```
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140344792426048) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140344792426048) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140344792426048, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007fa4ae242476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007fa4ae2287f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007fa4ae6a2b9e in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007fa4ae6ae20c in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007fa4ae6ae277 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00007fa4ae6ae4d8 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007fa4ae6a54cd in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#10 0x00007fa48b431984 in std::vector<double, std::allocator<double> >::_M_range_check (this=<optimized out>, this=<optimized out>, __n=<optimized out>)
    at /usr/include/c++/11/bits/stl_vector.h:1073
#11 std::vector<double, std::allocator<double> >::at (__n=<optimized out>, this=<optimized out>) at /usr/include/c++/11/bits/stl_vector.h:1094
#12 behavior_path_planner::AvoidanceModule::generateTotalShiftLine (this=0x7fa464054a70, avoid_lines=std::vector of length 0, capacity 0, shift_line_data=...)
    at /home/kosuke55/pilot-auto.rclcpp-patch/src/autoware/universe/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp:1098
#13 0x00007fa48b43d63e in behavior_path_planner::AvoidanceModule::mergeShiftLines (this=0x7fa464054a70, raw_shift_lines=std::vector of length 0, capacity 0,
    debug=...)
    at /home/kosuke55/pilot-auto.rclcpp-patch/src/autoware/universe/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp:1276
#14 0x00007fa48b44bb83 in behavior_path_planner::AvoidanceModule::applyPreProcessToRawShiftLines (this=0x7fa464054a70,
    raw_shift_lines=std::vector of length 0, capacity 0, debug=...)
    at /home/kosuke55/pilot-auto.rclcpp-patch/src/autoware/universe/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp:751
#15 0x00007fa48b44c7ed in behavior_path_planner::AvoidanceModule::fillShiftLine (this=0x7fa464054a70, data=..., debug=...)
    at /home/kosuke55/pilot-auto.rclcpp-patch/src/autoware/universe/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp:417
#16 0x00007fa48b44d0bd in behavior_path_planner::AvoidanceModule::updateData (this=0x7fa464054a70)
    at /home/kosuke55/pilot-auto.rclcpp-patch/src/autoware/universe/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp:2475
#17 0x00007fa48b343e62 in behavior_path_planner::SceneModuleManagerInterface::isExecutionRequested (this=0x7fa46c27a010, previous_module_output=...)
    at /home/kosuke55/pilot-auto.rclcpp-patch/src/autoware/universe/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp:91
#18 0x00007fa48b33555a in behavior_path_planner::PlannerManager::getRequestModules (this=0x7fa46c188620, previous_module_output=...)
    at /usr/include/c++/11/bits/shared_ptr_base.h:1295
f #19 0x00007fa48b33a4e9 in operator() (__closure=0x7fa4917f88e0)
    at /home/kosuke55/pilot-auto.rclcpp-patch/src/autoware/universe/planning/behavior_path_planner/src/planner_manager.cpp:91
#20 0x00007fa48b33b0bb in behavior_path_planner::PlannerManager::run (this=this@entry=0x7fa46c188620,
    data=std::shared_ptr<behavior_path_planner::PlannerData> (use count 19, weak count 0) = {...})
    at /home/kosuke55/pilot-auto.rclcpp-patch/src/autoware/universe/planning/behavior_path_planner/src/planner_manager.cpp:51
#21 0x00007fa48b36afae in behavior_path_planner::BehaviorPathPlannerNode::run (this=0x7fa46c081b70) at /usr/include/c++/11/bits/shared_ptr_base.h:1295
#22 0x00007fa48b370255 in std::__invoke_impl<void, void (behavior_path_planner::BehaviorPathPlannerNode::*&)(), behavior_path_planner::BehaviorPathPlannerNode*&>
    (__t=@0x7fa46c300020: 0x7fa46c081b70,
    __f=@0x7fa46c300010: (void (behavior_path_planner::BehaviorPathPlannerNode::*)(behavior_path_planner::BehaviorPathPlannerNode * const)) 0x7fa48b36ab80 <behavior_path_planner::BehaviorPathPlannerNode::run()>) at /usr/include/c++/11/bits/invoke.h:71
#23 std::__invoke<void (behavior_path_planner::BehaviorPathPlannerNode::*&)(), behavior_path_planner::BehaviorPathPlannerNode*&> (
    __fn=@0x7fa46c300010: (void (behavior_path_planner::BehaviorPathPlannerNode::*)(behavior_path_planner::BehaviorPathPlannerNode * const)) 0x7fa48b36ab80 <behavior_path_planner::BehaviorPathPlannerNode::run()>) at /usr/include/c++/11/bits/invoke.h:96
#24 std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (__args=..., this=0x7fa46c300010) at /usr/include/c++/11/functional:420
#25 std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>::operator()<, void>() (
    this=0x7fa46c300010) at /usr/include/c++/11/functional:503
#26 rclcpp::GenericTimer<std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>, (void*)0>::execute_callback_delegate<std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>, (void*)0>() (
    this=0x7fa46c2fffe0) at /home/kosuke55/pilot-auto.rclcpp-patch/install/rclcpp/include/rclcpp/rclcpp/timer.hpp:244
#27 rclcpp::GenericTimer<std::_Bind<void (behavior_path_planner::BehaviorPathPlannerNode::*(behavior_path_planner::BehaviorPathPlannerNode*))()>, (void*)0>::execute_callback() (this=0x7fa46c2fffe0) at /home/kosuke55/pilot-auto.rclcpp-patch/install/rclcpp/include/rclcpp/rclcpp/timer.hpp:230
#28 0x00007fa4aeb5e69e in rclcpp::Executor::execute_any_executable(rclcpp::AnyExecutable&) ()
   from /home/kosuke55/pilot-auto.rclcpp-patch/install/rclcpp/lib/librclcpp.so
#29 0x00007fa4aeb64ad2 in rclcpp::executors::MultiThreadedExecutor::run(unsigned long) ()
   from /home/kosuke55/pilot-auto.rclcpp-patch/install/rclcpp/lib/librclcpp.so
#30 0x00007fa4ae6dc253 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#31 0x00007fa4ae294b43 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#32 0x00007fa4ae326a00 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
(gdb) f 12
#12 behavior_path_planner::AvoidanceModule::generateTotalShiftLine (this=0x7fa464054a70, avoid_lines=std::vector of length 0, capacity 0, shift_line_data=...)
    at /home/kosuke55/pilot-auto.rclcpp-patch/src/autoware/universe/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp:1098
1098        sl.shift_line.at(i) = current_shift;
(gdb) p sl.sift_line
There is no member or method named sift_line.
(gdb) l
1093      }
1094
1095      // overwrite shift with current_ego_shift until ego pose.
1096      const auto current_shift = helper_.getEgoLinearShift();
1097      for (size_t i = 0; i <= avoidance_data_.ego_closest_path_index; ++i) {
1098        sl.shift_line.at(i) = current_shift;
1099        sl.shift_line_grad.at(i) = 0.0;
1100      }
1101
1102      // If the shift point does not have an associated object,
(gdb) p sl.shift_line
$1 = std::vector of length 0, capacity 0
(gdb) p i
$2 = <optimized out>
(gdb) p N
$3 = 0
(gdb) p avoidance_data_.ego_closest_path_index
$4 = 0
```


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
