### PR TITLE
ci: reverting control ignorance

### DIFF
--- a/.cspell-partial.json
+++ b/.cspell-partial.json
@@ -3,7 +3,7 @@
     "**/perception/**",
     "**/planning/**",
     "**/sensing/**",
-    "**/control/**",
+    "**/*.svg",
     "perception/bytetrack/lib/**"
   ],
   "ignoreRegExpList": [],

--- a/.cspell-partial.json
+++ b/.cspell-partial.json
@@ -3,7 +3,6 @@
     "**/perception/**",
     "**/planning/**",
     "**/sensing/**",
-    "**/*.svg",
     "perception/bytetrack/lib/**"
   ],
   "ignoreRegExpList": [],


### PR DESCRIPTION
## Description

.svg files were sometimes causing unreasonable error e.g. in https://github.com/autowarefoundation/autoware.universe/pull/4549 where the following part was not ignored by spell-check.

```host=&quot;0i6112g2df9b6ngu9buda4iblme4t77dtbb7m4umbjihr1cp3ej8&quot; ```

Since the above issue has been resolved in https://github.com/tier4/autoware-spell-check-dict/pull/607, I'd like to revert the modification.

<!-- Write a brief description of this PR. -->

## Related links
N/A
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
N/A
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
N/A
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
N/A
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
N/A
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
