### PR TITLE
feat(surround_obstacle_checker): make parameters more tunable

### DIFF
--- a/planning/surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
+++ b/planning/surround_obstacle_checker/config/surround_obstacle_checker.param.yaml
@@ -1,12 +1,61 @@
 /**:
   ros__parameters:
-
     # obstacle check
-    use_pointcloud: true # use pointcloud as obstacle check
-    use_dynamic_object: true # use dynamic object as obstacle check
-    surround_check_distance: 0.5 # if objects exist in this distance, transit to "exist-surrounding-obstacle" status [m]
-    surround_check_recover_distance: 0.8 # if no object exists in this distance, transit to "non-surrounding-obstacle" status [m]
+    # surround_check_*_distance: if objects exist in this distance, transit to "exist-surrounding-obstacle" status [m]
+    # surround_check_hysteresis_distance: if no object exists in this hysteresis distance added to the above distance, transit to "non-surrounding-obstacle" status [m]
+    pointcloud:
+      enable_check: false
+      surround_check_front_distance: 0.5
+      surround_check_side_distance: 0.5
+      surround_check_back_distance: 0.5
+    unknown:
+      enable_check: true
+      surround_check_front_distance: 0.5
+      surround_check_side_distance: 0.5
+      surround_check_back_distance: 0.5
+    car:
+      enable_check: true
+      surround_check_front_distance: 0.5
+      surround_check_side_distance: 0.0
+      surround_check_back_distance: 0.5
+    truck:
+      enable_check: true
+      surround_check_front_distance: 0.5
+      surround_check_side_distance: 0.0
+      surround_check_back_distance: 0.5
+    bus:
+      enable_check: true
+      surround_check_front_distance: 0.5
+      surround_check_side_distance: 0.0
+      surround_check_back_distance: 0.5
+    trailer:
+      enable_check: true
+      surround_check_front_distance: 0.5
+      surround_check_side_distance: 0.0
+      surround_check_back_distance: 0.5
+    motorcycle:
+      enable_check: true
+      surround_check_front_distance: 0.5
+      surround_check_side_distance: 0.0
+      surround_check_back_distance: 0.5
+    bicycle:
+      enable_check: true
+      surround_check_front_distance: 0.5
+      surround_check_side_distance: 0.5
+      surround_check_back_distance: 0.5
+    pedestrian:
+      enable_check: true
+      surround_check_front_distance: 0.5
+      surround_check_side_distance: 0.5
+      surround_check_back_distance: 0.5
+
+    surround_check_hysteresis_distance: 0.3
+
     state_clear_time: 2.0
+
+    # ego stop state
+    stop_state_ego_speed: 0.1 #[m/s]
 
     # debug
     publish_debug_footprints: true # publish vehicle footprint & footprints with surround_check_distance and surround_check_recover_distance offsets
+    debug_footprint_label: "car"

--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
@@ -38,6 +38,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -62,18 +63,25 @@ public:
 
   struct NodeParam
   {
-    bool use_pointcloud;
-    bool use_dynamic_object;
     bool is_surround_obstacle;
-    // For preventing chattering,
-    // surround_check_recover_distance_ must be  bigger than surround_check_distance_
-    double surround_check_recover_distance;
-    double surround_check_distance;
+    std::unordered_map<int, bool> enable_check_map;
+    std::unordered_map<int, double> surround_check_front_distance_map;
+    std::unordered_map<int, double> surround_check_side_distance_map;
+    std::unordered_map<int, double> surround_check_back_distance_map;
+    bool pointcloud_enable_check;
+    double pointcloud_surround_check_front_distance;
+    double pointcloud_surround_check_side_distance;
+    double pointcloud_surround_check_back_distance;
+    double surround_check_hysteresis_distance;
     double state_clear_time;
     bool publish_debug_footprints;
+    std::string debug_footprint_label;
   };
 
 private:
+  rcl_interfaces::msg::SetParametersResult onParam(
+    const std::vector<rclcpp::Parameter> & parameters);
+
   void onTimer();
 
   void onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
@@ -106,6 +114,9 @@ private:
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr pub_stop_reason_;
   rclcpp::Publisher<VelocityLimitClearCommand>::SharedPtr pub_clear_velocity_limit_;
   rclcpp::Publisher<VelocityLimit>::SharedPtr pub_velocity_limit_;
+
+  // parameter callback result
+  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 
   // stop checker
   std::unique_ptr<VehicleStopChecker> vehicle_stop_checker_;

--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
@@ -82,6 +82,8 @@ private:
   rcl_interfaces::msg::SetParametersResult onParam(
     const std::vector<rclcpp::Parameter> & parameters);
 
+  std::array<double, 3> getCheckDistances(const std::string & str_label) const;
+
   void onTimer();
 
   void onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);

--- a/planning/surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/surround_obstacle_checker/src/debug_marker.cpp
@@ -26,6 +26,29 @@
 
 namespace surround_obstacle_checker
 {
+namespace
+{
+Polygon2d createSelfPolygon(
+  const VehicleInfo & vehicle_info, const double front_margin = 0.0, const double side_margin = 0.0,
+  const double rear_margin = 0.0)
+{
+  const double & front_m = vehicle_info.max_longitudinal_offset_m + front_margin;
+  const double & width_left_m = vehicle_info.max_lateral_offset_m + side_margin;
+  const double & width_right_m = vehicle_info.min_lateral_offset_m - side_margin;
+  const double & rear_m = vehicle_info.min_longitudinal_offset_m - rear_margin;
+
+  Polygon2d ego_polygon;
+
+  ego_polygon.outer().push_back(Point2d(front_m, width_left_m));
+  ego_polygon.outer().push_back(Point2d(front_m, width_right_m));
+  ego_polygon.outer().push_back(Point2d(rear_m, width_right_m));
+  ego_polygon.outer().push_back(Point2d(rear_m, width_left_m));
+
+  bg::correct(ego_polygon);
+
+  return ego_polygon;
+}
+}  // namespace
 
 using motion_utils::createStopVirtualWallMarker;
 using tier4_autoware_utils::appendMarkerArray;
@@ -36,14 +59,18 @@ using tier4_autoware_utils::createMarkerScale;
 using tier4_autoware_utils::createPoint;
 
 SurroundObstacleCheckerDebugNode::SurroundObstacleCheckerDebugNode(
-  const Polygon2d & ego_polygon, const double base_link2front,
-  const double & surround_check_distance, const double & surround_check_recover_distance,
-  const geometry_msgs::msg::Pose & self_pose, const rclcpp::Clock::SharedPtr clock,
-  rclcpp::Node & node)
-: ego_polygon_(ego_polygon),
+  const vehicle_info_util::VehicleInfo & vehicle_info, const double base_link2front,
+  const std::string & object_label, const double & surround_check_front_distance,
+  const double & surround_check_side_distance, const double & surround_check_back_distance,
+  const double & surround_check_hysteresis_distance, const geometry_msgs::msg::Pose & self_pose,
+  const rclcpp::Clock::SharedPtr clock, rclcpp::Node & node)
+: vehicle_info_(vehicle_info),
   base_link2front_(base_link2front),
-  surround_check_distance_(surround_check_distance),
-  surround_check_recover_distance_(surround_check_recover_distance),
+  object_label_(object_label),
+  surround_check_front_distance_(surround_check_front_distance),
+  surround_check_side_distance_(surround_check_side_distance),
+  surround_check_back_distance_(surround_check_back_distance),
+  surround_check_hysteresis_distance_(surround_check_hysteresis_distance),
   self_pose_(self_pose),
   clock_(clock)
 {
@@ -86,20 +113,25 @@ bool SurroundObstacleCheckerDebugNode::pushObstaclePoint(
 
 void SurroundObstacleCheckerDebugNode::publishFootprints()
 {
+  const auto ego_polygon = createSelfPolygon(vehicle_info_);
+
   /* publish vehicle footprint polygon */
