### PR TITLE
fix(traffic_light_arbiter): use the shape as a key to find the highest confidence signal

### DIFF
--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -147,14 +147,14 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
 
   const auto get_highest_confidence_elements =
     [](const std::vector<ElementAndPriority> & elements_and_priority_vector) {
-      using Key = std::tuple<Element::_color_type, Element::_shape_type>;
+      using Key = Element::_shape_type;
       std::map<Key, ElementAndPriority> highest_score_element_and_priority_map;
       std::vector<Element> highest_score_elements_vector;
 
       for (const auto & elements_and_priority : elements_and_priority_vector) {
         const auto & element = elements_and_priority.first;
         const auto & element_priority = elements_and_priority.second;
-        const auto key = std::make_tuple(element.color, element.shape);
+        const auto key = element.shape;
         auto [iter, success] =
           highest_score_element_and_priority_map.try_emplace(key, elements_and_priority);
         const auto & iter_element = iter->second.first;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I think `Key` to find the highest confidence signal should be the `Shape` of the traffic signal.

For example, if the input from the internal has following elements:
- Color::GREEN
- Shape::CIRCLE
- Status::SOLID_ON
```
signals:
- traffic_signal_id: 21001
  elements:
  - color: 3
    shape: 1
    status: 2
    confidence: 1.0
```

and the input from the external has following elements:
- Color::RED
- Shape::CIRCLE
- Status::SOLID_ON
```
signals:
- traffic_signal_id: 21001
  elements:
  - color: 1
    shape: 1
    status: 2
    confidence: 1.0
```

the output from traffic_light_arbiter will have the multiple colors for the one signal in the current implementation.

```
signals:
- traffic_signal_id: 21001
  elements:
  - color: 1
    shape: 1
    status: 2
    confidence: 1.0
  - color: 3
    shape: 1
    status: 2
    confidence: 1.0
```


With this PR, the result will have one element with the same shape.
```
signals:
- traffic_signal_id: 21001
  elements:
  - color: 3
    shape: 1
    status: 2
    confidence: 1.0
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested in scenario simulator.
[TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/e2d32d9c-11f3-5b9b-bb10-fec344ad508e?project_id=x2_dev)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
