### PR TITLE
fix(radar_fusion_to_detected_object): fix confidence

### DIFF
--- a/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
+++ b/perception/radar_fusion_to_detected_object/src/radar_fusion_to_detected_object.cpp
@@ -296,7 +296,7 @@ TwistWithCovariance RadarFusionToDetectedObject::estimateTwist(
 bool RadarFusionToDetectedObject::isQualified(
   const DetectedObject & object, std::shared_ptr<std::vector<RadarInput>> & radars)
 {
-  if (object.classification[0].probability > param_.threshold_probability) {
+  if (object.existence_probability > param_.threshold_probability) {
     return true;
   } else {
     if (!radars || !(*radars).empty()) {


### PR DESCRIPTION
## Description

Fix confidence reference in radar_fusion_to_detected_object.

## Tests performed

Test by rosbag

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
