### PR TITLE
fix(tier4_perception_launch): camera lidar fusion launch

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -340,21 +340,10 @@
   </group>
 
   <group>
-    <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
-      <arg name="input/object0" value="$(var lidar_detection_model)_roi_cluster_fusion/objects"/>
-      <arg name="input/object1" value="roi_pointcloud_fusion/objects"/>
-      <arg name="output/object" value="$(var lidar_detection_model)_roi_fusion/objects"/>
-      <arg name="priority_mode" value="0"/>
-      <arg name="data_association_matrix_path" value="$(var object_recognition_detection_object_merger_data_association_matrix_param_path)"/>
-      <arg name="distance_threshold_list_path" value="$(var object_recognition_detection_object_merger_distance_threshold_list_path)"/>
-    </include>
-  </group>
-
-  <group>
     <let name="merger/output/objects" value="objects_before_filter" if="$(var use_object_filter)"/>
     <let name="merger/output/objects" value="$(var output/objects)" unless="$(var use_object_filter)"/>
     <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
-      <arg name="input/object0" value="$(var lidar_detection_model)_roi_fusion/objects"/>
+      <arg name="input/object0" value="$(var lidar_detection_model)_roi_cluster_fusion/objects"/>
       <arg name="input/object1" value="detection_by_tracker/objects"/>
       <arg name="priority_mode" value="0"/>
       <arg name="output/object" value="$(var merger/output/objects)"/>


### PR DESCRIPTION
## Description
Hotfix: In order to properly connect the topics, remove unnecessary nodes.


## Related links
https://github.com/tier4/autoware.universe/pull/833


## Tests performed
Confirmed the prediction object is being output, using logging.simulator.launch in camera_lidar_fusion mode
![image](https://github.com/tier4/autoware.universe/assets/37187849/4a070c8b-1cee-461d-95d5-89749eee40cd)
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
