### PR TITLE
feat(behavior_path_planner): update filter objects by velocity

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/objects_filtering.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/objects_filtering.hpp
@@ -55,25 +55,37 @@ PredictedObjects filterObjects(
   const std::shared_ptr<ObjectsFilteringParams> & params);
 
 /**
- * @brief Filter objects based on their velocity.
+ * @brief Filters objects based on their velocity.
  *
- * @param objects The predicted objects to filter.
- * @param lim_v Velocity limit for filtering.
- * @return PredictedObjects The filtered objects.
+ * Depending on the remove_above_threshold parameter, this function either removes objects with
+ * velocities above the given threshold or only keeps those objects. It uses the helper function
+ * filterObjectsByVelocity() to do the actual filtering.
+ *
+ * @param objects The objects to be filtered.
+ * @param velocity_threshold The velocity threshold for the filtering.
+ * @param remove_above_threshold If true, objects with velocities above the threshold are removed.
+ *                               If false, only objects with velocities above the threshold are
+ * kept.
+ * @return A new collection of objects that have been filtered according to the rules.
  */
 PredictedObjects filterObjectsByVelocity(
-  const PredictedObjects & objects, const double lim_v, const bool filter_dynamic_objects = true);
+  const PredictedObjects & objects, const double velocity_threshold,
+  const bool remove_above_threshold = true);
 
 /**
- * @brief Filter objects based on a velocity range.
+ * @brief Helper function to filter objects based on their velocity.
  *
- * @param objects The predicted objects to filter.
- * @param min_v Minimum velocity for filtering.
- * @param max_v Maximum velocity for filtering.
- * @return PredictedObjects The filtered objects.
+ * This function iterates over all objects and calculates their velocity norm. If the velocity norm
+ * is within the velocity_threshold and max_velocity range, the object is added to a new collection.
+ * This new collection is then returned.
+ *
+ * @param objects The objects to be filtered.
+ * @param velocity_threshold The minimum velocity for an object to be included in the output.
+ * @param max_velocity The maximum velocity for an object to be included in the output.
+ * @return A new collection of objects that have been filtered according to the rules.
  */
 PredictedObjects filterObjectsByVelocity(
-  const PredictedObjects & objects, double min_v, double max_v);
+  const PredictedObjects & objects, double velocity_threshold, double max_velocity);
 
 /**
  * @brief Filter objects based on their position relative to a current_pose.

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/objects_filtering.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/path_safety_checker/objects_filtering.hpp
@@ -61,7 +61,8 @@ PredictedObjects filterObjects(
  * @param lim_v Velocity limit for filtering.
  * @return PredictedObjects The filtered objects.
  */
-PredictedObjects filterObjectsByVelocity(const PredictedObjects & objects, double lim_v);
+PredictedObjects filterObjectsByVelocity(
+  const PredictedObjects & objects, const double lim_v, const bool filter_dynamic_objects = true);
 
 /**
  * @brief Filter objects based on a velocity range.

--- a/planning/behavior_path_planner/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner/src/utils/path_safety_checker/objects_filtering.cpp
@@ -52,17 +52,18 @@ PredictedObjects filterObjects(
 }
 
 PredictedObjects filterObjectsByVelocity(
-  const PredictedObjects & objects, double lim_v, const bool filter_dynamic_objects)
+  const PredictedObjects & objects, const double velocity_threshold,
+  const bool remove_above_threshold)
 {
-  if (filter_dynamic_objects) {
-    return filterObjectsByVelocity(objects, -lim_v, lim_v);
+  if (remove_above_threshold) {
+    return filterObjectsByVelocity(objects, -velocity_threshold, velocity_threshold);
   } else {
-    return filterObjectsByVelocity(objects, lim_v, std::numeric_limits<double>::max());
+    return filterObjectsByVelocity(objects, velocity_threshold, std::numeric_limits<double>::max());
   }
 }
 
 PredictedObjects filterObjectsByVelocity(
-  const PredictedObjects & objects, double min_v, double max_v)
+  const PredictedObjects & objects, double velocity_threshold, double max_velocity)
 {
   PredictedObjects filtered;
   filtered.header = objects.header;
@@ -70,7 +71,7 @@ PredictedObjects filterObjectsByVelocity(
     const auto v_norm = std::hypot(
       obj.kinematics.initial_twist_with_covariance.twist.linear.x,
       obj.kinematics.initial_twist_with_covariance.twist.linear.y);
-    if (min_v < v_norm && v_norm < max_v) {
+    if (velocity_threshold < v_norm && v_norm < max_velocity) {
       filtered.objects.push_back(obj);
     }
   }

--- a/planning/behavior_path_planner/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner/src/utils/path_safety_checker/objects_filtering.cpp
@@ -37,7 +37,7 @@ PredictedObjects filterObjects(
 
   PredictedObjects filtered_objects;
 
-  filtered_objects = filterObjectsByVelocity(*objects, ignore_object_velocity_threshold);
+  filtered_objects = filterObjectsByVelocity(*objects, ignore_object_velocity_threshold, false);
 
   filterObjectsByClass(filtered_objects, target_object_types);
 
@@ -51,9 +51,14 @@ PredictedObjects filterObjects(
   return filtered_objects;
 }
 
-PredictedObjects filterObjectsByVelocity(const PredictedObjects & objects, double lim_v)
+PredictedObjects filterObjectsByVelocity(
+  const PredictedObjects & objects, double lim_v, const bool filter_dynamic_objects)
 {
-  return filterObjectsByVelocity(objects, -lim_v, lim_v);
+  if (filter_dynamic_objects) {
+    return filterObjectsByVelocity(objects, -lim_v, lim_v);
+  } else {
+    return filterObjectsByVelocity(objects, lim_v, std::numeric_limits<double>::max());
+  }
 }
 
 PredictedObjects filterObjectsByVelocity(


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eeba145</samp>

Modified the `filterObjects` and `filterObjectsByVelocity` functions in `objects_filtering.cpp` and `objects_filtering.hpp` to improve the path safety checker's handling of static or slow-moving objects. Added a new parameter `filter_dynamic_objects` to control the filtering mode based on the object velocity.

filter objects by velocity and if you give arg of `filter_dynamic_objects` as false, object's velocity smaller than `lim_v` will be filtered.  

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
