### PR TITLE
refactor(no_stopping_area): use getOrDeclareParameter

### DIFF
--- a/planning/behavior_velocity_no_stopping_area_module/src/manager.cpp
+++ b/planning/behavior_velocity_no_stopping_area_module/src/manager.cpp
@@ -15,6 +15,7 @@
 #include "manager.hpp"
 
 #include <lanelet2_extension/utility/query.hpp>
+#include <tier4_autoware_utils/ros/parameter.hpp>
 
 #include <tf2/utils.h>
 
@@ -29,23 +30,24 @@
 namespace behavior_velocity_planner
 {
 using lanelet::autoware::NoStoppingArea;
+using tier4_autoware_utils::getOrDeclareParameter;
 
 NoStoppingAreaModuleManager::NoStoppingAreaModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterfaceWithRTC(
     node, getModuleName(),
-    node.declare_parameter<bool>(std::string(getModuleName()) + ".enable_rtc"))
+    getOrDeclareParameter<bool>(node, std::string(getModuleName()) + ".enable_rtc"))
 {
   const std::string ns(getModuleName());
   auto & pp = planner_param_;
   const auto & vi = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
-  pp.state_clear_time = node.declare_parameter<double>(ns + ".state_clear_time");
-  pp.stuck_vehicle_vel_thr = node.declare_parameter<double>(ns + ".stuck_vehicle_vel_thr");
-  pp.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
-  pp.dead_line_margin = node.declare_parameter<double>(ns + ".dead_line_margin");
-  pp.stop_line_margin = node.declare_parameter<double>(ns + ".stop_line_margin");
-  pp.detection_area_length = node.declare_parameter<double>(ns + ".detection_area_length");
+  pp.state_clear_time = getOrDeclareParameter<double>(node, ns + ".state_clear_time");
+  pp.stuck_vehicle_vel_thr = getOrDeclareParameter<double>(node, ns + ".stuck_vehicle_vel_thr");
+  pp.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin");
+  pp.dead_line_margin = getOrDeclareParameter<double>(node, ns + ".dead_line_margin");
+  pp.stop_line_margin = getOrDeclareParameter<double>(node, ns + ".stop_line_margin");
+  pp.detection_area_length = getOrDeclareParameter<double>(node, ns + ".detection_area_length");
   pp.stuck_vehicle_front_margin =
-    node.declare_parameter<double>(ns + ".stuck_vehicle_front_margin");
+    getOrDeclareParameter<double>(node, ns + ".stuck_vehicle_front_margin");
   pp.path_expand_width = vi.vehicle_width_m * 0.5;
 }
 


### PR DESCRIPTION
## Description

use `tier4_autoware_utils::getOrDeclareParameter` for the ros parameter to prevent duplicate parameter declaration.

## Tests performed

Run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
