### PR TITLE
fix(planning_debug_tools): disable traffic light msg in perception replay

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
@@ -73,7 +73,7 @@ class PerceptionReplayer(PerceptionReplayerCommon):
         # extract message by the timestamp
         msgs = copy.deepcopy(self.find_topics_by_timestamp(self.bag_timestamp))
         objects_msg = msgs[0]
-        traffic_signals_msg = msgs[1]
+        # traffic_signals_msg = msgs[1]
 
         # objects
         if objects_msg:
@@ -92,13 +92,13 @@ class PerceptionReplayer(PerceptionReplayerCommon):
             self.objects_pub.publish(objects_msg)
 
         # traffic signals
-        if traffic_signals_msg:
-            traffic_signals_msg.header.stamp = timestamp
-            self.traffic_signals_pub.publish(traffic_signals_msg)
-            self.prev_traffic_signals_msg = traffic_signals_msg
-        elif self.prev_traffic_signals_msg:
-            self.prev_traffic_signals_msg.header.stamp = timestamp
-            self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
+        # if traffic_signals_msg:
+        #     traffic_signals_msg.header.stamp = timestamp
+        #     self.traffic_signals_pub.publish(traffic_signals_msg)
+        #     self.prev_traffic_signals_msg = traffic_signals_msg
+        # elif self.prev_traffic_signals_msg:
+        #     self.prev_traffic_signals_msg.header.stamp = timestamp
+        #     self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
 
     def onPushed(self, event):
         if self.widget.button.isChecked():

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -56,7 +56,7 @@ class PerceptionReproducer(PerceptionReplayerCommon):
         # extract message by the nearest ego odom timestamp
         msgs = copy.deepcopy(self.find_topics_by_timestamp(pose_timestamp))
         objects_msg = msgs[0]
-        traffic_signals_msg = msgs[1]
+        # traffic_signals_msg = msgs[1]
 
         # objects
         if objects_msg:
@@ -66,13 +66,13 @@ class PerceptionReproducer(PerceptionReplayerCommon):
             self.objects_pub.publish(objects_msg)
 
         # traffic signals
-        if traffic_signals_msg:
-            traffic_signals_msg.header.stamp = timestamp
-            self.traffic_signals_pub.publish(traffic_signals_msg)
-            self.prev_traffic_signals_msg = traffic_signals_msg
-        elif self.prev_traffic_signals_msg:
-            self.prev_traffic_signals_msg.header.stamp = timestamp
-            self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
+        # if traffic_signals_msg:
+        #     traffic_signals_msg.header.stamp = timestamp
+        #     self.traffic_signals_pub.publish(traffic_signals_msg)
+        #     self.prev_traffic_signals_msg = traffic_signals_msg
+        # elif self.prev_traffic_signals_msg:
+        #     self.prev_traffic_signals_msg.header.stamp = timestamp
+        #     self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
 
     def find_nearest_ego_odom_by_observation(self, ego_pose):
         if self.ego_pose_idx:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR disables the publishing of traffic light messages from the perception replayer.
The message is going to change and will cause the script to crash. This will be reverted once the message change is finalized.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
