### PR TITLE
feat(tier4_autoware_utils): add function to print backtrace in runtime

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
@@ -1,0 +1,53 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TIER4_AUTOWARE_UTILS__SYSTEM__BACKTRACE_HPP_
+#define TIER4_AUTOWARE_UTILS__SYSTEM__BACKTRACE_HPP_
+
+#include <execinfo.h>
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+namespace tier4_autoware_utils
+{
+
+inline void print_backtrace()
+{
+  constexpr size_t max_frames = 100;
+  void * addrlist[max_frames + 1];
+
+  int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void *));
+
+  if (addrlen == 0) {
+    return;
+  }
+
+  char ** symbollist = backtrace_symbols(addrlist, addrlen);
+
+  std::stringstream ss;
+  ss << "  -- backtrace --" << std::endl;
+  for (int i = 1; i < addrlen; i++) {
+    ss << "   @   " << symbollist[i] << std::endl;
+  }
+  std::cerr << ss.str() << std::endl;
+
+  free(symbollist);
+}
+
+}  // namespace tier4_autoware_utils
+
+#endif  // TIER4_AUTOWARE_UTILS__SYSTEM__BACKTRACE_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/system/backtrace.hpp
@@ -36,16 +36,16 @@ inline void print_backtrace()
     return;
   }
 
-  char ** symbollist = backtrace_symbols(addrlist, addrlen);
+  char ** symbol_list = backtrace_symbols(addrlist, addrlen);
 
   std::stringstream ss;
-  ss << "  -- backtrace --" << std::endl;
+  ss << "  ********** back trace **********" << std::endl;
   for (int i = 1; i < addrlen; i++) {
-    ss << "   @   " << symbollist[i] << std::endl;
+    ss << "   @   " << symbol_list[i] << std::endl;
   }
   std::cerr << ss.str() << std::endl;
 
-  free(symbollist);
+  free(symbol_list);
 }
 
 }  // namespace tier4_autoware_utils

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
@@ -37,6 +37,7 @@
 #include "tier4_autoware_utils/ros/update_param.hpp"
 #include "tier4_autoware_utils/ros/uuid_helper.hpp"
 #include "tier4_autoware_utils/ros/wait_for_param.hpp"
+#include "tier4_autoware_utils/system/backtrace.hpp"
 #include "tier4_autoware_utils/system/stop_watch.hpp"
 #include "tier4_autoware_utils/transform/transforms.hpp"
 


### PR DESCRIPTION
## Description

This function displays the stack trace in runtime.

![image](https://github.com/autowarefoundation/autoware.universe/assets/21360593/49fa34ae-d5c1-4699-9a73-4a7ea6e89ad1)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

run psim

## Effects on system behavior

None, just adding a util function

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
