### PR TITLE
feat(ndt_scan_matcher): adding exe time to diagnostics for checking runtime_monitor

### DIFF
--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -87,4 +87,4 @@
     z_margin_for_ground_removal: 0.8
 
     # The execution time which means probably NDT cannot matches scans properly
-    critical_upperbound_exe_time_ms: 24 # [ms]
+    critical_upper_bound_exe_time_ms: 24 # [ms]

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -87,4 +87,4 @@
     z_margin_for_ground_removal: 0.8
 
     # The execution time which means probably NDT cannot matches scans properly
-    critical_upper_bound_exe_time_ms: 24 # [ms]
+    critical_upper_bound_exe_time_ms: 100 # [ms]

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -85,3 +85,6 @@
 
     # If lidar_point.z - base_link.z <= this threshold , the point will be removed
     z_margin_for_ground_removal: 0.8
+
+    # The execution time which means probably NDT cannot matches scans properly
+    critical_upperbound_exe_time: 24

--- a/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
+++ b/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml
@@ -87,4 +87,4 @@
     z_margin_for_ground_removal: 0.8
 
     # The execution time which means probably NDT cannot matches scans properly
-    critical_upperbound_exe_time: 24
+    critical_upperbound_exe_time_ms: 24 # [ms]

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -208,6 +208,9 @@ private:
   double z_margin_for_ground_removal_;
 
   bool use_dynamic_map_loading_;
+
+  // The execution time which means probably NDT cannot matches scans properly
+  int critical_upperbound_exe_time_;
 };
 
 #endif  // NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_CORE_HPP_

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -210,7 +210,7 @@ private:
   bool use_dynamic_map_loading_;
 
   // The execution time which means probably NDT cannot matches scans properly
-  int critical_upperbound_exe_time_;
+  int critical_upper_bound_exe_time_ms_;
 };
 
 #endif  // NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_CORE_HPP_

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -101,7 +101,7 @@ NDTScanMatcher::NDTScanMatcher()
   estimate_scores_for_degrounded_scan_(
     declare_parameter("estimate_scores_for_degrounded_scan", false)),
   z_margin_for_ground_removal_(declare_parameter("z_margin_for_ground_removal", 0.8)),
-  critical_upper_bound_exe_time_ms_(24)
+  critical_upper_bound_exe_time_ms_(100)
 {
   (*state_ptr_)["state"] = "Initializing";
   is_activated_ = false;

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -141,7 +141,8 @@ NDTScanMatcher::NDTScanMatcher()
     this->declare_parameter<double>("converged_param_nearest_voxel_transformation_likelihood");
 
   lidar_topic_timeout_sec_ = this->declare_parameter<double>("lidar_topic_timeout_sec");
-  critical_upper_bound_exe_time_ms_ = this->declare_parameter("critical_upperbound_exe_time",critical_upper_bound_exe_time_ms_);
+  critical_upper_bound_exe_time_ms_ =
+    this->declare_parameter("critical_upperbound_exe_time", critical_upper_bound_exe_time_ms_);
 
   initial_pose_timeout_sec_ =
     this->declare_parameter("initial_pose_timeout_sec", initial_pose_timeout_sec_);
@@ -297,9 +298,12 @@ void NDTScanMatcher::timer_diagnostic()
       diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       diag_status_msg.message += "NDT score is unreliably low. ";
     }
