### PR TITLE
fix(behavior_path_planner): fix condition when collision detected before approval

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/start_planner/start_planner_parameters.hpp
@@ -35,6 +35,7 @@ using freespace_planning_algorithms::RRTStarParam;
 
 struct StartPlannerParameters
 {
+  // TODO(someone): initialize variables
   double th_arrived_distance;
   double th_stopped_velocity;
   double th_stopped_time;

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -673,6 +673,7 @@ void GoalPlannerModule::setOutput(BehaviorModuleOutput & output)
     // insert stop point in current path if ego is able to stop with acceleration and jerk
     // constraints
     setStopPathFromCurrentPath(output);
+    status_.is_safe_dynamic_objects = true;
   } else {
     // situation : (safe against static and dynamic objects) or (safe against static objects and
     // before approval) don't stop

--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -673,7 +673,6 @@ void GoalPlannerModule::setOutput(BehaviorModuleOutput & output)
     // insert stop point in current path if ego is able to stop with acceleration and jerk
     // constraints
     setStopPathFromCurrentPath(output);
-    status_.is_safe_dynamic_objects = true;
   } else {
     // situation : (safe against static and dynamic objects) or (safe against static objects and
     // before approval) don't stop
@@ -701,7 +700,7 @@ void GoalPlannerModule::setOutput(BehaviorModuleOutput & output)
   // for the next loop setOutput().
   // this is used to determine whether to generate a new stop path or keep the current stop path.
   status_.prev_is_safe = status_.is_safe_static_objects;
-  status_.prev_is_safe_dynamic_objects = status_.is_safe_dynamic_objects;
+  status_.prev_is_safe_dynamic_objects = isSafePath();
 }
 
 void GoalPlannerModule::setStopPath(BehaviorModuleOutput & output)
@@ -1599,7 +1598,7 @@ bool GoalPlannerModule::isSafePath() const
     pull_over_lanes, route_handler, filtered_objects, objects_filtering_params_);
 
   const double hysteresis_factor =
-    status_.is_safe_dynamic_objects ? 1.0 : parameters_->hysteresis_factor_expand_rate;
+    status_.prev_is_safe_dynamic_objects ? 1.0 : parameters_->hysteresis_factor_expand_rate;
 
   utils::start_goal_planner_common::updateSafetyCheckTargetObjectsData(
     goal_planner_data_, filtered_objects, target_objects_on_lane, ego_predicted_path);


### PR DESCRIPTION
## Description

before:
collision detected against dynamic objects before aprroval, output is not generated and turnsignal information is calculated based on empty output. in this case, node get died.

after:
Separate condition into 3
1. not safe against **static** objects:
      stop on the reference path
2.  not safe against **dynamic** objects and after approval
      stop on the pull over path
3. none of above
      do nothing


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL TEST](https://evaluation.tier4.jp/evaluation/reports/743cad84-8fd7-534d-a276-eb8d6ccbe90e?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
