### PR TITLE
fix(operation_mode_transition_manager): check trajectory_follower_cmd for engage condition

### DIFF
--- a/control/operation_mode_transition_manager/src/state.hpp
+++ b/control/operation_mode_transition_manager/src/state.hpp
@@ -67,6 +67,7 @@ private:
   using Odometry = nav_msgs::msg::Odometry;
   using Trajectory = autoware_auto_planning_msgs::msg::Trajectory;
   rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_control_cmd_;
+  rclcpp::Subscription<AckermannControlCommand>::SharedPtr sub_trajectory_follower_control_cmd_;
   rclcpp::Subscription<Odometry>::SharedPtr sub_kinematics_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
   rclcpp::Logger logger_;
@@ -79,6 +80,7 @@ private:
   EngageAcceptableParam engage_acceptable_param_;
   StableCheckParam stable_check_param_;
   AckermannControlCommand control_cmd_;
+  AckermannControlCommand trajectory_follower_control_cmd_;
   Odometry kinematics_;
   Trajectory trajectory_;
   vehicle_info_util::VehicleInfo vehicle_info_;

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -239,6 +239,7 @@ def launch_setup(context, *args, **kwargs):
             ("steering", "/vehicle/status/steering_status"),
             ("trajectory", "/planning/scenario_planning/trajectory"),
             ("control_cmd", "/control/command/control_cmd"),
+            ("trajectory_follower_control_cmd", "/control/trajectory_follower/control_cmd"),
             ("control_mode_report", "/vehicle/status/control_mode"),
             ("gate_operation_mode", "/control/vehicle_cmd_gate/operation_mode"),
             # output


### PR DESCRIPTION
## Description

The vehicle engage in manual driving should be prohibited when the Autoware is indicating an urgent stop (represented by target `v=0`). 

However, due to the filtering in the `vehicle_cmd_gate`, even if the trajectory follower sends `v=0`, the target velocity of the vehicle_cmd_gate is not 0.

With this PR, `operation_mode_transition_manager` checks the control command from the `trajectory_follower` directly as well as the control command from the `vehicle_cmd_gate` to prohibit the engage in manual driving when the Autoware is indicating an urgent stop.

## Related links

[TIERIV internal ticket](https://tier4.atlassian.net/browse/RT1-3487)

## Tests performed

Run psim.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

The vehicle engage is prohibited when the control module is indicating an urgent stop.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
