### PR TITLE
fix(system_monitor): high-memory process are not provided in MEM order

### DIFF
--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -401,7 +401,7 @@ void ProcessMonitor::getHighMemoryProcesses(const std::string & output)
     bp::pipe err_pipe{err_fd[0], err_fd[1]};
     bp::ipstream is_err{std::move(err_pipe)};
 
-    bp::child c("sort -r -k 10", bp::std_out > p2, bp::std_err > is_err, bp::std_in < p1);
+    bp::child c("sort -r -k 10 -g", bp::std_out > p2, bp::std_err > is_err, bp::std_in < p1);
     c.wait();
     if (c.exit_code() != 0) {
       is_err >> os.rdbuf();

--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -401,7 +401,7 @@ void ProcessMonitor::getHighMemoryProcesses(const std::string & output)
     bp::pipe err_pipe{err_fd[0], err_fd[1]};
     bp::ipstream is_err{std::move(err_pipe)};
 
-    bp::child c("sort -r -k 10 -g", bp::std_out > p2, bp::std_err > is_err, bp::std_in < p1);
+    bp::child c("sort -r -k 10 -n", bp::std_out > p2, bp::std_err > is_err, bp::std_in < p1);
     c.wait();
     if (c.exit_code() != 0) {
       is_err >> os.rdbuf();


### PR DESCRIPTION
## Description

The `process_monitor` has a bug that it doesn't provide high-memory process information in `%MEM` order.
The results of `top` command are not sorted based on `%MEM` by numeric sort.
Added the `-n` option to the `sort` command.
![image](https://github.com/autowarefoundation/autoware.universe/assets/57388357/f5c6242b-2232-464f-8416-d4eaf9df4457)

I'm attaching the results of `top` and `sort` command without numeric sort.
![image](https://github.com/autowarefoundation/autoware.universe/assets/57388357/077909e8-3dda-4aa9-99c0-e173c6f33118)

## Related links

[TIER IV INTERNAL LINK TO JIRA](https://tier4.atlassian.net/browse/RT0-28841)

## Tests performed

1. Run Autoware.
2. Run rqt_runtime_monitor.
    ```console
    ros2 run rqt_runtime_monitor rqt_runtime_monitor
    ```

3. Verify high-memory process are provided in `%MEM` order.
![image](https://github.com/autowarefoundation/autoware.universe/assets/57388357/77e7339d-dc6a-4eed-9ea6-dcbc1cfc11a7)

The results of `top` and `sort` command with numeric sort
![image](https://github.com/autowarefoundation/autoware.universe/assets/57388357/7755db7d-100f-4c9a-8212-932d4dbbf41c)

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
