### PR TITLE
fix(goal_planner): set correct reference path

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -520,7 +520,12 @@ void GoalPlannerModule::generateGoalCandidates()
 
 BehaviorModuleOutput GoalPlannerModule::plan()
 {
+  resetPathCandidate();
+  resetPathReference();
+
   generateGoalCandidates();
+
+  path_reference_ = getPreviousModuleOutput().reference_path;
 
   if (goal_planner_utils::isAllowedGoalModification(
         planner_data_->route_handler, left_side_parking_)) {
@@ -840,6 +845,11 @@ BehaviorModuleOutput GoalPlannerModule::planWithGoalModification()
 
 BehaviorModuleOutput GoalPlannerModule::planWaitingApproval()
 {
+  resetPathCandidate();
+  resetPathReference();
+
+  path_reference_ = getPreviousModuleOutput().reference_path;
+
   if (goal_planner_utils::isAllowedGoalModification(
         planner_data_->route_handler, left_side_parking_)) {
     return planWaitingApprovalWithGoalModification();

--- a/planning/behavior_path_planner/src/utils/goal_planner/default_fixed_goal_planner.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/default_fixed_goal_planner.cpp
@@ -35,7 +35,7 @@ BehaviorModuleOutput DefaultFixedGoalPlanner::plan(
   const PathWithLaneId smoothed_path =
     modifyPathForSmoothGoalConnection(*(output.path), planner_data);
   output.path = std::make_shared<PathWithLaneId>(smoothed_path);
-  output.reference_path = std::make_shared<PathWithLaneId>(smoothed_path);
+  output.reference_path = getPreviousModuleOutput().reference_path;
   return output;
 }
 


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9de1aa</samp>

Fix a bug in the goal planner module that caused lane deviation, and modify the output of the default fixed goal planner to use a consistent reference path. These changes improve the path planning stability and robustness.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/d8c9ba0d-8c04-5f95-9ad2-4117bc13204a?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
