### PR TITLE
fix(behavior_path_planner): proper drivable area expansion limit with lines

### DIFF
--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
@@ -30,8 +30,8 @@ double calculateDistanceLimit(
     boost::geometry::intersection(expansion_polygon, limit_lines, intersections);
     for (const auto & p : intersections)
       dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
-    if (!intersections.empty())
-      for (const auto & p : line)
+    for (const auto & p : line)
+      if (boost::geometry::within(p, expansion_polygon))
         dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
   }
   return dist_limit;

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
@@ -25,10 +25,15 @@ double calculateDistanceLimit(
   const multi_linestring_t & limit_lines)
 {
   auto dist_limit = std::numeric_limits<double>::max();
-  multi_point_t intersections;
-  boost::geometry::intersection(expansion_polygon, limit_lines, intersections);
-  for (const auto & p : intersections)
-    dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
+  for (const auto & line : limit_lines) {
+    multi_point_t intersections;
+    boost::geometry::intersection(expansion_polygon, limit_lines, intersections);
+    for (const auto & p : intersections)
+      dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
+    if (!intersections.empty())
+      for (const auto & p : line)
+        dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
+  }
   return dist_limit;
 }
 

--- a/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
@@ -18,7 +18,6 @@
 #include "behavior_path_planner/utils/drivable_area_expansion/types.hpp"
 #include "lanelet2_extension/utility/message_conversion.hpp"
 
-#include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
 
 using drivable_area_expansion::linestring_t;

--- a/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
@@ -338,7 +338,7 @@ TEST(DrivableAreaExpansion, calculateDistanceLimitEdgeCases)
 
   const linestring_t base_ls = {{0.0, 0.0}, {10.0, 0.0}};
   const polygon_t expansion_polygon = {
-    {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {10.0, -4.0}}, {}};
+    {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {0.0, -4.0}}, {}};
   {  // intersection points further than the line point inside the expansion polygon
     const linestring_t uncrossable_lines = {{4.0, 5.0}, {6.0, 3.0}};
     const auto limit_distance =
@@ -351,17 +351,6 @@ TEST(DrivableAreaExpansion, calculateDistanceLimitEdgeCases)
       calculateDistanceLimit(base_ls, expansion_polygon, {uncrossable_lines});
     EXPECT_NEAR(limit_distance, 2.0, 1e-9);
   }
-}
-
-TEST(DrivableAreaExpansion, DISABLED_calculateDistanceLimitEdgeCases)
-{
-  using drivable_area_expansion::calculateDistanceLimit;
-  using drivable_area_expansion::linestring_t;
-  using drivable_area_expansion::polygon_t;
-
-  const linestring_t base_ls = {{0.0, 0.0}, {10.0, 0.0}};
-  const polygon_t expansion_polygon = {
-    {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {10.0, -4.0}}, {}};
   {  // line completely inside the expansion polygon
     const linestring_t uncrossable_lines = {{4.0, 2.0}, {6.0, 3.0}};
     const auto limit_distance =

--- a/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/test/test_drivable_area_expansion.cpp
@@ -18,6 +18,7 @@
 #include "behavior_path_planner/utils/drivable_area_expansion/types.hpp"
 #include "lanelet2_extension/utility/message_conversion.hpp"
 
+#include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
 
 using drivable_area_expansion::linestring_t;
@@ -304,7 +305,7 @@ TEST(DrivableAreaExpansion, calculateDistanceLimit)
     const linestring_t base_ls = {{0.0, 0.0}, {10.0, 0.0}};
     const multi_linestring_t uncrossable_lines = {};
     const polygon_t expansion_polygon = {
-      {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {10.0, -4.0}}, {}};
+      {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {0.0, -4.0}}, {}};
     const auto limit_distance =
       calculateDistanceLimit(base_ls, expansion_polygon, uncrossable_lines);
     EXPECT_NEAR(limit_distance, std::numeric_limits<double>::max(), 1e-9);
@@ -313,7 +314,7 @@ TEST(DrivableAreaExpansion, calculateDistanceLimit)
     const linestring_t base_ls = {{0.0, 0.0}, {10.0, 0.0}};
     const linestring_t uncrossable_line = {{0.0, 2.0}, {10.0, 2.0}};
     const polygon_t expansion_polygon = {
-      {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {10.0, -4.0}}, {}};
+      {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {0.0, -4.0}}, {}};
     const auto limit_distance =
       calculateDistanceLimit(base_ls, expansion_polygon, {uncrossable_line});
     EXPECT_NEAR(limit_distance, 2.0, 1e-9);
