### PR TITLE
build: remove Boost from CMakeLists.txt

### DIFF
--- a/common/perception_utils/CMakeLists.txt
+++ b/common/perception_utils/CMakeLists.txt
@@ -4,6 +4,4 @@ project(perception_utils)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-find_package(Boost REQUIRED)
-
 ament_auto_package()


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Boost does not seem to be used anywhere in the code, but it's declared in `CMakeLists.txt`, this PR removes that reference.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
