### PR TITLE
feat(out_of_lane): filter predicted paths and add min assumed velocity

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/behavior_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -34,6 +34,7 @@
           distance_threshold: 15.0 # [m] insert a stop when closer than this distance from an overlap
 
       ego:
+        min_assumed_velocity: 2.0 # [m/s] minimum velocity used to calculate the enter and exit times of ego
         extra_front_offset: 0.0 # [m] extra front distance
         extra_rear_offset: 0.0 # [m] extra rear distance
         extra_right_offset: 0.0 # [m] extra right distance

--- a/planning/behavior_velocity_out_of_lane_module/src/decisions.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/decisions.hpp
@@ -48,6 +48,7 @@ double distance_along_path(const EgoData & ego_data, const size_t target_idx);
 /// @brief estimate the time when ego will reach some target path index
 /// @param [in] ego_data data related to the ego vehicle
 /// @param [in] target_idx target ego path index
+/// @param [in] min_velocity minimum ego velocity used to estimate the time
 /// @return time taken by ego to reach the target [s]
 double time_along_path(const EgoData & ego_data, const size_t target_idx);
 /// @brief use an object's predicted paths to estimate the times it will reach the enter and exit
@@ -57,14 +58,12 @@ double time_along_path(const EgoData & ego_data, const size_t target_idx);
 /// @param [in] object dynamic object
 /// @param [in] range overlapping range
 /// @param [in] route_handler route handler used to estimate the path of the dynamic object
-/// @param [in] min_confidence minimum confidence to consider a predicted path
 /// @param [in] logger ros logger
 /// @return an optional pair (time at enter [s], time at exit [s]). If the dynamic object drives in
 /// the opposite direction, time at enter > time at exit
 std::optional<std::pair<double, double>> object_time_to_range(
   const autoware_auto_perception_msgs::msg::PredictedObject & object, const OverlapRange & range,
-  const std::shared_ptr<route_handler::RouteHandler> route_handler, const double min_confidence,
-  const rclcpp::Logger & logger);
+  const std::shared_ptr<route_handler::RouteHandler> route_handler, const rclcpp::Logger & logger);
 /// @brief use the lanelet map to estimate the times when an object will reach the enter and exit
 /// points of an overlapping range
 /// @param [in] object dynamic object

--- a/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
@@ -1,0 +1,68 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FILTER_PREDICTED_OBJECTS_HPP_
+#define FILTER_PREDICTED_OBJECTS_HPP_
+
+#include "types.hpp"
+
+#include <string>
+
+namespace behavior_velocity_planner::out_of_lane
+{
+/// @brief filter predicted objects and their predicted paths
+/// @param [in] objects predicted objects to filter
+/// @param [in] ego_data ego data
+/// @param [in] params parameters
+/// @return filtered predicted objects
+autoware_auto_perception_msgs::msg::PredictedObjects filter_predicted_objects(
+  const autoware_auto_perception_msgs::msg::PredictedObjects & objects, const EgoData & ego_data,
+  const PlannerParam & params)
+{
+  autoware_auto_perception_msgs::msg::PredictedObjects filtered_objects;
+  filtered_objects.header = objects.header;
+  for (const auto & object : objects.objects) {
+    const auto is_pedestrian =
+      std::find_if(object.classification.begin(), object.classification.end(), [](const auto & c) {
+        return c.label == autoware_auto_perception_msgs::msg::ObjectClassification::PEDESTRIAN;
+      }) != object.classification.end();
+    if (is_pedestrian) continue;
+
+    auto filtered_object = object;
+    const auto is_invalid_predicted_path = [&](const auto & predicted_path) {
+      const auto is_low_confidence = predicted_path.confidence < params.objects_min_confidence;
+      const auto lat_offset_to_current_ego =
+        std::abs(motion_utils::calcLateralOffset(predicted_path.path, ego_data.pose.position));
+      const auto is_crossing_ego =
+        lat_offset_to_current_ego <=
+        object.shape.dimensions.y / 2.0 + std::max(
+                                            params.left_offset + params.extra_left_offset,
+                                            params.right_offset + params.extra_right_offset);
+      return is_low_confidence || is_crossing_ego;
+    };
+    if (params.objects_use_predicted_paths) {
+      auto & predicted_paths = filtered_object.kinematics.predicted_paths;
+      const auto new_end =
+        std::remove_if(predicted_paths.begin(), predicted_paths.end(), is_invalid_predicted_path);
+      predicted_paths.erase(new_end, predicted_paths.end());
+    }
+    if (!params.objects_use_predicted_paths || !filtered_object.kinematics.predicted_paths.empty())
+      filtered_objects.objects.push_back(filtered_object);
+  }
+  return filtered_objects;
+}
+
+}  // namespace behavior_velocity_planner::out_of_lane
+
+#endif  // FILTER_PREDICTED_OBJECTS_HPP_

