### PR TITLE
feat(behavior_path_planner): add PullOutPath member variables for ego predicted path generation

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/pull_out_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/pull_out_path.hpp
@@ -19,6 +19,7 @@
 
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 
+#include <utility>
 #include <vector>
 
 namespace behavior_path_planner
@@ -27,11 +28,10 @@ using autoware_auto_planning_msgs::msg::PathWithLaneId;
 struct PullOutPath
 {
   std::vector<PathWithLaneId> partial_paths{};
+  // accelerate with constant acceleration to the target velocity
+  std::vector<std::pair<double, double>> pairs_terminal_velocity_and_accel{};
   Pose start_pose{};
   Pose end_pose{};
-  // accelerate with constant acceleration to the target velocity
-  double acceleration{};
-  double terminal_velocity{};
 };
 }  // namespace behavior_path_planner
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__START_PLANNER__PULL_OUT_PATH_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/pull_out_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/pull_out_path.hpp
@@ -29,6 +29,9 @@ struct PullOutPath
   std::vector<PathWithLaneId> partial_paths{};
   Pose start_pose{};
   Pose end_pose{};
+  // accelerate with constant acceleration to the target velocity
+  double acceleration{};
+  double terminal_velocity{};
 };
 }  // namespace behavior_path_planner
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__START_PLANNER__PULL_OUT_PATH_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
@@ -65,6 +65,7 @@ struct StartPlannerParameters
   double backward_search_resolution;
   double backward_path_update_duration;
   double ignore_distance_from_lane_end;
+
   // freespace planner
   bool enable_freespace_planner;
   std::string freespace_planner_algorithm;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
@@ -65,7 +65,6 @@ struct StartPlannerParameters
   double backward_search_resolution;
   double backward_path_update_duration;
   double ignore_distance_from_lane_end;
-
   // freespace planner
   bool enable_freespace_planner;
   std::string freespace_planner_algorithm;

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -106,7 +106,8 @@ void StartPlannerModule::processOnExit()
 
 bool StartPlannerModule::isExecutionRequested() const
 {
-  // Execute when current pose is near route start pose
+  // TODO(Sugahara): if required lateral shift distance is small, don't engage this module.
+  //  Execute when current pose is near route start pose
   const Pose & start_pose = planner_data_->route_handler->getOriginalStartPose();
   const Pose & current_pose = planner_data_->self_odometry->pose.pose;
   if (

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -107,7 +107,7 @@ void StartPlannerModule::processOnExit()
 bool StartPlannerModule::isExecutionRequested() const
 {
   // TODO(Sugahara): if required lateral shift distance is small, don't engage this module.
-  //  Execute when current pose is near route start pose
+  // Execute when current pose is near route start pose
   const Pose & start_pose = planner_data_->route_handler->getOriginalStartPose();
   const Pose & current_pose = planner_data_->self_odometry->pose.pose;
   if (

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -109,7 +109,7 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
     output.pairs_terminal_velocity_and_accel.push_back(
       std::make_pair(average_velocity, average_acceleration));
     const double arc_length_on_second_arc_path =
-      motion_utils::calcArcLength(std::next(output.partial_paths.begin(), 1)->points);
+      motion_utils::calcArcLength(planner_.getArcPaths().at(1).points);
     output.pairs_terminal_velocity_and_accel.push_back(
       std::make_pair(velocity, velocity * velocity / (2 * arc_length_on_second_arc_path)));
   } else {

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -84,12 +84,33 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
 
   if (parameters_.divide_pull_out_path) {
     output.partial_paths = planner_.getPaths();
+    // Calculate the acceleration required to reach the forward parking velocity at the center of
+    // the front path, assuming constant acceleration and deceleration.
+    // v                     v
+    // |                     |
+    // |    /\               |    /\
+    // |   /  \              |   /  \
+    // |  /    \             |  /    \
+    // | /      \            | /      \
+    // |/________\_____ x    |/________\______ t
+    // 0  a_l/2  a_l         0    t_c 2*t_c
+    // Notes:
+    // a_l represents "arc_length_on_path_front"
+    // t_c represents "time_to_center"
     // insert stop velocity to first arc path end
-    const double arc_length_on_path =
-      motion_utils::calcArcLength(output.partial_paths.front().points);
     output.partial_paths.front().points.back().point.longitudinal_velocity_mps = 0.0;
+    const double arc_length_on_path_front =
+      motion_utils::calcArcLength(output.partial_paths.front().points);
+    const double acceleration = velocity * velocity / arc_length_on_path;
+    const double time_to_center = arc_length_on_path_front / (2 * velocity);
+    const double average_velocity = arc_length_on_path_front / (time_to_center * 2);
+    const double average_acceleration = average_velocity / (time_to_center * 2);
     output.pairs_terminal_velocity_and_accel.push_back(
-      std::make_pair(velocity, velocity * velocity / (2 * arc_length_on_path)));
+      std::make_pair(average_velocity, average_acceleration));
+    const double arc_length_on_path_back =
+      motion_utils::calcArcLength(output.partial_paths.front().points);
+    output.pairs_terminal_velocity_and_accel.push_back(
+      std::make_pair(velocity, velocity * velocity / (2 * arc_length_on_path_back)));
   } else {
     const auto partial_paths = planner_.getPaths();
     const auto combined_path = combineReferencePath(partial_paths.at(0), partial_paths.at(1));
@@ -98,12 +119,8 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
     // Calculate the acceleration required to reach the forward parking velocity at the center of
     // the path, assuming constant acceleration and deceleration.
     const double arc_length_on_path = motion_utils::calcArcLength(combined_path.points);
-    const double acceleration = velocity * velocity / arc_length_on_path;
-    const double time_to_center = velocity / acceleration;
-    const double average_velocity = arc_length_on_path / (time_to_center * 2);
-    const double average_acceleration = average_velocity / (time_to_center * 2);
     output.pairs_terminal_velocity_and_accel.push_back(
-      std::make_pair(average_velocity, average_acceleration));
+      std::make_pair(velocity, velocity * velocity / 2 * arc_length_on_path));
   }
   output.start_pose = planner_.getArcPaths().at(0).points.front().point.pose;
   output.end_pose = planner_.getArcPaths().at(1).points.back().point.pose;

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -80,7 +80,6 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
         parameters_.collision_check_margin)) {
     return {};
   }
