### PR TITLE
feat(avoidance): flexible avoidance safety check param

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -140,7 +140,8 @@
         # collision check parameters
         check_all_predicted_path: false                  # [-]
         time_resolution: 0.5                             # [s]
-        time_horizon: 10.0                               # [s]
+        time_horizon_for_front_object: 10.0              # [s]
+        time_horizon_for_rear_object: 10.0               # [s]
         safety_check_backward_distance: 100.0            # [m]
         hysteresis_factor_expand_rate: 2.0               # [-]
         hysteresis_factor_safe_count: 10                 # [-]

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -187,7 +187,8 @@ struct AvoidanceParameters
 
   // parameters for collision check.
   bool check_all_predicted_path{false};
-  double safety_check_time_horizon{0.0};
+  double time_horizon_for_front_object{0.0};
+  double time_horizon_for_rear_object{0.0};
   double safety_check_time_resolution{0.0};
 
   // find adjacent lane vehicles

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -89,7 +89,7 @@ std::vector<DrivableAreaInfo::Obstacle> generateObstaclePolygonsForDrivableArea(
 
 std::vector<PoseWithVelocityStamped> convertToPredictedPath(
   const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data,
-  const std::shared_ptr<AvoidanceParameters> & parameters);
+  const bool is_object_front, const std::shared_ptr<AvoidanceParameters> & parameters);
 
 double getLongitudinalVelocity(const Pose & p_ref, const Pose & p_target, const double v);
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -139,7 +139,10 @@ AvoidanceModuleManager::AvoidanceModuleManager(
     p.check_other_object = getOrDeclareParameter<bool>(*node, ns + "check_other_object");
     p.check_all_predicted_path =
       getOrDeclareParameter<bool>(*node, ns + "check_all_predicted_path");
-    p.safety_check_time_horizon = getOrDeclareParameter<double>(*node, ns + "time_horizon");
+    p.time_horizon_for_front_object =
+      getOrDeclareParameter<double>(*node, ns + "time_horizon_for_front_object");
+    p.time_horizon_for_rear_object =
+      getOrDeclareParameter<double>(*node, ns + "time_horizon_for_rear_object");
     p.safety_check_time_resolution = getOrDeclareParameter<double>(*node, ns + "time_resolution");
     p.safety_check_backward_distance =
       getOrDeclareParameter<double>(*node, ns + "safety_check_backward_distance");

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -1436,7 +1436,7 @@ AvoidLineArray combineRawShiftLinesWithUniqueCheck(
 
 std::vector<PoseWithVelocityStamped> convertToPredictedPath(
   const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data,
-  const std::shared_ptr<AvoidanceParameters> & parameters)
+  const bool is_object_front, const std::shared_ptr<AvoidanceParameters> & parameters)
 {
   if (path.points.empty()) {
     return {};
@@ -1445,7 +1445,8 @@ std::vector<PoseWithVelocityStamped> convertToPredictedPath(
   const auto & acceleration = parameters->max_acceleration;
   const auto & vehicle_pose = planner_data->self_odometry->pose.pose;
   const auto & initial_velocity = std::abs(planner_data->self_odometry->twist.twist.linear.x);
-  const auto & time_horizon = parameters->safety_check_time_horizon;
+  const auto & time_horizon = is_object_front ? parameters->time_horizon_for_front_object
+                                              : parameters->time_horizon_for_rear_object;
   const auto & time_resolution = parameters->safety_check_time_resolution;
 
   const size_t ego_seg_idx = planner_data->findEgoSegmentIndex(path.points);
@@ -1477,7 +1478,8 @@ ExtendedPredictedObject transform(
 
   const auto & obj_velocity_norm = std::hypot(
     extended_object.initial_twist.twist.linear.x, extended_object.initial_twist.twist.linear.y);
-  const auto & time_horizon = parameters->safety_check_time_horizon;
+  const auto & time_horizon =
+    std::max(parameters->time_horizon_for_front_object, parameters->time_horizon_for_rear_object);
   const auto & time_resolution = parameters->safety_check_time_resolution;
 
   extended_object.predicted_paths.resize(object.kinematics.predicted_paths.size());


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3359697</samp>

This pull request improves the collision avoidance module of the behavior path planner by using different time horizons and predicted paths for objects in front and behind the ego vehicle. It modifies the `isSafePath`, `convertToPredictedPath`, and `transform` functions, as well as the `AvoidanceParameters` struct and the `AvoidanceModuleManager` constructor. It also updates the corresponding header files and node parameters.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/ac1b726b-b640-52ad-8801-0221cfead30c?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
