### PR TITLE
feat(pid_longitudinal_controller): improve delay and slope compensation

### DIFF
--- a/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/pid_longitudinal_controller/include/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -66,13 +66,25 @@ private:
     double vel{0.0};
     double acc{0.0};
   };
-
+  struct StateAfterDelay
+  {
+    StateAfterDelay(const double velocity, const double acceleration, const double distance)
+    : vel(velocity), acc(acceleration), running_distance(distance)
+    {
+    }
+    double vel{0.0};
+    double acc{0.0};
+    double running_distance{0.0};
+  };
   enum class Shift { Forward = 0, Reverse };
 
   struct ControlData
   {
     bool is_far_from_trajectory{false};
+    autoware_auto_planning_msgs::msg::Trajectory interpolated_traj{};
     size_t nearest_idx{0};  // nearest_idx = 0 when nearest_idx is not found with findNearestIdx
+    size_t target_idx{0};
+    StateAfterDelay state_after_delay{0.0, 0.0, 0.0};
     Motion current_motion{};
     Shift shift{Shift::Forward};  // shift is used only to calculate the sign of pitch compensation
     double stop_dist{0.0};  // signed distance that is positive when car is before the stopline
@@ -184,7 +196,9 @@ private:
   double m_min_jerk;
 
   // slope compensation
-  bool m_use_traj_for_pitch;
+  enum class SlopeSource { RAW_PITCH = 0, TRAJECTORY_PITCH, TRAJECTORY_ADAPTIVE };
+  SlopeSource m_slope_source{SlopeSource::RAW_PITCH};
+  double m_adaptive_trajectory_velocity_th;
   std::shared_ptr<LowpassFilter1d> m_lpf_pitch{nullptr};
   double m_max_pitch_rad;
   double m_min_pitch_rad;
@@ -276,11 +290,9 @@ private:
 
   /**
    * @brief calculate control command based on the current control state
-   * @param [in] current_pose current ego pose
    * @param [in] control_data control data
    */
-  Motion calcCtrlCmd(
-    const geometry_msgs::msg::Pose & current_pose, const ControlData & control_data);
+  Motion calcCtrlCmd(const ControlData & control_data);
 
   /**
    * @brief publish control command
@@ -309,9 +321,9 @@ private:
 
   /**
    * @brief calculate direction (forward or backward) that vehicle moves
-   * @param [in] nearest_idx nearest index on trajectory to vehicle
+   * @param [in] control_data data for control calculation
    */
-  enum Shift getCurrentShift(const size_t nearest_idx) const;
+  enum Shift getCurrentShift(const ControlData & control_data) const;
 
   /**
    * @brief filter acceleration command with limitation of acceleration and jerk, and slope
@@ -341,8 +353,7 @@ private:
    * @param [in] motion delay compensated target motion
    */
   Motion keepBrakeBeforeStop(
-    const autoware_auto_planning_msgs::msg::Trajectory & traj, const Motion & target_motion,
-    const size_t nearest_idx) const;
+    const ControlData & control_data, const Motion & target_motion, const size_t nearest_idx) const;
 
   /**
    * @brief interpolate trajectory point that is nearest to vehicle
@@ -350,7 +361,8 @@ private:
    * @param [in] point vehicle position
    * @param [in] nearest_idx index of the trajectory point nearest to the vehicle position
    */
