### PR TITLE
refactor(no-drivable-lane): use getOrDeclareParameter

### DIFF
--- a/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
@@ -14,17 +14,20 @@
 
 #include "manager.hpp"
 
+#include <tier4_autoware_utils/ros/parameter.hpp>
+
 #include <string>
 
 namespace behavior_velocity_planner
 {
+using tier4_autoware_utils::getOrDeclareParameter;
 
 NoDrivableLaneModuleManager::NoDrivableLaneModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
 {
   const std::string ns(getModuleName());
-  planner_param_.stop_margin = node.declare_parameter(ns + ".stop_margin", 1.5);
-  planner_param_.print_debug_info = node.declare_parameter(ns + ".print_debug_info", false);
+  planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin");
+  planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info");
 }
 
 void NoDrivableLaneModuleManager::launchNewModules(

--- a/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
@@ -26,7 +26,7 @@ NoDrivableLaneModuleManager::NoDrivableLaneModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
 {
   const std::string ns(getModuleName());
-  planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin", 1.5);
+  planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin");
   planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info", false);
 }
 

--- a/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
@@ -27,7 +27,7 @@ NoDrivableLaneModuleManager::NoDrivableLaneModuleManager(rclcpp::Node & node)
 {
   const std::string ns(getModuleName());
   planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin", 1.5);
-  planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info, false");
+  planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info", false);
 }
 
 void NoDrivableLaneModuleManager::launchNewModules(

--- a/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
@@ -27,7 +27,7 @@ NoDrivableLaneModuleManager::NoDrivableLaneModuleManager(rclcpp::Node & node)
 {
   const std::string ns(getModuleName());
   planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin", 1.5);
-  planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info");
+  planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info, false");
 }
 
 void NoDrivableLaneModuleManager::launchNewModules(

--- a/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
@@ -26,7 +26,7 @@ NoDrivableLaneModuleManager::NoDrivableLaneModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
 {
   const std::string ns(getModuleName());
-  planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin");
+  planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin", 1.5);
   planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info");
 }
 

--- a/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_no_drivable_lane_module/src/manager.cpp
@@ -27,7 +27,7 @@ NoDrivableLaneModuleManager::NoDrivableLaneModuleManager(rclcpp::Node & node)
 {
   const std::string ns(getModuleName());
   planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin");
-  planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info", false);
+  planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info");
 }
 
 void NoDrivableLaneModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/test/src/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/test/src/test_node_interface.cpp
@@ -79,7 +79,8 @@ std::shared_ptr<BehaviorVelocityPlannerNode> generateNode()
      get_behavior_velocity_module_config("stop_line"),
      get_behavior_velocity_module_config("traffic_light"),
      get_behavior_velocity_module_config("virtual_traffic_light"),
-     get_behavior_velocity_module_config("out_of_lane")});
+     get_behavior_velocity_module_config("out_of_lane"),
+     get_behavior_velocity_module_config("no_drivable_lane")});
 
   // TODO(Takagi, Isamu): set launch_modules
   // TODO(Kyoichi Sugahara) set to true launch_virtual_traffic_light


### PR DESCRIPTION
## Description

use `tier4_autoware_utils::getOrDeclareParameter` for the ros parameter to prevent duplicate parameter declaration.

## Tests performed

Run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
