### PR TITLE
fix(start/goal_planner): set previous lane_ids if freespace path is out of lanes

### DIFF
--- a/planning/behavior_path_planner/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/path_utils.cpp
@@ -341,14 +341,23 @@ PathWithLaneId convertWayPointsToPathWithLaneId(
 {
   PathWithLaneId path;
   path.header = waypoints.header;
-  for (const auto & waypoint : waypoints.waypoints) {
+  for (size_t i = 0; i < waypoints.waypoints.size(); ++i) {
+    const auto & waypoint = waypoints.waypoints.at(i);
     PathPointWithLaneId point{};
     point.point.pose = waypoint.pose.pose;
+    // put the lane that contain waypoints in lane_ids.
+    bool is_in_lanes = false;
     for (const auto & lane : lanelets) {
       if (lanelet::utils::isInLanelet(point.point.pose, lane)) {
         point.lane_ids.push_back(lane.id());
+        is_in_lanes = true;
       }
     }
+    // If none of them corresponds, assign the previous lane_ids.
+    if (!is_in_lanes && i > 0) {
+      point.lane_ids = path.points.at(i - 1).lane_ids;
+    }
+
     point.point.longitudinal_velocity_mps = (waypoint.is_back ? -1 : 1) * velocity;
     path.points.push_back(point);
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

If freespace path is out of lanes it has no lane ids, this causes behaivor_velocity dying.
```
#12 behavior_velocity_planner::util::getEgoLaneWithNextLane (path=..., associative_ids=..., width=1.8959999999999999) at /home/kosuke55/pilot-auto/src/autoware/universe/planning/behavior_velocity_intersection_module/src/util.cpp:886
886         const int next_id = path.points.at(ego_end).lane_ids.at(0);
```
In this PR set previous point lanes ids if out of laens.


before

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/b4a3695a-e0ca-439b-8d1e-5b9287bcad82)


after

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/46e79d6a-2856-492a-bf71-3d1b6c6f342e)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware.universe/pull/4668

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

[tier4 internal scenario test](https://evaluation.tier4.jp/evaluation/reports/774cb365-55ae-5eed-bae9-d87a964834e1?project_id=prd_jt)
fix goal planner scenario

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
