### PR TITLE
feat(goal_planner): add extra front margin for collision check considering stopping distance

### DIFF
--- a/planning/behavior_path_planner/config/goal_planner/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/config/goal_planner/goal_planner.param.yaml
@@ -31,7 +31,8 @@
       # object recognition
       object_recognition:
         use_object_recognition: true
-        object_recognition_collision_check_margin: 1.0
+        object_recognition_collision_check_margin: 0.5
+        object_recognition_collision_check_extra_max_stopping_margin: 1.0
 
       # pull over
       pull_over:

--- a/planning/behavior_path_planner/config/goal_planner/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/config/goal_planner/goal_planner.param.yaml
@@ -31,7 +31,7 @@
       # object recognition
       object_recognition:
         use_object_recognition: true
-        object_recognition_collision_check_margin: 0.5
+        object_recognition_collision_check_margin: 0.6 # this should be larger than `surround_check_distance` of surround_obstacle_checker
         object_recognition_collision_check_max_extra_stopping_margin: 1.0
 
       # pull over

--- a/planning/behavior_path_planner/config/goal_planner/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/config/goal_planner/goal_planner.param.yaml
@@ -32,7 +32,7 @@
       object_recognition:
         use_object_recognition: true
         object_recognition_collision_check_margin: 0.5
-        object_recognition_collision_check_extra_max_stopping_margin: 1.0
+        object_recognition_collision_check_max_extra_stopping_margin: 1.0
 
       # pull over
       pull_over:

--- a/planning/behavior_path_planner/docs/behavior_path_planner_goal_planner_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_goal_planner_design.md
@@ -150,10 +150,11 @@ Generate footprints from ego-vehicle path points and determine obstacle collisio
 
 #### Parameters for object recognition based collision check
 
-| Name                                      | Unit | Type   | Description                                                | Default value |
-| :---------------------------------------- | :--- | :----- | :--------------------------------------------------------- | :------------ |
-| use_object_recognition                    | [-]  | bool   | flag whether to use object recognition for collision check | true          |
-| object_recognition_collision_check_margin | [m]  | double | margin to calculate ego-vehicle cells from footprint.      | 1.0           |
+| Name                                                         | Unit | Type   | Description                                                | Default value |
+| :----------------------------------------------------------- | :--- | :----- | :--------------------------------------------------------- | :------------ | ---------------------------------------------------------------------------------------------------------- |
+| use_object_recognition                                       | [-]  | bool   | flag whether to use object recognition for collision check | true          |
+| object_recognition_collision_check_margin                    | [m]  | double | margin to calculate ego-vehicle cells from footprint.      | 0.5           |
+| object_recognition_collision_check_extra_max_stopping_margin | [m]  | double |                                                            | 1.0           | 　maximum value when adding longitudinal distance margin for collision check considering stopping distance |
 
 ## **Goal Search**
 

--- a/planning/behavior_path_planner/docs/behavior_path_planner_goal_planner_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_goal_planner_design.md
@@ -153,7 +153,7 @@ Generate footprints from ego-vehicle path points and determine obstacle collisio
 | Name                                                         | Unit | Type   | Description                                                | Default value |
 | :----------------------------------------------------------- | :--- | :----- | :--------------------------------------------------------- | :------------ | ---------------------------------------------------------------------------------------------------------- |
 | use_object_recognition                                       | [-]  | bool   | flag whether to use object recognition for collision check | true          |
-| object_recognition_collision_check_margin                    | [m]  | double | margin to calculate ego-vehicle cells from footprint.      | 0.5           |
+| object_recognition_collision_check_margin                    | [m]  | double | margin to calculate ego-vehicle cells from footprint.      | 0.6           |
 | object_recognition_collision_check_max_extra_stopping_margin | [m]  | double |                                                            | 1.0           | 　maximum value when adding longitudinal distance margin for collision check considering stopping distance |
 
 ## **Goal Search**

