### PR TITLE
fix(radar_fusion_sync_policy): change sync policy for radar_fusion_to_detected_object

### DIFF
--- a/perception/radar_fusion_to_detected_object/src/radar_object_fusion_to_detected_object_node/radar_object_fusion_to_detected_object_node.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_object_fusion_to_detected_object_node/radar_object_fusion_to_detected_object_node.cpp
@@ -97,7 +97,7 @@ RadarObjectFusionToDetectedObjectNode::RadarObjectFusionToDetectedObjectNode(
 
   using std::placeholders::_1;
   using std::placeholders::_2;
-  sync_ptr_ = std::make_shared<Sync>(SyncPolicy(10), sub_object_, sub_radar_);
+  sync_ptr_ = std::make_shared<Sync>(SyncPolicy(20), sub_object_, sub_radar_);
   sync_ptr_->registerCallback(
     std::bind(&RadarObjectFusionToDetectedObjectNode::onData, this, _1, _2));
 


### PR DESCRIPTION
## Description

This PR changes the sync policy of `radar_fusion_to_detected_object`.

- Background

Due to the bigger functions of Camera-LiDAR fusion, it took time to output objects using Camera-LiDAR fusion.
Therefore, there was a time difference with the radar object, and there were cases where the object was not output by the message filter of radar fusion.

- Change points

This PR loosen the sync policy of `radar_fusion_to_detected_object`.

## Tests performed

Test by rosbag.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
