### PR TITLE
refactor(speed_bump): use getOrDeclareParameter

### DIFF
--- a/planning/behavior_velocity_speed_bump_module/src/manager.cpp
+++ b/planning/behavior_velocity_speed_bump_module/src/manager.cpp
@@ -15,6 +15,7 @@
 #include "manager.hpp"
 
 #include <lanelet2_extension/utility/query.hpp>
+#include <tier4_autoware_utils/ros/parameter.hpp>
 
 #include <tf2/utils.h>
 
@@ -28,25 +29,26 @@
 namespace behavior_velocity_planner
 {
 using lanelet::autoware::SpeedBump;
+using tier4_autoware_utils::getOrDeclareParameter;
 
 SpeedBumpModuleManager::SpeedBumpModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
 {
   std::string ns(getModuleName());
-  planner_param_.slow_start_margin = node.declare_parameter<double>(ns + ".slow_start_margin");
-  planner_param_.slow_end_margin = node.declare_parameter<double>(ns + ".slow_end_margin");
-  planner_param_.print_debug_info = node.declare_parameter<bool>(ns + ".print_debug_info");
+  planner_param_.slow_start_margin = getOrDeclareParameter<double>(node, ns + ".slow_start_margin");
+  planner_param_.slow_end_margin = getOrDeclareParameter<double>(node, ns + ".slow_end_margin");
+  planner_param_.print_debug_info = getOrDeclareParameter<bool>(node, ns + ".print_debug_info");
 
   // limits for speed bump height and slow down speed
   ns += ".speed_calculation";
   planner_param_.speed_calculation_min_height =
-    static_cast<float>(node.declare_parameter<double>(ns + ".min_height"));
+    static_cast<float>(getOrDeclareParameter<double>(node, ns + ".min_height"));
   planner_param_.speed_calculation_max_height =
-    static_cast<float>(node.declare_parameter<double>(ns + ".max_height"));
+    static_cast<float>(getOrDeclareParameter<double>(node, ns + ".max_height"));
   planner_param_.speed_calculation_min_speed =
-    static_cast<float>(node.declare_parameter<double>(ns + ".min_speed"));
+    static_cast<float>(getOrDeclareParameter<double>(node, ns + ".min_speed"));
   planner_param_.speed_calculation_max_speed =
-    static_cast<float>(node.declare_parameter<double>(ns + ".max_speed"));
+    static_cast<float>(getOrDeclareParameter<double>(node, ns + ".max_speed"));
 }
 
 void SpeedBumpModuleManager::launchNewModules(


### PR DESCRIPTION
## Description

use `tier4_autoware_utils::getOrDeclareParameter` for the ros parameter to prevent duplicate parameter declaration.

## Tests performed

Run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