--- a/planning/behavior_path_planner/docs/behavior_path_planner_goal_planner_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_goal_planner_design.md
@@ -154,7 +154,7 @@ Generate footprints from ego-vehicle path points and determine obstacle collisio
 | :----------------------------------------------------------- | :--- | :----- | :--------------------------------------------------------- | :------------ | ---------------------------------------------------------------------------------------------------------- |
 | use_object_recognition                                       | [-]  | bool   | flag whether to use object recognition for collision check | true          |
 | object_recognition_collision_check_margin                    | [m]  | double | margin to calculate ego-vehicle cells from footprint.      | 0.5           |
-| object_recognition_collision_check_extra_max_stopping_margin | [m]  | double |                                                            | 1.0           | 　maximum value when adding longitudinal distance margin for collision check considering stopping distance |
+| object_recognition_collision_check_max_extra_stopping_margin | [m]  | double |                                                            | 1.0           | 　maximum value when adding longitudinal distance margin for collision check considering stopping distance |
 
 ## **Goal Search**
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_planner_parameters.hpp
@@ -68,6 +68,7 @@ struct GoalPlannerParameters
   // object recognition
   bool use_object_recognition;
   double object_recognition_collision_check_margin;
+  double object_recognition_collision_check_extra_max_stopping_margin;
 
   // pull over general params
   double pull_over_velocity;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/goal_planner/goal_planner_parameters.hpp
@@ -68,7 +68,7 @@ struct GoalPlannerParameters
   // object recognition
   bool use_object_recognition;
   double object_recognition_collision_check_margin;
-  double object_recognition_collision_check_extra_max_stopping_margin;
+  double object_recognition_collision_check_max_extra_stopping_margin;
 
   // pull over general params
   double pull_over_velocity;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/safety_check.hpp
@@ -101,6 +101,15 @@ bool checkCollision(
   const BehaviorPathPlannerParameters & common_parameters, const double front_object_deceleration,
   const double rear_object_deceleration, CollisionCheckDebug & debug);
 
+/**
+ * @brief Check collision between ego path footprints with extra longitudinal stopping margin and
+ * objects.
+ * @return Has collision or not
+ */
+bool checkCollisionWithExtraStoppingMargin(
+  const PathWithLaneId & ego_path, const PredictedObjects & dynamic_objects,
+  const double base_to_front, const double base_to_rear, const double width,
+  const double maximum_deceleration, const double margin, const double max_stopping_margin);
 }  // namespace behavior_path_planner::utils::path_safety_checker
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__PATH_SAFETY_CHECKER__SAFETY_CHECK_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -165,6 +165,16 @@ double getDistanceBetweenPredictedPathAndObject(
   const double end_time, const double resolution);
 
 /**
+ * @brief Check collision between ego path footprints with extra longitudinal stopping margin and
+ * objects.
+ * @return Has collision or not
+ */
+bool checkCollisionWithExtraStoppingMargin(
+  const PathWithLaneId & ego_path, const PredictedObjects & dynamic_objects,
+  const double base_to_front, const double base_to_rear, const double width,
+  const double maximum_deceleration, const double margin, const double max_stopping_margin);
+
+/**
  * @brief Check collision between ego path footprints and objects.
  * @return Has collision or not
  */

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -1184,7 +1184,7 @@ bool GoalPlannerModule::checkCollision(const PathWithLaneId & path) const
     const double base_link2front = common_parameters.base_link2front;
     const double base_link2rear = common_parameters.base_link2rear;
     const double vehicle_width = common_parameters.vehicle_width;
