### PR TITLE
chore: do not display steer and velocity value when message is not subscribed yet

### DIFF
--- a/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
@@ -150,7 +150,11 @@ void ConsoleMeterDisplay::update(float wall_dt, float ros_dt)
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream velocity_ss;
-  velocity_ss << std::fixed << std::setprecision(2) << linear_x * 3.6 << "km/h";
+  if (last_msg_ptr_) {
+    velocity_ss << std::fixed << std::setprecision(2) << linear_x * 3.6 << "km/h";
+  } else {
+    velocity_ss << "no received";
+  }
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,
     std::max(h - property_value_height_offset_->getInt(), 1), Qt::AlignCenter | Qt::AlignVCenter,

--- a/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/console_meter.cpp
@@ -153,7 +153,7 @@ void ConsoleMeterDisplay::update(float wall_dt, float ros_dt)
   if (last_msg_ptr_) {
     velocity_ss << std::fixed << std::setprecision(2) << linear_x * 3.6 << "km/h";
   } else {
-    velocity_ss << "no received";
+    velocity_ss << "Not received";
   }
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,

--- a/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -153,7 +153,11 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   font.setBold(true);
   painter.setFont(font);
   std::ostringstream steering_angle_ss;
-  steering_angle_ss << std::fixed << std::setprecision(1) << steering * 180.0 / M_PI << "deg";
+  if (last_msg_ptr_) {
+    steering_angle_ss << std::fixed << std::setprecision(1) << steering * 180.0 / M_PI << "deg";
+  } else {
+    steering_angle_ss << "no received";
+  }
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,
     std::max(h - property_value_height_offset_->getInt(), 1), Qt::AlignCenter | Qt::AlignVCenter,

--- a/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -156,7 +156,7 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   if (last_msg_ptr_) {
     steering_angle_ss << std::fixed << std::setprecision(1) << steering * 180.0 / M_PI << "deg";
   } else {
-    steering_angle_ss << "no received";
+    steering_angle_ss << "Not received";
   }
   painter.drawText(
     0, std::min(property_value_height_offset_->getInt(), h - 1), w,


### PR DESCRIPTION
## Description
I changed the visualization of vehicle_rviz_plugin to make it more understandable when a speed or steering information is not available.

<!-- Write a brief description of this PR. -->

## Tests performed
Tested on Psim
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/ea8292bd-5ee1-442f-8333-6958db5094d8)
->
![image](https://github.com/autowarefoundation/autoware.universe/assets/59680180/5d568558-2d1d-4764-b203-69a1c3ab2223)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
