### PR TITLE
feat(obstacle_velocity_limiter): consider object velocity direction

### DIFF
--- a/planning/obstacle_velocity_limiter/src/obstacles.cpp
+++ b/planning/obstacle_velocity_limiter/src/obstacles.cpp
@@ -67,7 +67,7 @@ multipolygon_t createObjectPolygons(
     const double obj_vel_norm = std::hypot(
       object.kinematics.initial_twist_with_covariance.twist.linear.x,
       object.kinematics.initial_twist_with_covariance.twist.linear.y);
-    if (min_velocity < obj_vel_norm) {
+    if (min_velocity <= obj_vel_norm) {
       polygons.push_back(createObjectPolygon(
         object.kinematics.initial_pose_with_covariance.pose, object.shape.dimensions, buffer));
     }

--- a/planning/obstacle_velocity_limiter/src/obstacles.cpp
+++ b/planning/obstacle_velocity_limiter/src/obstacles.cpp
@@ -64,9 +64,10 @@ multipolygon_t createObjectPolygons(
 {
   multipolygon_t polygons;
   for (const auto & object : objects.objects) {
-    if (
-      object.kinematics.initial_twist_with_covariance.twist.linear.x >= min_velocity ||
-      object.kinematics.initial_twist_with_covariance.twist.linear.x <= -min_velocity) {
+    const double obj_vel_norm = std::hypot(
+      object.kinematics.initial_twist_with_covariance.twist.linear.x,
+      object.kinematics.initial_twist_with_covariance.twist.linear.y);
+    if (min_velocity < obj_vel_norm) {
       polygons.push_back(createObjectPolygon(
         object.kinematics.initial_pose_with_covariance.pose, object.shape.dimensions, buffer));
     }


### PR DESCRIPTION
## Description

With the following PR, the vehicle object velocity direction will not be the same as the vehicle object orientation since the velocity center is not the rear wheel center but CoM.
https://github.com/autowarefoundation/autoware.universe/pull/4637

This PR considers the vehicle object velocity direction in a planning package.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Unit test

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
