### PR TITLE
fix(start/goal_planner): fix inverse order path points

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_goal_planner_common/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_goal_planner_common/utils.hpp
@@ -98,6 +98,21 @@ std::pair<double, double> getPairsTerminalVelocityAndAccel(
   const std::vector<std::pair<double, double>> & pairs_terminal_velocity_and_accel,
   const size_t current_path_idx);
 
+/**
+ * @brief removeInverseOrderPathPoints function
+ *
+ * This function is designed to handle a situation that can arise when shifting paths on a curve,
+ * where the positions of the path points may become inverted (i.e., a point further along the path
+ * comes to be located before an earlier point). It corrects for this by using the function
+ * tier4_autoware_utils::isDrivingForward(p1, p2) to check if each pair of adjacent points is in
+ * the correct order (with the second point being 'forward' of the first). Any points which fail
+ * this test are omitted from the returned PathWithLaneId.
+ *
+ * @param path A path with points possibly in incorrect order.
+ * @return Returns a new PathWithLaneId that has all points in the correct order.
+ */
+PathWithLaneId removeInverseOrderPathPoints(const PathWithLaneId & path);
+
 }  // namespace behavior_path_planner::utils::start_goal_planner_common
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__START_GOAL_PLANNER_COMMON__UTILS_HPP_

--- a/planning/behavior_path_planner/src/utils/goal_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/src/utils/goal_planner/shift_pull_over.cpp
@@ -16,6 +16,7 @@
 
 #include "behavior_path_planner/utils/goal_planner/util.hpp"
 #include "behavior_path_planner/utils/path_utils.hpp"
+#include "behavior_path_planner/utils/start_goal_planner_common/utils.hpp"
 #include "motion_utils/trajectory/path_with_lane_id.hpp"
 
 #include <lanelet2_extension/utility/query.hpp>
@@ -170,6 +171,9 @@ boost::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
     }
     shifted_path.path.points.push_back(p);
   }
+
+  shifted_path.path =
+    utils::start_goal_planner_common::removeInverseOrderPathPoints(shifted_path.path);
 
   // set the same z as the goal
   for (auto & p : shifted_path.path.points) {

--- a/planning/behavior_path_planner/src/utils/start_goal_planner_common/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/start_goal_planner_common/utils.cpp
@@ -169,4 +169,19 @@ std::pair<double, double> getPairsTerminalVelocityAndAccel(
   return pairs_terminal_velocity_and_accel.at(current_path_idx);
 }
 
+PathWithLaneId removeInverseOrderPathPoints(const PathWithLaneId & path)
+{
+  PathWithLaneId fixed_path;
+  fixed_path.header = path.header;
+  fixed_path.points.push_back(path.points.at(0));
+  for (size_t i = 1; i < path.points.size(); i++) {
+    const auto p1 = path.points.at(i - 1).point.pose;
+    const auto p2 = path.points.at(i).point.pose;
+    if (tier4_autoware_utils::isDrivingForward(p1, p2)) {
+      fixed_path.points.push_back(path.points.at(i));
+    }
+  }
+  return fixed_path;
+}
+
 }  // namespace behavior_path_planner::utils::start_goal_planner_common

--- a/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/src/utils/start_planner/shift_pull_out.cpp
@@ -16,6 +16,7 @@
 
 #include "behavior_path_planner/utils/path_safety_checker/objects_filtering.hpp"
 #include "behavior_path_planner/utils/path_utils.hpp"
+#include "behavior_path_planner/utils/start_goal_planner_common/utils.hpp"
 #include "behavior_path_planner/utils/start_planner/util.hpp"
 #include "behavior_path_planner/utils/utils.hpp"
 #include "motion_utils/trajectory/path_with_lane_id.hpp"
@@ -297,6 +298,9 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     if (!path_shifter.generate(&shifted_path, offset_back)) {
       continue;
     }
+
+    shifted_path.path =
+      utils::start_goal_planner_common::removeInverseOrderPathPoints(shifted_path.path);
 
     // set velocity
     const size_t pull_out_end_idx =


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

shifting path make path point order wrong and is_driving_forward false, this causes wrong drivable area.
In this PR remove inverse position path point.


before

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/c40c065e-52b1-415b-a8ae-e42d66e4214c)


```
[component_container_mt-28] is_driving_forward in generateCombinedDrivableArea: 0
[component_container_mt-28] is_driving_forward: 0
```

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/23b4cbec-71a8-4e83-88fd-40e1a163ff8e)

after

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/83dd0a9e-2a26-456e-a716-1489bf4f188f)

![image](https://github.com/autowarefoundation/autoware.universe/assets/39142679/134894b8-1f44-4d0a-a0b4-e2febe5bfb83)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://tier4.atlassian.net/08ab1e03-283d-4096-9af4-08b3fd6658a6#media-blob-url=true&id=ef931a2e-2c9e-4636-a230-5e3759bab867&contextId=86702&collection=


## Tests performed

<!-- Describe how you have tested this PR. -->
https://evaluation.tier4.jp/evaluation/reports/66d65d25-8bad-5657-ab02-52686ca71601?project_id=prd_jt
https://evaluation.tier4.jp/evaluation/reports/09e72de7-3ce1-5d09-8582-af3915e70d12?project_id=prd_jt

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
