### PR TITLE
feat(dynamic_avoidance): not avoid back object

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -543,7 +543,8 @@ void DynamicAvoidanceModule::updateTargetObjects()
       continue;
     }
 
-    // 2.h. calculate longitudinal and lateral offset to avoid
+    // 2.h. calculate longitudinal and lateral offset to avoid to generate object polygon by
+    // "object_path_base"
     const auto obj_points = tier4_autoware_utils::toPolygon2d(object.pose, object.shape);
     const auto lon_offset_to_avoid = calcMinMaxLongitudinalOffsetToAvoid(
       path_points_for_object_polygon, object.pose, obj_points, object.vel, time_to_collision);

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -521,8 +521,6 @@ void DynamicAvoidanceModule::updateTargetObjects()
     // 2.g. check if the ego is not ahead of the object.
     const double signed_dist_ego_to_obj = [&]() {
       const size_t ego_seg_idx = planner_data_->findEgoSegmentIndex(prev_module_path->points);
-      const size_t obj_seg_idx =
-        motion_utils::findNearestSegmentIndex(prev_module_path->points, object.pose.position);
       const double lon_offset_ego_to_obj = motion_utils::calcSignedArcLength(
         prev_module_path->points, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx);
       if (0 < lon_offset_ego_to_obj) {


### PR DESCRIPTION
## Description

The ego does not have to avoid objects behind the ego.
This object filtering is explicitly implemented in this PR.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
