### PR TITLE
feat(intersection): do not generate stuck vehicle detect area before attention area if attention area exists

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -774,7 +774,8 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
   const auto & conflicting_area = intersection_lanelets_.value().conflicting_area();
   const auto path_lanelets_opt = util::generatePathLanelets(
     lanelets_on_path, interpolated_path_info, associative_ids_, first_conflicting_area.value(),
-    conflicting_area, closest_idx, planner_data_->vehicle_info_.vehicle_width_m);
+    conflicting_area, first_attention_area, intersection_lanelets_.value().attention_area(),
+    closest_idx, planner_data_->vehicle_info_.vehicle_width_m);
   if (!path_lanelets_opt.has_value()) {
     RCLCPP_DEBUG(logger_, "failed to generate PathLanelets");
     return IntersectionModule::Indecisive{};

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -335,9 +335,16 @@ void reactRTCApprovalByDecisionResult(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
     "StuckStop, approval = (default: %d, occlusion: %d)", rtc_default_approved,
     rtc_occlusion_approved);
+  const auto closest_idx = decision_result.stop_lines.closest_idx;
   if (!rtc_default_approved) {
     // use default_rtc uuid for stuck vehicle detection
-    const auto stop_line_idx = decision_result.stop_line_idx;
+    auto stop_line_idx = decision_result.stop_line_idx;
+    if (
+      !decision_result.is_detection_area_empty &&
+      motion_utils::calcSignedArcLength(path->points, stop_line_idx, closest_idx) >
+        planner_param.common.stop_overshoot_margin) {
+      stop_line_idx = decision_result.stop_lines.default_stop_line;
+    }
     planning_utils::setVelocityFromIndex(stop_line_idx, 0.0, path);
     debug_data->collision_stop_wall_pose =
       planning_utils::getAheadPose(stop_line_idx, baselink2front, *path);
@@ -347,7 +354,7 @@ void reactRTCApprovalByDecisionResult(
       stop_factor.stop_factor_points = planning_utils::toRosPoints(debug_data->conflicting_targets);
       planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
-        path->points, path->points.at(decision_result.stop_lines.closest_idx).point.pose,
+        path->points, path->points.at(closest_idx).point.pose,
         path->points.at(stop_line_idx).point.pose, VelocityFactor::INTERSECTION);
     }
   }
@@ -363,7 +370,7 @@ void reactRTCApprovalByDecisionResult(
       stop_factor.stop_pose = path->points.at(occlusion_stop_line_idx).point.pose;
       planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
-        path->points, path->points.at(decision_result.stop_lines.closest_idx).point.pose,
+        path->points, path->points.at(closest_idx).point.pose,
         path->points.at(occlusion_stop_line_idx).point.pose, VelocityFactor::INTERSECTION);
     }
   }

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -1155,7 +1155,9 @@ std::optional<PathLanelets> generatePathLanelets(
   const lanelet::ConstLanelets & lanelets_on_path,
   const util::InterpolatedPathInfo & interpolated_path_info, const std::set<int> & associative_ids,
   const lanelet::CompoundPolygon3d & first_conflicting_area,
-  const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas, const size_t closest_idx,
+  const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
+  const std::optional<lanelet::CompoundPolygon3d> & first_attention_area,
+  const std::vector<lanelet::CompoundPolygon3d> & attention_areas, const size_t closest_idx,
   const double width)
 {
   const auto & assigned_lane_interval_opt = interpolated_path_info.lane_id_interval;
@@ -1195,9 +1197,13 @@ std::optional<PathLanelets> generatePathLanelets(
   }
 
   const auto first_inside_conflicting_idx_opt =
-    getFirstPointInsidePolygon(path, assigned_lane_interval, first_conflicting_area);
+    first_attention_area.has_value()
+      ? getFirstPointInsidePolygon(path, assigned_lane_interval, first_attention_area.value())
+      : getFirstPointInsidePolygon(path, assigned_lane_interval, first_conflicting_area);
   const auto last_inside_conflicting_idx_opt =
-    getFirstPointInsidePolygons(path, assigned_lane_interval, conflicting_areas, false);
+    first_attention_area.has_value()
+      ? getFirstPointInsidePolygons(path, assigned_lane_interval, attention_areas, false)
+      : getFirstPointInsidePolygons(path, assigned_lane_interval, conflicting_areas, false);
   if (first_inside_conflicting_idx_opt && last_inside_conflicting_idx_opt) {
     const auto first_inside_conflicting_idx = first_inside_conflicting_idx_opt.value();
     const auto last_inside_conflicting_idx = last_inside_conflicting_idx_opt.value().first;

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -158,7 +158,9 @@ std::optional<PathLanelets> generatePathLanelets(
   const lanelet::ConstLanelets & lanelets_on_path,
   const util::InterpolatedPathInfo & interpolated_path_info, const std::set<int> & associative_ids,
   const lanelet::CompoundPolygon3d & first_conflicting_area,
-  const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas, const size_t closest_idx,
+  const std::vector<lanelet::CompoundPolygon3d> & conflicting_areas,
+  const std::optional<lanelet::CompoundPolygon3d> & first_attention_area,
+  const std::vector<lanelet::CompoundPolygon3d> & attention_areas, const size_t closest_idx,
   const double width);
 
 }  // namespace util


### PR DESCRIPTION
## Description

Fixed unnecessary stuck vehicle detection for vehicles before the attention area.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

### Before this PR

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/a334e24b-381a-460b-b1cb-74d056e0abde)

### After this PR

![image](https://github.com/autowarefoundation/autoware.universe/assets/28677420/7277d746-6c62-4e9d-8e5f-93affe37d3fa)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
