### PR TITLE
fix(start_planner): uninitialized hysteresis_factor_expand_rate (#838)

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
@@ -83,7 +83,7 @@ struct StartPlannerParameters
   double maximum_jerk_for_stop;
 
   // hysteresis parameter
-  double hysteresis_factor_expand_rate;
+  double hysteresis_factor_expand_rate = 0.0;
 
   // path safety checker
   utils::path_safety_checker::EgoPredictedPathParams ego_predicted_path_params;


### PR DESCRIPTION
## Description

The node has died when starting due to an uninitialized value.

This PR fixes it by initializing a default value.

## Tests performed

run psim

## Effects on system behavior

Start planner node will not die.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
