### PR TITLE
fix(mpc): use optimization result when polish failed

### DIFF
--- a/control/mpc_lateral_controller/src/qp_solver/qp_solver_osqp.cpp
+++ b/control/mpc_lateral_controller/src/qp_solver/qp_solver_osqp.cpp
@@ -75,7 +75,7 @@ bool QPSolverOSQP::solve(
   if (status_polish == -1 || status_polish == 0) {
     const auto s = (status_polish == 0) ? "Polish process is not performed in osqp."
                                         : "Polish process failed in osqp.";
-    RCLCPP_INFO(logger_, "%s The required accuracy is met, but the solution can be inaccurate.");
+    RCLCPP_INFO(logger_, "%s The required accuracy is met, but the solution can be inaccurate.", s);
     return true;
   }
   return true;

--- a/control/mpc_lateral_controller/src/qp_solver/qp_solver_osqp.cpp
+++ b/control/mpc_lateral_controller/src/qp_solver/qp_solver_osqp.cpp
@@ -72,12 +72,10 @@ bool QPSolverOSQP::solve(
 
   // polish status: successful (1), unperformed (0), (-1) unsuccessful
   int status_polish = std::get<2>(result);
-  if (status_polish == -1) {
-    RCLCPP_WARN(logger_, "osqp status_polish = %d (unsuccessful)", status_polish);
-    return false;
-  }
-  if (status_polish == 0) {
-    RCLCPP_WARN(logger_, "osqp status_polish = %d (unperformed)", status_polish);
+  if (status_polish == -1 || status_polish == 0) {
+    const auto s = (status_polish == 0) ? "Polish process is not performed in osqp."
+                                        : "Polish process failed in osqp.";
+    RCLCPP_INFO(logger_, "%s The required accuracy is met, but the solution can be inaccurate.");
     return true;
   }
   return true;

--- a/control/mpc_lateral_controller/test/test_mpc.cpp
+++ b/control/mpc_lateral_controller/test/test_mpc.cpp
@@ -252,9 +252,8 @@ TEST_F(MPCTest, OsqpCalculate)
   AckermannLateralCommand ctrl_cmd;
   Trajectory pred_traj;
   Float32MultiArrayStamped diag;
-  // with OSQP this function returns false despite finding correct solutions
   const auto odom = makeOdometry(pose_zero, default_velocity);
-  EXPECT_FALSE(mpc.calculateMPC(neutral_steer, odom, ctrl_cmd, pred_traj, diag));
+  EXPECT_TRUE(mpc.calculateMPC(neutral_steer, odom, ctrl_cmd, pred_traj, diag));
   EXPECT_EQ(ctrl_cmd.steering_tire_angle, 0.0f);
   EXPECT_EQ(ctrl_cmd.steering_tire_rotation_rate, 0.0f);
 }


### PR DESCRIPTION
## Description

Sometimes, the polish process in OSQP, which is designed to enhance result accuracy after optimization, can fail, particularly when the problem has a lot of constraints. However, in almost all cases, the optimization result meets the desired accuracy even if the polish fails. This PR allows the use of the optimization result even when the polish process is unsuccessful.

Before:
- Optimization failure -> publish stop command
- Polish failure (but optimization success) -> publish stop command

After:
- Optimization failure -> publish stop command
- Polish failure (but optimization success) -> keep using the optimization result


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