-    if (utils::checkCollisionWithExtraStoppingMargin(
+    if (utils::path_safety_checker::checkCollisionWithExtraStoppingMargin(
           path, *(planner_data_->dynamic_object), base_link2front, base_link2rear, vehicle_width,
           parameters_->maximum_deceleration, parameters_->object_recognition_collision_check_margin,
           parameters_->object_recognition_collision_check_extra_max_stopping_margin)) {

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -553,7 +553,9 @@ void GoalPlannerModule::selectSafePullOverPath()
     }
 
     // check if path is valid and safe
-    if (!hasEnoughDistance(pull_over_path) || checkCollision(pull_over_path.getParkingPath())) {
+    if (
+      !hasEnoughDistance(pull_over_path) ||
+      checkCollision(utils::resamplePathWithSpline(pull_over_path.getParkingPath(), 0.5))) {
       continue;
     }
 
@@ -1178,9 +1180,14 @@ bool GoalPlannerModule::checkCollision(const PathWithLaneId & path) const
   }
 
   if (parameters_->use_object_recognition) {
-    if (utils::checkCollisionBetweenPathFootprintsAndObjects(
-          vehicle_footprint_, path, *(planner_data_->dynamic_object),
-          parameters_->object_recognition_collision_check_margin)) {
+    const auto common_parameters = planner_data_->parameters;
+    const double base_link2front = common_parameters.base_link2front;
+    const double base_link2rear = common_parameters.base_link2rear;
+    const double vehicle_width = common_parameters.vehicle_width;
+    if (utils::checkCollisionWithExtraStoppingMargin(
+          path, *(planner_data_->dynamic_object), base_link2front, base_link2rear, vehicle_width,
+          parameters_->maximum_deceleration, parameters_->object_recognition_collision_check_margin,
+          parameters_->object_recognition_collision_check_extra_max_stopping_margin)) {
       return true;
     }
   }

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -1187,7 +1187,7 @@ bool GoalPlannerModule::checkCollision(const PathWithLaneId & path) const
     if (utils::path_safety_checker::checkCollisionWithExtraStoppingMargin(
           path, *(planner_data_->dynamic_object), base_link2front, base_link2rear, vehicle_width,
           parameters_->maximum_deceleration, parameters_->object_recognition_collision_check_margin,
-          parameters_->object_recognition_collision_check_extra_max_stopping_margin)) {
+          parameters_->object_recognition_collision_check_max_extra_stopping_margin)) {
       return true;
     }
   }

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
@@ -88,9 +88,9 @@ GoalPlannerModuleManager::GoalPlannerModuleManager(
     p.use_object_recognition = node->declare_parameter<bool>(ns + "use_object_recognition");
     p.object_recognition_collision_check_margin =
       node->declare_parameter<double>(ns + "object_recognition_collision_check_margin");
-    p.object_recognition_collision_check_extra_max_stopping_margin =
+    p.object_recognition_collision_check_max_extra_stopping_margin =
       node->declare_parameter<double>(
-        ns + "object_recognition_collision_check_extra_max_stopping_margin");
+        ns + "object_recognition_collision_check_max_extra_stopping_margin");
   }
 
   // pull over general params

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/manager.cpp
@@ -88,6 +88,9 @@ GoalPlannerModuleManager::GoalPlannerModuleManager(
     p.use_object_recognition = node->declare_parameter<bool>(ns + "use_object_recognition");
     p.object_recognition_collision_check_margin =
       node->declare_parameter<double>(ns + "object_recognition_collision_check_margin");
+    p.object_recognition_collision_check_extra_max_stopping_margin =
+      node->declare_parameter<double>(
+        ns + "object_recognition_collision_check_extra_max_stopping_margin");
   }
 
   // pull over general params

--- a/planning/behavior_path_planner/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/src/utils/path_safety_checker/safety_check.cpp
@@ -303,4 +303,27 @@ bool checkCollision(
 
   return true;
 }
+
+bool checkCollisionWithExtraStoppingMargin(
+  const PathWithLaneId & ego_path, const PredictedObjects & dynamic_objects,
+  const double base_to_front, const double base_to_rear, const double width,
+  const double maximum_deceleration, const double margin, const double max_extra_stopping_margin)
+{
+  for (const auto & p : ego_path.points) {
+    const double extra_stopping_margin = std::min(
+      std::pow(p.point.longitudinal_velocity_mps, 2) * 0.5 / maximum_deceleration,
+      max_extra_stopping_margin);
+
+    const auto ego_polygon = tier4_autoware_utils::toFootprint(
+      p.point.pose, base_to_front + extra_stopping_margin, base_to_rear, width);
+
+    for (const auto & object : dynamic_objects.objects) {
+      const auto obj_polygon = tier4_autoware_utils::toPolygon2d(object);
+      const double distance = boost::geometry::distance(obj_polygon, ego_polygon);
+      if (distance < margin) return true;
+    }
+  }
+
+  return false;
+}
 }  // namespace behavior_path_planner::utils::path_safety_checker

