### PR TITLE
fix(goal_planner): fix disabling safety check

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -669,7 +669,9 @@ void GoalPlannerModule::setOutput(BehaviorModuleOutput & output)
   if (!status_.is_safe_static_objects) {
     // situation : not safe against static objects use stop_path
     setStopPath(output);
-  } else if (!isSafePath() && status_.has_decided_path && isActivated()) {
+  } else if (
+    parameters_->safety_check_params.enable_safety_check && !isSafePath() &&
+    status_.has_decided_path && isActivated()) {
     // situation : not safe against dynamic objects after approval
     // insert stop point in current path if ego is able to stop with acceleration and jerk
     // constraints
@@ -701,7 +703,8 @@ void GoalPlannerModule::setOutput(BehaviorModuleOutput & output)
   // for the next loop setOutput().
   // this is used to determine whether to generate a new stop path or keep the current stop path.
   status_.prev_is_safe = status_.is_safe_static_objects;
-  status_.prev_is_safe_dynamic_objects = isSafePath();
+  status_.prev_is_safe_dynamic_objects =
+    parameters_->safety_check_params.enable_safety_check ? isSafePath() : true;
 }
 
 void GoalPlannerModule::setStopPath(BehaviorModuleOutput & output)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

if setting `enable_safety_check: false` the node die.

```
[component_container_mt-28]     @     0x7f4fecdc8968 behavior_path_planner::utils::start_goal_planner_common::updatePathProperty()
[component_container_mt-28]     @     0x7f4fecca359c behavior_path_planner::GoalPlannerModule::isSafePath()
[component_container_mt-28]     @     0x7f4feccb3e1e behavior_path_planner::GoalPlannerModule::setOutput()
[component_container_mt-28]     @     0x7f4feccb44bf behavior_path_planner::GoalPlannerModule::planWithGoalModification()
[component_container_mt-28]     @     0x7f4feccb4be3 behavior_path_planner::GoalPlannerModule::plan()
[component_container_mt-28]     @     0x7f4feccb1f16 behavior_path_planner::GoalPlannerModule::planWaitingApprovalWithGoalModification()
[component_container_mt-28]     @     0x7f4feccb2abb behavior_path_planner::GoalPlannerModule::planWaitingApproval()
[component_container_mt-28]     @     0x7f4feccb1b6b behavior_path_planner::GoalPlannerModule::run()
[component_container_mt-28]     @     0x7f4fecb41077 behavior_path_planner::PlannerManager::run()
[component_container_mt-28]     @     0x7f4fecb323ea behavior_path_planner::PlannerManager::runRequestModules()
[component_container_mt-28]     @     0x7f4fecb340fb _ZZN21behavior_path_planner14PlannerManager3runERKSt10shared_ptrINS_11PlannerDataEEENKUlvE0_clEv
[component_container_mt-28]     @     0x7f4fecb34ba9 behavior_path_planner::PlannerManager::run()
[component_container_mt-28]     @     0x7f4fecb675ec behavior_path_planner::BehaviorPathPlannerNode::run()
[component_container_mt-28]     @     0x7f4fecb704c5 rclcpp::GenericTimer<>::execute_callback()
[component_container_mt-28]     @     0x7f4ffc55effe rclcpp::Executor::execute_any_executable()
[component_container_mt-28]     @     0x7f4ffc565432 rclcpp::executors::MultiThreadedExecutor::run()
```



## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
