### PR TITLE
fix(radar_fusion_to_detected_object): fix parameter handling

### DIFF
--- a/perception/radar_fusion_to_detected_object/README.md
+++ b/perception/radar_fusion_to_detected_object/README.md
@@ -13,11 +13,11 @@ The document of core algorithm is [here](docs/algorithm.md)
 
 ### Parameters for sensor fusion
 
-| Name                     | Type   | Description                                                                                                                                                                                                                    | Default value |
-| :----------------------- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| bounding_box_margin      | double | The distance to extend the 2D bird's-eye view Bounding Box on each side. This distance is used as a threshold to find radar centroids falling inside the extended box. [m]                                                     | 2.0           |
-| split_threshold_velocity | double | The object's velocity threshold to decide to split for two objects from radar information (currently not implemented) [m/s]                                                                                                    | 5.0           |
-| threshold_yaw_diff       | double | The yaw orientation threshold. If ∣*θob* − *θra*∣ < threshold × yaw*diff attached to radar information include estimated velocity, where*θob*is yaw angle from 3d detected object,*θra\_ is yaw angle from radar object. [rad] | 0.35          |
+| Name                     | Type   | Description                                                                                                                                                                                                                       | Default value |
+| :----------------------- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| bounding_box_margin      | double | The distance to extend the 2D bird's-eye view Bounding Box on each side. This distance is used as a threshold to find radar centroids falling inside the extended box. [m]                                                        | 2.0           |
+| split_threshold_velocity | double | The object's velocity threshold to decide to split for two objects from radar information (currently not implemented) [m/s]                                                                                                       | 5.0           |
+| threshold_yaw_diff       | double | The yaw orientation threshold. If ∣ θ\_ob − θ\_ra ∣ < threshold × yaw\_diff attached to radar information include estimated velocity, where*θob*is yaw angle from 3d detected object,*θ\_ra is yaw angle from radar object. [rad] | 0.35          |
 
 ### Weight parameters for velocity estimation
 

--- a/perception/radar_fusion_to_detected_object/README.md
+++ b/perception/radar_fusion_to_detected_object/README.md
@@ -13,11 +13,11 @@ The document of core algorithm is [here](docs/algorithm.md)
 
 ### Parameters for sensor fusion
 
-| Name                     | Type   | Description                                                                                                                                                                                                                       | Default value |
-| :----------------------- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| bounding_box_margin      | double | The distance to extend the 2D bird's-eye view Bounding Box on each side. This distance is used as a threshold to find radar centroids falling inside the extended box. [m]                                                        | 2.0           |
-| split_threshold_velocity | double | The object's velocity threshold to decide to split for two objects from radar information (currently not implemented) [m/s]                                                                                                       | 5.0           |
-| threshold_yaw_diff       | double | The yaw orientation threshold. If ∣ θ\_ob − θ\_ra ∣ < threshold × yaw\_diff attached to radar information include estimated velocity, where*θob*is yaw angle from 3d detected object,*θ\_ra is yaw angle from radar object. [rad] | 0.35          |
+| Name                     | Type   | Description                                                                                                                                                                                                                    | Default value |
+| :----------------------- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| bounding_box_margin      | double | The distance to extend the 2D bird's-eye view Bounding Box on each side. This distance is used as a threshold to find radar centroids falling inside the extended box. [m]                                                     | 2.0           |
+| split_threshold_velocity | double | The object's velocity threshold to decide to split for two objects from radar information (currently not implemented) [m/s]                                                                                                    | 5.0           |
+| threshold_yaw_diff       | double | The yaw orientation threshold. If ∣ θ_ob − θ_ra ∣ < threshold × yaw_diff attached to radar information include estimated velocity, where*θob*is yaw angle from 3d detected object,\*θ_ra is yaw angle from radar object. [rad] | 0.35          |
 
 ### Weight parameters for velocity estimation
 

--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -40,7 +40,7 @@ void RadarFusionToDetectedObject::setParam(const Param & param)
   // Radar fusion param
   param_.bounding_box_margin = param.bounding_box_margin;
   param_.split_threshold_velocity = param.split_threshold_velocity;
-  param_.threshold_yaw_diff = param.split_threshold_velocity;
+  param_.threshold_yaw_diff = param.threshold_yaw_diff;
 
   // Normalize weight param
   double sum_weight = param.velocity_weight_median + param.velocity_weight_min_distance +


### PR DESCRIPTION
## Description

Fix the bug that `threshold_yaw_diff` parameter is not reflected.

## Tests performed

Not applicable.

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
