### PR TITLE
chore(build): remove tier4_autoware_utils.hpp/motion_utils.hpp from other planning packages

### DIFF
--- a/planning/path_smoother/include/path_smoother/common_structs.hpp
+++ b/planning/path_smoother/include/path_smoother/common_structs.hpp
@@ -17,7 +17,8 @@
 
 #include "path_smoother/type_alias.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+#include "tier4_autoware_utils/ros/update_param.hpp"
+#include "tier4_autoware_utils/system/stop_watch.hpp"
 
 #include <memory>
 #include <optional>

--- a/planning/path_smoother/include/path_smoother/elastic_band_smoother.hpp
+++ b/planning/path_smoother/include/path_smoother/elastic_band_smoother.hpp
@@ -15,13 +15,12 @@
 #ifndef PATH_SMOOTHER__ELASTIC_BAND_SMOOTHER_HPP_
 #define PATH_SMOOTHER__ELASTIC_BAND_SMOOTHER_HPP_
 
-#include "motion_utils/motion_utils.hpp"
+#include "motion_utils/trajectory/trajectory.hpp"
 #include "path_smoother/common_structs.hpp"
 #include "path_smoother/elastic_band.hpp"
 #include "path_smoother/replan_checker.hpp"
 #include "path_smoother/type_alias.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 
 #include <algorithm>
 #include <memory>

--- a/planning/path_smoother/src/elastic_band.cpp
+++ b/planning/path_smoother/src/elastic_band.cpp
@@ -14,7 +14,7 @@
 
 #include "path_smoother/elastic_band.hpp"
 
-#include "motion_utils/motion_utils.hpp"
+#include "motion_utils/trajectory/trajectory.hpp"
 #include "path_smoother/type_alias.hpp"
 #include "path_smoother/utils/geometry_utils.hpp"
 #include "path_smoother/utils/trajectory_utils.hpp"

--- a/planning/path_smoother/src/utils/trajectory_utils.cpp
+++ b/planning/path_smoother/src/utils/trajectory_utils.cpp
@@ -14,7 +14,8 @@
 
 #include "path_smoother/utils/trajectory_utils.hpp"
 
-#include "motion_utils/motion_utils.hpp"
+#include "motion_utils/resample/resample.hpp"
+#include "motion_utils/trajectory/tmp_conversion.hpp"
 #include "path_smoother/utils/geometry_utils.hpp"
 
 #include "autoware_auto_planning_msgs/msg/path_point.hpp"

--- a/planning/planning_validator/src/debug_marker.cpp
+++ b/planning/planning_validator/src/debug_marker.cpp
@@ -14,8 +14,8 @@
 
 #include "planning_validator/debug_marker.hpp"
 
-#include <motion_utils/motion_utils.hpp>
-#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
+#include <motion_utils/marker/marker_helper.hpp>
+#include <tier4_autoware_utils/ros/marker_helper.hpp>
 
 #include <memory>
 #include <string>

--- a/planning/planning_validator/src/planning_validator.cpp
+++ b/planning/planning_validator/src/planning_validator.cpp
@@ -17,7 +17,7 @@
 #include "planning_validator/utils.hpp"
 
 #include <motion_utils/trajectory/trajectory.hpp>
-#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
 
 #include <memory>
 #include <string>

--- a/planning/planning_validator/src/utils.cpp
+++ b/planning/planning_validator/src/utils.cpp
@@ -15,7 +15,7 @@
 #include "planning_validator/utils.hpp"
 
 #include <motion_utils/trajectory/trajectory.hpp>
-#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
 
 #include <memory>
 #include <string>

--- a/planning/sampling_based_planner/path_sampler/include/path_sampler/common_structs.hpp
+++ b/planning/sampling_based_planner/path_sampler/include/path_sampler/common_structs.hpp
@@ -18,7 +18,10 @@
 #include "path_sampler/type_alias.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sampler_common/structures.hpp"
-#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+#include "tier4_autoware_utils/ros/update_param.hpp"
+#include "tier4_autoware_utils/system/stop_watch.hpp"
+
+#include <tier4_autoware_utils/geometry/boost_geometry.hpp>
 
 #include <memory>
 #include <optional>

--- a/planning/sampling_based_planner/path_sampler/include/path_sampler/node.hpp
+++ b/planning/sampling_based_planner/path_sampler/include/path_sampler/node.hpp
@@ -15,13 +15,11 @@
 #ifndef PATH_SAMPLER__NODE_HPP_
 #define PATH_SAMPLER__NODE_HPP_
 
-#include "motion_utils/motion_utils.hpp"
 #include "path_sampler/common_structs.hpp"
 #include "path_sampler/parameters.hpp"
 #include "path_sampler/type_alias.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sampler_common/transform/spline_transform.hpp"
-#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
 
 #include <sampler_common/structures.hpp>

--- a/planning/sampling_based_planner/path_sampler/src/node.cpp
+++ b/planning/sampling_based_planner/path_sampler/src/node.cpp
@@ -15,6 +15,7 @@
 #include "path_sampler/node.hpp"
 
 #include "interpolation/spline_interpolation_points_2d.hpp"
