### PR TITLE
fix(probabilistic_occupancy_gridmap): prevent node death by adding lookupTransform exception in util function

### DIFF
--- a/perception/probabilistic_occupancy_grid_map/src/utils/utils.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/utils/utils.cpp
@@ -26,16 +26,13 @@ bool transformPointcloud(
 {
   geometry_msgs::msg::TransformStamped tf_stamped;
   // lookup transform
-  try
-  {
+  try {
     tf_stamped = tf2.lookupTransform(
       target_frame, input.header.frame_id, input.header.stamp, rclcpp::Duration::from_seconds(0.5));
-  }
-  catch (tf2::TransformException & ex)
-  {
+  } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(
-      rclcpp::get_logger("probabilistic_occupancy_grid_map"),
-      "Failed to lookup transform: %s", ex.what());
+      rclcpp::get_logger("probabilistic_occupancy_grid_map"), "Failed to lookup transform: %s",
+      ex.what());
     return false;
   }
   // transform pointcloud

--- a/perception/probabilistic_occupancy_grid_map/src/utils/utils.cpp
+++ b/perception/probabilistic_occupancy_grid_map/src/utils/utils.cpp
@@ -25,8 +25,19 @@ bool transformPointcloud(
   const std::string & target_frame, sensor_msgs::msg::PointCloud2 & output)
 {
   geometry_msgs::msg::TransformStamped tf_stamped;
-  tf_stamped = tf2.lookupTransform(
-    target_frame, input.header.frame_id, input.header.stamp, rclcpp::Duration::from_seconds(0.5));
+  // lookup transform
+  try
+  {
+    tf_stamped = tf2.lookupTransform(
+      target_frame, input.header.frame_id, input.header.stamp, rclcpp::Duration::from_seconds(0.5));
+  }
+  catch (tf2::TransformException & ex)
+  {
+    RCLCPP_WARN(
+      rclcpp::get_logger("probabilistic_occupancy_grid_map"),
+      "Failed to lookup transform: %s", ex.what());
+    return false;
+  }
   // transform pointcloud
   Eigen::Matrix4f tf_matrix = tf2::transformToEigen(tf_stamped.transform).matrix().cast<float>();
   pcl_ros::transformPointCloud(tf_matrix, input, output);

--- a/perception/probabilistic_occupancy_grid_map/test/test_pointcloud_based_method.py
+++ b/perception/probabilistic_occupancy_grid_map/test/test_pointcloud_based_method.py
@@ -238,6 +238,28 @@ class TestNodeIO(unittest.TestCase):
         self.assertIn("occupancy_grid_map_node", nodes)
         self.assertEqual(len(self.msg_buffer), 1)
 
+    def test_null_input2(self, proc_info):
+        """Test null input.
+
+        input: null pointcloud without even frame_id
+        output: null ogm
+        """
+        # wait for the node to be ready
+        time.sleep(3)
+        input_points = []
+        pub_raw, pub_obstacle, sub = self.create_pub_sub()
+        # publish input pointcloud
+        pt_msg = get_pointcloud_msg(input_points)
+        pt_msg.header.frame_id = ""
+        pub_raw.publish(pt_msg)
+        pub_obstacle.publish(pt_msg)
+        # try to subscribe output pointcloud once
+        rclpy.spin_once(self.node, timeout_sec=3.0)
+
+        # check if process is successfully terminated
+        nodes = self.node.get_node_names()
+        self.assertIn("occupancy_grid_map_node", nodes)
+        self.assertEqual(len(self.msg_buffer), 0)
 
 @launch_testing.post_shutdown_test()
 class TestProcessOutput(unittest.TestCase):

--- a/perception/probabilistic_occupancy_grid_map/test/test_pointcloud_based_method.py
+++ b/perception/probabilistic_occupancy_grid_map/test/test_pointcloud_based_method.py
@@ -261,6 +261,7 @@ class TestNodeIO(unittest.TestCase):
         self.assertIn("occupancy_grid_map_node", nodes)
         self.assertEqual(len(self.msg_buffer), 0)
 
+
 @launch_testing.post_shutdown_test()
 class TestProcessOutput(unittest.TestCase):
     def test_exit_code(self, proc_info):


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->


Pointcloud based occupancy grid map generation node sometimes died by null pointcloud input. (see figure below)

![image](https://github.com/autowarefoundation/autoware.universe/assets/20086766/b835b077-6296-4c2a-94ac-c1785f5651eb)

This PR enables to prevent this error by fixing util function and its effectiveness is tested with launch_test.

[TIER IV INTERNAL TICKET](https://tier4.atlassian.net/browse/RT0-28767)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested in launch_test.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