--- a/planning/behavior_path_planner/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/src/utils/path_safety_checker/safety_check.cpp
@@ -307,7 +307,8 @@ bool checkCollision(
 bool checkCollisionWithExtraStoppingMargin(
   const PathWithLaneId & ego_path, const PredictedObjects & dynamic_objects,
   const double base_to_front, const double base_to_rear, const double width,
-  const double maximum_deceleration, const double margin, const double max_extra_stopping_margin)
+  const double maximum_deceleration, const double collision_check_margin,
+  const double max_extra_stopping_margin)
 {
   for (const auto & p : ego_path.points) {
     const double extra_stopping_margin = std::min(
@@ -320,7 +321,7 @@ bool checkCollisionWithExtraStoppingMargin(
     for (const auto & object : dynamic_objects.objects) {
       const auto obj_polygon = tier4_autoware_utils::toPolygon2d(object);
       const double distance = boost::geometry::distance(obj_polygon, ego_polygon);
-      if (distance < margin) return true;
+      if (distance < collision_check_margin) return true;
     }
   }
 

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -621,29 +621,6 @@ bool checkCollisionBetweenPathFootprintsAndObjects(
   return false;
 }
 
-bool checkCollisionWithExtraStoppingMargin(
-  const PathWithLaneId & ego_path, const PredictedObjects & dynamic_objects,
-  const double base_to_front, const double base_to_rear, const double width,
-  const double maximum_deceleration, const double margin, const double max_extra_stopping_margin)
-{
-  for (const auto & p : ego_path.points) {
-    const double extra_stopping_margin = std::min(
-      std::pow(p.point.longitudinal_velocity_mps, 2) * 0.5 / maximum_deceleration,
-      max_extra_stopping_margin);
-
-    const auto ego_polygon = tier4_autoware_utils::toFootprint(
-      p.point.pose, base_to_front + extra_stopping_margin, base_to_rear, width);
-
-    for (const auto & object : dynamic_objects.objects) {
-      const auto obj_polygon = tier4_autoware_utils::toPolygon2d(object);
-      const double distance = boost::geometry::distance(obj_polygon, ego_polygon);
-      if (distance < margin) return true;
-    }
-  }
-
-  return false;
-}
-
 bool checkCollisionBetweenFootprintAndObjects(
   const tier4_autoware_utils::LinearRing2d & local_vehicle_footprint, const Pose & ego_pose,
   const PredictedObjects & dynamic_objects, const double margin)


### PR DESCRIPTION
# Description

<!-- Write a brief description of this PR. -->

currently, the collision check margin is the same value in any direction.
In this PR, add extra front margin dynamically considering stopping distance.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84fbda8</samp>

This pull request enhances the goal planner module of the behavior path planner by using spline interpolation and extra stopping margin for pull over path planning. It adds a new parameter `object_recognition_collision_check_extra_max_stopping_margin` to control the extra margin and updates the collision check functions and the documentation accordingly. It also modifies the files `goal_planner_module.cpp`, `goal_planner.param.yaml`, `goal_planner_parameters.hpp`, `utils.hpp`, `manager.cpp`, and `utils.cpp`.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware_launch/pull/520

## Tests performed

<!-- Describe how you have tested this PR. -->

psim


https://github.com/autowarefoundation/autoware.universe/assets/39142679/f7536332-0e97-43d6-8ff3-6e3869003ea0


https://evaluation.tier4.jp/evaluation/reports/466af58f-2513-5a1c-9df3-efcffe9bae0e?project_id=prd_jt


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
