### PR TITLE
fix(avoidance): add guard for empty path in updateData

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2460,6 +2460,10 @@ void AvoidanceModule::updateData()
 
   debug_data_ = DebugData();
   avoidance_data_ = calcAvoidancePlanningData(debug_data_);
+  if (avoidance_data_.reference_path.points.empty()) {
+    // an empty path will kill further processing
+    return;
+  }
 
   utils::avoidance::updateRegisteredObject(
     registered_objects_, avoidance_data_.target_objects, parameters_);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
 

add guard for empty path in updateData



sometimes center_path will be empty and the further processing die.
```
  // center line path (output of this function must have size > 1)
  const auto center_path = utils::calcCenterLinePath(
    planner_data_, reference_pose, longest_dist_to_shift_line,
    *getPreviousModuleOutput().reference_path);
```

```
[component_container_mt-28] calcAvoidancePlanningData: 219, getPreviousModuleOutput().path->points.size() : 2
[component_container_mt-28] calcAvoidancePlanningData: 225, center_path.points.size() : 0
```



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

[internal slack](https://star4.slack.com/archives/C03QW0GU6P7/p1692087479355029)

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior


<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
