### PR TITLE
chore(control_validator): use throttle for the error log

### DIFF
--- a/control/control_validator/src/control_validator.cpp
+++ b/control/control_validator/src/control_validator.cpp
@@ -163,7 +163,9 @@ void ControlValidator::publishDebugInfo()
 void ControlValidator::validate(const Trajectory & predicted_trajectory)
 {
   if (predicted_trajectory.points.size() < 2) {
-    RCLCPP_ERROR(get_logger(), "predicted_trajectory size is less than 2. Cannot validate.");
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "predicted_trajectory size is less than 2. Cannot validate.");
     return;
   }
 


### PR DESCRIPTION
## Description

Use log_throttle for the error message, otherwise the terminal is filled by the same log.

## Tests performed

run psim

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
