### PR TITLE
feat(planning_debug_tools): support old auto TrafficSignalArray

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
@@ -94,20 +94,20 @@ class PerceptionReplayer(PerceptionReplayerCommon):
         # traffic signals
         # temporary support old auto msgs
         if traffic_signals_msg:
-            if "autoware_perception_msgs" in type(traffic_signals_msg).__module__:
-                traffic_signals_msg.stamp = timestamp
-                self.traffic_signals_pub.publish(traffic_signals_msg)
-            elif "autoware_auto_perception_msgs" in type(traffic_signals_msg).__module__:
+            if self.is_auto_traffic_signals:
                 traffic_signals_msg.header.stamp = timestamp
                 self.auto_traffic_signals_pub.publish(traffic_signals_msg)
+            else:
+                traffic_signals_msg.stamp = timestamp
+                self.traffic_signals_pub.publish(traffic_signals_msg)
             self.prev_traffic_signals_msg = traffic_signals_msg
         elif self.prev_traffic_signals_msg:
-            if "autoware_perception_msgs" in type(self.prev_traffic_signals_msg).__module__:
-                self.prev_traffic_signals_msg.stamp = timestamp
-                self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
-            elif "autoware_auto_perception_msgs" in type(self.prev_traffic_signals_msg).__module__:
+            if self.is_auto_traffic_signals:
                 self.prev_traffic_signals_msg.header.stamp = timestamp
                 self.auto_traffic_signals_pub.publish(self.prev_traffic_signals_msg)
+            else:
+                self.prev_traffic_signals_msg.stamp = timestamp
+                self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
 
     def onPushed(self, event):
         if self.widget.button.isChecked():

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
@@ -92,13 +92,22 @@ class PerceptionReplayer(PerceptionReplayerCommon):
             self.objects_pub.publish(objects_msg)
 
         # traffic signals
+        # temporary support old auto msgs
         if traffic_signals_msg:
-            traffic_signals_msg.stamp = timestamp
-            self.traffic_signals_pub.publish(traffic_signals_msg)
+            if "autoware_perception_msgs" in type(traffic_signals_msg).__module__:
+                traffic_signals_msg.stamp = timestamp
+                self.traffic_signals_pub.publish(traffic_signals_msg)
+            elif "autoware_auto_perception_msgs" in type(traffic_signals_msg).__module__:
+                traffic_signals_msg.header.stamp = timestamp
+                self.auto_traffic_signals_pub.publish(traffic_signals_msg)
             self.prev_traffic_signals_msg = traffic_signals_msg
         elif self.prev_traffic_signals_msg:
-            self.prev_traffic_signals_msg.stamp = timestamp
-            self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
+            if "autoware_perception_msgs" in type(self.prev_traffic_signals_msg).__module__:
+                self.prev_traffic_signals_msg.stamp = timestamp
+                self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
+            elif "autoware_auto_perception_msgs" in type(self.prev_traffic_signals_msg).__module__:
+                self.prev_traffic_signals_msg.header.stamp = timestamp
+                self.auto_traffic_signals_pub.publish(self.prev_traffic_signals_msg)
 
     def onPushed(self, event):
         if self.widget.button.isChecked():

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -66,13 +66,22 @@ class PerceptionReproducer(PerceptionReplayerCommon):
             self.objects_pub.publish(objects_msg)
 
         # traffic signals
+        # temporary support old auto msgs
         if traffic_signals_msg:
-            traffic_signals_msg.stamp = timestamp
-            self.traffic_signals_pub.publish(traffic_signals_msg)
+            if "autoware_perception_msgs" in type(traffic_signals_msg).__module__:
+                traffic_signals_msg.stamp = timestamp
+                self.traffic_signals_pub.publish(traffic_signals_msg)
+            elif "autoware_auto_perception_msgs" in type(traffic_signals_msg).__module__:
+                traffic_signals_msg.header.stamp = timestamp
+                self.auto_traffic_signals_pub.publish(traffic_signals_msg)
             self.prev_traffic_signals_msg = traffic_signals_msg
         elif self.prev_traffic_signals_msg:
