### PR TITLE
feat(tier4_autoware_utils): add getOrDeclearParam function

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/parameter.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/parameter.hpp
@@ -1,0 +1,44 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TIER4_AUTOWARE_UTILS__ROS__PARAMETER_HPP_
+#define TIER4_AUTOWARE_UTILS__ROS__PARAMETER_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace tier4_autoware_utils
+{
+template <class T>
+T getOrDeclareParameter(rclcpp::Node & node, const std::string & name)
+{
+  if (node.has_parameter(name)) {
+    return node.get_parameter(name).get_value<T>();
+  }
+
+  try {
+    return node.declare_parameter<T>(name);
+  } catch (const rclcpp::ParameterTypeException & ex) {
+    RCLCPP_ERROR(
+      node.get_logger(), "Failed to get parameter `%s`, please set it when you launch the node.",
+      name.c_str());
+    throw(ex);
+  }
+}
+}  // namespace tier4_autoware_utils
+
+#endif  // TIER4_AUTOWARE_UTILS__ROS__PARAMETER_HPP_

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/parameter.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/parameter.hpp
@@ -17,8 +17,6 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <chrono>
-#include <memory>
 #include <string>
 
 namespace tier4_autoware_utils

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/parameter.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/ros/parameter.hpp
@@ -28,14 +28,7 @@ T getOrDeclareParameter(rclcpp::Node & node, const std::string & name)
     return node.get_parameter(name).get_value<T>();
   }
 
-  try {
-    return node.declare_parameter<T>(name);
-  } catch (const rclcpp::ParameterTypeException & ex) {
-    RCLCPP_ERROR(
-      node.get_logger(), "Failed to get parameter `%s`, please set it when you launch the node.",
-      name.c_str());
-    throw(ex);
-  }
+  return node.declare_parameter<T>(name);
 }
 }  // namespace tier4_autoware_utils
 

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/tier4_autoware_utils.hpp
@@ -31,6 +31,7 @@
 #include "tier4_autoware_utils/ros/marker_helper.hpp"
 #include "tier4_autoware_utils/ros/msg_covariance.hpp"
 #include "tier4_autoware_utils/ros/msg_operation.hpp"
+#include "tier4_autoware_utils/ros/parameter.hpp"
 #include "tier4_autoware_utils/ros/processing_time_publisher.hpp"
 #include "tier4_autoware_utils/ros/self_pose_listener.hpp"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"


### PR DESCRIPTION
## Description

Add a new function to get ros param.
This function is copied from [here](https://github.com/autowarefoundation/autoware.universe/blob/main/vehicle/vehicle_info_util/src/vehicle_info_util.cpp/#L22-L36)

## Related links

None

## Tests performed

build pass

## Notes for reviewers

None

## Interface changes
None
## Effects on system behavior
None
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