+#include "motion_utils/marker/marker_helper.hpp"
 #include "path_sampler/path_generation.hpp"
 #include "path_sampler/prepare_inputs.hpp"
 #include "path_sampler/utils/geometry_utils.hpp"
@@ -22,6 +23,8 @@
 #include "rclcpp/time.hpp"
 #include "sampler_common/constraints/hard_constraint.hpp"
 #include "sampler_common/constraints/soft_constraint.hpp"
+
+#include <boost/geometry/algorithms/distance.hpp>
 
 #include <chrono>
 #include <limits>

--- a/planning/sampling_based_planner/path_sampler/src/prepare_inputs.cpp
+++ b/planning/sampling_based_planner/path_sampler/src/prepare_inputs.cpp
@@ -18,6 +18,7 @@
 #include "path_sampler/utils/geometry_utils.hpp"
 #include "sampler_common/structures.hpp"
 #include "sampler_common/transform/spline_transform.hpp"
+#include "tier4_autoware_utils/geometry/boost_polygon_utils.hpp"
 
 #include <eigen3/unsupported/Eigen/Splines>
 

--- a/planning/sampling_based_planner/path_sampler/src/utils/trajectory_utils.cpp
+++ b/planning/sampling_based_planner/path_sampler/src/utils/trajectory_utils.cpp
@@ -14,7 +14,8 @@
 
 #include "path_sampler/utils/trajectory_utils.hpp"
 
-#include "motion_utils/motion_utils.hpp"
+#include "motion_utils/resample/resample.hpp"
+#include "motion_utils/trajectory/tmp_conversion.hpp"
 #include "path_sampler/utils/geometry_utils.hpp"
 #include "tf2/utils.h"
 

--- a/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/static_centerline_optimizer_node.cpp
@@ -18,16 +18,20 @@
 #include "lanelet2_extension/utility/query.hpp"
 #include "lanelet2_extension/utility/utilities.hpp"
 #include "map_loader/lanelet2_map_loader_node.hpp"
-#include "motion_utils/motion_utils.hpp"
+#include "motion_utils/trajectory/tmp_conversion.hpp"
 #include "static_centerline_optimizer/msg/points_with_lane_id.hpp"
 #include "static_centerline_optimizer/successive_trajectory_optimizer_node.hpp"
 #include "static_centerline_optimizer/type_alias.hpp"
 #include "static_centerline_optimizer/utils.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/ros/marker_helper.hpp"
 
 #include <mission_planner/mission_planner_plugin.hpp>
 #include <pluginlib/class_loader.hpp>
 
 #include <tier4_map_msgs/msg/map_projector_info.hpp>
+
+#include <boost/geometry/algorithms/correct.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_io/Io.h>

--- a/planning/static_centerline_optimizer/src/successive_trajectory_optimizer_node.cpp
+++ b/planning/static_centerline_optimizer/src/successive_trajectory_optimizer_node.cpp
@@ -14,9 +14,11 @@
 
 #include "static_centerline_optimizer/successive_trajectory_optimizer_node.hpp"
 
-#include "motion_utils/motion_utils.hpp"
+#include "motion_utils/resample/resample.hpp"
+#include "motion_utils/trajectory/tmp_conversion.hpp"
+#include "motion_utils/trajectory/trajectory.hpp"
 #include "obstacle_avoidance_planner/utils/trajectory_utils.hpp"
-#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
 
 #include <algorithm>

--- a/planning/static_centerline_optimizer/src/utils.cpp
+++ b/planning/static_centerline_optimizer/src/utils.cpp
@@ -16,8 +16,8 @@
 
 #include "behavior_path_planner/data_manager.hpp"
 #include "behavior_path_planner/utils/utils.hpp"
-#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
-
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/ros/marker_helper.hpp"
 namespace static_centerline_optimizer
 {
 namespace

--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
@@ -17,10 +17,8 @@
 
 #include "surround_obstacle_checker/debug_marker.hpp"
 
-#include <motion_utils/motion_utils.hpp>
+#include <motion_utils/vehicle/vehicle_state_checker.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
-#include <tier4_autoware_utils/transform/transforms.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
@@ -31,6 +29,8 @@
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
+
+#include <boost/optional/optional.hpp>
 
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>

--- a/planning/surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/surround_obstacle_checker/src/debug_marker.cpp
@@ -14,8 +14,9 @@
 
 #include "surround_obstacle_checker/debug_marker.hpp"
 
-#include <motion_utils/motion_utils.hpp>
-#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
+#include <motion_utils/marker/virtual_wall_marker_creator.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+#include <tier4_autoware_utils/ros/marker_helper.hpp>
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -15,6 +15,9 @@
 #include "surround_obstacle_checker/node.hpp"
 
 #include <autoware_auto_tf2/tf2_autoware_auto_msgs.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+#include <tier4_autoware_utils/ros/update_param.hpp>
+#include <tier4_autoware_utils/transform/transforms.hpp>
 
 #include <boost/assert.hpp>
 #include <boost/assign/list_of.hpp>


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/issues/4821

## Tests performed

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
