### PR TITLE
chore(autoware_auto_perception_rviz_plugin): higher visibility of predicted path color

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -348,7 +348,7 @@ protected:
     sample_color.r = 1.0;
     sample_color.g = 0.65;
     sample_color.b = 0.0;
-    colors.push_back(sample_color);  // orange;
+    colors.push_back(sample_color);  // orange
     sample_color.r = 1.0;
     sample_color.g = 1.0;
     sample_color.b = 0.0;
@@ -376,7 +376,7 @@ protected:
     sample_color.r = 1.0;
     sample_color.g = 0.41;
     sample_color.b = 0.71;
-    colors.push_back(sample_color);  // hotpink
+    colors.push_back(sample_color);  // hot pink
   }
 
   double get_line_width() { return m_line_width_property.getFloat(); }

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -346,9 +346,13 @@ protected:
   {
     std_msgs::msg::ColorRGBA sample_color;
     sample_color.r = 1.0;
-    sample_color.g = 0.0;
-    sample_color.b = 1.0;
-    colors.push_back(sample_color);  // magenta
+    sample_color.g = 0.65;
+    sample_color.b = 0.0;
+    colors.push_back(sample_color);  // orange;
+    sample_color.r = 1.0;
+    sample_color.g = 1.0;
+    sample_color.b = 0.0;
+    colors.push_back(sample_color);  // yellow
     sample_color.r = 0.69;
     sample_color.g = 1.0;
     sample_color.b = 0.18;
@@ -361,22 +365,18 @@ protected:
     sample_color.g = 1.0;
     sample_color.b = 0.0;
     colors.push_back(sample_color);  // chartreuse green
-    sample_color.r = 0.12;
-    sample_color.g = 0.56;
-    sample_color.b = 1.0;
-    colors.push_back(sample_color);  // dodger blue
     sample_color.r = 0.0;
     sample_color.g = 1.0;
     sample_color.b = 1.0;
     colors.push_back(sample_color);  // cyan
-    sample_color.r = 0.54;
-    sample_color.g = 0.168;
-    sample_color.b = 0.886;
-    colors.push_back(sample_color);  // blueviolet
-    sample_color.r = 0.0;
-    sample_color.g = 1.0;
-    sample_color.b = 0.5;
-    colors.push_back(sample_color);  // spring green
+    sample_color.r = 0.53;
+    sample_color.g = 0.81;
+    sample_color.b = 0.98;
+    colors.push_back(sample_color);  // light skyblue
+    sample_color.r = 1.0;
+    sample_color.g = 0.41;
+    sample_color.b = 0.71;
+    colors.push_back(sample_color);  // hotpink
   }
 
   double get_line_width() { return m_line_width_property.getFloat(); }

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -80,7 +80,7 @@ visualization_msgs::msg::Marker::SharedPtr get_predicted_path_marker_ptr(
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
   marker_ptr->pose = initPose();
   marker_ptr->color = predicted_path_color;
-  marker_ptr->color.a = 0.7;
+  marker_ptr->color.a = 0.6;
   marker_ptr->scale.x = 0.015;
   calc_path_line_list(predicted_path, marker_ptr->points, is_simple);
   for (size_t k = 0; k < marker_ptr->points.size(); ++k) {

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -64,8 +64,7 @@ visualization_msgs::msg::Marker::SharedPtr get_path_confidence_marker_ptr(
   marker_ptr->color = path_confidence_color;
   marker_ptr->pose.position = predicted_path.path.back().position;
   marker_ptr->text = std::to_string(predicted_path.confidence);
-  marker_ptr->color.a = std::max(
-    static_cast<double>(std::min(static_cast<double>(predicted_path.confidence), 0.999)), 0.5);
+  marker_ptr->color.a = 0.5;
   return marker_ptr;
 }
 
@@ -81,9 +80,8 @@ visualization_msgs::msg::Marker::SharedPtr get_predicted_path_marker_ptr(
   marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
   marker_ptr->pose = initPose();
   marker_ptr->color = predicted_path_color;
-  marker_ptr->color.a = std::max(
-    static_cast<double>(std::min(static_cast<double>(predicted_path.confidence), 0.999)), 0.5);
-  marker_ptr->scale.x = 0.03 * marker_ptr->color.a;
+  marker_ptr->color.a = 0.7;
+  marker_ptr->scale.x = 0.015;
   calc_path_line_list(predicted_path, marker_ptr->points, is_simple);
   for (size_t k = 0; k < marker_ptr->points.size(); ++k) {
     marker_ptr->points.at(k).z -= shape.dimensions.z / 2.0;


### PR DESCRIPTION
## Description

The visibility of predicted path is not so good depending on the path confidence.
It's hard to tell the difference in the figure.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/77df95a5-5f3b-4552-843e-f1f51f047813)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
