### PR TITLE
feat(behavior_path_planner): more stable dynamic drivable area expansion

### DIFF
--- a/planning/behavior_path_planner/config/drivable_area_expansion.param.yaml
+++ b/planning/behavior_path_planner/config/drivable_area_expansion.param.yaml
@@ -21,12 +21,14 @@
           rear: 0.5 # [m] extra length to add to the rear of the dynamic object footprint
           left: 0.5 # [m] extra length to add to the left of the dynamic object footprint
           right: 0.5 # [m] extra length to add to the rear of the dynamic object footprint
+      path_preprocessing:
+        max_arc_length: 50.0 # [m] maximum arc length along the path where the ego footprint is projected (0.0 means no limit)
+        resample_interval: 2.0 # [m] fixed interval between resampled path points (0.0 means path points are directly used)
       expansion:
         method: polygon # method used to expand the drivable area. Either 'lanelet' or 'polygon'.
                          # 'lanelet': add lanelets overlapped by the ego footprints
                          # 'polygon': add polygons built around sections of the ego footprint that go out of the drivable area
         max_distance: 0.0 # [m] maximum distance by which the drivable area can be expended (0.0 means no limit)
-        max_path_arc_length: 50.0 # [m] maximum arc length along the path where the ego footprint is projected (0.0 means no limit)
         extra_arc_length: 0.5 # [m] extra expansion arc length around an ego footprint
       avoid_linestring:
         types: # linestring types in the lanelet maps that will not be crossed when expanding the drivable area

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -29,6 +29,7 @@
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -147,6 +148,7 @@ struct PlannerData
   std::shared_ptr<RouteHandler> route_handler{std::make_shared<RouteHandler>()};
   BehaviorPathPlannerParameters parameters{};
   drivable_area_expansion::DrivableAreaExpansionParameters drivable_area_expansion_parameters{};
+  std::optional<geometry_msgs::msg::Point> drivable_area_expansion_prev_crop_point;
 
   mutable TurnSignalDecider turn_signal_decider;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -29,7 +29,7 @@
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
-#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -148,7 +148,7 @@ struct PlannerData
   std::shared_ptr<RouteHandler> route_handler{std::make_shared<RouteHandler>()};
   BehaviorPathPlannerParameters parameters{};
   drivable_area_expansion::DrivableAreaExpansionParameters drivable_area_expansion_parameters{};
-  std::optional<geometry_msgs::msg::Point> drivable_area_expansion_prev_crop_point;
+  std::optional<geometry_msgs::msg::Pose> drivable_area_expansion_prev_crop_pose;
 
   mutable TurnSignalDecider turn_signal_decider;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -148,8 +148,8 @@ struct PlannerData
   std::shared_ptr<RouteHandler> route_handler{std::make_shared<RouteHandler>()};
   BehaviorPathPlannerParameters parameters{};
   drivable_area_expansion::DrivableAreaExpansionParameters drivable_area_expansion_parameters{};
-  std::optional<geometry_msgs::msg::Pose> drivable_area_expansion_prev_crop_pose;
 
