### PR TITLE
refactor(out_of_lane): use getOrDeclareParameter

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/manager.cpp
@@ -17,6 +17,7 @@
 #include "scene_out_of_lane.hpp"
 
 #include <behavior_velocity_planner_common/utilization/util.hpp>
+#include <tier4_autoware_utils/ros/parameter.hpp>
 
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
@@ -26,42 +27,47 @@
 
 namespace behavior_velocity_planner
 {
+using tier4_autoware_utils::getOrDeclareParameter;
+
 OutOfLaneModuleManager::OutOfLaneModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName()), module_id_(0UL)
 {
   const std::string ns(getModuleName());
   auto & pp = planner_param_;
 
-  pp.mode = node.declare_parameter<std::string>(ns + ".mode");
+  pp.mode = getOrDeclareParameter<std::string>(node, ns + ".mode");
   pp.skip_if_already_overlapping =
-    node.declare_parameter<bool>(ns + ".skip_if_already_overlapping");
+    getOrDeclareParameter<bool>(node, ns + ".skip_if_already_overlapping");
 
-  pp.time_threshold = node.declare_parameter<double>(ns + ".threshold.time_threshold");
-  pp.intervals_ego_buffer = node.declare_parameter<double>(ns + ".intervals.ego_time_buffer");
-  pp.intervals_obj_buffer = node.declare_parameter<double>(ns + ".intervals.objects_time_buffer");
-  pp.ttc_threshold = node.declare_parameter<double>(ns + ".ttc.threshold");
+  pp.time_threshold = getOrDeclareParameter<double>(node, ns + ".threshold.time_threshold");
+  pp.intervals_ego_buffer = getOrDeclareParameter<double>(node, ns + ".intervals.ego_time_buffer");
+  pp.intervals_obj_buffer =
+    getOrDeclareParameter<double>(node, ns + ".intervals.objects_time_buffer");
+  pp.ttc_threshold = getOrDeclareParameter<double>(node, ns + ".ttc.threshold");
 
-  pp.objects_min_vel = node.declare_parameter<double>(ns + ".objects.minimum_velocity");
+  pp.objects_min_vel = getOrDeclareParameter<double>(node, ns + ".objects.minimum_velocity");
   pp.objects_use_predicted_paths =
-    node.declare_parameter<bool>(ns + ".objects.use_predicted_paths");
+    getOrDeclareParameter<bool>(node, ns + ".objects.use_predicted_paths");
   pp.objects_min_confidence =
-    node.declare_parameter<double>(ns + ".objects.predicted_path_min_confidence");
+    getOrDeclareParameter<double>(node, ns + ".objects.predicted_path_min_confidence");
 
-  pp.overlap_min_dist = node.declare_parameter<double>(ns + ".overlap.minimum_distance");
-  pp.overlap_extra_length = node.declare_parameter<double>(ns + ".overlap.extra_length");
+  pp.overlap_min_dist = getOrDeclareParameter<double>(node, ns + ".overlap.minimum_distance");
+  pp.overlap_extra_length = getOrDeclareParameter<double>(node, ns + ".overlap.extra_length");
 
-  pp.skip_if_over_max_decel = node.declare_parameter<bool>(ns + ".action.skip_if_over_max_decel");
-  pp.strict = node.declare_parameter<bool>(ns + ".action.strict");
-  pp.dist_buffer = node.declare_parameter<double>(ns + ".action.distance_buffer");
-  pp.slow_velocity = node.declare_parameter<double>(ns + ".action.slowdown.velocity");
+  pp.skip_if_over_max_decel =
+    getOrDeclareParameter<bool>(node, ns + ".action.skip_if_over_max_decel");
+  pp.strict = getOrDeclareParameter<bool>(node, ns + ".action.strict");
+  pp.dist_buffer = getOrDeclareParameter<double>(node, ns + ".action.distance_buffer");
+  pp.slow_velocity = getOrDeclareParameter<double>(node, ns + ".action.slowdown.velocity");
   pp.slow_dist_threshold =
-    node.declare_parameter<double>(ns + ".action.slowdown.distance_threshold");
-  pp.stop_dist_threshold = node.declare_parameter<double>(ns + ".action.stop.distance_threshold");
+    getOrDeclareParameter<double>(node, ns + ".action.slowdown.distance_threshold");
+  pp.stop_dist_threshold =
+    getOrDeclareParameter<double>(node, ns + ".action.stop.distance_threshold");
 
-  pp.extra_front_offset = node.declare_parameter<double>(ns + ".ego.extra_front_offset");
-  pp.extra_rear_offset = node.declare_parameter<double>(ns + ".ego.extra_rear_offset");
-  pp.extra_left_offset = node.declare_parameter<double>(ns + ".ego.extra_left_offset");
-  pp.extra_right_offset = node.declare_parameter<double>(ns + ".ego.extra_right_offset");
+  pp.extra_front_offset = getOrDeclareParameter<double>(node, ns + ".ego.extra_front_offset");
+  pp.extra_rear_offset = getOrDeclareParameter<double>(node, ns + ".ego.extra_rear_offset");
+  pp.extra_left_offset = getOrDeclareParameter<double>(node, ns + ".ego.extra_left_offset");
+  pp.extra_right_offset = getOrDeclareParameter<double>(node, ns + ".ego.extra_right_offset");
   const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
   pp.front_offset = vehicle_info.max_longitudinal_offset_m;
   pp.rear_offset = vehicle_info.min_longitudinal_offset_m;


### PR DESCRIPTION
## Description

use `tier4_autoware_utils::getOrDeclareParameter` for the ros parameter to prevent duplicate parameter declaration.

## Tests performed

Run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