-  const auto footprint = boostPolygonToPolygonStamped(ego_polygon_, self_pose_.position.z);
+  const auto footprint = boostPolygonToPolygonStamped(ego_polygon, self_pose_.position.z);
   vehicle_footprint_pub_->publish(footprint);
 
   /* publish vehicle footprint polygon with offset */
-  const auto polygon_with_offset =
-    createSelfPolygonWithOffset(ego_polygon_, surround_check_distance_);
+  const auto polygon_with_offset = createSelfPolygon(
+    vehicle_info_, surround_check_front_distance_, surround_check_side_distance_,
+    surround_check_back_distance_);
   const auto footprint_with_offset =
     boostPolygonToPolygonStamped(polygon_with_offset, self_pose_.position.z);
   vehicle_footprint_offset_pub_->publish(footprint_with_offset);
 
   /* publish vehicle footprint polygon with recover offset */
-  const auto polygon_with_recover_offset =
-    createSelfPolygonWithOffset(ego_polygon_, surround_check_recover_distance_);
+  const auto polygon_with_recover_offset = createSelfPolygon(
+    vehicle_info_, surround_check_front_distance_ + surround_check_hysteresis_distance_,
+    surround_check_side_distance_ + surround_check_hysteresis_distance_,
+    surround_check_back_distance_ + surround_check_hysteresis_distance_);
   const auto footprint_with_recover_offset =
     boostPolygonToPolygonStamped(polygon_with_recover_offset, self_pose_.position.z);
   vehicle_footprint_recover_offset_pub_->publish(footprint_with_recover_offset);
