### PR TITLE
feat(ndt_scan_matcher): added logging initial pose

### DIFF
--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
@@ -86,4 +86,8 @@ T transform(const T & input, const geometry_msgs::msg::TransformStamped & transf
 
 double norm(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2);
 
+void output_pose_with_cov_to_log(
+  const rclcpp::Logger logger, const std::string & prefix,
+  const geometry_msgs::msg::PoseWithCovarianceStamped & pose_with_cov);
+
 #endif  // NDT_SCAN_MATCHER__UTIL_FUNC_HPP_

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
@@ -33,6 +33,7 @@
 #include <cmath>
 #include <deque>
 #include <random>
+#include <string>
 #include <vector>
 
 // ref by http://takacity.blog.fc2.com/blog-entry-69.html

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -783,6 +783,8 @@ geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::align_using_monte_
     return geometry_msgs::msg::PoseWithCovarianceStamped();
   }
 
+  output_pose_with_cov_to_log(get_logger(), "align_using_monte_carlo_input", initial_pose_with_cov);
+
   // generateParticle
   const auto initial_poses =
     create_random_pose_array(initial_pose_with_cov, initial_estimate_particles_num_);
@@ -819,6 +821,10 @@ geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::align_using_monte_
   result_pose_with_cov_msg.header.stamp = initial_pose_with_cov.header.stamp;
   result_pose_with_cov_msg.header.frame_id = map_frame_;
   result_pose_with_cov_msg.pose.pose = best_particle_ptr->result_pose;
+
+  output_pose_with_cov_to_log(
+    get_logger(), "align_using_monte_carlo_output", result_pose_with_cov_msg);
+  RCLCPP_INFO_STREAM(get_logger(), "best_score," << best_particle_ptr->score);
 
   return result_pose_with_cov_msg;
 }

--- a/localization/ndt_scan_matcher/src/util_func.cpp
+++ b/localization/ndt_scan_matcher/src/util_func.cpp
@@ -287,3 +287,24 @@ double norm(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Poin
   const double dz = p1.z - p2.z;
   return std::sqrt(dx * dx + dy * dy + dz * dz);
 }
+
+void output_pose_with_cov_to_log(
+  const rclcpp::Logger logger, const std::string & prefix,
+  const geometry_msgs::msg::PoseWithCovarianceStamped & pose_with_cov)
+{
+  const Eigen::Map<const RowMatrixXd> covariance =
+    make_eigen_covariance(pose_with_cov.pose.covariance);
+  const geometry_msgs::msg::Pose pose = pose_with_cov.pose.pose;
+  geometry_msgs::msg::Vector3 rpy = get_rpy(pose);
+  rpy.x = rpy.x * 180.0 / M_PI;
+  rpy.y = rpy.y * 180.0 / M_PI;
+  rpy.z = rpy.z * 180.0 / M_PI;
+
+  RCLCPP_INFO_STREAM(
+    logger, std::fixed << prefix << "," << pose.position.x << "," << pose.position.y << ","
+                       << pose.position.z << "," << pose.orientation.x << "," << pose.orientation.y
+                       << "," << pose.orientation.z << "," << pose.orientation.w << "," << rpy.x
+                       << "," << rpy.y << "," << rpy.z << "," << covariance(0, 0) << ","
+                       << covariance(1, 1) << "," << covariance(2, 2) << "," << covariance(3, 3)
+                       << "," << covariance(4, 4) << "," << covariance(5, 5));
+}


### PR DESCRIPTION
## Description

Added code to log input and output Pose of initial position estimation in `align_using_monte_carlo`.

## Tests performed

It was confirmed that it can be successfully executed against sample rosbag.

## Effects on system behavior

Each time an initial position estimation is performed using NDT, the following three lines of log are output.

Each value is `(x, y, z, qx, qy, qz, qw, roll, pitch, yaw(deg), cov(0,0), cov(1,1), ... cov(5, 5))`.

```
1695192506.8527462 [ndt_scan_matcher-31] [INFO 1695192506.851505952] [localization.pose_estimator.ndt_scan_matcher]: align_using_monte_carlo_input,89570.098658,42300.198565,-3.188279,0.000363,-0.007508,0.018195,0.999806,0.025985,-0.860952,2.084941,1.000000,1.000000,0.010000,0.010000,0.010000,10.000000
...
1695192509.4600489 [ndt_scan_matcher-31] [INFO 1695192509.439114040] [localization.pose_estimator.ndt_scan_matcher]: align_using_monte_carlo_output,89571.156250,42301.187500,-3.157603,-0.008684,-0.001767,0.287582,0.957715,-1.011302,0.092282,33.427036,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000
1695192509.4605412 [ndt_scan_matcher-31] [INFO 1695192509.439304247] [localization.pose_estimator.ndt_scan_matcher]: best_score,5.89776
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