-
   const double velocity = parallel_parking_parameters_.forward_parking_velocity;
 
   if (parameters_.divide_pull_out_path) {
@@ -106,7 +105,6 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
     output.pairs_terminal_velocity_and_accel.push_back(
       std::make_pair(average_velocity, average_acceleration));
   }
-
   output.start_pose = planner_.getArcPaths().at(0).points.front().point.pose;
   output.end_pose = planner_.getArcPaths().at(1).points.back().point.pose;
 

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -81,15 +81,32 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
     return {};
   }
 
+  const double velocity = parallel_parking_parameters_.forward_parking_velocity;
+
   if (parameters_.divide_pull_out_path) {
     output.partial_paths = planner_.getPaths();
     // insert stop velocity to first arc path end
+    const double arc_length_on_path =
+      motion_utils::calcArcLength(output.partial_paths.front().points);
     output.partial_paths.front().points.back().point.longitudinal_velocity_mps = 0.0;
+    output.terminal_velocity = velocity;
+    output.acceleration = velocity * velocity / (2 * arc_length_on_path);
   } else {
-    auto partial_paths = planner_.getPaths();
+    const auto partial_paths = planner_.getPaths();
     const auto combined_path = combineReferencePath(partial_paths.at(0), partial_paths.at(1));
     output.partial_paths.push_back(combined_path);
+
+    // Calculate the acceleration required to reach the forward parking velocity at the center of
+    // the path, assuming constant acceleration and deceleration.
+    const double arc_length_on_path = motion_utils::calcArcLength(combined_path.points);
+    const double acceleration = velocity * velocity / arc_length_on_path;
+    const double time_to_center = velocity / acceleration;
+    const double average_velocity = arc_length_on_path / (time_to_center * 2);
+    const double average_acceleration = average_velocity / (time_to_center * 2);
+    output.terminal_velocity = average_velocity;
+    output.acceleration = average_acceleration;
   }
