### PR TITLE
refactor(virtual_traffic_light): use getOrDeclareParameter

### DIFF
--- a/planning/behavior_velocity_virtual_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_virtual_traffic_light_module/src/manager.cpp
@@ -15,6 +15,7 @@
 #include "manager.hpp"
 
 #include <tier4_autoware_utils/math/unit_conversion.hpp>
+#include <tier4_autoware_utils/ros/parameter.hpp>
 
 #include <memory>
 #include <set>
@@ -25,6 +26,7 @@
 namespace behavior_velocity_planner
 {
 using lanelet::autoware::VirtualTrafficLight;
+using tier4_autoware_utils::getOrDeclareParameter;
 
 VirtualTrafficLightModuleManager::VirtualTrafficLightModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
@@ -33,14 +35,15 @@ VirtualTrafficLightModuleManager::VirtualTrafficLightModuleManager(rclcpp::Node 
 
   {
     auto & p = planner_param_;
-    p.max_delay_sec = node.declare_parameter<double>(ns + ".max_delay_sec");
-    p.near_line_distance = node.declare_parameter<double>(ns + ".near_line_distance");
-    p.dead_line_margin = node.declare_parameter<double>(ns + ".dead_line_margin");
-    p.hold_stop_margin_distance = node.declare_parameter<double>(ns + ".hold_stop_margin_distance");
-    p.max_yaw_deviation_rad =
-      tier4_autoware_utils::deg2rad(node.declare_parameter<double>(ns + ".max_yaw_deviation_deg"));
+    p.max_delay_sec = getOrDeclareParameter<double>(node, ns + ".max_delay_sec");
+    p.near_line_distance = getOrDeclareParameter<double>(node, ns + ".near_line_distance");
+    p.dead_line_margin = getOrDeclareParameter<double>(node, ns + ".dead_line_margin");
+    p.hold_stop_margin_distance =
+      getOrDeclareParameter<double>(node, ns + ".hold_stop_margin_distance");
+    p.max_yaw_deviation_rad = tier4_autoware_utils::deg2rad(
+      getOrDeclareParameter<double>(node, ns + ".max_yaw_deviation_deg"));
     p.check_timeout_after_stop_line =
-      node.declare_parameter<bool>(ns + ".check_timeout_after_stop_line");
+      getOrDeclareParameter<bool>(node, ns + ".check_timeout_after_stop_line");
   }
 }
 


### PR DESCRIPTION
## Description

use `tier4_autoware_utils::getOrDeclareParameter` for the ros parameter to prevent duplicate parameter declaration.

## Tests performed

Run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
