### PR TITLE
feat(occlusion spot): consider object velocity direction

### DIFF
--- a/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -186,15 +186,19 @@ bool isVehicle(const PredictedObject & obj)
 bool isStuckVehicle(const PredictedObject & obj, const double min_vel)
 {
   if (!isVehicle(obj)) return false;
-  const auto & obj_vel = obj.kinematics.initial_twist_with_covariance.twist.linear.x;
-  return std::abs(obj_vel) <= min_vel;
+  const auto & obj_vel_norm = std::hypot(
+    obj.kinematics.initial_twist_with_covariance.twist.linear.x,
+    obj.kinematics.initial_twist_with_covariance.twist.linear.y);
+  return obj_vel_norm <= min_vel;
 }
 
 bool isMovingVehicle(const PredictedObject & obj, const double min_vel)
 {
   if (!isVehicle(obj)) return false;
-  const auto & obj_vel = obj.kinematics.initial_twist_with_covariance.twist.linear.x;
-  return std::abs(obj_vel) > min_vel;
+  const auto & obj_vel_norm = std::hypot(
+    obj.kinematics.initial_twist_with_covariance.twist.linear.x,
+    obj.kinematics.initial_twist_with_covariance.twist.linear.y);
+  return obj_vel_norm > min_vel;
 }
 
 std::vector<PredictedObject> extractVehicles(


### PR DESCRIPTION
## Description

With the following PR, the vehicle object velocity direction will not be the same as the vehicle object orientation since the velocity center is not the rear wheel center but CoM.
https://github.com/autowarefoundation/autoware.universe/pull/4637

This PR considers the vehicle object velocity direction in a planning package.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Unit test

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
