### PR TITLE
feat(start_planner): prevent start planner execution in the middle of the road

### DIFF
--- a/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
+++ b/planning/behavior_path_planner/config/start_planner/start_planner.param.yaml
@@ -7,6 +7,7 @@
       collision_check_margin: 1.0
       collision_check_distance_from_end: 1.0
       th_moving_object_velocity: 1.0
+      th_distance_to_middle_of_the_road: 0.1
       # shift pull out
       enable_shift_pull_out: true
       check_shift_path_lane_departure: false

--- a/planning/behavior_path_planner/docs/behavior_path_planner_start_planner_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_start_planner_design.md
@@ -59,16 +59,17 @@ PullOutPath --o PullOutPlannerBase
 
 ## General parameters for start_planner
 
-| Name                                                        | Unit  | Type   | Description                                                          | Default value |
-| :---------------------------------------------------------- | :---- | :----- | :------------------------------------------------------------------- | :------------ |
-| th_arrived_distance_m                                       | [m]   | double | distance threshold for arrival of path termination                   | 1.0           |
-| th_stopped_velocity_mps                                     | [m/s] | double | velocity threshold for arrival of path termination                   | 0.01          |
-| th_stopped_time_sec                                         | [s]   | double | time threshold for arrival of path termination                       | 1.0           |
-| th_turn_signal_on_lateral_offset                            | [m]   | double | lateral distance threshold for turning on blinker                    | 1.0           |
-| intersection_search_length                                  | [m]   | double | check if intersections exist within this length                      | 30.0          |
-| length_ratio_for_turn_signal_deactivation_near_intersection | [m]   | double | deactivate turn signal of this module near intersection              | 0.5           |
-| collision_check_margin                                      | [m]   | double | Obstacle collision check margin                                      | 1.0           |
-| collision_check_distance_from_end                           | [m]   | double | collision check distance from end point. currently only for pull out | 15.0          |
+| Name                                                        | Unit  | Type   | Description                                                                 | Default value |
+| :---------------------------------------------------------- | :---- | :----- | :-------------------------------------------------------------------------- | :------------ |
+| th_arrived_distance_m                                       | [m]   | double | distance threshold for arrival of path termination                          | 1.0           |
+| th_distance_to_middle_of_the_road                           | [m]   | double | distance threshold to determine if the vehicle is on the middle of the road |
+| th_stopped_velocity_mps                                     | [m/s] | double | velocity threshold for arrival of path termination                          | 0.01          |
+| th_stopped_time_sec                                         | [s]   | double | time threshold for arrival of path termination                              | 1.0           |
+| th_turn_signal_on_lateral_offset                            | [m]   | double | lateral distance threshold for turning on blinker                           | 1.0           |
+| intersection_search_length                                  | [m]   | double | check if intersections exist within this length                             | 30.0          |
+| length_ratio_for_turn_signal_deactivation_near_intersection | [m]   | double | deactivate turn signal of this module near intersection                     | 0.5           |
+| collision_check_margin                                      | [m]   | double | Obstacle collision check margin                                             | 1.0           |
+| collision_check_distance_from_end                           | [m]   | double | collision check distance from end point. currently only for pull out        | 15.0          |
 
 ## Safety check with static obstacles
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
@@ -39,11 +39,13 @@ struct StartPlannerParameters
   double th_stopped_velocity{0.0};
   double th_stopped_time{0.0};
   double th_turn_signal_on_lateral_offset{0.0};
+  double th_distance_to_middle_of_the_road{0.0};
   double intersection_search_length{0.0};
   double length_ratio_for_turn_signal_deactivation_near_intersection{0.0};
   double collision_check_margin{0.0};
   double collision_check_distance_from_end{0.0};
   double th_moving_object_velocity{0.0};
+
   // shift pull out
   bool enable_shift_pull_out{false};
   bool check_shift_path_lane_departure{false};

--- a/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/manager.cpp
@@ -38,6 +38,8 @@ StartPlannerModuleManager::StartPlannerModuleManager(
   p.th_stopped_time = node->declare_parameter<double>(ns + "th_stopped_time");
   p.th_turn_signal_on_lateral_offset =
     node->declare_parameter<double>(ns + "th_turn_signal_on_lateral_offset");
+  p.th_distance_to_middle_of_the_road =
+    node->declare_parameter<double>(ns + "th_distance_to_middle_of_the_road");
   p.intersection_search_length = node->declare_parameter<double>(ns + "intersection_search_length");
   p.length_ratio_for_turn_signal_deactivation_near_intersection = node->declare_parameter<double>(
     ns + "length_ratio_for_turn_signal_deactivation_near_intersection");

--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -122,10 +122,16 @@ void StartPlannerModule::processOnExit()
 
 bool StartPlannerModule::isExecutionRequested() const
 {
-  // TODO(Sugahara): if required lateral shift distance is small, don't engage this module.
-  // Execute when current pose is near route start pose
-  const Pose start_pose = planner_data_->route_handler->getOriginalStartPose();
   const Pose & current_pose = planner_data_->self_odometry->pose.pose;
+  const lanelet::ConstLanelets current_lanes = utils::getCurrentLanes(planner_data_);
+  const double lateral_distance_to_center_lane =
+    lanelet::utils::getArcCoordinates(current_lanes, current_pose).distance;
+
+  if (std::abs(lateral_distance_to_center_lane) < parameters_->th_distance_to_middle_of_the_road) {
+    return false;
+  }
+
+  const Pose start_pose = planner_data_->route_handler->getOriginalStartPose();
   if (
     tier4_autoware_utils::calcDistance2d(start_pose.position, current_pose.position) >
     parameters_->th_arrived_distance) {


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e0f5c6</samp>

Add a new parameter `th_distance_to_middle_of_the_road` to the start planner module, which controls whether the module should be executed or not based on the lateral distance to the center of the current lane. Update the configuration file, the header file, and the source files accordingly.

## Related links

Parameter changes: [link](https://github.com/autowarefoundation/autoware_launch/pull/579?expand=1&template=standard-change.md)

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
