### PR TITLE
fix(resample): remove duplicated poinnt before resampling

### DIFF
--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -109,13 +109,16 @@ std::vector<geometry_msgs::msg::Point> resamplePointVector(
 }
 
 std::vector<geometry_msgs::msg::Pose> resamplePoseVector(
-  const std::vector<geometry_msgs::msg::Pose> & points,
+  const std::vector<geometry_msgs::msg::Pose> & points_raw,
   const std::vector<double> & resampled_arclength, const bool use_akima_spline_for_xy,
   const bool use_lerp_for_z)
 {
+  // Remove overlap points for resampling
+  const auto points = motion_utils::removeOverlapPoints(points_raw);
+
   // validate arguments
   if (!resample_utils::validate_arguments(points, resampled_arclength)) {
-    return points;
+    return points_raw;
   }
 
   std::vector<geometry_msgs::msg::Point> position(points.size());


### PR DESCRIPTION
## Description

remove duplicated points before resampling to suppress the log:

```
[component_container_mt-28] input points has some duplicated points
[component_container_mt-28] input points has some duplicated points
[component_container_mt-28] input points has some duplicated points
[component_container_mt-28] input points has some duplicated points
[component_container_mt-28] input points has some duplicated points
[component_container_mt-28] input points has some duplicated points
[component_container_mt-28] input points has some duplicated points
[component_container_mt-28] input points has some duplicated points
[component_container_mt-28] input points has some duplicated points
```

## Tests performed

run psim, evaluator
https://evaluation.tier4.jp/evaluation/reports/d846b328-b093-5a9d-854a-ffe056ac94ae?project_id=prd_jt

## Effects on system behavior

suppress unnecessary messages.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