-            self.prev_traffic_signals_msg.stamp = timestamp
-            self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
+            if "autoware_perception_msgs" in type(self.prev_traffic_signals_msg).__module__:
+                self.prev_traffic_signals_msg.stamp = timestamp
+                self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
+            elif "autoware_auto_perception_msgs" in type(self.prev_traffic_signals_msg).__module__:
+                self.prev_traffic_signals_msg.header.stamp = timestamp
+                self.auto_traffic_signals_pub.publish(self.prev_traffic_signals_msg)
 
     def find_nearest_ego_odom_by_observation(self, ego_pose):
         if self.ego_pose_idx:

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -68,20 +68,20 @@ class PerceptionReproducer(PerceptionReplayerCommon):
         # traffic signals
         # temporary support old auto msgs
         if traffic_signals_msg:
-            if "autoware_perception_msgs" in type(traffic_signals_msg).__module__:
-                traffic_signals_msg.stamp = timestamp
-                self.traffic_signals_pub.publish(traffic_signals_msg)
-            elif "autoware_auto_perception_msgs" in type(traffic_signals_msg).__module__:
+            if self.is_auto_traffic_signals:
                 traffic_signals_msg.header.stamp = timestamp
                 self.auto_traffic_signals_pub.publish(traffic_signals_msg)
+            else:
+                traffic_signals_msg.stamp = timestamp
+                self.traffic_signals_pub.publish(traffic_signals_msg)
             self.prev_traffic_signals_msg = traffic_signals_msg
         elif self.prev_traffic_signals_msg:
-            if "autoware_perception_msgs" in type(self.prev_traffic_signals_msg).__module__:
-                self.prev_traffic_signals_msg.stamp = timestamp
-                self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
-            elif "autoware_auto_perception_msgs" in type(self.prev_traffic_signals_msg).__module__:
+            if self.is_auto_traffic_signals:
                 self.prev_traffic_signals_msg.header.stamp = timestamp
                 self.auto_traffic_signals_pub.publish(self.prev_traffic_signals_msg)
+            else:
+                self.prev_traffic_signals_msg.stamp = timestamp
+                self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
 
     def find_nearest_ego_odom_by_observation(self, ego_pose):
         if self.ego_pose_idx:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

support old auto TrafficSignalArray temporary

https://github.com/autowarefoundation/autoware.universe/pull/4133#discussion_r1318047173

fix the issue with old rosbag
```
$ ros2 run planning_debug_tools perception_replayer.py -b /media/kosuke55/sandisk/rosbag/start_planner_stop_publishing_path/d4d1adc7-4fdf-4613-86b3-0daa2d945b9e_2023-08-25-13-41-44_p0900_5.db3
Stared loading rosbag
[INFO 1694057248.905715364] [rosbag2_storage]: Opened database '/media/kosuke55/sandisk/rosbag/start_planner_stop_publishing_path/d4d1adc7-4fdf-4613-86b3-0daa2d945b9e_2023-08-25-13-41-44_p0900_5.db3' for READ_ONLY. (open() at ./src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp:227)
Ended loading rosbag
Start timer callback
autoware_auto_perception_msgs.msg._traffic_signal_array
Traceback (most recent call last):
  File "/home/kosuke55/pilot-auto/install/planning_debug_tools/lib/planning_debug_tools/perception_replayer.py", line 189, in <module>
    rclpy.spin_once(node, timeout_sec=0.01)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/__init__.py", line 202, in spin_once
    executor.spin_once(timeout_sec=timeout_sec)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 713, in spin_once
    raise handler.exception()
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/task.py", line 239, in __call__
    self._handler.send(None)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 418, in handler
    await call_coroutine(entity, arg)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 332, in _execute_timer
    await await_or_execute(tmr.callback)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 107, in await_or_execute
    return callback(*args)
  File "/home/kosuke55/pilot-auto/install/planning_debug_tools/lib/planning_debug_tools/perception_replayer.py", line 102, in on_timer
    traffic_signals_msg.stamp = timestamp
AttributeError: 'TrafficSignalArray' object has no attribute 'stamp'
[ros2run]: Process exited with failure 1
```



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->


run with only old bag

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

noen
## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
none
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