@@ -206,26 +238,6 @@ VelocityFactorArray SurroundObstacleCheckerDebugNode::makeVelocityFactorArray()
   return velocity_factor_array;
 }
 
-Polygon2d SurroundObstacleCheckerDebugNode::createSelfPolygonWithOffset(
-  const Polygon2d & base_polygon, const double & offset)
-{
-  typedef double coordinate_type;
-  const double buffer_distance = offset;
-  const int points_per_circle = 36;
-  boost::geometry::strategy::buffer::distance_symmetric<coordinate_type> distance_strategy(
-    buffer_distance);
-  boost::geometry::strategy::buffer::join_round join_strategy(points_per_circle);
-  boost::geometry::strategy::buffer::end_round end_strategy(points_per_circle);
-  boost::geometry::strategy::buffer::point_circle circle_strategy(points_per_circle);
-  boost::geometry::strategy::buffer::side_straight side_strategy;
-  boost::geometry::model::multi_polygon<Polygon2d> result;
-  // Create the buffer of a multi polygon
-  boost::geometry::buffer(
-    base_polygon, result, distance_strategy, side_strategy, join_strategy, end_strategy,
-    circle_strategy);
-  return result.front();
-}
-
 PolygonStamped SurroundObstacleCheckerDebugNode::boostPolygonToPolygonStamped(
   const Polygon2d & boost_polygon, const double & z)
 {
@@ -242,6 +254,16 @@ PolygonStamped SurroundObstacleCheckerDebugNode::boostPolygonToPolygonStamped(
   }
 
   return polygon_stamped;
+}
+
+void SurroundObstacleCheckerDebugNode::updateFootprintMargin(
+  const std::string & object_label, const double front_distance, const double side_distance,
+  const double back_distance)
+{
+  object_label_ = object_label;
+  surround_check_front_distance_ = front_distance;
+  surround_check_side_distance_ = side_distance;
+  surround_check_back_distance_ = back_distance;
 }
 
 }  // namespace surround_obstacle_checker

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -287,7 +287,16 @@ void SurroundObstacleCheckerNode::onTimer()
     return;
   }
 
