### PR TITLE
refactor(safety_check): use safety check common param struct

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -143,6 +143,14 @@
         time_horizon: 10.0                               # [s]
         safety_check_backward_distance: 100.0            # [m]
         safety_check_hysteresis_factor: 2.0              # [-]
+        # rss parameters
+        expected_front_deceleration: -1.0                # [m/ss]
+        expected_rear_deceleration: -1.0                 # [m/ss]
+        rear_vehicle_reaction_time: 2.0                  # [s]
+        rear_vehicle_safety_time_margin: 1.0             # [s]
+        lateral_distance_max_threshold: 2.0              # [m]
+        longitudinal_distance_min_threshold: 3.0         # [m]
+        longitudinal_velocity_delta_time: 0.8            # [s]
 
       # For avoidance maneuver
       avoidance:

--- a/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -25,19 +25,6 @@
 
     visualize_maximum_drivable_area: true
 
-    lateral_distance_max_threshold: 2.0
-    longitudinal_distance_min_threshold: 3.0
-    longitudinal_velocity_delta_time: 0.8 # [s]
-
-    expected_front_deceleration: -1.0
-    expected_rear_deceleration: -1.0
-
-    expected_front_deceleration_for_abort: -1.0
-    expected_rear_deceleration_for_abort: -2.0
-
-    rear_vehicle_reaction_time: 2.0
-    rear_vehicle_safety_time_margin: 1.0
-
     lane_following:
       drivable_area_right_bound_offset: 0.0
       drivable_area_left_bound_offset: 0.0

--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -26,6 +26,18 @@
       min_longitudinal_acc: -1.0
       max_longitudinal_acc: 1.0
 
+      # safety check
+      safety_check:
+        expected_front_deceleration: -1.0
+        expected_rear_deceleration: -1.0
+        expected_front_deceleration_for_abort: -1.0
+        expected_rear_deceleration_for_abort: -2.0
+        rear_vehicle_reaction_time: 2.0
+        rear_vehicle_safety_time_margin: 1.0
+        lateral_distance_max_threshold: 2.0
+        longitudinal_distance_min_threshold: 3.0
+        longitudinal_velocity_delta_time: 0.8
+
       # lateral acceleration map
       lateral_acceleration:
         velocity: [0.0, 4.0, 10.0]

--- a/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/parameters.hpp
@@ -141,20 +141,6 @@ struct BehaviorPathPlannerParameters
 
   // maximum drivable area visualization
   bool visualize_maximum_drivable_area;