+
   output.start_pose = planner_.getArcPaths().at(0).points.front().point.pose;
   output.end_pose = planner_.getArcPaths().at(1).points.back().point.pose;
 

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -84,31 +84,32 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
 
   if (parameters_.divide_pull_out_path) {
     output.partial_paths = planner_.getPaths();
-    // Calculate the acceleration required to reach the forward parking velocity at the center of
-    // the front path, assuming constant acceleration and deceleration.
-    // v                     v
-    // |                     |
-    // |    /\               |    /\
-    // |   /  \              |   /  \
-    // |  /    \             |  /    \
-    // | /      \            | /      \
-    // |/________\_____ x    |/________\______ t
-    // 0  a_l/2  a_l         0    t_c 2*t_c
-    // Notes:
-    // a_l represents "arc_length_on_path_front"
-    // t_c represents "time_to_center"
+    /*
+    Calculate the acceleration required to reach the forward parking velocity at the center of
+    the front path, assuming constant acceleration and deceleration.
+    v                     v
+    |                     |
+    |    /\               |    /\
+    |   /  \              |   /  \
+    |  /    \             |  /    \
+    | /      \            | /      \
+    |/________\_____ x    |/________\______ t
+    0  a_l/2  a_l         0    t_c 2*t_c
+    Notes:
+    a_l represents "arc_length_on_path_front"
+    t_c represents "time_to_center"
+    */
     // insert stop velocity to first arc path end
     output.partial_paths.front().points.back().point.longitudinal_velocity_mps = 0.0;
     const double arc_length_on_path_front =
       motion_utils::calcArcLength(output.partial_paths.front().points);
-    const double acceleration = velocity * velocity / arc_length_on_path;
     const double time_to_center = arc_length_on_path_front / (2 * velocity);
     const double average_velocity = arc_length_on_path_front / (time_to_center * 2);
     const double average_acceleration = average_velocity / (time_to_center * 2);
     output.pairs_terminal_velocity_and_accel.push_back(
       std::make_pair(average_velocity, average_acceleration));
     const double arc_length_on_path_back =
-      motion_utils::calcArcLength(output.partial_paths.front().points);
+      motion_utils::calcArcLength(output.partial_paths.back().points);
     output.pairs_terminal_velocity_and_accel.push_back(
       std::make_pair(velocity, velocity * velocity / (2 * arc_length_on_path_back)));
   } else {

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -89,8 +89,8 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
     const double arc_length_on_path =
       motion_utils::calcArcLength(output.partial_paths.front().points);
     output.partial_paths.front().points.back().point.longitudinal_velocity_mps = 0.0;
-    output.terminal_velocity = velocity;
-    output.acceleration = velocity * velocity / (2 * arc_length_on_path);
+    output.pairs_terminal_velocity_and_accel.push_back(
+      std::make_pair(velocity, velocity * velocity / (2 * arc_length_on_path)));
   } else {
     const auto partial_paths = planner_.getPaths();
     const auto combined_path = combineReferencePath(partial_paths.at(0), partial_paths.at(1));
@@ -103,8 +103,8 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
     const double time_to_center = velocity / acceleration;
     const double average_velocity = arc_length_on_path / (time_to_center * 2);
     const double average_acceleration = average_velocity / (time_to_center * 2);
-    output.terminal_velocity = average_velocity;
-    output.acceleration = average_acceleration;
+    output.pairs_terminal_velocity_and_accel.push_back(
+      std::make_pair(average_velocity, average_acceleration));
   }
 
   output.start_pose = planner_.getArcPaths().at(0).points.front().point.pose;

