### PR TITLE
fix(lane_change): skip safety check for stopping vehicles

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -645,10 +645,6 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
   const auto & route_handler = *getRouteHandler();
   const auto & common_parameters = planner_data_->parameters;
   const auto & objects = *planner_data_->dynamic_object;
-  const auto & object_check_min_road_shoulder_width =
-    lane_change_parameters_->object_check_min_road_shoulder_width;
-  const auto & object_shiftable_ratio_threshold =
-    lane_change_parameters_->object_shiftable_ratio_threshold;
 
   // Guard
   if (objects.objects.empty()) {
@@ -709,9 +705,8 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
     // check if the object intersects with target lanes
     if (target_polygon && boost::geometry::intersects(target_polygon.value(), obj_polygon)) {
       // ignore static parked object that are in front of the ego vehicle in target lanes
-      bool is_parked_object = utils::lane_change::isParkedObject(
-        target_path, route_handler, extended_object, object_check_min_road_shoulder_width,
-        object_shiftable_ratio_threshold);
+      bool is_parked_object =
+        utils::lane_change::isParkedObject(target_path, route_handler, extended_object, 0.0, 0.0);
       if (is_parked_object && min_dist_ego_to_obj > min_dist_to_lane_changing_start) {
         continue;
       }


### PR DESCRIPTION
## Description

Before this change, we can not change lane if the stopping vehicle is behind of a traffic light stop line.
To fix this issue, I change the parameters for getting parked object function.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

[TIER IV INTERNAL TEST](https://evaluation.tier4.jp/evaluation/reports/ede8ead2-204c-57ac-ad70-a5bb19816e80?project_id=prd_jt)

Tested in planning simulator

Before:

![Screenshot from 2023-08-24 15-01-10](https://github.com/autowarefoundation/autoware.universe/assets/10190493/f45c1293-9214-4247-94f2-a68c3e29ea09)

After:

![Screenshot from 2023-08-24 15-05-43](https://github.com/autowarefoundation/autoware.universe/assets/10190493/3522efcf-afc3-4a62-99ea-115ec7f2266a)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Nothing.
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

If stopping vehicles are behind of traffic light stop line, it will be plan lane change.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