-  autoware_auto_planning_msgs::msg::TrajectoryPoint calcInterpolatedTargetValue(
+  std::pair<autoware_auto_planning_msgs::msg::TrajectoryPoint, size_t>
+  calcInterpolatedTrajPointAndSegment(
     const autoware_auto_planning_msgs::msg::Trajectory & traj,
     const geometry_msgs::msg::Pose & pose) const;
 
@@ -359,18 +371,14 @@ private:
    * @param [in] current_motion current velocity and acceleration of the vehicle
    * @param [in] delay_compensation_time predicted time delay
    */
-  double predictedVelocityInTargetPoint(
+  StateAfterDelay predictedStateAfterDelay(
     const Motion current_motion, const double delay_compensation_time) const;
 
   /**
    * @brief calculate velocity feedback with feed forward and pid controller
-   * @param [in] target_motion reference velocity and acceleration. This acceleration will be used
-   * as feed forward.
-   * @param [in] dt time step to use
-   * @param [in] current_vel current velocity of the vehicle
+   * @param [in] control_data data for control calculation
    */
-  double applyVelocityFeedback(
-    const Motion target_motion, const double dt, const double current_vel, const Shift & shift);
+  double applyVelocityFeedback(const ControlData & control_data);
 
   /**
    * @brief update variables for debugging about pitch
@@ -383,12 +391,9 @@ private:
   /**
    * @brief update variables for velocity and acceleration
    * @param [in] ctrl_cmd latest calculated control command
-   * @param [in] current_pose current pose of the vehicle
    * @param [in] control_data data for control calculation
    */
-  void updateDebugVelAcc(
-    const Motion & ctrl_cmd, const geometry_msgs::msg::Pose & current_pose,
-    const ControlData & control_data);
+  void updateDebugVelAcc(const ControlData & control_data);
 
   double getTimeUnderControl();
 };

--- a/control/pid_longitudinal_controller/param/longitudinal_controller_defaults.param.yaml
+++ b/control/pid_longitudinal_controller/param/longitudinal_controller_defaults.param.yaml
@@ -69,8 +69,9 @@
     max_jerk: 2.0
     min_jerk: -5.0
 
-    # pitch
-    use_trajectory_for_pitch_calculation: false
+    # slope compensation
     lpf_pitch_gain: 0.95
+    slope_source: "raw_pitch" # raw_pitch, trajectory_pitch or trajectory_adaptive
+    adaptive_trajectory_velocity_th: 1.0
     max_pitch_rad: 0.1
     min_pitch_rad: -0.1

--- a/control/pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -132,32 +132,30 @@ TEST(TestLongitudinalControllerUtils, getPitchByTraj)
   point.pose.position.z = 0.0;
   traj.points.push_back(point);
   // non stopping trajectory: stop distance = trajectory length
-  point.pose.position.x = 1.0;
+  point.pose.position.x = 0.6;
   point.pose.position.y = 0.0;
-  point.pose.position.z = 1.0;
+  point.pose.position.z = 0.8;
   traj.points.push_back(point);
-  point.pose.position.x = 2.0;
+  point.pose.position.x = 1.2;
   point.pose.position.y = 0.0;
   point.pose.position.z = 0.0;
   traj.points.push_back(point);
-  point.pose.position.x = 3.0;
+  point.pose.position.x = 1.8;
   point.pose.position.y = 0.0;
-  point.pose.position.z = 0.5;
+  point.pose.position.z = 0.8;
   traj.points.push_back(point);
   size_t closest_idx = 0;
   EXPECT_DOUBLE_EQ(
-    std::abs(longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base)), M_PI_4);
+    longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base), std::atan2(0.8, 0.6));
   closest_idx = 1;
   EXPECT_DOUBLE_EQ(
-    std::abs(longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base)), M_PI_4);
+    longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base), std::atan2(-0.8, 0.6));
   closest_idx = 2;
   EXPECT_DOUBLE_EQ(
-    std::abs(longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base)),
-    std::atan2(0.5, 1));
+    longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base), std::atan2(0.8, 0.6));
   closest_idx = 3;
   EXPECT_DOUBLE_EQ(
-    std::abs(longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base)),
-    std::atan2(0.5, 1));
+    longitudinal_utils::getPitchByTraj(traj, closest_idx, wheel_base), std::atan2(0.8, 0.6));
 }
 
 TEST(TestLongitudinalControllerUtils, calcPoseAfterTimeDelay)
