### PR TITLE
feat!: rename map_projector_type to map_projector_info

### DIFF
--- a/common/component_interface_specs/include/component_interface_specs/map.hpp
+++ b/common/component_interface_specs/include/component_interface_specs/map.hpp
@@ -25,7 +25,7 @@ namespace map_interface
 struct MapProjectorInfo
 {
   using Message = tier4_map_msgs::msg::MapProjectorInfo;
-  static constexpr char name[] = "/map/map_projector_type";
+  static constexpr char name[] = "/map/map_projector_info";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;

--- a/map/map_loader/README.md
+++ b/map/map_loader/README.md
@@ -140,7 +140,7 @@ Please see [the description of `GetSelectedPointCloudMap.srv`](https://github.co
 ### Feature
 
 lanelet2_map_loader loads Lanelet2 file and publishes the map data as autoware_auto_mapping_msgs/HADMapBin message.
-The node projects lan/lon coordinates into arbitrary coordinates defined in `/map/map_projector_type` from `map_projection_loader`.
+The node projects lan/lon coordinates into arbitrary coordinates defined in `/map/map_projector_info` from `map_projection_loader`.
 The node supports the following three types of coordinate systems:
 
 - MGRS

--- a/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
+++ b/map/map_loader/include/map_loader/lanelet2_map_loader_node.hpp
@@ -47,7 +47,7 @@ private:
 
   void on_map_projector_info(const MapProjectorInfo::Message::ConstSharedPtr msg);
 
-  component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr sub_map_projector_type_;
+  component_interface_utils::Subscription<MapProjectorInfo>::SharedPtr sub_map_projector_info_;
   rclcpp::Publisher<HADMapBin>::SharedPtr pub_map_bin_;
 };
 

--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
@@ -55,7 +55,7 @@ Lanelet2MapLoaderNode::Lanelet2MapLoaderNode(const rclcpp::NodeOptions & options
 
   // subscription
   adaptor.init_sub(
-    sub_map_projector_type_,
+    sub_map_projector_info_,
     [this](const MapProjectorInfo::Message::ConstSharedPtr msg) { on_map_projector_info(msg); });
 }
 

--- a/map/map_projection_loader/test/test_node_load_local_from_yaml.test.py
+++ b/map/map_projection_loader/test/test_node_load_local_from_yaml.test.py
@@ -110,7 +110,7 @@ class TestLoadLocalFromYaml(unittest.TestCase):
         # Create subscription to map_projector_info topic
         subscription = self.test_node.create_subscription(
             MapProjectorInfo,
-            "/map/map_projector_type",
+            "/map/map_projector_info",
             self.callback,
             custom_qos_profile,
         )

--- a/map/map_projection_loader/test/test_node_load_mgrs_from_yaml.test.py
+++ b/map/map_projection_loader/test/test_node_load_mgrs_from_yaml.test.py
@@ -110,7 +110,7 @@ class TestLoadMGRSFromYaml(unittest.TestCase):
         # Create subscription to map_projector_info topic
         subscription = self.test_node.create_subscription(
             MapProjectorInfo,
-            "/map/map_projector_type",
+            "/map/map_projector_info",
             self.callback,
             custom_qos_profile,
         )

--- a/map/map_projection_loader/test/test_node_load_utm_from_yaml.test.py
+++ b/map/map_projection_loader/test/test_node_load_utm_from_yaml.test.py
@@ -110,7 +110,7 @@ class TestLoadUTMFromYaml(unittest.TestCase):
         # Create subscription to map_projector_info topic
         subscription = self.test_node.create_subscription(
             MapProjectorInfo,
-            "/map/map_projector_type",
+            "/map/map_projector_info",
             self.callback,
             custom_qos_profile,
         )


### PR DESCRIPTION
## Description

I'd like to rename `/map/map_projector_type` to `/map/map_projector_info`.

Reasons:
- The type of the topic is `tier4_map_msgs/msg/MapProjectorInfo` which is a little bit different from the topic name. This inconsistency may confuse developers in the near future that may lead to a potential bugs.
- The topic is relatively new and only used in few modules at this moment. Thus, the cost of change is acceptable.
<!-- Write a brief description of this PR. -->

## Related links

[TIER IV INTERNAL LINK](https://star4.slack.com/archives/CEL0DR2S2/p1691398284897649)
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
- Launch logging_simulator and ...
  - Run `ros2 topic info -v /map/map_projector_type` before this PR and `ros2 topic info -v /map/map_projector_info` after this PR, and confirmed that both matches the same.
  - Run sample rosbag from Autoware Tutorial and confirmed that the system works the same (without any failure in pose initialization, etc)
- Launch planning_simulator and ...
  - Run `ros2 topic info -v /map/map_projector_type` before this PR and `ros2 topic info -v /map/map_projector_info` after this PR, and confirmed that both matches the same.
  - Put initial pose and goal pose, engaged the vehicle, and confirmed that that the system works the same before and after the PR.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

N/A
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Yes. The topic name has been changed. 
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

No effect expected
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
