### PR TITLE
feat(dynamic drivable area expansion): add replan checker

### DIFF
--- a/planning/behavior_path_planner/config/drivable_area_expansion.param.yaml
+++ b/planning/behavior_path_planner/config/drivable_area_expansion.param.yaml
@@ -37,3 +37,7 @@
         compensate:
           enable: true  # if true, when the drivable area cannot be expanded in one direction to completely include the ego footprint, it is expanded in the opposite direction
           extra_distance: 3.0 # [m] extra distance to add to the compensation
+      replan_checker:
+        enable: true  # if true, only recalculate the expanded drivable area when the path or its original drivable area change significantly
+                      # not compatible with dynamic_objects.avoid
+        max_deviation: 0.5  # [m] full replan is only done if the path or its original drivable area change by more than this distance

--- a/planning/behavior_path_planner/config/drivable_area_expansion.param.yaml
+++ b/planning/behavior_path_planner/config/drivable_area_expansion.param.yaml
@@ -8,6 +8,7 @@
     # Dynamic expansion by projecting the ego footprint along the path
     dynamic_expansion:
       enabled: false
+      debug_print: false  # if true, print some debug runtime measurements
       ego:
         extra_footprint_offset:
           front: 0.5 # [m] extra length to add to the front of the ego footprint
@@ -15,7 +16,7 @@
           left: 0.5 # [m] extra length to add to the left of the ego footprint
           right: 0.5 # [m] extra length to add to the rear of the ego footprint
       dynamic_objects:
-        avoid: true # if true, the drivable area is not expanded in the predicted path of dynamic objects
+        avoid: false # if true, the drivable area is not expanded in the predicted path of dynamic objects
         extra_footprint_offset:
           front: 0.5 # [m] extra length to add to the front of the dynamic object footprint
           rear: 0.5 # [m] extra length to add to the rear of the dynamic object footprint
@@ -40,4 +41,4 @@
       replan_checker:
         enable: true  # if true, only recalculate the expanded drivable area when the path or its original drivable area change significantly
                       # not compatible with dynamic_objects.avoid
-        max_deviation: 0.5  # [m] full replan is only done if the path or its original drivable area change by more than this distance
+        max_deviation: 0.5  # [m] full replan is only done if the path changes by more than this distance

--- a/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/data_manager.hpp
@@ -18,6 +18,7 @@
 #include "behavior_path_planner/parameters.hpp"
 #include "behavior_path_planner/turn_signal_decider.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/parameters.hpp"
+#include "behavior_path_planner/utils/drivable_area_expansion/replan_checker.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 #include <route_handler/route_handler.hpp>
@@ -150,6 +151,7 @@ struct PlannerData
   drivable_area_expansion::DrivableAreaExpansionParameters drivable_area_expansion_parameters{};
 
   mutable std::optional<geometry_msgs::msg::Pose> drivable_area_expansion_prev_crop_pose;
