### PR TITLE
refactor(perception_rviz_plugin): only delete markers with unused MarkersIDs during updates.

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -146,6 +146,8 @@ public:
     m_marker_common.addMessage(markers_ptr);
   }
 
+  void deleteMarker(rviz_default_plugins::displays::MarkerID marker_id){m_marker_common.deleteMarker(marker_id);}
+
 protected:
   /// \brief Convert given shape msg into a Marker
   /// \tparam ClassificationContainerT List type with ObjectClassificationMsg

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -146,7 +146,10 @@ public:
     m_marker_common.addMessage(markers_ptr);
   }
 
-  void deleteMarker(rviz_default_plugins::displays::MarkerID marker_id){m_marker_common.deleteMarker(marker_id);}
+  void deleteMarker(rviz_default_plugins::displays::MarkerID marker_id)
+  {
+    m_marker_common.deleteMarker(marker_id);
+  }
 
 protected:
   /// \brief Convert given shape msg into a Marker

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <set>
 
 namespace autoware
 {

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
@@ -24,10 +24,10 @@
 
 #include <condition_variable>
 #include <list>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <set>
 
 namespace autoware
 {

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/predicted_objects_display.hpp
@@ -112,6 +112,7 @@ private:
   std::mutex mutex;
   std::condition_variable condition;
   std::vector<visualization_msgs::msg::Marker::SharedPtr> markers;
+  std::set<rviz_default_plugins::displays::MarkerID> existing_marker_ids;
 };
 
 }  // namespace object_detection

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -15,6 +15,7 @@
 #include <object_detection/predicted_objects_display.hpp>
 
 #include <memory>
+#include <set>
 
 namespace autoware
 {

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -197,14 +197,13 @@ void PredictedObjectsDisplay::update(float wall_dt, float ros_dt)
   if (!markers.empty()) {
     std::set new_marker_ids = std::set<rviz_default_plugins::displays::MarkerID>();
     for (const auto & marker : markers) {
-      rviz_default_plugins::displays::MarkerID marker_id = rviz_default_plugins::displays::MarkerID(marker->ns, marker->id);
+      rviz_default_plugins::displays::MarkerID marker_id =
+        rviz_default_plugins::displays::MarkerID(marker->ns, marker->id);
       add_marker(marker);
       new_marker_ids.insert(marker_id);
     }
-    for (auto itr = existing_marker_ids.begin(); itr != existing_marker_ids.end(); itr++)
-    {
-      if (new_marker_ids.find(*itr) == new_marker_ids.end())
-      {
+    for (auto itr = existing_marker_ids.begin(); itr != existing_marker_ids.end(); itr++) {
+      if (new_marker_ids.find(*itr) == new_marker_ids.end()) {
         deleteMarker(*itr);
       }
     }

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/predicted_objects_display.cpp
@@ -130,7 +130,7 @@ std::vector<visualization_msgs::msg::Marker::SharedPtr> PredictedObjectsDisplay:
       auto acceleration_text_marker_ptr = acceleration_text_marker.value();
       acceleration_text_marker_ptr->header = msg->header;
       acceleration_text_marker_ptr->id = uuid_to_marker_id(object.object_id);
-      add_marker(acceleration_text_marker_ptr);
+      markers.push_back(acceleration_text_marker_ptr);
     }
 
     // Get marker for twist
@@ -195,11 +195,20 @@ void PredictedObjectsDisplay::update(float wall_dt, float ros_dt)
   std::unique_lock<std::mutex> lock(mutex);
 
   if (!markers.empty()) {
-    clear_markers();
-
+    std::set new_marker_ids = std::set<rviz_default_plugins::displays::MarkerID>();
     for (const auto & marker : markers) {
+      rviz_default_plugins::displays::MarkerID marker_id = rviz_default_plugins::displays::MarkerID(marker->ns, marker->id);
       add_marker(marker);
+      new_marker_ids.insert(marker_id);
     }
+    for (auto itr = existing_marker_ids.begin(); itr != existing_marker_ids.end(); itr++)
+    {
+      if (new_marker_ids.find(*itr) == new_marker_ids.end())
+      {
+        deleteMarker(*itr);
+      }
+    }
+    existing_marker_ids = new_marker_ids;
 
     markers.clear();
   }


### PR DESCRIPTION
## Description

We have observed issues related to the processing speed of RVIZ (perception plugin) under scenarios with large amounts of detectable objects.

After profiling, we note that PredictedObjectsDisplay clears / re-adds all markers during updates with new messages, and this behavior is related to the increasing processing time.

By only deleting old marker ids not used in the newest frame, and allowing RVIZ to directly modify the old markers instead of re-adding them, this PR should improve the processing efficiency of PredictedObjectsDisplay at scenes with lots of objects. 



## Related links


[Private Profiling Results](https://docs.google.com/spreadsheets/d/10ZMnt6rfGExKgIW8CM_S--FvdeLONLpMw3JkQoMIpJI/edit#gid=0)

## Tests performed

The tests are performed on the private [ROSbag](https://console.data-search.tier4.jp/projects/prd_jt/environments/393c3af9-bee1-42fc-85d7-f55f3d68a9e7/rosbags/bf5ebb8b-812c-4c74-9d6f-c605af96bb2d) 

Profiling Results:

![image](https://github.com/autowarefoundation/autoware.universe/assets/31618608/e6040264-99f7-4441-ae4a-f270d5051567)

Selective Delete improved significantly on the time (1e-6 s) consumed in the update function.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

This PR will add a public "_deleteMarker_" method in [object_polygon_display_base.hpp](https://github.com/autowarefoundation/autoware.universe/blob/main/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp). 


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
