### PR TITLE
fix(costmap_generator): prevent invalid access for current_pose

### DIFF
--- a/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
+++ b/planning/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
@@ -350,6 +350,7 @@ bool CostmapGenerator::isActive()
     return false;
   } else {
     const auto & current_pose_wrt_map = getCurrentPose(tf_buffer_, this->get_logger());
+    if (!current_pose_wrt_map) return false;
     return isInParkingLot(lanelet_map_, current_pose_wrt_map->pose);
   }
 }


### PR DESCRIPTION
## Description
Add guard for preventing access to null ```current_pose_wrt_map```.
(Fixed costmap_generator process dying when playing rosbag)

<!-- Write a brief description of this PR. -->

## Tests performed
Tested on logging_simulator
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