+  mutable drivable_area_expansion::ReplanChecker drivable_area_expansion_replan_checker{};
   mutable TurnSignalDecider turn_signal_decider;
 
   TurnIndicatorsCommand getTurnSignal(

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
@@ -62,6 +62,7 @@ struct DrivableAreaExpansionParameters
   static constexpr auto REPLAN_ENABLE_PARAM = "dynamic_expansion.replan_checker.enable";
   static constexpr auto REPLAN_MAX_DEVIATION_PARAM =
     "dynamic_expansion.replan_checker.max_deviation";
+  static constexpr auto DEBUG_PRINT_PARAM = "dynamic_expansion.debug_print";
 
   double drivable_area_right_bound_offset;
   double drivable_area_left_bound_offset;
@@ -91,6 +92,7 @@ struct DrivableAreaExpansionParameters
   double compensate_extra_dist{};
   bool replan_enable{};
   double replan_max_deviation{};
+  bool debug_print{};
 
   DrivableAreaExpansionParameters() = default;
   explicit DrivableAreaExpansionParameters(rclcpp::Node & node) { init(node); }
@@ -129,6 +131,7 @@ struct DrivableAreaExpansionParameters
     expansion_method = node.declare_parameter<std::string>(EXPANSION_METHOD_PARAM);
     replan_enable = node.declare_parameter<bool>(REPLAN_ENABLE_PARAM);
     replan_max_deviation = node.declare_parameter<double>(REPLAN_MAX_DEVIATION_PARAM);
+    debug_print = node.declare_parameter<bool>(DEBUG_PRINT_PARAM);
 
     const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
     ego_left_offset = vehicle_info.max_lateral_offset_m;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/parameters.hpp
@@ -59,6 +59,9 @@ struct DrivableAreaExpansionParameters
   static constexpr auto COMPENSATE_PARAM = "dynamic_expansion.avoid_linestring.compensate.enable";
   static constexpr auto EXTRA_COMPENSATE_PARAM =
     "dynamic_expansion.avoid_linestring.compensate.extra_distance";
+  static constexpr auto REPLAN_ENABLE_PARAM = "dynamic_expansion.replan_checker.enable";
+  static constexpr auto REPLAN_MAX_DEVIATION_PARAM =
+    "dynamic_expansion.replan_checker.max_deviation";
 
   double drivable_area_right_bound_offset;
   double drivable_area_left_bound_offset;
@@ -86,6 +89,8 @@ struct DrivableAreaExpansionParameters
   std::vector<std::string> avoid_linestring_types{};
   bool compensate_uncrossable_lines = false;
   double compensate_extra_dist{};
+  bool replan_enable{};
+  double replan_max_deviation{};
 
   DrivableAreaExpansionParameters() = default;
   explicit DrivableAreaExpansionParameters(rclcpp::Node & node) { init(node); }
@@ -122,6 +127,8 @@ struct DrivableAreaExpansionParameters
     compensate_uncrossable_lines = node.declare_parameter<bool>(COMPENSATE_PARAM);
     compensate_extra_dist = node.declare_parameter<double>(EXTRA_COMPENSATE_PARAM);
     expansion_method = node.declare_parameter<std::string>(EXPANSION_METHOD_PARAM);
+    replan_enable = node.declare_parameter<bool>(REPLAN_ENABLE_PARAM);
+    replan_max_deviation = node.declare_parameter<double>(REPLAN_MAX_DEVIATION_PARAM);
 
     const auto vehicle_info = vehicle_info_util::VehicleInfoUtil(node).getVehicleInfo();
     ego_left_offset = vehicle_info.max_lateral_offset_m;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/replan_checker.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/replan_checker.hpp
@@ -1,0 +1,100 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_PATH_PLANNER__UTILS__DRIVABLE_AREA_EXPANSION__REPLAN_CHECKER_HPP_
+#define BEHAVIOR_PATH_PLANNER__UTILS__DRIVABLE_AREA_EXPANSION__REPLAN_CHECKER_HPP_
+
+#include "behavior_path_planner/utils/drivable_area_expansion/types.hpp"
+
+#include <boost/geometry.hpp>
+
+#include <vector>
+
+namespace drivable_area_expansion
+{
+namespace
+{
+linestring_t to_linestring(const PathWithLaneId & path)
+{
+  linestring_t ls;
+  ls.reserve(path.points.size());
+  for (const auto & p : path.points)
+    ls.emplace_back(p.point.pose.position.x, p.point.pose.position.y);
+  return ls;
+}
+linestring_t to_linestring(const std::vector<Point> & points)
+{
+  linestring_t ls;
+  ls.reserve(points.size());
+  for (const auto & p : points) ls.emplace_back(p.x, p.y);
+  return ls;
+}
+size_t first_deviating_index(
+  const linestring_t & ls, const linestring_t & prev_ls, const double max_deviation)
+{
+  if (prev_ls.empty()) return 0;
+  for (size_t i = 0; i < ls.size(); ++i) {
+    const auto & point = ls[i];
+    const auto deviation_distance = boost::geometry::distance(point, prev_ls);
+    if (deviation_distance > max_deviation) return i;
+  }
+  return ls.size();
+};
+};  // namespace
+
+class ReplanChecker
+{
+private:
+  linestring_t prev_path_ls_{};
+  linestring_t prev_left_bound_ls_{};
+  linestring_t prev_right_bound_ls_{};
+  polygon_t prev_expanded_drivable_area_{};
+
+public:
+  void set_previous(const PathWithLaneId & path, const polygon_t & prev_expanded_drivable_area)
+  {
+    prev_path_ls_.clear();
+    prev_left_bound_ls_.clear();
+    prev_right_bound_ls_.clear();
+    for (const auto & p : path.points)
+      prev_path_ls_.emplace_back(p.point.pose.position.x, p.point.pose.position.y);
+    for (const auto & p : path.left_bound) prev_left_bound_ls_.emplace_back(p.x, p.y);
+    for (const auto & p : path.right_bound) prev_right_bound_ls_.emplace_back(p.x, p.y);
+    prev_expanded_drivable_area_ = prev_expanded_drivable_area;
+  }
+
+  polygon_t get_previous_expanded_drivable_area() { return prev_expanded_drivable_area_; }
+
+  void reset()
+  {
+    boost::geometry::clear(prev_path_ls_);
+    boost::geometry::clear(prev_left_bound_ls_);
+    boost::geometry::clear(prev_right_bound_ls_);
+    boost::geometry::clear(prev_expanded_drivable_area_);
+  }
+
+  size_t calculate_replan_index(const PathWithLaneId & path, const double max_deviation) const
+  {
+    const auto path_ls = to_linestring(path);
+    const auto left_bound_ls = to_linestring(path.left_bound);
+    const auto right_bound_ls = to_linestring(path.right_bound);
+    return std::min(
+      {first_deviating_index(path_ls, prev_path_ls_, max_deviation),
+       first_deviating_index(left_bound_ls, prev_left_bound_ls_, max_deviation),
+       first_deviating_index(right_bound_ls, prev_right_bound_ls_, max_deviation)});
+  }
+};
+}  // namespace drivable_area_expansion
+
+#endif  // BEHAVIOR_PATH_PLANNER__UTILS__DRIVABLE_AREA_EXPANSION__REPLAN_CHECKER_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/replan_checker.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/drivable_area_expansion/replan_checker.hpp
@@ -81,7 +81,6 @@ public:
       const auto & point = path_ls[i];
       const auto deviation_distance = boost::geometry::distance(point, prev_path_ls_);
       if (deviation_distance > max_deviation) {
-        std::printf("[ REPLAN ] dev_dist = %2.2f, idx = %ld\n", deviation_distance, i);
         return i;
       }
     }

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -1063,6 +1063,9 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
     updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::REPLAN_MAX_DEVIATION_PARAM,
       planner_data_->drivable_area_expansion_parameters.replan_max_deviation);
