### PR TITLE
fix(tier4_planning_rviz_plugin): update vehicle info parameters in panel received from global parameter

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
@@ -506,6 +506,10 @@ protected:
       vehicle_footprint_info_ = std::make_shared<VehicleFootprintInfo>(
         vehicle_info_->vehicle_length_m, vehicle_info_->vehicle_width_m,
         vehicle_info_->rear_overhang_m);
+
+      property_vehicle_length_.setValue(vehicle_info_->vehicle_length_m);
+      property_vehicle_width_.setValue(vehicle_info_->vehicle_width_m);
+      property_rear_overhang_.setValue(vehicle_info_->rear_overhang_m);
     } else {
       const float length{property_vehicle_length_.getFloat()};
       const float width{property_vehicle_width_.getFloat()};


### PR DESCRIPTION
## Description

The vehicle size parameters of the path rviz plugin are received from the global parameter.
These parameters are applied to the plugin's footprint size but not to the parameters shown in the panel.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

rviz

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