-    if (state_ptr_->count("execution_time") && std::stod((*state_ptr_)["execution_time"]) >= critical_upper_bound_exe_time_ms_) {
+    if (
+      state_ptr_->count("execution_time") &&
+      std::stod((*state_ptr_)["execution_time"]) >= critical_upper_bound_exe_time_ms_) {
       diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-      diag_status_msg.message += "NDT exe time is too long. (took " + (*state_ptr_)["execution_time"] + " [ms])";
+      diag_status_msg.message +=
+        "NDT exe time is too long. (took " + (*state_ptr_)["execution_time"] + " [ms])";
     }
     // Ignore local optimal solution
     if (

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -90,7 +90,6 @@ NDTScanMatcher::NDTScanMatcher()
   converged_param_type_(ConvergedParamType::TRANSFORM_PROBABILITY),
   converged_param_transform_probability_(4.5),
   converged_param_nearest_voxel_transformation_likelihood_(2.3),
-  critical_upperbound_exe_time_(24),
   initial_estimate_particles_num_(100),
   lidar_topic_timeout_sec_(1.0),
   initial_pose_timeout_sec_(1.0),
@@ -100,8 +99,9 @@ NDTScanMatcher::NDTScanMatcher()
   output_pose_covariance_(),
   regularization_enabled_(declare_parameter<bool>("regularization_enabled")),
   estimate_scores_for_degrounded_scan_(
-    declare_parameter<bool>("estimate_scores_for_degrounded_scan")),
-  z_margin_for_ground_removal_(declare_parameter<double>("z_margin_for_ground_removal"))
+    declare_parameter("estimate_scores_for_degrounded_scan", false)),
+  z_margin_for_ground_removal_(declare_parameter("z_margin_for_ground_removal", 0.8)),
+  critical_upperbound_exe_time_(24)
 {
   (*state_ptr_)["state"] = "Initializing";
   is_activated_ = false;

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -141,7 +141,7 @@ NDTScanMatcher::NDTScanMatcher()
     this->declare_parameter<double>("converged_param_nearest_voxel_transformation_likelihood");
 
   lidar_topic_timeout_sec_ = this->declare_parameter<double>("lidar_topic_timeout_sec");
-  critical_upperbound_exe_time_ = this->declare_parameter("critical_upperbound_exe_time",critical_upperbound_exe_time_);
+  critical_upper_bound_exe_time_ms_ = this->declare_parameter("critical_upperbound_exe_time",critical_upper_bound_exe_time_ms_);
 
   initial_pose_timeout_sec_ =
     this->declare_parameter("initial_pose_timeout_sec", initial_pose_timeout_sec_);
@@ -297,7 +297,7 @@ void NDTScanMatcher::timer_diagnostic()
       diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       diag_status_msg.message += "NDT score is unreliably low. ";
     }
-    if (state_ptr_->count("execution_time") && std::stod((*state_ptr_)["execution_time"]) >= critical_upperbound_exe_time_) {
+    if (state_ptr_->count("execution_time") && std::stod((*state_ptr_)["execution_time"]) >= critical_upper_bound_exe_time_ms_) {
       diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       diag_status_msg.message += "NDT exe time is too long. (took " + (*state_ptr_)["execution_time"] + " [ms])";
     }

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -90,6 +90,7 @@ NDTScanMatcher::NDTScanMatcher()
   converged_param_type_(ConvergedParamType::TRANSFORM_PROBABILITY),
   converged_param_transform_probability_(4.5),
   converged_param_nearest_voxel_transformation_likelihood_(2.3),
+  critical_upperbound_exe_time_(24),
   initial_estimate_particles_num_(100),
   lidar_topic_timeout_sec_(1.0),
   initial_pose_timeout_sec_(1.0),
@@ -141,6 +142,8 @@ NDTScanMatcher::NDTScanMatcher()
     this->declare_parameter<double>("converged_param_nearest_voxel_transformation_likelihood");
 
   lidar_topic_timeout_sec_ = this->declare_parameter<double>("lidar_topic_timeout_sec");
+  critical_upperbound_exe_time_ = this->declare_parameter("critical_upperbound_exe_time",critical_upperbound_exe_time_);
+
   critical_upperbound_exe_time_ = this->declare_parameter("critical_upperbound_exe_time",critical_upperbound_exe_time_);
 
   initial_pose_timeout_sec_ =

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -90,6 +90,7 @@ NDTScanMatcher::NDTScanMatcher()
   converged_param_type_(ConvergedParamType::TRANSFORM_PROBABILITY),
   converged_param_transform_probability_(4.5),
   converged_param_nearest_voxel_transformation_likelihood_(2.3),
+  critical_upperbound_exe_time_(24),
   initial_estimate_particles_num_(100),
   lidar_topic_timeout_sec_(1.0),
   initial_pose_timeout_sec_(1.0),
@@ -140,6 +141,10 @@ NDTScanMatcher::NDTScanMatcher()
     this->declare_parameter<double>("converged_param_nearest_voxel_transformation_likelihood");
 
   lidar_topic_timeout_sec_ = this->declare_parameter<double>("lidar_topic_timeout_sec");
+  critical_upperbound_exe_time_ = this->declare_parameter("critical_upperbound_exe_time",critical_upperbound_exe_time_);
+
+  initial_pose_timeout_sec_ =
+    this->declare_parameter("initial_pose_timeout_sec", initial_pose_timeout_sec_);
 
   initial_pose_timeout_sec_ = this->declare_parameter<double>("initial_pose_timeout_sec");
 
@@ -291,6 +296,10 @@ void NDTScanMatcher::timer_diagnostic()
         converged_param_nearest_voxel_transformation_likelihood_) {
       diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       diag_status_msg.message += "NDT score is unreliably low. ";
+    }
+    if (state_ptr_->count("exe_time") && std::stod((*state_ptr_)["exe_time"]) >= critical_upperbound_exe_time_) {
+      diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      diag_status_msg.message += "NDT exe time is too long. ";
     }
     // Ignore local optimal solution
     if (
@@ -528,6 +537,7 @@ void NDTScanMatcher::callback_sensor_points(
   } else {
     (*state_ptr_)["is_local_optimal_solution_oscillation"] = "0";
   }
+  (*state_ptr_)["exe_time"] = std::to_string(exe_time);
 }
 
 void NDTScanMatcher::transform_sensor_measurement(

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -101,7 +101,7 @@ NDTScanMatcher::NDTScanMatcher()
   estimate_scores_for_degrounded_scan_(
     declare_parameter("estimate_scores_for_degrounded_scan", false)),
   z_margin_for_ground_removal_(declare_parameter("z_margin_for_ground_removal", 0.8)),
-  critical_upperbound_exe_time_(24)
+  critical_upper_bound_exe_time_ms_(24)
 {
   (*state_ptr_)["state"] = "Initializing";
   is_activated_ = false;

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -297,7 +297,7 @@ void NDTScanMatcher::timer_diagnostic()
       diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       diag_status_msg.message += "NDT score is unreliably low. ";
     }
-    if (state_ptr_->count("exe_time") && std::stod((*state_ptr_)["exe_time"]) >= critical_upperbound_exe_time_) {
+    if (state_ptr_->count("execution_time") && std::stod((*state_ptr_)["execution_time"]) >= critical_upperbound_exe_time_) {
       diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       diag_status_msg.message += "NDT exe time is too long. (took " + (*state_ptr_)["execution_time"] + " [ms])";
     }

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -142,7 +142,7 @@ NDTScanMatcher::NDTScanMatcher()
 
   lidar_topic_timeout_sec_ = this->declare_parameter<double>("lidar_topic_timeout_sec");
   critical_upper_bound_exe_time_ms_ =
-    this->declare_parameter("critical_upperbound_exe_time", critical_upper_bound_exe_time_ms_);
+    this->declare_parameter("critical_upper_bound_exe_time_ms", critical_upper_bound_exe_time_ms_);
 
   initial_pose_timeout_sec_ =
     this->declare_parameter("initial_pose_timeout_sec", initial_pose_timeout_sec_);

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -537,7 +537,7 @@ void NDTScanMatcher::callback_sensor_points(
   } else {
     (*state_ptr_)["is_local_optimal_solution_oscillation"] = "0";
   }
-  (*state_ptr_)["exe_time"] = std::to_string(exe_time);
+  (*state_ptr_)["execution_time"] = std::to_string(exe_time);
 }
 
 void NDTScanMatcher::transform_sensor_measurement(

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -90,7 +90,6 @@ NDTScanMatcher::NDTScanMatcher()
   converged_param_type_(ConvergedParamType::TRANSFORM_PROBABILITY),
   converged_param_transform_probability_(4.5),
   converged_param_nearest_voxel_transformation_likelihood_(2.3),
-  critical_upperbound_exe_time_(24),
   initial_estimate_particles_num_(100),
   lidar_topic_timeout_sec_(1.0),
   initial_pose_timeout_sec_(1.0),
@@ -142,8 +141,6 @@ NDTScanMatcher::NDTScanMatcher()
     this->declare_parameter<double>("converged_param_nearest_voxel_transformation_likelihood");
 
   lidar_topic_timeout_sec_ = this->declare_parameter<double>("lidar_topic_timeout_sec");
-  critical_upperbound_exe_time_ = this->declare_parameter("critical_upperbound_exe_time",critical_upperbound_exe_time_);
-
   critical_upperbound_exe_time_ = this->declare_parameter("critical_upperbound_exe_time",critical_upperbound_exe_time_);
 
   initial_pose_timeout_sec_ =
@@ -302,7 +299,7 @@ void NDTScanMatcher::timer_diagnostic()
     }
     if (state_ptr_->count("exe_time") && std::stod((*state_ptr_)["exe_time"]) >= critical_upperbound_exe_time_) {
       diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-      diag_status_msg.message += "NDT exe time is too long. ";
+      diag_status_msg.message += "NDT exe time is too long. (took " + (*state_ptr_)["execution_time"] + " [ms])";
     }
     // Ignore local optimal solution
     if (


### PR DESCRIPTION
## Description

This PR offersto add exe_time to diagnostics.

Exe time is useful for observe does NDT have problems while matching scans. I can say with my observations, if NDT exe_time is exceeded 24ms, it will be most likely started to cannot match scans properly. So while I'm checking runtime_monitor i would like to see NDT exe_time. Formerly this PR is a part of https://github.com/autowarefoundation/autoware.universe/pull/4854.

Related: https://github.com/autowarefoundation/autoware_launch/pull/559

## Tests performed

All added options runned through logging simulator and test vehicle. 

## Effects on system behavior

It gives a facility for observing changes in nearest_voxel_transformation_likelihood and exe_time.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
