### PR TITLE
feat(dynamic_avoidance): generate drivable area by ego/object-path-based depending on the case

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -74,7 +74,6 @@ struct DynamicAvoidanceParameters
   double max_oncoming_crossing_object_angle{0.0};
 
   // drivable area generation
-  std::string polygon_generation_method{};
   double min_obj_path_based_lon_polygon_margin{0.0};
   double lat_offset_from_obstacle{0.0};
   double max_lat_offset_to_avoid{0.0};
@@ -94,9 +93,8 @@ struct DynamicAvoidanceParameters
 class DynamicAvoidanceModule : public SceneModuleInterface
 {
 public:
-  enum class PolygonGenerationMethod
-  {
-    EGO_PATH_BASE=0,
+  enum class PolygonGenerationMethod {
+    EGO_PATH_BASE = 0,
     OBJECT_PATH_BASE,
   };
   struct DynamicAvoidanceObject
@@ -137,7 +135,8 @@ public:
 
     void update(
       const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid,
-      const bool arg_is_collision_left, const bool arg_should_be_avoided, const PolygonGenerationMethod & arg_polygon_generation_method)
+      const bool arg_is_collision_left, const bool arg_should_be_avoided,
+      const PolygonGenerationMethod & arg_polygon_generation_method)
     {
       lon_offset_to_avoid = arg_lon_offset_to_avoid;
       lat_offset_to_avoid = arg_lat_offset_to_avoid;
@@ -241,7 +240,8 @@ public:
     {
       if (object_map_.count(uuid) != 0) {
         object_map_.at(uuid).update(
-          lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided, polygon_generation_method);
+          lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided,
+          polygon_generation_method);
       }
     }
 
@@ -319,7 +319,8 @@ private:
   void updateTargetObjects();
   bool willObjectCutIn(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
-    const double obj_tangent_vel, const LatLonOffset & lat_lon_offset, PolygonGenerationMethod & polygon_generation_method) const;
+    const double obj_tangent_vel, const LatLonOffset & lat_lon_offset,
+    PolygonGenerationMethod & polygon_generation_method) const;
   DecisionWithReason willObjectCutOut(
     const double obj_tangent_vel, const double obj_normal_vel, const bool is_object_left,
     const std::optional<DynamicAvoidanceObject> & prev_object) const;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/dynamic_avoidance/dynamic_avoidance_module.hpp
@@ -94,6 +94,11 @@ struct DynamicAvoidanceParameters
 class DynamicAvoidanceModule : public SceneModuleInterface
 {
 public:
+  enum class PolygonGenerationMethod
+  {
+    EGO_PATH_BASE=0,
+    OBJECT_PATH_BASE,
+  };
   struct DynamicAvoidanceObject
   {
     DynamicAvoidanceObject(
@@ -128,15 +133,17 @@ public:
     std::optional<MinMaxValue> lat_offset_to_avoid{std::nullopt};
     bool is_collision_left;
     bool should_be_avoided{false};
+    PolygonGenerationMethod polygon_generation_method{PolygonGenerationMethod::OBJECT_PATH_BASE};
 
     void update(
       const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid,
-      const bool arg_is_collision_left, const bool arg_should_be_avoided)
+      const bool arg_is_collision_left, const bool arg_should_be_avoided, const PolygonGenerationMethod & arg_polygon_generation_method)
     {
       lon_offset_to_avoid = arg_lon_offset_to_avoid;
       lat_offset_to_avoid = arg_lat_offset_to_avoid;
       is_collision_left = arg_is_collision_left;
       should_be_avoided = arg_should_be_avoided;
+      polygon_generation_method = arg_polygon_generation_method;
     }
   };
 
@@ -230,11 +237,11 @@ public:
     void updateObject(
       const std::string & uuid, const MinMaxValue & lon_offset_to_avoid,
       const MinMaxValue & lat_offset_to_avoid, const bool is_collision_left,
-      const bool should_be_avoided)
+      const bool should_be_avoided, const PolygonGenerationMethod & polygon_generation_method)
     {
       if (object_map_.count(uuid) != 0) {
         object_map_.at(uuid).update(
-          lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided);
+          lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided, polygon_generation_method);
       }
     }
 