-  if (!object_ptr_) {
+  const bool use_dynamic_object =
+    node_param_.enable_check_map.at(ObjectClassification::UNKNOWN) ||
+    node_param_.enable_check_map.at(ObjectClassification::CAR) ||
+    node_param_.enable_check_map.at(ObjectClassification::TRUCK) ||
+    node_param_.enable_check_map.at(ObjectClassification::BUS) ||
+    node_param_.enable_check_map.at(ObjectClassification::TRAILER) ||
+    node_param_.enable_check_map.at(ObjectClassification::MOTORCYCLE) ||
+    node_param_.enable_check_map.at(ObjectClassification::BICYCLE) ||
+    node_param_.enable_check_map.at(ObjectClassification::PEDESTRIAN);
+  if (use_dynamic_object && !object_ptr_) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for dynamic object info...");
     return;

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -47,6 +47,7 @@ namespace surround_obstacle_checker
 namespace bg = boost::geometry;
 using Point2d = bg::model::d2::point_xy<double>;
 using Polygon2d = bg::model::polygon<Point2d>;
+using autoware_auto_perception_msgs::msg::ObjectClassification;
 using tier4_autoware_utils::createPoint;
 using tier4_autoware_utils::pose2transform;
 
@@ -120,12 +121,14 @@ Polygon2d createObjPolygon(
   return createObjPolygon(pose, polygon);
 }
 
-Polygon2d createSelfPolygon(const VehicleInfo & vehicle_info)
+Polygon2d createSelfPolygon(
+  const VehicleInfo & vehicle_info, const double front_margin, const double side_margin,
+  const double rear_margin)
 {
-  const double & front_m = vehicle_info.max_longitudinal_offset_m;
-  const double & width_left_m = vehicle_info.max_lateral_offset_m;
-  const double & width_right_m = vehicle_info.min_lateral_offset_m;
-  const double & rear_m = vehicle_info.min_longitudinal_offset_m;
+  const double & front_m = vehicle_info.max_longitudinal_offset_m + front_margin;
+  const double & width_left_m = vehicle_info.max_lateral_offset_m + side_margin;
+  const double & width_right_m = vehicle_info.min_lateral_offset_m - side_margin;
+  const double & rear_m = vehicle_info.min_longitudinal_offset_m - rear_margin;
 
   Polygon2d ego_polygon;
 
@@ -138,6 +141,16 @@ Polygon2d createSelfPolygon(const VehicleInfo & vehicle_info)
 
   return ego_polygon;
 }
+
+int convertLabelToInt(const std::string & str_label)
+{
+  std::unordered_map<std::string, int> label_map{
+    {"unknown", ObjectClassification::UNKNOWN}, {"car", ObjectClassification::CAR},
+    {"truck", ObjectClassification::TRUCK},     {"bus", ObjectClassification::BUS},
+    {"trailer", ObjectClassification::TRAILER}, {"motorcycle", ObjectClassification::MOTORCYCLE},
+    {"bicycle", ObjectClassification::BICYCLE}, {"pedestrian", ObjectClassification::PEDESTRIAN}};
+  return label_map.at(str_label);
+}
 }  // namespace
 
 SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptions & node_options)
