### PR TITLE
fix(ring_outlier_filter): change a parameter to be less misleading

### DIFF
--- a/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
+++ b/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
@@ -27,7 +27,7 @@ This implementation inherits `pointcloud_preprocessor::Filter` class, please ref
 | `distance_ratio`          | double  | 1.03          |             |
 | `object_length_threshold` | double  | 0.1           |             |
 | `num_points_threshold`    | int     | 4             |             |
-| `max_rings_num`           | uint_16 | 128           |             |
+| `max_ring_index`          | uint_16 | 128           |             |
 
 ## Assumptions / Known limits
 

--- a/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
+++ b/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
@@ -22,12 +22,12 @@ This implementation inherits `pointcloud_preprocessor::Filter` class, please ref
 
 ### Core Parameters
 
-| Name                      | Type    | Default Value | Description                |
-| ------------------------- | ------- | ------------- | -------------------------- |
-| `distance_ratio`          | double  | 1.03          |                            |
-| `object_length_threshold` | double  | 0.1           |                            |
-| `num_points_threshold`    | int     | 4             |                            |
-| `max_ring_index`          | uint_16 | 128           |`128` corresponds to vls128.|
+| Name                      | Type    | Default Value | Description                  |
+| ------------------------- | ------- | ------------- | ---------------------------- |
+| `distance_ratio`          | double  | 1.03          |                              |
+| `object_length_threshold` | double  | 0.1           |                              |
+| `num_points_threshold`    | int     | 4             |                              |
+| `max_ring_index`          | uint_16 | 128           | `128` corresponds to vls128. |
 
 ## Assumptions / Known limits
 

--- a/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
+++ b/sensing/pointcloud_preprocessor/docs/ring-outlier-filter.md
@@ -22,12 +22,12 @@ This implementation inherits `pointcloud_preprocessor::Filter` class, please ref
 
 ### Core Parameters
 
-| Name                      | Type    | Default Value | Description |
-| ------------------------- | ------- | ------------- | ----------- |
-| `distance_ratio`          | double  | 1.03          |             |
-| `object_length_threshold` | double  | 0.1           |             |
-| `num_points_threshold`    | int     | 4             |             |
-| `max_ring_index`          | uint_16 | 128           |             |
+| Name                      | Type    | Default Value | Description                |
+| ------------------------- | ------- | ------------- | -------------------------- |
+| `distance_ratio`          | double  | 1.03          |                            |
+| `object_length_threshold` | double  | 0.1           |                            |
+| `num_points_threshold`    | int     | 4             |                            |
+| `max_ring_index`          | uint_16 | 128           |`128` corresponds to vls128.|
 
 ## Assumptions / Known limits
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
@@ -45,7 +45,7 @@ private:
   double distance_ratio_;
   double object_length_threshold_;
   int num_points_threshold_;
-  uint16_t max_rings_num_;
+  uint16_t max_ring_index_;
 
   /** \brief Parameter service callback result : needed to be hold */
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;


### PR DESCRIPTION
## Description
The name of a ring_outlier_filter parameter (`max_rings_num`) has been changed to be less misleading (`max_ring_index`), and the source code has been modified accordingly.

In a project using Autoware, `max_rings_num` was set to `128` (i.e. the range of ring index was set to be `0~127`), but actually the maximum value of ring index was `128`.
To prevent this kind of thing, the parameter name should be changed to be less misleading.

[TIER IV internal link](https://tier4.atlassian.net/wiki/spaces/~5ed0b4584824b20c18371c06/pages/2885976248/pilot-auto.xx1+AWSIM+ring+outlier+filter+die)

## Tests performed
Even in projects with a maximum ring index of 128, it worked without error messages.

## Effects on system behavior

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
