### PR TITLE
refactor(traffic_light): use getOrDeclareParameter

### DIFF
--- a/planning/behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/manager.cpp
@@ -14,6 +14,8 @@
 
 #include "manager.hpp"
 
+#include <tier4_autoware_utils/ros/parameter.hpp>
+
 #include <tf2/utils.h>
 
 #include <limits>
@@ -26,17 +28,19 @@
 namespace behavior_velocity_planner
 {
 using lanelet::TrafficLight;
+using tier4_autoware_utils::getOrDeclareParameter;
 
 TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterfaceWithRTC(
     node, getModuleName(),
-    node.declare_parameter<bool>(std::string(getModuleName()) + ".enable_rtc"))
+    getOrDeclareParameter<bool>(node, std::string(getModuleName()) + ".enable_rtc"))
 {
   const std::string ns(getModuleName());
-  planner_param_.stop_margin = node.declare_parameter<double>(ns + ".stop_margin");
-  planner_param_.tl_state_timeout = node.declare_parameter<double>(ns + ".tl_state_timeout");
-  planner_param_.enable_pass_judge = node.declare_parameter<bool>(ns + ".enable_pass_judge");
-  planner_param_.yellow_lamp_period = node.declare_parameter<double>(ns + ".yellow_lamp_period");
+  planner_param_.stop_margin = getOrDeclareParameter<double>(node, ns + ".stop_margin");
+  planner_param_.tl_state_timeout = getOrDeclareParameter<double>(node, ns + ".tl_state_timeout");
+  planner_param_.enable_pass_judge = getOrDeclareParameter<bool>(node, ns + ".enable_pass_judge");
+  planner_param_.yellow_lamp_period =
+    getOrDeclareParameter<double>(node, ns + ".yellow_lamp_period");
   pub_tl_state_ = node.create_publisher<autoware_auto_perception_msgs::msg::LookingTrafficSignal>(
     "~/output/traffic_signal", 1);
 }


### PR DESCRIPTION
## Description

use `tier4_autoware_utils::getOrDeclareParameter` for the ros parameter to prevent duplicate parameter declaration.

## Tests performed

Run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
