### PR TITLE
feat(object_merger): add queue size parameter

### DIFF
--- a/perception/object_merger/include/object_association_merger/node.hpp
+++ b/perception/object_merger/include/object_association_merger/node.hpp
@@ -59,14 +59,16 @@ private:
   tf2_ros::TransformListener tf_listener_;
   rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
     merged_object_pub_;
-  message_filters::Subscriber<autoware_auto_perception_msgs::msg::DetectedObjects> object0_sub_;
-  message_filters::Subscriber<autoware_auto_perception_msgs::msg::DetectedObjects> object1_sub_;
-  typedef message_filters::sync_policies::ApproximateTime<
+  message_filters::Subscriber<autoware_auto_perception_msgs::msg::DetectedObjects> object0_sub_{};
+  message_filters::Subscriber<autoware_auto_perception_msgs::msg::DetectedObjects> object1_sub_{};
+
+  using SyncPolicy = message_filters::sync_policies::ApproximateTime<
     autoware_auto_perception_msgs::msg::DetectedObjects,
-    autoware_auto_perception_msgs::msg::DetectedObjects>
-    SyncPolicy;
-  typedef message_filters::Synchronizer<SyncPolicy> Sync;
-  Sync sync_;
+    autoware_auto_perception_msgs::msg::DetectedObjects>;
+  using Sync = message_filters::Synchronizer<SyncPolicy>;
+  typename std::shared_ptr<Sync> sync_ptr_;
+
+  int sync_queue_size_;
   std::unique_ptr<DataAssociation> data_association_;
   std::string base_link_frame_id_;  // associated with the base_link frame
 

--- a/perception/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_merger/launch/object_association_merger.launch.xml
@@ -6,6 +6,7 @@
   <arg name="priority_mode" default="2" description="0: Object0, 1: Object1, 2: Confidence"/>
   <arg name="data_association_matrix_path" default="$(find-pkg-share object_merger)/config/data_association_matrix.param.yaml"/>
   <arg name="distance_threshold_list_path" default="$(find-pkg-share object_merger)/config/overlapped_judge.param.yaml"/>
+  <arg name="sync_queue_size" default="20"/>
 
   <node pkg="object_merger" exec="object_association_merger_node" name="$(anon object_association_merger)" output="screen">
     <remap from="input/object0" to="$(var input/object0)"/>
@@ -14,6 +15,7 @@
     <param from="$(var data_association_matrix_path)"/>
     <param from="$(var distance_threshold_list_path)"/>
     <param name="priority_mode" value="$(var priority_mode)"/>
+    <param name="sync_queue_size" value="sync_queue_size"/>
     <param name="precision_threshold_to_judge_overlapped" value="0.4"/>
     <param name="remove_overlapped_unknown_objects" value="true"/>
   </node>


### PR DESCRIPTION
## Description

To merger between object with large time difference, this PR add queue size parameter for message filter.
As the perception process becomes longer, there are more opportunities to merge objects with header time differences.
So this PR add add queue size parameter for message filter in `object_merger`, and make it easier to debug for the message filter.

## Tests performed

Test by rosbag

## Effects on system behavior

Default parameter is same as until now, so behavior doesn't change by this PR.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