@@ -355,95 +353,113 @@ TEST(TestLongitudinalControllerUtils, lerpTrajectoryPoint)
   TrajectoryPoint p;
   p.pose.position.x = 0.0;
   p.pose.position.y = 0.0;
+  p.pose.position.z = 0.0;
   p.longitudinal_velocity_mps = 10.0;
   p.acceleration_mps2 = 10.0;
   points.push_back(p);
   p.pose.position.x = 1.0;
   p.pose.position.y = 0.0;
+  p.pose.position.z = 0.0;
   p.longitudinal_velocity_mps = 20.0;
   p.acceleration_mps2 = 20.0;
   points.push_back(p);
   p.pose.position.x = 1.0;
   p.pose.position.y = 1.0;
+  p.pose.position.z = 1.0;
   p.longitudinal_velocity_mps = 30.0;
   p.acceleration_mps2 = 30.0;
   points.push_back(p);
   p.pose.position.x = 2.0;
   p.pose.position.y = 1.0;
+  p.pose.position.z = 2.0;
   p.longitudinal_velocity_mps = 40.0;
   p.acceleration_mps2 = 40.0;
   points.push_back(p);
-  TrajectoryPoint result;
   Pose pose;
   double max_dist = 3.0;
   double max_yaw = 0.7;
   // Points on the trajectory gives back the original trajectory points values
   pose.position.x = 0.0;
   pose.position.y = 0.0;
-  result = longitudinal_utils::lerpTrajectoryPoint(points, pose, max_dist, max_yaw);
-  EXPECT_NEAR(result.pose.position.x, pose.position.x, abs_err);
-  EXPECT_NEAR(result.pose.position.y, pose.position.y, abs_err);
-  EXPECT_NEAR(result.longitudinal_velocity_mps, 10.0, abs_err);
-  EXPECT_NEAR(result.acceleration_mps2, 10.0, abs_err);
+  pose.position.z = 0.0;
+
+  auto result = longitudinal_utils::lerpTrajectoryPoint(points, pose, max_dist, max_yaw);
+  EXPECT_NEAR(result.first.pose.position.x, pose.position.x, abs_err);
+  EXPECT_NEAR(result.first.pose.position.y, pose.position.y, abs_err);
+  EXPECT_NEAR(result.first.pose.position.z, pose.position.z, abs_err);
+  EXPECT_NEAR(result.first.longitudinal_velocity_mps, 10.0, abs_err);
+  EXPECT_NEAR(result.first.acceleration_mps2, 10.0, abs_err);
 
   pose.position.x = 1.0;
   pose.position.y = 0.0;
+  pose.position.z = 0.0;
   result = longitudinal_utils::lerpTrajectoryPoint(points, pose, max_dist, max_yaw);
-  EXPECT_NEAR(result.pose.position.x, pose.position.x, abs_err);
-  EXPECT_NEAR(result.pose.position.y, pose.position.y, abs_err);
-  EXPECT_NEAR(result.longitudinal_velocity_mps, 20.0, abs_err);
-  EXPECT_NEAR(result.acceleration_mps2, 20.0, abs_err);
+  EXPECT_NEAR(result.first.pose.position.x, pose.position.x, abs_err);
+  EXPECT_NEAR(result.first.pose.position.y, pose.position.y, abs_err);
+  EXPECT_NEAR(result.first.pose.position.z, pose.position.z, abs_err);
+  EXPECT_NEAR(result.first.longitudinal_velocity_mps, 20.0, abs_err);
+  EXPECT_NEAR(result.first.acceleration_mps2, 20.0, abs_err);
 
   pose.position.x = 1.0;
   pose.position.y = 1.0;
+  pose.position.z = 1.0;
   result = longitudinal_utils::lerpTrajectoryPoint(points, pose, max_dist, max_yaw);