-
-  // collision check
-  double lateral_distance_max_threshold;
-  double longitudinal_distance_min_threshold;
-  double longitudinal_velocity_delta_time;
-
-  double expected_front_deceleration;  // brake parameter under normal lane change
-  double expected_rear_deceleration;   // brake parameter under normal lane change
-
-  double expected_front_deceleration_for_abort;  // hard brake parameter for abort
-  double expected_rear_deceleration_for_abort;   // hard brake parameter for abort
-
-  double rear_vehicle_reaction_time;
-  double rear_vehicle_safety_time_margin;
 };
 
 #endif  // BEHAVIOR_PATH_PLANNER__PARAMETERS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -140,7 +140,7 @@ protected:
 
   PathSafetyStatus isLaneChangePathSafe(
     const LaneChangePath & lane_change_path, const LaneChangeTargetObjects & target_objects,
-    const double front_decel, const double rear_decel,
+    const utils::path_safety_checker::RSSparams & rss_params,
     std::unordered_map<std::string, CollisionCheckDebug> & debug_data) const;
 
   LaneChangeTargetObjectIndices filterObject(

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -16,6 +16,7 @@
 #define BEHAVIOR_PATH_PLANNER__UTILS__AVOIDANCE__AVOIDANCE_MODULE_DATA_HPP_
 
 #include "behavior_path_planner/marker_utils/utils.hpp"
+#include "behavior_path_planner/utils/path_safety_checker/path_safety_checker_parameters.hpp"
 #include "behavior_path_planner/utils/path_shifter/path_shifter.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -295,6 +296,9 @@ struct AvoidanceParameters
 
   // parameters depend on object class
   std::unordered_map<uint8_t, ObjectParameter> object_parameters;
+
+  // rss parameters
+  utils::path_safety_checker::RSSparams rss_params;
 
   // clip left and right bounds for objects
   bool enable_bound_clipping{false};

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -76,6 +76,10 @@ struct LaneChangeParameters
   bool check_motorcycle{true};  // check object motorbike
   bool check_pedestrian{true};  // check object pedestrian
 
+  // safety check
+  utils::path_safety_checker::RSSparams rss_params;
+  utils::path_safety_checker::RSSparams rss_params_for_abort;
+
   // abort
   LaneChangeCancelParameters cancel;
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/path_safety_checker_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/path_safety_checker_parameters.hpp
@@ -123,6 +123,8 @@ struct RSSparams
   double longitudinal_distance_min_threshold{
     0.0};                                        ///< Minimum threshold for longitudinal distance.
   double longitudinal_velocity_delta_time{0.0};  ///< Delta time for longitudinal velocity.
+  double front_vehicle_deceleration;             ///< brake parameter
+  double rear_vehicle_deceleration;              ///< brake parameter
 };
 
 /**

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/safety_check.hpp
@@ -65,8 +65,7 @@ Polygon2d createExtendedPolygon(
 
 double calcRssDistance(
   const double front_object_velocity, const double rear_object_velocity,
-  const double front_object_deceleration, const double rear_object_deceleration,
-  const BehaviorPathPlannerParameters & params);
+  const RSSparams & rss_params);
 
 double calcMinimumLongitudinalLength(
   const double front_object_velocity, const double rear_object_velocity,
@@ -98,8 +97,8 @@ bool checkCollision(
   const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
   const ExtendedPredictedObject & target_object,
   const PredictedPathWithPolygon & target_object_path,
-  const BehaviorPathPlannerParameters & common_parameters, const double front_object_deceleration,
-  const double rear_object_deceleration, CollisionCheckDebug & debug);
+  const BehaviorPathPlannerParameters & common_parameters, const RSSparams & rss_parameters,
+  CollisionCheckDebug & debug);
 
 /**
  * @brief Check collision between ego path footprints with extra longitudinal stopping margin and

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -391,23 +391,6 @@ BehaviorPathPlannerParameters BehaviorPathPlannerNode::getCommonParam()
   p.ego_nearest_dist_threshold = declare_parameter<double>("ego_nearest_dist_threshold");
   p.ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
 
-  p.lateral_distance_max_threshold = declare_parameter<double>("lateral_distance_max_threshold");
-  p.longitudinal_distance_min_threshold =
-    declare_parameter<double>("longitudinal_distance_min_threshold");
-  p.longitudinal_velocity_delta_time =
-    declare_parameter<double>("longitudinal_velocity_delta_time");
-
-  p.expected_front_deceleration = declare_parameter<double>("expected_front_deceleration");
-  p.expected_rear_deceleration = declare_parameter<double>("expected_rear_deceleration");
-
-  p.expected_front_deceleration_for_abort =
-    declare_parameter<double>("expected_front_deceleration_for_abort");
-  p.expected_rear_deceleration_for_abort =
-    declare_parameter<double>("expected_rear_deceleration_for_abort");
-
-  p.rear_vehicle_reaction_time = declare_parameter<double>("rear_vehicle_reaction_time");
-  p.rear_vehicle_safety_time_margin = declare_parameter<double>("rear_vehicle_safety_time_margin");
-
   if (p.backward_length_buffer_for_end_of_lane < 1.0) {
     RCLCPP_WARN_STREAM(
       get_logger(), "Lane change buffer must be more than 1 meter. Modifying the buffer.");

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -1879,8 +1879,8 @@ bool AvoidanceModule::isSafePath(
     for (const auto & obj_path : obj_predicted_paths) {
       CollisionCheckDebug collision{};
       if (!utils::path_safety_checker::checkCollision(
-            shifted_path.path, ego_predicted_path, object, obj_path, p,
-            p.expected_front_deceleration, p.expected_rear_deceleration, collision)) {
+            shifted_path.path, ego_predicted_path, object, obj_path, p, parameters_->rss_params,
+            collision)) {
         return false;
       }
     }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -131,7 +131,7 @@ AvoidanceModuleManager::AvoidanceModuleManager(
     p.object_last_seen_threshold = get_parameter<double>(node, ns + "object_last_seen_threshold");
   }
 
-  // safety check
+  // safety check general params
   {
     std::string ns = "avoidance.safety_check.";
     p.enable_safety_check = get_parameter<bool>(node, ns + "enable");
@@ -147,6 +147,25 @@ AvoidanceModuleManager::AvoidanceModuleManager(
       get_parameter<double>(node, ns + "safety_check_backward_distance");
     p.safety_check_hysteresis_factor =
       get_parameter<double>(node, ns + "safety_check_hysteresis_factor");
+  }
+
+  // safety check rss params
+  {
+    std::string ns = "avoidance.safety_check.";
+    p.rss_params.longitudinal_distance_min_threshold =
+      get_parameter<double>(node, ns + "longitudinal_distance_min_threshold");
+    p.rss_params.longitudinal_velocity_delta_time =
+      get_parameter<double>(node, ns + "longitudinal_velocity_delta_time");
+    p.rss_params.front_vehicle_deceleration =
+      get_parameter<double>(node, ns + "expected_front_deceleration");
+    p.rss_params.rear_vehicle_deceleration =
+      get_parameter<double>(node, ns + "expected_rear_deceleration");
+    p.rss_params.rear_vehicle_reaction_time =
+      get_parameter<double>(node, ns + "rear_vehicle_reaction_time");
+    p.rss_params.rear_vehicle_safety_time_margin =
+      get_parameter<double>(node, ns + "rear_vehicle_safety_time_margin");
+    p.rss_params.lateral_distance_max_threshold =
+      get_parameter<double>(node, ns + "lateral_distance_max_threshold");
   }
 
   // avoidance maneuver (lateral)

--- a/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/manager.cpp
@@ -85,6 +85,36 @@ LaneChangeModuleManager::LaneChangeModuleManager(
     get_parameter<bool>(node, parameter("check_objects_on_other_lanes"));
   p.use_all_predicted_path = get_parameter<bool>(node, parameter("use_all_predicted_path"));
 
+  p.rss_params.longitudinal_distance_min_threshold =
+    get_parameter<double>(node, parameter("safety_check.longitudinal_distance_min_threshold"));
+  p.rss_params.longitudinal_velocity_delta_time =
+    get_parameter<double>(node, parameter("safety_check.longitudinal_velocity_delta_time"));
+  p.rss_params.front_vehicle_deceleration =
+    get_parameter<double>(node, parameter("safety_check.expected_front_deceleration"));
+  p.rss_params.rear_vehicle_deceleration =
+    get_parameter<double>(node, parameter("safety_check.expected_rear_deceleration"));
+  p.rss_params.rear_vehicle_reaction_time =
+    get_parameter<double>(node, parameter("safety_check.rear_vehicle_reaction_time"));
+  p.rss_params.rear_vehicle_safety_time_margin =
+    get_parameter<double>(node, parameter("safety_check.rear_vehicle_safety_time_margin"));
+  p.rss_params.lateral_distance_max_threshold =
+    get_parameter<double>(node, parameter("safety_check.lateral_distance_max_threshold"));
+
+  p.rss_params_for_abort.longitudinal_distance_min_threshold =
+    get_parameter<double>(node, parameter("safety_check.longitudinal_distance_min_threshold"));
+  p.rss_params_for_abort.longitudinal_velocity_delta_time =
+    get_parameter<double>(node, parameter("safety_check.longitudinal_velocity_delta_time"));
+  p.rss_params_for_abort.front_vehicle_deceleration =
+    get_parameter<double>(node, parameter("safety_check.expected_front_deceleration_for_abort"));
+  p.rss_params_for_abort.rear_vehicle_deceleration =
+    get_parameter<double>(node, parameter("safety_check.expected_rear_deceleration_for_abort"));
+  p.rss_params_for_abort.rear_vehicle_reaction_time =
+    get_parameter<double>(node, parameter("safety_check.rear_vehicle_reaction_time"));
+  p.rss_params_for_abort.rear_vehicle_safety_time_margin =
+    get_parameter<double>(node, parameter("safety_check.rear_vehicle_safety_time_margin"));
+  p.rss_params_for_abort.lateral_distance_max_threshold =
+    get_parameter<double>(node, parameter("safety_check.lateral_distance_max_threshold"));
+
   // target object
   {
     std::string ns = "lane_change.target_object.";

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -1045,8 +1045,7 @@ bool NormalLaneChange::getLaneChangePaths(
       }
 
       const auto [is_safe, is_object_coming_from_rear] = isLaneChangePathSafe(
-        *candidate_path, target_objects, common_parameters.expected_front_deceleration,
-        common_parameters.expected_rear_deceleration, object_debug_);
+        *candidate_path, target_objects, lane_change_parameters_->rss_params, object_debug_);
 
       if (is_safe) {
         return true;
@@ -1059,7 +1058,6 @@ bool NormalLaneChange::getLaneChangePaths(
 
 PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
 {
-  const auto & common_parameters = getCommonParam();
   const auto & path = status_.lane_change_path;
   const auto & current_lanes = status_.current_lanes;
   const auto & target_lanes = status_.target_lanes;
@@ -1068,8 +1066,7 @@ PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
 
   CollisionCheckDebugMap debug_data;
   const auto safety_status = isLaneChangePathSafe(
-    path, target_objects, common_parameters.expected_front_deceleration_for_abort,
-    common_parameters.expected_rear_deceleration_for_abort, debug_data);
+    path, target_objects, lane_change_parameters_->rss_params_for_abort, debug_data);
   {
     // only for debug purpose
     object_debug_.clear();
@@ -1326,7 +1323,7 @@ bool NormalLaneChange::getAbortPath()
 
 PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
   const LaneChangePath & lane_change_path, const LaneChangeTargetObjects & target_objects,
-  const double front_decel, const double rear_decel,
+  const utils::path_safety_checker::RSSparams & rss_params,
   std::unordered_map<std::string, CollisionCheckDebug> & debug_data) const
 {
   PathSafetyStatus path_safety_status;
@@ -1388,7 +1385,7 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
       obj, lane_change_parameters_->use_all_predicted_path);
     for (const auto & obj_path : obj_predicted_paths) {
       if (!utils::path_safety_checker::checkCollision(
-            path, ego_predicted_path, obj, obj_path, common_parameters, front_decel, rear_decel,
+            path, ego_predicted_path, obj, obj_path, common_parameters, rss_params,
             current_debug_data.second)) {
         path_safety_status.is_safe = false;
         updateDebugInfo(current_debug_data, path_safety_status.is_safe);

--- a/planning/behavior_path_planner/test/test_safety_check.cpp
+++ b/planning/behavior_path_planner/test/test_safety_check.cpp
@@ -178,18 +178,20 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedObjPolygon)
 TEST(BehaviorPathPlanningSafetyUtilsTest, calcRssDistance)
 {
   using behavior_path_planner::utils::path_safety_checker::calcRssDistance;
+  using behavior_path_planner::utils::path_safety_checker::RSSparams;
 
   {
     const double front_vel = 5.0;
     const double front_decel = -2.0;
     const double rear_vel = 10.0;
     const double rear_decel = -1.0;
-    BehaviorPathPlannerParameters params;
+    RSSparams params;
     params.rear_vehicle_reaction_time = 1.0;
     params.rear_vehicle_safety_time_margin = 1.0;
     params.longitudinal_distance_min_threshold = 3.0;
+    params.rear_vehicle_deceleration = rear_decel;
+    params.front_vehicle_deceleration = front_decel;
 
-    EXPECT_NEAR(
-      calcRssDistance(front_vel, rear_vel, front_decel, rear_decel, params), 63.75, epsilon);
+    EXPECT_NEAR(calcRssDistance(front_vel, rear_vel, params), 63.75, epsilon);
   }
 }


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9691e17</samp>

This pull request refactors the behavior path planner to use a `RSSparams` struct to pass and store the rss parameters for the avoidance and lane change modules. The rss parameters are used for the Responsibility Sensitive Safety (RSS) model, which ensures safe driving behavior based on deceleration values and distance thresholds. The pull request also updates the yaml files to load and configure the rss parameters for each module, and modifies the function signatures and unit tests accordingly.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/9dbab920-6aaa-52af-bbaa-2692de073b0c?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
