### PR TITLE
chore(traffic_light_arbiter): use THROTTLE to prevent obscuring other logs

### DIFF
--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -111,7 +111,8 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
   std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> regulatory_element_signals_map;
 
   if (map_regulatory_elements_set_ == nullptr) {
-    RCLCPP_WARN(get_logger(), "Received traffic signal messages before a map");
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000, "Received traffic signal messages before a map");
     return;
   }
 
@@ -126,8 +127,9 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
   auto add_signal_function = [&](const auto & signal, bool priority) {
     const auto id = signal.traffic_signal_id;
     if (!map_regulatory_elements_set_->count(id)) {
-      RCLCPP_WARN(
-        get_logger(), "Received a traffic signal not present in the current map (%lu)", id);
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "Received a traffic signal not present in the current map (%lu)", id);
       return;
     }
 


### PR DESCRIPTION
## Description

Switched to using THROTTLE for warning logs to prevent obscuring other logs.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested in simple planning simulator.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
