### PR TITLE
fix(out_of_lane): handle undetected overlap edge cases

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
@@ -54,16 +54,21 @@ lanelet::ConstLanelets calculate_other_lanelets(
   const auto lanelets_within_range = lanelet::geometry::findWithin2d(
     route_handler.getLaneletMapPtr()->laneletLayer, ego_point,
     std::max(params.slow_dist_threshold, params.stop_dist_threshold));
+  const auto is_overlapped_by_path_lanelets = [&](const auto & l) {
+    for (const auto & path_ll : path_lanelets) {
+      if (
+        boost::geometry::overlaps(
+          path_ll.polygon2d().basicPolygon(), l.polygon2d().basicPolygon()) ||
+        boost::geometry::within(path_ll.polygon2d().basicPolygon(), l.polygon2d().basicPolygon()) ||
+        boost::geometry::within(l.polygon2d().basicPolygon(), path_ll.polygon2d().basicPolygon())) {
+        return true;
+      }
+    }
+    return false;
+  };
   for (const auto & ll : lanelets_within_range) {
     const auto is_path_lanelet = contains_lanelet(path_lanelets, ll.second.id());
     const auto is_ignored_lanelet = contains_lanelet(ignored_lanelets, ll.second.id());
-    const auto is_overlapped_by_path_lanelets = [&](const auto & l) {
-      for (const auto & path_ll : path_lanelets)
-        if (boost::geometry::overlaps(
-              path_ll.polygon2d().basicPolygon(), l.polygon2d().basicPolygon()))
-          return true;
-      return false;
-    };
     if (!is_path_lanelet && !is_ignored_lanelet && !is_overlapped_by_path_lanelets(ll.second))
       other_lanelets.push_back(ll.second);
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR fixes bugs with the `out_of_lane` module where some lanelets could incorrectly be considered as "other" lanes that should not be entered by ego.
The bug was caused by the `boost::geometry::overlaps` function which does not consider the case of the following picture as an overlap.

![image](https://github.com/autowarefoundation/autoware.universe/assets/78338830/23d087fe-42f6-42b4-9d80-7a3fda96fcdb)

With this PR, we add checks with `boost::geometry::within` to handle cases where one lanelet is inside the other (e.g., in the picture, blue is inside red).

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Prevents some unwanted stops caused by the `out_of_lane` module

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
