### PR TITLE
fix(vehicle_cmd_gate): use real velocity for the lateral filter

### DIFF
--- a/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_filter.hpp
@@ -81,6 +81,7 @@ private:
   bool setParameterWithValidation(const VehicleCmdFilterParam & p);
 
   double calcLatAcc(const AckermannControlCommand & cmd) const;
+  double calcLatAcc(const AckermannControlCommand & cmd, const double v) const;
   double calcSteerFromLatacc(const double v, const double latacc) const;
   double limitDiff(const double curr, const double prev, const double diff_lim) const;
 

--- a/control/vehicle_cmd_gate/test/src/test_vehicle_cmd_filter.cpp
+++ b/control/vehicle_cmd_gate/test/src/test_vehicle_cmd_filter.cpp
@@ -56,12 +56,20 @@ AckermannControlCommand genCmd(double s, double sr, double v, double a)
   return cmd;
 }
 
+// calc from ego velocity
+double calcLatAcc(const AckermannControlCommand & cmd, const double wheelbase, const double ego_v)
+{
+  return ego_v * ego_v * std::tan(cmd.lateral.steering_tire_angle) / wheelbase;
+}
+
+// calc from command velocity
 double calcLatAcc(const AckermannControlCommand & cmd, const double wheelbase)
 {
   double v = cmd.longitudinal.speed;
   return v * v * std::tan(cmd.lateral.steering_tire_angle) / wheelbase;
 }
 
+// calc from command velocity
 double calcLatJerk(
   const AckermannControlCommand & cmd, const AckermannControlCommand & prev_cmd,
   const double wheelbase, const double dt)
@@ -75,14 +83,28 @@ double calcLatJerk(
   return (curr - prev) / dt;
 }
 
+// calc from ego velocity
+double calcLatJerk(
+  const AckermannControlCommand & cmd, const AckermannControlCommand & prev_cmd,
+  const double wheelbase, const double dt, const double ego_v)
+{
+  const auto prev = ego_v * ego_v * std::tan(prev_cmd.lateral.steering_tire_angle) / wheelbase;
+
+  const auto curr = ego_v * ego_v * std::tan(cmd.lateral.steering_tire_angle) / wheelbase;
+
+  return (curr - prev) / dt;
+}
+
 void test_1d_limit(
-  double V_LIM, double A_LIM, double J_LIM, double LAT_A_LIM, double LAT_J_LIM, double STEER_DIFF,
-  const AckermannControlCommand & prev_cmd, const AckermannControlCommand & raw_cmd)
+  double ego_v, double V_LIM, double A_LIM, double J_LIM, double LAT_A_LIM, double LAT_J_LIM,
+  double STEER_DIFF, const AckermannControlCommand & prev_cmd,
+  const AckermannControlCommand & raw_cmd)
 {
   const double WHEELBASE = 3.0;
   const double DT = 0.1;  // [s]
 
   vehicle_cmd_gate::VehicleCmdFilter filter;
+  filter.setCurrentSpeed(ego_v);
   setFilterParams(
     filter, V_LIM, {0.0}, {A_LIM}, {J_LIM}, {LAT_A_LIM}, {LAT_J_LIM}, {STEER_DIFF}, WHEELBASE);
   filter.setPrevCmd(prev_cmd);
@@ -153,8 +175,8 @@ void test_1d_limit(
   {
     auto filtered_cmd = raw_cmd;
     filter.limitLateralWithLatAcc(DT, filtered_cmd);
-    const double filtered_latacc = calcLatAcc(filtered_cmd, WHEELBASE);
-    const double raw_latacc = calcLatAcc(raw_cmd, WHEELBASE);
+    const double filtered_latacc = calcLatAcc(filtered_cmd, WHEELBASE, ego_v);
+    const double raw_latacc = calcLatAcc(raw_cmd, WHEELBASE, ego_v);
 
     // check if the filtered value does not exceed the limit.
     ASSERT_LT_NEAR(std::abs(filtered_latacc), LAT_A_LIM);
@@ -169,9 +191,9 @@ void test_1d_limit(
   {
     auto filtered_cmd = raw_cmd;
     filter.limitLateralWithLatJerk(DT, filtered_cmd);
-    const double prev_lat_acc = calcLatAcc(prev_cmd, WHEELBASE);
-    const double filtered_lat_acc = calcLatAcc(filtered_cmd, WHEELBASE);
-    const double raw_lat_acc = calcLatAcc(raw_cmd, WHEELBASE);
+    const double prev_lat_acc = calcLatAcc(prev_cmd, WHEELBASE, ego_v);
+    const double filtered_lat_acc = calcLatAcc(filtered_cmd, WHEELBASE, ego_v);
+    const double raw_lat_acc = calcLatAcc(raw_cmd, WHEELBASE, ego_v);
     const double filtered_lateral_jerk = (filtered_lat_acc - prev_lat_acc) / DT;
 
     // check if the filtered value does not exceed the limit.
@@ -211,6 +233,7 @@ TEST(VehicleCmdFilter, VehicleCmdFilter)
   const std::vector<double> lat_a_arr = {0.01, 1.0, 100.0};
   const std::vector<double> lat_j_arr = {0.01, 1.0, 100.0};
   const std::vector<double> steer_diff_arr = {0.01, 1.0, 100.0};
+  const std::vector<double> ego_v_arr = {0.0, 0.1, 1.0, 3.0, 15.0};
 
   const std::vector<AckermannControlCommand> prev_cmd_arr = {
     genCmd(0.0, 0.0, 0.0, 0.0), genCmd(1.0, 1.0, 1.0, 1.0)};
@@ -226,7 +249,9 @@ TEST(VehicleCmdFilter, VehicleCmdFilter)
             for (const auto & prev_cmd : prev_cmd_arr) {
               for (const auto & raw_cmd : raw_cmd_arr) {
                 for (const auto & steer_diff : steer_diff_arr) {
-                  test_1d_limit(v, a, j, la, lj, steer_diff, prev_cmd, raw_cmd);
+                  for (const auto & ego_v : ego_v_arr) {
+                    test_1d_limit(ego_v, v, a, j, la, lj, steer_diff, prev_cmd, raw_cmd);
+                  }
                 }
               }
             }
@@ -371,66 +396,72 @@ TEST(VehicleCmdFilter, VehicleCmdFilterInterpolate)
   // lateral acc lim
   // p.reference_speed_points = std::vector<double>{2.0, 4.0, 10.0};
   // p.lat_acc_lim = std::vector<double>{0.1, 0.2, 0.3};
-  const auto _calcLatAcc = [&](const auto & cmd) { return calcLatAcc(cmd, WHEELBASE); };
+  const auto _calcLatAcc = [&](const auto & cmd, const double ego_v) {
+    return calcLatAcc(cmd, WHEELBASE, ego_v);
+  };
   {
+    // since the lateral acceleration is 0 when the velocity is 0, the target value is 0 only in
+    // this case
     set_speed_and_reset_prev(0.0);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd)), 0.1, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd), 0.0), 0.0, ep);
 
     set_speed_and_reset_prev(2.0);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd)), 0.1, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd), 2.0), 0.1, ep);
 
     set_speed_and_reset_prev(3.0);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd)), 0.15, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd), 3.0), 0.15, ep);
 
     set_speed_and_reset_prev(5.0);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd)), 0.2 + 0.1 / 6.0, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd), 5.0), 0.2 + 0.1 / 6.0, ep);
 
     set_speed_and_reset_prev(8.0);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd)), 0.2 + 0.4 / 6.0, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd), 8.0), 0.2 + 0.4 / 6.0, ep);
 
     set_speed_and_reset_prev(10.0);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd)), 0.3, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd), 10.0), 0.3, ep);
 
     set_speed_and_reset_prev(15.0);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd)), 0.3, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatAcc(orig_cmd), 15.0), 0.3, ep);
   }
 
   // lateral jerk lim
   // p.reference_speed_points = std::vector<double>{2.0, 4.0, 10.0};
   // p.lat_jerk_lim = std::vector<double>{0.9, 0.7, 0.1};
