### PR TITLE
fix(multi_object_tracker): consider vehicle twist direction

### DIFF
--- a/perception/multi_object_tracker/models.md
+++ b/perception/multi_object_tracker/models.md
@@ -65,6 +65,18 @@ $$
 \end{array}\right]
 $$
 
+#### remarks on the output twist
+
+Remarks that the velocity $v_{k}$ is the norm of velocity of vehicle, not the longitudinal velocity.
+So the output twist in the object coordinate $(x,y)$ is calculated as follows.
+
+$$
+\begin{aligned}
+v_{x} &= v_{k} \cos \left(\beta_{k}\right) \\
+v_{y} &= v_{k} \sin \left(\beta_{k}\right)
+\end{aligned}
+$$
+
 ## Anchor point based estimation
 
 To separate the estimation of the position and the shape, we use anchor point based position estimation.

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -427,7 +427,8 @@ bool BicycleTracker::getTrackedObject(
   pose_with_cov.covariance[utils::MSG_COV_IDX::YAW_YAW] = P(IDX::YAW, IDX::YAW);
 
   // twist
-  twist_with_cov.twist.linear.x = X_t(IDX::VX);
+  twist_with_cov.twist.linear.x = X_t(IDX::VX) * std::cos(X_t(IDX::SLIP));
+  twist_with_cov.twist.linear.y = X_t(IDX::VX) * std::sin(X_t(IDX::SLIP));
   twist_with_cov.twist.angular.z =
     X_t(IDX::VX) / lr_ * std::sin(X_t(IDX::SLIP));  // yaw_rate = vx_k / l_r * sin(slip_k)
   // twist covariance

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -478,7 +478,8 @@ bool BigVehicleTracker::getTrackedObject(
   pose_with_cov.covariance[utils::MSG_COV_IDX::YAW_YAW] = P(IDX::YAW, IDX::YAW);
 
   // twist
-  twist_with_cov.twist.linear.x = X_t(IDX::VX);
+  twist_with_cov.twist.linear.x = X_t(IDX::VX) * std::cos(X_t(IDX::SLIP));
+  twist_with_cov.twist.linear.y = X_t(IDX::VX) * std::sin(X_t(IDX::SLIP));
   twist_with_cov.twist.angular.z =
     X_t(IDX::VX) / lr_ * std::sin(X_t(IDX::SLIP));  // yaw_rate = vx_k / l_r * sin(slip_k)
   // twist covariance

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -494,7 +494,8 @@ bool NormalVehicleTracker::getTrackedObject(
   pose_with_cov.covariance[utils::MSG_COV_IDX::YAW_YAW] = P(IDX::YAW, IDX::YAW);
 
   // twist
-  twist_with_cov.twist.linear.x = X_t(IDX::VX);
+  twist_with_cov.twist.linear.x = X_t(IDX::VX) * std::cos(X_t(IDX::SLIP));
+  twist_with_cov.twist.linear.y = X_t(IDX::VX) * std::sin(X_t(IDX::SLIP));
   twist_with_cov.twist.angular.z =
     X_t(IDX::VX) / lr_ * std::sin(X_t(IDX::SLIP));  // yaw_rate = vx_k / l_r * sin(slip_k)
   // twist covariance


### PR DESCRIPTION
## Description

Fixed the twist direction bug, which was the object's orientation, but actually the slip angle should be considered. 
The kinematics model used in the tracker is CoG frame where the direction of twist and object orientation is not the same.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] planning simulator
- [x] scenario simulator
    - https://evaluation.tier4.jp/evaluation/reports/cb5db4b2-c286-5eb3-996d-676f01957581?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Release Notes:
- Bug fix: Fixed a bug in the twist direction calculation in the multi-object tracker code.
- Refactor: Updated the calculation of the twist values in the `getTrackedObject` function of the `BicycleTracker`, `BigVehicleTracker`, and `NormalVehicleTracker` classes to consider the slip angle.

> "Bug fixed, twists refined,
> Slip angles now aligned.
> Objects tracked with precision,
> A bug's demise, a coder's mission."
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->