@@ -323,9 +324,55 @@ TEST(DrivableAreaExpansion, calculateDistanceLimit)
     const multi_linestring_t uncrossable_lines = {
       {{0.0, 2.0}, {10.0, 2.0}}, {{0.0, 1.5}, {10.0, 1.0}}};
     const polygon_t expansion_polygon = {
-      {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {10.0, -4.0}}, {}};
+      {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {0.0, -4.0}}, {}};
     const auto limit_distance =
       calculateDistanceLimit(base_ls, expansion_polygon, uncrossable_lines);
     EXPECT_NEAR(limit_distance, 1.0, 1e-9);
+  }
+}
+
+TEST(DrivableAreaExpansion, calculateDistanceLimitEdgeCases)
+{
+  using drivable_area_expansion::calculateDistanceLimit;
+  using drivable_area_expansion::linestring_t;
+  using drivable_area_expansion::polygon_t;
+
+  const linestring_t base_ls = {{0.0, 0.0}, {10.0, 0.0}};
+  const polygon_t expansion_polygon = {
+    {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {10.0, -4.0}}, {}};
+  {  // intersection points further than the line point inside the expansion polygon
+    const linestring_t uncrossable_lines = {{4.0, 5.0}, {6.0, 3.0}};
+    const auto limit_distance =
+      calculateDistanceLimit(base_ls, expansion_polygon, {uncrossable_lines});
+    EXPECT_NEAR(limit_distance, 3.0, 1e-9);
+  }
+  {  // intersection points further than the line point inside the expansion polygon
+    const linestring_t uncrossable_lines = {{4.0, 5.0}, {5.0, 2.0}, {6.0, 4.5}};
+    const auto limit_distance =
+      calculateDistanceLimit(base_ls, expansion_polygon, {uncrossable_lines});
+    EXPECT_NEAR(limit_distance, 2.0, 1e-9);
+  }
+}
+
+TEST(DrivableAreaExpansion, DISABLED_calculateDistanceLimitEdgeCases)
+{
+  using drivable_area_expansion::calculateDistanceLimit;
+  using drivable_area_expansion::linestring_t;
+  using drivable_area_expansion::polygon_t;
+
+  const linestring_t base_ls = {{0.0, 0.0}, {10.0, 0.0}};
+  const polygon_t expansion_polygon = {
+    {{0.0, -4.0}, {0.0, 4.0}, {10.0, 4.0}, {10.0, -4.0}, {10.0, -4.0}}, {}};
+  {  // line completely inside the expansion polygon
+    const linestring_t uncrossable_lines = {{4.0, 2.0}, {6.0, 3.0}};
+    const auto limit_distance =
+      calculateDistanceLimit(base_ls, expansion_polygon, {uncrossable_lines});
+    EXPECT_NEAR(limit_distance, 2.0, 1e-9);
+  }
+  {  // line completely inside the expansion polygon
+    const linestring_t uncrossable_lines = {{4.0, 3.5}, {6.0, 3.0}};
+    const auto limit_distance =
+      calculateDistanceLimit(base_ls, expansion_polygon, {uncrossable_lines});
+    EXPECT_NEAR(limit_distance, 3.0, 1e-9);
   }
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR fixes an issue with lines that should not be crossed by the drivable area (e.g., `road_border`).
The current implementation recalculates the expansion distance by using the intersection points between the expanded polygon, and the line to avoid.
The issue occurs when the line to avoid has points _inside_ the polygon that were previously ignored but were closer to the path than the intersection points. With this PR, the points are considered such that the recalculated expansion distance is now correct.

:warning: ~one edge case is still not handled: when the linestring is completely inside the expansion polygon (see the added unit tests).~

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim
New unit tests

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Lines to avoid (e.g., `road_border`) should no longer be crossed by the expanded drivable area.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
