### PR TITLE
feat(crosswalk): no stop decision with braking distance 

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
@@ -42,12 +42,18 @@
         ego_pass_later_margin_x: [0.0] # [[s]] time to vehicle margin vector for object pass first situation (the module judges that ego don't have to stop at TTV + MARGIN < TTC condition)
         ego_pass_later_margin_y: [10.0] # [[s]] time to collision margin vector for object pass first situation (the module judges that ego don't have to stop at TTV + MARGIN < TTC condition)
         ego_pass_later_additional_margin: 0.5 # [s] additional time margin for object pass first situation to suppress chattering
-        max_offset_to_crosswalk_for_yield: 0.0 # [m] maximum offset from ego's front to crosswalk for yield. Positive value means in front of the crosswalk.
+
+        no_stop_decision:
+          max_offset_to_crosswalk_for_yield: 0.0 # [m] maximum offset from ego's front to crosswalk for yield. Positive value means in front of the crosswalk.
+          min_acc: -1.0   # min acceleration [m/ss]
+          min_jerk: -1.0  # min jerk [m/sss]
+          max_jerk: 1.0   # max jerk [m/sss]
+
         stop_object_velocity_threshold: 0.28 # [m/s] velocity threshold for the module to judge whether the objects is stopped (0.28 m/s = 1.0 kmph)
         min_object_velocity: 1.39 # [m/s] minimum object velocity (compare the estimated velocity by perception module with this parameter and adopt the larger one to calculate TTV. 1.39 m/s = 5.0 kmph)
         ## param for yielding
-        disable_stop_for_yield_cancel: false # for the crosswalk where there is a traffic signal
-        disable_yield_for_new_stopped_object: false # for the crosswalk where there is a traffic signal
+        disable_stop_for_yield_cancel: true # for the crosswalk where there is a traffic signal
+        disable_yield_for_new_stopped_object: true # for the crosswalk where there is a traffic signal
         timeout_no_intention_to_walk: 3.0 # [s] if the pedestrian does not move for X seconds after stopping before the crosswalk, the module judge that ego is able to pass first.
         timeout_ego_stop_for_yield: 3.0 # [s] the amount of time which ego should be stopping to query whether it yields or not
 

--- a/planning/behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/manager.cpp
@@ -88,8 +88,14 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
     getOrDeclareParameter<std::vector<double>>(node, ns + ".pass_judge.ego_pass_later_margin_y");
   cp.ego_pass_later_additional_margin =
     getOrDeclareParameter<double>(node, ns + ".pass_judge.ego_pass_later_additional_margin");
-  cp.max_offset_to_crosswalk_for_yield =
-    getOrDeclareParameter<double>(node, ns + ".pass_judge.max_offset_to_crosswalk_for_yield");
+  cp.max_offset_to_crosswalk_for_yield = getOrDeclareParameter<double>(
+    node, ns + ".pass_judge.no_stop_decision.max_offset_to_crosswalk_for_yield");
+  cp.min_acc_for_no_stop_decision =
+    getOrDeclareParameter<double>(node, ns + ".pass_judge.no_stop_decision.min_acc");
+  cp.max_jerk_for_no_stop_decision =
+    getOrDeclareParameter<double>(node, ns + ".pass_judge.no_stop_decision.max_jerk");
+  cp.min_jerk_for_no_stop_decision =
+    getOrDeclareParameter<double>(node, ns + ".pass_judge.no_stop_decision.min_jerk");
   cp.stop_object_velocity =
     getOrDeclareParameter<double>(node, ns + ".pass_judge.stop_object_velocity_threshold");
   cp.min_object_velocity =

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -106,6 +106,9 @@ public:
     std::vector<double> ego_pass_later_margin_y;
     double ego_pass_later_additional_margin;
     double max_offset_to_crosswalk_for_yield;
+    double min_acc_for_no_stop_decision;
+    double max_jerk_for_no_stop_decision;
+    double min_jerk_for_no_stop_decision;
     double stop_object_velocity;
     double min_object_velocity;
     bool disable_stop_for_yield_cancel;


### PR DESCRIPTION
## Description

Depends on https://github.com/autowarefoundation/autoware.universe/pull/4781

Added a braking distance calculated by current velocity/acceleration and limitation of acceleration/jerk to the pass judge line added by the following PR.
https://github.com/autowarefoundation/autoware.universe/pull/4492
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

scenario simulator
https://evaluation.tier4.jp/evaluation/reports/54768bcb-5b11-5c3e-99fb-b39bcb4378be?project_id=prd_jt
https://evaluation.tier4.jp/evaluation/reports/ffe1d1f7-ea22-5ad1-84ac-795d4f0d1e5b?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
