### PR TITLE
fix(lane_change): fix target object filter

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -666,6 +666,8 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
     utils::lane_change::createPolygon(target_lanes, 0.0, std::numeric_limits<double>::max());
   const auto target_backward_polygon = utils::lane_change::createPolygon(
     target_backward_lanes, 0.0, std::numeric_limits<double>::max());
+  const auto dist_ego_to_current_lanes_center =
+    lanelet::utils::getLateralDistanceToClosestLanelet(current_lanes, current_pose);
 
   LaneChangeTargetObjectIndices filtered_obj_indices;
   for (size_t i = 0; i < objects.objects.size(); ++i) {
@@ -695,9 +697,11 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
     }
 
     const auto is_lateral_far = [&]() {
-      const auto lateral = tier4_autoware_utils::calcLateralDeviation(
-        current_pose, object.kinematics.initial_pose_with_covariance.pose.position);
-      return std::abs(lateral) > common_parameters.vehicle_width;
+      const auto dist_object_to_current_lanes_center =
+        lanelet::utils::getLateralDistanceToClosestLanelet(
+          current_lanes, object.kinematics.initial_pose_with_covariance.pose);
+      const auto lateral = dist_object_to_current_lanes_center - dist_ego_to_current_lanes_center;
+      return std::abs(lateral) > (common_parameters.vehicle_width / 2);
     };
 
     // ignore static object that are behind the ego vehicle
@@ -710,7 +714,7 @@ LaneChangeTargetObjectIndices NormalLaneChange::filterObject(
       // TODO(watanabe): ignore static parked object that are in front of the ego vehicle in target
       // lanes
 
-      if (is_lateral_far()) {
+      if (max_dist_ego_to_obj >= 0 || is_lateral_far()) {
         filtered_obj_indices.target_lane.push_back(i);
         continue;
       }


### PR DESCRIPTION
## Description

In the lane change `NormalLaneChange::filterObject` function, the target objects are classified based on which lanelet it is currently occupied, with the target lane's objects being prioritized first during the search.

Therefore, although the target object's base link is in current lane, if its polygon intersect with the target lane, it will be considered as target lane's object.

![image1](https://github.com/autowarefoundation/autoware.universe/assets/93502286/a7ed1114-e920-42e6-99e3-56f0ac43dc97)

This caused an issue, since based on the above images, the object is causing unnecessary lane change CANCEL/ABORT.

To fix this, I am placing the lateral check to ensure that the filtering doesn't consider the object as target lane object.

## Related links

[TIER IV internal link](https://tier4.atlassian.net/browse/RT1-3172)

## Tests performed

Using PSIM

### Before PR
Unnecessary lane change cancel occured the whole way.

https://github.com/autowarefoundation/autoware.universe/assets/93502286/93af1092-a956-4455-9702-a02cb3295bf0

### After PR

https://github.com/autowarefoundation/autoware.universe/assets/93502286/c360f20e-fc65-4f4f-88b4-52741b89f806

## Notes for reviewers

I used lateral filter instead on longitudinal filter.
The reason is that, for object in target lane, we should observe all object, regardless of whether the object is lagging or leading.


[All scenario passes](https://evaluation.tier4.jp/evaluation/reports/d059f8e0-328b-54ae-b2d1-8e745d60ab49?project_id=prd_jt)

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
