### PR TITLE
fix(start_planner): start pose candidates

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -416,6 +416,9 @@ void StartPlannerModule::planWithPriority(
   }
 
   const auto is_safe_with_pose_planner = [&](const size_t i, const auto & planner) {
+    // Set back_finished flag based on the current index
+    status_.back_finished = i == 0;
+
     // Get the pull_out_start_pose for the current index
     const auto & pull_out_start_pose = start_pose_candidates.at(i);
 
@@ -495,8 +498,6 @@ void StartPlannerModule::planWithPriority(
   for (const auto & p : order_priority) {
     if (is_safe_with_pose_planner(p.first, p.second)) {
       const std::lock_guard<std::mutex> lock(mutex_);
-      // Set back_finished flag based on the current index
-      status_.back_finished = p.first == 0;
       return;
     }
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
fix start pose candidates


before
![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/e3ebf34c-64f3-4994-af59-a3c6050665de)


after
![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/73f89d53-25d4-4cb1-bd4b-63a55c071711)



## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
https://evaluation.tier4.jp/evaluation/reports/412a6397-1b87-586f-88c7-56febb7def53?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