@@ -146,13 +159,40 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
   // Parameters
   {
     auto & p = node_param_;
-    p.use_pointcloud = this->declare_parameter<bool>("use_pointcloud");
-    p.use_dynamic_object = this->declare_parameter<bool>("use_dynamic_object");
-    p.surround_check_distance = this->declare_parameter<double>("surround_check_distance");
-    p.surround_check_recover_distance =
-      this->declare_parameter<double>("surround_check_recover_distance");
+
+    // for object label
+    std::unordered_map<std::string, int> label_map{
+      {"unknown", ObjectClassification::UNKNOWN}, {"car", ObjectClassification::CAR},
+      {"truck", ObjectClassification::TRUCK},     {"bus", ObjectClassification::BUS},
+      {"trailer", ObjectClassification::TRAILER}, {"motorcycle", ObjectClassification::MOTORCYCLE},
+      {"bicycle", ObjectClassification::BICYCLE}, {"pedestrian", ObjectClassification::PEDESTRIAN}};
+    for (const auto & label_pair : label_map) {
+      p.enable_check_map.emplace(
+        label_pair.second, this->declare_parameter<bool>(label_pair.first + ".enable_check"));
+      p.surround_check_front_distance_map.emplace(
+        label_pair.second,
+        this->declare_parameter<double>(label_pair.first + ".surround_check_front_distance"));
+      p.surround_check_side_distance_map.emplace(
+        label_pair.second,
+        this->declare_parameter<double>(label_pair.first + ".surround_check_side_distance"));
+      p.surround_check_back_distance_map.emplace(
+        label_pair.second,
+        this->declare_parameter<double>(label_pair.first + ".surround_check_back_distance"));
+    }
+
+    // for pointcloud
+    p.pointcloud_enable_check = this->declare_parameter<bool>("pointcloud.enable_check");
+    p.pointcloud_surround_check_front_distance =
+      this->declare_parameter<double>("pointcloud.surround_check_front_distance");
+    p.pointcloud_surround_check_side_distance =
+      this->declare_parameter<double>("pointcloud.surround_check_side_distance");
+
+    p.surround_check_hysteresis_distance =
+      this->declare_parameter<double>("surround_check_hysteresis_distance");
+
     p.state_clear_time = this->declare_parameter<double>("state_clear_time");
     p.publish_debug_footprints = this->declare_parameter<bool>("publish_debug_footprints");
+    p.debug_footprint_label = this->declare_parameter<std::string>("debug_footprint_label");
   }
 
   vehicle_info_ = vehicle_info_util::VehicleInfoUtil(*this).getVehicleInfo();
@@ -176,6 +216,10 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
     "~/input/odometry", 1,
     std::bind(&SurroundObstacleCheckerNode::onOdometry, this, std::placeholders::_1));
 
+  // Parameter callback
+  set_param_res_ = this->add_on_set_parameters_callback(
+    std::bind(&SurroundObstacleCheckerNode::onParam, this, std::placeholders::_1));
+
   using std::chrono_literals::operator""ms;
   timer_ = rclcpp::create_timer(
     this, get_clock(), 100ms, std::bind(&SurroundObstacleCheckerNode::onTimer, this));
@@ -184,13 +228,41 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
   vehicle_stop_checker_ = std::make_unique<VehicleStopChecker>(this);
 
   // Debug
-  auto const self_polygon = createSelfPolygon(vehicle_info_);
   odometry_ptr_ = std::make_shared<nav_msgs::msg::Odometry>();
 
+  const int int_label = convertLabelToInt(node_param_.debug_footprint_label);
   debug_ptr_ = std::make_shared<SurroundObstacleCheckerDebugNode>(
-    self_polygon, vehicle_info_.max_longitudinal_offset_m, node_param_.surround_check_distance,
-    node_param_.surround_check_recover_distance, odometry_ptr_->pose.pose, this->get_clock(),
+    vehicle_info_, vehicle_info_.max_longitudinal_offset_m, node_param_.debug_footprint_label,
+    node_param_.surround_check_front_distance_map.at(int_label),
+    node_param_.surround_check_side_distance_map.at(int_label),
+    node_param_.surround_check_back_distance_map.at(int_label),
+    node_param_.surround_check_hysteresis_distance, odometry_ptr_->pose.pose, this->get_clock(),
     *this);
