### PR TITLE
fix(behavior_path_planner): prevent crashes with the drivable area expansion

### DIFF
--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
@@ -59,7 +59,7 @@ polygon_t createExpansionPolygon(
   boost::geometry::buffer(
     base_ls, polygons, distance_strategy, strategy::side_straight(), strategy::join_miter(),
     strategy::end_flat(), strategy::point_square());
-  return polygons.empty() ? polyton_t{} : polygons.front();
+  return polygons.empty() ? polygon_t{} : polygons.front();
 }
 
 std::array<double, 3> calculate_arc_length_range_and_distance(

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
@@ -59,7 +59,7 @@ polygon_t createExpansionPolygon(
   boost::geometry::buffer(
     base_ls, polygons, distance_strategy, strategy::side_straight(), strategy::join_miter(),
     strategy::end_flat(), strategy::point_square());
-  return polygons.front();
+  return polygons.empty() ? polyton_t{} : polygons.front();
 }
 
 std::array<double, 3> calculate_arc_length_range_and_distance(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR add a guards for when the `boost::geometry::buffer`  function returns an empty set of polygons.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Prevents some crashes of the `behavior_path_planner`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