--- a/planning/behavior_velocity_out_of_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/manager.cpp
@@ -64,6 +64,7 @@ OutOfLaneModuleManager::OutOfLaneModuleManager(rclcpp::Node & node)
   pp.stop_dist_threshold =
     getOrDeclareParameter<double>(node, ns + ".action.stop.distance_threshold");
 
+  pp.ego_min_velocity = getOrDeclareParameter<double>(node, ns + ".ego.min_assumed_velocity");
   pp.extra_front_offset = getOrDeclareParameter<double>(node, ns + ".ego.extra_front_offset");
   pp.extra_rear_offset = getOrDeclareParameter<double>(node, ns + ".ego.extra_rear_offset");
   pp.extra_left_offset = getOrDeclareParameter<double>(node, ns + ".ego.extra_left_offset");

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -16,6 +16,7 @@
 
 #include "debug.hpp"
 #include "decisions.hpp"
+#include "filter_predicted_objects.hpp"
 #include "footprint.hpp"
 #include "lanelets_selection.hpp"
 #include "overlapping_range.hpp"
@@ -103,7 +104,7 @@ bool OutOfLaneModule::modifyPathVelocity(
   DecisionInputs inputs;
   inputs.ranges = ranges;
   inputs.ego_data = ego_data;
-  inputs.objects = *planner_data_->predicted_objects;
+  inputs.objects = filter_predicted_objects(*planner_data_->predicted_objects, ego_data, params_);
   inputs.route_handler = planner_data_->route_handler_;
   inputs.lanelets = other_lanelets;
   auto decisions = calculate_decisions(inputs, params_, logger_);

--- a/planning/behavior_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/types.hpp
@@ -42,10 +42,11 @@ struct PlannerParam
   double intervals_ego_buffer;  // [s](mode="intervals") buffer to extend the ego time range
   double intervals_obj_buffer;  // [s](mode="intervals") buffer to extend the objects time range
   double ttc_threshold;  // [s](mode="ttc") threshold on time to collision between ego and an object
+  double ego_min_velocity;  // [m/s] minimum velocity of ego used to calculate its ttc or time range
 
-  bool objects_use_predicted_paths;  //  # whether to use the objects' predicted paths
-  double objects_min_vel;            //  # [m/s] objects lower than this velocity will be ignored
-  double objects_min_confidence;     //  # minimum confidence to consider a predicted path
+  bool objects_use_predicted_paths;  // whether to use the objects' predicted paths
+  double objects_min_vel;            // [m/s] objects lower than this velocity will be ignored
+  double objects_min_confidence;     // minimum confidence to consider a predicted path
 
   double overlap_extra_length;  // [m] extra length to add around an overlap range
   double overlap_min_dist;      // [m] min distance inside another lane to consider an overlap


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR improves the `out_of_lane` module with the following new features:
- pedestrians are ignored.
- predicted paths that cross the ego vehicle are ignored.
- add a parameter for the minimum ego velocity used for calculating time-to-collision or overlap time ranges.

Requires launch PR https://github.com/autowarefoundation/autoware_launch/pull/548

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Evaluator (TIER INTERNAL LINK): https://evaluation.tier4.jp/evaluation/reports/7f7acc7e-dc51-5798-be87-076d91582290?project_id=x2_dev
Psim.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Less incorrect stops when using the `out_of_lane` module, and when ego is stopped or driving slowly, stops are triggered more consistently.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