-  EXPECT_NEAR(result.pose.position.x, pose.position.x, abs_err);
-  EXPECT_NEAR(result.pose.position.y, pose.position.y, abs_err);
-  EXPECT_NEAR(result.longitudinal_velocity_mps, 30.0, abs_err);
-  EXPECT_NEAR(result.acceleration_mps2, 30.0, abs_err);
+  EXPECT_NEAR(result.first.pose.position.x, pose.position.x, abs_err);
+  EXPECT_NEAR(result.first.pose.position.y, pose.position.y, abs_err);
+  EXPECT_NEAR(result.first.pose.position.z, pose.position.z, abs_err);
+  EXPECT_NEAR(result.first.longitudinal_velocity_mps, 30.0, abs_err);
+  EXPECT_NEAR(result.first.acceleration_mps2, 30.0, abs_err);
 
   pose.position.x = 2.0;
   pose.position.y = 1.0;
+  pose.position.z = 2.0;
   result = longitudinal_utils::lerpTrajectoryPoint(points, pose, max_dist, max_yaw);
-  EXPECT_NEAR(result.pose.position.x, pose.position.x, abs_err);
-  EXPECT_NEAR(result.pose.position.y, pose.position.y, abs_err);
-  EXPECT_NEAR(result.longitudinal_velocity_mps, 40.0, abs_err);
-  EXPECT_NEAR(result.acceleration_mps2, 40.0, abs_err);
+  EXPECT_NEAR(result.first.pose.position.x, pose.position.x, abs_err);
+  EXPECT_NEAR(result.first.pose.position.y, pose.position.y, abs_err);
+  EXPECT_NEAR(result.first.pose.position.z, pose.position.z, abs_err);
+  EXPECT_NEAR(result.first.longitudinal_velocity_mps, 40.0, abs_err);
+  EXPECT_NEAR(result.first.acceleration_mps2, 40.0, abs_err);
 
   // Interpolate between trajectory points
   pose.position.x = 0.5;
   pose.position.y = 0.0;
+  pose.position.z = 0.0;
   result = longitudinal_utils::lerpTrajectoryPoint(points, pose, max_dist, max_yaw);
-  EXPECT_NEAR(result.pose.position.x, pose.position.x, abs_err);
-  EXPECT_NEAR(result.pose.position.y, pose.position.y, abs_err);
-  EXPECT_NEAR(result.longitudinal_velocity_mps, 15.0, abs_err);
-  EXPECT_NEAR(result.acceleration_mps2, 15.0, abs_err);
+  EXPECT_NEAR(result.first.pose.position.x, pose.position.x, abs_err);
+  EXPECT_NEAR(result.first.pose.position.y, pose.position.y, abs_err);
+  EXPECT_NEAR(result.first.pose.position.z, pose.position.z, abs_err);
+  EXPECT_NEAR(result.first.longitudinal_velocity_mps, 15.0, abs_err);
+  EXPECT_NEAR(result.first.acceleration_mps2, 15.0, abs_err);
   pose.position.x = 0.75;
   pose.position.y = 0.0;
+  pose.position.z = 0.0;
   result = longitudinal_utils::lerpTrajectoryPoint(points, pose, max_dist, max_yaw);
 
-  EXPECT_NEAR(result.pose.position.x, pose.position.x, abs_err);
-  EXPECT_NEAR(result.pose.position.y, pose.position.y, abs_err);
-  EXPECT_NEAR(result.longitudinal_velocity_mps, 17.5, abs_err);
-  EXPECT_NEAR(result.acceleration_mps2, 17.5, abs_err);
+  EXPECT_NEAR(result.first.pose.position.x, pose.position.x, abs_err);
+  EXPECT_NEAR(result.first.pose.position.y, pose.position.y, abs_err);
+  EXPECT_NEAR(result.first.pose.position.z, pose.position.z, abs_err);
+  EXPECT_NEAR(result.first.longitudinal_velocity_mps, 17.5, abs_err);
+  EXPECT_NEAR(result.first.acceleration_mps2, 17.5, abs_err);
 
   // Interpolate away from the trajectory (interpolated point is projected)
   pose.position.x = 0.5;
   pose.position.y = -1.0;
   result = longitudinal_utils::lerpTrajectoryPoint(points, pose, max_dist, max_yaw);
