### PR TITLE
fix(image_projection_based_fusion): update parameter value

### DIFF
--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_cluster_fusion/node.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/roi_cluster_fusion/node.hpp
@@ -43,13 +43,13 @@ protected:
   bool use_iou_{false};
   bool use_cluster_semantic_type_{false};
   bool only_allow_inside_cluster_{false};
-  float roi_scale_factor_{1.1f};
-  float iou_threshold_{0.0f};
-  float unknown_iou_threshold_{0.0f};
+  double roi_scale_factor_{1.1};
+  double iou_threshold_{0.0};
+  double unknown_iou_threshold_{0.0};
   const float min_roi_existence_prob_ =
     0.1;  // keep small value to lessen affect on merger object stage
   bool remove_unknown_;
-  float trust_distance_;
+  double trust_distance_;
 
   bool filter_by_distance(const DetectedObjectWithFeature & obj);
   bool out_of_scope(const DetectedObjectWithFeature & obj);

--- a/perception/image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
+++ b/perception/image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
@@ -48,9 +48,10 @@
       <param name="use_iou" value="true"/>
       <param name="use_iou_x" value="false"/>
       <param name="use_iou_y" value="false"/>
+      <param name="use_cluster_semantic_type" value="false"/>
       <param name="only_allow_inside_cluster" value="true"/>
       <param name="roi_scale_factor" value="1.1"/>
-      <param name="iou_threshold" value="0.35"/>
+      <param name="iou_threshold" value="0.65"/>
       <param name="unknown_iou_threshold" value="0.1"/>
       <param name="rois_number" value="$(var input/rois_number)"/>
       <param name="remove_unknown" value="$(var remove_unknown)"/>

--- a/perception/image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
+++ b/perception/image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
@@ -36,16 +36,16 @@ namespace image_projection_based_fusion
 RoiClusterFusionNode::RoiClusterFusionNode(const rclcpp::NodeOptions & options)
 : FusionNode<DetectedObjectsWithFeature, DetectedObjectWithFeature>("roi_cluster_fusion", options)
 {
-  use_iou_x_ = declare_parameter("use_iou_x", true);
-  use_iou_y_ = declare_parameter("use_iou_y", false);
-  use_iou_ = declare_parameter("use_iou", false);
-  use_cluster_semantic_type_ = declare_parameter("use_cluster_semantic_type", false);
-  only_allow_inside_cluster_ = declare_parameter("only_allow_inside_cluster_", true);
-  roi_scale_factor_ = declare_parameter("roi_scale_factor", 1.1);
-  iou_threshold_ = declare_parameter("iou_threshold", 0.1);
-  unknown_iou_threshold_ = declare_parameter("unknown_iou_threshold", 0.1);
-  remove_unknown_ = declare_parameter("remove_unknown", false);
-  trust_distance_ = declare_parameter("trust_distance", 100.0);
+  use_iou_x_ = declare_parameter<bool>("use_iou_x");
+  use_iou_y_ = declare_parameter<bool>("use_iou_y");
+  use_iou_ = declare_parameter<bool>("use_iou");
+  use_cluster_semantic_type_ = declare_parameter<bool>("use_cluster_semantic_type");
+  only_allow_inside_cluster_ = declare_parameter<bool>("only_allow_inside_cluster");
+  roi_scale_factor_ = declare_parameter<double>("roi_scale_factor");
+  iou_threshold_ = declare_parameter<double>("iou_threshold");
+  unknown_iou_threshold_ = declare_parameter<double>("unknown_iou_threshold");
+  remove_unknown_ = declare_parameter<bool>("remove_unknown");
+  trust_distance_ = declare_parameter<double>("trust_distance");
 }
 
 void RoiClusterFusionNode::preprocess(DetectedObjectsWithFeature & output_cluster_msg)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Update default launcher parameter `iou_threshold : 0.35 -> 0.65`.
Also, the default values are removed specified in RoIClusterFusion node.  

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
