### PR TITLE
refactor(stop_line): use getOrDeclareParameter

### DIFF
--- a/planning/behavior_velocity_stop_line_module/src/manager.cpp
+++ b/planning/behavior_velocity_stop_line_module/src/manager.cpp
@@ -14,6 +14,8 @@
 
 #include "manager.hpp"
 
+#include "tier4_autoware_utils/ros/parameter.hpp"
+
 #include <memory>
 #include <set>
 #include <string>
@@ -22,20 +24,22 @@
 namespace behavior_velocity_planner
 {
 using lanelet::TrafficSign;
+using tier4_autoware_utils::getOrDeclareParameter;
 
 StopLineModuleManager::StopLineModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
 {
   const std::string ns(getModuleName());
   auto & p = planner_param_;
-  p.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
-  p.hold_stop_margin_distance = node.declare_parameter<double>(ns + ".hold_stop_margin_distance");
-  p.stop_duration_sec = node.declare_parameter<double>(ns + ".stop_duration_sec");
+  p.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin");
+  p.hold_stop_margin_distance =
+    getOrDeclareParameter<double>(node, ns + ".hold_stop_margin_distance");
+  p.stop_duration_sec = getOrDeclareParameter<double>(node, ns + ".stop_duration_sec");
   p.use_initialization_stop_line_state =
-    node.declare_parameter<bool>(ns + ".use_initialization_stop_line_state");
+    getOrDeclareParameter<bool>(node, ns + ".use_initialization_stop_line_state");
   // debug
   p.show_stop_line_collision_check =
-    node.declare_parameter<bool>(ns + ".debug.show_stop_line_collision_check");
+    getOrDeclareParameter<bool>(node, ns + ".debug.show_stop_line_collision_check");
 }
 
 std::vector<StopLineWithLaneId> StopLineModuleManager::getStopLinesWithLaneIdOnPath(


### PR DESCRIPTION
## Description

use `tier4_autoware_utils::getOrDeclareParameter` for the ros parameter to prevent duplicate parameter declaration.

## Tests performed

Run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