-  EXPECT_NEAR(result.pose.position.x, pose.position.x, abs_err);
-  EXPECT_NEAR(result.pose.position.y, 0.0, abs_err);
-  EXPECT_NEAR(result.longitudinal_velocity_mps, 15.0, abs_err);
-  EXPECT_NEAR(result.acceleration_mps2, 15.0, abs_err);
+  EXPECT_NEAR(result.first.pose.position.x, pose.position.x, abs_err);
+  EXPECT_NEAR(result.first.pose.position.y, 0.0, abs_err);
+  EXPECT_NEAR(result.first.pose.position.z, pose.position.z, abs_err);
+  EXPECT_NEAR(result.first.longitudinal_velocity_mps, 15.0, abs_err);
+  EXPECT_NEAR(result.first.acceleration_mps2, 15.0, abs_err);
 
   // Ambiguous projections: possibility with the lowest index is used
   pose.position.x = 0.5;
   pose.position.y = 0.5;
   result = longitudinal_utils::lerpTrajectoryPoint(points, pose, max_dist, max_yaw);
-  EXPECT_NEAR(result.pose.position.x, pose.position.x, abs_err);
-  EXPECT_NEAR(result.pose.position.y, 0.0, abs_err);
-  EXPECT_NEAR(result.longitudinal_velocity_mps, 15.0, abs_err);
-  EXPECT_NEAR(result.acceleration_mps2, 15.0, abs_err);
+  EXPECT_NEAR(result.first.pose.position.x, pose.position.x, abs_err);
+  EXPECT_NEAR(result.first.pose.position.y, 0.0, abs_err);
+  EXPECT_NEAR(result.first.pose.position.z, pose.position.z, abs_err);
+  EXPECT_NEAR(result.first.longitudinal_velocity_mps, 15.0, abs_err);
+  EXPECT_NEAR(result.first.acceleration_mps2, 15.0, abs_err);
 }
 
 TEST(TestLongitudinalControllerUtils, applyDiffLimitFilter)
@@ -485,4 +501,64 @@ TEST(TestLongitudinalControllerUtils, applyDiffLimitFilter)
     EXPECT_DOUBLE_EQ(new_val, prev + max_val);
     prev = new_val;
   }
