### PR TITLE
fix(utils): improve sharp bound cleaning

### DIFF
--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1902,18 +1902,18 @@ void makeBoundLongitudinallyMonotonic(
 
     std::vector<Point> ret;
 
-    ret.push_back(bound.front());
+    for (size_t i = 0; i < bound.size(); i++) {
+      const auto & p_new = bound.at(i);
+      const auto duplicated_points_itr = std::find_if(
+        ret.begin(), ret.end(),
+        [&p_new](const auto & p) { return calcDistance2d(p, p_new) < 0.1; });
 
-    for (size_t i = 0; i < bound.size() - 2; i++) {
-      try {
-        motion_utils::validateNonSharpAngle(bound.at(i), bound.at(i + 1), bound.at(i + 2));
-        ret.push_back(bound.at(i + 1));
-      } catch (const std::exception & e) {
-        continue;
+      if (duplicated_points_itr != ret.end() && std::next(duplicated_points_itr, 2) == ret.end()) {
+        ret.erase(duplicated_points_itr, ret.end());
       }
-    }
 
-    ret.push_back(bound.back());
+      ret.push_back(p_new);
+    }
 
     return ret;
   };


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 606ca70</samp>

Fixed a bug in `makeBoundLongitudinallyMonotonic` function in `utils.cpp` that caused the behavior path planner to fail with duplicated bound points. Improved the logic to remove duplicates and ensure monotonicity of the output bound vector.

---

This PR contains following two modifications:

1. supress redundant try & catch, `Sharp angle` messages.
2. improve sharp angle drivable area bound cleaning logic.

![Screenshot from 2023-08-31 18-51-54](https://github.com/autowarefoundation/autoware.universe/assets/44889564/76dc9e65-f3ad-4d1a-a920-6ab0c7aba216)

![Screenshot from 2023-08-31 18-52-05](https://github.com/autowarefoundation/autoware.universe/assets/44889564/905044b3-45c2-469b-998c-cfd436a53373)

before this PR

![Screenshot from 2023-09-01 08-28-57](https://github.com/autowarefoundation/autoware.universe/assets/44889564/b3185d6b-1f1d-44a9-ac1b-a557067ae0f4)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/fe9b785f-d6fa-5014-beea-bb1d0ae04528?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