+    updateParam(
+      parameters, DrivableAreaExpansionParameters::DEBUG_PRINT_PARAM,
+      planner_data_->drivable_area_expansion_parameters.debug_print);
     if (updated) planner_data_->drivable_area_expansion_replan_checker.reset();
   } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
     result.successful = false;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -990,72 +990,80 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
     // Drivable area expansion parameters
     using drivable_area_expansion::DrivableAreaExpansionParameters;
     const std::lock_guard<std::mutex> lock(mutex_pd_);  // for planner_data_
-    updateParam(
+    bool updated = false;
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::DRIVABLE_AREA_RIGHT_BOUND_OFFSET_PARAM,
       planner_data_->drivable_area_expansion_parameters.drivable_area_right_bound_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::DRIVABLE_AREA_LEFT_BOUND_OFFSET_PARAM,
       planner_data_->drivable_area_expansion_parameters.drivable_area_left_bound_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::DRIVABLE_AREA_TYPES_TO_SKIP_PARAM,
       planner_data_->drivable_area_expansion_parameters.drivable_area_types_to_skip);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::ENABLED_PARAM,
       planner_data_->drivable_area_expansion_parameters.enabled);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::AVOID_DYN_OBJECTS_PARAM,
       planner_data_->drivable_area_expansion_parameters.avoid_dynamic_objects);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::EXPANSION_METHOD_PARAM,
       planner_data_->drivable_area_expansion_parameters.expansion_method);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::AVOID_LINESTRING_TYPES_PARAM,
       planner_data_->drivable_area_expansion_parameters.avoid_linestring_types);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::AVOID_LINESTRING_DIST_PARAM,
       planner_data_->drivable_area_expansion_parameters.avoid_linestring_dist);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::EGO_EXTRA_OFFSET_FRONT,
       planner_data_->drivable_area_expansion_parameters.ego_extra_front_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::EGO_EXTRA_OFFSET_REAR,
       planner_data_->drivable_area_expansion_parameters.ego_extra_rear_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::EGO_EXTRA_OFFSET_LEFT,
       planner_data_->drivable_area_expansion_parameters.ego_extra_left_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::EGO_EXTRA_OFFSET_RIGHT,
       planner_data_->drivable_area_expansion_parameters.ego_extra_right_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::DYN_OBJECTS_EXTRA_OFFSET_FRONT,
       planner_data_->drivable_area_expansion_parameters.dynamic_objects_extra_front_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::DYN_OBJECTS_EXTRA_OFFSET_REAR,
       planner_data_->drivable_area_expansion_parameters.dynamic_objects_extra_rear_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::DYN_OBJECTS_EXTRA_OFFSET_LEFT,
       planner_data_->drivable_area_expansion_parameters.dynamic_objects_extra_left_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::DYN_OBJECTS_EXTRA_OFFSET_RIGHT,
       planner_data_->drivable_area_expansion_parameters.dynamic_objects_extra_right_offset);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::MAX_EXP_DIST_PARAM,
       planner_data_->drivable_area_expansion_parameters.max_expansion_distance);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::MAX_PATH_ARC_LENGTH_PARAM,
       planner_data_->drivable_area_expansion_parameters.max_path_arc_length);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::RESAMPLE_INTERVAL_PARAM,
       planner_data_->drivable_area_expansion_parameters.resample_interval);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::EXTRA_ARC_LENGTH_PARAM,
       planner_data_->drivable_area_expansion_parameters.extra_arc_length);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::COMPENSATE_PARAM,
       planner_data_->drivable_area_expansion_parameters.compensate_uncrossable_lines);
