### PR TITLE
fix(mission_planner): routing api uninitialization

### DIFF
--- a/planning/mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.cpp
@@ -141,6 +141,7 @@ void MissionPlanner::checkInitialization()
   }
 
   // All data is ready. Now API is available.
+  RCLCPP_INFO(get_logger(), "Route API is ready.");
   change_state(RouteState::Message::UNSET);
   data_check_timer_->cancel();  // stop timer callback
 }

--- a/planning/mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/mission_planner/src/mission_planner/mission_planner.hpp
@@ -82,6 +82,9 @@ private:
   void on_map(const HADMapBin::ConstSharedPtr msg);
   void on_reroute_availability(const RerouteAvailability::ConstSharedPtr msg);
 
+  rclcpp::TimerBase::SharedPtr data_check_timer_;
+  void checkInitialization();
+
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
   void clear_route();
   void clear_mrm_route();


### PR DESCRIPTION
## Description

To fix the issue: "the set_route api is rejected even though the autoware_state is `WAIT_FOR_ROUTE`".

Publish `routing_state = UNKNOWN` until the routing system is not initialized.

Without this PR, it gets `autoware_state = WAIT_FOR_ROUTE` and `routing_state = UNSET` even if the mission_planner is not ready. Due to this inconsistency, calling set_route while in the wait_for_route state causes the API to fail.

Before this PR, when the ego pose is not set, the route state is UNSET:
```
ros2 topic echo /planning/mission_planning/route_state
stamp:
  sec: 1694341968
  nanosec: 326244268
state: 0
```

After this PR, when the ego pose is not set, the route state is UNKNOWN:
```
ros2 topic echo /planning/mission_planning/route_state
stamp:
  sec: 1694342360
  nanosec: 163490802
state: 1
---
```


## Related links

[TIERIV Internal ticket](https://tier4.atlassian.net/browse/RT1-3637)

## Tests performed

Run psim

## Notes for reviewers

check 

## Interface changes

None

## Effects on system behavior

route_state behavior will change

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