+}
+
+rcl_interfaces::msg::SetParametersResult SurroundObstacleCheckerNode::onParam(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  tier4_autoware_utils::updateParam<std::string>(
+    parameters, "debug_footprint_label", node_param_.debug_footprint_label);
+  if (node_param_.debug_footprint_label == "pointcloud") {
+    debug_ptr_->updateFootprintMargin(
+      node_param_.debug_footprint_label, node_param_.pointcloud_surround_check_front_distance,
+      node_param_.pointcloud_surround_check_side_distance,
+      node_param_.pointcloud_surround_check_back_distance);
+  } else {
+    const int int_label = convertLabelToInt(node_param_.debug_footprint_label);
+    debug_ptr_->updateFootprintMargin(
+      node_param_.debug_footprint_label,
+      node_param_.surround_check_front_distance_map.at(int_label),
+      node_param_.surround_check_side_distance_map.at(int_label),
+      node_param_.surround_check_back_distance_map.at(int_label));
+  }
+
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  result.reason = "success";
+  return result;
 }
 
 void SurroundObstacleCheckerNode::onTimer()
@@ -205,13 +277,13 @@ void SurroundObstacleCheckerNode::onTimer()
     debug_ptr_->publishFootprints();
   }
 
-  if (node_param_.use_pointcloud && !pointcloud_ptr_) {
+  if (node_param_.pointcloud_enable_check && !pointcloud_ptr_) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for pointcloud info...");
     return;
   }
 