-    updateParam(
+    updated |= updateParam(
       parameters, DrivableAreaExpansionParameters::EXTRA_COMPENSATE_PARAM,
       planner_data_->drivable_area_expansion_parameters.compensate_extra_dist);
+    updated |= updateParam(
+      parameters, DrivableAreaExpansionParameters::REPLAN_ENABLE_PARAM,
+      planner_data_->drivable_area_expansion_parameters.replan_enable);
+    updated |= updateParam(
+      parameters, DrivableAreaExpansionParameters::REPLAN_MAX_DEVIATION_PARAM,
+      planner_data_->drivable_area_expansion_parameters.replan_max_deviation);
+    if (updated) planner_data_->drivable_area_expansion_replan_checker.reset();
   } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
     result.successful = false;
     result.reason = e.what();

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -115,17 +115,17 @@ void expandDrivableArea(
   const auto update_duration = stopwatch.toc("update");
   planner_data->drivable_area_expansion_replan_checker.set_previous(path);
 
-  std::printf("Dynamic drivable area expansion runtime: %2.2fms\n", stopwatch.toc());
-  std::printf("\tcalc_replan: %2.2fms\n", calc_replan_duration);
-  std::printf("\textract_lines: %2.2fms\n", extra_uncrossable_lines_duration);
-  std::printf("\tcrop: %2.2fms\n", crop_duration);
-  std::printf("\tfootprints: %2.2fms\n", footprints_duration);
-  std::printf("\texp_polys: %2.2fms\n", exp_polygons_duration);
-  std::printf("\texp_da: %2.2fms\n", exp_da_duration);
-  std::printf("\tupdate: %2.2fms\n", update_duration);
-  std::printf(
-    "\t [REPLAN] replan index: %ld %s", replan_index, is_replanning ? " [IS REPLANNING]" : "");
-  std::cout << std::endl;
+  if (params.debug_print) {
+    std::printf("Dynamic drivable area expansion runtime: %2.2fms\n", stopwatch.toc());
+    std::printf("\tcalc_replan: %2.2fms\n", calc_replan_duration);
+    std::printf("\textract_lines: %2.2fms\n", extra_uncrossable_lines_duration);
+    std::printf("\tcrop: %2.2fms\n", crop_duration);
+    std::printf("\tfootprints: %2.2fms\n", footprints_duration);
+    std::printf("\texp_polys: %2.2fms\n", exp_polygons_duration);
+    std::printf("\texp_da: %2.2fms\n", exp_da_duration);
+    std::printf("\tupdate: %2.2fms\n", update_duration);
+    std::cout << std::endl;
+  }
 }
 
 point_t convert_point(const Point & p)

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -26,15 +26,6 @@
 
 #include <boost/geometry.hpp>
 