@@ -312,7 +319,7 @@ private:
   void updateTargetObjects();
   bool willObjectCutIn(
     const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
-    const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const;
+    const double obj_tangent_vel, const LatLonOffset & lat_lon_offset, PolygonGenerationMethod & polygon_generation_method) const;
   DecisionWithReason willObjectCutOut(
     const double obj_tangent_vel, const double obj_normal_vel, const bool is_object_left,
     const std::optional<DynamicAvoidanceObject> & prev_object) const;

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -153,10 +153,10 @@ double calcDiffAngleAgainstPath(
 }
 
 double calcDiffAngleBetweenPaths(
-  const std::vector<PathPointWithLaneId> & path_points,
-  const PredictedPath & predicted_path)
+  const std::vector<PathPointWithLaneId> & path_points, const PredictedPath & predicted_path)
 {
-  const size_t nearest_idx = motion_utils::findNearestSegmentIndex(path_points, predicted_path.path.front().position);
+  const size_t nearest_idx =
+    motion_utils::findNearestSegmentIndex(path_points, predicted_path.path.front().position);
   const double ego_yaw = tf2::getYaw(path_points.at(nearest_idx).point.pose.orientation);
 
   constexpr size_t max_predicted_path_size = 5;
@@ -396,7 +396,8 @@ void DynamicAvoidanceModule::updateTargetObjects()
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y);
     const auto prev_object = getObstacleFromUuid(prev_objects, obj_uuid);
     const auto obj_path = *std::max_element(
-      predicted_object.kinematics.predicted_paths.begin(), predicted_object.kinematics.predicted_paths.end(),
+      predicted_object.kinematics.predicted_paths.begin(),
+      predicted_object.kinematics.predicted_paths.end(),
       [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
 
     // 1.a. check label
@@ -496,8 +497,8 @@ void DynamicAvoidanceModule::updateTargetObjects()
       getLateralLongitudinalOffset(prev_module_path->points, object.pose, object.shape);
 
     // 2.c. check if object will not cut in
-    const bool will_object_cut_in =
-      willObjectCutIn(prev_module_path->points, obj_path, object.vel, lat_lon_offset, polygon_generation_method);
+    const bool will_object_cut_in = willObjectCutIn(
+      prev_module_path->points, obj_path, object.vel, lat_lon_offset, polygon_generation_method);
     if (will_object_cut_in) {
       RCLCPP_INFO_EXPRESSION(
         getLogger(), parameters_->enable_debug_info,
@@ -575,7 +576,8 @@ void DynamicAvoidanceModule::updateTargetObjects()
 
     const bool should_be_avoided = true;
     target_objects_manager_.updateObject(
-      obj_uuid, lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided, polygon_generation_method);
+      obj_uuid, lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided,
+      polygon_generation_method);
   }
 }
 
@@ -651,7 +653,8 @@ bool DynamicAvoidanceModule::isObjectFarFromPath(
 
 bool DynamicAvoidanceModule::willObjectCutIn(
   const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
-  const double obj_tangent_vel, const LatLonOffset & lat_lon_offset, PolygonGenerationMethod & polygon_generation_method) const
+  const double obj_tangent_vel, const LatLonOffset & lat_lon_offset,
+  PolygonGenerationMethod & polygon_generation_method) const
 {
   // Check if ego's path and object's path are close.
   const bool will_object_cut_in = [&]() {
@@ -674,12 +677,12 @@ bool DynamicAvoidanceModule::willObjectCutIn(
   const double relative_velocity = getEgoSpeed() - obj_tangent_vel;
   const double lon_offset_ego_to_obj =
     motion_utils::calcSignedArcLength(
-                                      ego_path, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx) +
+      ego_path, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx) +
     lat_lon_offset.min_lon_offset;
   if (
-      lon_offset_ego_to_obj < std::max(
-                                       parameters_->min_lon_offset_ego_to_cut_in_object,
-                                       relative_velocity * parameters_->min_time_to_start_cut_in)) {
+    lon_offset_ego_to_obj < std::max(
+                              parameters_->min_lon_offset_ego_to_cut_in_object,
+                              relative_velocity * parameters_->min_time_to_start_cut_in)) {
     polygon_generation_method = PolygonGenerationMethod::EGO_PATH_BASE;
     return false;
   }

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/dynamic_avoidance_module.cpp
@@ -63,7 +63,7 @@ void appendObjectMarker(MarkerArray & marker_array, const geometry_msgs::msg::Po
 }
 
 void appendExtractedPolygonMarker(
-  MarkerArray & marker_array, const tier4_autoware_utils::Polygon2d & obj_poly)
+  MarkerArray & marker_array, const tier4_autoware_utils::Polygon2d & obj_poly, const double obj_z)
 {
   auto marker = tier4_autoware_utils::createDefaultMarker(
     "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "extracted_polygons", marker_array.markers.size(),
@@ -78,6 +78,7 @@ void appendExtractedPolygonMarker(
     geometry_msgs::msg::Point bound_geom_point;
     bound_geom_point.x = bound_point.x();
     bound_geom_point.y = bound_point.y();
+    bound_geom_point.z = obj_z;
     marker.points.push_back(bound_geom_point);
   }
 
@@ -149,6 +150,25 @@ double calcDiffAngleAgainstPath(
 
   const double diff_yaw = tier4_autoware_utils::normalizeRadian(target_yaw - traj_yaw);
   return diff_yaw;
+}
+
+double calcDiffAngleBetweenPaths(
+  const std::vector<PathPointWithLaneId> & path_points,
+  const PredictedPath & predicted_path)
+{
+  const size_t nearest_idx = motion_utils::findNearestSegmentIndex(path_points, predicted_path.path.front().position);
+  const double ego_yaw = tf2::getYaw(path_points.at(nearest_idx).point.pose.orientation);
+
+  constexpr size_t max_predicted_path_size = 5;
+  double signed_max_angle{0.0};
+  for (size_t i = 0; i < std::min(max_predicted_path_size, predicted_path.path.size()); ++i) {
+    const double obj_yaw = tf2::getYaw(predicted_path.path.at(i).orientation);
+    const double diff_yaw = tier4_autoware_utils::normalizeRadian(obj_yaw - ego_yaw);
+    if (std::abs(signed_max_angle) < std::abs(diff_yaw)) {
+      signed_max_angle = diff_yaw;
+    }
+  }
+  return signed_max_angle;
 }
 
 double calcDistanceToPath(
@@ -281,10 +301,10 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
   std::vector<DrivableAreaInfo::Obstacle> obstacles_for_drivable_area;
   for (const auto & object : target_objects_) {
     const auto obstacle_poly = [&]() {
-      if (parameters_->polygon_generation_method == "ego_path_base") {
+      if (object.polygon_generation_method == PolygonGenerationMethod::EGO_PATH_BASE) {
         return calcEgoPathBasedDynamicObstaclePolygon(object);
       }
-      if (parameters_->polygon_generation_method == "object_path_base") {
+      if (object.polygon_generation_method == PolygonGenerationMethod::OBJECT_PATH_BASE) {
         return calcObjectPathBasedDynamicObstaclePolygon(object);
       }
       throw std::logic_error("The polygon_generation_method's string is invalid.");
@@ -294,7 +314,7 @@ BehaviorModuleOutput DynamicAvoidanceModule::plan()
         {object.pose, obstacle_poly.value(), object.is_collision_left});
 
       appendObjectMarker(info_marker_, object.pose);
-      appendExtractedPolygonMarker(debug_marker_, obstacle_poly.value());
+      appendExtractedPolygonMarker(debug_marker_, obstacle_poly.value(), object.pose.position.z);
     }
   }
 
@@ -375,6 +395,9 @@ void DynamicAvoidanceModule::updateTargetObjects()
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x,
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y);
     const auto prev_object = getObstacleFromUuid(prev_objects, obj_uuid);
+    const auto obj_path = *std::max_element(
+      predicted_object.kinematics.predicted_paths.begin(), predicted_object.kinematics.predicted_paths.end(),
+      [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
 
     // 1.a. check label
     const bool is_label_target_obstacle =
@@ -391,7 +414,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
     }
 
     // 1.c. check if object is not crossing ego's path
-    const double obj_angle = calcDiffAngleAgainstPath(prev_module_path->points, obj_pose);
+    const double obj_angle = calcDiffAngleBetweenPaths(prev_module_path->points, obj_path);
     const double max_crossing_object_angle = 0.0 <= obj_tangent_vel
                                                ? parameters_->max_overtaking_crossing_object_angle
                                                : parameters_->max_oncoming_crossing_object_angle;
@@ -448,6 +471,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
 
   // 2. Precise filtering of target objects and check if they should be avoided
   for (const auto & object : target_objects_manager_.getValidObjects()) {
+    PolygonGenerationMethod polygon_generation_method{PolygonGenerationMethod::EGO_PATH_BASE};
     const auto obj_uuid = object.uuid;
     const auto prev_object = getObstacleFromUuid(prev_objects, obj_uuid);
     const auto obj_path = *std::max_element(
@@ -473,7 +497,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
 
     // 2.c. check if object will not cut in
     const bool will_object_cut_in =
-      willObjectCutIn(prev_module_path->points, obj_path, object.vel, lat_lon_offset);
+      willObjectCutIn(prev_module_path->points, obj_path, object.vel, lat_lon_offset, polygon_generation_method);
     if (will_object_cut_in) {
       RCLCPP_INFO_EXPRESSION(
         getLogger(), parameters_->enable_debug_info,
@@ -551,7 +575,7 @@ void DynamicAvoidanceModule::updateTargetObjects()
 
     const bool should_be_avoided = true;
     target_objects_manager_.updateObject(
-      obj_uuid, lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided);
+      obj_uuid, lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided, polygon_generation_method);
   }
 }
 
@@ -627,37 +651,40 @@ bool DynamicAvoidanceModule::isObjectFarFromPath(
 
 bool DynamicAvoidanceModule::willObjectCutIn(
   const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
-  const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const
+  const double obj_tangent_vel, const LatLonOffset & lat_lon_offset, PolygonGenerationMethod & polygon_generation_method) const
 {
-  constexpr double epsilon_path_lat_diff = 0.3;
-
-  // Ignore oncoming object
-  if (obj_tangent_vel < 0) {
+  // Check if ego's path and object's path are close.
+  const bool will_object_cut_in = [&]() {
+    for (const auto & predicted_path_point : predicted_path.path) {
+      const double paths_lat_diff =
+        motion_utils::calcLateralOffset(ego_path, predicted_path_point.position);
+      if (std::abs(paths_lat_diff) < planner_data_->parameters.vehicle_width / 2.0) {
+        return true;
+      }
+    }
+    return false;
+  }();
+  if (!will_object_cut_in) {
+    // The object's path will not cut in
     return false;
   }
 
-  // Ignore object close to the ego
+  // Ignore object longitudinally close to the ego
   const size_t ego_seg_idx = planner_data_->findEgoSegmentIndex(ego_path);
   const double relative_velocity = getEgoSpeed() - obj_tangent_vel;
   const double lon_offset_ego_to_obj =
     motion_utils::calcSignedArcLength(
-      ego_path, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx) +
+                                      ego_path, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx) +
     lat_lon_offset.min_lon_offset;
   if (
-    lon_offset_ego_to_obj < std::max(
-                              parameters_->min_lon_offset_ego_to_cut_in_object,
-                              relative_velocity * parameters_->min_time_to_start_cut_in)) {
+      lon_offset_ego_to_obj < std::max(
+                                       parameters_->min_lon_offset_ego_to_cut_in_object,
+                                       relative_velocity * parameters_->min_time_to_start_cut_in)) {
+    polygon_generation_method = PolygonGenerationMethod::EGO_PATH_BASE;
     return false;
   }
 
-  for (const auto & predicted_path_point : predicted_path.path) {
-    const double paths_lat_diff =
-      motion_utils::calcLateralOffset(ego_path, predicted_path_point.position);
-    if (std::abs(paths_lat_diff) < epsilon_path_lat_diff) {
-      return true;
-    }
-  }
-  return false;
+  return true;
 }
 
 DynamicAvoidanceModule::DecisionWithReason DynamicAvoidanceModule::willObjectCutOut(

--- a/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/dynamic_avoidance/manager.cpp
@@ -81,8 +81,6 @@ DynamicAvoidanceModuleManager::DynamicAvoidanceModuleManager(
 
   {  // drivable_area_generation
     std::string ns = "dynamic_avoidance.drivable_area_generation.";
-    p.polygon_generation_method =
-      node->declare_parameter<std::string>(ns + "polygon_generation_method");
     p.min_obj_path_based_lon_polygon_margin =
       node->declare_parameter<double>(ns + "object_path_base.min_longitudinal_polygon_margin");
     p.lat_offset_from_obstacle = node->declare_parameter<double>(ns + "lat_offset_from_obstacle");
@@ -181,9 +179,6 @@ void DynamicAvoidanceModuleManager::updateModuleParams(
 
   {  // drivable_area_generation
     const std::string ns = "dynamic_avoidance.drivable_area_generation.";
-
-    updateParam<std::string>(
-      parameters, ns + "polygon_generation_method", p->polygon_generation_method);
     updateParam<double>(
       parameters, ns + "object_path_base.min_longitudinal_polygon_margin",
       p->min_obj_path_based_lon_polygon_margin);


### PR DESCRIPTION
## Description

- If the object's path is a cutting-in path, but the object is very close to the ego which has to be avoided, without the PR, the decision is no avoidance.
    - To deal with this case, if the object path is like above, the decision to avoid is calculated by the ego and object position.
- Fixed the debug marker's z.
- Dealt with the case where the object is crossing the ego's path, but the decision was avoidance without this PR.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/958e1e94-b7b6-49af-894b-f2fceccf048a)




<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
