### PR TITLE
fix(avoidance): fix lateral distance calculation

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -70,7 +70,7 @@ void fillLongitudinalAndLengthByClosestEnvelopeFootprint(
   const PathWithLaneId & path, const Point & ego_pos, ObjectData & obj);
 
 double calcEnvelopeOverhangDistance(
-  const ObjectData & object_data, const Pose & base_pose, Point & overhang_pose);
+  const ObjectData & object_data, const PathWithLaneId & path, Point & overhang_pose);
 
 void setEndData(
   AvoidLine & al, const double length, const geometry_msgs::msg::Pose & end, const size_t end_idx,

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -332,7 +332,7 @@ ObjectData AvoidanceModule::createObjectData(
 
   // Find the footprint point closest to the path, set to object_data.overhang_distance.
   object_data.overhang_dist = utils::avoidance::calcEnvelopeOverhangDistance(
-    object_data, object_closest_pose, object_data.overhang_pose.position);
+    object_data, data.reference_path, object_data.overhang_pose.position);
 
   // Check whether the the ego should avoid the object.
   const auto & vehicle_width = planner_data_->parameters.vehicle_width;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -983,6 +983,9 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
     if (is_valid_shift_line(al_avoid) && is_valid_shift_line(al_return)) {
       avoid_lines.push_back(al_avoid);
       avoid_lines.push_back(al_return);
+    } else {
+      o.reason = "InvalidShiftLine";
+      continue;
     }
 
     o.is_avoidable = true;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/avoidance_by_lane_change.cpp
@@ -216,7 +216,7 @@ ObjectData AvoidanceByLaneChange::createObjectData(
 
   // Find the footprint point closest to the path, set to object_data.overhang_distance.
   object_data.overhang_dist = utils::avoidance::calcEnvelopeOverhangDistance(
-    object_data, object_closest_pose, object_data.overhang_pose.position);
+    object_data, data.reference_path, object_data.overhang_pose.position);
 
   // Check whether the the ego should avoid the object.
   const auto & vehicle_width = planner_data_->parameters.vehicle_width;

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -406,13 +406,14 @@ void fillLongitudinalAndLengthByClosestEnvelopeFootprint(
 }
 
 double calcEnvelopeOverhangDistance(
-  const ObjectData & object_data, const Pose & base_pose, Point & overhang_pose)
+  const ObjectData & object_data, const PathWithLaneId & path, Point & overhang_pose)
 {
   double largest_overhang = isOnRight(object_data) ? -100.0 : 100.0;  // large number
 
   for (const auto & p : object_data.envelope_poly.outer()) {
     const auto point = tier4_autoware_utils::createPoint(p.x(), p.y(), 0.0);
-    const auto lateral = tier4_autoware_utils::calcLateralDeviation(base_pose, point);
+    const auto idx = findFirstNearestIndex(path.points, point);
+    const auto lateral = calcLateralDeviation(getPose(path.points.at(idx)), point);
 
     const auto & overhang_pose_on_right = [&overhang_pose, &largest_overhang, &point, &lateral]() {
       if (lateral > largest_overhang) {

--- a/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/avoidance/utils.cpp
@@ -1014,7 +1014,7 @@ void filterTargetObjects(
         const auto lines =
           rh->getFurthestLinestring(target_lanelet, get_right, get_left, get_opposite, true);
         const auto & line = isOnRight(o) ? lines.back() : lines.front();
-        const auto d = distance2d(to2D(overhang_basic_pose), to2D(line.basicLineString()));
+        const auto d = boost::geometry::distance(o.envelope_poly, to2D(line.basicLineString()));
         if (d < o.to_road_shoulder_distance) {
           o.to_road_shoulder_distance = d;
           target_line = line;


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4cc379f</samp>

The pull request improves the object avoidance logic in the behavior path planner by using the reference path instead of the ego pose to calculate the overhang and road shoulder distances of objects. It modifies the function `calcEnvelopeOverhangDistance` and updates its calls in `avoidance_module.cpp` and `avoidance_by_lane_change.cpp`.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/c9166fae-c0d1-4ba0-acfa-8333d0ee8c9e)

---

### Before this PR

Since there is a bug in  shiftable length caluclation logic, sometimes it outputs unfeasible (outside drivable area) avoidance path.

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/cda58aaf-2adb-4234-bc04-3d85560c47e1)

Psim

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/19542bf9-d993-4114-afc8-08e8c2c46d91)

### After this PR

In this PR, module calculates precise distance between object polygon and road shoulder so that it can judge if the ego  is able to avoid and path is feasible.

```c++
const auto d = boost::geometry::distance(o.envelope_poly, to2D(line.basicLineString()));
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/44889564/aa87e132-8d4e-426b-9770-101725e3cc67)


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/bd29e23c-4cf7-511f-a5a6-7a2944d5fa96?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Fix invalid behavior

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