-// for writing the svg file
-#include <fstream>
-#include <iostream>
-// for the geometry types
-#include <tier4_autoware_utils/geometry/geometry.hpp>
-// for the svg mapper
-#include <boost/geometry/io/svg/svg_mapper.hpp>
-#include <boost/geometry/io/svg/write.hpp>
-
 namespace drivable_area_expansion
 {
 
@@ -65,9 +56,6 @@ void expandDrivableArea(
   const lanelet::ConstLanelets & path_lanes)
 {
   if (path.points.empty() || path.left_bound.empty() || path.right_bound.empty()) return;
-  // Declare a stream and an SVG mapper
-  std::ofstream svg("/home/mclement/Pictures/debug.svg");  // /!\ CHANGE PATH
-  boost::geometry::svg_mapper<tier4_autoware_utils::Point2d> mapper(svg, 400, 400);
 
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stopwatch;
   const auto & params = planner_data->drivable_area_expansion_parameters;
@@ -75,14 +63,15 @@ void expandDrivableArea(
   const auto & route_handler = *planner_data->route_handler;
 
   stopwatch.tic("calc_replan");
+  const auto ego_index = planner_data->findEgoIndex(path.points);
   auto & replan_checker = planner_data->drivable_area_expansion_replan_checker;
-  const auto replan_index =
-    params.replan_enable ? replan_checker.calculate_replan_index(path, params.replan_max_deviation)
-                         : 0;
+  const auto replan_index = params.replan_enable ? replan_checker.calculate_replan_index(
+                                                     path, ego_index, params.replan_max_deviation)
+                                                 : 0;
   const auto & prev_expanded_drivable_area = replan_checker.get_previous_expanded_drivable_area();
   const auto is_replanning =
     params.expansion_method == "polygon" && !params.avoid_dynamic_objects &&
-    !boost::geometry::is_empty(prev_expanded_drivable_area) && replan_index > 0;
+    !boost::geometry::is_empty(prev_expanded_drivable_area) && replan_index > ego_index;
   const auto calc_replan_duration = stopwatch.toc("calc_replan");
 
   stopwatch.tic("extract_uncrossable_lines");
@@ -116,7 +105,6 @@ void expandDrivableArea(
   stopwatch.tic("exp_da");
   const auto expanded_drivable_area = createExpandedDrivableAreaPolygon(path, expansion_polygons);
   const auto exp_da_duration = stopwatch.toc("exp_da");
-  planner_data->drivable_area_expansion_replan_checker.set_previous(path, expanded_drivable_area);
 
   linestring_t path_ls;
   for (const auto & p : path.points)
@@ -125,6 +113,7 @@ void expandDrivableArea(
   stopwatch.tic("update");
   updateDrivableAreaBounds(path, expanded_drivable_area);
   const auto update_duration = stopwatch.toc("update");
+  planner_data->drivable_area_expansion_replan_checker.set_previous(path);
 
   std::printf("Dynamic drivable area expansion runtime: %2.2fms\n", stopwatch.toc());
   std::printf("\tcalc_replan: %2.2fms\n", calc_replan_duration);
@@ -137,24 +126,6 @@ void expandDrivableArea(
   std::printf(
     "\t [REPLAN] replan index: %ld %s", replan_index, is_replanning ? " [IS REPLANNING]" : "");
   std::cout << std::endl;
-
-  mapper.add(prev_expanded_drivable_area);
-  mapper.add(expanded_drivable_area);
-  mapper.add(replan_checker.prev_path_ls_);
-  mapper.add(path_ls);
-  mapper.map(
-    prev_expanded_drivable_area,
-    "opacity:0.2;fill-opacity:0.3;fill:blue;stroke:none;stroke-width:2");
-  mapper.map(
-    replan_checker.prev_path_ls_,
-    "opacity:0.3;fill-opacity:0.3;fill:blue;stroke:blue;stroke-width:2");
-  mapper.map(path_ls, "opacity:0.3;fill-opacity:0.3;fill:red;stroke:red;stroke-width:2");
-  if (replan_index < path_ls.size())
-    mapper.map(
-      path_ls[replan_index], "opacity:0.3;fill-opacity:0.3;fill:pink;stroke:pink;stroke-width:2",
-      2);
-  mapper.map(
-    expanded_drivable_area, "opacity:0.2;fill-opacity:0.3;fill:red;stroke:none;stroke-width:2");
 }
 
 point_t convert_point(const Point & p)

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/footprints.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/footprints.cpp
@@ -47,20 +47,18 @@ multi_polygon_t createObjectFootprints(
   const DrivableAreaExpansionParameters & params)
 {
   multi_polygon_t footprints;
-  if (params.avoid_dynamic_objects) {
-    for (const auto & object : objects.objects) {
-      const auto front = object.shape.dimensions.x / 2 + params.dynamic_objects_extra_front_offset;
-      const auto rear = -object.shape.dimensions.x / 2 - params.dynamic_objects_extra_rear_offset;
-      const auto left = object.shape.dimensions.y / 2 + params.dynamic_objects_extra_left_offset;
-      const auto right = -object.shape.dimensions.y / 2 - params.dynamic_objects_extra_right_offset;
-      polygon_t base_footprint;
-      base_footprint.outer() = {
-        point_t{front, left}, point_t{front, right}, point_t{rear, right}, point_t{rear, left},
-        point_t{front, left}};
-      for (const auto & path : object.kinematics.predicted_paths)
-        for (const auto & pose : path.path)
-          footprints.push_back(createFootprint(pose, base_footprint));
-    }
+  for (const auto & object : objects.objects) {
+    const auto front = object.shape.dimensions.x / 2 + params.dynamic_objects_extra_front_offset;
+    const auto rear = -object.shape.dimensions.x / 2 - params.dynamic_objects_extra_rear_offset;
+    const auto left = object.shape.dimensions.y / 2 + params.dynamic_objects_extra_left_offset;
+    const auto right = -object.shape.dimensions.y / 2 - params.dynamic_objects_extra_right_offset;
+    polygon_t base_footprint;
+    base_footprint.outer() = {
+      point_t{front, left}, point_t{front, right}, point_t{rear, right}, point_t{rear, left},
+      point_t{front, left}};
+    for (const auto & path : object.kinematics.predicted_paths)
+      for (const auto & pose : path.path)
+        footprints.push_back(createFootprint(pose, base_footprint));
   }
   return footprints;
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Add a replan checker for the dynamic drivable area expansion. This allows reusing the previously calculated drivable area, greatly improving the stability of the corresponding left and right bound.

Requires the following launch PR: https://github.com/autowarefoundation/autoware_launch/pull/558

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim.
Evaluator (TIER IV INTERNAL LINK): https://evaluation.tier4.jp/evaluation/reports/c74138f2-c7c3-52b5-bca6-51120f1d5931?project_id=x2_dev
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
The drivable area, when using the dynamic expansion, is much more stable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
