### PR TITLE
refactor(avoidance): align function style

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -438,7 +438,8 @@ private:
   void addNewShiftLines(PathShifter & path_shifter, const AvoidLineArray & shift_lines) const;
 
   /**
-   * @brief validate shift lines.
+   * @brief once generate avoidance path from new shift lines, and calculate lateral offset between
+   * ego and the path.
    * @param new shift lines.
    * @param path shifter.
    * @return result. if there is huge gap between the ego position and candidate path, return false.

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -325,10 +325,16 @@ private:
    * 3. merge raw shirt lines.
    * 4. trim unnecessary shift lines.
    */
-  AvoidLineArray applyPreProcessToRawShiftLines(
+  AvoidLineArray applyPreProcess(
     AvoidLineArray & current_raw_shift_points, DebugData & debug) const;
 
-  AvoidLineArray getFillGapShiftLines(const AvoidLineArray & shift_lines) const;
+  /*
+   * @brief fill gap among shift lines.
+   * @param original shift lines.
+   * @param debug data.
+   * @return processed shift lines.
+   */
+  AvoidLineArray applyFillGapProcess(const AvoidLineArray & shift_lines, DebugData & debug) const;
 
   /*
    * @brief merge negative & positive shift lines.
@@ -336,7 +342,18 @@ private:
    * @param debug data.
    * @return processed shift lines.
    */
-  AvoidLineArray mergeShiftLines(const AvoidLineArray & raw_shift_lines, DebugData & debug) const;
+  AvoidLineArray applyMergeProcess(const AvoidLineArray & shift_lines, DebugData & debug) const;
+
+  /*
+   * @brief add return shift line from ego position.
+   * @param shift lines which the return shift is added.
+   * Pick up the last shift point, which is the most farthest from ego, from the current candidate
+   * avoidance points and registered points in the shifter. If the last shift length of the point is
+   * non-zero, add a return-shift to center line from the point. If there is no shift point in
+   * candidate avoidance points nor registered points, and base_shift > 0, add a return-shift to
+   * center line from ego.
+   */
+  AvoidLineArray addReturnShiftLine(const AvoidLineArray & shift_lines, DebugData & debug) const;
 
   /*
    * @brief extract shift lines from total shift lines based on their gradient.
@@ -356,7 +373,7 @@ private:
    * - Change the shift length to the previous one if the deviation is small.
    * - Remove unnecessary return shift (back to the center line).
    */
-  AvoidLineArray trimShiftLine(const AvoidLineArray & shift_lines, DebugData & debug) const;
+  AvoidLineArray applyTrimProcess(const AvoidLineArray & shift_lines, DebugData & debug) const;
 
   /*
    * @brief extract new shift lines based on current shifted path. the module makes a RTC request
@@ -365,17 +382,6 @@ private:
    * @return new shift lines.
    */
   AvoidLineArray findNewShiftLine(const AvoidLineArray & shift_lines) const;
-
-  /*
-   * @brief add return shift line from ego position.
-   * @param shift lines which the return shift is added.
-   * Pick up the last shift point, which is the most farthest from ego, from the current candidate
-   * avoidance points and registered points in the shifter. If the last shift length of the point is
-   * non-zero, add a return-shift to center line from the point. If there is no shift point in
-   * candidate avoidance points nor registered points, and base_shift > 0, add a return-shift to
-   * center line from ego.
-   */
-  void addReturnShiftLineFromEgo(AvoidLineArray & shift_lines) const;
 
   /*
    * @brief fill gap between two shift lines.
@@ -397,27 +403,27 @@ private:
    * @param threshold. shift length is quantized by this value. (if it is 0.3[m], the output shift
    * length is 0.0, 0.3, 0.6...)
    */
-  void quantizeShiftLine(AvoidLineArray & shift_lines, const double threshold) const;
+  void applyQuantizeProcess(AvoidLineArray & shift_lines, const double threshold) const;
 
   /*
    * @brief trim shift line whose relative longitudinal distance is less than threshold.
    * @param target shift lines.
    * @param threshold.
    */
-  void trimSmallShiftLine(AvoidLineArray & shift_lines, const double threshold) const;
+  void applySmallShiftFilter(AvoidLineArray & shift_lines, const double threshold) const;
 
   /*
    * @brief merge multiple shift lines whose relative gradient is less than threshold.
    * @param target shift lines.
    * @param threshold.
    */
-  void trimSimilarGradShiftLine(AvoidLineArray & shift_lines, const double threshold) const;
+  void applySimilarGradFilter(AvoidLineArray & shift_lines, const double threshold) const;
 
   /*
    * @brief trim invalid shift lines whose gradient it too large to follow.
    * @param target shift lines.
    */
-  void trimSharpReturn(AvoidLineArray & shift_lines, const double threshold) const;
+  void applySharpShiftFilter(AvoidLineArray & shift_lines, const double threshold) const;
 
   /**
    * @brief add new shift line to path shifter if the RTC status is activated.

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -525,22 +525,29 @@ struct DebugData
 
   lanelet::ConstLineStrings3d bounds;
 
-  AvoidLineArray current_shift_lines;  // in path shifter
-  AvoidLineArray new_shift_lines;      // in path shifter
+  // combine process
+  AvoidLineArray step1_registered_shift_line;
+  AvoidLineArray step1_current_raw_shift_line;
+  AvoidLineArray step1_filled_shift_line;
+  AvoidLineArray step1_merged_shift_line;
+  AvoidLineArray step1_combined_shift_line;
+  AvoidLineArray step1_return_shift_line;
+  AvoidLineArray step1_front_shift_line;
+  AvoidLineArray step1_shift_line;
 
-  AvoidLineArray registered_raw_shift;
-  AvoidLineArray current_raw_shift;
-  AvoidLineArray extra_return_shift;
+  // create outline process
+  AvoidLineArray step2_merged_shift_line;
 
-  AvoidLineArray merged;
-  AvoidLineArray gap_filled;
-  AvoidLineArray trim_similar_grad_shift;
-  AvoidLineArray quantized;
-  AvoidLineArray trim_small_shift;
-  AvoidLineArray trim_similar_grad_shift_second;
-  AvoidLineArray trim_similar_grad_shift_third;
-  AvoidLineArray trim_momentary_return;
-  AvoidLineArray trim_too_sharp_shift;
+  // trimming process
+  AvoidLineArray step3_quantized_shift_line;
+  AvoidLineArray step3_noise_removed;
+  AvoidLineArray step3_grad_filtered_first;
+  AvoidLineArray step3_grad_filtered_second;
+  AvoidLineArray step3_grad_filtered_third;
+
+  // registered process
+  AvoidLineArray step4_new_shift_line;
+  AvoidLineArray step4_valid_shift_line;
 
   // shift length
   std::vector<double> pos_shift;


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c9fed2</samp>

Refactored the avoidance module in the behavior path planner to improve the code quality and readability. Renamed and restructured the functions and data structures related to the shift line processing and filtering logic, and added debug data output for the processed shift lines. Updated the corresponding header and source files to reflect the changes.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/6421ba1b-888c-5960-a72f-e15876df6a66?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