--- a/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/geometric_pull_out.cpp
@@ -101,17 +101,17 @@ boost::optional<PullOutPath> GeometricPullOut::plan(Pose start_pose, Pose goal_p
     */
     // insert stop velocity to first arc path end
     output.partial_paths.front().points.back().point.longitudinal_velocity_mps = 0.0;
-    const double arc_length_on_path_front =
+    const double arc_length_on_first_arc_path =
       motion_utils::calcArcLength(output.partial_paths.front().points);
-    const double time_to_center = arc_length_on_path_front / (2 * velocity);
-    const double average_velocity = arc_length_on_path_front / (time_to_center * 2);
+    const double time_to_center = arc_length_on_first_arc_path / (2 * velocity);
+    const double average_velocity = arc_length_on_first_arc_path / (time_to_center * 2);
     const double average_acceleration = average_velocity / (time_to_center * 2);
     output.pairs_terminal_velocity_and_accel.push_back(
       std::make_pair(average_velocity, average_acceleration));
-    const double arc_length_on_path_back =
-      motion_utils::calcArcLength(output.partial_paths.back().points);
+    const double arc_length_on_second_arc_path =
+      motion_utils::calcArcLength(std::next(output.partial_paths.begin(), 1)->points);
     output.pairs_terminal_velocity_and_accel.push_back(
-      std::make_pair(velocity, velocity * velocity / (2 * arc_length_on_path_back)));
+      std::make_pair(velocity, velocity * velocity / (2 * arc_length_on_second_arc_path)));
   } else {
     const auto partial_paths = planner_.getPaths();
     const auto combined_path = combineReferencePath(partial_paths.at(0), partial_paths.at(1));

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -165,16 +165,12 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
   // non_shifted_path for when shift length or pull out distance is too short
   const PullOutPath non_shifted_path = std::invoke([&]() {
     PullOutPath non_shifted_path{};
-    // The assumption for this calculation of velocity and acceleration is to accelerate with
-    // constant acceleration until the road velocity limit is reached at the shift end point.
-    const double terminal_velocity =
-      road_lane_reference_path.points.at(shift_end_idx).point.longitudinal_velocity_mps;
-    const double time_to_end_pose = shift_distance / terminal_velocity;
+    // In non_shifted_path, to minimize safety checks, 0 is assigned to prevent the predicted_path
+    // of the ego vehicle from becoming too large.
     non_shifted_path.partial_paths.push_back(road_lane_reference_path);
     non_shifted_path.start_pose = start_pose;
     non_shifted_path.end_pose = start_pose;
-    non_shifted_path.pairs_terminal_velocity_and_accel.push_back(
-      std::make_pair(terminal_velocity, 2 * shift_distance / std::pow(time_to_end_pose, 2)));
+    non_shifted_path.pairs_terminal_velocity_and_accel.push_back(std::make_pair(0, 0));
     return non_shifted_path;
   });
 

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -155,12 +155,10 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     start_planner_utils::calcEndArcLength(s_start, forward_path_length, road_lanes, goal_pose);
   const double s_end = path_end_info.first;
   const bool path_terminal_is_goal = path_end_info.second;
+
   constexpr double RESAMPLE_INTERVAL = 1.0;
   PathWithLaneId road_lane_reference_path = utils::resamplePathWithSpline(
     route_handler.getCenterLinePath(road_lanes, s_start, s_end), RESAMPLE_INTERVAL);
-  const double shift_distance = s_end - s_start;
-  const size_t shift_end_idx =
-    findNearestIndex(road_lane_reference_path.points, goal_pose.position);
 
   // non_shifted_path for when shift length or pull out distance is too short
   const PullOutPath non_shifted_path = std::invoke([&]() {

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -173,8 +173,8 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     non_shifted_path.partial_paths.push_back(road_lane_reference_path);
     non_shifted_path.start_pose = start_pose;
     non_shifted_path.end_pose = start_pose;
-    non_shifted_path.acceleration = 2 * shift_distance / std::pow(time_to_end_pose, 2);
-    non_shifted_path.terminal_velocity = terminal_velocity;
+    non_shifted_path.pairs_terminal_velocity_and_accel.push_back(
+      std::make_pair(terminal_velocity, 2 * shift_distance / std::pow(time_to_end_pose, 2)));
     return non_shifted_path;
   });
 
@@ -292,8 +292,8 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     candidate_path.partial_paths.push_back(shifted_path.path);
     candidate_path.start_pose = shift_line.start;
     candidate_path.end_pose = shift_line.end;
-    candidate_path.acceleration = longitudinal_acc;
-    candidate_path.terminal_velocity = terminal_velocity;
+    candidate_path.pairs_terminal_velocity_and_accel.push_back(
+      std::make_pair(terminal_velocity, longitudinal_acc));
     candidate_paths.push_back(candidate_path);
   }
 


### PR DESCRIPTION
## Description

I added member variables for `PullOutPath`.
They will be used for ego predicted path generation in safety check

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