-  if (node_param_.use_dynamic_object && !object_ptr_) {
+  if (!object_ptr_) {
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for dynamic object info...");
     return;
@@ -220,11 +292,11 @@ void SurroundObstacleCheckerNode::onTimer()
   const auto nearest_obstacle = getNearestObstacle();
   const auto is_vehicle_stopped = vehicle_stop_checker_->isVehicleStopped();
 
+  constexpr double epsilon = 1e-3;
   switch (state_) {
     case State::PASS: {
       const auto is_obstacle_found =
-        !nearest_obstacle ? false
-                          : nearest_obstacle.get().first < node_param_.surround_check_distance;
+        !nearest_obstacle ? false : nearest_obstacle.get().first < epsilon;
 
       if (!isStopRequired(is_obstacle_found, is_vehicle_stopped)) {
         break;
@@ -250,7 +322,7 @@ void SurroundObstacleCheckerNode::onTimer()
       const auto is_obstacle_found =
         !nearest_obstacle
           ? false
-          : nearest_obstacle.get().first < node_param_.surround_check_recover_distance;
+          : nearest_obstacle.get().first < node_param_.surround_check_hysteresis_distance;
 
       if (isStopRequired(is_obstacle_found, is_vehicle_stopped)) {
         break;
@@ -304,17 +376,8 @@ void SurroundObstacleCheckerNode::onOdometry(const nav_msgs::msg::Odometry::Cons
 
 boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacle() const
 {
-  boost::optional<Obstacle> nearest_pointcloud{boost::none};
-  boost::optional<Obstacle> nearest_object{boost::none};
-
-  if (node_param_.use_pointcloud) {
-    nearest_pointcloud = getNearestObstacleByPointCloud();
-  }
-
-  if (node_param_.use_dynamic_object) {
-    nearest_object = getNearestObstacleByDynamicObject();
-  }
-
+  const auto nearest_pointcloud = getNearestObstacleByPointCloud();
+  const auto nearest_object = getNearestObstacleByDynamicObject();
   if (!nearest_pointcloud && !nearest_object) {
     return {};
   }
@@ -333,14 +396,12 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacle() cons
 
 boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCloud() const
 {
-  if (pointcloud_ptr_->data.empty()) {
+  if (!node_param_.pointcloud_enable_check || pointcloud_ptr_->data.empty()) {
     return boost::none;
   }
+
   const auto transform_stamped =
     getTransform("base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
-
-  geometry_msgs::msg::Point nearest_point;
-  auto minimum_distance = std::numeric_limits<double>::max();
 
   if (!transform_stamped) {
     return {};
@@ -352,8 +413,14 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPoint
   tier4_autoware_utils::transformPointCloud(
     transformed_pointcloud, transformed_pointcloud, isometry);
 
-  const auto ego_polygon = createSelfPolygon(vehicle_info_);
+  const double front_margin = node_param_.pointcloud_surround_check_front_distance;
+  const double side_margin = node_param_.pointcloud_surround_check_side_distance;
+  const double back_margin = node_param_.pointcloud_surround_check_back_distance;
+  const auto ego_polygon = createSelfPolygon(vehicle_info_, front_margin, side_margin, back_margin);
 
+  geometry_msgs::msg::Point nearest_point;
+  double minimum_distance = std::numeric_limits<double>::max();
+  bool was_minimum_distance_updated = false;
   for (const auto & p : transformed_pointcloud) {
     Point2d boost_point(p.x, p.y);
 
@@ -362,19 +429,20 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPoint
     if (distance_to_object < minimum_distance) {
       nearest_point = createPoint(p.x, p.y, p.z);
       minimum_distance = distance_to_object;
+      was_minimum_distance_updated = true;
     }
   }
 
-  return std::make_pair(minimum_distance, nearest_point);
+  if (was_minimum_distance_updated) {
+    return std::make_pair(minimum_distance, nearest_point);
+  }
+  return boost::none;
 }
 
 boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynamicObject() const
 {
   const auto transform_stamped =
     getTransform(object_ptr_->header.frame_id, "base_link", object_ptr_->header.stamp, 0.5);
-
-  geometry_msgs::msg::Point nearest_point;
-  auto minimum_distance = std::numeric_limits<double>::max();
 
   if (!transform_stamped) {
     return {};
@@ -383,10 +451,23 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynam
   tf2::Transform tf_src2target;
   tf2::fromMsg(transform_stamped.get().transform, tf_src2target);
 
-  const auto ego_polygon = createSelfPolygon(vehicle_info_);
-
+  // TODO(murooka) check computation cost
+  geometry_msgs::msg::Point nearest_point;
+  double minimum_distance = std::numeric_limits<double>::max();
+  bool was_minimum_distance_updated = false;
   for (const auto & object : object_ptr_->objects) {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
+    const int label = object.classification.front().label;
+
+    if (!node_param_.enable_check_map.at(label)) {
+      continue;
+    }
+
+    const double front_margin = node_param_.surround_check_front_distance_map.at(label);
+    const double side_margin = node_param_.surround_check_side_distance_map.at(label);
+    const double back_margin = node_param_.surround_check_back_distance_map.at(label);
+    const auto ego_polygon =
+      createSelfPolygon(vehicle_info_, front_margin, side_margin, back_margin);
 
     tf2::Transform tf_src2object;
     tf2::fromMsg(object_pose, tf_src2object);
@@ -404,10 +485,14 @@ boost::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynam
     if (distance_to_object < minimum_distance) {
       nearest_point = object_pose.position;
       minimum_distance = distance_to_object;
+      was_minimum_distance_updated = true;
     }
   }
 
-  return std::make_pair(minimum_distance, nearest_point);
+  if (was_minimum_distance_updated) {
+    return std::make_pair(minimum_distance, nearest_point);
+  }
+  return boost::none;
 }
 
 boost::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleCheckerNode::getTransform(


### PR DESCRIPTION
## Description

Currently, the footprint margin cannot be changed depending on the object label
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/ec18db27-e765-4384-98a8-2f06b43801b9)

This PR enables
- footprint margins depending on object's label
    - e.g.
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/b2fb13bc-cc87-40fc-8737-e6f594cfdbb2)

- footprint margins depending on front, side, and back
    - e.g. 
![image](https://github.com/autowarefoundation/autoware.universe/assets/20228327/72b5fe74-1c2f-4fc9-a4c0-66309568efe4)


### Parameters' change
- Just check dynamic object but pointcloud
- Side margin for vehicle objects is 0.
    - The ego may have to start when the object is laterally close. The slow down feature by obstacle_cruise_planner adjusts the velocity in this case.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
planning simulator
scenario simulator: https://evaluation.tier4.jp/evaluation/reports/1277aee0-04b7-5319-b6ec-9fedac39ec4c?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