+  mutable std::optional<geometry_msgs::msg::Pose> drivable_area_expansion_prev_crop_pose;
   mutable TurnSignalDecider turn_signal_decider;
 
   TurnIndicatorsCommand getTurnSignal(

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/drivable_area_expansion.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/drivable_area_expansion.hpp
@@ -32,7 +32,8 @@ namespace drivable_area_expansion
 /// @param[inout] planner_data planning data (params, dynamic objects, route handler, ...)
 /// @param[in] path_lanes lanelets of the path
 void expandDrivableArea(
-  PathWithLaneId & path, const std::shared_ptr<behavior_path_planner::PlannerData> planner_data,
+  PathWithLaneId & path,
+  const std::shared_ptr<const behavior_path_planner::PlannerData> planner_data,
   const lanelet::ConstLanelets & path_lanes);
 
 /// @brief Create a polygon combining the drivable area of a path and some expansion polygons

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/drivable_area_expansion.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/drivable_area_expansion.hpp
@@ -15,6 +15,7 @@
 #ifndef BEHAVIOR_PATH_PLANNER__UTILS__DRIVABLE_AREA_EXPANSION__DRIVABLE_AREA_EXPANSION_HPP_
 #define BEHAVIOR_PATH_PLANNER__UTILS__DRIVABLE_AREA_EXPANSION__DRIVABLE_AREA_EXPANSION_HPP_
 
+#include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/parameters.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/types.hpp"
 
@@ -22,17 +23,16 @@
 
 #include <lanelet2_core/Forward.h>
 
+#include <memory>
+
 namespace drivable_area_expansion
 {
 /// @brief Expand the drivable area based on the projected ego footprint along the path
-/// @param[in] path path whose drivable area will be expanded
-/// @param[in] params expansion parameters
-/// @param[in] dynamic_objects dynamic objects
-/// @param[in] route_handler route handler
+/// @param[inout] path path whose drivable area will be expanded
+/// @param[inout] planner_data planning data (params, dynamic objects, route handler, ...)
 /// @param[in] path_lanes lanelets of the path
 void expandDrivableArea(
-  PathWithLaneId & path, const DrivableAreaExpansionParameters & params,
-  const PredictedObjects & dynamic_objects, const route_handler::RouteHandler & route_handler,
+  PathWithLaneId & path, const std::shared_ptr<behavior_path_planner::PlannerData> planner_data,
   const lanelet::ConstLanelets & path_lanes);
 
 /// @brief Create a polygon combining the drivable area of a path and some expansion polygons

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/footprints.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/footprints.hpp
@@ -64,6 +64,6 @@ multi_polygon_t createObjectFootprints(
 /// @param[in] params expansion parameters defining how to create the footprint
 /// @return footprint polygons of the path
 multi_polygon_t createPathFootprints(
-  const PathWithLaneId & path, const DrivableAreaExpansionParameters & params);
+  const std::vector<PathPointWithLaneId> & path, const DrivableAreaExpansionParameters & params);
 }  // namespace drivable_area_expansion
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__DRIVABLE_AREA_EXPANSION__FOOTPRINTS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
@@ -48,8 +48,10 @@ struct DrivableAreaExpansionParameters
     "dynamic_expansion.dynamic_objects.extra_footprint_offset.right";
   static constexpr auto EXPANSION_METHOD_PARAM = "dynamic_expansion.expansion.method";
   static constexpr auto MAX_EXP_DIST_PARAM = "dynamic_expansion.expansion.max_distance";
+  static constexpr auto RESAMPLE_INTERVAL_PARAM =
+    "dynamic_expansion.path_preprocessing.resample_interval";
   static constexpr auto MAX_PATH_ARC_LENGTH_PARAM =
-    "dynamic_expansion.expansion.max_path_arc_length";
+    "dynamic_expansion.path_preprocessing.max_arc_length";
   static constexpr auto EXTRA_ARC_LENGTH_PARAM = "dynamic_expansion.expansion.extra_arc_length";
   static constexpr auto AVOID_DYN_OBJECTS_PARAM = "dynamic_expansion.dynamic_objects.avoid";
   static constexpr auto AVOID_LINESTRING_TYPES_PARAM = "dynamic_expansion.avoid_linestring.types";
@@ -78,6 +80,7 @@ struct DrivableAreaExpansionParameters
   double dynamic_objects_extra_front_offset{};
   double max_expansion_distance{};
   double max_path_arc_length{};
+  double resample_interval{};
   double extra_arc_length{};
   bool avoid_dynamic_objects{};
   std::vector<std::string> avoid_linestring_types{};
@@ -98,6 +101,7 @@ struct DrivableAreaExpansionParameters
     enabled = node.declare_parameter<bool>(ENABLED_PARAM);
     max_expansion_distance = node.declare_parameter<double>(MAX_EXP_DIST_PARAM);
     max_path_arc_length = node.declare_parameter<double>(MAX_PATH_ARC_LENGTH_PARAM);
+    resample_interval = node.declare_parameter<double>(RESAMPLE_INTERVAL_PARAM);
     ego_extra_front_offset = node.declare_parameter<double>(EGO_EXTRA_OFFSET_FRONT);
     ego_extra_rear_offset = node.declare_parameter<double>(EGO_EXTRA_OFFSET_REAR);
     ego_extra_left_offset = node.declare_parameter<double>(EGO_EXTRA_OFFSET_LEFT);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/types.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/types.hpp
@@ -26,6 +26,7 @@ namespace drivable_area_expansion
 {
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::PathPoint;
+using autoware_auto_planning_msgs::msg::PathPointWithLaneId;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using geometry_msgs::msg::Point;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -229,7 +229,7 @@ std::vector<DrivableLanes> cutOverlappedLanes(
 void generateDrivableArea(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes,
   const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
-  const double vehicle_length, const std::shared_ptr<const PlannerData> planner_data,
+  const double vehicle_length, const std::shared_ptr<PlannerData> planner_data,
   const bool is_driving_forward = true);
 
 void generateDrivableArea(

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -229,7 +229,7 @@ std::vector<DrivableLanes> cutOverlappedLanes(
 void generateDrivableArea(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes,
   const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
-  const double vehicle_length, const std::shared_ptr<PlannerData> planner_data,
+  const double vehicle_length, const std::shared_ptr<const PlannerData> planner_data,
   const bool is_driving_forward = true);
 
 void generateDrivableArea(

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1061,6 +1061,9 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
       parameters, DrivableAreaExpansionParameters::MAX_PATH_ARC_LENGTH_PARAM,
       planner_data_->drivable_area_expansion_parameters.max_path_arc_length);
     updateParam(
+      parameters, DrivableAreaExpansionParameters::RESAMPLE_INTERVAL_PARAM,
+      planner_data_->drivable_area_expansion_parameters.resample_interval);
+    updateParam(
       parameters, DrivableAreaExpansionParameters::EXTRA_ARC_LENGTH_PARAM,
       planner_data_->drivable_area_expansion_parameters.extra_arc_length);
     updateParam(

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -31,9 +31,9 @@ namespace drivable_area_expansion
 
 std::vector<PathPointWithLaneId> crop_and_resample(
   const std::vector<PathPointWithLaneId> & points,
-  const std::shared_ptr<const behavior_path_planner::PlannerData> planner_data)
+  const std::shared_ptr<const behavior_path_planner::PlannerData> planner_data,
+  const double resample_interval)
 {
-  constexpr auto resample_interval = 2.0;  // TODO(Maxime): param
   auto lon_offset = 0.0;
   auto crop_pose = *planner_data->drivable_area_expansion_prev_crop_pose;
   // reuse or update the previous crop point
@@ -91,7 +91,7 @@ void expandDrivableArea(
   for (const auto & line : uncrossable_lines)
     if (boost::geometry::distance(line, point_t{p.x, p.y}) < params.max_path_arc_length)
       uncrossable_lines_in_range.push_back(line);
-  const auto points = crop_and_resample(path.points, planner_data);
+  const auto points = crop_and_resample(path.points, planner_data, params.resample_interval);
   const auto path_footprints = createPathFootprints(points, params);
   const auto predicted_paths = createObjectFootprints(dynamic_objects, params);
   const auto expansion_polygons =

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -43,8 +43,9 @@ std::vector<PathPointWithLaneId> crop_and_resample(
     if (lon_offset < 0.0) {
       planner_data->drivable_area_expansion_prev_crop_pose.reset();
     } else {
-      const auto is_behind_ego = motion_utils::calcSignedArcLength(
-        points, crop_pose.position, planner_data->self_odometry->pose.pose.position);
+      const auto is_behind_ego =
+        motion_utils::calcSignedArcLength(
+          points, crop_pose.position, planner_data->self_odometry->pose.pose.position) > 0.0;
       const auto is_too_far = motion_utils::calcLateralOffset(points, crop_pose.position) > 0.1;
       if (!is_behind_ego || is_too_far)
         planner_data->drivable_area_expansion_prev_crop_pose.reset();

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -31,7 +31,7 @@ namespace drivable_area_expansion
 
 std::vector<PathPointWithLaneId> crop_and_resample(
   const std::vector<PathPointWithLaneId> & points,
-  const std::shared_ptr<behavior_path_planner::PlannerData> planner_data)
+  const std::shared_ptr<const behavior_path_planner::PlannerData> planner_data)
 {
   constexpr auto resample_interval = 2.0;  // TODO(Maxime): param
   auto lon_offset = 0.0;
@@ -76,7 +76,8 @@ std::vector<PathPointWithLaneId> crop_and_resample(
 }
 
 void expandDrivableArea(
-  PathWithLaneId & path, const std::shared_ptr<behavior_path_planner::PlannerData> planner_data,
+  PathWithLaneId & path,
+  const std::shared_ptr<const behavior_path_planner::PlannerData> planner_data,
   const lanelet::ConstLanelets & path_lanes)
 {
   const auto & params = planner_data->drivable_area_expansion_parameters;

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
@@ -80,7 +80,7 @@ std::array<double, 3> calculate_arc_length_range_and_distance(
     }
     for (const auto & p : footprint.outer()) {
       const auto projection = point_to_linestring_projection(p, path_ls);
-      if (projection.arc_length <= 0.0 || projection.arc_length >= path_length) continue;
+      if (projection.arc_length <= 0.0 || projection.arc_length >= path_length - 1e-3) continue;
       if (is_left == (projection.distance > 0) && std::abs(projection.distance) > expansion_dist) {
         expansion_dist = std::abs(projection.distance);
         from_arc_length = std::min(from_arc_length, projection.arc_length);

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/footprints.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/footprints.cpp
@@ -63,7 +63,7 @@ multi_polygon_t createObjectFootprints(
 }
 
 multi_polygon_t createPathFootprints(
-  const PathWithLaneId & path, const DrivableAreaExpansionParameters & params)
+  const std::vector<PathPointWithLaneId> & points, const DrivableAreaExpansionParameters & params)
 {
   const auto left = params.ego_left_offset + params.ego_extra_left_offset;
   const auto right = params.ego_right_offset - params.ego_extra_right_offset;
@@ -75,9 +75,9 @@ multi_polygon_t createPathFootprints(
     point_t{front, left}};
   multi_polygon_t footprints;
   // skip the last footprint as its orientation is usually wrong
-  footprints.reserve(path.points.size() - 1);
+  footprints.reserve(points.size() - 1);
   double arc_length = 0.0;
-  for (auto it = path.points.begin(); std::next(it) != path.points.end(); ++it) {
+  for (auto it = points.begin(); std::next(it) != points.end(); ++it) {
     footprints.push_back(createFootprint(it->point.pose, base_footprint));
     if (params.max_path_arc_length > 0.0) {
       arc_length += tier4_autoware_utils::calcDistance2d(it->point.pose, std::next(it)->point.pose);

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1324,7 +1324,7 @@ geometry_msgs::msg::Point calcLongitudinalOffsetGoalPoint(
 void generateDrivableArea(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes,
   const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
-  const double vehicle_length, const std::shared_ptr<const PlannerData> planner_data,
+  const double vehicle_length, const std::shared_ptr<PlannerData> planner_data,
   const bool is_driving_forward)
 {
   // extract data
@@ -1497,9 +1497,7 @@ void generateDrivableArea(
   }
   const auto & expansion_params = planner_data->drivable_area_expansion_parameters;
   if (expansion_params.enabled) {
-    drivable_area_expansion::expandDrivableArea(
-      path, expansion_params, *planner_data->dynamic_object, *planner_data->route_handler,
-      transformed_lanes);
+    drivable_area_expansion::expandDrivableArea(path, planner_data, transformed_lanes);
   }
 
   // make bound longitudinally monotonic

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1324,7 +1324,7 @@ geometry_msgs::msg::Point calcLongitudinalOffsetGoalPoint(
 void generateDrivableArea(
   PathWithLaneId & path, const std::vector<DrivableLanes> & lanes,
   const bool enable_expanding_hatched_road_markings, const bool enable_expanding_intersection_areas,
-  const double vehicle_length, const std::shared_ptr<PlannerData> planner_data,
+  const double vehicle_length, const std::shared_ptr<const PlannerData> planner_data,
   const bool is_driving_forward)
 {
   // extract data

--- a/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
@@ -258,6 +258,7 @@ TEST(DrivableAreaExpansionProjection, expandDrivableArea)
     params.compensate_extra_dist = false;
     params.max_expansion_distance = 0.0;  // means no limit
     params.max_path_arc_length = 0.0;     // means no limit
+    params.resample_interval = 1.0;
     params.extra_arc_length = 1.0;
     params.expansion_method = "polygon";
     // 2m x 4m ego footprint

--- a/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/drivable_area_expansion.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/expansion.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/path_projection.hpp"
@@ -265,9 +266,15 @@ TEST(DrivableAreaExpansionProjection, expandDrivableArea)
     params.ego_left_offset = 2.0;
     params.ego_right_offset = -2.0;
   }
+  behavior_path_planner::PlannerData planner_data;
+  planner_data.drivable_area_expansion_parameters = params;
+  planner_data.reference_path = std::make_shared<drivable_area_expansion::PathWithLaneId>(path);
+  planner_data.dynamic_object =
+    std::make_shared<drivable_area_expansion::PredictedObjects>(dynamic_objects);
+  planner_data.route_handler = std::make_shared<route_handler::RouteHandler>(route_handler);
   // we expect the drivable area to be expanded by 1m on each side
   drivable_area_expansion::expandDrivableArea(
-    path, params, dynamic_objects, route_handler, path_lanes);
+    path, std::make_shared<behavior_path_planner::PlannerData>(planner_data), path_lanes);
   // unchanged path points
   ASSERT_EQ(path.points.size(), 3ul);
   for (auto i = 0.0; i < path.points.size(); ++i) {


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Improve the stability of the drivable area bounds when using the dynamic expansion.
The instability is caused by the path points moving, so this PR adds a resampling of the points at fixed intervals.

Requires the following PR to add the new parameter: https://github.com/autowarefoundation/autoware_launch/pull/522.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim and evaluator.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

More stable drivable area bounds when using the dynamic expansion.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