-  const auto _calcLatJerk = [&](const auto & cmd) {
-    return calcLatJerk(cmd, AckermannControlCommand{}, WHEELBASE, DT);
+  const auto _calcLatJerk = [&](const auto & cmd, const double ego_v) {
+    return calcLatJerk(cmd, AckermannControlCommand{}, WHEELBASE, DT, ego_v);
   };
   {
+    // since the lateral acceleration and jerk is 0 when the velocity is 0, the target value is 0
+    // only in this case
     set_speed_and_reset_prev(0.0);
-    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd)), 0.9, ep);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd)), DT * 0.9, ep);
+    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd), 0.0), 0.0, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd), 0.0), DT * 0.0, ep);
 
     set_speed_and_reset_prev(2.0);
-    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd)), 0.9, ep);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd)), DT * 0.9, ep);
+    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd), 2.0), 0.9, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd), 2.0), DT * 0.9, ep);
 
     set_speed_and_reset_prev(3.0);
-    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd)), 0.8, ep);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd)), DT * 0.8, ep);
+    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd), 3.0), 0.8, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd), 3.0), DT * 0.8, ep);
 
     set_speed_and_reset_prev(5.0);
     const auto expect_v5 = 0.7 - 0.6 * (1.0 / 6.0);
-    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd)), expect_v5, ep);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd)), DT * expect_v5, ep);
+    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd), 5.0), expect_v5, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd), 5.0), DT * expect_v5, ep);
 
     set_speed_and_reset_prev(8.0);
     const auto expect_v8 = 0.7 - 0.6 * (4.0 / 6.0);
-    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd)), expect_v8, ep);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd)), DT * expect_v8, ep);
+    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd), 8.0), expect_v8, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd), 8.0), DT * expect_v8, ep);
 
     set_speed_and_reset_prev(10.0);
-    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd)), 0.1, ep);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd)), DT * 0.1, ep);
+    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd), 10.0), 0.1, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd), 10.0), DT * 0.1, ep);
 
     set_speed_and_reset_prev(15.0);
-    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd)), 0.1, ep);
-    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd)), DT * 0.1, ep);
+    EXPECT_NEAR(_calcLatJerk(_limitLateralWithLatJerk(orig_cmd), 15.0), 0.1, ep);
+    EXPECT_NEAR(_calcLatAcc(_limitLateralWithLatJerk(orig_cmd), 15.0), DT * 0.1, ep);
   }
 
   // steering diff lim


### PR DESCRIPTION
## Description

Use the real velocity for the lateral command filter.
Otherwise, if the velocity command oscillates, the filtered steering oscillates.
The drawback is that it won't guarantee the constraints are met in the series of the output command itself. (We need to see the actual velocity data to check it.) But this is much safer than the previous implementation.

## Related links

[TIERIV Internal ticket](https://tier4.atlassian.net/browse/RT1-3765)

## Tests performed

Run in a real vehicle testing and it worked well.

## Notes for reviewers

None

## Interface changes

None
## Effects on system behavior

Improve the filtering. No effect in the default parameter.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
