### PR TITLE
feat(obstacle_stop_planner): consider object velocity direction

### DIFF
--- a/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -415,22 +415,26 @@ bool AdaptiveCruiseController::estimatePointVelocityFromObject(
   /* get object velocity, and current yaw */
   bool get_obj = false;
   double obj_vel;
-  double obj_yaw;
+  double obj_vel_yaw;
   const Point collision_point_2d = convertPointRosToBoost(nearest_collision_p_ros);
   for (const auto & obj : object_ptr->objects) {
     const Polygon obj_poly = getPolygon(
       obj.kinematics.initial_pose_with_covariance.pose, obj.shape.dimensions, 0.0,
       param_.object_polygon_length_margin, param_.object_polygon_width_margin);
     if (boost::geometry::distance(obj_poly, collision_point_2d) <= 0) {
-      obj_vel = obj.kinematics.initial_twist_with_covariance.twist.linear.x;
-      obj_yaw = tf2::getYaw(obj.kinematics.initial_pose_with_covariance.pose.orientation);
+      obj_vel = std::hypot(
+        obj.kinematics.initial_twist_with_covariance.twist.linear.x,
+        obj.kinematics.initial_twist_with_covariance.twist.linear.y);
+      obj_vel_yaw = std::atan2(
+        obj.kinematics.initial_twist_with_covariance.twist.linear.y,
+        obj.kinematics.initial_twist_with_covariance.twist.linear.x);
       get_obj = true;
       break;
     }
   }
 
   if (get_obj) {
-    *velocity = obj_vel * std::cos(obj_yaw - traj_yaw);
+    *velocity = obj_vel * std::cos(obj_vel_yaw - traj_yaw);
     debug_values_.data.at(DBGVAL::ESTIMATED_VEL_OBJ) = *velocity;
     return true;
   } else {
@@ -442,10 +446,14 @@ void AdaptiveCruiseController::calculateProjectedVelocityFromObject(
   const PredictedObject & object, const double traj_yaw, double * velocity)
 {
   /* get object velocity, and current yaw */
-  double obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear.x;
-  double obj_yaw = tf2::getYaw(object.kinematics.initial_pose_with_covariance.pose.orientation);
+  double obj_vel = std::hypot(
+    object.kinematics.initial_twist_with_covariance.twist.linear.x,
+    object.kinematics.initial_twist_with_covariance.twist.linear.y);
+  double obj_vel_yaw = std::atan2(
+    object.kinematics.initial_twist_with_covariance.twist.linear.y,
+    object.kinematics.initial_twist_with_covariance.twist.linear.x);
 
-  *velocity = obj_vel * std::cos(tier4_autoware_utils::normalizeRadian(obj_yaw - traj_yaw));
+  *velocity = obj_vel * std::cos(tier4_autoware_utils::normalizeRadian(obj_vel_yaw - traj_yaw));
   debug_values_.data.at(DBGVAL::ESTIMATED_VEL_OBJ) = *velocity;
 }
 

--- a/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -414,7 +414,7 @@ bool AdaptiveCruiseController::estimatePointVelocityFromObject(
 
   /* get object velocity, and current yaw */
   bool get_obj = false;
-  double obj_vel;
+  double obj_vel_norm;
   double obj_vel_yaw;
   const Point collision_point_2d = convertPointRosToBoost(nearest_collision_p_ros);
   for (const auto & obj : object_ptr->objects) {
@@ -422,7 +422,7 @@ bool AdaptiveCruiseController::estimatePointVelocityFromObject(
       obj.kinematics.initial_pose_with_covariance.pose, obj.shape.dimensions, 0.0,
       param_.object_polygon_length_margin, param_.object_polygon_width_margin);
     if (boost::geometry::distance(obj_poly, collision_point_2d) <= 0) {
-      obj_vel = std::hypot(
+      obj_vel_norm = std::hypot(
         obj.kinematics.initial_twist_with_covariance.twist.linear.x,
         obj.kinematics.initial_twist_with_covariance.twist.linear.y);
       obj_vel_yaw = std::atan2(
@@ -434,7 +434,7 @@ bool AdaptiveCruiseController::estimatePointVelocityFromObject(
   }
 
   if (get_obj) {
-    *velocity = obj_vel * std::cos(obj_vel_yaw - traj_yaw);
+    *velocity = obj_vel_norm * std::cos(obj_vel_yaw - traj_yaw);
     debug_values_.data.at(DBGVAL::ESTIMATED_VEL_OBJ) = *velocity;
     return true;
   } else {
@@ -446,14 +446,15 @@ void AdaptiveCruiseController::calculateProjectedVelocityFromObject(
   const PredictedObject & object, const double traj_yaw, double * velocity)
 {
   /* get object velocity, and current yaw */
-  double obj_vel = std::hypot(
+  double obj_vel_norm = std::hypot(
     object.kinematics.initial_twist_with_covariance.twist.linear.x,
     object.kinematics.initial_twist_with_covariance.twist.linear.y);
   double obj_vel_yaw = std::atan2(
     object.kinematics.initial_twist_with_covariance.twist.linear.y,
     object.kinematics.initial_twist_with_covariance.twist.linear.x);
 
-  *velocity = obj_vel * std::cos(tier4_autoware_utils::normalizeRadian(obj_vel_yaw - traj_yaw));
+  *velocity =
+    obj_vel_norm * std::cos(tier4_autoware_utils::normalizeRadian(obj_vel_yaw - traj_yaw));
   debug_values_.data.at(DBGVAL::ESTIMATED_VEL_OBJ) = *velocity;
 }
 


### PR DESCRIPTION
## Description

With the following PR, the vehicle object velocity direction will not be the same as the vehicle object orientation since the velocity center is not the rear wheel center but CoM.
https://github.com/autowarefoundation/autoware.universe/pull/4637

This PR considers the vehicle object velocity direction in a planning package.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Unit test

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
