### PR TITLE
fix(intersection): guard invalid access

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -1130,6 +1130,10 @@ bool IntersectionModule::checkCollision(
         const auto trimmed_ego_polygon =
           getPolygonFromArcLength(ego_lane_with_next_lanes, start_arc_length, end_arc_length);
 
+        if (trimmed_ego_polygon.empty()) {
+          continue;
+        }
+
         Polygon2d polygon{};
         for (const auto & p : trimmed_ego_polygon) {
           polygon.outer().emplace_back(p.x(), p.y());


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a8a2a8</samp>

Fix a bug in `scene_intersection.cpp` that could cause a crash when the ego vehicle polygon is empty. Add a check to skip the collision detection in this case.

![Screenshot from 2023-08-17 16-46-57](https://github.com/autowarefoundation/autoware.universe/assets/44889564/383b6820-ff69-4e9a-acad-8b1ee28a60de)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