+}
+
+TEST(TestLongitudinalControllerUtils, findTrajectoryPoseAfterDistance)
+{
+  using autoware_auto_planning_msgs::msg::Trajectory;
+  using autoware_auto_planning_msgs::msg::TrajectoryPoint;
+  using geometry_msgs::msg::Pose;
+  const double abs_err = 1e-5;
+  Trajectory traj;
+  TrajectoryPoint point;
+  point.pose.position.x = 0.0;
+  point.pose.position.y = 0.0;
+  point.pose.position.z = 0.0;
+  traj.points.push_back(point);
+  point.pose.position.x = 1.0;
+  point.pose.position.y = 0.0;
+  point.pose.position.z = 0.0;
+  traj.points.push_back(point);
+  point.pose.position.x = 1.0;
+  point.pose.position.y = 1.0;
+  point.pose.position.z = 1.0;
+  traj.points.push_back(point);
+  point.pose.position.x = 2.0;
+  point.pose.position.y = 1.0;
+  point.pose.position.z = 2.0;
+  traj.points.push_back(point);
+  size_t src_idx = 0;
+  double distance = 0.0;
+  Pose result = longitudinal_utils::findTrajectoryPoseAfterDistance(src_idx, distance, traj);
+  EXPECT_NEAR(result.position.x, 0.0, abs_err);
+  EXPECT_NEAR(result.position.y, 0.0, abs_err);
+  EXPECT_NEAR(result.position.z, 0.0, abs_err);
+
+  src_idx = 0;
+  distance = 0.5;
+  result = longitudinal_utils::findTrajectoryPoseAfterDistance(src_idx, distance, traj);
+  EXPECT_NEAR(result.position.x, 0.5, abs_err);
+  EXPECT_NEAR(result.position.y, 0.0, abs_err);
+  EXPECT_NEAR(result.position.z, 0.0, abs_err);
+
+  src_idx = 0;
+  distance = 1.0;
+  result = longitudinal_utils::findTrajectoryPoseAfterDistance(src_idx, distance, traj);
+  EXPECT_NEAR(result.position.x, 1.0, abs_err);
+  EXPECT_NEAR(result.position.y, 0.0, abs_err);
+  EXPECT_NEAR(result.position.z, 0.0, abs_err);
+
+  src_idx = 0;
+  distance = 1.5;
+  result = longitudinal_utils::findTrajectoryPoseAfterDistance(src_idx, distance, traj);
+  EXPECT_NEAR(result.position.x, 1.0, abs_err);
+  EXPECT_NEAR(result.position.y, 1.0 / (2.0 * sqrt(2.0)), abs_err);
+  EXPECT_NEAR(result.position.z, 1.0 / (2.0 * sqrt(2.0)), abs_err);
+
+  src_idx = 0;
+  distance = 20.0;  // beyond the trajectory, should return the last point
+  result = longitudinal_utils::findTrajectoryPoseAfterDistance(src_idx, distance, traj);
+  EXPECT_NEAR(result.position.x, 2.0, abs_err);
+  EXPECT_NEAR(result.position.y, 1.0, abs_err);
+  EXPECT_NEAR(result.position.z, 2.0, abs_err);
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
In the current implementation on Autoware, while calculating the output command, we are compensating for the slope and delay in `pid_longitudinal_controller`. 

We are doing the delay compensation by using the estimation of the drive distance of the vehicle after `delay_compensation_time` and we are looking at the future `TrajectoryPoint` and calculating the output command with respect to this future point. 

However, before sending the output command, we are also doing slope compensation with respect to **Current** `TrajectoryPoint`. However, in some scenarios on hilly roads, this way is causing some conflicts because of the time like below.

![delayslope drawio](https://github.com/autowarefoundation/autoware.universe/assets/45468306/3a096dab-97ab-4f37-b1ad-226be2f78c79)

As you can see in this scenario, there is a conflict between slope and delay compensation because they are using different reference times. In this scenario, the node will send FF with respect to the target point however it sums negative slope compensation value because of the current position of the vehicle and it causes undesired behavior. To avoid this behavior, I made some changes to delay and slope compensation in this package to sum compensations at the same time.

Also, after this PR, the following PRs should be merged by order here:

1- https://github.com/autowarefoundation/autoware.universe/pull/5077
2- https://github.com/autowarefoundation/autoware.universe/pull/5079
3- https://github.com/autowarefoundation/autoware.universe/pull/5080
4- https://github.com/autowarefoundation/autoware.universe/pull/5081

## Related links


<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
I tested on the real vehicle and also on the planning simulator. It solves our problems in the real environment and there is no behavioral change in the planning simulator.

## Notes for reviewers
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
<!-- Describe how this PR affects the system behavior. -->

The only effect is that we will use the raw pitch info at only starting (while not moving), if the vehicle is moving, it needs the future pitch info, to achieve this, it depends on the pitch values of the trajectory points.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Improved delay and slope compensation in the `pid_longitudinal_controller` package, resulting in more accurate output commands. The changes include updates to the `getPitchByTraj` function, introduction of the `findTrajectoryPoseAfterDistance` function, and modification of the return type of the `lerpTrajectoryPoint` function. These enhancements may impact the behavior of the code.
- Bug Fix: Addressed delay and slope compensation issues in the `PidLongitudinalController` class of Autoware. The modifications involve using drive distance estimation after a specified delay time for delay compensation and adjusting slope compensation to avoid conflicts. The changes also introduce the `StateAfterDelay` struct and a new `SlopeSource` enum.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->