### PR TITLE
refactor(walkway): use getOrDeclareParameter

### DIFF
--- a/planning/behavior_velocity_walkway_module/src/manager.cpp
+++ b/planning/behavior_velocity_walkway_module/src/manager.cpp
@@ -15,6 +15,7 @@
 #include "manager.hpp"
 
 #include <behavior_velocity_planner_common/utilization/util.hpp>
+#include <tier4_autoware_utils/ros/parameter.hpp>
 
 #include <limits>
 #include <memory>
@@ -26,6 +27,7 @@ namespace behavior_velocity_planner
 {
 
 using lanelet::autoware::Crosswalk;
+using tier4_autoware_utils::getOrDeclareParameter;
 
 WalkwayModuleManager::WalkwayModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
@@ -35,8 +37,8 @@ WalkwayModuleManager::WalkwayModuleManager(rclcpp::Node & node)
   // for walkway parameters
   auto & wp = walkway_planner_param_;
   wp.stop_distance_from_crosswalk =
-    node.declare_parameter<double>(ns + ".stop_distance_from_crosswalk");
-  wp.stop_duration = node.declare_parameter<double>(ns + ".stop_duration");
+    getOrDeclareParameter<double>(node, ns + ".stop_distance_from_crosswalk");
+  wp.stop_duration = getOrDeclareParameter<double>(node, ns + ".stop_duration");
 }
 
 void WalkwayModuleManager::launchNewModules(const PathWithLaneId & path)


### PR DESCRIPTION
## Description

use `tier4_autoware_utils::getOrDeclareParameter` for the ros parameter to prevent duplicate parameter declaration.

## Tests performed

Run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
